### PR TITLE
Add tenant message board with real-time moderation

### DIFF
--- a/app/(tenant)/message-board/actions.ts
+++ b/app/(tenant)/message-board/actions.ts
@@ -1,0 +1,281 @@
+"use server"
+
+import { createSupbaseServerClient } from "@/utils/supaone"
+import type { Database, Json } from "@/lib/supabase"
+
+const MESSAGE_SELECT = `
+  id,
+  created_at,
+  updated_at,
+  property_id,
+  unit_id,
+  author_id,
+  body,
+  attachments,
+  pinned,
+  pinned_at,
+  pinned_by,
+  removed,
+  removed_at,
+  removed_by,
+  moderation_note,
+  updated_by,
+  author:profiles!tenant_messages_author_id_fkey ( id, full_name, avatar_url, role ),
+  property:properties!tenant_messages_property_id_fkey ( id, name ),
+  unit:property_units!tenant_messages_unit_id_fkey ( id, label )
+`
+
+export type TenantMessageRecord = Database["public"]["Tables"]["tenant_messages"]["Row"]
+export type TenantMessageWithRelations = TenantMessageRecord & {
+  author: Pick<
+    Database["public"]["Tables"]["profiles"]["Row"],
+    "id" | "full_name" | "avatar_url" | "role"
+  > | null
+  property: Pick<Database["public"]["Tables"]["properties"]["Row"], "id" | "name"> | null
+  unit: Pick<Database["public"]["Tables"]["property_units"]["Row"], "id" | "label"> | null
+}
+
+export type TenantMembershipRecord = Database["public"]["Tables"]["tenant_property_memberships"]["Row"]
+
+export type ListTenantMessagesInput = {
+  propertyId: string
+  unitId?: string | null
+  cursor?: string
+  limit?: number
+  includeRemoved?: boolean
+}
+
+export type ListTenantMessagesResult = {
+  pinned: TenantMessageWithRelations[]
+  messages: TenantMessageWithRelations[]
+  nextCursor: string | null
+}
+
+const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 100
+
+function applyThreadScope(
+  query: any,
+  propertyId: string,
+  unitId: string | null | undefined
+) {
+  let scoped = query.eq("property_id", propertyId)
+  if (unitId === null) {
+    scoped = scoped.is("unit_id", null)
+  } else if (unitId) {
+    scoped = scoped.eq("unit_id", unitId)
+  }
+  return scoped
+}
+
+export async function listTenantMessages({
+  propertyId,
+  unitId,
+  cursor,
+  limit = DEFAULT_PAGE_SIZE,
+  includeRemoved = false,
+}: ListTenantMessagesInput): Promise<ListTenantMessagesResult> {
+  const supabase = await createSupbaseServerClient()
+  const size = Math.min(Math.max(limit, 1), MAX_PAGE_SIZE)
+
+  const pinnedQuery = applyThreadScope(
+    supabase.from("tenant_messages").select(MESSAGE_SELECT),
+    propertyId,
+    unitId
+  )
+    .eq("pinned", true)
+    .order("created_at", { ascending: false })
+
+  if (!includeRemoved) {
+    pinnedQuery.eq("removed", false)
+  }
+
+  const { data: pinnedData, error: pinnedError } = await pinnedQuery
+  if (pinnedError) {
+    throw pinnedError
+  }
+
+  let listQuery = applyThreadScope(
+    supabase.from("tenant_messages").select(MESSAGE_SELECT),
+    propertyId,
+    unitId
+  )
+    .eq("pinned", false)
+    .order("created_at", { ascending: false })
+    .limit(size + 1)
+
+  if (!includeRemoved) {
+    listQuery = listQuery.eq("removed", false)
+  }
+
+  if (cursor) {
+    listQuery = listQuery.lt("created_at", cursor)
+  }
+
+  const { data: messageData, error: listError } = await listQuery
+  if (listError) {
+    throw listError
+  }
+
+  let nextCursor: string | null = null
+  let messages = messageData ?? []
+  if (messages.length > size) {
+    const next = messages.pop()
+    nextCursor = next?.created_at ?? null
+  }
+
+  return {
+    pinned: (pinnedData ?? []) as TenantMessageWithRelations[],
+    messages: messages as TenantMessageWithRelations[],
+    nextCursor,
+  }
+}
+
+export type CreateTenantMessageInput = {
+  propertyId: string
+  unitId?: string | null
+  body: string
+  attachments?: Array<{ url: string; name?: string; type?: string }>
+}
+
+export async function createTenantMessage({
+  propertyId,
+  unitId,
+  body,
+  attachments = [],
+}: CreateTenantMessageInput): Promise<TenantMessageWithRelations> {
+  const supabase = await createSupbaseServerClient()
+  const payload: Database["public"]["Tables"]["tenant_messages"]["Insert"] = {
+    property_id: propertyId,
+    unit_id: unitId ?? null,
+    body,
+    attachments: attachments as unknown as Json,
+  }
+
+  const { data, error } = await supabase
+    .from("tenant_messages")
+    .insert(payload)
+    .select(MESSAGE_SELECT)
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  return data as TenantMessageWithRelations
+}
+
+export type TenantMessageSubscriptionConfig = {
+  channel: string
+  event: "*"
+  schema: "public"
+  table: "tenant_messages"
+  filter: string
+}
+
+export async function getTenantMessageById(
+  id: number
+): Promise<TenantMessageWithRelations | null> {
+  const supabase = await createSupbaseServerClient()
+  const { data, error } = await supabase
+    .from("tenant_messages")
+    .select(MESSAGE_SELECT)
+    .eq("id", id)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return (data as TenantMessageWithRelations) ?? null
+}
+
+export async function subscribeToTenantMessages({
+  propertyId,
+  unitId,
+}: {
+  propertyId: string
+  unitId?: string | null
+}): Promise<TenantMessageSubscriptionConfig> {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error("Not authenticated")
+  }
+
+  const channelId = `tenant-messages:${propertyId}:${unitId ?? "all"}`
+  let filter = `property_id=eq.${propertyId}`
+  if (unitId === null) {
+    filter = `${filter},unit_id=is.null`
+  } else if (unitId) {
+    filter = `${filter},unit_id=eq.${unitId}`
+  }
+
+  return {
+    channel: channelId,
+    event: "*",
+    schema: "public",
+    table: "tenant_messages",
+    filter,
+  }
+}
+
+export type ModerateTenantMessageInput = {
+  messageId: number
+  pinned?: boolean
+  removed?: boolean
+  moderationNote?: string | null
+}
+
+export async function moderateTenantMessage({
+  messageId,
+  pinned,
+  removed,
+  moderationNote,
+}: ModerateTenantMessageInput): Promise<TenantMessageWithRelations> {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error("Not authenticated")
+  }
+
+  const updates: Database["public"]["Tables"]["tenant_messages"]["Update"] = {
+    updated_by: user.id,
+    updated_at: new Date().toISOString(),
+  }
+
+  if (typeof pinned !== "undefined") {
+    updates.pinned = pinned
+    updates.pinned_at = pinned ? new Date().toISOString() : null
+    updates.pinned_by = pinned ? user.id : null
+  }
+
+  if (typeof removed !== "undefined") {
+    updates.removed = removed
+    updates.removed_at = removed ? new Date().toISOString() : null
+    updates.removed_by = removed ? user.id : null
+  }
+
+  if (typeof moderationNote !== "undefined") {
+    updates.moderation_note = moderationNote
+  }
+
+  const { data, error } = await supabase
+    .from("tenant_messages")
+    .update(updates)
+    .eq("id", messageId)
+    .select(MESSAGE_SELECT)
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  return data as TenantMessageWithRelations
+}

