### PR TITLE
Add shared space diagram management for tenants and staff

### DIFF
--- a/app/(tenant)/shared-spaces/actions.ts
+++ b/app/(tenant)/shared-spaces/actions.ts
@@ -1,0 +1,84 @@
+'use server'
+
+import { cookies } from 'next/headers'
+
+import {
+  SHARED_SPACE_BUCKET,
+  SIGNED_URL_TTL_SECONDS,
+  normaliseSharedSpaceMetadata,
+  type SharedSpaceMetadata,
+} from '@/lib/shared-space-maps'
+import { createClient } from '@/utils/supa-server-actions'
+
+export type TenantSharedSpaceDiagram = {
+  id: string
+  title: string | null
+  description: string | null
+  leaseId: string
+  unitId: string | null
+  signedUrl: string
+  bucketId: string
+  metadata: SharedSpaceMetadata
+  updatedAt: string
+  lastUploadedAt: string
+}
+
+export type TenantSharedSpaceResponse =
+  | { data: TenantSharedSpaceDiagram[]; error: null }
+  | { data: null; error: string }
+
+export async function fetchTenantSharedSpaceMaps(): Promise<TenantSharedSpaceResponse> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return { data: null, error: 'Not authenticated' }
+  }
+
+  const { data, error } = await supabase
+    .from('shared_space_maps')
+    .select('*')
+    .eq('tenant_profile_id', user.id)
+    .order('updated_at', { ascending: false })
+
+  if (error) {
+    return { data: null, error: error.message }
+  }
+
+  if (!data?.length) {
+    return { data: [], error: null }
+  }
+
+  const diagrams: TenantSharedSpaceDiagram[] = []
+
+  for (const map of data) {
+    const bucketId = map.bucket_id || SHARED_SPACE_BUCKET
+    const { data: signedData, error: signedError } = await supabase.storage
+      .from(bucketId)
+      .createSignedUrl(map.diagram_path, SIGNED_URL_TTL_SECONDS)
+
+    if (signedError || !signedData?.signedUrl) {
+      return { data: null, error: signedError?.message ?? 'Unable to access diagram asset' }
+    }
+
+    diagrams.push({
+      id: map.id,
+      title: map.title,
+      description: map.description,
+      leaseId: map.lease_id,
+      unitId: map.unit_id,
+      signedUrl: signedData.signedUrl,
+      bucketId,
+      metadata: normaliseSharedSpaceMetadata(map),
+      updatedAt: map.updated_at,
+      lastUploadedAt: map.last_uploaded_at,
+    })
+  }
+
+  return { data: diagrams, error: null }
+}

