### PR TITLE
Handle missing Resend API key during build

### DIFF
--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -1,9 +1,15 @@
 import { EmailTemplate } from "@/components/email-template";
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
-
 export async function POST() {
+  const resendApiKey = process.env.RESEND_API_KEY;
+
+  if (!resendApiKey) {
+    return Response.json({ error: "Resend API key is not configured." }, { status: 500 });
+  }
+
+  const resend = new Resend(resendApiKey);
+
   try {
     const { data, error } = await resend.emails.send({
       from: 'Acme <onboarding@resend.dev>',


### PR DESCRIPTION
## Summary
- guard the Resend API client creation with a runtime API key check so builds do not fail when the key is absent

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce721fa40c83288de3e18c2f7e5cdd