### PR TITLE
feat: add shared space diagrams management

### DIFF
--- a/app/(tenant)/shared-spaces/actions.ts
+++ b/app/(tenant)/shared-spaces/actions.ts
@@ -1,0 +1,54 @@
+"use server"
+
+import { cache } from "react"
+
+import { mapRowToDiagram, type SharedSpaceDiagram } from "@/lib/shared-space-maps"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+const SIGNED_URL_TTL_SECONDS = 60 * 60 // 1 hour
+
+export const getTenantSharedSpaceMaps = cache(async (): Promise<SharedSpaceDiagram[]> => {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from("shared_space_maps")
+    .select("*")
+    .eq("tenant_id", user.id)
+    .order("updated_at", { ascending: false })
+
+  if (error) {
+    console.error("Failed to load shared space maps", error)
+    throw new Error("Unable to load shared space diagrams")
+  }
+
+  if (!data) {
+    return []
+  }
+
+  const diagrams = await Promise.all(
+    data.map(async (row) => {
+      const { data: signed, error: signedError } = await supabase.storage
+        .from(row.bucket_id)
+        .createSignedUrl(row.file_path, SIGNED_URL_TTL_SECONDS)
+
+      if (signedError) {
+        console.warn("Could not create signed URL for shared space map", {
+          file_path: row.file_path,
+          error: signedError.message,
+        })
+      }
+
+      const signedUrl = signed?.signedUrl ?? null
+      return mapRowToDiagram(row, signedUrl)
+    })
+  )
+
+  return diagrams
+})

