### PR TITLE
Add amenity reservations and management interfaces

### DIFF
--- a/app/(tenant)/amenities/actions.ts
+++ b/app/(tenant)/amenities/actions.ts
@@ -1,0 +1,222 @@
+'use server'
+
+import { addMinutes, isBefore, isPast, setHours, setMilliseconds, setMinutes, setSeconds, startOfDay } from 'date-fns'
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import type { Database } from '@/lib/supabase'
+import { createSupbaseServerClient } from '@/utils/supaone'
+
+const availabilitySchema = z.object({
+  amenityId: z.string().uuid(),
+  date: z.coerce.date(),
+  slotMinutes: z.number().int().positive().max(12 * 60).default(60),
+  openHour: z.number().int().min(0).max(23).default(8),
+  closeHour: z.number().int().min(1).max(24).default(22),
+})
+
+const reservationSchema = z.object({
+  amenityId: z.string().uuid(),
+  startTime: z.coerce.date(),
+  endTime: z.coerce.date(),
+})
+
+const catalogSchema = z
+  .object({
+    includeInactive: z.boolean().optional(),
+  })
+  .optional()
+
+type Amenity = Database['public']['Tables']['amenities']['Row']
+type AmenityReservation = Database['public']['Tables']['amenity_reservations']['Row']
+
+export async function fetchAmenityCatalog(params?: z.input<typeof catalogSchema>) {
+  const options = catalogSchema.parse(params)
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error('You must be signed in to view amenities.')
+  }
+
+  let query = supabase.from('amenities').select('*').order('name', { ascending: true })
+
+  if (!options?.includeInactive) {
+    query = query.eq('is_active', true)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    console.error('Failed to fetch amenities', error)
+    throw new Error('Unable to load amenities right now.')
+  }
+
+  return data as Amenity[]
+}
+
+export async function getAmenityAvailability(rawInput: z.input<typeof availabilitySchema>) {
+  const input = availabilitySchema.parse(rawInput)
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error('You must be signed in to view availability.')
+  }
+
+  const dayStart = startOfDay(input.date)
+  const bookingWindowStart = setHours(setMinutes(setSeconds(setMilliseconds(dayStart, 0), 0), 0), input.openHour)
+  const bookingWindowEnd = setHours(
+    setMinutes(setSeconds(setMilliseconds(dayStart, 0), 0), 0),
+    input.closeHour,
+  )
+
+  const activeStatuses = ['pending', 'approved'] as const
+
+  const { data: reservations, error } = await supabase
+    .from('amenity_reservations')
+    .select('id,start_time,end_time,status')
+    .eq('amenity_id', input.amenityId)
+    .in('status', activeStatuses)
+    .lt('start_time', bookingWindowEnd.toISOString())
+    .gt('end_time', bookingWindowStart.toISOString())
+
+  if (error) {
+    console.error('Failed to load reservations for availability', error)
+    throw new Error('Unable to compute availability for this amenity right now.')
+  }
+
+  const slots: { start: string; end: string }[] = []
+  let current = bookingWindowStart
+
+  while (isBefore(current, bookingWindowEnd)) {
+    const slotEnd = addMinutes(current, input.slotMinutes)
+
+    if (slotEnd > bookingWindowEnd) {
+      break
+    }
+
+    const overlaps = (reservations ?? []).some((reservation) => {
+      const reservationStart = new Date(reservation.start_time)
+      const reservationEnd = new Date(reservation.end_time)
+
+      return reservationStart < slotEnd && reservationEnd > current
+    })
+
+    const isSlotInPast = isPast(slotEnd)
+
+    if (!overlaps && !isSlotInPast) {
+      slots.push({ start: current.toISOString(), end: slotEnd.toISOString() })
+    }
+
+    current = addMinutes(current, input.slotMinutes)
+  }
+
+  return slots
+}
+
+interface ReservationResult {
+  success: boolean
+  message: string
+  error?: string
+}
+
+export async function createAmenityReservation(rawInput: z.input<typeof reservationSchema>): Promise<ReservationResult> {
+  const input = reservationSchema.parse(rawInput)
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { success: false, message: '', error: 'You must be signed in to reserve an amenity.' }
+  }
+
+  if (isBefore(input.endTime, input.startTime) || input.endTime.getTime() === input.startTime.getTime()) {
+    return { success: false, message: '', error: 'End time must be after the start time.' }
+  }
+
+  if (isPast(input.startTime)) {
+    return { success: false, message: '', error: 'You cannot reserve an amenity in the past.' }
+  }
+
+  const { data: amenity, error: amenityError } = await supabase
+    .from('amenities')
+    .select('id,is_active')
+    .eq('id', input.amenityId)
+    .maybeSingle()
+
+  if (amenityError) {
+    console.error('Failed to validate amenity before reservation', amenityError)
+    return { success: false, message: '', error: 'Unable to validate amenity. Please try again.' }
+  }
+
+  if (!amenity || !amenity.is_active) {
+    return { success: false, message: '', error: 'This amenity is not currently available for reservations.' }
+  }
+
+  const { data: conflictingReservations, error: conflictError } = await supabase
+    .from('amenity_reservations')
+    .select('id,start_time,end_time,status')
+    .eq('amenity_id', input.amenityId)
+    .in('status', ['pending', 'approved'])
+    .lt('start_time', input.endTime.toISOString())
+    .gt('end_time', input.startTime.toISOString())
+
+  if (conflictError) {
+    console.error('Failed to check reservation conflicts', conflictError)
+    return { success: false, message: '', error: 'Could not verify availability. Please try again.' }
+  }
+
+  if ((conflictingReservations ?? []).length > 0) {
+    return { success: false, message: '', error: 'That time slot has already been requested. Please choose another window.' }
+  }
+
+  const { error: insertError } = await supabase.from('amenity_reservations').insert({
+    amenity_id: input.amenityId,
+    lease_id: user.id,
+    start_time: input.startTime.toISOString(),
+    end_time: input.endTime.toISOString(),
+    status: 'pending',
+  })
+
+  if (insertError) {
+    console.error('Failed to create amenity reservation', insertError)
+    return { success: false, message: '', error: 'Unable to submit reservation. Please try again.' }
+  }
+
+  revalidatePath('/amenities')
+
+  return {
+    success: true,
+    message: 'Amenity reservation submitted for review.',
+  }
+}
+
+export async function fetchTenantReservations() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error('You must be signed in to view reservations.')
+  }
+
+  const { data, error } = await supabase
+    .from('amenity_reservations')
+    .select('id,amenity_id,start_time,end_time,status,amenities(name)')
+    .eq('lease_id', user.id)
+    .order('start_time', { ascending: true })
+
+  if (error) {
+    console.error('Failed to load tenant reservations', error)
+    throw new Error('Unable to load your reservations right now.')
+  }
+
+  return data as (AmenityReservation & { amenities: Pick<Amenity, 'name'> | null })[]
+}

