### PR TITLE
Add lease document storage and management

### DIFF
--- a/app/(tenant)/leases/page.tsx
+++ b/app/(tenant)/leases/page.tsx
@@ -1,0 +1,108 @@
+import { format } from 'date-fns'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { listTenantLeaseDocuments } from '@/app/dashboard/leases/actions'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+function formatDate(value: string | null): string {
+  if (!value) return '—'
+  try {
+    return format(new Date(value), 'MMM d, yyyy')
+  } catch (error) {
+    return value
+  }
+}
+
+export default async function TenantLeasesPage() {
+  const { data: documents, error, unauthorized, requiresAuth } = await listTenantLeaseDocuments()
+
+  if (requiresAuth) {
+    redirect('/auth')
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Lease agreements</h1>
+        <p className="text-muted-foreground">
+          Review your current lease agreements and download signed copies for your records.
+        </p>
+      </div>
+      {unauthorized ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Access restricted</CardTitle>
+            <CardDescription>
+              You do not have permission to view lease agreements with this account.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Available documents</CardTitle>
+            <CardDescription>
+              Documents are available for download for 60 minutes after each link is generated.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {error ? (
+              <p className="text-sm text-destructive">{error}</p>
+            ) : documents.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No lease documents are currently available. Please contact property staff if you
+                believe this is incorrect.
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {documents.map((document) => {
+                  const isExpired = document.expiration_date
+                    ? new Date(document.expiration_date) < new Date()
+                    : false
+
+                  return (
+                    <div
+                      key={document.id}
+                      className="flex flex-col gap-4 rounded-lg border p-4 md:flex-row md:items-center md:justify-between"
+                    >
+                      <div className="space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium">{document.title}</span>
+                          <Badge variant="outline">v{document.version}</Badge>
+                          {isExpired ? <Badge variant="destructive">Expired</Badge> : null}
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          Effective {formatDate(document.effective_date)}
+                          {document.expiration_date
+                            ? ` · Expires ${formatDate(document.expiration_date)}`
+                            : ''}
+                        </p>
+                        {document.lease ? (
+                          <p className="text-sm text-muted-foreground">
+                            {document.lease.property_name} · {document.lease.unit_label}
+                          </p>
+                        ) : null}
+                      </div>
+                      {document.downloadUrl ? (
+                        <Button asChild>
+                          <Link href={document.downloadUrl} target="_blank" rel="noopener noreferrer">
+                            Download PDF
+                          </Link>
+                        </Button>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">Download unavailable</span>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, FileTextIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -14,12 +14,17 @@ export default function NavLinks() {
 			text: "Members",
 			Icon: PersonIcon,
 		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+                {
+                        href: "/dashboard/leases",
+                        text: "Leases",
+                        Icon: FileTextIcon,
+                },
+        ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/leases/actions.ts
+++ b/app/dashboard/leases/actions.ts
@@ -1,0 +1,377 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { createClient } from '@/utils/supa-server-actions'
+import type { Database } from '@/lib/supabase'
+
+const STAFF_ROLES = new Set(['admin', 'staff'])
+const LEASE_BUCKET = 'lease-documents'
+
+type TypedSupabaseClient = SupabaseClient<Database>
+type LeaseRow = Database['public']['Tables']['leases']['Row']
+type LeaseDocumentRow = Database['public']['Tables']['lease_documents']['Row']
+type ProfileRow = Database['public']['Tables']['profiles']['Row']
+
+type StaffProfile = Pick<ProfileRow, 'id' | 'role' | 'full_name' | 'email'>
+
+type UploadResult = {
+  success: boolean
+  error?: string
+}
+
+type LeaseOverviewEntry = {
+  lease: LeaseRow
+  tenant: Pick<ProfileRow, 'id' | 'full_name' | 'email'> | null
+  documents: LeaseDocumentWithUrl[]
+}
+
+type LeaseOverviewResult = {
+  data: LeaseOverviewEntry[]
+  error?: string
+  unauthorized?: boolean
+}
+
+type TenantLeaseDocument = LeaseDocumentWithUrl & {
+  lease: LeaseRow | null
+}
+
+type TenantLeaseDocumentsResult = {
+  data: TenantLeaseDocument[]
+  error?: string
+  unauthorized?: boolean
+  requiresAuth?: boolean
+}
+
+export type LeaseDocumentWithUrl = LeaseDocumentRow & {
+  downloadUrl: string | null
+}
+
+const uploadSchema = z.object({
+  leaseId: z.string().uuid({ message: 'A valid lease is required.' }),
+  title: z.string().min(1, 'Document title is required.'),
+  effectiveDate: z
+    .string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), 'Effective date must be a valid date.'),
+  documentId: z.string().uuid().optional(),
+})
+
+async function getSupabaseClient() {
+  const cookieStore = cookies()
+  return createClient(cookieStore)
+}
+
+function isStaff(profile: ProfileRow | null): profile is StaffProfile {
+  if (!profile?.role) return false
+  return STAFF_ROLES.has(profile.role)
+}
+
+async function fetchCurrentProfile(supabase: TypedSupabaseClient) {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    return { user: null, error: error?.message ?? 'Not authenticated.' }
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, role, full_name, email')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (profileError || !profile) {
+    return { user, error: profileError?.message ?? 'Profile not found.' }
+  }
+
+  return { user, profile, error: null }
+}
+
+async function withSignedUrls(
+  supabase: TypedSupabaseClient,
+  documents: LeaseDocumentRow[]
+): Promise<LeaseDocumentWithUrl[]> {
+  if (!documents.length) return []
+
+  const results = await Promise.all(
+    documents.map(async (doc) => {
+      const { data, error } = await supabase.storage
+        .from(LEASE_BUCKET)
+        .createSignedUrl(doc.storage_path, 60 * 60)
+
+      return {
+        ...doc,
+        downloadUrl: error ? null : data?.signedUrl ?? null,
+      }
+    })
+  )
+
+  return results
+}
+
+export async function uploadLeaseDocument(formData: FormData): Promise<UploadResult> {
+  const supabase = await getSupabaseClient()
+  const { profile, error: authError } = await fetchCurrentProfile(supabase)
+
+  if (authError || !profile) {
+    return { success: false, error: authError ?? 'You must be signed in.' }
+  }
+
+  if (!isStaff(profile)) {
+    return { success: false, error: 'Only staff members can manage lease documents.' }
+  }
+
+  const parsed = uploadSchema.safeParse({
+    leaseId: formData.get('leaseId'),
+    title: formData.get('title'),
+    effectiveDate: formData.get('effectiveDate'),
+    documentId: formData.get('documentId') || undefined,
+  })
+
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.errors[0]?.message ?? 'Invalid form submission.' }
+  }
+
+  const { leaseId, title, effectiveDate, documentId } = parsed.data
+
+  const rawExpiration = formData.get('expirationDate')
+  const expirationDate =
+    typeof rawExpiration === 'string' && rawExpiration.length > 0 ? rawExpiration : null
+
+  if (expirationDate && Number.isNaN(Date.parse(expirationDate))) {
+    return { success: false, error: 'Expiration date must be a valid date.' }
+  }
+
+  const file = formData.get('file')
+  if (!(file instanceof File)) {
+    return { success: false, error: 'A PDF document must be provided.' }
+  }
+
+  if (file.size === 0) {
+    return { success: false, error: 'The uploaded file is empty.' }
+  }
+
+  if (file.type !== 'application/pdf') {
+    return { success: false, error: 'Only PDF documents are supported.' }
+  }
+
+  const { data: lease, error: leaseError } = await supabase
+    .from('leases')
+    .select('id')
+    .eq('id', leaseId)
+    .maybeSingle()
+
+  if (leaseError || !lease) {
+    return { success: false, error: 'The selected lease could not be found.' }
+  }
+
+  let documentPath: string
+  let version = 1
+
+  if (documentId) {
+    const { data: existingDocument, error: existingError } = await supabase
+      .from('lease_documents')
+      .select('id, lease_id, storage_path, version')
+      .eq('id', documentId)
+      .maybeSingle()
+
+    if (existingError || !existingDocument) {
+      return { success: false, error: 'The lease document to replace was not found.' }
+    }
+
+    if (existingDocument.lease_id !== leaseId) {
+      return { success: false, error: 'This document does not belong to the selected lease.' }
+    }
+
+    documentPath = existingDocument.storage_path
+    version = existingDocument.version + 1
+  } else {
+    const { data: latestVersion } = await supabase
+      .from('lease_documents')
+      .select('version')
+      .eq('lease_id', leaseId)
+      .order('version', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    version = latestVersion?.version ? latestVersion.version + 1 : 1
+    const sanitizedName = file.name.replace(/[^a-zA-Z0-9.\-]/g, '_')
+    documentPath = `${leaseId}/${randomUUID()}-${sanitizedName}`
+  }
+
+  const fileBuffer = Buffer.from(await file.arrayBuffer())
+  const { error: uploadError } = await supabase.storage.from(LEASE_BUCKET).upload(documentPath, fileBuffer, {
+    contentType: 'application/pdf',
+    upsert: true,
+  })
+
+  if (uploadError) {
+    return { success: false, error: uploadError.message }
+  }
+
+  if (documentId) {
+    const { error: updateError } = await supabase
+      .from('lease_documents')
+      .update({
+        storage_path: documentPath,
+        title,
+        effective_date: effectiveDate,
+        expiration_date: expirationDate,
+        version,
+      })
+      .eq('id', documentId)
+
+    if (updateError) {
+      return { success: false, error: updateError.message }
+    }
+  } else {
+    const { error: insertError } = await supabase.from('lease_documents').insert({
+      lease_id: leaseId,
+      storage_path: documentPath,
+      title,
+      effective_date: effectiveDate,
+      expiration_date: expirationDate,
+      version,
+    })
+
+    if (insertError) {
+      await supabase.storage.from(LEASE_BUCKET).remove([documentPath])
+      return { success: false, error: insertError.message }
+    }
+  }
+
+  revalidatePath('/dashboard/leases')
+  revalidatePath('/leases')
+
+  return { success: true }
+}
+
+export async function fetchLeaseOverview(): Promise<LeaseOverviewResult> {
+  const supabase = await getSupabaseClient()
+  const { profile, error: authError } = await fetchCurrentProfile(supabase)
+
+  if (authError || !profile) {
+    return { data: [], error: authError ?? 'Unable to authenticate.', unauthorized: true }
+  }
+
+  if (!isStaff(profile)) {
+    return { data: [], error: 'Only staff members can view leases.', unauthorized: true }
+  }
+
+  const { data: leases, error: leasesError } = await supabase
+    .from('leases')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  if (leasesError || !leases) {
+    return { data: [], error: leasesError?.message ?? 'Unable to load leases.' }
+  }
+
+  const leaseIds = leases.map((lease) => lease.id)
+
+  let documents: LeaseDocumentRow[] = []
+  if (leaseIds.length) {
+    const { data: leaseDocuments, error: documentsError } = await supabase
+      .from('lease_documents')
+      .select('*')
+      .in('lease_id', leaseIds)
+      .order('version', { ascending: false })
+
+    if (documentsError) {
+      return { data: [], error: documentsError.message }
+    }
+
+    documents = leaseDocuments ?? []
+  }
+
+  const documentsByLease = new Map<string, LeaseDocumentWithUrl[]>()
+  const documentsWithUrls = await withSignedUrls(supabase, documents)
+  documentsWithUrls.forEach((doc) => {
+    const list = documentsByLease.get(doc.lease_id) ?? []
+    list.push(doc)
+    documentsByLease.set(doc.lease_id, list)
+  })
+
+  const tenantIds = leases.map((lease) => lease.tenant_profile_id)
+  const uniqueTenantIds = Array.from(new Set(tenantIds))
+
+  let tenantProfiles: ProfileRow[] = []
+  if (uniqueTenantIds.length) {
+    const { data: tenants, error: tenantsError } = await supabase
+      .from('profiles')
+      .select('id, full_name, email')
+      .in('id', uniqueTenantIds)
+
+    if (!tenantsError && tenants) {
+      tenantProfiles = tenants
+    }
+  }
+
+  const tenantById = new Map<string, ProfileRow>()
+  tenantProfiles.forEach((tenant) => tenantById.set(tenant.id, tenant))
+
+  const data: LeaseOverviewEntry[] = leases.map((lease) => ({
+    lease,
+    tenant: tenantById.get(lease.tenant_profile_id) ?? null,
+    documents: documentsByLease.get(lease.id) ?? [],
+  }))
+
+  return { data }
+}
+
+export async function listTenantLeaseDocuments(): Promise<TenantLeaseDocumentsResult> {
+  const supabase = await getSupabaseClient()
+  const { profile, error: authError } = await fetchCurrentProfile(supabase)
+
+  if (authError || !profile) {
+    return {
+      data: [],
+      error: authError ?? 'You must be signed in to view lease documents.',
+      unauthorized: true,
+      requiresAuth: true,
+    }
+  }
+
+  const { data: documents, error: documentsError } = await supabase
+    .from('lease_documents')
+    .select('*')
+    .order('effective_date', { ascending: false })
+
+  if (documentsError) {
+    return { data: [], error: documentsError.message }
+  }
+
+  const docList = documents ?? []
+  const leaseIds = Array.from(new Set(docList.map((doc) => doc.lease_id)))
+
+  let leases: LeaseRow[] = []
+  if (leaseIds.length) {
+    const { data: leaseRows, error: leaseError } = await supabase
+      .from('leases')
+      .select('*')
+      .in('id', leaseIds)
+
+    if (leaseError) {
+      return { data: [], error: leaseError.message }
+    }
+
+    leases = leaseRows ?? []
+  }
+
+  const leaseById = new Map<string, LeaseRow>()
+  leases.forEach((lease) => leaseById.set(lease.id, lease))
+
+  const documentsWithUrls = await withSignedUrls(supabase, docList)
+  const data: TenantLeaseDocument[] = documentsWithUrls.map((doc) => ({
+    ...doc,
+    lease: leaseById.get(doc.lease_id) ?? null,
+  }))
+
+  return { data }
+}

--- a/app/dashboard/leases/page.tsx
+++ b/app/dashboard/leases/page.tsx
@@ -1,0 +1,204 @@
+import { format } from 'date-fns'
+
+import {
+  fetchLeaseOverview,
+  uploadLeaseDocument,
+  type LeaseDocumentWithUrl,
+} from './actions'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+function formatDate(value: string | null): string {
+  if (!value) return '—'
+  try {
+    return format(new Date(value), 'MMM d, yyyy')
+  } catch (error) {
+    return value
+  }
+}
+
+type LeaseDocumentFormProps = {
+  leaseId: string
+  document?: LeaseDocumentWithUrl
+}
+
+function LeaseDocumentForm({ leaseId, document }: LeaseDocumentFormProps) {
+  const formId = document ? `replace-${document.id}` : `new-${leaseId}`
+
+  return (
+    <form
+      action={uploadLeaseDocument}
+      className="grid gap-3 rounded-lg border p-4"
+      encType="multipart/form-data"
+    >
+      <input type="hidden" name="leaseId" value={leaseId} />
+      {document ? <input type="hidden" name="documentId" value={document.id} /> : null}
+      <div className="grid gap-1">
+        <Label htmlFor={`${formId}-title`}>Document title</Label>
+        <Input
+          id={`${formId}-title`}
+          name="title"
+          defaultValue={document?.title ?? ''}
+          placeholder="Signed lease agreement"
+          required
+        />
+      </div>
+      <div className="grid gap-1">
+        <Label htmlFor={`${formId}-effective`}>Effective date</Label>
+        <Input
+          id={`${formId}-effective`}
+          type="date"
+          name="effectiveDate"
+          defaultValue={document?.effective_date?.slice(0, 10) ?? ''}
+          required
+        />
+      </div>
+      <div className="grid gap-1">
+        <Label htmlFor={`${formId}-expiration`}>Expiration date</Label>
+        <Input
+          id={`${formId}-expiration`}
+          type="date"
+          name="expirationDate"
+          defaultValue={document?.expiration_date?.slice(0, 10) ?? ''}
+        />
+      </div>
+      <div className="grid gap-1">
+        <Label htmlFor={`${formId}-file`}>PDF document</Label>
+        <Input id={`${formId}-file`} type="file" name="file" accept="application/pdf" required />
+        <p className="text-xs text-muted-foreground">Only PDF files are supported.</p>
+      </div>
+      <Button type="submit">{document ? 'Upload replacement' : 'Upload document'}</Button>
+    </form>
+  )
+}
+
+export default async function DashboardLeasesPage() {
+  const { data: overview, error, unauthorized } = await fetchLeaseOverview()
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Lease documents</h1>
+        <p className="text-muted-foreground">
+          Upload new agreements, replace expiring documents, and provide tenants with the latest
+          versions.
+        </p>
+      </div>
+      {unauthorized ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Access restricted</CardTitle>
+            <CardDescription>Only property staff can manage lease documents.</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : overview.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No leases found</CardTitle>
+            <CardDescription>
+              Create leases in the database to begin attaching documents for tenants.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <div className="grid gap-6">
+          {error ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Unable to load lease documents</CardTitle>
+                <CardDescription>{error}</CardDescription>
+              </CardHeader>
+            </Card>
+          ) : (
+            overview.map(({ lease, tenant, documents }) => {
+              return (
+                <Card key={lease.id} className="border">
+                  <CardHeader>
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <CardTitle>
+                          {lease.property_name} · {lease.unit_label}
+                        </CardTitle>
+                        <CardDescription>
+                          Lease ID {lease.id}
+                          {tenant ? ` · ${tenant.full_name ?? tenant.email ?? ''}` : ''}
+                        </CardDescription>
+                      </div>
+                      <Badge variant={lease.status === 'active' ? 'default' : 'outline'}>
+                        {lease.status}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Effective {formatDate(lease.start_date)}
+                      {lease.end_date ? ` · Ends ${formatDate(lease.end_date)}` : ''}
+                    </p>
+                  </CardHeader>
+                  <CardContent className="space-y-6">
+                    <div className="space-y-4">
+                      {documents.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">
+                          No documents have been uploaded for this lease yet.
+                        </p>
+                      ) : (
+                        documents.map((document) => {
+                          const isExpired = document.expiration_date
+                            ? new Date(document.expiration_date) < new Date()
+                            : false
+
+                          return (
+                            <div key={document.id} className="space-y-3 rounded-lg border p-4">
+                              <div className="flex flex-wrap items-center justify-between gap-2">
+                                <div className="space-y-1">
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <span className="font-medium">{document.title}</span>
+                                    <Badge variant="outline">v{document.version}</Badge>
+                                    {isExpired ? <Badge variant="destructive">Expired</Badge> : null}
+                                  </div>
+                                  <p className="text-sm text-muted-foreground">
+                                    Effective {formatDate(document.effective_date)}
+                                    {document.expiration_date
+                                      ? ` · Expires ${formatDate(document.expiration_date)}`
+                                      : ''}
+                                  </p>
+                                </div>
+                                {document.downloadUrl ? (
+                                  <Button variant="secondary" asChild>
+                                    <a
+                                      href={document.downloadUrl}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                    >
+                                      Preview PDF
+                                    </a>
+                                  </Button>
+                                ) : null}
+                              </div>
+                              <LeaseDocumentForm leaseId={lease.id} document={document} />
+                            </div>
+                          )
+                        })
+                      )}
+                    </div>
+                    <div className="space-y-2 rounded-lg border border-dashed p-4">
+                      <div>
+                        <h3 className="font-medium">Upload new document</h3>
+                        <p className="text-sm text-muted-foreground">
+                          Creating a new document automatically increments the version number for
+                          this lease.
+                        </p>
+                      </div>
+                      <LeaseDocumentForm leaseId={lease.id} />
+                    </div>
+                  </CardContent>
+                </Card>
+              )
+            })
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -14,9 +14,17 @@ export const siteConfig = {
       title: "Account",
       href: "/account",
     },
-    { 
+    {
       title: "Dashboard",
       href: "/dashboard",
+    },
+    {
+      title: "Leases",
+      href: "/leases",
+    },
+    {
+      title: "Lease Admin",
+      href: "/dashboard/leases",
     },
     { 
       title: "OpenAI",

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -968,6 +968,94 @@ export type Database = {
         }
         Relationships: []
       }
+      lease_documents: {
+        Row: {
+          created_at: string
+          effective_date: string
+          expiration_date: string | null
+          id: string
+          lease_id: string
+          storage_path: string
+          title: string
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          created_at?: string
+          effective_date: string
+          expiration_date?: string | null
+          id?: string
+          lease_id: string
+          storage_path: string
+          title: string
+          updated_at?: string
+          version?: number
+        }
+        Update: {
+          created_at?: string
+          effective_date?: string
+          expiration_date?: string | null
+          id?: string
+          lease_id?: string
+          storage_path?: string
+          title?: string
+          updated_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lease_documents_lease_id_fkey"
+            columns: ["lease_id"]
+            isOneToOne: false
+            referencedRelation: "leases"
+            referencedColumns: ["id"]
+          },
+        ]
+      },
+      leases: {
+        Row: {
+          created_at: string
+          end_date: string | null
+          id: string
+          property_name: string
+          start_date: string
+          status: string
+          tenant_profile_id: string
+          unit_label: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          end_date?: string | null
+          id?: string
+          property_name: string
+          start_date: string
+          status?: string
+          tenant_profile_id: string
+          unit_label: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          end_date?: string | null
+          id?: string
+          property_name?: string
+          start_date?: string
+          status?: string
+          tenant_profile_id?: string
+          unit_label?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "leases_tenant_profile_id_fkey"
+            columns: ["tenant_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      },
       meetings: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250410_add_lease_documents.sql
+++ b/supabase/migrations/20250410_add_lease_documents.sql
@@ -1,0 +1,255 @@
+create extension if not exists "pgcrypto";
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create table if not exists public.leases (
+  id uuid primary key default gen_random_uuid(),
+  tenant_profile_id uuid not null references public.profiles(id) on delete cascade,
+  property_name text not null,
+  unit_label text not null,
+  start_date date not null,
+  end_date date,
+  status text not null default 'active',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.leases enable row level security;
+
+create index if not exists leases_tenant_profile_id_idx on public.leases (tenant_profile_id);
+
+create trigger set_leases_updated_at
+before update on public.leases
+for each row
+execute function public.set_updated_at();
+
+create policy if not exists "Tenants and staff can view leases"
+on public.leases
+for select
+using (
+  tenant_profile_id = auth.uid()
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create policy if not exists "Staff can insert leases"
+on public.leases
+for insert
+with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create policy if not exists "Staff can update leases"
+on public.leases
+for update
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create policy if not exists "Staff can delete leases"
+on public.leases
+for delete
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create table if not exists public.lease_documents (
+  id uuid primary key default gen_random_uuid(),
+  lease_id uuid not null references public.leases(id) on delete cascade,
+  storage_path text not null,
+  title text not null,
+  effective_date date not null,
+  expiration_date date,
+  version integer not null default 1,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.lease_documents enable row level security;
+
+create index if not exists lease_documents_lease_id_idx on public.lease_documents (lease_id);
+create unique index if not exists lease_documents_lease_id_version_key on public.lease_documents (lease_id, version);
+
+create trigger set_lease_documents_updated_at
+before update on public.lease_documents
+for each row
+execute function public.set_updated_at();
+
+create policy if not exists "Lease parties can view documents"
+on public.lease_documents
+for select
+using (
+  exists (
+    select 1
+    from public.leases l
+    where l.id = lease_documents.lease_id
+      and l.tenant_profile_id = auth.uid()
+  )
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create policy if not exists "Staff can insert lease documents"
+on public.lease_documents
+for insert
+with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create policy if not exists "Staff can update lease documents"
+on public.lease_documents
+for update
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create policy if not exists "Staff can delete lease documents"
+on public.lease_documents
+for delete
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+insert into storage.buckets (id, name, public)
+values ('lease-documents', 'lease-documents', false)
+on conflict (id) do nothing;
+
+alter table storage.objects enable row level security;
+
+create policy if not exists "Lease parties can read lease document storage"
+on storage.objects
+for select
+using (
+  bucket_id = 'lease-documents'
+  and (
+    exists (
+      select 1
+      from public.lease_documents ld
+      where ld.storage_path = storage.objects.name
+        and (
+          exists (
+            select 1
+            from public.leases l
+            where l.id = ld.lease_id
+              and l.tenant_profile_id = auth.uid()
+          )
+          or exists (
+            select 1
+            from public.profiles p
+            where p.id = auth.uid()
+              and p.role in ('staff', 'admin')
+          )
+        )
+    )
+  )
+);
+
+create policy if not exists "Staff can insert lease document storage"
+on storage.objects
+for insert
+with check (
+  bucket_id = 'lease-documents'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create policy if not exists "Staff can update lease document storage"
+on storage.objects
+for update
+using (
+  bucket_id = 'lease-documents'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+)
+with check (
+  bucket_id = 'lease-documents'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);
+
+create policy if not exists "Staff can delete lease document storage"
+on storage.objects
+for delete
+using (
+  bucket_id = 'lease-documents'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('staff', 'admin')
+  )
+);

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,8 +1,10 @@
 import { type CookieOptions, createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import type { Database } from '@/lib/supabase'
+
 export function createClient(cookieStore: ReturnType<typeof cookies>) {
-  return createServerClient(
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,10 +1,12 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import type { Database } from '@/lib/supabase'
+
 export function createClient() {
   const cookieStore = cookies()
 
-  return createServerClient(
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {


### PR DESCRIPTION
## Summary
- add Supabase migration for lease and lease_document tables with RLS and storage policies
- extend Supabase typings and server helpers for lease document operations
- add tenant and staff lease pages with document upload workflows and navigation links

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7adc957c8328ba42b7a5f3c49ff7