--- a/app/(tenant)/shared-spaces/components/diagram-card.tsx
+++ b/app/(tenant)/shared-spaces/components/diagram-card.tsx
@@ -1,0 +1,282 @@
+"use client"
+
+import { useMemo, useRef, useState } from "react"
+import Image from "next/image"
+import { CalendarClock, RefreshCcw, ZoomIn, ZoomOut } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+
+import type { RoomLabel, SharedSpaceDiagram } from "@/lib/shared-space-maps"
+
+const MIN_SCALE = 0.6
+const MAX_SCALE = 3
+const ZOOM_STEP = 0.2
+const PAN_LIMIT = 800
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown"
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}
+
+type DiagramCardProps = {
+  diagram: SharedSpaceDiagram
+}
+
+export function DiagramCard({ diagram }: DiagramCardProps) {
+  const [scale, setScale] = useState(1)
+  const [offset, setOffset] = useState({ x: 0, y: 0 })
+  const [isPanning, setIsPanning] = useState(false)
+  const originRef = useRef<{ x: number; y: number } | null>(null)
+  const canvasRef = useRef<HTMLDivElement | null>(null)
+
+  const labelCount = diagram.roomLabels.length
+  const metadataEntries = useMemo(() => {
+    return Object.entries(diagram.metadata ?? {})
+      .filter(([key]) => !["room_labels", "labels"].includes(key))
+      .map(([key, value]) => {
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+          return [key, String(value)] as const
+        }
+        try {
+          return [key, JSON.stringify(value, null, 0)] as const
+        } catch (error) {
+          console.warn("Unable to stringify metadata value", { key, error })
+          return [key, ""] as const
+        }
+      })
+      .filter(([, value]) => value.length > 0)
+  }, [diagram.metadata])
+
+  const handleZoomIn = () => {
+    setScale((previous) => clamp(previous + ZOOM_STEP, MIN_SCALE, MAX_SCALE))
+  }
+
+  const handleZoomOut = () => {
+    setScale((previous) => clamp(previous - ZOOM_STEP, MIN_SCALE, MAX_SCALE))
+  }
+
+  const handleReset = () => {
+    setScale(1)
+    setOffset({ x: 0, y: 0 })
+  }
+
+  const handleWheel: React.WheelEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault()
+    const delta = event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP
+    setScale((previous) => clamp(previous + delta, MIN_SCALE, MAX_SCALE))
+  }
+
+  const handlePointerDown: React.PointerEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault()
+    originRef.current = { x: event.clientX, y: event.clientY }
+    setIsPanning(true)
+    canvasRef.current?.setPointerCapture(event.pointerId)
+  }
+
+  const handlePointerMove: React.PointerEventHandler<HTMLDivElement> = (event) => {
+    if (!isPanning || !originRef.current) {
+      return
+    }
+
+    const deltaX = event.clientX - originRef.current.x
+    const deltaY = event.clientY - originRef.current.y
+    originRef.current = { x: event.clientX, y: event.clientY }
+
+    setOffset((previous) => ({
+      x: clamp(previous.x + deltaX, -PAN_LIMIT, PAN_LIMIT),
+      y: clamp(previous.y + deltaY, -PAN_LIMIT, PAN_LIMIT),
+    }))
+  }
+
+  const finishPan = (event: React.PointerEvent<HTMLDivElement>) => {
+    originRef.current = null
+    setIsPanning(false)
+    try {
+      canvasRef.current?.releasePointerCapture(event.pointerId)
+    } catch (error) {
+      // Safari may throw when pointer capture is not active
+    }
+  }
+
+  const handlePointerUp: React.PointerEventHandler<HTMLDivElement> = (event) => {
+    finishPan(event)
+  }
+
+  const handlePointerLeave: React.PointerEventHandler<HTMLDivElement> = (event) => {
+    if (isPanning) {
+      finishPan(event)
+    }
+  }
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-lg font-semibold">{diagram.title}</CardTitle>
+            <CardDescription>
+              Lease {diagram.leaseId}
+              {diagram.unitId ? ` • Unit ${diagram.unitId}` : null}
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleZoomOut}
+              aria-label="Zoom out"
+            >
+              <ZoomOut className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleReset}
+              aria-label="Reset view"
+            >
+              <RefreshCcw className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleZoomIn}
+              aria-label="Zoom in"
+            >
+              <ZoomIn className="size-4" />
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <CalendarClock className="size-4" aria-hidden />
+            Last updated {formatDate(diagram.diagramUpdatedAt)}
+          </span>
+          <Badge variant="outline">{labelCount} labels</Badge>
+        </div>
+        {diagram.description ? (
+          <p className="text-sm text-muted-foreground">{diagram.description}</p>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="relative h-[420px] w-full overflow-hidden rounded-md border bg-muted">
+          <div
+            ref={canvasRef}
+            className={cn(
+              "absolute inset-0 cursor-grab select-none",
+              isPanning && "cursor-grabbing"
+            )}
+            style={{
+              transform: `translate3d(${offset.x}px, ${offset.y}px, 0) scale(${scale})`,
+              transformOrigin: "center center",
+            }}
+            onWheel={handleWheel}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerLeave={handlePointerLeave}
+          >
+            {diagram.signedUrl ? (
+              <Image
+                src={diagram.signedUrl}
+                alt={diagram.title}
+                fill
+                unoptimized
+                sizes="(max-width: 768px) 100vw, 800px"
+                priority={false}
+                draggable={false}
+                className="object-contain"
+              />
+            ) : (
+              <div className="flex size-full items-center justify-center bg-background text-sm text-muted-foreground">
+                Diagram not available
+              </div>
+            )}
+            {diagram.roomLabels.map((label) => (
+              <RoomLabelMarker key={label.id} label={label} />
+            ))}
+          </div>
+        </div>
+        {metadataEntries.length > 0 ? (
+          <div className="space-y-2 text-sm">
+            <h3 className="text-sm font-semibold">Diagram metadata</h3>
+            <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {metadataEntries.map(([key, value]) => (
+                <div key={key} className="rounded-md border bg-background p-2">
+                  <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {key.replace(/_/g, " ")}
+                  </dt>
+                  <dd className="mt-1 break-words text-sm leading-snug">{value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        ) : null}
+      </CardContent>
+      <CardFooter className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span>
+          Storage object: <code>{diagram.bucketId}/{diagram.filePath}</code>
+        </span>
+        <span>Scale: {scale.toFixed(2)}×</span>
+      </CardFooter>
+    </Card>
+  )
+}
+
+type RoomLabelMarkerProps = {
+  label: RoomLabel
+}
+
+function RoomLabelMarker({ label }: RoomLabelMarkerProps) {
+  return (
+    <HoverCard openDelay={100} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-background bg-primary px-2 py-1 text-xs font-medium text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          style={{
+            left: `${label.x * 100}%`,
+            top: `${label.y * 100}%`,
+          }}
+        >
+          {label.title}
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent className="text-sm">
+        <p className="font-medium">{label.title}</p>
+        {label.description ? <p className="mt-1 text-sm text-muted-foreground">{label.description}</p> : null}
+        {label.data && Object.keys(label.data).length > 0 ? (
+          <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+            {Object.entries(label.data).map(([key, value]) => (
+              <div key={key} className="flex items-center justify-between gap-4">
+                <span className="font-medium">{key}</span>
+                <span>{String(value)}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </HoverCardContent>
+    </HoverCard>
+  )
+}

--- a/app/(tenant)/shared-spaces/components/diagram-grid.tsx
+++ b/app/(tenant)/shared-spaces/components/diagram-grid.tsx
@@ -1,0 +1,38 @@
+import { DiagramCard } from "./diagram-card"
+import type { SharedSpaceDiagramGroup } from "@/lib/shared-space-maps"
+
+export function DiagramGrid({ groups }: { groups: SharedSpaceDiagramGroup[] }) {
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed bg-muted/40 p-12 text-center">
+        <h2 className="text-lg font-semibold">No shared space diagrams yet</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Your property manager hasn&apos;t published any shared area diagrams for your lease. Check
+          back soon or reach out to your community team for an update.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-10">
+      {groups.map((group) => (
+        <section key={group.leaseId} className="space-y-4">
+          <header className="space-y-1">
+            <h2 className="text-xl font-semibold">Lease {group.leaseId}</h2>
+            <p className="text-sm text-muted-foreground">
+              {group.diagrams.length === 1
+                ? `1 shared space diagram`
+                : `${group.diagrams.length} shared space diagrams`}
+            </p>
+          </header>
+          <div className="grid gap-6 md:grid-cols-2">
+            {group.diagrams.map((diagram) => (
+              <DiagramCard key={diagram.id} diagram={diagram} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/app/(tenant)/shared-spaces/page.tsx
+++ b/app/(tenant)/shared-spaces/page.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation"
+
+import { readUserSession } from "@/utils/actions"
+
+import { getTenantSharedSpaceMaps } from "./actions"
+import { groupSharedSpaceMapsByLease } from "@/lib/shared-space-maps"
+import { DiagramGrid } from "./components/diagram-grid"
+
+export const dynamic = "force-dynamic"
+
+export default async function SharedSpacesPage() {
+  const { data } = await readUserSession()
+
+  if (!data.session) {
+    redirect("/auth")
+  }
+
+  const diagrams = await getTenantSharedSpaceMaps()
+  const grouped = groupSharedSpaceMapsByLease(diagrams)
+
+  return (
+    <div className="container mx-auto space-y-10 py-10">
+      <header className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-widest text-primary">Shared community areas</p>
+        <h1 className="text-3xl font-bold tracking-tight">Shared space diagrams</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          Review updated floor plans, amenity guides, and shared area diagrams that are specific to your lease
+          and unit. Use the interactive overlays to locate rooms, resources, and safety information before your
+          next visit.
+        </p>
+      </header>
+      <DiagramGrid groups={grouped} />
+    </div>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, DrawingPinIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,16 +8,21 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/shared-spaces",
+                        text: "Shared Spaces",
+                        Icon: DrawingPinIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
 		},
 	];
 

--- a/app/dashboard/shared-spaces/actions.ts
+++ b/app/dashboard/shared-spaces/actions.ts
@@ -1,0 +1,501 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { Buffer } from "node:buffer"
+import { randomUUID } from "node:crypto"
+import { extname } from "node:path"
+import { z } from "zod"
+
+import {
+  mapRowToDiagram,
+  type SharedSpaceDiagram,
+} from "@/lib/shared-space-maps"
+import { createSupbaseServerClient } from "@/utils/supaone"
+import type {
+  SharedSpaceMapInsert,
+  SharedSpaceMapRow,
+  SharedSpaceMapUpdate,
+  TypedSupabaseClient,
+} from "@/utils/typed-supabase-client"
+
+const DEFAULT_BUCKET_ID = "shared-space-maps"
+const SIGNED_URL_TTL_SECONDS = 60 * 60
+
+const createFieldsSchema = z.object({
+  tenantId: z.string().min(1, "Tenant ID is required"),
+  leaseId: z.string().min(1, "Lease ID is required"),
+  unitId: z.string().optional(),
+  title: z.string().min(1, "Title is required"),
+  description: z.string().optional(),
+  bucketId: z.string().min(1).optional(),
+  diagramUpdatedAt: z.string().optional(),
+})
+
+const roomLabelSchema = z.object({
+  id: z.string().optional(),
+  key: z.string().optional(),
+  slug: z.string().optional(),
+  identifier: z.string().optional(),
+  title: z.string().optional(),
+  label: z.string().optional(),
+  name: z.string().optional(),
+  text: z.string().optional(),
+  description: z.string().optional().or(z.null()).optional(),
+  tooltip: z.string().optional().or(z.null()).optional(),
+  note: z.string().optional().or(z.null()).optional(),
+  x: z.number().min(0).max(1).optional(),
+  y: z.number().min(0).max(1).optional(),
+  position: z
+    .object({
+      x: z.number().min(0).max(1).optional(),
+      y: z.number().min(0).max(1).optional(),
+    })
+    .optional(),
+  data: z.record(z.any()).optional(),
+  metadata: z.record(z.any()).optional(),
+})
+
+const roomLabelsSchema = z.array(roomLabelSchema)
+const metadataSchema = z.record(z.any())
+
+export type SharedSpaceActionResult =
+  | { status: "success"; message: string }
+  | { status: "error"; message: string }
+
+async function requireAdminClient() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError) {
+    throw new Error(authError.message)
+  }
+
+  if (!user) {
+    throw new Error("Authentication required")
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw new Error(profileError.message)
+  }
+
+  if (!profile || (profile.role ?? "user") !== "admin") {
+    throw new Error("Admin access required to manage shared spaces")
+  }
+
+  return { supabase, userId: user.id }
+}
+
+function parseJsonField<T>(
+  value: FormDataEntryValue | null,
+  schema: z.Schema<T>,
+  fallback: T,
+  context: string
+): { ok: true; value: T } | { ok: false; message: string } {
+  if (value === null || value === undefined) {
+    return { ok: true, value: fallback }
+  }
+
+  if (typeof value !== "string") {
+    return { ok: false, message: `${context} must be valid JSON` }
+  }
+
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return { ok: true, value: fallback }
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    const validated = schema.parse(parsed)
+    return { ok: true, value: validated }
+  } catch (error) {
+    return { ok: false, message: `${context} must be valid JSON` }
+  }
+}
+
+function parseDiagramUpdatedAt(
+  value: string | null | undefined
+): { ok: true; value?: string } | { ok: false; message: string } {
+  if (!value) {
+    return { ok: true, value: undefined }
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return { ok: true, value: undefined }
+  }
+
+  const parsed = new Date(trimmed)
+  if (Number.isNaN(parsed.getTime())) {
+    return { ok: false, message: "Diagram timestamp must be a valid date" }
+  }
+
+  return { ok: true, value: parsed.toISOString() }
+}
+
+function buildFilePath(tenantId: string, leaseId: string, fileName: string) {
+  const extension = extname(fileName)
+  const base = fileName.slice(0, fileName.length - extension.length)
+  const normalizedBase = base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  const unique = randomUUID()
+  const safeBase = normalizedBase.length > 0 ? normalizedBase : "diagram"
+  return `${tenantId}/${leaseId}/${unique}-${safeBase}${extension}`
+}
+
+async function fetchSharedSpaceMapById(supabase: TypedSupabaseClient, id: string) {
+  const { data, error } = await supabase
+    .from("shared_space_maps")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!data) {
+    throw new Error("Shared space map not found")
+  }
+
+  return data
+}
+
+async function createSignedUrlForRow(supabase: TypedSupabaseClient, row: SharedSpaceMapRow) {
+  const { data: signed, error } = await supabase.storage
+    .from(row.bucket_id)
+    .createSignedUrl(row.file_path, SIGNED_URL_TTL_SECONDS)
+
+  if (error) {
+    console.warn("Unable to generate signed URL for shared space map", {
+      id: row.id,
+      error: error.message,
+    })
+  }
+
+  return signed?.signedUrl ?? null
+}
+
+export async function getSharedSpaceMapsForAdmin(): Promise<SharedSpaceDiagram[]> {
+  const { supabase } = await requireAdminClient()
+
+  const { data, error } = await supabase
+    .from("shared_space_maps")
+    .select("*")
+    .order("updated_at", { ascending: false })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!data) {
+    return []
+  }
+
+  const diagrams = await Promise.all(
+    data.map(async (row) => {
+      const signedUrl = await createSignedUrlForRow(supabase, row)
+      return mapRowToDiagram(row, signedUrl)
+    })
+  )
+
+  return diagrams
+}
+
+export async function createSharedSpaceMap(
+  formData: FormData
+): Promise<SharedSpaceActionResult> {
+  try {
+    const { supabase } = await requireAdminClient()
+
+    const parsed = createFieldsSchema.parse({
+      tenantId: formData.get("tenantId"),
+      leaseId: formData.get("leaseId"),
+      unitId: formData.get("unitId"),
+      title: formData.get("title"),
+      description: formData.get("description"),
+      bucketId: formData.get("bucketId"),
+      diagramUpdatedAt: formData.get("diagramUpdatedAt"),
+    })
+
+    const metadataResult = parseJsonField(formData.get("metadata"), metadataSchema, {}, "Metadata")
+    if (!metadataResult.ok) {
+      return { status: "error", message: metadataResult.message }
+    }
+
+    const roomLabelsResult = parseJsonField(
+      formData.get("roomLabels"),
+      roomLabelsSchema,
+      [],
+      "Room labels"
+    )
+    if (!roomLabelsResult.ok) {
+      return { status: "error", message: roomLabelsResult.message }
+    }
+
+    const timestampResult = parseDiagramUpdatedAt(parsed.diagramUpdatedAt ?? null)
+    if (!timestampResult.ok) {
+      return { status: "error", message: timestampResult.message }
+    }
+
+    const file = formData.get("file") as File | null
+    if (!file || file.size === 0) {
+      return { status: "error", message: "Please upload a diagram file" }
+    }
+
+    const bucketId = parsed.bucketId ?? DEFAULT_BUCKET_ID
+    const filePath = buildFilePath(parsed.tenantId, parsed.leaseId, file.name)
+
+    const arrayBuffer = await file.arrayBuffer()
+    const uploadResult = await supabase.storage
+      .from(bucketId)
+      .upload(filePath, Buffer.from(arrayBuffer), {
+        upsert: true,
+        contentType: file.type || "application/octet-stream",
+      })
+
+    if (uploadResult.error) {
+      return { status: "error", message: uploadResult.error.message }
+    }
+
+    const payload: SharedSpaceMapInsert = {
+      tenant_id: parsed.tenantId,
+      lease_id: parsed.leaseId,
+      unit_id: parsed.unitId?.length ? parsed.unitId : null,
+      title: parsed.title,
+      description: parsed.description?.trim() ? parsed.description.trim() : null,
+      bucket_id: bucketId,
+      file_path: filePath,
+      metadata: metadataResult.value,
+      room_labels: roomLabelsResult.value,
+      diagram_updated_at: timestampResult.value ?? undefined,
+    }
+
+    const { error } = await supabase.from("shared_space_maps").insert(payload)
+    if (error) {
+      return { status: "error", message: error.message }
+    }
+
+    await Promise.all([
+      revalidatePath("/dashboard/shared-spaces"),
+      revalidatePath("/shared-spaces"),
+    ])
+
+    return { status: "success", message: "Shared space diagram created" }
+  } catch (error) {
+    console.error("createSharedSpaceMap", error)
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : "Unable to create shared space diagram",
+    }
+  }
+}
+
+export async function updateSharedSpaceMap(
+  formData: FormData
+): Promise<SharedSpaceActionResult> {
+  try {
+    const { supabase } = await requireAdminClient()
+
+    const id = formData.get("id")
+    if (typeof id !== "string" || id.trim().length === 0) {
+      return { status: "error", message: "Diagram identifier is required" }
+    }
+
+    const existing = await fetchSharedSpaceMapById(supabase, id)
+
+    const metadataResult = parseJsonField(
+      formData.get("metadata"),
+      metadataSchema,
+      (existing.metadata as Record<string, unknown> | null) ?? {},
+      "Metadata"
+    )
+    if (!metadataResult.ok) {
+      return { status: "error", message: metadataResult.message }
+    }
+
+    const roomLabelsResult = parseJsonField(
+      formData.get("roomLabels"),
+      roomLabelsSchema,
+      Array.isArray(existing.room_labels) ? (existing.room_labels as unknown[]) : [],
+      "Room labels"
+    )
+    if (!roomLabelsResult.ok) {
+      return { status: "error", message: roomLabelsResult.message }
+    }
+
+    const diagramUpdatedAtInput = formData.get("diagramUpdatedAt")
+    const timestampResult = parseDiagramUpdatedAt(
+      typeof diagramUpdatedAtInput === "string" ? diagramUpdatedAtInput : null
+    )
+    if (!timestampResult.ok) {
+      return { status: "error", message: timestampResult.message }
+    }
+
+    const updates: SharedSpaceMapUpdate = {}
+
+    const tenantId = formData.get("tenantId")
+    if (typeof tenantId === "string" && tenantId.trim().length > 0 && tenantId !== existing.tenant_id) {
+      updates.tenant_id = tenantId.trim()
+    }
+
+    const leaseId = formData.get("leaseId")
+    if (typeof leaseId === "string" && leaseId.trim().length > 0 && leaseId !== existing.lease_id) {
+      updates.lease_id = leaseId.trim()
+    }
+
+    if (formData.has("unitId")) {
+      const unitId = formData.get("unitId")
+      if (typeof unitId === "string" && unitId.trim().length > 0) {
+        updates.unit_id = unitId.trim()
+      } else {
+        updates.unit_id = null
+      }
+    }
+
+    if (formData.has("title")) {
+      const title = formData.get("title")
+      if (typeof title === "string" && title.trim().length > 0) {
+        updates.title = title.trim()
+      }
+    }
+
+    if (formData.has("description")) {
+      const description = formData.get("description")
+      if (typeof description === "string" && description.trim().length > 0) {
+        updates.description = description.trim()
+      } else {
+        updates.description = null
+      }
+    }
+
+    updates.metadata = metadataResult.value
+    updates.room_labels = roomLabelsResult.value
+
+    if (timestampResult.value) {
+      updates.diagram_updated_at = timestampResult.value
+    }
+
+    const bucketIdInput = formData.get("bucketId")
+    const bucketOverride =
+      typeof bucketIdInput === "string" && bucketIdInput.trim().length > 0
+        ? bucketIdInput.trim()
+        : null
+
+    const file = formData.get("file") as File | null
+    if (bucketOverride && (!file || file.size === 0)) {
+      return {
+        status: "error",
+        message: "Upload a new file when changing storage buckets",
+      }
+    }
+
+    let filePath = existing.file_path
+    let bucketId = bucketOverride ?? existing.bucket_id
+
+    if (file && file.size > 0) {
+      bucketId = bucketOverride ?? existing.bucket_id ?? DEFAULT_BUCKET_ID
+      filePath = buildFilePath(updates.tenant_id ?? existing.tenant_id, updates.lease_id ?? existing.lease_id, file.name)
+
+      const arrayBuffer = await file.arrayBuffer()
+      const uploadResult = await supabase.storage
+        .from(bucketId)
+        .upload(filePath, Buffer.from(arrayBuffer), {
+          upsert: true,
+          contentType: file.type || "application/octet-stream",
+        })
+
+      if (uploadResult.error) {
+        return { status: "error", message: uploadResult.error.message }
+      }
+
+      updates.file_path = filePath
+      updates.bucket_id = bucketId
+
+      if (timestampResult.value === undefined) {
+        updates.diagram_updated_at = new Date().toISOString()
+      }
+
+      await supabase.storage
+        .from(existing.bucket_id)
+        .remove([existing.file_path])
+        .catch((error) => {
+          console.warn("Unable to remove previous diagram", { id, error })
+        })
+    } else if (bucketOverride) {
+      updates.bucket_id = bucketOverride
+    }
+
+    const { error } = await supabase.from("shared_space_maps").update(updates).eq("id", id)
+    if (error) {
+      return { status: "error", message: error.message }
+    }
+
+    await Promise.all([
+      revalidatePath("/dashboard/shared-spaces"),
+      revalidatePath("/shared-spaces"),
+    ])
+
+    return { status: "success", message: "Shared space diagram updated" }
+  } catch (error) {
+    console.error("updateSharedSpaceMap", error)
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : "Unable to update shared space diagram",
+    }
+  }
+}
+
+export async function deleteSharedSpaceMap(
+  formData: FormData
+): Promise<SharedSpaceActionResult> {
+  try {
+    const { supabase } = await requireAdminClient()
+
+    const id = formData.get("id")
+    if (typeof id !== "string" || id.trim().length === 0) {
+      return { status: "error", message: "Diagram identifier is required" }
+    }
+
+    const existing = await fetchSharedSpaceMapById(supabase, id)
+
+    const { error } = await supabase.from("shared_space_maps").delete().eq("id", id)
+    if (error) {
+      return { status: "error", message: error.message }
+    }
+
+    await supabase.storage
+      .from(existing.bucket_id)
+      .remove([existing.file_path])
+      .catch((storageError) => {
+        console.warn("Unable to remove shared space diagram from storage", {
+          id,
+          error: storageError,
+        })
+      })
+
+    await Promise.all([
+      revalidatePath("/dashboard/shared-spaces"),
+      revalidatePath("/shared-spaces"),
+    ])
+
+    return { status: "success", message: "Shared space diagram deleted" }
+  } catch (error) {
+    console.error("deleteSharedSpaceMap", error)
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : "Unable to delete shared space diagram",
+    }
+  }
+}

--- a/app/dashboard/shared-spaces/components/create-form.tsx
+++ b/app/dashboard/shared-spaces/components/create-form.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useEffect, useRef, type ReactNode } from "react"
+import { useFormState, useFormStatus } from "react-dom"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+import {
+  createSharedSpaceMap,
+  type SharedSpaceActionResult,
+} from "../actions"
+
+const initialState: SharedSpaceActionResult | { status: "idle" } = { status: "idle" }
+
+type FormState = SharedSpaceActionResult | { status: "idle" }
+
+async function createSharedSpaceMapAction(_: FormState, formData: FormData) {
+  return createSharedSpaceMap(formData)
+}
+
+function SubmitButton({ children }: { children: ReactNode }) {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" disabled={pending} aria-disabled={pending}>
+      {pending ? "Uploading…" : children}
+    </Button>
+  )
+}
+
+export function CreateDiagramForm() {
+  const formRef = useRef<HTMLFormElement | null>(null)
+  const [state, action] = useFormState(createSharedSpaceMapAction, initialState)
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset()
+    }
+  }, [state])
+
+  return (
+    <form
+      ref={formRef}
+      action={action}
+      encType="multipart/form-data"
+      className="grid gap-4 rounded-lg border bg-card p-6 shadow-sm"
+    >
+      <div>
+        <h2 className="text-lg font-semibold">Upload new diagram</h2>
+        <p className="text-sm text-muted-foreground">
+          Provide tenant and lease identifiers, upload a diagram file, and optionally include metadata to
+          power overlay labels in the tenant portal.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-2">
+          <Label htmlFor="tenantId">Tenant ID</Label>
+          <Input id="tenantId" name="tenantId" placeholder="uuid" required />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="leaseId">Lease ID</Label>
+          <Input id="leaseId" name="leaseId" placeholder="Lease identifier" required />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="unitId">Unit ID (optional)</Label>
+          <Input id="unitId" name="unitId" placeholder="Unit identifier" />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="title">Diagram title</Label>
+          <Input id="title" name="title" placeholder="Shared kitchen layout" required />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="bucketId">Storage bucket (optional)</Label>
+          <Input id="bucketId" name="bucketId" placeholder="shared-space-maps" />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="diagramUpdatedAt">Diagram last updated</Label>
+          <Input id="diagramUpdatedAt" name="diagramUpdatedAt" type="datetime-local" />
+        </div>
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="description">Description</Label>
+        <Textarea
+          id="description"
+          name="description"
+          placeholder="Short context for teammates"
+          rows={2}
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="metadata">Metadata JSON</Label>
+        <Textarea
+          id="metadata"
+          name="metadata"
+          placeholder='{"notes":"Include recycling bins","access":"Residents only"}'
+          rows={3}
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="roomLabels">Room labels JSON</Label>
+        <Textarea
+          id="roomLabels"
+          name="roomLabels"
+          placeholder='[{"title":"Kitchen","x":0.32,"y":0.58}]'
+          rows={3}
+        />
+        <p className="text-xs text-muted-foreground">
+          Provide an array of label objects with normalized <code>x</code> and <code>y</code> coordinates between 0
+          and 1. Optional keys such as <code>description</code> and nested metadata are supported.
+        </p>
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="file">Diagram file</Label>
+        <Input id="file" name="file" type="file" accept="image/*,application/pdf" required />
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <SubmitButton>Upload diagram</SubmitButton>
+        {state.status !== "idle" ? (
+          <p
+            className={cn(
+              "text-sm",
+              state.status === "error" ? "text-destructive" : "text-muted-foreground"
+            )}
+          >
+            {state.message}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  )
+}

--- a/app/dashboard/shared-spaces/components/diagram-manager.tsx
+++ b/app/dashboard/shared-spaces/components/diagram-manager.tsx
@@ -1,0 +1,346 @@
+"use client"
+
+import { useEffect, useMemo, useRef, type ReactNode } from "react"
+import Image from "next/image"
+import { CalendarClock, Save, Trash2 } from "lucide-react"
+import { useFormState, useFormStatus } from "react-dom"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+import type { SharedSpaceDiagram } from "@/lib/shared-space-maps"
+import {
+  deleteSharedSpaceMap,
+  updateSharedSpaceMap,
+  type SharedSpaceActionResult,
+} from "../actions"
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown"
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}
+
+function toDateInput(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return ""
+  }
+  const iso = date.toISOString()
+  return iso.slice(0, 16)
+}
+
+type FormState = SharedSpaceActionResult | { status: "idle" }
+
+const initialState: FormState = { status: "idle" }
+
+type DiagramManagerListProps = {
+  diagrams: SharedSpaceDiagram[]
+}
+
+export function DiagramManagerList({ diagrams }: DiagramManagerListProps) {
+  const sorted = useMemo(
+    () => [...diagrams].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    [diagrams]
+  )
+
+  if (sorted.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed bg-muted/40 p-12 text-center">
+        <h2 className="text-lg font-semibold">No shared space diagrams</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Upload a diagram to make it available to tenants and maintain an interactive overlay.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {sorted.map((diagram) => (
+        <DiagramManagerCard key={diagram.id} diagram={diagram} />
+      ))}
+    </div>
+  )
+}
+
+function DiagramManagerCard({ diagram }: { diagram: SharedSpaceDiagram }) {
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold">{diagram.title}</h3>
+          <p className="text-sm text-muted-foreground">
+            Lease {diagram.leaseId}
+            {diagram.unitId ? ` • Unit ${diagram.unitId}` : null}
+          </p>
+          <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+            <CalendarClock className="size-4" aria-hidden /> Updated {formatDate(diagram.updatedAt)}
+          </p>
+        </div>
+        <Badge variant="outline">{diagram.roomLabels.length} labels</Badge>
+      </div>
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,320px)]">
+        <UpdateDiagramForm diagram={diagram} />
+        <DiagramDetailsPanel diagram={diagram} />
+      </div>
+    </div>
+  )
+}
+
+function UpdateDiagramForm({ diagram }: { diagram: SharedSpaceDiagram }) {
+  const [state, formAction] = useFormState(updateAction, initialState)
+  const formRef = useRef<HTMLFormElement | null>(null)
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset()
+    }
+  }, [state])
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      encType="multipart/form-data"
+      className="grid gap-4"
+    >
+      <input type="hidden" name="id" value={diagram.id} />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-2">
+          <Label htmlFor={`tenant-${diagram.id}`}>Tenant ID</Label>
+          <Input
+            id={`tenant-${diagram.id}`}
+            name="tenantId"
+            defaultValue={diagram.tenantId}
+            placeholder="uuid"
+            required
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={`lease-${diagram.id}`}>Lease ID</Label>
+          <Input
+            id={`lease-${diagram.id}`}
+            name="leaseId"
+            defaultValue={diagram.leaseId}
+            required
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={`unit-${diagram.id}`}>Unit ID</Label>
+          <Input id={`unit-${diagram.id}`} name="unitId" defaultValue={diagram.unitId ?? ""} />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={`title-${diagram.id}`}>Title</Label>
+          <Input id={`title-${diagram.id}`} name="title" defaultValue={diagram.title} required />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={`bucket-${diagram.id}`}>Bucket</Label>
+          <Input id={`bucket-${diagram.id}`} name="bucketId" placeholder="shared-space-maps" />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={`diagram-updated-${diagram.id}`}>Diagram last updated</Label>
+          <Input
+            id={`diagram-updated-${diagram.id}`}
+            name="diagramUpdatedAt"
+            type="datetime-local"
+            defaultValue={toDateInput(diagram.diagramUpdatedAt)}
+          />
+        </div>
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor={`description-${diagram.id}`}>Description</Label>
+        <Textarea
+          id={`description-${diagram.id}`}
+          name="description"
+          defaultValue={diagram.description ?? ""}
+          rows={2}
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor={`metadata-${diagram.id}`}>Metadata JSON</Label>
+        <Textarea
+          id={`metadata-${diagram.id}`}
+          name="metadata"
+          defaultValue={prettyPrint(diagram.metadata)}
+          rows={3}
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor={`labels-${diagram.id}`}>Room labels JSON</Label>
+        <Textarea
+          id={`labels-${diagram.id}`}
+          name="roomLabels"
+          defaultValue={prettyPrint(diagram.roomLabels)}
+          rows={3}
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor={`file-${diagram.id}`}>Replace file</Label>
+        <Input id={`file-${diagram.id}`} name="file" type="file" accept="image/*,application/pdf" />
+        <p className="text-xs text-muted-foreground">
+          Uploading a new file will generate a fresh signed URL and update the diagram timestamp if not specified.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <SubmitButton icon={<Save className="size-4" aria-hidden />} pendingText="Saving…">
+          Save changes
+        </SubmitButton>
+        {state.status !== "idle" ? (
+          <p
+            className={cn(
+              "text-sm",
+              state.status === "error" ? "text-destructive" : "text-muted-foreground"
+            )}
+          >
+            {state.message}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  )
+}
+
+function DiagramDetailsPanel({ diagram }: { diagram: SharedSpaceDiagram }) {
+  return (
+    <div className="space-y-4">
+      <div className="relative h-48 w-full overflow-hidden rounded-md border bg-muted">
+        {diagram.signedUrl ? (
+          <Image
+            src={diagram.signedUrl}
+            alt={diagram.title}
+            fill
+            unoptimized
+            sizes="(max-width: 1024px) 100vw, 360px"
+            className="object-contain"
+          />
+        ) : (
+          <div className="flex size-full items-center justify-center text-sm text-muted-foreground">
+            No preview available
+          </div>
+        )}
+      </div>
+      <dl className="space-y-2 text-sm">
+        <div>
+          <dt className="font-medium text-muted-foreground">Storage object</dt>
+          <dd className="truncate">
+            <code>{diagram.bucketId}/{diagram.filePath}</code>
+          </dd>
+        </div>
+        <div>
+          <dt className="font-medium text-muted-foreground">Diagram updated</dt>
+          <dd>{formatDate(diagram.diagramUpdatedAt)}</dd>
+        </div>
+        {Object.entries(diagram.metadata).length > 0 ? (
+          <div>
+            <dt className="font-medium text-muted-foreground">Metadata summary</dt>
+            <dd className="mt-1 space-y-1">
+              {Object.entries(diagram.metadata).map(([key, value]) => (
+                <div key={key} className="flex items-center justify-between gap-4 text-xs">
+                  <span className="font-medium capitalize">{key.replace(/_/g, " ")}</span>
+                  <span className="truncate">{stringifyValue(value)}</span>
+                </div>
+              ))}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+      <DeleteDiagramForm id={diagram.id} />
+    </div>
+  )
+}
+
+function DeleteDiagramForm({ id }: { id: string }) {
+  const [state, formAction] = useFormState(deleteAction, initialState)
+  const { pending } = useFormStatus()
+
+  return (
+    <form
+      action={formAction}
+      onSubmit={(event) => {
+        if (!confirm("Delete this diagram? This action cannot be undone.")) {
+          event.preventDefault()
+        }
+      }}
+      className="flex flex-col gap-2"
+    >
+      <input type="hidden" name="id" value={id} />
+      <Button
+        type="submit"
+        variant="destructive"
+        disabled={pending}
+        aria-disabled={pending}
+        className="inline-flex items-center gap-2"
+      >
+        <Trash2 className="size-4" aria-hidden />
+        {pending ? "Deleting…" : "Delete diagram"}
+      </Button>
+      {state.status !== "idle" ? (
+        <p
+          className={cn(
+            "text-sm",
+            state.status === "error" ? "text-destructive" : "text-muted-foreground"
+          )}
+        >
+          {state.message}
+        </p>
+      ) : null}
+    </form>
+  )
+}
+
+function SubmitButton({
+  children,
+  icon,
+  pendingText,
+}: {
+  children: ReactNode
+  icon: ReactNode
+  pendingText: string
+}) {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" className="inline-flex items-center gap-2" disabled={pending} aria-disabled={pending}>
+      {icon}
+      {pending ? pendingText : children}
+    </Button>
+  )
+}
+
+function prettyPrint(value: unknown) {
+  if (value === null || value === undefined) {
+    return ""
+  }
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch (error) {
+    return ""
+  }
+}
+
+function stringifyValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return ""
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value)
+  }
+  try {
+    return JSON.stringify(value)
+  } catch (error) {
+    return ""
+  }
+}
+
+const updateAction = async (_: FormState, formData: FormData) => updateSharedSpaceMap(formData)
+const deleteAction = async (_: FormState, formData: FormData) => deleteSharedSpaceMap(formData)

