### PR TITLE
feat: send payment receipt emails

### DIFF
--- a/app/api/payments/receipt/route.ts
+++ b/app/api/payments/receipt/route.ts
@@ -1,0 +1,116 @@
+import { PaymentReceiptEmail } from '@/components/emails/payment-receipt';
+import { Resend } from 'resend';
+import { z } from 'zod';
+
+const lineItemSchema = z.object({
+  description: z.string().min(1, "Line item description is required."),
+  quantity: z.number().positive().optional(),
+  unitAmount: z.number().nonnegative().optional(),
+  totalAmount: z.number().nonnegative().optional(),
+});
+
+const paymentReceiptSchema = z.object({
+  customerEmail: z.string().email(),
+  customerName: z.string().min(1),
+  paymentId: z.string().min(1),
+  amountPaid: z.number().positive(),
+  currency: z.string().min(3).max(10),
+  paymentDate: z.coerce.date().optional(),
+  items: z.array(lineItemSchema).optional(),
+  businessName: z.string().optional(),
+  supportEmail: z.string().email().optional(),
+  billingAddress: z.string().optional(),
+  notes: z.string().optional(),
+  subtotalAmount: z.number().nonnegative().optional(),
+  taxAmount: z.number().nonnegative().optional(),
+  discountAmount: z.number().nonnegative().optional(),
+  sendCopyTo: z.array(z.string().email()).optional(),
+});
+
+export async function POST(request: Request) {
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (!resendApiKey) {
+    return Response.json(
+      { error: "Resend API key is not configured." },
+      { status: 500 },
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return Response.json(
+      { error: "Invalid JSON payload." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = paymentReceiptSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return Response.json(
+      {
+        error: "Invalid payment receipt payload.",
+        details: parsed.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const {
+    customerEmail,
+    customerName,
+    paymentId,
+    amountPaid,
+    currency,
+    paymentDate,
+    items,
+    businessName,
+    supportEmail,
+    billingAddress,
+    notes,
+    subtotalAmount,
+    taxAmount,
+    discountAmount,
+    sendCopyTo,
+  } = parsed.data;
+
+  const resend = new Resend(resendApiKey);
+
+  const fromAddress = process.env.RESEND_RECEIPTS_FROM ?? 'Onyx Receipts <receipts@resend.dev>';
+  const emailRecipients = [customerEmail, ...(sendCopyTo ?? [])];
+
+  try {
+    const { data, error } = await resend.emails.send({
+      from: fromAddress,
+      to: emailRecipients,
+      subject: `Receipt for payment ${paymentId}`,
+      react: PaymentReceiptEmail({
+        customerName,
+        paymentId,
+        amountPaid,
+        currency,
+        paymentDate: paymentDate ?? new Date(),
+        items,
+        businessName,
+        supportEmail,
+        billingAddress,
+        notes,
+        subtotalAmount,
+        taxAmount,
+        discountAmount,
+      }),
+    });
+
+    if (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return Response.json({ error: message }, { status: 502 });
+    }
+
+    return Response.json({ id: data?.id ?? null });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/components/emails/payment-receipt.tsx
+++ b/components/emails/payment-receipt.tsx
@@ -1,0 +1,270 @@
+import * as React from 'react';
+
+export interface PaymentReceiptLineItem {
+  description: string;
+  quantity?: number;
+  unitAmount?: number;
+  totalAmount?: number;
+}
+
+export interface PaymentReceiptEmailProps {
+  customerName: string;
+  paymentId: string;
+  amountPaid: number;
+  currency: string;
+  paymentDate: Date;
+  items?: PaymentReceiptLineItem[];
+  businessName?: string;
+  supportEmail?: string;
+  billingAddress?: string;
+  notes?: string;
+  subtotalAmount?: number;
+  taxAmount?: number;
+  discountAmount?: number;
+}
+
+const formatCurrency = (amount: number, currency: string) => {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+    }).format(amount);
+  } catch (error) {
+    const formattedAmount = amount.toFixed(2);
+    return `${formattedAmount} ${currency}`;
+  }
+};
+
+const formatDate = (date: Date) => {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+};
+
+const renderLineItems = (
+  items: PaymentReceiptLineItem[] | undefined,
+  currency: string,
+) => {
+  if (!items?.length) return null;
+
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '16px' }}>
+      <thead>
+        <tr>
+          <th style={{ textAlign: 'left', padding: '8px 0', borderBottom: '1px solid #e2e8f0' }}>Item</th>
+          <th style={{ textAlign: 'right', padding: '8px 0', borderBottom: '1px solid #e2e8f0' }}>Qty</th>
+          <th style={{ textAlign: 'right', padding: '8px 0', borderBottom: '1px solid #e2e8f0' }}>Unit</th>
+          <th style={{ textAlign: 'right', padding: '8px 0', borderBottom: '1px solid #e2e8f0' }}>Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((item, index) => (
+          <tr key={`${item.description}-${index}`}>
+            <td style={{ padding: '8px 0', borderBottom: '1px solid #f1f5f9' }}>{item.description}</td>
+            <td style={{ padding: '8px 0', textAlign: 'right', borderBottom: '1px solid #f1f5f9' }}>
+              {item.quantity ?? '-'}
+            </td>
+            <td style={{ padding: '8px 0', textAlign: 'right', borderBottom: '1px solid #f1f5f9' }}>
+              {item.unitAmount != null ? formatCurrency(item.unitAmount, currency) : '—'}
+            </td>
+            <td style={{ padding: '8px 0', textAlign: 'right', borderBottom: '1px solid #f1f5f9' }}>
+              {item.totalAmount != null
+                ? formatCurrency(item.totalAmount, currency)
+                : item.unitAmount != null && item.quantity != null
+                  ? formatCurrency(item.unitAmount * item.quantity, currency)
+                  : '—'}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+const renderTotals = (
+  props: Pick<
+    PaymentReceiptEmailProps,
+    'subtotalAmount' | 'taxAmount' | 'discountAmount' | 'amountPaid' | 'currency'
+  >,
+) => {
+  const { subtotalAmount, taxAmount, discountAmount, amountPaid, currency } = props;
+
+  const hasAdjustments =
+    subtotalAmount != null || taxAmount != null || discountAmount != null;
+
+  if (!hasAdjustments) {
+    return (
+      <p style={{ textAlign: 'right', fontWeight: 600, marginTop: '16px' }}>
+        Total: {formatCurrency(amountPaid, currency)}
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: '16px' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <tbody>
+          {subtotalAmount != null && (
+            <tr>
+              <td style={{ padding: '4px 0', textAlign: 'right', color: '#475569' }}>Subtotal</td>
+              <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 500 }}>
+                {formatCurrency(subtotalAmount, currency)}
+              </td>
+            </tr>
+          )}
+          {taxAmount != null && (
+            <tr>
+              <td style={{ padding: '4px 0', textAlign: 'right', color: '#475569' }}>Tax</td>
+              <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 500 }}>
+                {formatCurrency(taxAmount, currency)}
+              </td>
+            </tr>
+          )}
+          {discountAmount != null && (
+            <tr>
+              <td style={{ padding: '4px 0', textAlign: 'right', color: '#475569' }}>Discount</td>
+              <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 500 }}>
+                -{formatCurrency(discountAmount, currency)}
+              </td>
+            </tr>
+          )}
+          <tr>
+            <td style={{ padding: '8px 0', textAlign: 'right', fontWeight: 600 }}>Total Paid</td>
+            <td style={{ padding: '8px 0', textAlign: 'right', fontWeight: 600 }}>
+              {formatCurrency(amountPaid, currency)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export const PaymentReceiptEmail: React.FC<Readonly<PaymentReceiptEmailProps>> = ({
+  customerName,
+  paymentId,
+  amountPaid,
+  currency,
+  paymentDate,
+  items,
+  businessName = 'Onyx',
+  supportEmail,
+  billingAddress,
+  notes,
+  subtotalAmount,
+  taxAmount,
+  discountAmount,
+}) => {
+  return (
+    <div
+      style={{
+        fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        backgroundColor: '#f8fafc',
+        padding: '24px',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: '600px',
+          margin: '0 auto',
+          backgroundColor: '#ffffff',
+          borderRadius: '12px',
+          overflow: 'hidden',
+          boxShadow: '0 10px 25px rgba(15, 23, 42, 0.08)',
+        }}
+      >
+        <div style={{ backgroundColor: '#111827', color: '#f8fafc', padding: '24px' }}>
+          <h1 style={{ margin: 0, fontSize: '24px' }}>{businessName}</h1>
+          <p style={{ margin: '8px 0 0', color: '#cbd5f5' }}>Payment Receipt</p>
+        </div>
+
+        <div style={{ padding: '24px' }}>
+          <p style={{ margin: '0 0 16px', fontSize: '16px', color: '#0f172a' }}>
+            Hi {customerName},
+          </p>
+          <p style={{ margin: '0 0 24px', color: '#475569', lineHeight: 1.6 }}>
+            Thank you for your payment. This email is a receipt for your recent transaction. A
+            summary of the payment is included below for your records.
+          </p>
+
+          <div
+            style={{
+              backgroundColor: '#f1f5f9',
+              borderRadius: '10px',
+              padding: '16px',
+              marginBottom: '24px',
+              display: 'grid',
+              gap: '8px',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+            }}
+          >
+            <div>
+              <p style={{ margin: 0, color: '#64748b', fontSize: '12px', textTransform: 'uppercase' }}>
+                Payment ID
+              </p>
+              <p style={{ margin: '4px 0 0', color: '#0f172a', fontWeight: 600 }}>{paymentId}</p>
+            </div>
+            <div>
+              <p style={{ margin: 0, color: '#64748b', fontSize: '12px', textTransform: 'uppercase' }}>
+                Paid On
+              </p>
+              <p style={{ margin: '4px 0 0', color: '#0f172a', fontWeight: 600 }}>
+                {formatDate(paymentDate)}
+              </p>
+            </div>
+            <div>
+              <p style={{ margin: 0, color: '#64748b', fontSize: '12px', textTransform: 'uppercase' }}>
+                Amount Paid
+              </p>
+              <p style={{ margin: '4px 0 0', color: '#0f172a', fontWeight: 600 }}>
+                {formatCurrency(amountPaid, currency)}
+              </p>
+            </div>
+          </div>
+
+          {renderLineItems(items, currency)}
+
+          {renderTotals({
+            subtotalAmount,
+            taxAmount,
+            discountAmount,
+            amountPaid,
+            currency,
+          })}
+
+          {billingAddress && (
+            <div style={{ marginTop: '24px' }}>
+              <h3 style={{ margin: '0 0 8px', fontSize: '16px', color: '#0f172a' }}>Billing Address</h3>
+              <p style={{ margin: 0, whiteSpace: 'pre-line', color: '#475569' }}>{billingAddress}</p>
+            </div>
+          )}
+
+          {notes && (
+            <div style={{ marginTop: '24px' }}>
+              <h3 style={{ margin: '0 0 8px', fontSize: '16px', color: '#0f172a' }}>Notes</h3>
+              <p style={{ margin: 0, color: '#475569' }}>{notes}</p>
+            </div>
+          )}
+
+          <div style={{ marginTop: '32px', color: '#475569', fontSize: '14px', lineHeight: 1.6 }}>
+            <p style={{ margin: 0 }}>
+              If you have any questions about this payment, please contact
+              {supportEmail ? (
+                <a href={`mailto:${supportEmail}`} style={{ color: '#2563eb', textDecoration: 'none', marginLeft: '4px' }}>
+                  {supportEmail}
+                </a>
+              ) : (
+                ' our support team'
+              )}
+              .
+            </p>
+            <p style={{ margin: '16px 0 0' }}>Thank you for choosing {businessName}.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentReceiptEmail;


### PR DESCRIPTION
## Summary
- add a reusable payment receipt email template with support for line items, totals, and support messaging
- add an API route that validates payment completion payloads and sends receipt emails through Resend

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cee75d52f4832893bf96602f525b17