--- a/app/(tenant)/message-board/message-board-client.tsx
+++ b/app/(tenant)/message-board/message-board-client.tsx
@@ -1,0 +1,781 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { formatDistanceToNow } from "date-fns"
+import { Loader2, Paperclip, Pin, PinOff, Shield, Trash2, Undo2 } from "lucide-react"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Textarea } from "@/components/ui/textarea"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useToast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+import type { Database, Json } from "@/lib/supabase"
+import type { ListTenantMessagesResult, TenantMessageWithRelations, TenantMembershipRecord } from "./actions"
+import { createTenantMessage, getTenantMessageById, listTenantMessages, moderateTenantMessage, subscribeToTenantMessages } from "./actions"
+
+const attachmentSchema = z.string().url("Enter a valid URL")
+
+const composerSchema = z.object({
+  body: z.string().min(1, "Message cannot be empty").max(2000, "Keep messages under 2,000 characters"),
+  attachments: z
+    .string()
+    .optional()
+    .transform((value) => (value ?? "").trim()),
+})
+
+type ComposerValues = z.infer<typeof composerSchema>
+
+type Profile = Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "full_name" | "avatar_url" | "role">
+
+type MembershipWithRelations = TenantMembershipRecord & {
+  property: Pick<Database["public"]["Tables"]["properties"]["Row"], "id" | "name"> | null
+  unit: Pick<Database["public"]["Tables"]["property_units"]["Row"], "id" | "label"> | null
+}
+
+type MessageAttachment = {
+  url: string
+  name?: string | null
+  type?: string | null
+}
+
+type ClientMessage = TenantMessageWithRelations & {
+  clientKey: string
+  optimistic?: boolean
+}
+
+type MessageBoardClientProps = {
+  profile: Profile
+  memberships: MembershipWithRelations[]
+  initialThreadId: string
+  initialData: ListTenantMessagesResult
+  allowModeration?: boolean
+  initialIncludeRemoved?: boolean
+}
+
+function toAttachments(value: Json): MessageAttachment[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((item) => {
+      if (!item || typeof item !== "object") {
+        return null
+      }
+      const record = item as Record<string, unknown>
+      if (typeof record.url !== "string") {
+        return null
+      }
+      return {
+        url: record.url,
+        name: typeof record.name === "string" ? record.name : null,
+        type: typeof record.type === "string" ? record.type : null,
+      }
+    })
+    .filter((entry): entry is MessageAttachment => Boolean(entry))
+}
+
+function withClientMeta(message: TenantMessageWithRelations): ClientMessage {
+  return {
+    ...message,
+    clientKey: `${message.id}`,
+    optimistic: false,
+  }
+}
+
+function initials(name?: string | null) {
+  if (!name) return "?"
+  const parts = name.trim().split(/\s+/)
+  if (!parts.length) return "?"
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase()
+  return (parts[0]![0] ?? "?") + (parts[parts.length - 1]![0] ?? "?")
+}
+
+const STAFF_ROLES = new Set(["admin", "staff", "manager"])
+
+export default function MessageBoardClient({
+  profile,
+  memberships,
+  initialThreadId,
+  initialData,
+  allowModeration = false,
+  initialIncludeRemoved = false,
+}: MessageBoardClientProps) {
+  const supabase = useSupabaseBrowser()
+  const { toast } = useToast()
+  const [currentThreadId, setCurrentThreadId] = useState(initialThreadId)
+  const [pinnedMessages, setPinnedMessages] = useState<ClientMessage[]>(() =>
+    initialData.pinned.map(withClientMeta)
+  )
+  const [messages, setMessages] = useState<ClientMessage[]>(() =>
+    initialData.messages.map(withClientMeta)
+  )
+  const [nextCursor, setNextCursor] = useState<string | null>(initialData.nextCursor)
+  const [includeRemoved, setIncludeRemoved] = useState(initialIncludeRemoved)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [isRefreshing, startRefresh] = useTransition()
+  const [isPosting, setIsPosting] = useState(false)
+
+  const currentMembership = useMemo(
+    () => memberships.find((membership) => membership.id === currentThreadId) ?? memberships[0]!,
+    [currentThreadId, memberships]
+  )
+
+  const canModerate = allowModeration || STAFF_ROLES.has(profile.role ?? "") || STAFF_ROLES.has(currentMembership.role ?? "")
+
+  useEffect(() => {
+    if (!canModerate && includeRemoved) {
+      setIncludeRemoved(false)
+    }
+  }, [canModerate, includeRemoved])
+
+  const form = useForm<ComposerValues>({
+    resolver: zodResolver(composerSchema),
+    defaultValues: {
+      body: "",
+      attachments: "",
+    },
+  })
+
+  const refreshThread = useCallback(() => {
+    startRefresh(async () => {
+      try {
+        const data = await listTenantMessages({
+          propertyId: currentMembership.property_id,
+          unitId: currentMembership.unit_id,
+          includeRemoved: includeRemoved && canModerate,
+        })
+        setPinnedMessages(data.pinned.map(withClientMeta))
+        setMessages(data.messages.map(withClientMeta))
+        setNextCursor(data.nextCursor)
+      } catch (error) {
+        console.error(error)
+        toast({
+          title: "Unable to refresh thread",
+          description: error instanceof Error ? error.message : "Unexpected error",
+          variant: "destructive",
+        })
+      }
+    })
+  }, [canModerate, currentMembership.property_id, currentMembership.unit_id, includeRemoved, toast])
+
+  useEffect(() => {
+    setPinnedMessages(initialData.pinned.map(withClientMeta))
+    setMessages(initialData.messages.map(withClientMeta))
+    setNextCursor(initialData.nextCursor)
+  }, [initialData])
+
+  useEffect(() => {
+    const abortController = new AbortController()
+    let isMounted = true
+    let channel: ReturnType<typeof supabase.channel> | null = null
+
+    async function subscribe() {
+      try {
+        const config = await subscribeToTenantMessages({
+          propertyId: currentMembership.property_id,
+          unitId: currentMembership.unit_id,
+        })
+
+        if (!isMounted) {
+          return
+        }
+
+        channel = supabase
+          .channel(config.channel)
+          .on(
+            "postgres_changes",
+            {
+              event: "*",
+              schema: config.schema,
+              table: config.table,
+              filter: config.filter,
+            },
+            async (payload) => {
+              if (abortController.signal.aborted) return
+              const recordId = (payload.new as { id?: number } | null)?.id ??
+                (payload.old as { id?: number } | null)?.id
+              if (!recordId) return
+
+              try {
+                if (payload.eventType === "DELETE") {
+                  setPinnedMessages((prev) => prev.filter((message) => message.id !== recordId))
+                  setMessages((prev) => prev.filter((message) => message.id !== recordId))
+                  return
+                }
+
+                const latest = await getTenantMessageById(recordId)
+                if (!latest) {
+                  setPinnedMessages((prev) => prev.filter((message) => message.id !== recordId))
+                  setMessages((prev) => prev.filter((message) => message.id !== recordId))
+                  return
+                }
+
+                setPinnedMessages((prev) => {
+                  const existingIndex = prev.findIndex((message) => message.id === latest.id)
+                  if (latest.removed) {
+                    if (existingIndex === -1) return prev
+                    const clone = [...prev]
+                    clone.splice(existingIndex, 1)
+                    return clone
+                  }
+
+                  if (!latest.pinned) {
+                    if (existingIndex === -1) return prev
+                    const clone = [...prev]
+                    clone.splice(existingIndex, 1)
+                    return clone
+                  }
+
+                  const nextMessage: ClientMessage = {
+                    ...latest,
+                    clientKey: existingIndex >= 0 ? prev[existingIndex]!.clientKey : `${latest.id}`,
+                    optimistic: false,
+                  }
+
+                  if (existingIndex >= 0) {
+                    const clone = [...prev]
+                    clone[existingIndex] = nextMessage
+                    return clone
+                  }
+
+                  return [nextMessage, ...prev]
+                })
+
+                setMessages((prev) => {
+                  const existingIndex = prev.findIndex((message) => message.id === latest.id)
+
+                  if (latest.removed) {
+                    if (existingIndex === -1) return prev
+                    const clone = [...prev]
+                    clone.splice(existingIndex, 1)
+                    return clone
+                  }
+
+                  if (latest.pinned) {
+                    if (existingIndex === -1) return prev
+                    const clone = [...prev]
+                    clone.splice(existingIndex, 1)
+                    return clone
+                  }
+
+                  const nextMessage: ClientMessage = {
+                    ...latest,
+                    clientKey: existingIndex >= 0 ? prev[existingIndex]!.clientKey : `${latest.id}`,
+                    optimistic: false,
+                  }
+
+                  if (existingIndex >= 0) {
+                    const clone = [...prev]
+                    clone[existingIndex] = nextMessage
+                    return clone
+                  }
+
+                  return [nextMessage, ...prev]
+                })
+              } catch (error) {
+                console.error("Realtime handler error", error)
+              }
+            }
+          )
+          .subscribe()
+      } catch (error) {
+        console.error(error)
+        toast({
+          title: "Realtime unavailable",
+          description: error instanceof Error ? error.message : "Unable to subscribe to updates",
+          variant: "destructive",
+        })
+      }
+    }
+
+    subscribe()
+
+    return () => {
+      isMounted = false
+      abortController.abort()
+      if (channel) {
+        supabase.removeChannel(channel)
+      }
+    }
+  }, [currentMembership.property_id, currentMembership.unit_id, supabase, toast])
+
+  useEffect(() => {
+    if (!includeRemoved) {
+      setPinnedMessages((prev) => prev.filter((message) => !message.removed))
+      setMessages((prev) => prev.filter((message) => !message.removed))
+    } else if (canModerate) {
+      refreshThread()
+    }
+  }, [includeRemoved, canModerate, refreshThread])
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const attachments = (values.attachments ?? "")
+      .split(/\n|,/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+
+    const invalid = attachments.find((url) => !attachmentSchema.safeParse(url).success)
+    if (invalid) {
+      form.setError("attachments", { message: "One or more attachment links are invalid" })
+      return
+    }
+
+    const attachmentPayload: MessageAttachment[] = attachments.map((url) => ({ url }))
+    const now = new Date().toISOString()
+    const clientKey = crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)
+    const optimisticMessage: ClientMessage = {
+      id: Number.MIN_SAFE_INTEGER + Math.floor(Math.random() * 1000),
+      clientKey,
+      optimistic: true,
+      created_at: now,
+      updated_at: now,
+      property_id: currentMembership.property_id,
+      unit_id: currentMembership.unit_id,
+      author_id: profile.id,
+      body: values.body,
+      attachments: attachmentPayload as unknown as Json,
+      pinned: false,
+      pinned_at: null,
+      pinned_by: null,
+      removed: false,
+      removed_at: null,
+      removed_by: null,
+      moderation_note: null,
+      updated_by: profile.id,
+      author: {
+        id: profile.id,
+        full_name: profile.full_name,
+        avatar_url: profile.avatar_url,
+        role: profile.role,
+      },
+      property: currentMembership.property,
+      unit: currentMembership.unit,
+    }
+
+    setMessages((prev) => [optimisticMessage, ...prev])
+    setIsPosting(true)
+
+    try {
+      const inserted = await createTenantMessage({
+        propertyId: currentMembership.property_id,
+        unitId: currentMembership.unit_id ?? null,
+        body: values.body,
+        attachments: attachmentPayload,
+      })
+
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.clientKey === clientKey
+            ? { ...inserted, clientKey, optimistic: false }
+            : message
+        )
+      )
+      form.reset()
+    } catch (error) {
+      console.error(error)
+      setMessages((prev) => prev.filter((message) => message.clientKey !== clientKey))
+      toast({
+        title: "Could not post message",
+        description: error instanceof Error ? error.message : "Unexpected error",
+        variant: "destructive",
+      })
+    } finally {
+      setIsPosting(false)
+    }
+  })
+
+  const handleLoadMore = useCallback(async () => {
+    if (!nextCursor) return
+    setIsLoadingMore(true)
+    try {
+      const data = await listTenantMessages({
+        propertyId: currentMembership.property_id,
+        unitId: currentMembership.unit_id,
+        cursor: nextCursor,
+        includeRemoved: includeRemoved && canModerate,
+      })
+      setMessages((prev) => [...prev, ...data.messages.map(withClientMeta)])
+      setNextCursor(data.nextCursor)
+    } catch (error) {
+      console.error(error)
+      toast({
+        title: "Unable to load more messages",
+        description: error instanceof Error ? error.message : "Unexpected error",
+        variant: "destructive",
+      })
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }, [canModerate, currentMembership.property_id, currentMembership.unit_id, includeRemoved, nextCursor, toast])
+
+  const handleThreadChange = useCallback(
+    (value: string) => {
+      setCurrentThreadId(value)
+      setMessages([])
+      setPinnedMessages([])
+      setNextCursor(null)
+      startRefresh(async () => {
+        try {
+          const membership = memberships.find((item) => item.id === value)
+          if (!membership) return
+          const data = await listTenantMessages({
+            propertyId: membership.property_id,
+            unitId: membership.unit_id,
+            includeRemoved: includeRemoved && canModerate,
+          })
+          setPinnedMessages(data.pinned.map(withClientMeta))
+          setMessages(data.messages.map(withClientMeta))
+          setNextCursor(data.nextCursor)
+        } catch (error) {
+          console.error(error)
+          toast({
+            title: "Unable to load thread",
+            description: error instanceof Error ? error.message : "Unexpected error",
+            variant: "destructive",
+          })
+        }
+      })
+    },
+    [canModerate, includeRemoved, memberships, startRefresh, toast]
+  )
+
+  const handleModeration = useCallback(
+    async (message: ClientMessage, action: "pin" | "unpin" | "remove" | "restore") => {
+      if (!canModerate || !Number.isFinite(message.id)) return
+      try {
+        const updates =
+          action === "pin"
+            ? { pinned: true }
+            : action === "unpin"
+              ? { pinned: false }
+              : action === "remove"
+                ? { removed: true }
+                : { removed: false }
+
+        const updated = await moderateTenantMessage({
+          messageId: message.id as number,
+          ...updates,
+        })
+        setPinnedMessages((prev) => {
+          const existingIndex = prev.findIndex((item) => item.id === updated.id)
+          if (updated.removed) {
+            if (existingIndex === -1) return prev
+            const clone = [...prev]
+            clone.splice(existingIndex, 1)
+            return clone
+          }
+          if (!updated.pinned) {
+            if (existingIndex === -1) return prev
+            const clone = [...prev]
+            clone.splice(existingIndex, 1)
+            return clone
+          }
+          const nextMessage: ClientMessage = {
+            ...updated,
+            clientKey: existingIndex >= 0 ? prev[existingIndex]!.clientKey : `${updated.id}`,
+            optimistic: false,
+          }
+          if (existingIndex >= 0) {
+            const clone = [...prev]
+            clone[existingIndex] = nextMessage
+            return clone
+          }
+          return [nextMessage, ...prev]
+        })
+        setMessages((prev) => {
+          const existingIndex = prev.findIndex((item) => item.id === updated.id)
+          if (updated.removed) {
+            if (existingIndex === -1) return prev
+            const clone = [...prev]
+            clone.splice(existingIndex, 1)
+            return clone
+          }
+          if (updated.pinned) {
+            if (existingIndex === -1) return prev
+            const clone = [...prev]
+            clone.splice(existingIndex, 1)
+            return clone
+          }
+          const nextMessage: ClientMessage = {
+            ...updated,
+            clientKey: existingIndex >= 0 ? prev[existingIndex]!.clientKey : `${updated.id}`,
+            optimistic: false,
+          }
+          if (existingIndex >= 0) {
+            const clone = [...prev]
+            clone[existingIndex] = nextMessage
+            return clone
+          }
+          return [nextMessage, ...prev]
+        })
+      } catch (error) {
+        console.error(error)
+        toast({
+          title: "Moderation failed",
+          description: error instanceof Error ? error.message : "Unexpected error",
+          variant: "destructive",
+        })
+        refreshThread()
+      }
+    },
+    [canModerate, refreshThread, toast]
+  )
+
+  const threadName = `${currentMembership.property?.name ?? "Property"}${
+    currentMembership.unit?.label ? ` • ${currentMembership.unit?.label}` : ""
+  }`
+
+  return (
+    <Card className="space-y-6">
+      <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <CardTitle className="text-2xl">Community Message Board</CardTitle>
+          <p className="text-sm text-muted-foreground">Share updates with neighbors and stay informed in real time.</p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Select value={currentThreadId} onValueChange={handleThreadChange} disabled={isRefreshing}>
+            <SelectTrigger className="w-64">
+              <SelectValue placeholder="Select a thread" />
+            </SelectTrigger>
+            <SelectContent>
+              {memberships.map((membership) => (
+                <SelectItem key={membership.id} value={membership.id}>
+                  {membership.property?.name ?? "Property"}
+                  {membership.unit?.label ? ` • ${membership.unit?.label}` : ""}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {canModerate ? (
+            <div className="flex items-center gap-2 text-sm">
+              <Badge variant={includeRemoved ? "default" : "outline"} className="cursor-pointer" onClick={() => setIncludeRemoved((prev) => !prev)}>
+                {includeRemoved ? "Showing removed" : "Hide removed"}
+              </Badge>
+            </div>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-8">
+        <section aria-labelledby="thread-title" className="space-y-6">
+          <div className="rounded-md border bg-muted/30 p-4">
+            <h2 id="thread-title" className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              {threadName}
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Messages are visible to residents in this property thread. Attach helpful links or resources to keep everyone aligned.
+            </p>
+          </div>
+          <Form {...form}>
+            <form onSubmit={onSubmit} className="space-y-6">
+              <FormField
+                control={form.control}
+                name="body"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Message</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        rows={4}
+                        placeholder="Share an update, ask a question, or welcome a new neighbor..."
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="attachments"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Attachment links</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        rows={2}
+                        placeholder="https://example.com/flyer.pdf"
+                      />
+                    </FormControl>
+                    <FormDescription>Optional. Separate multiple links with commas or line breaks.</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex items-center gap-3">
+                <Button type="submit" disabled={isPosting || isRefreshing}>
+                  {isPosting ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                  Post message
+                </Button>
+                <span className="text-sm text-muted-foreground">Your update will publish instantly for everyone in this thread.</span>
+              </div>
+            </form>
+          </Form>
+        </section>
+
+        {pinnedMessages.length ? (
+          <section className="space-y-3">
+            <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              <Pin className="size-4" /> Pinned
+            </div>
+            <div className="space-y-3">
+              {pinnedMessages.map((message) => (
+                <MessageItem
+                  key={message.clientKey}
+                  message={message}
+                  profile={profile}
+                  canModerate={canModerate}
+                  onModerate={handleModeration}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Latest messages</div>
+            {isRefreshing ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="size-3 animate-spin" /> Refreshing
+              </div>
+            ) : null}
+          </div>
+          <div className="space-y-3">
+            {messages.length === 0 ? (
+              <p className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                Be the first to start the conversation for this thread.
+              </p>
+            ) : (
+              messages.map((message) => (
+                <MessageItem
+                  key={message.clientKey}
+                  message={message}
+                  profile={profile}
+                  canModerate={canModerate}
+                  onModerate={handleModeration}
+                />
+              ))
+            )}
+          </div>
+          {nextCursor ? (
+            <div className="flex justify-center">
+              <Button variant="outline" onClick={handleLoadMore} disabled={isLoadingMore}>
+                {isLoadingMore ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                Load earlier messages
+              </Button>
+            </div>
+          ) : null}
+        </section>
+      </CardContent>
+    </Card>
+  )
+}
+
+type MessageItemProps = {
+  message: ClientMessage
+  profile: Profile
+  canModerate: boolean
+  onModerate: (message: ClientMessage, action: "pin" | "unpin" | "remove" | "restore") => Promise<void>
+}
+
+function MessageItem({ message, profile, canModerate, onModerate }: MessageItemProps) {
+  const attachments = useMemo(() => toAttachments(message.attachments), [message.attachments])
+  const createdLabel = useMemo(
+    () => formatDistanceToNow(new Date(message.created_at), { addSuffix: true }),
+    [message.created_at]
+  )
+
+  const isAuthor = profile.id === message.author_id
+  const isRemoved = message.removed
+
+  return (
+    <article
+      className={cn(
+        "rounded-lg border bg-background p-4 shadow-sm",
+        message.optimistic && "opacity-60",
+        isRemoved && "border-destructive/40 bg-destructive/10"
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-1 gap-3">
+          <Avatar className="size-10">
+            <AvatarImage src={message.author?.avatar_url ?? undefined} alt={message.author?.full_name ?? "Tenant"} />
+            <AvatarFallback>{initials(message.author?.full_name)}</AvatarFallback>
+          </Avatar>
+          <div className="flex-1 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-semibold">{message.author?.full_name ?? "Tenant"}</span>
+              <span className="text-xs text-muted-foreground">{createdLabel}</span>
+              {message.pinned ? (
+                <Badge variant="secondary" className="gap-1">
+                  <Pin className="size-3" /> Pinned
+                </Badge>
+              ) : null}
+              {isAuthor ? (
+                <Badge variant="outline" className="gap-1 text-xs">
+                  <Shield className="size-3" /> You
+                </Badge>
+              ) : null}
+              {isRemoved ? (
+                <Badge variant="destructive" className="gap-1">
+                  <Trash2 className="size-3" /> Removed
+                </Badge>
+              ) : null}
+            </div>
+            <p className="whitespace-pre-wrap text-sm leading-6 text-muted-foreground">
+              {message.body}
+            </p>
+            {attachments.length ? (
+              <ul className="mt-3 space-y-2 text-sm">
+                {attachments.map((attachment, index) => (
+                  <li key={`${message.clientKey}-attachment-${index}`} className="flex items-center gap-2">
+                    <Paperclip className="size-3 text-muted-foreground" />
+                    <a
+                      className="truncate text-primary underline"
+                      href={attachment.url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {attachment.name ?? attachment.url}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </div>
+        {canModerate && !message.optimistic ? (
+          <div className="flex flex-col gap-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onModerate(message, message.pinned ? "unpin" : "pin")}
+            >
+              {message.pinned ? <PinOff className="mr-2 size-4" /> : <Pin className="mr-2 size-4" />}
+              {message.pinned ? "Unpin" : "Pin"}
+            </Button>
+            <Button
+              size="sm"
+              variant={isRemoved ? "outline" : "ghost"}
+              onClick={() => onModerate(message, isRemoved ? "restore" : "remove")}
+            >
+              {isRemoved ? <Undo2 className="mr-2 size-4" /> : <Trash2 className="mr-2 size-4" />}
+              {isRemoved ? "Restore" : "Remove"}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/app/(tenant)/message-board/page.tsx
+++ b/app/(tenant)/message-board/page.tsx
@@ -1,0 +1,111 @@
+import { redirect } from "next/navigation"
+
+import { createSupbaseServerClient } from "@/utils/supaone"
+import MessageBoardClient from "./message-board-client"
+import { listTenantMessages } from "./actions"
+import type { Database } from "@/lib/supabase"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+const STAFF_ROLES = new Set(["admin", "staff", "manager"])
+
+type Profile = Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "full_name" | "avatar_url" | "role">
+type MembershipWithRelations = Database["public"]["Tables"]["tenant_property_memberships"]["Row"] & {
+  property: Pick<Database["public"]["Tables"]["properties"]["Row"], "id" | "name"> | null
+  unit: Pick<Database["public"]["Tables"]["property_units"]["Row"], "id" | "label"> | null
+}
+
+type MessageBoardPageProps = {
+  searchParams?: {
+    thread?: string
+  }
+}
+
+export default async function MessageBoardPage({ searchParams }: MessageBoardPageProps) {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, full_name, avatar_url, role")
+    .eq("id", user!.id)
+    .single()
+
+  if (profileError) {
+    throw profileError
+  }
+
+  const { data: memberships, error: membershipsError } = await supabase
+    .from("tenant_property_memberships")
+    .select(
+      `
+        id,
+        created_at,
+        property_id,
+        unit_id,
+        role,
+        property:properties ( id, name ),
+        unit:property_units ( id, label )
+      `
+    )
+    .order("created_at", { ascending: true })
+
+  if (membershipsError) {
+    throw membershipsError
+  }
+
+  const typedMemberships = (memberships ?? []) as MembershipWithRelations[]
+
+  if (!typedMemberships.length) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col gap-6 py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>No property access yet</CardTitle>
+            <CardDescription>
+              We couldn&apos;t find an active property or unit associated with your profile. Once your property manager
+              connects your lease, the community message board will unlock automatically.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>If this seems incorrect, please reach out to your property manager so they can assign you to the correct unit.</p>
+            <Button asChild variant="outline">
+              <a href="/contact">Contact support</a>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const requestedThreadId = searchParams?.thread
+  const defaultMembership =
+    typedMemberships.find((membership) => membership.id === requestedThreadId) ?? typedMemberships[0]!
+
+  const initialData = await listTenantMessages({
+    propertyId: defaultMembership.property_id,
+    unitId: defaultMembership.unit_id,
+    includeRemoved: false,
+  })
+
+  const allowModeration = STAFF_ROLES.has(profile.role ?? "")
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 py-10">
+      <MessageBoardClient
+        profile={profile as Profile}
+        memberships={typedMemberships}
+        initialThreadId={defaultMembership.id}
+        initialData={initialData}
+        allowModeration={allowModeration}
+        initialIncludeRemoved={allowModeration}
+      />
+    </div>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, ChatBubbleIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -14,11 +14,16 @@ export default function NavLinks() {
 			text: "Members",
 			Icon: PersonIcon,
 		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
+                {
+                        href: "/dashboard/message-board",
+                        text: "Message Board",
+                        Icon: ChatBubbleIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
 	];
 
 	return (

--- a/app/dashboard/message-board/moderation.tsx
+++ b/app/dashboard/message-board/moderation.tsx
@@ -1,0 +1,47 @@
+import type { Database } from "@/lib/supabase"
+import type { ListTenantMessagesResult } from "@/app/(tenant)/message-board/actions"
+import MessageBoardClient from "@/app/(tenant)/message-board/message-board-client"
+
+const STAFF_ROLES = new Set(["admin", "staff", "manager"])
+
+type Profile = Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "full_name" | "avatar_url" | "role">
+type MembershipWithRelations = Database["public"]["Tables"]["tenant_property_memberships"]["Row"] & {
+  property: Pick<Database["public"]["Tables"]["properties"]["Row"], "id" | "name"> | null
+  unit: Pick<Database["public"]["Tables"]["property_units"]["Row"], "id" | "label"> | null
+}
+
+type ModerationBoardProps = {
+  profile: Profile
+  memberships: MembershipWithRelations[]
+  initialThreadId: string
+  initialData: ListTenantMessagesResult
+}
+
+export default function ModerationBoard({
+  profile,
+  memberships,
+  initialThreadId,
+  initialData,
+}: ModerationBoardProps) {
+  const isStaff = STAFF_ROLES.has(profile.role ?? "")
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Message board moderation</h1>
+        <p className="text-sm text-muted-foreground">
+          Keep community conversations productive. Pin critical announcements, archive outdated threads, and remove posts that
+          violate policies—all without leaving the dashboard.
+        </p>
+      </div>
+      <MessageBoardClient
+        profile={profile}
+        memberships={memberships}
+        initialThreadId={initialThreadId}
+        initialData={initialData}
+        allowModeration={true}
+        initialIncludeRemoved={isStaff}
+      />
+    </div>
+  )
+}

--- a/app/dashboard/message-board/page.tsx
+++ b/app/dashboard/message-board/page.tsx
@@ -1,0 +1,96 @@
+import { redirect } from "next/navigation"
+
+import { createSupbaseServerClient } from "@/utils/supaone"
+import ModerationBoard from "./moderation"
+import { listTenantMessages } from "@/app/(tenant)/message-board/actions"
+import type { Database } from "@/lib/supabase"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const STAFF_ROLES = new Set(["admin", "staff", "manager"])
+
+type Profile = Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "full_name" | "avatar_url" | "role">
+type MembershipWithRelations = Database["public"]["Tables"]["tenant_property_memberships"]["Row"] & {
+  property: Pick<Database["public"]["Tables"]["properties"]["Row"], "id" | "name"> | null
+  unit: Pick<Database["public"]["Tables"]["property_units"]["Row"], "id" | "label"> | null
+}
+
+export default async function DashboardMessageBoardPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, full_name, avatar_url, role")
+    .eq("id", user!.id)
+    .single()
+
+  if (profileError) {
+    throw profileError
+  }
+
+  if (!STAFF_ROLES.has(profile.role ?? "")) {
+    redirect("/dashboard")
+  }
+
+  const { data: memberships, error: membershipsError } = await supabase
+    .from("tenant_property_memberships")
+    .select(
+      `
+        id,
+        created_at,
+        property_id,
+        unit_id,
+        role,
+        property:properties ( id, name ),
+        unit:property_units ( id, label )
+      `
+    )
+    .order("created_at", { ascending: true })
+
+  if (membershipsError) {
+    throw membershipsError
+  }
+
+  const typedMemberships = (memberships ?? []) as MembershipWithRelations[]
+
+  if (!typedMemberships.length) {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>No managed properties</CardTitle>
+            <CardDescription>
+              Add yourself to a property or unit before moderating community conversations. You&apos;ll be able to pin and remove
+              tenant messages once a property is assigned.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Connect a property from the property management console to unlock moderation controls.
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const defaultMembership = typedMemberships[0]!
+  const initialData = await listTenantMessages({
+    propertyId: defaultMembership.property_id,
+    unitId: defaultMembership.unit_id,
+    includeRemoved: true,
+  })
+
+  return (
+    <ModerationBoard
+      profile={profile as Profile}
+      memberships={typedMemberships}
+      initialThreadId={defaultMembership.id}
+      initialData={initialData}
+    />
+  )
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -14,9 +14,13 @@ export const siteConfig = {
       title: "Account",
       href: "/account",
     },
-    { 
+    {
       title: "Dashboard",
       href: "/dashboard",
+    },
+    {
+      title: "Message Board",
+      href: "/message-board",
     },
     { 
       title: "OpenAI",
@@ -49,6 +53,7 @@ export const siteConfig = {
     login: "https://onyx-rho-pink.vercel.app/auth",
     signup: "https://onyx-rho-pink.vercel.app/onboarding",
     contact: "/contact",
+    messageBoard: "/message-board",
     linkedin:
 "https://linkedin.com/in/robertmoureyjr",
   },

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -450,38 +450,216 @@ export type Database = {
         }
         Relationships: []
       }
-      chat: {
+      properties: {
         Row: {
+          address: string | null
           created_at: string
-          id: number
-          messages: string[] | null
-          path: string | null
-          profile_id: string
-          sharepath: string | null
-          title: string | null
-          user_id: string | null
+          id: string
+          metadata: Json
+          name: string
+          updated_at: string
         }
         Insert: {
+          address?: string | null
+          created_at?: string
+          id?: string
+          metadata?: Json
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          address?: string | null
+          created_at?: string
+          id?: string
+          metadata?: Json
+          name?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      property_units: {
+        Row: {
           created_at: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
-          profile_id: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
+          id: string
+          label: string
+          metadata: Json
+          property_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          label: string
+          metadata?: Json
+          property_id: string
+          updated_at?: string
         }
         Update: {
           created_at?: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
-          profile_id?: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
+          id?: string
+          label?: string
+          metadata?: Json
+          property_id?: string
+          updated_at?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "property_units_property_id_fkey"
+            columns: ["property_id"]
+            isOneToOne: false
+            referencedRelation: "properties"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tenant_messages: {
+        Row: {
+          attachments: Json
+          author_id: string
+          body: string
+          created_at: string
+          id: number
+          moderation_note: string | null
+          pinned: boolean
+          pinned_at: string | null
+          pinned_by: string | null
+          property_id: string
+          removed: boolean
+          removed_at: string | null
+          removed_by: string | null
+          unit_id: string | null
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          attachments?: Json
+          author_id?: string
+          body: string
+          created_at?: string
+          id?: number
+          moderation_note?: string | null
+          pinned?: boolean
+          pinned_at?: string | null
+          pinned_by?: string | null
+          property_id: string
+          removed?: boolean
+          removed_at?: string | null
+          removed_by?: string | null
+          unit_id?: string | null
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          attachments?: Json
+          author_id?: string
+          body?: string
+          created_at?: string
+          id?: number
+          moderation_note?: string | null
+          pinned?: boolean
+          pinned_at?: string | null
+          pinned_by?: string | null
+          property_id?: string
+          removed?: boolean
+          removed_at?: string | null
+          removed_by?: string | null
+          unit_id?: string | null
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_messages_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_pinned_by_fkey"
+            columns: ["pinned_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_property_id_fkey"
+            columns: ["property_id"]
+            isOneToOne: false
+            referencedRelation: "properties"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_removed_by_fkey"
+            columns: ["removed_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "property_units"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tenant_property_memberships: {
+        Row: {
+          created_at: string
+          id: string
+          profile_id: string
+          property_id: string
+          role: string
+          unit_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          profile_id: string
+          property_id: string
+          role?: string
+          unit_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          profile_id?: string
+          property_id?: string
+          role?: string
+          unit_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_property_memberships_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_property_memberships_property_id_fkey"
+            columns: ["property_id"]
+            isOneToOne: false
+            referencedRelation: "properties"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_property_memberships_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "property_units"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       countries: {
         Row: {

--- a/supabase/migrations/20250517_tenant_messages.sql
+++ b/supabase/migrations/20250517_tenant_messages.sql
@@ -1,0 +1,216 @@
+-- Replace legacy chat table with tenant message board schema
+set check_function_bodies = off;
+
+create extension if not exists "pgcrypto" with schema public;
+
+drop table if exists public.chat cascade;
+
+create table public.properties (
+    id uuid primary key default gen_random_uuid(),
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    name text not null,
+    address text null,
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create table public.property_units (
+    id uuid primary key default gen_random_uuid(),
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    property_id uuid not null references public.properties(id) on delete cascade,
+    label text not null,
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create table public.tenant_property_memberships (
+    id uuid primary key default gen_random_uuid(),
+    created_at timestamptz not null default now(),
+    profile_id uuid not null references public.profiles(id) on delete cascade,
+    property_id uuid not null references public.properties(id) on delete cascade,
+    unit_id uuid null references public.property_units(id) on delete set null,
+    role text not null default 'tenant',
+    constraint tenant_property_memberships_role_check check (
+        role in ('tenant', 'staff', 'manager', 'admin')
+    )
+);
+
+create table public.tenant_messages (
+    id bigint generated always as identity primary key,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    property_id uuid not null references public.properties(id) on delete cascade,
+    unit_id uuid null references public.property_units(id) on delete set null,
+    author_id uuid not null default auth.uid() references public.profiles(id) on delete cascade,
+    body text not null,
+    attachments jsonb not null default '[]'::jsonb,
+    pinned boolean not null default false,
+    pinned_at timestamptz null,
+    pinned_by uuid null references public.profiles(id) on delete set null,
+    removed boolean not null default false,
+    removed_at timestamptz null,
+    removed_by uuid null references public.profiles(id) on delete set null,
+    moderation_note text null,
+    updated_by uuid null references public.profiles(id) on delete set null
+);
+
+create or replace function public.set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger properties_set_updated_at
+before update on public.properties
+for each row execute procedure public.set_updated_at();
+
+create trigger property_units_set_updated_at
+before update on public.property_units
+for each row execute procedure public.set_updated_at();
+
+create trigger tenant_messages_set_updated_at
+before update on public.tenant_messages
+for each row execute procedure public.set_updated_at();
+
+create index tenant_messages_property_created_idx
+    on public.tenant_messages (property_id, created_at desc);
+
+create index tenant_messages_unit_created_idx
+    on public.tenant_messages (unit_id, created_at desc);
+
+create index tenant_messages_pinned_idx
+    on public.tenant_messages (pinned) where pinned is true;
+
+alter table public.properties enable row level security;
+alter table public.property_units enable row level security;
+alter table public.tenant_property_memberships enable row level security;
+alter table public.tenant_messages enable row level security;
+
+create policy "Members can read their properties" on public.properties
+for select using (
+    exists (
+        select 1
+        from public.tenant_property_memberships tpm
+        where tpm.profile_id = auth.uid()
+          and tpm.property_id = properties.id
+    )
+    or exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+);
+
+create policy "Staff can manage properties" on public.properties
+for all using (
+    exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+) with check (
+    exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+);
+
+create policy "Members can read their units" on public.property_units
+for select using (
+    exists (
+        select 1
+        from public.tenant_property_memberships tpm
+        where tpm.profile_id = auth.uid()
+          and tpm.property_id = property_units.property_id
+    )
+    or exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+);
+
+create policy "Staff can manage units" on public.property_units
+for all using (
+    exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+) with check (
+    exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+);
+
+create policy "Members can read their memberships" on public.tenant_property_memberships
+for select using (profile_id = auth.uid() or exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+));
+
+create policy "Staff can manage memberships" on public.tenant_property_memberships
+for all using (
+    exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+) with check (
+    exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+);
+
+create policy "Tenants can read property messages" on public.tenant_messages
+for select using (
+    (
+        exists (
+            select 1
+            from public.tenant_property_memberships tpm
+            where tpm.profile_id = auth.uid()
+              and tpm.property_id = tenant_messages.property_id
+              and (tpm.unit_id is null or tenant_messages.unit_id is null or tpm.unit_id = tenant_messages.unit_id)
+        )
+        and not tenant_messages.removed
+    )
+    or exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+);
+
+create policy "Tenants can insert property messages" on public.tenant_messages
+for insert with check (
+    auth.uid() = author_id and (
+        exists (
+            select 1
+            from public.tenant_property_memberships tpm
+            where tpm.profile_id = auth.uid()
+              and tpm.property_id = tenant_messages.property_id
+              and (tpm.unit_id is null or tenant_messages.unit_id is null or tpm.unit_id = tenant_messages.unit_id)
+        )
+        or exists (
+            select 1 from public.profiles p
+            where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+        )
+    )
+);
+
+create policy "Authors can update their messages" on public.tenant_messages
+for update using (auth.uid() = author_id) with check (auth.uid() = author_id);
+
+create policy "Staff can moderate tenant messages" on public.tenant_messages
+for update using (
+    exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+) with check (true);
+
+create policy "Staff can delete tenant messages" on public.tenant_messages
+for delete using (
+    exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid() and p.role in ('admin', 'staff', 'manager')
+    )
+);


### PR DESCRIPTION
## Summary
- replace the legacy chat schema with property scoped tenant messaging tables, helper policies, and Supabase types
- add server actions plus tenant UI for composing, paging, and streaming board updates with optimistic interactions
- deliver dashboard moderation tooling and navigation updates so staff can pin or remove posts and tenants can reach the board easily

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7ade489483288141015e813309d3