### PR TITLE
Add WorkOS SSO support for Supabase auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ complete Supabase SSR Auth and DB integration, Zod validation, Tanstack React Qu
     - SUPABASE_JWT_SECRET="Your supabase JWT secret"
     - NEXT_PUBLIC_SUPABASE_URL="Your supabase project URL"
     - SUPABASE_SERVIC_ROLE_KEY="Your supabase service role key"
+    - NEXT_PUBLIC_SITE_URL="http://localhost:3000" # Used for auth redirects in development
+    - SUPABASE_WORKOS_CONNECTION_ID="Your WorkOS connection ID" # Optional, required to enable SSO via WorkOS
+
+  - Enable WorkOS SSO (optional)
+    - Create a WorkOS connection in the Supabase dashboard and copy the connection ID from the Connections table
+    - Add the issuer URL from WorkOS when prompted in Supabase so that Supabase can validate the JWTs
+    - Configure the SUPABASE_WORKOS_CONNECTION_ID environment variable with the copied value
 
   - Ensure your Supabase tables match the tables and types found in '@/lib/supabase'.
   - Add authorized development and production URL's to Supabase URL config. 

--- a/app/auth/actions/index.tsx
+++ b/app/auth/actions/index.tsx
@@ -1,5 +1,6 @@
 "use server";
 
+import type { SignInWithSSO } from "@supabase/supabase-js";
 import { createSupbaseServerClient } from "@/utils/supaone";
 import { redirect } from "next/navigation";
 import { revalidatePath } from 'next/cache'