--- a/app/dashboard/shared-spaces/page.tsx
+++ b/app/dashboard/shared-spaces/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation"
+
+import { getSharedSpaceMapsForAdmin } from "./actions"
+import { CreateDiagramForm } from "./components/create-form"
+import { DiagramManagerList } from "./components/diagram-manager"
+
+export const dynamic = "force-dynamic"
+
+export default async function SharedSpacesAdminPage() {
+  try {
+    const diagrams = await getSharedSpaceMapsForAdmin()
+
+    return (
+      <div className="space-y-10">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">Shared space diagrams</h1>
+          <p className="max-w-2xl text-muted-foreground">
+            Upload, annotate, and manage shared area diagrams for each lease. Tenants will see signed URLs and
+            label overlays generated from the metadata defined here.
+          </p>
+        </header>
+        <CreateDiagramForm />
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Published diagrams</h2>
+          <DiagramManagerList diagrams={diagrams} />
+        </section>
+      </div>
+    )
+  } catch (error) {
+    console.error("Unable to load shared space maps", error)
+    redirect("/dashboard")
+  }
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -19,6 +19,10 @@ export const siteConfig = {
       href: "/dashboard",
     },
     {
+      title: "Shared Spaces",
+      href: "/shared-spaces",
+    },
+    {
       title: "OpenAI",
       href: "/playground",
     },

--- a/lib/shared-space-maps.ts
+++ b/lib/shared-space-maps.ts
@@ -1,0 +1,152 @@
+import type { SharedSpaceMapRow } from "@/utils/typed-supabase-client"
+
+export type RoomLabel = {
+  id: string
+  title: string
+  description?: string
+  x: number
+  y: number
+  data?: Record<string, unknown>
+}
+
+export type SharedSpaceDiagram = {
+  id: string
+  leaseId: string
+  unitId: string | null
+  tenantId: string
+  title: string
+  description: string | null
+  bucketId: string
+  filePath: string
+  signedUrl: string | null
+  updatedAt: string
+  diagramUpdatedAt: string
+  metadata: Record<string, unknown>
+  roomLabels: RoomLabel[]
+}
+
+export type SharedSpaceDiagramGroup = {
+  leaseId: string
+  diagrams: SharedSpaceDiagram[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+export function parseRoomLabels(raw: SharedSpaceMapRow["room_labels"]): RoomLabel[] {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+
+  return raw
+    .map((entry, index) => {
+      if (!isRecord(entry)) {
+        return null
+      }
+
+      const idCandidate = [entry.id, entry.key, entry.slug, entry.identifier]
+        .find((value): value is string => typeof value === "string" && value.trim().length > 0)
+      const labelCandidate = [entry.title, entry.label, entry.name, entry.text]
+        .find((value): value is string => typeof value === "string" && value.trim().length > 0)
+
+      if (!labelCandidate) {
+        return null
+      }
+
+      const baseId = idCandidate ?? `label-${index}`
+
+      const { x: directX, y: directY } = {
+        x: typeof entry.x === "number" ? entry.x : undefined,
+        y: typeof entry.y === "number" ? entry.y : undefined,
+      }
+
+      let x = directX
+      let y = directY
+
+      if ((x === undefined || y === undefined) && isRecord(entry.position)) {
+        const { position } = entry as { position?: Record<string, unknown> }
+        if (isRecord(position)) {
+          if (typeof position.x === "number") {
+            x = position.x
+          }
+          if (typeof position.y === "number") {
+            y = position.y
+          }
+        }
+      }
+
+      if (typeof x !== "number" || typeof y !== "number") {
+        return null
+      }
+
+      const descriptionCandidate = [entry.description, entry.tooltip, entry.note]
+        .find((value): value is string => typeof value === "string" && value.trim().length > 0)
+
+      const labelData = isRecord(entry.data)
+        ? entry.data
+        : isRecord(entry.metadata)
+          ? entry.metadata
+          : undefined
+
+      return {
+        id: baseId,
+        title: labelCandidate,
+        description: descriptionCandidate,
+        x: clamp01(x),
+        y: clamp01(y),
+        data: labelData,
+      }
+    })
+    .filter((label): label is RoomLabel => Boolean(label))
+}
+
+export function parseMetadata(raw: SharedSpaceMapRow["metadata"]): Record<string, unknown> {
+  if (isRecord(raw)) {
+    return raw
+  }
+
+  return {}
+}
+
+export function mapRowToDiagram(row: SharedSpaceMapRow, signedUrl: string | null): SharedSpaceDiagram {
+  return {
+    id: row.id,
+    leaseId: row.lease_id,
+    unitId: row.unit_id,
+    tenantId: row.tenant_id,
+    title: row.title,
+    description: row.description,
+    bucketId: row.bucket_id,
+    filePath: row.file_path,
+    signedUrl,
+    updatedAt: row.updated_at,
+    diagramUpdatedAt: row.diagram_updated_at,
+    metadata: parseMetadata(row.metadata),
+    roomLabels: parseRoomLabels(row.room_labels),
+  }
+}
+
+export function groupSharedSpaceMapsByLease(
+  diagrams: SharedSpaceDiagram[]
+): SharedSpaceDiagramGroup[] {
+  const grouped = new Map<string, SharedSpaceDiagram[]>()
+
+  diagrams.forEach((diagram) => {
+    const existing = grouped.get(diagram.leaseId) ?? []
+    existing.push(diagram)
+    grouped.set(diagram.leaseId, existing)
+  })
+
+  return Array.from(grouped.entries()).map(([leaseId, leaseDiagrams]) => ({
+    leaseId,
+    diagrams: leaseDiagrams.sort((a, b) => b.diagramUpdatedAt.localeCompare(a.diagramUpdatedAt)),
+  }))
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1558,6 +1558,62 @@ export type Database = {
         }
         Relationships: []
       }
+      shared_space_maps: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          description: string | null
+          diagram_updated_at: string
+          file_path: string
+          id: string
+          lease_id: string
+          metadata: Json
+          room_labels: Json
+          tenant_id: string
+          title: string
+          unit_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          bucket_id?: string
+          created_at?: string
+          description?: string | null
+          diagram_updated_at?: string
+          file_path: string
+          id?: string
+          lease_id: string
+          metadata?: Json
+          room_labels?: Json
+          tenant_id: string
+          title: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          description?: string | null
+          diagram_updated_at?: string
+          file_path?: string
+          id?: string
+          lease_id?: string
+          metadata?: Json
+          room_labels?: Json
+          tenant_id?: string
+          title?: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "shared_space_maps_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       todos: {
         Row: {
           created_at: string

--- a/supabase/migrations/20250711_shared_space_maps.sql
+++ b/supabase/migrations/20250711_shared_space_maps.sql
@@ -1,0 +1,70 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.shared_space_maps (
+    id uuid primary key default gen_random_uuid(),
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    tenant_id uuid not null references public.profiles(id) on delete cascade,
+    lease_id uuid not null,
+    unit_id uuid,
+    bucket_id text not null default 'shared-space-maps',
+    file_path text not null,
+    title text not null,
+    description text,
+    room_labels jsonb not null default '[]'::jsonb,
+    metadata jsonb not null default '{}'::jsonb,
+    diagram_updated_at timestamptz not null default now(),
+    constraint shared_space_maps_lease_file_key unique (tenant_id, lease_id, file_path)
+);
+
+comment on column public.shared_space_maps.room_labels is
+    'Array of labels with normalized x/y positions and optional descriptions for overlay rendering.';
+
+create index if not exists shared_space_maps_tenant_idx on public.shared_space_maps (tenant_id);
+create index if not exists shared_space_maps_lease_idx on public.shared_space_maps (lease_id);
+
+create or replace function public.handle_shared_space_maps_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$;
+
+create trigger set_shared_space_maps_updated_at
+before update on public.shared_space_maps
+for each row
+execute function public.handle_shared_space_maps_updated_at();
+
+alter table public.shared_space_maps enable row level security;
+
+create policy "Tenants can view their shared space maps"
+    on public.shared_space_maps
+    for select
+    to authenticated
+    using (
+        tenant_id = auth.uid()
+    );
+
+create policy "Admins can manage shared space maps"
+    on public.shared_space_maps
+    for all
+    to authenticated
+    using (
+        exists (
+            select 1
+            from public.profiles p
+            where p.id = auth.uid()
+              and coalesce(p.role, 'user') = 'admin'
+        )
+    )
+    with check (
+        exists (
+            select 1
+            from public.profiles p
+            where p.id = auth.uid()
+              and coalesce(p.role, 'user') = 'admin'
+        )
+    );

--- a/utils/typed-supabase-client.tsx
+++ b/utils/typed-supabase-client.tsx
@@ -2,3 +2,7 @@ import { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '@/lib/supabase'
 
 export type TypedSupabaseClient = SupabaseClient<Database>
+
+export type SharedSpaceMapRow = Database['public']['Tables']['shared_space_maps']['Row']
+export type SharedSpaceMapInsert = Database['public']['Tables']['shared_space_maps']['Insert']
+export type SharedSpaceMapUpdate = Database['public']['Tables']['shared_space_maps']['Update']


### PR DESCRIPTION
## Summary
- add a shared_space_maps table, indexes, and RLS policies so leases can reference diagram files
- extend Supabase typings plus new shared-space helpers and tenant actions to serve signed URLs and overlay metadata
- build tenant shared spaces page and dashboard management UI with upload, edit, and delete flows, and wire up navigation links

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ceea912810832899bdf3adebc0defa