### PR TITLE
Implement Supabase-backed payment scheduling tasks

### DIFF
--- a/app/dashboard/todo/actions/index.ts
+++ b/app/dashboard/todo/actions/index.ts
@@ -1,9 +1,151 @@
-// "use server";
-export async function createTodo() {
-	console.log("create todo");
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createSupbaseServerClient } from "@/utils/supaone";
+import { z } from "zod";
+import type { TablesInsert, TablesUpdate } from "@/lib/supabase";
+
+const createTodoSchema = z.object({
+        title: z.string().min(3, { message: "Title must be at least 3 characters long." }),
+        task: z.string().min(10, { message: "Task details must be at least 10 characters long." }),
+});
+
+const updateTodoSchema = z.object({
+        title: z.string().min(3, { message: "Title must be at least 3 characters long." }),
+        task: z.string().min(10, { message: "Task details must be at least 10 characters long." }),
+        is_complete: z.boolean(),
+});
+
+const TODO_PATH = "/dashboard/todo";
+
+export async function createTodo(input: z.infer<typeof createTodoSchema>) {
+        const validation = createTodoSchema.safeParse(input);
+
+        if (!validation.success) {
+                const message = validation.error.errors.map((err) => err.message).join(" ");
+                return { success: false, error: message } as const;
+        }
+
+        const supabase = await createSupbaseServerClient();
+        const {
+                data: { user },
+                error: authError,
+        } = await supabase.auth.getUser();
+
+        if (authError || !user) {
+                return { success: false, error: "You must be logged in to create a task." } as const;
+        }
+
+        const { title, task } = validation.data;
+
+        const payload: TablesInsert<"todos"> = {
+                title,
+                task,
+                user_id: user.id,
+                created_by: user.id,
+                created_at: new Date().toISOString(),
+                is_complete: false,
+        };
+
+        const { error } = await supabase.from("todos").insert(payload);
+
+        if (error) {
+                const message = error.message.includes("todos_created_by_fkey")
+                        ? "Unable to save the task because your account is not linked to the members directory. Please contact an administrator."
+                        : error.message;
+                return { success: false, error: message } as const;
+        }
+
+        revalidatePath(TODO_PATH);
+        return { success: true } as const;
 }
