### PR TITLE
Add lease document management for tenants and staff

### DIFF
--- a/app/(tenant)/leases/page.tsx
+++ b/app/(tenant)/leases/page.tsx
@@ -1,0 +1,186 @@
+import { format } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+import { getTenantLeaseDocuments } from "@/app/dashboard/leases/actions"
+
+function formatDate(value: string | null, fallback = "Not set") {
+  if (!value) {
+    return fallback
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return fallback
+  }
+
+  return format(parsed, "PPP")
+}
+
+function formatDateTime(value: string | null) {
+  if (!value) {
+    return "Unknown"
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+
+  return format(parsed, "PPP p")
+}
+
+function hasExpired(expirationDate: string | null) {
+  if (!expirationDate) {
+    return false
+  }
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const expires = new Date(expirationDate)
+  expires.setHours(0, 0, 0, 0)
+
+  return expires < today
+}
+
+export default async function TenantLeasePage() {
+  const documents = await getTenantLeaseDocuments()
+
+  const grouped = new Map<
+    string,
+    {
+      leaseId: string
+      leaseLabel: string
+      propertyAddress: string | null
+      leaseStartDate: string | null
+      leaseEndDate: string | null
+      documents: typeof documents
+    }
+  >()
+
+  documents.forEach((doc) => {
+    const existing = grouped.get(doc.leaseId)
+    if (existing) {
+      existing.documents.push(doc)
+    } else {
+      grouped.set(doc.leaseId, {
+        leaseId: doc.leaseId,
+        leaseLabel: doc.leaseLabel,
+        propertyAddress: doc.propertyAddress,
+        leaseStartDate: doc.leaseStartDate,
+        leaseEndDate: doc.leaseEndDate,
+        documents: [doc],
+      })
+    }
+  })
+
+  const leases = Array.from(grouped.values()).map((entry) => ({
+    ...entry,
+    documents: [...entry.documents].sort((a, b) => {
+      const aDate = new Date(a.effectiveDate).getTime()
+      const bDate = new Date(b.effectiveDate).getTime()
+      return bDate - aDate
+    }),
+  }))
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">My lease agreements</h1>
+        <p className="text-muted-foreground">
+          Download signed agreements, review current versions, and confirm upcoming renewals.
+        </p>
+      </div>
+
+      {leases.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No documents available</CardTitle>
+            <CardDescription>
+              When your property manager uploads a lease agreement it will appear here.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <div className="grid gap-6">
+          {leases.map((lease) => (
+            <Card key={lease.leaseId} className="border-muted">
+              <CardHeader className="space-y-1">
+                <CardTitle>{lease.leaseLabel}</CardTitle>
+                <CardDescription>
+                  {lease.propertyAddress ? `${lease.propertyAddress} · ` : ""}
+                  Active from {formatDate(lease.leaseStartDate)}
+                  {lease.leaseEndDate ? ` · Ends ${formatDate(lease.leaseEndDate)}` : ""}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {lease.documents.map((doc) => {
+                  const expired = hasExpired(doc.expirationDate)
+
+                  return (
+                    <div
+                      key={doc.id}
+                      className="rounded-lg border border-dashed p-4 shadow-sm"
+                    >
+                      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div className="space-y-1">
+                          <h3 className="text-base font-semibold">{doc.title}</h3>
+                          <p className="text-sm text-muted-foreground">
+                            Version {doc.version} · Effective {formatDate(doc.effectiveDate)}
+                            {doc.expirationDate ? ` · Expires ${formatDate(doc.expirationDate)}` : ""}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            Last updated {formatDateTime(doc.updatedAt)}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Badge variant={expired ? "destructive" : "secondary"}>
+                            {expired ? "Expired" : "Active"}
+                          </Badge>
+                          <Badge variant="outline">v{doc.version}</Badge>
+                        </div>
+                      </div>
+
+                      <CardFooter className="mt-4 flex flex-wrap items-center gap-3 p-0">
+                        {doc.signedUrl ? (
+                          <Button asChild>
+                            <a
+                              href={doc.signedUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              Download PDF
+                            </a>
+                          </Button>
+                        ) : (
+                          <Button variant="outline" disabled>
+                            Download PDF
+                          </Button>
+                        )}
+                        {!doc.signedUrl ? (
+                          <span className="text-xs text-muted-foreground">
+                            Contact your property manager if the download link is unavailable.
+                          </span>
+                        ) : null}
+                      </CardFooter>
+                    </div>
+                  )
+                })}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/leases/actions.ts
+++ b/app/dashboard/leases/actions.ts
@@ -1,0 +1,413 @@
+"use server"
+
+import { randomUUID } from "crypto"
+
+import { format } from "date-fns"
+import { cookies } from "next/headers"
+import { revalidatePath } from "next/cache"
+import { z } from "zod"
+
+import { createClient } from "@/utils/supa-server-actions"
+import type { Database } from "@/lib/supabase"
+
+const STORAGE_BUCKET_ID = "lease-documents"
+const STAFF_ROLES = new Set(["admin", "staff"])
+
+export type LeaseDocumentRecord = Database["public"]["Tables"]["lease_documents"]["Row"]
+export type LeaseRecord = Database["public"]["Tables"]["leases"]["Row"]
+export type ProfileRecord = Database["public"]["Tables"]["profiles"]["Row"]
+
+export type AdminLeaseDocument = LeaseDocumentRecord & { signedUrl: string | null }
+
+export type TenantLeaseDocument = {
+  id: string
+  leaseId: string
+  leaseLabel: string
+  propertyAddress: string | null
+  leaseStartDate: string | null
+  leaseEndDate: string | null
+  title: string
+  version: string
+  effectiveDate: string
+  expirationDate: string | null
+  storagePath: string
+  signedUrl: string | null
+  updatedAt: string
+  createdAt: string
+}
+
+export type LeaseManagementSummary = Array<
+  LeaseRecord & {
+    tenant: Pick<ProfileRecord, "id" | "full_name" | "email"> | null
+    lease_documents: AdminLeaseDocument[]
+  }
+>
+
+type SupabaseClient = ReturnType<typeof createClient>
+
+export type ActionResult = {
+  success: boolean
+  message: string | null
+  error: string | null
+}
+
+const leaseDocumentFormSchema = z.object({
+  leaseId: z.string().uuid({ message: "A lease selection is required." }),
+  documentId: z.string().uuid().optional(),
+  title: z.string().min(1, { message: "Please provide a document title." }),
+  version: z.string().min(1, { message: "Please specify a version label." }),
+  effectiveDate: z.coerce.date({ message: "Effective date is required." }),
+  expirationDate: z
+    .preprocess((value) => {
+      if (value === null || value === undefined) {
+        return null
+      }
+      if (typeof value === "string" && value.trim().length === 0) {
+        return null
+      }
+      return value
+    }, z.coerce.date({ message: "Invalid expiration date." }).nullable())
+    .nullable(),
+})
+
+async function getSupabaseClient(): Promise<SupabaseClient> {
+  const cookieStore = cookies()
+  return createClient(cookieStore)
+}
+
+async function getAuthenticatedProfile(client: SupabaseClient) {
+  const {
+    data: { user },
+    error: userError,
+  } = await client.auth.getUser()
+
+  if (userError) {
+    throw new Error(userError.message)
+  }
+
+  if (!user) {
+    throw new Error("You must be signed in to continue.")
+  }
+
+  const { data: profile, error: profileError } = await client
+    .from("profiles")
+    .select("*")
+    .eq("id", user.id)
+    .single()
+
+  if (profileError) {
+    throw new Error(profileError.message)
+  }
+
+  if (!profile) {
+    throw new Error("Profile could not be located for the active session.")
+  }
+
+  return { user, profile }
+}
+
+function ensureStaff(profile: ProfileRecord) {
+  if (!profile.role || !STAFF_ROLES.has(profile.role)) {
+    throw new Error("You do not have permission to manage lease documents.")
+  }
+}
+
+export async function getLeaseManagementData(): Promise<LeaseManagementSummary> {
+  const supabase = await getSupabaseClient()
+  const { profile } = await getAuthenticatedProfile(supabase)
+  ensureStaff(profile)
+
+  const { data, error } = await supabase
+    .from("leases")
+    .select(
+      `
+        id,
+        created_at,
+        updated_at,
+        tenant_profile_id,
+        label,
+        property_address,
+        start_date,
+        end_date,
+        status,
+        tenant:profiles(id, full_name, email),
+        lease_documents (
+          id,
+          created_at,
+          updated_at,
+          lease_id,
+          title,
+          version,
+          effective_date,
+          expiration_date,
+          storage_path
+        )
+      `
+    )
+    .order("label", { ascending: true })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const storage = supabase.storage.from(STORAGE_BUCKET_ID)
+
+  const leasesWithDocuments = await Promise.all(
+    (data ?? []).map(async (lease) => {
+      const docs = lease.lease_documents ?? []
+      const documentsWithUrls = await Promise.all(
+        docs.map(async (doc) => {
+          const { data: signedUrlData, error: signedUrlError } =
+            await storage.createSignedUrl(doc.storage_path, 60 * 60)
+
+          return {
+            ...doc,
+            signedUrl: signedUrlError ? null : signedUrlData?.signedUrl ?? null,
+          } satisfies AdminLeaseDocument
+        })
+      )
+
+      return {
+        ...lease,
+        lease_documents: documentsWithUrls,
+        tenant: lease.tenant ?? null,
+      }
+    })
+  )
+
+  return leasesWithDocuments
+}
+
+export async function getTenantLeaseDocuments(): Promise<TenantLeaseDocument[]> {
+  const supabase = await getSupabaseClient()
+  const { user } = await getAuthenticatedProfile(supabase)
+
+  const { data, error } = await supabase
+    .from("leases")
+    .select(
+      `
+        id,
+        label,
+        property_address,
+        start_date,
+        end_date,
+        status,
+        lease_documents (
+          id,
+          created_at,
+          updated_at,
+          lease_id,
+          title,
+          version,
+          effective_date,
+          expiration_date,
+          storage_path
+        )
+      `
+    )
+    .eq("tenant_profile_id", user.id)
+    .order("start_date", { ascending: false })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const leases = data ?? []
+  const storage = supabase.storage.from(STORAGE_BUCKET_ID)
+
+  const documents = await Promise.all(
+    leases.flatMap((lease) => {
+      const entries = lease.lease_documents ?? []
+
+      return entries.map(async (doc) => {
+        const { data: signedUrlData, error: signedUrlError } =
+          await storage.createSignedUrl(doc.storage_path, 60 * 60)
+
+        return {
+          id: doc.id,
+          leaseId: lease.id,
+          leaseLabel: lease.label,
+          propertyAddress: lease.property_address ?? null,
+          leaseStartDate: lease.start_date ?? null,
+          leaseEndDate: lease.end_date ?? null,
+          title: doc.title,
+          version: doc.version,
+          effectiveDate: doc.effective_date,
+          expirationDate: doc.expiration_date,
+          storagePath: doc.storage_path,
+          signedUrl: signedUrlError ? null : signedUrlData?.signedUrl ?? null,
+          updatedAt: doc.updated_at,
+          createdAt: doc.created_at,
+        } satisfies TenantLeaseDocument
+      })
+    })
+  )
+
+  return documents
+}
+
+export async function getLeaseDocumentDownloadUrl(documentId: string) {
+  const supabase = await getSupabaseClient()
+  await getAuthenticatedProfile(supabase)
+
+  const { data, error } = await supabase
+    .from("lease_documents")
+    .select("id, storage_path")
+    .eq("id", documentId)
+    .single()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!data) {
+    throw new Error("Document not found.")
+  }
+
+  const { data: signedUrlData, error: signedUrlError } = await supabase.storage
+    .from(STORAGE_BUCKET_ID)
+    .createSignedUrl(data.storage_path, 60 * 10)
+
+  if (signedUrlError) {
+    throw new Error(signedUrlError.message)
+  }
+
+  return signedUrlData?.signedUrl ?? null
+}
+
+export async function saveLeaseDocument(formData: FormData): Promise<ActionResult> {
+  const supabase = await getSupabaseClient()
+  const { profile } = await getAuthenticatedProfile(supabase)
+  ensureStaff(profile)
+
+  const rawFile = formData.get("file")
+  const file = rawFile instanceof File ? rawFile : null
+
+  const parseResult = leaseDocumentFormSchema.safeParse({
+    leaseId: formData.get("leaseId"),
+    documentId: formData.get("documentId") ?? undefined,
+    title: formData.get("title"),
+    version: formData.get("version"),
+    effectiveDate: formData.get("effectiveDate"),
+    expirationDate: formData.get("expirationDate"),
+  })
+
+  if (!parseResult.success) {
+    const message = parseResult.error.issues
+      .map((issue) => issue.message)
+      .join(" ")
+
+    return {
+      success: false,
+      message: null,
+      error: message || "Invalid lease document payload.",
+    }
+  }
+
+  const payload = parseResult.data
+
+  if (!payload.documentId && !file) {
+    return {
+      success: false,
+      message: null,
+      error: "A PDF must be provided for new lease documents.",
+    }
+  }
+
+  if (file) {
+    if (file.size === 0) {
+      return {
+        success: false,
+        message: null,
+        error: "The uploaded file is empty.",
+      }
+    }
+
+    const mimeType = file.type?.toLowerCase() ?? ""
+    if (mimeType !== "application/pdf" && !file.name.toLowerCase().endsWith(".pdf")) {
+      return {
+        success: false,
+        message: null,
+        error: "Only PDF documents can be uploaded.",
+      }
+    }
+  }
+
+  const effectiveDate = format(payload.effectiveDate, "yyyy-MM-dd")
+  const expirationDate = payload.expirationDate
+    ? format(payload.expirationDate, "yyyy-MM-dd")
+    : null
+
+  const documentId = payload.documentId ?? randomUUID()
+
+  const { data: existingDoc, error: fetchError } = await supabase
+    .from("lease_documents")
+    .select("*")
+    .eq("id", documentId)
+    .maybeSingle()
+
+  if (fetchError) {
+    return {
+      success: false,
+      message: null,
+      error: fetchError.message,
+    }
+  }
+
+  let storagePath = existingDoc?.storage_path ?? `${payload.leaseId}/${documentId}.pdf`
+
+  if (file) {
+    storagePath = existingDoc?.storage_path ?? `${payload.leaseId}/${documentId}.pdf`
+
+    const { error: uploadError } = await supabase.storage
+      .from(STORAGE_BUCKET_ID)
+      .upload(storagePath, file, {
+        cacheControl: "3600",
+        upsert: true,
+        contentType: "application/pdf",
+      })
+
+    if (uploadError) {
+      return {
+        success: false,
+        message: null,
+        error: uploadError.message,
+      }
+    }
+  }
+
+  const { error: upsertError } = await supabase
+    .from("lease_documents")
+    .upsert(
+      {
+        id: documentId,
+        lease_id: payload.leaseId,
+        title: payload.title,
+        version: payload.version,
+        effective_date: effectiveDate,
+        expiration_date: expirationDate,
+        storage_path: storagePath,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "id" }
+    )
+
+  if (upsertError) {
+    return {
+      success: false,
+      message: null,
+      error: upsertError.message,
+    }
+  }
+
+  revalidatePath("/dashboard/leases")
+  revalidatePath("/leases")
+
+  return {
+    success: true,
+    message: payload.documentId
+      ? "Lease document updated successfully."
+      : "Lease document uploaded successfully.",
+    error: null,
+  }
+}

--- a/app/dashboard/leases/page.tsx
+++ b/app/dashboard/leases/page.tsx
@@ -1,0 +1,299 @@
+import Link from "next/link"
+
+import { format } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+
+import {
+  getLeaseManagementData,
+  saveLeaseDocument,
+  type LeaseManagementSummary,
+} from "./actions"
+
+function formatDisplayDate(dateString: string | null): string {
+  if (!dateString) {
+    return "Not set"
+  }
+
+  const parsed = new Date(dateString)
+  if (Number.isNaN(parsed.getTime())) {
+    return dateString
+  }
+
+  return format(parsed, "PPP")
+}
+
+function isExpired(expirationDate: string | null): boolean {
+  if (!expirationDate) return false
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const expires = new Date(expirationDate)
+  expires.setHours(0, 0, 0, 0)
+  return expires < today
+}
+
+export default async function DashboardLeaseDocumentsPage() {
+  let leases: LeaseManagementSummary = []
+
+  try {
+    leases = await getLeaseManagementData()
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "You do not have access to the lease management area."
+
+    return (
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Lease documents</h1>
+          <p className="text-muted-foreground">
+            Property staff can upload agreements and distribute new versions from this
+            dashboard.
+          </p>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Access denied</CardTitle>
+            <CardDescription>{message}</CardDescription>
+          </CardHeader>
+          <CardFooter>
+            <Button asChild variant="outline">
+              <Link href="/">Return home</Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Lease documents</h1>
+        <p className="text-muted-foreground">
+          Upload resident agreements, track version history, and replace expiring files. Tenants can
+          download their latest agreements from the{" "}
+          <Link href="/leases" className="underline">
+            tenant lease portal
+          </Link>
+          .
+        </p>
+      </div>
+
+      <div className="grid gap-6">
+        {leases.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>No leases configured</CardTitle>
+              <CardDescription>
+                Create leases in Supabase and associate residents to begin managing documents.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        ) : (
+          leases.map((lease) => (
+            <Card key={lease.id}>
+              <CardHeader className="space-y-2">
+                <CardTitle className="flex flex-wrap items-center gap-2">
+                  <span>{lease.label}</span>
+                  <Badge variant="outline" className="uppercase tracking-wide">
+                    {lease.status ?? "active"}
+                  </Badge>
+                </CardTitle>
+                <CardDescription className="space-y-1">
+                  <div>
+                    Resident:{" "}
+                    {lease.tenant ? (
+                      <span className="font-medium">
+                        {lease.tenant.full_name ?? lease.tenant.email ?? "Unknown"}
+                      </span>
+                    ) : (
+                      <span className="font-medium">Unassigned</span>
+                    )}
+                    {lease.tenant?.email ? (
+                      <span className="text-muted-foreground"> · {lease.tenant.email}</span>
+                    ) : null}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {lease.property_address ? `${lease.property_address} · ` : ""}
+                    Starts {formatDisplayDate(lease.start_date)}
+                    {lease.end_date ? ` · Ends ${formatDisplayDate(lease.end_date)}` : ""}
+                  </div>
+                </CardDescription>
+              </CardHeader>
+
+              <CardContent className="space-y-8">
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+                      Current documents
+                    </h2>
+                  </div>
+
+                  {lease.lease_documents.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      No lease documents have been uploaded yet.
+                    </p>
+                  ) : (
+                    <div className="space-y-4">
+                      {lease.lease_documents.map((doc) => {
+                        const expired = isExpired(doc.expiration_date)
+
+                        return (
+                          <div key={doc.id} className="rounded-lg border p-4">
+                            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                              <div className="space-y-1">
+                                <p className="font-medium leading-tight">{doc.title}</p>
+                                <p className="text-sm text-muted-foreground">
+                                  Version {doc.version} · Effective {formatDisplayDate(doc.effective_date)}
+                                  {doc.expiration_date
+                                    ? ` · Expires ${formatDisplayDate(doc.expiration_date)}`
+                                    : ""}
+                                </p>
+                              </div>
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Badge variant={expired ? "destructive" : "secondary"}>
+                                  {expired ? "Expired" : "Active"}
+                                </Badge>
+                                {doc.signedUrl ? (
+                                  <Button asChild size="sm" variant="outline">
+                                    <a
+                                      href={doc.signedUrl}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                    >
+                                      Download
+                                    </a>
+                                  </Button>
+                                ) : null}
+                              </div>
+                            </div>
+
+                            <form
+                              action={saveLeaseDocument}
+                              encType="multipart/form-data"
+                              className="mt-4 grid gap-3 md:grid-cols-2"
+                            >
+                              <input type="hidden" name="leaseId" value={lease.id} />
+                              <input type="hidden" name="documentId" value={doc.id} />
+                              <label className="flex flex-col gap-1 text-sm">
+                                <span className="font-medium">Title</span>
+                                <Input
+                                  name="title"
+                                  defaultValue={doc.title}
+                                  required
+                                  placeholder="Resident lease agreement"
+                                />
+                              </label>
+
+                              <label className="flex flex-col gap-1 text-sm">
+                                <span className="font-medium">Version</span>
+                                <Input
+                                  name="version"
+                                  defaultValue={doc.version}
+                                  required
+                                  placeholder="v1.0"
+                                />
+                              </label>
+
+                              <label className="flex flex-col gap-1 text-sm">
+                                <span className="font-medium">Effective date</span>
+                                <Input
+                                  type="date"
+                                  name="effectiveDate"
+                                  defaultValue={doc.effective_date ?? undefined}
+                                  required
+                                />
+                              </label>
+
+                              <label className="flex flex-col gap-1 text-sm">
+                                <span className="font-medium">Expiration date</span>
+                                <Input
+                                  type="date"
+                                  name="expirationDate"
+                                  defaultValue={doc.expiration_date ?? undefined}
+                                />
+                              </label>
+
+                              <label className="flex flex-col gap-1 text-sm md:col-span-2">
+                                <span className="font-medium">Replace PDF (optional)</span>
+                                <Input type="file" name="file" accept="application/pdf" />
+                                <span className="text-xs text-muted-foreground">
+                                  Leave blank to keep the current file.
+                                </span>
+                              </label>
+
+                              <div className="md:col-span-2">
+                                <Button type="submit">Save changes</Button>
+                              </div>
+                            </form>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
+                </section>
+
+                <section className="space-y-3">
+                  <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+                    Upload a new version
+                  </h2>
+                  <form
+                    action={saveLeaseDocument}
+                    encType="multipart/form-data"
+                    className="grid gap-3 md:grid-cols-2"
+                  >
+                    <input type="hidden" name="leaseId" value={lease.id} />
+
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium">Title</span>
+                      <Input name="title" placeholder="Lease agreement" required />
+                    </label>
+
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium">Version</span>
+                      <Input name="version" placeholder="v2.0" required />
+                    </label>
+
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium">Effective date</span>
+                      <Input type="date" name="effectiveDate" required />
+                    </label>
+
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium">Expiration date</span>
+                      <Input type="date" name="expirationDate" />
+                    </label>
+
+                    <label className="flex flex-col gap-1 text-sm md:col-span-2">
+                      <span className="font-medium">PDF file</span>
+                      <Input type="file" name="file" accept="application/pdf" required />
+                      <span className="text-xs text-muted-foreground">
+                        Only PDF documents up to 10 MB are supported.
+                      </span>
+                    </label>
+
+                    <div className="flex items-center gap-2 md:col-span-2">
+                      <Button type="submit">Upload document</Button>
+                    </div>
+                  </form>
+                </section>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -11,15 +11,17 @@ interface MainNavProps {
 }
 
 export function MainNav({ items }: MainNavProps) {
+  const navItems = items?.length ? items : siteConfig.mainNav
+
   return (
-        <div className="mr-2 hidden gap-4 md:flex md:gap-8">
+    <div className="mr-2 hidden gap-4 md:flex md:gap-8">
       <Link href="/" className="flex items-center space-x-2">
         <Icons.logo className="size-6" />
         <span className="inline-block font-bold">{siteConfig.name}</span>
       </Link>
-      {items?.length ? (
+      {navItems.length ? (
         <nav className="flex gap-6">
-          {items?.map(
+          {navItems.map(
             (item, index) =>
               item.href && (
                 <Link

--- a/config/site.ts
+++ b/config/site.ts
@@ -15,8 +15,16 @@ export const siteConfig = {
       href: "/account",
     },
     {
+      title: "Leases",
+      href: "/leases",
+    },
+    {
       title: "Dashboard",
       href: "/dashboard",
+    },
+    {
+      title: "Lease Admin",
+      href: "/dashboard/leases",
     },
     {
       title: "OpenAI",

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -968,6 +968,94 @@ export type Database = {
         }
         Relationships: []
       }
+      lease_documents: {
+        Row: {
+          created_at: string
+          effective_date: string
+          expiration_date: string | null
+          id: string
+          lease_id: string
+          storage_path: string
+          title: string
+          updated_at: string
+          version: string
+        }
+        Insert: {
+          created_at?: string
+          effective_date: string
+          expiration_date?: string | null
+          id?: string
+          lease_id: string
+          storage_path: string
+          title: string
+          updated_at?: string
+          version?: string
+        }
+        Update: {
+          created_at?: string
+          effective_date?: string
+          expiration_date?: string | null
+          id?: string
+          lease_id?: string
+          storage_path?: string
+          title?: string
+          updated_at?: string
+          version?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lease_documents_lease_id_fkey"
+            columns: ["lease_id"]
+            isOneToOne: false
+            referencedRelation: "leases"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      leases: {
+        Row: {
+          created_at: string
+          end_date: string | null
+          id: string
+          label: string
+          property_address: string | null
+          start_date: string | null
+          status: string
+          tenant_profile_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          end_date?: string | null
+          id?: string
+          label: string
+          property_address?: string | null
+          start_date?: string | null
+          status?: string
+          tenant_profile_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          end_date?: string | null
+          id?: string
+          label?: string
+          property_address?: string | null
+          start_date?: string | null
+          status?: string
+          tenant_profile_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "leases_tenant_profile_id_fkey"
+            columns: ["tenant_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       meetings: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250524_add_lease_documents.sql
+++ b/supabase/migrations/20250524_add_lease_documents.sql
@@ -1,0 +1,267 @@
+-- Ensure UUID generation is available
+create extension if not exists "pgcrypto";
+
+-- Create leases table when it does not yet exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename = 'leases'
+  ) THEN
+    CREATE TABLE public.leases (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      tenant_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+      label text NOT NULL,
+      property_address text,
+      start_date date,
+      end_date date,
+      status text NOT NULL DEFAULT 'active',
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS leases_tenant_profile_idx
+  ON public.leases (tenant_profile_id);
+
+ALTER TABLE IF EXISTS public.leases
+  ENABLE ROW LEVEL SECURITY;
+
+-- Policies for leases
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'leases'
+      AND polname = 'lease_owner_select'
+  ) THEN
+    EXECUTE $$
+      CREATE POLICY "lease_owner_select"
+      ON public.leases
+      FOR SELECT
+      TO authenticated
+      USING (tenant_profile_id = auth.uid());
+    $$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'leases'
+      AND polname = 'lease_staff_manage'
+  ) THEN
+    EXECUTE $$
+      CREATE POLICY "lease_staff_manage"
+      ON public.leases
+      FOR ALL
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.role IN ('admin', 'staff')
+        )
+      )
+      WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.role IN ('admin', 'staff')
+        )
+      );
+    $$;
+  END IF;
+END
+$$;
+
+-- Create lease documents table
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename = 'lease_documents'
+  ) THEN
+    CREATE TABLE public.lease_documents (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      lease_id uuid NOT NULL REFERENCES public.leases(id) ON DELETE CASCADE,
+      title text NOT NULL,
+      version text NOT NULL DEFAULT 'v1',
+      storage_path text NOT NULL,
+      effective_date date NOT NULL,
+      expiration_date date,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+  END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS lease_documents_storage_path_idx
+  ON public.lease_documents (storage_path);
+
+CREATE UNIQUE INDEX IF NOT EXISTS lease_documents_lease_version_idx
+  ON public.lease_documents (lease_id, version);
+
+CREATE INDEX IF NOT EXISTS lease_documents_lease_id_idx
+  ON public.lease_documents (lease_id);
+
+ALTER TABLE public.lease_documents
+  ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies for lease documents
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'lease_documents'
+      AND polname = 'lease_documents_staff_manage'
+  ) THEN
+    EXECUTE $$
+      CREATE POLICY "lease_documents_staff_manage"
+      ON public.lease_documents
+      FOR ALL
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.role IN ('admin', 'staff')
+        )
+      )
+      WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.role IN ('admin', 'staff')
+        )
+      );
+    $$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'lease_documents'
+      AND polname = 'lease_documents_tenant_select'
+  ) THEN
+    EXECUTE $$
+      CREATE POLICY "lease_documents_tenant_select"
+      ON public.lease_documents
+      FOR SELECT
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.leases l
+          WHERE l.id = lease_documents.lease_id
+            AND l.tenant_profile_id = auth.uid()
+        )
+      );
+    $$;
+  END IF;
+END
+$$;
+
+-- Ensure private storage bucket exists for lease documents
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'lease-documents',
+  'lease-documents',
+  false,
+  10485760,
+  ARRAY['application/pdf']
+)
+ON CONFLICT (id) DO UPDATE
+SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- Storage policies for lease documents bucket
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND polname = 'lease_documents_staff_manage_bucket'
+  ) THEN
+    EXECUTE $$
+      CREATE POLICY "lease_documents_staff_manage_bucket"
+      ON storage.objects
+      FOR ALL
+      TO authenticated
+      USING (
+        bucket_id = 'lease-documents'
+        AND EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.role IN ('admin', 'staff')
+        )
+      )
+      WITH CHECK (
+        bucket_id = 'lease-documents'
+        AND EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.role IN ('admin', 'staff')
+        )
+      );
+    $$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND polname = 'lease_documents_tenant_access_bucket'
+  ) THEN
+    EXECUTE $$
+      CREATE POLICY "lease_documents_tenant_access_bucket"
+      ON storage.objects
+      FOR SELECT
+      TO authenticated
+      USING (
+        bucket_id = 'lease-documents'
+        AND (
+          EXISTS (
+            SELECT 1
+            FROM public.profiles p
+            WHERE p.id = auth.uid()
+              AND p.role IN ('admin', 'staff')
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM public.lease_documents ld
+            JOIN public.leases l
+              ON l.id = ld.lease_id
+            WHERE ld.storage_path = storage.objects.name
+              AND storage.objects.bucket_id = 'lease-documents'
+              AND l.tenant_profile_id = auth.uid()
+          )
+        )
+      );
+    $$;
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- add a migration that creates leases/lease_documents tables, row level security, and storage policies for lease PDFs
- extend Supabase typings and server actions so staff can upload or update lease documents and tenants receive signed download URLs
- build dashboard and tenant UIs for managing lease agreements and surface both in the main navigation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceea8d106c8328b9293741ceab7199