--- a/app/(tenant)/amenities/components/amenity-booking.tsx
+++ b/app/(tenant)/amenities/components/amenity-booking.tsx
@@ -1,0 +1,319 @@
+'use client'
+
+import { useEffect, useMemo, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { format, parseISO } from 'date-fns'
+
+import type { Database } from '@/lib/supabase'
+import { getAmenityAvailability, createAmenityReservation } from '@/app/(tenant)/amenities/actions'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useToast } from '@/components/ui/use-toast'
+import { Badge } from '@/components/ui/badge'
+
+const DEFAULT_SLOT_LENGTH_MINUTES = 60
+const DEFAULT_OPEN_HOUR = 8
+const DEFAULT_CLOSE_HOUR = 22
+
+type Amenity = Database['public']['Tables']['amenities']['Row']
+type AmenityReservation = Database['public']['Tables']['amenity_reservations']['Row']
+
+type ReservationWithAmenity = AmenityReservation & {
+  amenities: Pick<Amenity, 'name'> | null
+}
+
+interface AmenityBookingProps {
+  amenities: Amenity[]
+  reservations: ReservationWithAmenity[]
+}
+
+export function AmenityBooking({ amenities, reservations }: AmenityBookingProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [selectedAmenityId, setSelectedAmenityId] = useState<string | undefined>(amenities[0]?.id)
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(() => {
+    if (amenities.length === 0) {
+      return undefined
+    }
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  })
+  const [selectedSlot, setSelectedSlot] = useState<string | undefined>(undefined)
+  const [availability, setAvailability] = useState<{ start: string; end: string }[]>([])
+  const [availabilityError, setAvailabilityError] = useState<string | null>(null)
+  const [isLoadingAvailability, startAvailabilityTransition] = useTransition()
+  const [isSubmitting, startReservationTransition] = useTransition()
+  const today = useMemo(() => {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  }, [])
+
+  const activeAmenity = useMemo(
+    () => amenities.find((amenity) => amenity.id === selectedAmenityId),
+    [amenities, selectedAmenityId],
+  )
+
+  useEffect(() => {
+    if (!selectedAmenityId || !selectedDate) {
+      return
+    }
+
+    setAvailability([])
+    setSelectedSlot(undefined)
+    setAvailabilityError(null)
+
+    startAvailabilityTransition(async () => {
+      try {
+        const slots = await getAmenityAvailability({
+          amenityId: selectedAmenityId,
+          date: selectedDate.toISOString(),
+          slotMinutes: DEFAULT_SLOT_LENGTH_MINUTES,
+          openHour: DEFAULT_OPEN_HOUR,
+          closeHour: DEFAULT_CLOSE_HOUR,
+        })
+        setAvailability(slots)
+      } catch (error) {
+        console.error('Failed to load amenity availability', error)
+        setAvailabilityError('Unable to load availability for that date. Please try again later.')
+      }
+    })
+  }, [selectedAmenityId, selectedDate])
+
+  const handleSlotSelection = (slot: string) => {
+    setSelectedSlot(slot)
+  }
+
+  const handleSubmit = async () => {
+    if (!selectedAmenityId || !selectedSlot) {
+      toast({
+        title: 'Select a time slot',
+        description: 'Choose a date and time before submitting your reservation.',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    const slot = availability.find((value) => value.start === selectedSlot)
+
+    if (!slot) {
+      toast({
+        title: 'Unknown time slot',
+        description: 'Please refresh availability and try again.',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    startReservationTransition(async () => {
+      const result = await createAmenityReservation({
+        amenityId: selectedAmenityId,
+        startTime: slot.start,
+        endTime: slot.end,
+      })
+
+      if (!result.success) {
+        toast({
+          title: 'Reservation not submitted',
+          description: result.error ?? 'Please try again.',
+          variant: 'destructive',
+        })
+        return
+      }
+
+      toast({
+        title: 'Reservation submitted',
+        description: result.message,
+      })
+
+      setSelectedSlot(undefined)
+      router.refresh()
+    })
+  }
+
+  const upcomingReservations = useMemo(
+    () =>
+      reservations.filter((reservation) => {
+        const end = parseISO(reservation.end_time)
+        return end.getTime() > Date.now()
+      }),
+    [reservations],
+  )
+
+  const statusBadgeVariant = (status: ReservationWithAmenity['status']) => {
+    switch (status) {
+      case 'approved':
+        return 'default' as const
+      case 'denied':
+        return 'destructive' as const
+      case 'cancelled':
+        return 'outline' as const
+      default:
+        return 'secondary' as const
+    }
+  }
+
+  const readableStatus = (status: ReservationWithAmenity['status']) =>
+    status.charAt(0).toUpperCase() + status.slice(1)
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+      <Card className="order-2 lg:order-1">
+        <CardHeader>
+          <CardTitle>Amenity reservations</CardTitle>
+          <CardDescription>
+            Choose an amenity, pick a date, then reserve an available time slot.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-2">
+            <label className="text-sm font-medium">Amenity</label>
+            <Select
+              value={selectedAmenityId}
+              onValueChange={(value) => {
+                setSelectedAmenityId(value)
+                setAvailability([])
+                setSelectedDate(today)
+              }}
+              disabled={amenities.length === 0}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select an amenity" />
+              </SelectTrigger>
+              <SelectContent>
+                {amenities.map((amenity) => (
+                  <SelectItem key={amenity.id} value={amenity.id}>
+                    {amenity.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {amenities.length === 0 ? (
+              <p className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+                Staff members have not published any bookable amenities yet.
+              </p>
+            ) : (
+              activeAmenity && (
+                <div className="rounded-md border bg-muted/30 p-4 text-sm">
+                  {activeAmenity.description && (
+                    <p className="mb-2 font-medium">{activeAmenity.description}</p>
+                  )}
+                  {activeAmenity.rules && (
+                    <div className="space-y-1 text-muted-foreground">
+                      {activeAmenity.rules
+                        .split('\n')
+                        .map((line) => line.trim())
+                        .filter(Boolean)
+                        .map((line, index) => (
+                          <p key={`${line}-${index}`}>&bull; {line}</p>
+                        ))}
+                    </div>
+                  )}
+                </div>
+              )
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            <label className="text-sm font-medium">Select a date</label>
+            {amenities.length === 0 ? (
+              <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                Add amenities in the dashboard to enable bookings.
+              </div>
+            ) : (
+              <Calendar
+                selected={selectedDate}
+                onSelect={(value) => setSelectedDate(value ?? undefined)}
+                mode="single"
+                disabled={{ before: today }}
+                className="rounded-md border"
+              />
+            )}
+          </div>
+
+          <div className="grid gap-3">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">Available time slots</label>
+              {selectedDate && (
+                <span className="text-xs text-muted-foreground">
+                  {format(selectedDate, 'PPP')}
+                </span>
+              )}
+            </div>
+            {availabilityError && (
+              <p className="text-sm text-destructive">{availabilityError}</p>
+            )}
+            <div className="flex flex-wrap gap-2">
+              {isLoadingAvailability ? (
+                <p className="text-sm text-muted-foreground">Loading availability…</p>
+              ) : availability.length > 0 ? (
+                availability.map((slot) => {
+                  const label = `${format(parseISO(slot.start), 'p')} – ${format(parseISO(slot.end), 'p')}`
+                  return (
+                    <Button
+                      key={slot.start}
+                      type="button"
+                      variant={selectedSlot === slot.start ? 'default' : 'outline'}
+                      onClick={() => handleSlotSelection(slot.start)}
+                    >
+                      {label}
+                    </Button>
+                  )
+                })
+              ) : selectedDate ? (
+                <p className="text-sm text-muted-foreground">No open slots for this date.</p>
+              ) : (
+                <p className="text-sm text-muted-foreground">Select a date to view availability.</p>
+              )}
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button onClick={handleSubmit} disabled={isSubmitting || !selectedSlot || amenities.length === 0}>
+            {isSubmitting ? 'Submitting…' : 'Request reservation'}
+          </Button>
+        </CardFooter>
+      </Card>
+
+      <Card className="order-1 lg:order-2">
+        <CardHeader>
+          <CardTitle>Your upcoming reservations</CardTitle>
+          <CardDescription>Track pending and approved reservations at a glance.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {upcomingReservations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No upcoming reservations yet.</p>
+          ) : (
+            <ScrollArea className="h-72 pr-4">
+              <div className="space-y-4">
+                {upcomingReservations.map((reservation) => (
+                  <div key={reservation.id} className="rounded-md border p-4">
+                    <div className="flex items-center justify-between">
+                      <p className="font-medium">
+                        {reservation.amenities?.name ?? 'Amenity'}
+                      </p>
+                      <Badge variant={statusBadgeVariant(reservation.status)}>
+                        {readableStatus(reservation.status)}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {format(parseISO(reservation.start_time), 'PPP p')} – {format(parseISO(reservation.end_time), 'p')}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/(tenant)/amenities/page.tsx
+++ b/app/(tenant)/amenities/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation'
+
+import { AmenityBooking } from '@/app/(tenant)/amenities/components/amenity-booking'
+import { fetchAmenityCatalog, fetchTenantReservations } from '@/app/(tenant)/amenities/actions'
+import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+
+export default async function TenantAmenitiesPage() {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth')
+  }
+
+  const [amenities, reservations] = await Promise.all([
+    fetchAmenityCatalog(),
+    fetchTenantReservations(),
+  ])
+
+  return (
+    <div className="container space-y-6 py-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Book a community amenity</h1>
+        <p className="text-muted-foreground">
+          Browse available amenities, review any house rules, and send a reservation request for the time slot that
+          works best for you.
+        </p>
+      </div>
+      <AmenityBooking amenities={amenities} reservations={reservations} />
+    </div>
+  )
+}

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next"
 import Image from "next/image"
+import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -144,7 +145,7 @@ export default function DashboardPage() {
                 <Card>
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                     <CardTitle className="text-sm font-medium">
-                      Active Now
+                      Amenity requests
                     </CardTitle>
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -156,14 +157,18 @@ export default function DashboardPage() {
                       strokeWidth="2"
                       className="size-4 text-muted-foreground"
                     >
-                      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+                      <path d="M8 2v4M16 2v4M3 9h18M5 9v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9" />
+                      <path d="M10 13h4" />
                     </svg>
                   </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">+573</div>
+                  <CardContent className="space-y-2">
+                    <div className="text-2xl font-bold">Review queue</div>
                     <p className="text-xs text-muted-foreground">
-                      +201 since last hour
+                      Approve or deny shared space reservations from residents.
                     </p>
+                    <Button asChild size="sm" variant="outline" className="mt-2">
+                      <Link href="/dashboard/amenities">Open amenity desk</Link>
+                    </Button>
                   </CardContent>
                 </Card>
               </div>

--- a/app/dashboard/amenities/actions.ts
+++ b/app/dashboard/amenities/actions.ts
@@ -1,0 +1,193 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import { createSupbaseServerClient } from '@/utils/supaone'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+
+interface ActionResult {
+  success: boolean
+  message?: string
+  error?: string
+}
+
+const amenityFormSchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().trim().min(1, { message: 'Amenity name is required.' }),
+  description: z.string().trim().max(1000).optional(),
+  rules: z.string().trim().max(2000).optional(),
+  isActive: z.string().optional(),
+})
+
+const reservationStatusSchema = z.object({
+  reservationId: z.string().uuid(),
+  status: z.enum(['pending', 'approved', 'denied', 'cancelled']),
+})
+
+async function ensureStaffAccess(supabase: TypedSupabaseClient, userId: string | undefined) {
+  if (!userId) {
+    return false
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', userId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('Failed to verify staff permissions', error)
+    return false
+  }
+
+  return data?.role === 'admin' || data?.role === 'staff'
+}
+
+function normalizeAmenityPayload(values: z.infer<typeof amenityFormSchema>) {
+  return {
+    id: values.id,
+    name: values.name,
+    description: values.description && values.description.length > 0 ? values.description : null,
+    rules: values.rules && values.rules.length > 0 ? values.rules : null,
+    is_active:
+      values.isActive === undefined
+        ? true
+        : ['true', 'on', '1', 'yes'].includes(values.isActive.toLowerCase()),
+  }
+}
+
+export async function createAmenityAction(_prevState: ActionResult, formData: FormData): Promise<ActionResult> {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { success: false, error: 'You must be signed in to manage amenities.' }
+  }
+
+  if (!(await ensureStaffAccess(supabase, user.id))) {
+    return { success: false, error: 'Only staff members can manage amenities.' }
+  }
+
+  const parsed = amenityFormSchema.safeParse({
+    name: formData.get('name'),
+    description: formData.get('description') ?? undefined,
+    rules: formData.get('rules') ?? undefined,
+    isActive: formData.get('is_active')?.toString(),
+  })
+
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.errors.map((issue) => issue.message).join(' ') }
+  }
+
+  const payload = normalizeAmenityPayload(parsed.data)
+
+  const { error } = await supabase.from('amenities').insert({
+    name: payload.name,
+    description: payload.description,
+    rules: payload.rules,
+    is_active: payload.is_active,
+  })
+
+  if (error) {
+    console.error('Failed to create amenity', error)
+    return { success: false, error: 'Unable to create amenity. Please try again.' }
+  }
+
+  revalidatePath('/dashboard/amenities')
+  return { success: true, message: 'Amenity created successfully.' }
+}
+
+export async function updateAmenityAction(_prevState: ActionResult, formData: FormData): Promise<ActionResult> {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { success: false, error: 'You must be signed in to manage amenities.' }
+  }
+
+  if (!(await ensureStaffAccess(supabase, user.id))) {
+    return { success: false, error: 'Only staff members can manage amenities.' }
+  }
+
+  const parsed = amenityFormSchema.safeParse({
+    id: formData.get('id') ?? undefined,
+    name: formData.get('name'),
+    description: formData.get('description') ?? undefined,
+    rules: formData.get('rules') ?? undefined,
+    isActive: formData.get('is_active')?.toString(),
+  })
+
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.errors.map((issue) => issue.message).join(' ') }
+  }
+
+  const payload = normalizeAmenityPayload(parsed.data)
+
+  if (!payload.id) {
+    return { success: false, error: 'Amenity ID is required to update a record.' }
+  }
+
+  const { error } = await supabase
+    .from('amenities')
+    .update({
+      name: payload.name,
+      description: payload.description,
+      rules: payload.rules,
+      is_active: payload.is_active,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', payload.id)
+
+  if (error) {
+    console.error('Failed to update amenity', error)
+    return { success: false, error: 'Unable to update amenity. Please try again.' }
+  }
+
+  revalidatePath('/dashboard/amenities')
+  return { success: true, message: 'Amenity updated successfully.' }
+}
+
+export async function updateReservationStatusAction(
+  _prevState: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { success: false, error: 'You must be signed in to manage reservations.' }
+  }
+
+  if (!(await ensureStaffAccess(supabase, user.id))) {
+    return { success: false, error: 'Only staff members can manage reservations.' }
+  }
+
+  const parsed = reservationStatusSchema.safeParse({
+    reservationId: formData.get('reservation_id'),
+    status: formData.get('status'),
+  })
+
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.errors.map((issue) => issue.message).join(' ') }
+  }
+
+  const { error } = await supabase
+    .from('amenity_reservations')
+    .update({ status: parsed.data.status, updated_at: new Date().toISOString() })
+    .eq('id', parsed.data.reservationId)
+
+  if (error) {
+    console.error('Failed to update reservation status', error)
+    return { success: false, error: 'Unable to update reservation status. Please try again.' }
+  }
+
+  revalidatePath('/dashboard/amenities')
+  return { success: true, message: 'Reservation updated successfully.' }
+}

--- a/app/dashboard/amenities/components/amenity-card.tsx
+++ b/app/dashboard/amenities/components/amenity-card.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useFormState, useFormStatus } from 'react-dom'
+
+import { updateAmenityAction } from '@/app/dashboard/amenities/actions'
+import type { Database } from '@/lib/supabase'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+
+const initialState = { success: false, message: '', error: '' }
+
+type Amenity = Database['public']['Tables']['amenities']['Row']
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" variant="secondary" disabled={pending}>
+      {pending ? 'Saving…' : 'Save changes'}
+    </Button>
+  )
+}
+
+interface AmenityCardProps {
+  amenity: Amenity
+}
+
+export function AmenityCard({ amenity }: AmenityCardProps) {
+  const [state, formAction] = useFormState(updateAmenityAction, initialState)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{amenity.name}</CardTitle>
+        <CardDescription>Manage description, rules, and visibility.</CardDescription>
+      </CardHeader>
+      <form action={formAction} className="space-y-4">
+        <input type="hidden" name="id" value={amenity.id} />
+        <CardContent className="space-y-4">
+          <div className="grid gap-2">
+            <label htmlFor={`name-${amenity.id}`} className="text-sm font-medium">
+              Name
+            </label>
+            <Input id={`name-${amenity.id}`} name="name" defaultValue={amenity.name} required />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor={`description-${amenity.id}`} className="text-sm font-medium">
+              Description
+            </label>
+            <Textarea
+              id={`description-${amenity.id}`}
+              name="description"
+              defaultValue={amenity.description ?? ''}
+              rows={3}
+            />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor={`rules-${amenity.id}`} className="text-sm font-medium">
+              Usage rules
+            </label>
+            <Textarea id={`rules-${amenity.id}`} name="rules" defaultValue={amenity.rules ?? ''} rows={4} />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor={`is_active-${amenity.id}`} className="text-sm font-medium">
+              Availability
+            </label>
+            <select
+              id={`is_active-${amenity.id}`}
+              name="is_active"
+              defaultValue={amenity.is_active ? 'true' : 'false'}
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+            >
+              <option value="true">Visible to tenants</option>
+              <option value="false">Hidden from tenant portal</option>
+            </select>
+          </div>
+          {state.error && <p className="text-sm text-destructive">{state.error}</p>}
+          {state.success && state.message && <p className="text-sm text-green-600">{state.message}</p>}
+        </CardContent>
+        <CardFooter className="justify-end">
+          <SubmitButton />
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/app/dashboard/amenities/components/create-amenity-form.tsx
+++ b/app/dashboard/amenities/components/create-amenity-form.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useFormState, useFormStatus } from 'react-dom'
+
+import { createAmenityAction } from '@/app/dashboard/amenities/actions'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+
+const initialState = { success: false, message: '', error: '' }
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? 'Creating…' : 'Create amenity'}
+    </Button>
+  )
+}
+
+export function CreateAmenityForm() {
+  const [state, formAction] = useFormState(createAmenityAction, initialState)
+  const formRef = useRef<HTMLFormElement | null>(null)
+
+  useEffect(() => {
+    if (state.success) {
+      formRef.current?.reset()
+    }
+  }, [state.success])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Add a new amenity</CardTitle>
+        <CardDescription>Provide details and optional house rules for tenants.</CardDescription>
+      </CardHeader>
+      <form ref={formRef} action={formAction} className="space-y-4">
+        <CardContent className="space-y-4">
+          <div className="grid gap-2">
+            <label htmlFor="name" className="text-sm font-medium">
+              Name
+            </label>
+            <Input id="name" name="name" required placeholder="Gym, co-working room, rooftop grill…" />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="description" className="text-sm font-medium">
+              Description
+            </label>
+            <Textarea id="description" name="description" rows={3} placeholder="Brief overview shown to tenants." />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="rules" className="text-sm font-medium">
+              Usage rules (one per line)
+            </label>
+            <Textarea id="rules" name="rules" rows={4} placeholder={'Wipe down equipment after use\nReturn key within 15 minutes'} />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="is_active" className="text-sm font-medium">
+              Availability
+            </label>
+            <select
+              id="is_active"
+              name="is_active"
+              defaultValue="true"
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+            >
+              <option value="true">Visible to tenants</option>
+              <option value="false">Hidden from tenant portal</option>
+            </select>
+          </div>
+          {state.error && <p className="text-sm text-destructive">{state.error}</p>}
+          {state.success && state.message && <p className="text-sm text-green-600">{state.message}</p>}
+        </CardContent>
+        <CardFooter>
+          <SubmitButton />
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/app/dashboard/amenities/components/reservation-list.tsx
+++ b/app/dashboard/amenities/components/reservation-list.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useFormState, useFormStatus } from 'react-dom'
+import { format, parseISO } from 'date-fns'
+
+import { updateReservationStatusAction } from '@/app/dashboard/amenities/actions'
+import type { Database } from '@/lib/supabase'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+type Reservation = Database['public']['Tables']['amenity_reservations']['Row']
+
+type ReservationWithRelations = Reservation & {
+  amenities: { name: string } | null
+  lease: { full_name: string | null; email: string | null } | null
+}
+
+const initialState = { success: false, message: '', error: '' }
+
+const statusOptions: Reservation['status'][] = ['pending', 'approved', 'denied', 'cancelled']
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" size="sm" disabled={pending}>
+      {pending ? 'Updating…' : 'Update'}
+    </Button>
+  )
+}
+
+function StatusBadge({ status }: { status: Reservation['status'] }) {
+  switch (status) {
+    case 'approved':
+      return <Badge>Approved</Badge>
+    case 'denied':
+      return <Badge variant="destructive">Denied</Badge>
+    case 'cancelled':
+      return <Badge variant="outline">Cancelled</Badge>
+    default:
+      return <Badge variant="secondary">Pending</Badge>
+  }
+}
+
+function ReservationItem({ reservation }: { reservation: ReservationWithRelations }) {
+  const [state, formAction] = useFormState(updateReservationStatusAction, initialState)
+
+  return (
+    <div className="space-y-3 rounded-md border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="font-medium">{reservation.amenities?.name ?? 'Amenity'}</p>
+          <p className="text-sm text-muted-foreground">
+            {format(parseISO(reservation.start_time), 'PPP p')} – {format(parseISO(reservation.end_time), 'p')}
+          </p>
+        </div>
+        <StatusBadge status={reservation.status} />
+      </div>
+      <div className="grid gap-1 text-sm text-muted-foreground">
+        <span>
+          Tenant: {reservation.lease?.full_name ?? 'Unknown'}
+          {reservation.lease?.email ? ` • ${reservation.lease.email}` : ''}
+        </span>
+      </div>
+      <form action={formAction} className="flex flex-wrap items-center gap-2">
+        <input type="hidden" name="reservation_id" value={reservation.id} />
+        <label htmlFor={`status-${reservation.id}`} className="text-sm font-medium">
+          Status
+        </label>
+        <select
+          id={`status-${reservation.id}`}
+          name="status"
+          defaultValue={reservation.status}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+        >
+          {statusOptions.map((status) => (
+            <option key={status} value={status}>
+              {status.charAt(0).toUpperCase() + status.slice(1)}
+            </option>
+          ))}
+        </select>
+        <SubmitButton />
+        {state.error && <p className="text-sm text-destructive">{state.error}</p>}
+        {state.success && state.message && <p className="text-sm text-green-600">{state.message}</p>}
+      </form>
+    </div>
+  )
+}
+
+interface ReservationListProps {
+  reservations: ReservationWithRelations[]
+}
+
+export function ReservationList({ reservations }: ReservationListProps) {
+  const pendingReservations = useMemo(
+    () => reservations.filter((reservation) => reservation.status === 'pending'),
+    [reservations],
+  )
+
+  const otherReservations = useMemo(
+    () => reservations.filter((reservation) => reservation.status !== 'pending'),
+    [reservations],
+  )
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle>Pending approvals</CardTitle>
+          <CardDescription>Approve or deny new requests.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {pendingReservations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No pending requests.</p>
+          ) : (
+            <div className="space-y-4">
+              {pendingReservations.map((reservation) => (
+                <ReservationItem key={reservation.id} reservation={reservation} />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle>All reservations</CardTitle>
+          <CardDescription>Review the latest activity across amenities.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {otherReservations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No historical reservations yet.</p>
+          ) : (
+            <ScrollArea className="h-[28rem] pr-4">
+              <div className="space-y-4">
+                {otherReservations.map((reservation) => (
+                  <ReservationItem key={reservation.id} reservation={reservation} />
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/amenities/page.tsx
+++ b/app/dashboard/amenities/page.tsx
@@ -1,0 +1,80 @@
+import { redirect } from 'next/navigation'
+
+import { CreateAmenityForm } from '@/app/dashboard/amenities/components/create-amenity-form'
+import { AmenityCard } from '@/app/dashboard/amenities/components/amenity-card'
+import { ReservationList } from '@/app/dashboard/amenities/components/reservation-list'
+import type { Database } from '@/lib/supabase'
+import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+
+type Amenity = Database['public']['Tables']['amenities']['Row']
+type ReservationWithRelations = Database['public']['Tables']['amenity_reservations']['Row'] & {
+  amenities: { name: string } | null
+  lease: { full_name: string | null; email: string | null } | null
+}
+
+export default async function AmenitiesAdminPage() {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role, full_name')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (!profile || !['admin', 'staff'].includes(profile.role ?? '')) {
+    redirect('/dashboard')
+  }
+
+  const { data: amenities, error: amenitiesError } = await supabase
+    .from('amenities')
+    .select('*')
+    .order('name', { ascending: true })
+
+  if (amenitiesError) {
+    console.error('Failed to load amenities for dashboard', amenitiesError)
+  }
+
+  const { data: reservations, error: reservationsError } = await supabase
+    .from('amenity_reservations')
+    .select('id, amenity_id, start_time, end_time, status, amenities(name), lease:profiles(full_name, email)')
+    .order('start_time', { ascending: false })
+
+  if (reservationsError) {
+    console.error('Failed to load amenity reservations', reservationsError)
+  }
+
+  const amenityList = (amenities ?? []) as Amenity[]
+  const reservationList = (reservations ?? []) as ReservationWithRelations[]
+
+  return (
+    <div className="space-y-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Amenity management</h1>
+        <p className="text-muted-foreground">
+          Publish shared resources, maintain policies, and process tenant reservation requests from one place.
+        </p>
+      </div>
+
+      <CreateAmenityForm />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {amenityList.length === 0 ? (
+          <p className="rounded-md border border-dashed p-6 text-sm text-muted-foreground lg:col-span-2">
+            No amenities configured yet. Use the form above to add your first resource.
+          </p>
+        ) : (
+          amenityList.map((amenity) => <AmenityCard key={amenity.id} amenity={amenity} />)
+        )}
+      </div>
+
+      <ReservationList reservations={reservationList} />
+    </div>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, CalendarIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,16 +8,21 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/amenities",
+                        text: "Amenities",
+                        Icon: CalendarIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
 		},
 	];
 

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -11,11 +11,15 @@ export const docsConfig: DocsConfig = {
       title: "Home",
       href: "/",
     },
-    { 
+    {
       title: "Account",
       href: "/account",
     },
-    { 
+    {
+      title: "Amenities",
+      href: "/amenities",
+    },
+    {
       title: "Dashboard",
       href: "/dashboard",
     },

--- a/config/site.ts
+++ b/config/site.ts
@@ -15,6 +15,10 @@ export const siteConfig = {
       href: "/account",
     },
     {
+      title: "Amenities",
+      href: "/amenities",
+    },
+    {
       title: "Dashboard",
       href: "/dashboard",
     },

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -183,6 +183,84 @@ export type Database = {
   }
   public: {
     Tables: {
+      amenities: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: string
+          is_active: boolean
+          name: string
+          rules: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          is_active?: boolean | null
+          name: string
+          rules?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          is_active?: boolean | null
+          name?: string
+          rules?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      amenity_reservations: {
+        Row: {
+          amenity_id: string
+          created_at: string
+          end_time: string
+          id: string
+          lease_id: string
+          start_time: string
+          status: "approved" | "cancelled" | "denied" | "pending"
+          updated_at: string
+        }
+        Insert: {
+          amenity_id: string
+          created_at?: string | null
+          end_time: string
+          id?: string
+          lease_id: string
+          start_time: string
+          status?: "approved" | "cancelled" | "denied" | "pending"
+          updated_at?: string | null
+        }
+        Update: {
+          amenity_id?: string
+          created_at?: string | null
+          end_time?: string
+          id?: string
+          lease_id?: string
+          start_time?: string
+          status?: "approved" | "cancelled" | "denied" | "pending"
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "amenity_reservations_amenity_id_fkey"
+            columns: ["amenity_id"]
+            isOneToOne: false
+            referencedRelation: "amenities"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "amenity_reservations_lease_id_fkey"
+            columns: ["lease_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       ai_agents: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250507_amenities.sql
+++ b/supabase/migrations/20250507_amenities.sql
@@ -1,0 +1,108 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA public;
+CREATE EXTENSION IF NOT EXISTS "btree_gist" WITH SCHEMA public;
+
+CREATE TABLE public.amenities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  name text NOT NULL UNIQUE,
+  description text,
+  rules text,
+  is_active boolean NOT NULL DEFAULT true
+);
+
+ALTER TABLE public.amenities ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE public.amenity_reservations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  amenity_id uuid NOT NULL REFERENCES public.amenities(id) ON DELETE CASCADE,
+  lease_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  start_time timestamptz NOT NULL,
+  end_time timestamptz NOT NULL,
+  status text NOT NULL DEFAULT 'pending'::text,
+  CONSTRAINT amenity_reservations_status_check CHECK (status IN ('pending', 'approved', 'denied', 'cancelled')),
+  CONSTRAINT amenity_reservations_time_check CHECK (start_time < end_time)
+);
+
+ALTER TABLE public.amenity_reservations ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX amenity_reservations_amenity_start_idx ON public.amenity_reservations (amenity_id, start_time);
+CREATE INDEX amenity_reservations_lease_idx ON public.amenity_reservations (lease_id, start_time);
+
+CREATE UNIQUE INDEX amenity_reservations_no_overlap
+ON public.amenity_reservations
+USING gist (
+  amenity_id,
+  tstzrange(start_time, end_time, '[)')
+)
+WHERE status IN ('pending', 'approved');
+
+CREATE POLICY "Authenticated users can view amenities" ON public.amenities
+FOR SELECT
+TO authenticated
+USING (true);
+
+CREATE POLICY "Staff can manage amenities" ON public.amenities
+FOR ALL
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role IN ('admin', 'staff')
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role IN ('admin', 'staff')
+  )
+);
+
+CREATE POLICY "Tenants can view own reservations" ON public.amenity_reservations
+FOR SELECT
+TO authenticated
+USING (lease_id = auth.uid());
+
+CREATE POLICY "Tenants can manage own reservations" ON public.amenity_reservations
+FOR INSERT
+TO authenticated
+WITH CHECK (lease_id = auth.uid());
+
+CREATE POLICY "Tenants can update own reservations" ON public.amenity_reservations
+FOR UPDATE
+TO authenticated
+USING (lease_id = auth.uid())
+WITH CHECK (lease_id = auth.uid());
+
+CREATE POLICY "Tenants can delete own reservations" ON public.amenity_reservations
+FOR DELETE
+TO authenticated
+USING (lease_id = auth.uid());
+
+CREATE POLICY "Staff can view all reservations" ON public.amenity_reservations
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role IN ('admin', 'staff')
+  )
+);
+
+CREATE POLICY "Staff can manage reservations" ON public.amenity_reservations
+FOR ALL
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role IN ('admin', 'staff')
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role IN ('admin', 'staff')
+  )
+);


### PR DESCRIPTION
## Summary
- add database schema for amenities and amenity_reservations with RLS, indexes, and conflict protection
- refresh Supabase typings and implement tenant-facing amenity booking actions and UI
- deliver staff management actions/pages plus navigation updates and dashboard entry point

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceea8f24e88328b5d78e6271d8c817