-export async function updateTodoById(id: string) {
-	console.log("update todo");
+
+export async function updateTodoById(
+        id: number,
+        input: z.infer<typeof updateTodoSchema>,
+) {
+        const validation = updateTodoSchema.safeParse(input);
+
+        if (!validation.success) {
+                const message = validation.error.errors.map((err) => err.message).join(" ");
+                return { success: false, error: message } as const;
+        }
+
+        const supabase = await createSupbaseServerClient();
+        const {
+                data: { user },
+                error: authError,
+        } = await supabase.auth.getUser();
+
+        if (authError || !user) {
+                return { success: false, error: "You must be logged in to update a task." } as const;
+        }
+
+        const payload: TablesUpdate<"todos"> = {
+                title: validation.data.title,
+                task: validation.data.task,
+                is_complete: validation.data.is_complete,
+        };
+
+        const { error } = await supabase
+                .from("todos")
+                .update(payload)
+                .eq("id", id)
+                .eq("user_id", user.id);
+
+        if (error) {
+                return { success: false, error: error.message } as const;
+        }
+
+        revalidatePath(TODO_PATH);
+        return { success: true } as const;
 }
-export async function deleteTodoById(id: string) {}
-export async function readTodos() {}
+
+export async function deleteTodoById(id: number) {
+        const supabase = await createSupbaseServerClient();
+        const {
+                data: { user },
+                error: authError,
+        } = await supabase.auth.getUser();
+
+        if (authError || !user) {
+                return { success: false, error: "You must be logged in to delete a task." } as const;
+        }
+
+        const { error } = await supabase
+                .from("todos")
+                .delete()
+                .eq("id", id)
+                .eq("user_id", user.id);
+
+        if (error) {
+                return { success: false, error: error.message } as const;
+        }
+
+        revalidatePath(TODO_PATH);
+        return { success: true } as const;
+}
+
+export async function readTodos() {
+        const supabase = await createSupbaseServerClient();
+        const {
+                data: { user },
+                error: authError,
+        } = await supabase.auth.getUser();
+
+        if (authError || !user) {
+                return { data: [], userId: null, error: "You must be logged in to view tasks." } as const;
+        }
+
+        const { data, error } = await supabase
+                .from("todos")
+                .select("*")
+                .eq("user_id", user.id)
+                .order("created_at", { ascending: false });
+
+        if (error) {
+                return { data: [], userId: user.id, error: error.message } as const;
+        }
+
+        return { data: data ?? [], userId: user.id, error: null as string | null } as const;
+}

--- a/app/dashboard/todo/components/CreateForm.tsx
+++ b/app/dashboard/todo/components/CreateForm.tsx
@@ -6,49 +6,70 @@ import * as z from "zod";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
 
 import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
+        Form,
+        FormControl,
+        FormField,
+        FormItem,
+        FormLabel,
+        FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/use-toast";
 import { Button } from "@/components/ui/button";
 import { useTransition } from "react";
 import { cn } from "@/lib/utils";
+import { Textarea } from "@/components/ui/textarea";
+import { useRouter } from "next/navigation";
+import { createTodo } from "../actions";
 
 const FormSchema = z.object({
-	title: z.string().min(1, {
-		message: "Title is required.",
-	}),
+        title: z.string().min(3, {
+                message: "Title must be at least 3 characters.",
+        }),
+        details: z.string().min(10, {
+                message: "Add a few more details so the task is clear.",
+        }),
 });
 
 export default function CreateForm() {
-	const [isPending, startTransition] = useTransition();
+        const [isPending, startTransition] = useTransition();
+        const router = useRouter();
 
-	const form = useForm<z.infer<typeof FormSchema>>({
-		resolver: zodResolver(FormSchema),
-		defaultValues: {
-			title: "",
-		},
-	});
+        const form = useForm<z.infer<typeof FormSchema>>({
+                resolver: zodResolver(FormSchema),
+                defaultValues: {
+                        title: "",
+                        details: "",
+                },
+        });
 
-	function onSubmit(data: z.infer<typeof FormSchema>) {
-		toast({
-			title: "You have successfully create todo.",
-			description: (
-				<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-					<code className="text-white">{data.title} is created</code>
-				</pre>
-			),
-		});
-		form.reset();
-	}
+        function onSubmit(data: z.infer<typeof FormSchema>) {
+                startTransition(async () => {
+                        const result = await createTodo({
+                                title: data.title.trim(),
+                                task: data.details.trim(),
+                        });
 
-	return (
-		<Form {...form}>
+                        if (!result.success) {
+                                toast({
+                                        title: "Unable to create task",
+                                        description: result.error,
+                                        variant: "destructive",
+                                });
+                                return;
+                        }
+
+                        toast({
+                                title: "Task created",
+                                description: "Your payment scheduling step has been added to the list.",
+                        });
+                        form.reset();
+                        router.refresh();
+                });
+        }
+
+        return (
+                <Form {...form}>
 			<form
 				onSubmit={form.handleSubmit(onSubmit)}
 				className="w-full space-y-6"
@@ -59,28 +80,50 @@ export default function CreateForm() {
 					render={({ field }) => (
 						<FormItem>
 							<FormLabel>Title</FormLabel>
-							<FormControl>
-								<Input
-									placeholder="todo title"
-									{...field}
-									onChange={field.onChange}
-								/>
-							</FormControl>
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
-<Button
-				className="flex w-full items-center gap-2"
-				variant="outline"
-			>
-				Create{" "}
-				<AiOutlineLoading3Quarters
-					className={cn(" animate-spin", { hidden: !isPending })}
-				/>
-			</Button>
+                                                        <FormControl>
+                                                                <Input
+                                                                        placeholder="todo title"
+                                                                        {...field}
+                                                                        onChange={field.onChange}
+                                                                />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <FormField
+                                        control={form.control}
+                                        name="details"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Details</FormLabel>
+                                                        <FormControl>
+                                                                <Textarea
+                                                                        placeholder="Outline the next step to move the payment forward"
+                                                                        {...field}
+                                                                        onChange={field.onChange}
+                                                                        rows={4}
+                                                                />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <Button
+                                        type="submit"
+                                        className={cn("flex w-full items-center justify-center gap-2", {
+                                                "cursor-not-allowed opacity-75": isPending,
+                                        })}
+                                        variant="outline"
+                                        disabled={isPending}
+                                >
+                                        {isPending ? "Creating" : "Create"}
+                                        <AiOutlineLoading3Quarters
+                                                className={cn("size-4 animate-spin", { hidden: !isPending })}
+                                        />
+                                </Button>
 
-			</form>
-		</Form>
-	);
+                        </form>
+                </Form>
+        );
 }

--- a/app/dashboard/todo/components/EditTodo.tsx
+++ b/app/dashboard/todo/components/EditTodo.tsx
@@ -3,19 +3,24 @@ import DailogForm from "./DialogForm";
 import { Button } from "@/components/ui/button";
 import { Pencil1Icon } from "@radix-ui/react-icons";
 import MemberForm from "./TodoForm";
+import type { Tables } from "@/lib/supabase";
 
-export default function EditTodo() {
-	return (
-		<DailogForm
-			id="update-trigger"
-			title="Edit Todo"
-			Trigger={
-				<Button variant="outline">
-					<Pencil1Icon />
-					Edit
-				</Button>
-			}
-			form={<MemberForm isEdit={true} />}
-		/>
-	);
+type TodoRow = Tables<"todos">;
+
+export default function EditTodo({ todo }: { todo: TodoRow }) {
+        const dialogId = `update-trigger-${todo.id}`;
+
+        return (
+                <DailogForm
+                        id={dialogId}
+                        title="Edit Todo"
+                        Trigger={
+                                <Button variant="outline">
+                                        <Pencil1Icon />
+                                        Edit
+                                </Button>
+                        }
+                        form={<MemberForm isEdit={true} todo={todo} dialogId={dialogId} />}
+                />
+        );
 }

--- a/app/dashboard/todo/components/ListOfTodo.tsx
+++ b/app/dashboard/todo/components/ListOfTodo.tsx
@@ -1,87 +1,123 @@
-import React from "react";
+"use client";
+
+import React, { useMemo, useState, useTransition } from "react";
 import { TrashIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui/button";
 import EditTodo from "./EditTodo";
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { format } from "date-fns";
+import type { Tables } from "@/lib/supabase";
+import { deleteTodoById } from "../actions";
+import { toast } from "@/components/ui/use-toast";
+import { useRouter } from "next/navigation";
 
-export default function ListOfTodo() {
-	const todos = [
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Garfield",
-		},
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Trender",
-		},
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Some string",
-		},
-	];
-	return (
-		<div className="mx-2 rounded-sm bg-white dark:bg-inherit">
-			{todos.map((todo, index) => {
-				return (
-					<div
-						className=" grid grid-cols-5  rounded-sm  p-3 align-middle font-normal "
-						key={index}
-					>
-						{Object.keys(todo).map((key, index) => {
-							if (key === "status") {
-								return (
-									<div
-										key={index}
-										className="flex items-center"
-									>
-										<div>
-											<span
-												className={cn(
-													"  rounded-full border-[.5px] px-2 py-1 text-sm capitalize  shadow dark:bg-zinc-800",
-													{
-														"border-green-500 bg-green-400 dark:text-green-400":
-															todo.status ===
-															"completed",
-													}
-												)}
-											>
-												{todo.status}
-											</span>
-										</div>
-									</div>
-								);
-							} else {
-								return (
-									<h1
-										className="flex items-center text-lg dark:text-white"
-										key={index}
-									>
-										{todo[key as keyof typeof todo]}
-									</h1>
-								);
-							}
-						})}
+type TodoRow = Tables<"todos">;
 
-						<div className="flex items-center gap-2">
-							<Button
-								variant="outline"
-								className="bg-dark dark:bg-inherit"
-							>
-								<TrashIcon />
-								delete
-							</Button>
-							<EditTodo />
-						</div>
-					</div>
-				);
-			})}
-		</div>
-	);
+interface ListOfTodoProps {
+        todos: TodoRow[];
+        currentUserId?: string;
+}
+
+export default function ListOfTodo({ todos, currentUserId }: ListOfTodoProps) {
+        const [isPending, startTransition] = useTransition();
+        const [activeDelete, setActiveDelete] = useState<number | null>(null);
+        const router = useRouter();
+
+        const formattedTodos = useMemo(() => {
+                return todos.map((todo) => ({
+                        ...todo,
+                        createdLabel: todo.created_at ? format(new Date(todo.created_at), "PP p") : "",
+                        statusLabel: todo.is_complete ? "completed" : "pending",
+                        createdByLabel: todo.created_by === currentUserId ? "You" : todo.created_by ?? "—",
+                }));
+        }, [todos, currentUserId]);
+
+        const handleDelete = (id: number) => {
+                setActiveDelete(id);
+                startTransition(async () => {
+                        const result = await deleteTodoById(id);
+
+                        if (!result.success) {
+                                toast({
+                                        title: "Unable to delete task",
+                                        description: result.error,
+                                        variant: "destructive",
+                                });
+                                setActiveDelete(null);
+                                return;
+                        }
+
+                        toast({
+                                title: "Task deleted",
+                                description: "The payment scheduling step has been removed.",
+                        });
+                        setActiveDelete(null);
+                        router.refresh();
+                });
+        };
+
+        if (!formattedTodos.length) {
+                return (
+                        <div className="rounded-md border border-dashed border-zinc-300 p-6 text-center text-sm text-zinc-600 dark:border-zinc-700 dark:text-zinc-300">
+                                No tasks yet. Start by adding the next action you need to take to get the payment scheduled.
+                        </div>
+                );
+        }
+
+        return (
+                <div className="mx-2 rounded-sm bg-white dark:bg-inherit">
+                        {formattedTodos.map((todo) => {
+                                return (
+                                        <div
+                                                className="grid grid-cols-5 items-center rounded-sm p-3 align-middle font-normal"
+                                                key={todo.id}
+                                        >
+                                                <div className="flex flex-col">
+                                                        <span className="text-base font-medium text-zinc-900 dark:text-zinc-100">
+                                                                {todo.title || todo.task || "Untitled task"}
+                                                        </span>
+                                                        {todo.task && todo.task !== todo.title && (
+                                                                <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                                                                        {todo.task}
+                                                                </span>
+                                                        )}
+                                                </div>
+                                                <div className="flex items-center">
+                                                        <span
+                                                                className={cn(
+                                                                        "rounded-full border px-3 py-1 text-sm capitalize",
+                                                                        {
+                                                                                "border-green-500 bg-green-100 text-green-700 dark:border-green-700 dark:bg-green-950/40 dark:text-green-300":
+                                                                                        todo.statusLabel === "completed",
+                                                                                "border-amber-500 bg-amber-100 text-amber-700 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300":
+                                                                                        todo.statusLabel !== "completed",
+                                                                        },
+                                                                )}
+                                                        >
+                                                                {todo.statusLabel}
+                                                        </span>
+                                                </div>
+                                                <div className="flex items-center text-sm text-zinc-700 dark:text-zinc-300">
+                                                        {todo.createdLabel || "—"}
+                                                </div>
+                                                <div className="flex items-center text-sm text-zinc-700 dark:text-zinc-300">
+                                                        {todo.createdByLabel}
+                                                </div>
+                                                <div className="flex items-center gap-2">
+                                                        <Button
+                                                                variant="outline"
+                                                                className="flex items-center gap-2"
+                                                                onClick={() => handleDelete(todo.id)}
+                                                                disabled={isPending && activeDelete === todo.id}
+                                                        >
+                                                                <TrashIcon className="size-4" />
+                                                                {isPending && activeDelete === todo.id ? "Removing" : "Delete"}
+                                                        </Button>
+                                                        <EditTodo todo={todo} />
+                                                </div>
+                                        </div>
+                                );
+                        })}
+                </div>
+        );
 }

--- a/app/dashboard/todo/components/TodoForm.tsx
+++ b/app/dashboard/todo/components/TodoForm.tsx
@@ -7,78 +7,94 @@ import * as z from "zod";
 
 import { Button } from "@/components/ui/button";
 import {
-	Form,
-	FormControl,
-	FormDescription,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
+        Form,
+        FormControl,
+        FormDescription,
+        FormField,
+        FormItem,
+        FormLabel,
+        FormMessage,
 } from "@/components/ui/form";
 import { toast } from "@/components/ui/use-toast";
 
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import { createTodo, updateTodoById } from "../actions";
+import { updateTodoById } from "../actions";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Textarea } from "@/components/ui/textarea";
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { Tables } from "@/lib/supabase";
 
 const FormSchema = z.object({
-	title: z.string().min(10, {
-		message: "Title must be at least 10 characters.",
-	}),
-	completed: z.boolean(),
+        title: z.string().min(3, {
+                message: "Title must be at least 3 characters.",
+        }),
+        details: z.string().min(10, {
+                message: "Add a bit more context to the task.",
+        }),
+        completed: z.boolean(),
 });
 
-export default function TodoForm({ isEdit }: { isEdit: boolean }) {
-	const form = useForm<z.infer<typeof FormSchema>>({
-		resolver: zodResolver(FormSchema),
-		defaultValues: {
-			title: "",
-			completed: false,
-		},
-	});
+type TodoRow = Tables<"todos">;
 
-	const handleCreateMember = (data: z.infer<typeof FormSchema>) => {
-		createTodo();
+export default function TodoForm({
+        isEdit,
+        todo,
+        dialogId,
+}: {
+        isEdit: boolean;
+        todo: TodoRow;
+        dialogId: string;
+}) {
+        const [isPending, startTransition] = useTransition();
+        const router = useRouter();
 
-		document.getElementById("create-trigger")?.click();
+        const form = useForm<z.infer<typeof FormSchema>>({
+                resolver: zodResolver(FormSchema),
+                defaultValues: {
+                        title: todo.title ?? "",
+                        details: todo.task ?? "",
+                        completed: Boolean(todo.is_complete),
+                },
+        });
 
-		toast({
-			title: "You submitted the following values:",
-			description: (
-				<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-					<code className="text-white">
-						{JSON.stringify(data, null, 2)}
-					</code>
-				</pre>
-			),
-		});
-	};
+        const handleCreateMember = (data: z.infer<typeof FormSchema>) => {
+                toast({
+                        title: "Unsupported",
+                        description: "Creating a task from the edit form is not supported.",
+                        variant: "destructive",
+                });
+        };
 
-	const handleUpdateMember = (data: z.infer<typeof FormSchema>) => {
-		updateTodoById("hello");
-		document.getElementById("update-trigger")?.click();
+        const handleUpdateMember = (data: z.infer<typeof FormSchema>) => {
+                startTransition(async () => {
+                        const result = await updateTodoById(todo.id, {
+                                title: data.title.trim(),
+                                task: data.details.trim(),
+                                is_complete: data.completed,
+                        });
 
-		toast({
-			title: "You submitted the following values:",
-			description: (
-				<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-					<code className="text-white">
-						{JSON.stringify(data, null, 2)}
-					</code>
-				</pre>
-			),
-		});
-	};
+                        if (!result.success) {
+                                toast({
+                                        title: "Unable to update task",
+                                        description: result.error,
+                                        variant: "destructive",
+                                });
+                                return;
+                        }
 
-	function onSubmit(data: z.infer<typeof FormSchema>) {
-		if (isEdit) {
-			handleUpdateMember(data);
+                        toast({
+                                title: "Task updated",
+                                description: "The payment scheduling step has been updated.",
+                        });
+
+                        document.getElementById(dialogId)?.click();
+                        router.refresh();
+                });
+        };
+
+        function onSubmit(data: z.infer<typeof FormSchema>) {
+                if (isEdit) {
+                        handleUpdateMember(data);
 		} else {
 			handleCreateMember(data);
 		}
@@ -94,25 +110,46 @@ export default function TodoForm({ isEdit }: { isEdit: boolean }) {
 					control={form.control}
 					name="title"
 					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Title</FormLabel>
-							<FormControl>
-								<Input
-									placeholder="todo title"
-									type="text"
-									{...field}
-									onChange={field.onChange}
-								/>
-							</FormControl>
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
-				<FormField
-					control={form.control}
-					name="completed"
-					render={({ field }) => (
-						<FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4 shadow">
+                                                <FormItem>
+                                                        <FormLabel>Title</FormLabel>
+                                                        <FormControl>
+                                                                <Input
+                                                                        placeholder="todo title"
+                                                                        type="text"
+                                                                        {...field}
+                                                                        onChange={field.onChange}
+                                                                />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <FormField
+                                        control={form.control}
+                                        name="details"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Details</FormLabel>
+                                                        <FormControl>
+                                                                <Textarea
+                                                                        placeholder="Outline the work that needs to happen to schedule the payment"
+                                                                        {...field}
+                                                                        onChange={field.onChange}
+                                                                        rows={4}
+                                                                />
+                                                        </FormControl>
+                                                        <FormDescription>
+                                                                Keep the task focused on the next concrete action.
+                                                        </FormDescription>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <FormField
+                                        control={form.control}
+                                        name="completed"
+                                        render={({ field }) => (
+                                                <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4 shadow">
 							<FormControl>
 								<Checkbox
 									checked={field.value}
@@ -121,14 +158,19 @@ export default function TodoForm({ isEdit }: { isEdit: boolean }) {
 							</FormControl>
 							<div className="space-y-1 leading-none">
 								<FormLabel>complete</FormLabel>
-							</div>
-						</FormItem>
-					)}
-				/>
-				<Button type="submit" className="w-full" variant="outline">
-					Submit
-				</Button>
-			</form>
-		</Form>
-	);
+                                                                </div>
+                                                </FormItem>
+                                        )}
+                                />
+                                <Button
+                                        type="submit"
+                                        className="w-full"
+                                        variant="outline"
+                                        disabled={isPending}
+                                >
+                                        {isPending ? "Saving" : "Submit"}
+                                </Button>
+                        </form>
+                </Form>
+        );
 }

--- a/app/dashboard/todo/components/TodoTable.tsx
+++ b/app/dashboard/todo/components/TodoTable.tsx
@@ -1,13 +1,22 @@
 import React from "react";
 import ListOfTodo from "./ListOfTodo";
 import Table from "@/components/ui/Table";
+import type { Tables } from "@/lib/supabase";
 
-export default function TodoTable() {
-	const tableHeader = ["Title", "Status", "Created at", "Created by"];
+type TodoRow = Tables<"todos">;
 
-	return (
-		<Table headers={tableHeader}>
-			<ListOfTodo />
-		</Table>
-	);
+export default function TodoTable({
+        todos,
+        currentUserId,
+}: {
+        todos: TodoRow[];
+        currentUserId?: string;
+}) {
+        const tableHeader = ["Title", "Status", "Created at", "Created by", "Actions"];
+
+        return (
+                <Table headers={tableHeader}>
+                        <ListOfTodo todos={todos} currentUserId={currentUserId} />
+                </Table>
+        );
 }

--- a/app/dashboard/todo/page.tsx
+++ b/app/dashboard/todo/page.tsx
@@ -1,42 +1,33 @@
 
 import React from "react";
 import CreateForm from "./components/CreateForm";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import TodoTable from "./components/TodoTable";
+import { readTodos } from "./actions";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-export default function Todo() {
-	const todos = [
-		{
-			title: "Subscribe",
-			created_by: "091832901830",
-			id: "101981908",
-			completed: false,
-		},
-	];
+export default async function Todo() {
+        const { data: todos, userId, error } = await readTodos();
 
-	return (
-		<div className="flex h-screen items-center justify-center">
-			<div className="w-96 space-y-5">
+        return (
+                <div className="flex w-full justify-center">
+                        <div className="w-full max-w-4xl space-y-6">
+                                <Card>
+                                        <CardHeader>
+                                                <CardTitle>Create a payment scheduling task</CardTitle>
+                                        </CardHeader>
+                                        <CardContent>
+                                                <CreateForm />
+                                        </CardContent>
+                                </Card>
 
-				<CreateForm />
+                                {error && (
+                                        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+                                                {error}
+                                        </div>
+                                )}
 
-				{todos?.map((todo, index) => {
-					return (
-						<div key={index} className="flex items-center gap-6">
-							<h1
-								className={cn({
-									"line-through": todo.completed,
-								})}
-							>
-								{todo.title}
-							</h1>
-
-							<Button>delete</Button>
-							<Button>Update</Button>
-						</div>
-					);
-				})}
-			</div>
-		</div>
-	);
+                                <TodoTable todos={todos} currentUserId={userId ?? undefined} />
+                        </div>
+                </div>
+        );
 }


### PR DESCRIPTION
## Summary
- add Supabase-powered server actions to create, update, delete, and read payment scheduling tasks
- extend the todo dashboard UI to capture detailed task steps and manage completion state
- refresh task listings with client-side interactions, inline editing, and descriptive empty states

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce80e38d448328b01f66a2bc37de52