--- a/app/(tenant)/shared-spaces/components/diagram-viewer.tsx
+++ b/app/(tenant)/shared-spaces/components/diagram-viewer.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useCallback, useMemo, useRef, useState } from 'react'
+import Image from 'next/image'
+import { formatDistanceToNow, parseISO } from 'date-fns'
+import { ZoomIn, ZoomOut, RotateCcw } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { Slider } from '@/components/ui/slider'
+import { cn } from '@/lib/utils'
+
+import type { DiagramLabel } from '@/lib/shared-space-maps'
+
+import type { TenantSharedSpaceDiagram } from '../actions'
+
+const MIN_SCALE = 0.75
+const MAX_SCALE = 3
+const SCALE_STEP = 0.15
+
+type PointerPosition = { x: number; y: number }
+
+type DiagramViewerProps = {
+  diagram: TenantSharedSpaceDiagram
+}
+
+export function SharedSpaceDiagramCard({ diagram }: DiagramViewerProps) {
+  const [scale, setScale] = useState(1)
+  const [offset, setOffset] = useState({ x: 0, y: 0 })
+  const [isPanning, setIsPanning] = useState(false)
+  const [aspectRatio, setAspectRatio] = useState(4 / 3)
+  const pointerRef = useRef<PointerPosition | null>(null)
+
+  const clampScale = useCallback((value: number) => {
+    if (Number.isNaN(value)) {
+      return 1
+    }
+
+    return Math.min(MAX_SCALE, Math.max(MIN_SCALE, value))
+  }, [])
+
+  const handleWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    const direction = event.deltaY > 0 ? -SCALE_STEP : SCALE_STEP
+    setScale((previous) => clampScale(previous + direction))
+  }, [clampScale])
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.setPointerCapture(event.pointerId)
+    pointerRef.current = { x: event.clientX, y: event.clientY }
+    setIsPanning(true)
+  }, [])
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isPanning || !pointerRef.current) {
+      return
+    }
+
+    const dx = event.clientX - pointerRef.current.x
+    const dy = event.clientY - pointerRef.current.y
+
+    setOffset((previous) => ({ x: previous.x + dx, y: previous.y + dy }))
+    pointerRef.current = { x: event.clientX, y: event.clientY }
+  }, [isPanning])
+
+  const endPan = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    pointerRef.current = null
+    setIsPanning(false)
+  }, [])
+
+  const resetView = useCallback(() => {
+    setScale(1)
+    setOffset({ x: 0, y: 0 })
+  }, [])
+
+  const handleSliderChange = useCallback((value: number[]) => {
+    const nextValue = value?.[0]
+    if (typeof nextValue !== 'number') {
+      return
+    }
+    setScale(clampScale(nextValue / 100))
+  }, [clampScale])
+
+  const formattedUpdatedAt = useMemo(() => {
+    try {
+      return formatDistanceToNow(parseISO(diagram.updatedAt), { addSuffix: true })
+    } catch (error) {
+      return null
+    }
+  }, [diagram.updatedAt])
+
+  const formattedUploadedAt = useMemo(() => {
+    try {
+      return formatDistanceToNow(parseISO(diagram.lastUploadedAt), { addSuffix: true })
+    } catch (error) {
+      return null
+    }
+  }, [diagram.lastUploadedAt])
+
+  const handleLabelPointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+    setIsPanning(false)
+  }, [])
+
+  return (
+    <article className="space-y-4 rounded-xl border bg-card p-6 shadow-sm">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">
+            {diagram.title ?? `Lease ${diagram.leaseId}`}
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            Lease <span className="font-medium">{diagram.leaseId}</span>
+            {diagram.unitId ? (
+              <>
+                {' · '}Unit <span className="font-medium">{diagram.unitId}</span>
+              </>
+            ) : null}
+          </p>
+        </div>
+        <div className="flex flex-col text-right text-xs text-muted-foreground sm:text-sm">
+          {formattedUpdatedAt ? <span>Updated {formattedUpdatedAt}</span> : null}
+          {formattedUploadedAt ? <span>File refreshed {formattedUploadedAt}</span> : null}
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            onClick={() => setScale((previous) => clampScale(previous - SCALE_STEP))}
+            aria-label="Zoom out"
+          >
+            <ZoomOut className="size-4" />
+          </Button>
+          <Slider
+            min={MIN_SCALE * 100}
+            max={MAX_SCALE * 100}
+            step={5}
+            value={[scale * 100]}
+            onValueChange={handleSliderChange}
+            className="w-full sm:w-48"
+            aria-label="Zoom level"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            onClick={() => setScale((previous) => clampScale(previous + SCALE_STEP))}
+            aria-label="Zoom in"
+          >
+            <ZoomIn className="size-4" />
+          </Button>
+          <Button type="button" variant="ghost" size="icon" onClick={resetView} aria-label="Reset view">
+            <RotateCcw className="size-4" />
+          </Button>
+        </div>
+        {diagram.metadata.notes ? (
+          <p className="text-sm text-muted-foreground sm:max-w-md sm:text-right">
+            {diagram.metadata.notes}
+          </p>
+        ) : null}
+      </div>
+
+      <div
+        className="relative w-full overflow-hidden rounded-lg border bg-muted"
+        style={{ aspectRatio, minHeight: '320px' }}
+        onWheel={handleWheel}
+      >
+        <div
+          className={cn(
+            'relative size-full select-none',
+            isPanning ? 'cursor-grabbing' : 'cursor-grab'
+          )}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={endPan}
+          onPointerLeave={endPan}
+          style={{ touchAction: 'none' }}
+        >
+          <div
+            className="relative size-full"
+            style={{
+              transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+              transformOrigin: 'center',
+            }}
+          >
+            <Image
+              src={diagram.signedUrl}
+              alt={diagram.title ?? 'Shared space diagram'}
+              fill
+              priority={false}
+              sizes="(min-width: 1024px) 640px, 100vw"
+              className="pointer-events-none select-none object-contain"
+              onLoadingComplete={(image) => {
+                if (image.naturalWidth && image.naturalHeight) {
+                  setAspectRatio(image.naturalWidth / image.naturalHeight)
+                }
+              }}
+            />
+
+            {diagram.metadata.roomLabels?.map((label) => (
+              <DiagramLabelMarker key={label.id} label={label} onPointerDown={handleLabelPointerDown} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {diagram.description ? (
+        <p className="text-sm text-muted-foreground">{diagram.description}</p>
+      ) : null}
+    </article>
+  )
+}
+
+type DiagramLabelMarkerProps = {
+  label: DiagramLabel
+  onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => void
+}
+
+function DiagramLabelMarker({ label, onPointerDown }: DiagramLabelMarkerProps) {
+  return (
+    <HoverCard openDelay={100} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          onPointerDown={onPointerDown}
+          className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-background bg-primary/90 p-1 text-primary-foreground shadow focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          style={{ left: `${label.x * 100}%`, top: `${label.y * 100}%` }}
+        >
+          <span className="sr-only">{label.label}</span>
+          <span className="block size-2 rounded-full bg-background" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent side="top" align="center">
+        <div className="space-y-1">
+          <p className="font-medium leading-none">{label.label}</p>
+          {label.description ? (
+            <p className="text-sm text-muted-foreground">{label.description}</p>
+          ) : null}
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}

--- a/app/(tenant)/shared-spaces/page.tsx
+++ b/app/(tenant)/shared-spaces/page.tsx
@@ -1,0 +1,66 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { Button } from '@/components/ui/button'
+import { fetchTenantSharedSpaceMaps } from './actions'
+import { SharedSpaceDiagramCard } from './components/diagram-viewer'
+
+export const metadata: Metadata = {
+  title: 'Shared Spaces',
+  description:
+    'View the latest diagrams and reference maps for your shared spaces, including room labels and helpful notes from property staff.',
+}
+
+export default async function SharedSpacesPage() {
+  const result = await fetchTenantSharedSpaceMaps()
+
+  if (result.error === 'Not authenticated') {
+    redirect('/auth')
+  }
+
+  const diagrams = result.data ?? []
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="flex flex-col gap-3">
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Shared space diagrams</h1>
+        <p className="max-w-3xl text-muted-foreground">
+          Explore updated floor plans, amenity layouts, and other shared space diagrams for your lease. Hover over the markers to
+          see room labels and notes provided by property staff.
+        </p>
+      </div>
+
+      {result.error && result.error !== 'Not authenticated' ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+          <p className="font-medium">Unable to load diagrams</p>
+          <p className="mt-1 text-destructive/90">
+            {result.error}. Please try again later or{' '}
+            <Link href="/contact" className="underline">
+              contact support
+            </Link>
+            .
+          </p>
+        </div>
+      ) : null}
+
+      {!diagrams.length && !result.error ? (
+        <div className="rounded-xl border bg-card p-10 text-center">
+          <h2 className="text-lg font-semibold">No shared space diagrams yet</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            When your property manager uploads shared space diagrams for your lease you&apos;ll see them here.
+          </p>
+          <Button asChild variant="outline" className="mt-4">
+            <Link href="/contact">Request an update</Link>
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="grid gap-6">
+        {diagrams.map((diagram) => (
+          <SharedSpaceDiagramCard key={diagram.id} diagram={diagram} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, ImageIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,17 +8,22 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/shared-spaces",
+                        text: "Shared spaces",
+                        Icon: ImageIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
 	];
 
 	return (

--- a/app/dashboard/shared-spaces/actions.ts
+++ b/app/dashboard/shared-spaces/actions.ts
@@ -1,0 +1,368 @@
+'use server'
+
+import { randomUUID } from 'crypto'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+import { z } from 'zod'
+
+import {
+  SHARED_SPACE_BUCKET,
+  SIGNED_URL_TTL_SECONDS,
+  normaliseSharedSpaceMetadata,
+  type SharedSpaceMetadata,
+} from '@/lib/shared-space-maps'
+import { createClient } from '@/utils/supa-server-actions'
+import type { SharedSpaceMapInsert, SharedSpaceMapUpdate } from '@/utils/typed-supabase-client'
+
+const DASHBOARD_PATH = '/dashboard/shared-spaces'
+
+const metadataSchema = z
+  .object({
+    roomLabels: z
+      .array(
+        z
+          .object({
+            id: z.string().optional(),
+            label: z.string(),
+            x: z.number(),
+            y: z.number(),
+            description: z.string().optional().nullable(),
+          })
+          .passthrough()
+      )
+      .optional(),
+    notes: z.string().optional().nullable(),
+  })
+  .passthrough()
+
+type MetadataInput = z.infer<typeof metadataSchema>
+
+type StaffActionResult = {
+  status: 'success' | 'error'
+  message: string
+}
+
+export type StaffSharedSpaceDiagram = {
+  id: string
+  leaseId: string
+  unitId: string | null
+  tenantId: string
+  title: string | null
+  description: string | null
+  diagramPath: string
+  bucketId: string
+  signedUrl: string
+  metadata: SharedSpaceMetadata
+  updatedAt: string
+  lastUploadedAt: string
+}
+
+async function requireStaffClient() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    throw new Error('Not authenticated')
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (profileError) {
+    throw new Error('Unable to verify permissions')
+  }
+
+  if (profile?.role !== 'admin') {
+    throw new Error('You do not have access to manage shared space maps')
+  }
+
+  return { supabase, userId: user.id }
+}
+
+function parseMetadataInput(raw: FormDataEntryValue | null): MetadataInput | undefined {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return undefined
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    return metadataSchema.parse(parsed)
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Metadata must be valid JSON: ${error.message}`)
+    }
+    throw new Error('Metadata must be valid JSON')
+  }
+}
+
+export async function fetchStaffSharedSpaceMaps(): Promise<{
+  data: StaffSharedSpaceDiagram[]
+  error: string | null
+}> {
+  try {
+    const { supabase } = await requireStaffClient()
+
+    const { data, error } = await supabase
+      .from('shared_space_maps')
+      .select('*')
+      .order('updated_at', { ascending: false })
+
+    if (error) {
+      return { data: [], error: error.message }
+    }
+
+    if (!data?.length) {
+      return { data: [], error: null }
+    }
+
+    const diagrams: StaffSharedSpaceDiagram[] = []
+
+    for (const map of data) {
+      const bucketId = map.bucket_id || SHARED_SPACE_BUCKET
+      const { data: signed, error: signedError } = await supabase.storage
+        .from(bucketId)
+        .createSignedUrl(map.diagram_path, SIGNED_URL_TTL_SECONDS)
+
+      if (signedError || !signed?.signedUrl) {
+        return { data: [], error: signedError?.message ?? 'Failed to generate preview URL' }
+      }
+
+      diagrams.push({
+        id: map.id,
+        leaseId: map.lease_id,
+        unitId: map.unit_id,
+        tenantId: map.tenant_profile_id,
+        title: map.title,
+        description: map.description,
+        diagramPath: map.diagram_path,
+        bucketId,
+        signedUrl: signed.signedUrl,
+        metadata: normaliseSharedSpaceMetadata(map),
+        updatedAt: map.updated_at,
+        lastUploadedAt: map.last_uploaded_at,
+      })
+    }
+
+    return { data: diagrams, error: null }
+  } catch (error) {
+    return {
+      data: [],
+      error: error instanceof Error ? error.message : 'Unexpected error loading shared space maps',
+    }
+  }
+}
+
+export async function createSharedSpaceMap(
+  _prevState: StaffActionResult | null,
+  formData: FormData
+): Promise<StaffActionResult> {
+  try {
+    const { supabase, userId } = await requireStaffClient()
+
+    const leaseId = formData.get('leaseId')
+    const unitId = formData.get('unitId')
+    const tenantId = formData.get('tenantId')
+    const title = formData.get('title')
+    const description = formData.get('description')
+    const file = formData.get('diagram')
+    const metadataInput = parseMetadataInput(formData.get('metadata'))
+
+    if (typeof leaseId !== 'string' || !leaseId.trim()) {
+      return { status: 'error', message: 'Lease ID is required.' }
+    }
+
+    if (typeof tenantId !== 'string' || !tenantId.trim()) {
+      return { status: 'error', message: 'Tenant profile ID is required.' }
+    }
+
+    if (!(file instanceof File) || file.size === 0) {
+      return { status: 'error', message: 'Please upload a diagram file.' }
+    }
+
+    const metadata = metadataInput ?? {}
+
+    const extension = file.name.split('.').pop() ?? 'png'
+    const path = `${tenantId}/${leaseId}/${randomUUID()}.${extension}`
+
+    const { error: uploadError } = await supabase.storage
+      .from(SHARED_SPACE_BUCKET)
+      .upload(path, file, { upsert: false, cacheControl: '3600' })
+
+    if (uploadError) {
+      return { status: 'error', message: uploadError.message }
+    }
+
+    const payload: SharedSpaceMapInsert = {
+      lease_id: leaseId,
+      unit_id: typeof unitId === 'string' && unitId.trim() ? unitId : null,
+      tenant_profile_id: tenantId,
+      diagram_path: path,
+      bucket_id: SHARED_SPACE_BUCKET,
+      title: typeof title === 'string' && title.trim() ? title : null,
+      description:
+        typeof description === 'string' && description.trim() ? description : null,
+      metadata,
+      updated_by: userId,
+    }
+
+    const { error: insertError } = await supabase.from('shared_space_maps').insert(payload)
+
+    if (insertError) {
+      return { status: 'error', message: insertError.message }
+    }
+
+    revalidatePath(DASHBOARD_PATH)
+    return { status: 'success', message: 'Shared space map created successfully.' }
+  } catch (error) {
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Unexpected error creating shared space map.',
+    }
+  }
+}
+
+export async function updateSharedSpaceMap(
+  _prevState: StaffActionResult | null,
+  formData: FormData
+): Promise<StaffActionResult> {
+  try {
+    const { supabase, userId } = await requireStaffClient()
+
+    const id = formData.get('id')
+    const leaseId = formData.get('leaseId')
+    const unitId = formData.get('unitId')
+    const tenantId = formData.get('tenantId')
+    const title = formData.get('title')
+    const description = formData.get('description')
+    const metadataInput = parseMetadataInput(formData.get('metadata'))
+    const file = formData.get('diagram')
+
+    if (typeof id !== 'string' || !id) {
+      return { status: 'error', message: 'Invalid shared space map identifier.' }
+    }
+
+    const { data: existing, error: fetchError } = await supabase
+      .from('shared_space_maps')
+      .select('*')
+      .eq('id', id)
+      .single()
+
+    if (fetchError || !existing) {
+      return { status: 'error', message: fetchError?.message ?? 'Shared space map not found.' }
+    }
+
+    const updates: SharedSpaceMapUpdate = {
+      title: typeof title === 'string' ? (title.trim() ? title : null) : undefined,
+      description:
+        typeof description === 'string' ? (description.trim() ? description : null) : undefined,
+      metadata: metadataInput ?? undefined,
+      lease_id: typeof leaseId === 'string' && leaseId.trim() ? leaseId : undefined,
+      unit_id:
+        typeof unitId === 'string' ? (unitId.trim() ? unitId : null) : undefined,
+      tenant_profile_id:
+        typeof tenantId === 'string' && tenantId.trim() ? tenantId : undefined,
+      updated_by: userId,
+    }
+
+    let newPath: string | undefined
+    if (file instanceof File && file.size > 0) {
+      const extension = file.name.split('.').pop() ?? 'png'
+      newPath = `${existing.tenant_profile_id}/${existing.lease_id}/${randomUUID()}.${extension}`
+
+      const { error: uploadError } = await supabase.storage
+        .from(existing.bucket_id || SHARED_SPACE_BUCKET)
+        .upload(newPath, file, { upsert: false, cacheControl: '3600' })
+
+      if (uploadError) {
+        return { status: 'error', message: uploadError.message }
+      }
+
+      updates.diagram_path = newPath
+      updates.last_uploaded_at = new Date().toISOString()
+    }
+
+    const { error: updateError } = await supabase
+      .from('shared_space_maps')
+      .update(updates)
+      .eq('id', id)
+
+    if (updateError) {
+      if (newPath) {
+        await supabase.storage
+          .from(existing.bucket_id || SHARED_SPACE_BUCKET)
+          .remove([newPath])
+      }
+      return { status: 'error', message: updateError.message }
+    }
+
+    if (newPath && existing.diagram_path) {
+      await supabase.storage
+        .from(existing.bucket_id || SHARED_SPACE_BUCKET)
+        .remove([existing.diagram_path])
+    }
+
+    revalidatePath(DASHBOARD_PATH)
+    return { status: 'success', message: 'Shared space map updated successfully.' }
+  } catch (error) {
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Unexpected error updating shared space map.',
+    }
+  }
+}
+
+export async function deleteSharedSpaceMap(
+  _prevState: StaffActionResult | null,
+  formData: FormData
+): Promise<StaffActionResult> {
+  try {
+    const { supabase } = await requireStaffClient()
+    const id = formData.get('id')
+
+    if (typeof id !== 'string' || !id) {
+      return { status: 'error', message: 'Invalid shared space map identifier.' }
+    }
+
+    const { data: existing, error: fetchError } = await supabase
+      .from('shared_space_maps')
+      .select('bucket_id, diagram_path')
+      .eq('id', id)
+      .single()
+
+    if (fetchError) {
+      return { status: 'error', message: fetchError.message }
+    }
+
+    const { error: deleteError } = await supabase
+      .from('shared_space_maps')
+      .delete()
+      .eq('id', id)
+
+    if (deleteError) {
+      return { status: 'error', message: deleteError.message }
+    }
+
+    if (existing?.diagram_path) {
+      await supabase.storage
+        .from(existing.bucket_id || SHARED_SPACE_BUCKET)
+        .remove([existing.diagram_path])
+    }
+
+    revalidatePath(DASHBOARD_PATH)
+    return { status: 'success', message: 'Shared space map removed.' }
+  } catch (error) {
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Unexpected error removing shared space map.',
+    }
+  }
+}

--- a/app/dashboard/shared-spaces/components/create-shared-space-form.tsx
+++ b/app/dashboard/shared-spaces/components/create-shared-space-form.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useFormState, useFormStatus } from 'react-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+
+import { createSharedSpaceMap, type StaffActionResult } from '../actions'
+
+const initialState: StaffActionResult | null = null
+
+export function CreateSharedSpaceForm() {
+  const formRef = useRef<HTMLFormElement>(null)
+  const [state, formAction] = useFormState(createSharedSpaceMap, initialState)
+
+  useEffect(() => {
+    if (state?.status === 'success') {
+      formRef.current?.reset()
+    }
+  }, [state])
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-6 rounded-xl border bg-card p-6 shadow-sm">
+      <div>
+        <h2 className="text-lg font-semibold">Upload a shared space diagram</h2>
+        <p className="text-sm text-muted-foreground">
+          Provide lease, unit, and tenant identifiers along with the diagram asset and optional metadata describing room labels.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field id="leaseId" label="Lease ID" required>
+          <Input id="leaseId" name="leaseId" placeholder="e.g. lease-123" required />
+        </Field>
+        <Field id="unitId" label="Unit ID">
+          <Input id="unitId" name="unitId" placeholder="Optional unit identifier" />
+        </Field>
+        <Field id="tenantId" label="Tenant profile ID" required>
+          <Input id="tenantId" name="tenantId" placeholder="UUID of tenant profile" required />
+        </Field>
+        <Field id="title" label="Title">
+          <Input id="title" name="title" placeholder="Lobby overview" />
+        </Field>
+      </div>
+
+      <Field id="description" label="Description">
+        <Textarea
+          id="description"
+          name="description"
+          placeholder="Short description visible to tenants"
+          rows={3}
+        />
+      </Field>
+
+      <Field id="metadata" label="Metadata JSON">
+        <Textarea
+          id="metadata"
+          name="metadata"
+          placeholder='{"roomLabels":[{"label":"Kitchen","x":0.35,"y":0.42}]}'
+          rows={4}
+        />
+      </Field>
+
+      <Field id="diagram" label="Diagram file" required>
+        <Input id="diagram" name="diagram" type="file" accept="image/*,.pdf" required />
+      </Field>
+
+      {state ? <FormMessage state={state} /> : null}
+
+      <div className="flex items-center justify-end gap-3">
+        <SubmitButton />
+      </div>
+    </form>
+  )
+}
+
+function Field({
+  id,
+  label,
+  children,
+  required,
+}: {
+  id: string
+  label: string
+  children: React.ReactNode
+  required?: boolean
+}) {
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className={cn(required ? 'after:ml-1 after:text-destructive after:content-["*"]' : undefined)}>
+        {label}
+      </Label>
+      {children}
+    </div>
+  )
+}
+
+function FormMessage({ state }: { state: StaffActionResult }) {
+  const variant = state.status === 'error' ? 'destructive' : 'success'
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border p-3 text-sm',
+        variant === 'destructive'
+          ? 'border-destructive/40 bg-destructive/10 text-destructive'
+          : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700'
+      )}
+    >
+      {state.message}
+    </div>
+  )
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? 'Saving…' : 'Save diagram'}
+    </Button>
+  )
+}

--- a/app/dashboard/shared-spaces/components/shared-space-manager.tsx
+++ b/app/dashboard/shared-spaces/components/shared-space-manager.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { useMemo } from 'react'
+import Image from 'next/image'
+import { formatDistanceToNow, parseISO } from 'date-fns'
+import { useFormState, useFormStatus } from 'react-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+
+import {
+  deleteSharedSpaceMap,
+  updateSharedSpaceMap,
+  type StaffActionResult,
+  type StaffSharedSpaceDiagram,
+} from '../actions'
+
+const initialState: StaffActionResult | null = null
+
+export function SharedSpaceManagerList({ diagrams }: { diagrams: StaffSharedSpaceDiagram[] }) {
+  if (!diagrams.length) {
+    return null
+  }
+
+  return (
+    <div className="grid gap-6">
+      {diagrams.map((diagram) => (
+        <EditSharedSpaceCard key={diagram.id} diagram={diagram} />
+      ))}
+    </div>
+  )
+}
+
+function EditSharedSpaceCard({ diagram }: { diagram: StaffSharedSpaceDiagram }) {
+  const metadataString = useMemo(
+    () => JSON.stringify(diagram.metadata, null, 2),
+    [diagram.metadata]
+  )
+  const [state, formAction] = useFormState(updateSharedSpaceMap, initialState)
+
+  const updatedText = useMemo(() => {
+    try {
+      return formatDistanceToNow(parseISO(diagram.updatedAt), { addSuffix: true })
+    } catch (error) {
+      return null
+    }
+  }, [diagram.updatedAt])
+
+  const uploadedText = useMemo(() => {
+    try {
+      return formatDistanceToNow(parseISO(diagram.lastUploadedAt), { addSuffix: true })
+    } catch (error) {
+      return null
+    }
+  }, [diagram.lastUploadedAt])
+
+  return (
+    <div className="space-y-4 rounded-xl border bg-card p-6 shadow-sm">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">{diagram.title ?? 'Untitled diagram'}</h3>
+          <p className="text-sm text-muted-foreground">
+            Lease {diagram.leaseId}
+            {diagram.unitId ? <> · Unit {diagram.unitId}</> : null}
+          </p>
+        </div>
+        <div className="text-xs text-muted-foreground sm:text-sm">
+          {updatedText ? <p>Updated {updatedText}</p> : null}
+          {uploadedText ? <p>File refreshed {uploadedText}</p> : null}
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,320px)_1fr]">
+        <div className="relative aspect-video overflow-hidden rounded-lg border bg-muted">
+          <Image
+            src={diagram.signedUrl}
+            alt={diagram.title ?? 'Shared space preview'}
+            fill
+            sizes="320px"
+            className="object-cover"
+          />
+        </div>
+        <form action={formAction} className="space-y-4">
+          <input type="hidden" name="id" value={diagram.id} />
+          <div className="grid gap-4 md:grid-cols-2">
+            <Field id={`lease-${diagram.id}`} label="Lease ID">
+              <Input
+                id={`lease-${diagram.id}`}
+                name="leaseId"
+                defaultValue={diagram.leaseId}
+                placeholder="Lease identifier"
+              />
+            </Field>
+            <Field id={`unit-${diagram.id}`} label="Unit ID">
+              <Input
+                id={`unit-${diagram.id}`}
+                name="unitId"
+                defaultValue={diagram.unitId ?? ''}
+                placeholder="Unit identifier"
+              />
+            </Field>
+            <Field id={`tenant-${diagram.id}`} label="Tenant profile ID">
+              <Input
+                id={`tenant-${diagram.id}`}
+                name="tenantId"
+                defaultValue={diagram.tenantId}
+                placeholder="Tenant profile UUID"
+              />
+            </Field>
+            <Field id={`title-${diagram.id}`} label="Title">
+              <Input
+                id={`title-${diagram.id}`}
+                name="title"
+                defaultValue={diagram.title ?? ''}
+                placeholder="Diagram title"
+              />
+            </Field>
+          </div>
+
+          <Field id={`description-${diagram.id}`} label="Description">
+            <Textarea
+              id={`description-${diagram.id}`}
+              name="description"
+              defaultValue={diagram.description ?? ''}
+              rows={3}
+            />
+          </Field>
+
+          <Field id={`metadata-${diagram.id}`} label="Metadata JSON">
+            <Textarea
+              id={`metadata-${diagram.id}`}
+              name="metadata"
+              defaultValue={metadataString}
+              rows={6}
+            />
+          </Field>
+
+          <Field id={`diagram-${diagram.id}`} label="Replace diagram">
+            <Input id={`diagram-${diagram.id}`} name="diagram" type="file" accept="image/*,.pdf" />
+          </Field>
+
+          {state ? <FormMessage state={state} /> : null}
+
+          <div className="flex flex-wrap items-center gap-3">
+            <SubmitButton label="Save changes" />
+            <DeleteSharedSpaceForm id={diagram.id} />
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function Field({
+  id,
+  label,
+  children,
+}: {
+  id: string
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id}>{label}</Label>
+      {children}
+    </div>
+  )
+}
+
+function FormMessage({ state }: { state: StaffActionResult }) {
+  const variant = state.status === 'error' ? 'destructive' : 'success'
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border p-3 text-sm',
+        variant === 'destructive'
+          ? 'border-destructive/40 bg-destructive/10 text-destructive'
+          : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700'
+      )}
+    >
+      {state.message}
+    </div>
+  )
+}
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? 'Saving…' : label}
+    </Button>
+  )
+}
+
+function DeleteSharedSpaceForm({ id }: { id: string }) {
+  const [state, formAction] = useFormState(deleteSharedSpaceMap, initialState)
+
+  return (
+    <form action={formAction} className="flex items-center gap-2">
+      <input type="hidden" name="id" value={id} />
+      <DeleteButton />
+      {state ? <DeleteMessage state={state} /> : null}
+    </form>
+  )
+}
+
+function DeleteButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" variant="outline" className="border-destructive text-destructive" disabled={pending}>
+      {pending ? 'Removing…' : 'Remove'}
+    </Button>
+  )
+}
+
+function DeleteMessage({ state }: { state: StaffActionResult }) {
+  if (state.status === 'success') {
+    return <span className="text-sm text-emerald-600">{state.message}</span>
+  }
+
+  return <span className="text-sm text-destructive">{state.message}</span>
+}

--- a/app/dashboard/shared-spaces/page.tsx
+++ b/app/dashboard/shared-spaces/page.tsx
@@ -1,0 +1,63 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+
+import { Button } from '@/components/ui/button'
+import { CreateSharedSpaceForm } from './components/create-shared-space-form'
+import { SharedSpaceManagerList } from './components/shared-space-manager'
+import { fetchStaffSharedSpaceMaps } from './actions'
+
+export const metadata: Metadata = {
+  title: 'Shared Space Maps',
+  description:
+    'Manage shared space diagrams for tenants by uploading new files, adjusting metadata, and updating lease associations.',
+}
+
+export default async function DashboardSharedSpacesPage() {
+  const { data: diagrams, error } = await fetchStaffSharedSpaceMaps()
+
+  return (
+    <div className="flex flex-col gap-10">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Shared space maps</h1>
+        <p className="max-w-3xl text-muted-foreground">
+          Upload and maintain reference diagrams for each lease. Use metadata to annotate room labels and provide contextual notes
+          that surface in the tenant experience.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+          <p className="font-medium">{error}</p>
+          <p className="mt-1 text-destructive/90">
+            If you believe this is a mistake, please contact an administrator or{' '}
+            <Link href="/contact" className="underline">
+              reach out to support
+            </Link>
+            .
+          </p>
+        </div>
+      ) : null}
+
+      <CreateSharedSpaceForm />
+
+      {diagrams.length ? (
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-semibold">Existing diagrams</h2>
+            <Button asChild variant="outline">
+              <Link href="/shared-spaces">View tenant experience</Link>
+            </Button>
+          </div>
+          <SharedSpaceManagerList diagrams={diagrams} />
+        </section>
+      ) : !error ? (
+        <div className="rounded-xl border bg-card p-10 text-center">
+          <h2 className="text-lg font-semibold">No diagrams uploaded yet</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Use the form above to upload the first shared space map for your residents.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -10,11 +10,15 @@ export const siteConfig = {
       href: "/",
     },
 
-    { 
+    {
       title: "Account",
       href: "/account",
     },
-    { 
+    {
+      title: "Shared Spaces",
+      href: "/shared-spaces",
+    },
+    {
       title: "Dashboard",
       href: "/dashboard",
     },

--- a/lib/shared-space-maps.ts
+++ b/lib/shared-space-maps.ts
@@ -1,0 +1,116 @@
+import type { SharedSpaceMapRow } from '@/utils/typed-supabase-client'
+
+export const SHARED_SPACE_BUCKET = 'shared-space-diagrams'
+export const SIGNED_URL_TTL_SECONDS = 60 * 60 // 1 hour
+
+export type DiagramLabel = {
+  id: string
+  label: string
+  x: number
+  y: number
+  description?: string | null
+}
+
+export type SharedSpaceMetadata = {
+  roomLabels: DiagramLabel[]
+  notes?: string | null
+  lastUpdatedAt?: string | null
+  [key: string]: unknown
+}
+
+type RawMetadata = SharedSpaceMapRow['metadata'] extends infer M
+  ? M extends Record<string, any>
+    ? M
+    : Record<string, unknown>
+  : Record<string, unknown>
+
+function normaliseCoordinate(value: number | null): number | null {
+  if (value === null || Number.isNaN(value) || !Number.isFinite(value)) {
+    return null
+  }
+
+  if (value > 1) {
+    return Math.min(Math.max(value / 100, 0), 1)
+  }
+
+  if (value < 0) {
+    return 0
+  }
+
+  return value
+}
+
+function parseRoomLabels(metadata: RawMetadata): DiagramLabel[] {
+  const rawLabels = Array.isArray((metadata as any)?.roomLabels)
+    ? ((metadata as any).roomLabels as Array<Record<string, any>>)
+    : []
+
+  return rawLabels
+    .map((label, index) => {
+      const labelText =
+        typeof label?.label === 'string'
+          ? label.label
+          : typeof label?.name === 'string'
+            ? label.name
+            : typeof label?.title === 'string'
+              ? label.title
+              : null
+
+      const rawX =
+        typeof label?.x === 'number'
+          ? label.x
+          : typeof label?.x === 'string'
+            ? Number.parseFloat(label.x)
+            : Number(label?.position?.x)
+
+      const rawY =
+        typeof label?.y === 'number'
+          ? label.y
+          : typeof label?.y === 'string'
+            ? Number.parseFloat(label.y)
+            : Number(label?.position?.y)
+
+      const x = normaliseCoordinate(Number.isNaN(rawX) ? null : rawX)
+      const y = normaliseCoordinate(Number.isNaN(rawY) ? null : rawY)
+
+      if (!labelText || x === null || y === null) {
+        return null
+      }
+
+      return {
+        id: typeof label?.id === 'string' ? label.id : `label-${index}`,
+        label: labelText,
+        x,
+        y,
+        description:
+          typeof label?.description === 'string'
+            ? label.description
+            : typeof label?.tooltip === 'string'
+              ? label.tooltip
+              : undefined,
+      }
+    })
+    .filter((value): value is DiagramLabel => Boolean(value))
+}
+
+export function normaliseSharedSpaceMetadata(row: SharedSpaceMapRow): SharedSpaceMetadata {
+  const rawMetadata = (row.metadata ?? {}) as RawMetadata
+  const roomLabels = parseRoomLabels(rawMetadata)
+
+  const lastUpdatedAt =
+    typeof (rawMetadata as any)?.lastUpdatedAt === 'string'
+      ? ((rawMetadata as any).lastUpdatedAt as string)
+      : row.updated_at
+
+  const metadata: SharedSpaceMetadata = {
+    ...rawMetadata,
+    roomLabels,
+    lastUpdatedAt,
+  }
+
+  if (typeof (rawMetadata as any)?.notes === 'string' || (rawMetadata as any)?.notes === null) {
+    metadata.notes = (rawMetadata as any).notes as string | null
+  }
+
+  return metadata
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1226,6 +1226,69 @@ export type Database = {
         }
         Relationships: []
       }
+      shared_space_maps: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          description: string | null
+          diagram_path: string
+          id: string
+          last_uploaded_at: string
+          lease_id: string
+          metadata: Json
+          tenant_profile_id: string
+          title: string | null
+          unit_id: string | null
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          bucket_id?: string
+          created_at?: string
+          description?: string | null
+          diagram_path: string
+          id?: string
+          last_uploaded_at?: string
+          lease_id: string
+          metadata?: Json
+          tenant_profile_id: string
+          title?: string | null
+          unit_id?: string | null
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          description?: string | null
+          diagram_path?: string
+          id?: string
+          last_uploaded_at?: string
+          lease_id?: string
+          metadata?: Json
+          tenant_profile_id?: string
+          title?: string | null
+          unit_id?: string | null
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "shared_space_maps_tenant_profile_id_fkey"
+            columns: ["tenant_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shared_space_maps_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           avatar_url: string | null

--- a/supabase/migrations/20250410_shared_space_maps.sql
+++ b/supabase/migrations/20250410_shared_space_maps.sql
@@ -1,0 +1,78 @@
+-- Create storage bucket for shared space diagrams if it does not already exist
+insert into storage.buckets (id, name, public)
+values ('shared-space-diagrams', 'shared-space-diagrams', false)
+on conflict (id) do nothing;
+
+-- Helper function to maintain updated_at timestamps
+create or replace function public.set_current_timestamp_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+-- Table linking leases/units to diagram assets and metadata
+create table public.shared_space_maps (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  lease_id uuid not null,
+  unit_id uuid,
+  tenant_profile_id uuid not null references public.profiles(id) on delete cascade,
+  bucket_id text not null default 'shared-space-diagrams',
+  diagram_path text not null,
+  title text,
+  description text,
+  metadata jsonb not null default '{"roomLabels": [], "notes": null}'::jsonb,
+  last_uploaded_at timestamptz not null default timezone('utc', now()),
+  updated_by uuid references public.profiles(id),
+  constraint shared_space_maps_metadata_is_object check (jsonb_typeof(metadata) = 'object')
+);
+
+create index shared_space_maps_tenant_idx on public.shared_space_maps (tenant_profile_id);
+create index shared_space_maps_lease_idx on public.shared_space_maps (lease_id);
+create index shared_space_maps_unit_idx on public.shared_space_maps (unit_id);
+
+create trigger set_public_shared_space_maps_updated_at
+before update on public.shared_space_maps
+for each row
+execute function public.set_current_timestamp_updated_at();
+
+alter table public.shared_space_maps enable row level security;
+
+create policy "Tenants can view their shared space maps"
+on public.shared_space_maps
+for select
+using (
+  tenant_profile_id = auth.uid()
+  or auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+create policy "Property staff can manage shared space maps"
+on public.shared_space_maps
+for all
+to authenticated
+using (
+  auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+)
+with check (
+  auth.role() = 'service_role'
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+);

--- a/utils/typed-supabase-client.tsx
+++ b/utils/typed-supabase-client.tsx
@@ -1,4 +1,13 @@
 import { SupabaseClient } from '@supabase/supabase-js'
-import type { Database } from '@/lib/supabase'
+import type {
+  Database,
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from '@/lib/supabase'
 
 export type TypedSupabaseClient = SupabaseClient<Database>
+
+export type SharedSpaceMapRow = Tables<'shared_space_maps'>
+export type SharedSpaceMapInsert = TablesInsert<'shared_space_maps'>
+export type SharedSpaceMapUpdate = TablesUpdate<'shared_space_maps'>


### PR DESCRIPTION
## Summary
- add a shared_space_maps table, storage bucket entry, and row-level security policies for shared space diagrams
- update supabase typings and shared metadata utilities for the new table
- build tenant- and staff-facing shared space pages with upload/edit flows and navigation links

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7addf1488328a95c24e6eaa0b46a