@@ -46,9 +47,56 @@ supabase.auth.onAuthStateChange((event, session) => {
 }
 
 
+export async function signInWithWorkOS(domain?: string) {
+        const supabase = await createSupbaseServerClient();
+
+        const trimmedDomain = domain?.trim();
+        const workosProviderId = process.env.SUPABASE_WORKOS_CONNECTION_ID;
+        const redirectTo = process.env.NEXT_PUBLIC_SITE_URL
+                ? `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`
+                : undefined;
+
+        if (!trimmedDomain && !workosProviderId) {
+                return JSON.stringify({
+                        error: "SUPABASE_WORKOS_CONNECTION_ID is not configured.",
+                        url: null,
+                });
+        }
+
+        const options = redirectTo ? { redirectTo } : undefined;
+
+        let params: SignInWithSSO;
+
+        if (trimmedDomain) {
+                params = options
+                        ? { domain: trimmedDomain, options }
+                        : { domain: trimmedDomain };
+        } else {
+                params = options
+                        ? { providerId: workosProviderId!, options }
+                        : { providerId: workosProviderId! };
+        }
+
+        const { data, error } = await supabase.auth.signInWithSSO(params);
+
+        if (error) {
+                return JSON.stringify({ error: error.message, url: null });
+        }
+
+        if (!data?.url) {
+                return JSON.stringify({
+                        error: "The WorkOS sign-in URL could not be generated.",
+                        url: null,
+                });
+        }
+
+        return JSON.stringify({ error: null, url: data.url });
+}
+
+
 export async function signInWithGoogle() {
 
-     const supabase = await createSupbaseServerClient();  
+     const supabase = await createSupbaseServerClient();
 
 supabase.auth.onAuthStateChange((event, session) => {
   if (session && session.provider_token) {

--- a/app/auth/components/AuthForm.tsx
+++ b/app/auth/components/AuthForm.tsx
@@ -3,8 +3,8 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
-import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import {
 	Form,
 	FormControl,
@@ -19,7 +19,7 @@ import { toast } from "@/components/ui/use-toast";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import { cn } from "@/lib/utils";
 import { useTransition } from "react";
-import { loginWithEmailAndPassword } from "../actions";
+import { loginWithEmailAndPassword, signInWithWorkOS } from "../actions";
 import { AuthTokenResponse } from "@supabase/supabase-js";
 
 const LoginSchema = z.object({
@@ -28,7 +28,8 @@ const LoginSchema = z.object({
 });
 
 export default function AuthForm() {
-	const [isPending, startTransition] = useTransition();
+        const [isPending, startTransition] = useTransition();
+        const [isWorkosPending, startWorkosTransition] = useTransition();
 
 	const form = useForm<z.infer<typeof LoginSchema>>({
 		resolver: zodResolver(LoginSchema),
@@ -38,36 +39,61 @@ export default function AuthForm() {
 		},
 	});
 
-	function onSubmit(data: z.infer<typeof LoginSchema>) {
-		startTransition(async () => {
-			const { error } = JSON.parse(
-				await loginWithEmailAndPassword(data)
-			) as AuthTokenResponse;
+        function onSubmit(data: z.infer<typeof LoginSchema>) {
+                startTransition(async () => {
+                        const { error } = JSON.parse(
+                                await loginWithEmailAndPassword(data)
+                        ) as AuthTokenResponse;
 
-			if (error) {
-				toast({
-					title: "Fail to login",
-					description: (
-						<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-							<code className="text-white">{error.message}</code>
-						</pre>
-					),
-				});
-			} else {
-				toast({
-					title: "Successful login 🎉",
-				});
-			}
-		});
-	}
+                        if (error) {
+                                toast({
+                                        title: "Fail to login",
+                                        description: (
+                                                <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+                                                        <code className="text-white">{error.message}</code>
+                                                </pre>
+                                        ),
+                                });
+                        } else {
+                                toast({
+                                        title: "Successful login 🎉",
+                                });
+                        }
+                });
+        }
 
-	return (
-		<div className="w-96">
-			<Form {...form}>
-				<form
-					onSubmit={form.handleSubmit(onSubmit)}
-					className="w-full space-y-6"
-				>
+        function handleWorkosSignIn() {
+                startWorkosTransition(async () => {
+                        const { error, url } = JSON.parse(
+                                await signInWithWorkOS()
+                        ) as { error: string | null; url: string | null };
+
+                        if (error || !url) {
+                                toast({
+                                        title: "Unable to start SSO sign in",
+                                        description: (
+                                                <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+                                                        <code className="text-white">
+                                                                {error ?? "A sign in URL was not returned."}
+                                                        </code>
+                                                </pre>
+                                        ),
+                                });
+
+                                return;
+                        }
+
+                        window.location.href = url;
+                });
+        }
+
+        return (
+                <div className="w-96 space-y-6">
+                        <Form {...form}>
+                                <form
+                                        onSubmit={form.handleSubmit(onSubmit)}
+                                        className="w-full space-y-6"
+                                >
 					<FormField
 						control={form.control}
 						name="email"
@@ -104,17 +130,33 @@ export default function AuthForm() {
 							</FormItem>
 						)}
 					/>
-    <Button
-				className="flex w-full items-center gap-2"
-				variant="outline"
-			>
-				Log In{" "}
-				<AiOutlineLoading3Quarters
-					className={cn(" animate-spin", { hidden: !isPending })}
-				/>
-			</Button>
-				</form>
-			</Form>
-		</div>
-	);
+                                        <Button
+                                                className="flex w-full items-center gap-2"
+                                                type="submit"
+                                                variant="outline"
+                                        >
+                                                Log In{" "}
+                                                <AiOutlineLoading3Quarters
+                                                        className={cn(" animate-spin", { hidden: !isPending })}
+                                                />
+                                        </Button>
+                                </form>
+                        </Form>
+                        <div className="space-y-4">
+                                <Separator />
+                                <Button
+                                        className="flex w-full items-center gap-2"
+                                        disabled={isWorkosPending}
+                                        onClick={handleWorkosSignIn}
+                                        type="button"
+                                        variant="outline"
+                                >
+                                        Continue with SSO
+                                        <AiOutlineLoading3Quarters
+                                                className={cn(" animate-spin", { hidden: !isWorkosPending })}
+                                        />
+                                </Button>
+                        </div>
+                </div>
+        );
 }


### PR DESCRIPTION
## Summary
- add a Supabase server action that generates WorkOS SSO redirect URLs and returns errors in a serialisable format
- extend the auth form UI with an SSO button that consumes the new action and shows feedback if the redirect URL cannot be created
- document the environment variables and Supabase dashboard steps required to enable a WorkOS connection

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7bc633608328bcb63606a9339d99