### PR TITLE
feat: add tenant message board

### DIFF
--- a/app/(tenant)/message-board/actions.ts
+++ b/app/(tenant)/message-board/actions.ts
@@ -1,0 +1,511 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import type { Json, Tables } from "@/lib/supabase";
+import { createSupbaseServerClient, createSupbaseServerClientReadOnly } from "@/utils/supaone";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+
+export type TenantMessageAttachment = {
+  name: string;
+  url: string;
+  type?: string | null;
+};
+
+export type TenantThread = {
+  id: string;
+  role: string;
+  property: {
+    id: string;
+    name: string;
+    address_line: string | null;
+    city: string | null;
+    state: string | null;
+    postal_code: string | null;
+  } | null;
+  unit: {
+    id: string;
+    label: string;
+  } | null;
+  created_at: string;
+};
+
+type MinimalProfile = Pick<
+  Tables<"profiles">,
+  "id" | "full_name" | "avatar_url" | "role"
+>;
+
+export type TenantMessageRecord = Omit<
+  Tables<"tenant_messages">,
+  "attachments"
+> & {
+  attachments: TenantMessageAttachment[];
+  author: MinimalProfile | null;
+  property?: Pick<Tables<"properties">, "id" | "name"> | null;
+  unit?: Pick<Tables<"property_units">, "id" | "label"> | null;
+};
+
+type TenantMessageRow = Tables<"tenant_messages"> & {
+  author: MinimalProfile | null;
+  property?: Pick<Tables<"properties">, "id" | "name"> | null;
+  unit?: Pick<Tables<"property_units">, "id" | "label"> | null;
+};
+
+type TenantMessagePage = {
+  messages: TenantMessageRecord[];
+  nextCursor: string | null;
+  hasMore: boolean;
+};
+
+const globalRealtimeStore = globalThis as unknown as {
+  __tenantMessageChannels?: Map<string, RealtimeChannel>;
+};
+
+if (!globalRealtimeStore.__tenantMessageChannels) {
+  globalRealtimeStore.__tenantMessageChannels = new Map();
+}
+
+const channelRegistry = globalRealtimeStore.__tenantMessageChannels;
+
+const THREAD_SELECT = `
+  id,
+  role,
+  created_at,
+  property:properties(
+    id,
+    name,
+    address_line,
+    city,
+    state,
+    postal_code
+  ),
+  unit:property_units(
+    id,
+    label
+  )
+`;
+
+function parseAttachments(payload: Json | null): TenantMessageAttachment[] {
+  if (!payload) {
+    return [];
+  }
+
+  if (Array.isArray(payload)) {
+    const attachments: TenantMessageAttachment[] = [];
+
+    payload.forEach((item) => {
+      if (!item || typeof item !== "object") {
+        return;
+      }
+
+      const typed = item as Record<string, unknown>;
+      const url = typeof typed.url === "string" ? typed.url : null;
+
+      if (!url) {
+        return;
+      }
+
+      attachments.push({
+        url,
+        name:
+          typeof typed.name === "string" && typed.name.trim().length > 0
+            ? typed.name
+            : "Attachment",
+        type: typeof typed.type === "string" ? typed.type : null,
+      });
+    });
+
+    return attachments;
+  }
+
+  return [];
+}
+
+function mapTenantMessage(row: TenantMessageRow): TenantMessageRecord {
+  return {
+    ...row,
+    attachments: parseAttachments(row.attachments as Json),
+    author: row.author ?? null,
+    property: row.property ?? null,
+    unit: row.unit ?? null,
+  };
+}
+
+export async function fetchTenantThreads(): Promise<TenantThread[]> {
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    throw authError;
+  }
+
+  if (!user) {
+    throw new Error("Not authenticated");
+  }
+
+  const { data, error } = await supabase
+    .from("tenant_property_memberships")
+    .select(THREAD_SELECT)
+    .eq("profile_id", user.id)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((membership) => ({
+    id: membership.id,
+    role: membership.role ?? "tenant",
+    created_at: membership.created_at,
+    property: membership.property
+      ? {
+          id: membership.property.id,
+          name: membership.property.name ?? "",
+          address_line: membership.property.address_line ?? null,
+          city: membership.property.city ?? null,
+          state: membership.property.state ?? null,
+          postal_code: membership.property.postal_code ?? null,
+        }
+      : null,
+    unit: membership.unit
+      ? {
+          id: membership.unit.id,
+          label: membership.unit.label ?? "",
+        }
+      : null,
+  }));
+}
+
+export async function fetchTenantMessages(params: {
+  propertyId: string;
+  unitId?: string | null;
+  limit?: number;
+  before?: string | null;
+  includePropertyMeta?: boolean;
+}): Promise<TenantMessagePage> {
+  const { propertyId, unitId, limit = 20, before, includePropertyMeta } = params;
+  const supabase = await createSupbaseServerClient();
+
+  const columns = [
+    "*",
+    "author:profiles!tenant_messages_author_id_fkey(id,full_name,avatar_url,role)",
+  ];
+
+  if (includePropertyMeta) {
+    columns.push("property:properties(id,name)");
+    columns.push("unit:property_units(id,label)");
+  }
+
+  let query = supabase
+    .from("tenant_messages")
+    .select(columns.join(","))
+    .eq("property_id", propertyId)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (unitId) {
+    query = query.or(`unit_id.is.null,unit_id.eq.${unitId}`);
+  }
+
+  if (before) {
+    query = query.lt("created_at", before);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = Array.isArray(data)
+    ? ((data as unknown) as TenantMessageRow[])
+    : [];
+  const hasMore = rows.length === limit;
+  const nextCursor = hasMore && rows.length > 0 ? rows[rows.length - 1].created_at : null;
+  const normalized = rows
+    .slice()
+    .reverse()
+    .map((row) => mapTenantMessage(row));
+
+  return {
+    messages: normalized,
+    nextCursor,
+    hasMore,
+  };
+}
+
+export async function getTenantMessageById(params: {
+  messageId: number;
+  includePropertyMeta?: boolean;
+}): Promise<TenantMessageRecord | null> {
+  const { messageId, includePropertyMeta } = params;
+  const supabase = await createSupbaseServerClient();
+
+  const columns = [
+    "*",
+    "author:profiles!tenant_messages_author_id_fkey(id,full_name,avatar_url,role)",
+  ];
+
+  if (includePropertyMeta) {
+    columns.push("property:properties(id,name)");
+    columns.push("unit:property_units(id,label)");
+  }
+
+  const { data, error } = await supabase
+    .from("tenant_messages")
+    .select(columns.join(","))
+    .eq("id", messageId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return mapTenantMessage((data as unknown) as TenantMessageRow);
+}
+
+export async function createTenantMessage(params: {
+  propertyId: string;
+  unitId?: string | null;
+  body: string;
+  attachments?: TenantMessageAttachment[];
+}): Promise<TenantMessageRecord> {
+  const { propertyId, unitId, body, attachments = [] } = params;
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    throw authError;
+  }
+
+  if (!user) {
+    throw new Error("Not authenticated");
+  }
+
+  const normalizedAttachments = attachments.map((item) => ({
+    name: item.name,
+    url: item.url,
+    type: item.type ?? null,
+  }));
+
+  const { data, error } = await supabase
+    .from("tenant_messages")
+    .insert({
+      property_id: propertyId,
+      unit_id: unitId ?? null,
+      author_id: user.id,
+      body,
+      attachments: normalizedAttachments,
+    })
+    .select(
+      "*, author:profiles!tenant_messages_author_id_fkey(id,full_name,avatar_url,role), property:properties(id,name), unit:property_units(id,label)"
+    )
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath("/message-board");
+  revalidatePath("/dashboard/message-board/moderation");
+
+  return mapTenantMessage(data as TenantMessageRow);
+}
+
+async function mutateTenantMessage(
+  id: number,
+  updates: Partial<Tables<"tenant_messages">>
+): Promise<TenantMessageRecord> {
+  const supabase = await createSupbaseServerClient();
+  const { data, error } = await supabase
+    .from("tenant_messages")
+    .update(updates)
+    .eq("id", id)
+    .select(
+      "*, author:profiles!tenant_messages_author_id_fkey(id,full_name,avatar_url,role), property:properties(id,name), unit:property_units(id,label)"
+    )
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath("/message-board");
+  revalidatePath("/dashboard/message-board/moderation");
+
+  return mapTenantMessage(data as TenantMessageRow);
+}
+
+export async function pinTenantMessage(messageId: number): Promise<TenantMessageRecord> {
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    throw authError;
+  }
+
+  if (!user) {
+    throw new Error("Not authenticated");
+  }
+
+  return mutateTenantMessage(messageId, {
+    is_pinned: true,
+    pinned_at: new Date().toISOString(),
+    pinned_by: user.id,
+  });
+}
+
+export async function unpinTenantMessage(messageId: number): Promise<TenantMessageRecord> {
+  return mutateTenantMessage(messageId, {
+    is_pinned: false,
+    pinned_at: null,
+    pinned_by: null,
+  });
+}
+
+export async function removeTenantMessage(messageId: number): Promise<TenantMessageRecord> {
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    throw authError;
+  }
+
+  if (!user) {
+    throw new Error("Not authenticated");
+  }
+
+  return mutateTenantMessage(messageId, {
+    is_removed: true,
+    removed_at: new Date().toISOString(),
+    removed_by: user.id,
+  });
+}
+
+export async function restoreTenantMessage(messageId: number): Promise<TenantMessageRecord> {
+  return mutateTenantMessage(messageId, {
+    is_removed: false,
+    removed_at: null,
+    removed_by: null,
+  });
+}
+
+export async function ensureRealtimeSubscription(params: {
+  propertyId: string;
+  unitId?: string | null;
+}): Promise<{ channel: string; filter: string }> {
+  const { propertyId, unitId } = params;
+  const channelKey = `${propertyId}:${unitId ?? "all"}`;
+
+  if (channelRegistry.has(channelKey)) {
+    const existing = channelRegistry.get(channelKey)!;
+    return {
+      channel: existing.topic,
+      filter: `property_id=eq.${propertyId}`,
+    };
+  }
+
+  const supabase = await createSupbaseServerClientReadOnly();
+
+  const channel = supabase
+    .channel(`tenant-messages-${channelKey}`)
+    .on(
+      "postgres_changes",
+      {
+        event: "*",
+        schema: "public",
+        table: "tenant_messages",
+        filter: `property_id=eq.${propertyId}`,
+      },
+      async () => {
+        revalidatePath("/message-board");
+        revalidatePath("/dashboard/message-board/moderation");
+      }
+    );
+
+  await channel.subscribe();
+  channelRegistry.set(channelKey, channel);
+
+  return {
+    channel: channel.topic,
+    filter: `property_id=eq.${propertyId}`,
+  };
+}
+
+export async function fetchPropertyDirectory(): Promise<
+  Array<
+    Pick<Tables<"properties">, "id" | "name" | "address_line" | "city" | "state" | "postal_code"> & {
+      units: Array<Pick<Tables<"property_units">, "id" | "label">>;
+    }
+  >
+> {
+  const supabase = await createSupbaseServerClient();
+  const { data, error } = await supabase
+    .from("properties")
+    .select(
+      "id,name,address_line,city,state,postal_code, units:property_units(id,label)"
+    )
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((property) => ({
+    id: property.id,
+    name: property.name ?? "",
+    address_line: property.address_line ?? null,
+    city: property.city ?? null,
+    state: property.state ?? null,
+    postal_code: property.postal_code ?? null,
+    units: (property.units ?? []).map((unit: { id: string; label: string | null }) => ({
+      id: unit.id,
+      label: unit.label ?? "",
+    })),
+  }));
+}
+
+export async function fetchUserProfile() {
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    throw authError;
+  }
+
+  if (!user) {
+    throw new Error("Not authenticated");
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id,full_name,avatar_url,role")
+    .eq("id", user.id)
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return data as MinimalProfile;
+}
+

--- a/app/(tenant)/message-board/message-board-client.tsx
+++ b/app/(tenant)/message-board/message-board-client.tsx
@@ -1,0 +1,1115 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  AlertTriangle,
+  Loader2,
+  Paperclip,
+  Pin,
+  PinOff,
+  Plus,
+  Trash2,
+  Undo2,
+  X,
+} from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import useSupabaseBrowser from "@/utils/supabase-browser";
+
+import type { TenantMessageAttachment, TenantMessageRecord, TenantThread } from "./actions";
+import {
+  createTenantMessage,
+  ensureRealtimeSubscription,
+  fetchTenantMessages,
+  getTenantMessageById,
+  pinTenantMessage,
+  removeTenantMessage,
+  restoreTenantMessage,
+  unpinTenantMessage,
+} from "./actions";
+import { isStaffRole } from "./roles";
+
+const composerSchema = z.object({
+  body: z
+    .string()
+    .trim()
+    .min(1, { message: "Message cannot be empty" })
+    .max(2000, { message: "Message is too long" }),
+});
+
+type ComposerValues = z.infer<typeof composerSchema>;
+
+type ScopeValue = "all" | "property" | string;
+
+type MessageBoardClientProps = {
+  currentProfile: {
+    id: string;
+    full_name: string | null;
+    avatar_url: string | null;
+    role: string | null;
+  };
+  initialMessages: TenantMessageRecord[];
+  initialCursor: string | null;
+  initialHasMore: boolean;
+  initialPropertyId: string;
+  initialUnitId: string | null;
+  threads: TenantThread[];
+  pageSize: number;
+};
+
+type PropertyOption = {
+  property: NonNullable<TenantThread["property"]>;
+  units: Array<NonNullable<TenantThread["unit"]>>;
+};
+
+function scopeToUnitParam(scope: ScopeValue): string | null | undefined {
+  if (scope === "property") {
+    return null;
+  }
+
+  if (scope === "all") {
+    return undefined;
+  }
+
+  return scope;
+}
+
+function sortChronologically(messages: TenantMessageRecord[]) {
+  return [...messages].sort((a, b) => {
+    const aTime = new Date(a.created_at).getTime();
+    const bTime = new Date(b.created_at).getTime();
+    return aTime - bTime;
+  });
+}
+
+function abbreviateName(name: string | null) {
+  if (!name) {
+    return "GU";
+  }
+
+  const parts = name.split(" ").filter(Boolean);
+
+  if (parts.length === 0) {
+    return name.slice(0, 2).toUpperCase();
+  }
+
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2).toUpperCase();
+  }
+
+  return `${parts[0]![0] ?? ""}${parts[parts.length - 1]![0] ?? ""}`.toUpperCase();
+}
+
+function buildProperties(threads: TenantThread[]): PropertyOption[] {
+  const map = new Map<string, PropertyOption>();
+
+  threads.forEach((thread) => {
+    if (!thread.property) {
+      return;
+    }
+
+    if (!map.has(thread.property.id)) {
+      map.set(thread.property.id, {
+        property: thread.property,
+        units: [],
+      });
+    }
+
+    const entry = map.get(thread.property.id)!;
+
+    if (thread.unit) {
+      if (!entry.units.some((unit) => unit.id === thread.unit!.id)) {
+        entry.units.push(thread.unit);
+      }
+    }
+  });
+
+  return Array.from(map.values());
+}
+
+function resolveInitialScope(
+  options: PropertyOption[],
+  propertyId: string,
+  initialUnitId: string | null,
+  isStaff: boolean
+): ScopeValue {
+  if (isStaff) {
+    return "all";
+  }
+
+  if (initialUnitId) {
+    return initialUnitId;
+  }
+
+  const property = options.find((option) => option.property.id === propertyId);
+
+  if (property && property.units.length > 0) {
+    return property.units[0]!.id;
+  }
+
+  return "property";
+}
+
+function resolveScopeForProperty(
+  option: PropertyOption | undefined,
+  isStaff: boolean
+): ScopeValue {
+  if (isStaff) {
+    return "all";
+  }
+
+  if (option && option.units.length > 0) {
+    return option.units[0]!.id;
+  }
+
+  return "property";
+}
+
+export default function MessageBoardClient({
+  currentProfile,
+  initialMessages,
+  initialCursor,
+  initialHasMore,
+  initialPropertyId,
+  initialUnitId,
+  threads,
+  pageSize,
+}: MessageBoardClientProps) {
+  const isStaff = isStaffRole(currentProfile.role ?? null);
+  const { toast } = useToast();
+  const supabase = useSupabaseBrowser();
+  const propertyOptions = useMemo(() => buildProperties(threads), [threads]);
+  const [selectedPropertyId, setSelectedPropertyId] = useState(initialPropertyId);
+  const [scope, setScope] = useState<ScopeValue>(() =>
+    resolveInitialScope(propertyOptions, initialPropertyId, initialUnitId, isStaff)
+  );
+  const [messages, setMessages] = useState(() => sortChronologically(initialMessages));
+  const [cursor, setCursor] = useState<string | null>(initialCursor);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [moderatingIds, setModeratingIds] = useState<Set<number>>(new Set());
+  const [attachments, setAttachments] = useState<TenantMessageAttachment[]>([]);
+  const [attachmentDraft, setAttachmentDraft] = useState({ name: "", url: "" });
+  const [isAttachmentFormOpen, setIsAttachmentFormOpen] = useState(false);
+  const [isFetchingThread, startTransition] = useTransition();
+
+  const form = useForm<ComposerValues>({
+    resolver: zodResolver(composerSchema),
+    defaultValues: {
+      body: "",
+    },
+  });
+
+  const selectedProperty = useMemo(() => {
+    return propertyOptions.find((option) => option.property.id === selectedPropertyId);
+  }, [propertyOptions, selectedPropertyId]);
+
+  useEffect(() => {
+    if (!propertyOptions.length) {
+      return;
+    }
+
+    if (!propertyOptions.some((option) => option.property.id === selectedPropertyId)) {
+      const nextProperty = propertyOptions[0]!;
+      setSelectedPropertyId(nextProperty.property.id);
+      setScope(resolveScopeForProperty(nextProperty, isStaff));
+    }
+  }, [isStaff, propertyOptions, selectedPropertyId]);
+
+  useEffect(() => {
+    if (!selectedProperty) {
+      return;
+    }
+
+    const validScopes = new Set<ScopeValue>(["property"]);
+
+    if (isStaff) {
+      validScopes.add("all");
+    }
+
+    selectedProperty.units.forEach((unit) => validScopes.add(unit.id));
+
+    if (!validScopes.has(scope)) {
+      setScope(resolveScopeForProperty(selectedProperty, isStaff));
+    }
+  }, [isStaff, scope, selectedProperty]);
+
+  useEffect(() => {
+    if (!selectedProperty) {
+      return;
+    }
+
+    startTransition(() => {
+      const fetchData = async () => {
+        try {
+          const unitParam = scopeToUnitParam(scope);
+          const response = await fetchTenantMessages({
+            propertyId: selectedProperty.property.id,
+            unitId: unitParam,
+            limit: pageSize,
+            includePropertyMeta: isStaff,
+          });
+
+          setMessages(sortChronologically(response.messages));
+          setCursor(response.nextCursor);
+          setHasMore(response.hasMore);
+          setAttachments([]);
+          setAttachmentDraft({ name: "", url: "" });
+          setIsAttachmentFormOpen(false);
+          form.reset({ body: "" });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unable to load messages";
+          toast({
+            title: "Failed to load messages",
+            description: message,
+            variant: "destructive",
+          });
+        }
+      };
+
+      void fetchData();
+    });
+  }, [form, isStaff, pageSize, scope, selectedProperty, toast]);
+
+  useEffect(() => {
+    if (!selectedProperty) {
+      return;
+    }
+
+    const unitParam = scopeToUnitParam(scope);
+
+    void ensureRealtimeSubscription({
+      propertyId: selectedProperty.property.id,
+      unitId: unitParam,
+    }).catch((error) => {
+      const message = error instanceof Error ? error.message : "Unable to subscribe to updates";
+      toast({
+        title: "Realtime subscription failed",
+        description: message,
+        variant: "destructive",
+      });
+    });
+
+    const filter = `property_id=eq.${selectedProperty.property.id}`;
+    const channelName = `tenant-messages-${selectedProperty.property.id}:${unitParam ?? "all"}`;
+    const channel = supabase
+      .channel(channelName)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "tenant_messages",
+          filter,
+        },
+        async (payload) => {
+          const newUnitId = (payload.new.unit_id as string | null) ?? null;
+          const shouldInclude =
+            scope === "all" ||
+            (scope === "property" && newUnitId === null) ||
+            (scope !== "property" && scope !== "all" && (newUnitId === null || newUnitId === scope));
+
+          if (!shouldInclude) {
+            return;
+          }
+
+          try {
+            const record = await getTenantMessageById({
+              messageId: payload.new.id as number,
+              includePropertyMeta: isStaff,
+            });
+
+            if (!record) {
+              return;
+            }
+
+            setMessages((previous) => {
+              const withoutOptimistic = previous.filter((message) => message.id !== record.id);
+
+              if (withoutOptimistic.some((message) => message.id === record.id)) {
+                return sortChronologically(withoutOptimistic);
+              }
+
+              return sortChronologically([...withoutOptimistic, record]);
+            });
+          } catch (error) {
+            console.error("Failed to hydrate realtime insert", error);
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "tenant_messages",
+          filter,
+        },
+        async (payload) => {
+          try {
+            const record = await getTenantMessageById({
+              messageId: payload.new.id as number,
+              includePropertyMeta: isStaff,
+            });
+
+            if (!record) {
+              return;
+            }
+
+            setMessages((previous) => {
+              if (!previous.some((message) => message.id === record.id)) {
+                return previous;
+              }
+
+              return sortChronologically(
+                previous.map((message) => (message.id === record.id ? record : message))
+              );
+            });
+          } catch (error) {
+            console.error("Failed to hydrate realtime update", error);
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "DELETE",
+          schema: "public",
+          table: "tenant_messages",
+          filter,
+        },
+        (payload) => {
+          const deletedId = payload.old.id as number;
+          setMessages((previous) => previous.filter((message) => message.id !== deletedId));
+        }
+      );
+
+    channel.subscribe((status) => {
+      if (status === "CHANNEL_ERROR") {
+        toast({
+          title: "Realtime subscription failed",
+          description: "Unable to subscribe to updates",
+          variant: "destructive",
+        });
+      }
+    });
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [isStaff, scope, selectedProperty, supabase, toast]);
+
+  const visibleMessages = useMemo(() => {
+    const sorted = sortChronologically(messages);
+
+    if (isStaff) {
+      return sorted;
+    }
+
+    return sorted.filter((message) => !message.is_removed);
+  }, [isStaff, messages]);
+
+  const pinnedMessages = useMemo(
+    () =>
+      visibleMessages
+        .filter((message) => message.is_pinned && !message.is_removed)
+        .sort((a, b) => {
+          const aPinned = new Date(a.pinned_at ?? a.created_at).getTime();
+          const bPinned = new Date(b.pinned_at ?? b.created_at).getTime();
+          return bPinned - aPinned;
+        }),
+    [visibleMessages]
+  );
+
+  const regularMessages = useMemo(
+    () => visibleMessages.filter((message) => !message.is_pinned),
+    [visibleMessages]
+  );
+
+  const handlePropertyChange = useCallback(
+    (propertyId: string) => {
+      setSelectedPropertyId(propertyId);
+      const nextProperty = propertyOptions.find((option) => option.property.id === propertyId);
+      setScope(resolveScopeForProperty(nextProperty, isStaff));
+    },
+    [isStaff, propertyOptions]
+  );
+
+  const handleScopeChange = useCallback((value: string) => {
+    setScope(value as ScopeValue);
+  }, []);
+
+  const handleAddAttachment = useCallback(() => {
+    try {
+      const url = attachmentDraft.url.trim();
+
+      if (!url) {
+        toast({
+          title: "Attachment URL required",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const urlInstance = new URL(url);
+      const label = attachmentDraft.name.trim() || urlInstance.hostname;
+
+      setAttachments((previous) => {
+        if (previous.some((attachment) => attachment.url === url)) {
+          return previous;
+        }
+
+        return [...previous, { name: label, url, type: null }];
+      });
+
+      setAttachmentDraft({ name: "", url: "" });
+      setIsAttachmentFormOpen(false);
+    } catch (error) {
+      toast({
+        title: "Invalid attachment URL",
+        description: "Please enter a valid link (including https://)",
+        variant: "destructive",
+      });
+    }
+  }, [attachmentDraft.name, attachmentDraft.url, toast]);
+
+  const handleRemoveAttachment = useCallback((url: string) => {
+    setAttachments((previous) => previous.filter((attachment) => attachment.url !== url));
+  }, []);
+
+  const isModerating = useCallback(
+    (id: number) => moderatingIds.has(id),
+    [moderatingIds]
+  );
+
+  const toggleModerating = useCallback((id: number, active: boolean) => {
+    setModeratingIds((previous) => {
+      const updated = new Set(previous);
+      if (active) {
+        updated.add(id);
+      } else {
+        updated.delete(id);
+      }
+      return updated;
+    });
+  }, []);
+
+  const onSubmit = useCallback(
+    async (values: ComposerValues) => {
+      if (!selectedProperty) {
+        return;
+      }
+
+      const content = values.body.trim();
+
+      if (!content) {
+        return;
+      }
+
+      const unitParam = scopeToUnitParam(scope);
+      const optimisticId = -Date.now();
+      const optimisticMessage: TenantMessageRecord = {
+        id: optimisticId,
+        property_id: selectedProperty.property.id,
+        unit_id: typeof unitParam === "string" ? unitParam : null,
+        author_id: currentProfile.id,
+        body: content,
+        attachments,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        is_pinned: false,
+        pinned_at: null,
+        pinned_by: null,
+        is_removed: false,
+        removed_at: null,
+        removed_by: null,
+        author: currentProfile,
+        property: selectedProperty.property,
+        unit:
+          typeof unitParam === "string"
+            ? selectedProperty.units.find((unit) => unit.id === unitParam) ?? null
+            : null,
+      };
+
+      setMessages((previous) => sortChronologically([...previous, optimisticMessage]));
+      form.reset({ body: "" });
+      setAttachments([]);
+      setAttachmentDraft({ name: "", url: "" });
+      setIsAttachmentFormOpen(false);
+
+      try {
+        const created = await createTenantMessage({
+          propertyId: selectedProperty.property.id,
+          unitId: unitParam ?? null,
+          body: content,
+          attachments,
+        });
+
+        setMessages((previous) => {
+          const withoutOptimistic = previous.filter((message) => message.id !== optimisticId);
+
+          if (withoutOptimistic.some((message) => message.id === created.id)) {
+            return sortChronologically(withoutOptimistic);
+          }
+
+          return sortChronologically([...withoutOptimistic, created]);
+        });
+      } catch (error) {
+        setMessages((previous) => previous.filter((message) => message.id !== optimisticId));
+        const message = error instanceof Error ? error.message : "Unable to post your message";
+        toast({
+          title: "Message failed to send",
+          description: message,
+          variant: "destructive",
+        });
+      }
+    },
+    [attachments, currentProfile, form, selectedProperty, scope, toast]
+  );
+
+  const handleLoadMore = useCallback(async () => {
+    if (!cursor || !selectedProperty) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+
+    try {
+      const response = await fetchTenantMessages({
+        propertyId: selectedProperty.property.id,
+        unitId: scopeToUnitParam(scope),
+        limit: pageSize,
+        before: cursor,
+        includePropertyMeta: isStaff,
+      });
+
+      setMessages((previous) =>
+        sortChronologically([...response.messages, ...previous])
+      );
+      setCursor(response.nextCursor);
+      setHasMore(response.hasMore);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to load more messages";
+      toast({
+        title: "Could not load more messages",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [cursor, isStaff, pageSize, scope, selectedProperty, toast]);
+
+  const handlePinToggle = useCallback(
+    async (message: TenantMessageRecord, desiredState: boolean) => {
+      toggleModerating(message.id, true);
+
+      try {
+        const updated = desiredState
+          ? await pinTenantMessage(message.id)
+          : await unpinTenantMessage(message.id);
+
+        setMessages((previous) =>
+          sortChronologically(
+            previous.map((existing) => (existing.id === updated.id ? updated : existing))
+          )
+        );
+
+        toast({
+          title: desiredState ? "Message pinned" : "Message unpinned",
+        });
+      } catch (error) {
+        const description =
+          error instanceof Error ? error.message : "Unable to update message pin";
+        toast({
+          title: "Moderation update failed",
+          description,
+          variant: "destructive",
+        });
+      } finally {
+        toggleModerating(message.id, false);
+      }
+    },
+    [toast, toggleModerating]
+  );
+
+  const handleRemovalToggle = useCallback(
+    async (message: TenantMessageRecord, desiredState: boolean) => {
+      toggleModerating(message.id, true);
+
+      try {
+        const updated = desiredState
+          ? await removeTenantMessage(message.id)
+          : await restoreTenantMessage(message.id);
+
+        setMessages((previous) =>
+          sortChronologically(
+            previous.map((existing) => (existing.id === updated.id ? updated : existing))
+          )
+        );
+
+        toast({
+          title: desiredState ? "Message removed" : "Message restored",
+        });
+      } catch (error) {
+        const description =
+          error instanceof Error ? error.message : "Unable to update message status";
+        toast({
+          title: "Moderation update failed",
+          description,
+          variant: "destructive",
+        });
+      } finally {
+        toggleModerating(message.id, false);
+      }
+    },
+    [toast, toggleModerating]
+  );
+
+  const unitOptions = useMemo(() => {
+    if (!selectedProperty) {
+      return [] as Array<{ value: ScopeValue; label: string }>;
+    }
+
+    const options: Array<{ value: ScopeValue; label: string }> = [];
+
+    options.push({ value: "property", label: "Property announcements" });
+
+    if (isStaff) {
+      options.push({ value: "all", label: "All updates" });
+    }
+
+    selectedProperty.units.forEach((unit) => {
+      options.push({ value: unit.id, label: `Unit ${unit.label}` });
+    });
+
+    return options;
+  }, [isStaff, selectedProperty]);
+
+  const threadSubtitle = useMemo(() => {
+    if (!selectedProperty) {
+      return "";
+    }
+
+    const addressParts = [
+      selectedProperty.property.address_line,
+      selectedProperty.property.city,
+      selectedProperty.property.state,
+      selectedProperty.property.postal_code,
+    ].filter(Boolean);
+
+    return addressParts.join(", ");
+  }, [selectedProperty]);
+
+  return (
+    <Card className="border-border/60 shadow-sm">
+      <CardHeader className="gap-6">
+        <div className="space-y-2">
+          <CardTitle className="text-2xl">Community message board</CardTitle>
+          <CardDescription>
+            Coordinate with staff and neighbors, stay current on maintenance, and share
+            updates across your property.
+          </CardDescription>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Property</Label>
+            <Select value={selectedPropertyId} onValueChange={handlePropertyChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select a property" />
+              </SelectTrigger>
+              <SelectContent>
+                {propertyOptions.map((option) => (
+                  <SelectItem key={option.property.id} value={option.property.id}>
+                    {option.property.name || "Property"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Thread</Label>
+            <Select value={scope} onValueChange={handleScopeChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select thread scope" />
+              </SelectTrigger>
+              <SelectContent>
+                {unitOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        {threadSubtitle ? (
+          <div className="rounded-md border border-dashed bg-muted/40 p-4 text-sm text-muted-foreground">
+            {threadSubtitle}
+          </div>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {isFetchingThread ? (
+          <div className="flex items-center gap-2 rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            Loading thread…
+          </div>
+        ) : null}
+        {pinnedMessages.length > 0 ? (
+          <section className="space-y-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Pin className="size-4" />
+              Highlighted updates
+            </div>
+            <div className="space-y-3">
+              {pinnedMessages.map((message) => (
+                <MessageCard
+                  key={message.id}
+                  message={message}
+                  currentProfileId={currentProfile.id}
+                  isStaff={isStaff}
+                  isModerating={isModerating(message.id)}
+                  onPinToggle={handlePinToggle}
+                  onRemovalToggle={handleRemovalToggle}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-muted-foreground">Recent activity</h3>
+            {hasMore ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+              >
+                {isLoadingMore ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    Loading…
+                  </>
+                ) : (
+                  "Load older messages"
+                )}
+              </Button>
+            ) : null}
+          </div>
+          {regularMessages.length === 0 ? (
+            <div className="rounded-md border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+              {isFetchingThread ? "Loading messages…" : "No messages yet. Start the conversation below."}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {regularMessages.map((message) => (
+                <MessageCard
+                  key={message.id}
+                  message={message}
+                  currentProfileId={currentProfile.id}
+                  isStaff={isStaff}
+                  isModerating={isModerating(message.id)}
+                  onPinToggle={handlePinToggle}
+                  onRemovalToggle={handleRemovalToggle}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+        <section className="space-y-4 border-t pt-4">
+          <div>
+            <h3 className="text-sm font-medium text-muted-foreground">Share an update</h3>
+            <p className="text-xs text-muted-foreground">
+              Messages are visible to everyone participating in this thread.
+            </p>
+          </div>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="body"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Share a maintenance update, ask a question, or welcome your neighbors."
+                        rows={4}
+                        className="resize-none"
+                        disabled={isFetchingThread}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="space-y-2">
+                {attachments.length > 0 ? (
+                  <div className="flex flex-wrap items-center gap-2">
+                    {attachments.map((attachment) => (
+                      <span
+                        key={attachment.url}
+                        className="inline-flex items-center gap-2 rounded-md bg-muted px-3 py-1 text-xs text-muted-foreground"
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          <Paperclip className="size-3.5" />
+                          <span className="max-w-[180px] truncate">{attachment.name}</span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveAttachment(attachment.url)}
+                          className="rounded-full p-1 text-muted-foreground transition hover:bg-muted-foreground/10"
+                        >
+                          <X className="size-3" />
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+                {isAttachmentFormOpen ? (
+                  <div className="flex flex-col gap-3 rounded-md border bg-muted/20 p-3 md:flex-row md:items-end">
+                    <div className="flex-1 space-y-1">
+                      <Label htmlFor="attachment-name" className="text-xs font-medium uppercase tracking-wide">
+                        Label
+                      </Label>
+                      <Input
+                        id="attachment-name"
+                        value={attachmentDraft.name}
+                        onChange={(event) =>
+                          setAttachmentDraft((previous) => ({
+                            ...previous,
+                            name: event.target.value,
+                          }))
+                        }
+                        placeholder="Lease addendum"
+                      />
+                    </div>
+                    <div className="flex-1 space-y-1">
+                      <Label htmlFor="attachment-url" className="text-xs font-medium uppercase tracking-wide">
+                        Link
+                      </Label>
+                      <Input
+                        id="attachment-url"
+                        value={attachmentDraft.url}
+                        onChange={(event) =>
+                          setAttachmentDraft((previous) => ({
+                            ...previous,
+                            url: event.target.value,
+                          }))
+                        }
+                        placeholder="https://"
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button type="button" onClick={handleAddAttachment} size="sm">
+                        Add
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setIsAttachmentFormOpen(false);
+                          setAttachmentDraft({ name: "", url: "" });
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
+                <div className="flex flex-wrap items-center gap-3">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setIsAttachmentFormOpen((value) => !value)}
+                    disabled={attachments.length >= 5 || isFetchingThread}
+                  >
+                    <Plus className="mr-2 size-4" />
+                    Add attachment
+                  </Button>
+                  {attachments.length >= 5 ? (
+                    <span className="text-xs text-muted-foreground">
+                      Maximum of five attachments per message.
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-xs text-muted-foreground">
+                  {scope === "property"
+                    ? "Posting to property announcements only."
+                    : scope === "all"
+                      ? "Posting to the entire property."
+                      : `Posting to unit ${
+                          selectedProperty?.units.find((unit) => unit.id === scope)?.label ?? ""
+                        } and property announcements.`}
+                </p>
+                <Button
+                  type="submit"
+                  disabled={form.formState.isSubmitting || isFetchingThread}
+                >
+                  {form.formState.isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 size-4 animate-spin" />
+                      Sending
+                    </>
+                  ) : (
+                    "Post update"
+                  )}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}
+
+type MessageCardProps = {
+  message: TenantMessageRecord;
+  currentProfileId: string;
+  isStaff: boolean;
+  isModerating: boolean;
+  onPinToggle: (message: TenantMessageRecord, desiredState: boolean) => void;
+  onRemovalToggle: (message: TenantMessageRecord, desiredState: boolean) => void;
+};
+
+function MessageCard({
+  message,
+  currentProfileId,
+  isStaff,
+  isModerating,
+  onPinToggle,
+  onRemovalToggle,
+}: MessageCardProps) {
+  const authorName = message.author?.full_name ?? "Resident";
+  const relativeTime = formatDistanceToNow(new Date(message.created_at), {
+    addSuffix: true,
+  });
+  const attachments = message.attachments ?? [];
+  const isAuthor = message.author_id === currentProfileId;
+  const unitLabel = message.unit?.label ?? null;
+
+  return (
+    <div
+      className={cn(
+        "flex gap-3 rounded-md border bg-card p-4",
+        message.is_removed ? "opacity-70" : ""
+      )}
+    >
+      <Avatar className="size-10">
+        {message.author?.avatar_url ? (
+          <AvatarImage src={message.author.avatar_url} alt={authorName ?? "Resident"} />
+        ) : null}
+        <AvatarFallback>{abbreviateName(authorName)}</AvatarFallback>
+      </Avatar>
+      <div className="flex flex-1 flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="font-medium text-foreground">{authorName}</span>
+          {isAuthor ? <Badge variant="secondary">You</Badge> : null}
+          {unitLabel ? <Badge variant="outline">Unit {unitLabel}</Badge> : null}
+          {message.is_pinned ? (
+            <Badge variant="secondary" className="gap-1">
+              <Pin className="size-3" />
+              Pinned
+            </Badge>
+          ) : null}
+          {message.is_removed ? (
+            <Badge variant="destructive" className="gap-1">
+              <AlertTriangle className="size-3" />
+              Removed
+            </Badge>
+          ) : null}
+        </div>
+        <p
+          className={cn(
+            "whitespace-pre-line text-sm",
+            message.is_removed ? "text-muted-foreground" : "text-foreground"
+          )}
+        >
+          {message.body}
+        </p>
+        {attachments.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {attachments.map((attachment) => (
+              <a
+                key={attachment.url}
+                href={attachment.url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex max-w-[240px] items-center gap-2 truncate rounded-md border bg-muted px-3 py-1 text-xs text-muted-foreground transition hover:bg-muted/80"
+              >
+                <Paperclip className="size-3.5 shrink-0" />
+                <span className="truncate">{attachment.name}</span>
+              </a>
+            ))}
+          </div>
+        ) : null}
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span>{relativeTime}</span>
+          {isStaff ? (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() => onPinToggle(message, !message.is_pinned)}
+                disabled={isModerating}
+              >
+                {isModerating ? (
+                  <Loader2 className="mr-1 size-3 animate-spin" />
+                ) : message.is_pinned ? (
+                  <PinOff className="mr-1 size-3" />
+                ) : (
+                  <Pin className="mr-1 size-3" />
+                )}
+                {message.is_pinned ? "Unpin" : "Pin"}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() => onRemovalToggle(message, !message.is_removed)}
+                disabled={isModerating}
+              >
+                {isModerating ? (
+                  <Loader2 className="mr-1 size-3 animate-spin" />
+                ) : message.is_removed ? (
+                  <Undo2 className="mr-1 size-3" />
+                ) : (
+                  <Trash2 className="mr-1 size-3" />
+                )}
+                {message.is_removed ? "Restore" : "Remove"}
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(tenant)/message-board/page.tsx
+++ b/app/(tenant)/message-board/page.tsx
@@ -1,0 +1,125 @@
+import { redirect } from "next/navigation";
+
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+import {
+  ensureRealtimeSubscription,
+  fetchPropertyDirectory,
+  fetchTenantMessages,
+  fetchTenantThreads,
+  fetchUserProfile,
+} from "./actions";
+import { isStaffRole } from "./roles";
+import MessageBoardClient from "./message-board-client";
+
+const PAGE_SIZE = 25;
+
+type MessageBoardPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default async function MessageBoardPage({ searchParams }: MessageBoardPageProps) {
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth");
+  }
+
+  const profile = await fetchUserProfile();
+  const isStaffMember = isStaffRole(profile.role ?? null);
+
+  const threads = isStaffMember
+    ? (await fetchPropertyDirectory()).flatMap((property) => {
+        const timestamp = new Date().toISOString();
+        const propertyInfo = {
+          id: property.id,
+          name: property.name ?? "",
+          address_line: property.address_line ?? null,
+          city: property.city ?? null,
+          state: property.state ?? null,
+          postal_code: property.postal_code ?? null,
+        };
+
+        const propertyThread = {
+          id: property.id,
+          role: profile.role ?? "staff",
+          created_at: timestamp,
+          property: propertyInfo,
+          unit: null,
+        };
+
+        const unitThreads = property.units.map((unit) => ({
+          id: `${property.id}:${unit.id}`,
+          role: profile.role ?? "staff",
+          created_at: timestamp,
+          property: propertyInfo,
+          unit: {
+            id: unit.id,
+            label: unit.label ?? "",
+          },
+        }));
+
+        return [propertyThread, ...unitThreads];
+      })
+    : await fetchTenantThreads();
+
+  if (!threads.length) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>Message board</CardTitle>
+            <CardDescription>
+              We couldn&apos;t find any properties associated with your account yet. Once a
+              property manager connects you to a residence you&apos;ll be able to view and join
+              conversations here.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  const requestedProperty = searchParams?.property;
+  const requestedUnit = searchParams?.unit;
+
+  const resolvedPropertyId =
+    typeof requestedProperty === "string" &&
+    threads.some((thread) => thread.property?.id === requestedProperty)
+      ? requestedProperty
+      : threads[0]?.property?.id ?? threads[0]?.id;
+
+  const selectedThread = threads.find((thread) => thread.property?.id === resolvedPropertyId);
+
+  const resolvedUnitId =
+    typeof requestedUnit === "string" && selectedThread?.unit?.id === requestedUnit
+      ? requestedUnit
+      : selectedThread?.unit?.id ?? null;
+
+  await ensureRealtimeSubscription({ propertyId: resolvedPropertyId, unitId: resolvedUnitId });
+
+  const messagePage = await fetchTenantMessages({
+    propertyId: resolvedPropertyId,
+    unitId: resolvedUnitId,
+    limit: PAGE_SIZE,
+  });
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 py-8">
+      <MessageBoardClient
+        currentProfile={profile}
+        initialMessages={messagePage.messages}
+        initialCursor={messagePage.nextCursor}
+        initialHasMore={messagePage.hasMore}
+        initialPropertyId={resolvedPropertyId}
+        initialUnitId={resolvedUnitId}
+        threads={threads}
+        pageSize={PAGE_SIZE}
+      />
+    </div>
+  );
+}

--- a/app/(tenant)/message-board/roles.ts
+++ b/app/(tenant)/message-board/roles.ts
@@ -1,0 +1,16 @@
+const STAFF_ROLES = new Set([
+  "staff",
+  "admin",
+  "manager",
+  "property_manager",
+]);
+
+export function isStaffRole(role: string | null | undefined) {
+  if (!role) {
+    return false;
+  }
+
+  return STAFF_ROLES.has(role.toLowerCase());
+}
+
+export { STAFF_ROLES };

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next"
 import Image from "next/image"
+import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -188,6 +189,24 @@ export default function DashboardPage() {
                   </CardContent>
                 </Card>
               </div>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Community message board</CardTitle>
+                  <CardDescription>
+                    Coordinate with residents, share announcements, and log maintenance
+                    updates in real time.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-wrap items-center justify-between gap-4">
+                  <p className="max-w-xl text-sm text-muted-foreground">
+                    Visit the message board to post updates, pin critical notices, and keep
+                    every unit informed.
+                  </p>
+                  <Button asChild>
+                    <Link href="/message-board">Open message board</Link>
+                  </Button>
+                </CardContent>
+              </Card>
             </TabsContent>
           </Tabs>
         </div>

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,50 +1,105 @@
 "use client";
-import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import React, { useEffect, useState } from "react";
+import {
+  ChatBubbleIcon,
+  CrumpledPaperIcon,
+  LightningBoltIcon,
+  PersonIcon,
+} from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
+import useSupabaseBrowser from "@/utils/supabase-browser";
+import { isStaffRole } from "@/app/(tenant)/message-board/roles";
 
 export default function NavLinks() {
-	const pathname = usePathname();
+        const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+        const supabase = useSupabaseBrowser();
+        const [isStaff, setIsStaff] = useState(false);
 
-	return (
-		<div className="space-y-5">
-			{links.map((link, index) => {
-				const Icon = link.Icon;
-				return (
-					<Link
-						onClick={() =>
-							document.getElementById("sidebar-close")?.click()
-						}
-						href={link.href}
-						key={index}
-						className={cn(
-							"flex items-center gap-2 rounded-sm p-2",
-							{
-								" bg-gray-500 dark:bg-gray-700 text-white ":
-									pathname === link.href,
-							}
-						)}
-					>
-						<Icon />
-						{link.text}
-					</Link>
-				);
-			})}
-		</div>
-	);
+        useEffect(() => {
+                let active = true;
+
+                const loadRole = async () => {
+                        const {
+                                data: { user },
+                        } = await supabase.auth.getUser();
+
+                        if (!user) {
+                                return;
+                        }
+
+                        const { data } = await supabase
+                                .from("profiles")
+                                .select("role")
+                                .eq("id", user.id)
+                                .single();
+
+                        if (!active) {
+                                return;
+                        }
+
+                        setIsStaff(isStaffRole(data?.role ?? null));
+                };
+
+                void loadRole();
+
+                return () => {
+                        active = false;
+                };
+        }, [supabase]);
+
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+                {
+                        href: "/message-board",
+                        text: "Message Board",
+                        Icon: ChatBubbleIcon,
+                },
+        ];
+
+        if (isStaff) {
+                links.push({
+                        href: "/dashboard/message-board/moderation",
+                        text: "Moderation",
+                        Icon: LightningBoltIcon,
+                });
+        }
+
+        return (
+                <div className="space-y-5">
+                        {links.map((link, index) => {
+                                const Icon = link.Icon;
+                                return (
+                                        <Link
+                                                onClick={() =>
+                                                        document.getElementById("sidebar-close")?.click()
+                                                }
+                                                href={link.href}
+                                                key={index}
+                                                className={cn(
+                                                        "flex items-center gap-2 rounded-sm p-2",
+                                                        {
+                                                                " bg-gray-500 dark:bg-gray-700 text-white ":
+                                                                        pathname === link.href,
+                                                        }
+                                                )}
+                                        >
+                                                <Icon />
+                                                {link.text}
+                                        </Link>
+                                );
+                        })}
+                </div>
+        );
 }

--- a/app/dashboard/components/main-nav.tsx
+++ b/app/dashboard/components/main-nav.tsx
@@ -12,28 +12,28 @@ export function MainNav({
       {...props}
     >
       <Link
-        href="#"
+        href="/dashboard"
         className="text-sm font-medium transition-colors hover:text-primary"
       >
         Overview
       </Link>
       <Link
-        href="#"
+        href="/message-board"
         className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
       >
-        Customers
+        Message Board
       </Link>
       <Link
-       href="#"
+        href="/dashboard/message-board/moderation"
         className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
       >
-        Products
+        Moderation
       </Link>
       <Link
-        href="#"
+        href="/dashboard/members"
         className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
       >
-        Settings
+        Members
       </Link>
     </nav>
   )

--- a/app/dashboard/message-board/moderation-client.tsx
+++ b/app/dashboard/message-board/moderation-client.tsx
@@ -1,0 +1,426 @@
+"use client";
+
+import { useCallback, useMemo, useState, useTransition } from "react";
+import { formatDistanceToNow } from "date-fns";
+import {
+  AlertTriangle,
+  Loader2,
+  Paperclip,
+  Pin,
+  PinOff,
+  Trash2,
+  Undo2,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+
+import type { TenantMessageRecord } from "@/app/(tenant)/message-board/actions";
+import {
+  fetchTenantMessages,
+  pinTenantMessage,
+  removeTenantMessage,
+  restoreTenantMessage,
+  unpinTenantMessage,
+} from "@/app/(tenant)/message-board/actions";
+
+type PropertySummary = {
+  id: string;
+  name: string | null;
+  address_line: string | null;
+  city: string | null;
+  state: string | null;
+  postal_code: string | null;
+};
+
+type ModerationClientProps = {
+  currentProfile: {
+    id: string;
+    full_name: string | null;
+    role: string | null;
+  };
+  properties: PropertySummary[];
+  initialPropertyId: string;
+  initialMessages: TenantMessageRecord[];
+  initialCursor: string | null;
+  initialHasMore: boolean;
+  pageSize: number;
+};
+
+function sortByNewest(messages: TenantMessageRecord[]) {
+  return [...messages].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+}
+
+function formatPropertyAddress(property: PropertySummary | undefined) {
+  if (!property) {
+    return "";
+  }
+
+  const parts = [
+    property.address_line,
+    property.city,
+    property.state,
+    property.postal_code,
+  ].filter(Boolean);
+
+  return parts.join(", ");
+}
+
+export default function ModerationClient({
+  currentProfile,
+  properties,
+  initialPropertyId,
+  initialMessages,
+  initialCursor,
+  initialHasMore,
+  pageSize,
+}: ModerationClientProps) {
+  const { toast } = useToast();
+  const [selectedPropertyId, setSelectedPropertyId] = useState(initialPropertyId);
+  const [messages, setMessages] = useState(() => sortByNewest(initialMessages));
+  const [cursor, setCursor] = useState<string | null>(initialCursor);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [isLoadingProperty, startTransition] = useTransition();
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [moderatingIds, setModeratingIds] = useState<Set<number>>(new Set());
+
+  const selectedProperty = useMemo(
+    () => properties.find((property) => property.id === selectedPropertyId),
+    [properties, selectedPropertyId]
+  );
+
+  const propertyAddress = useMemo(
+    () => formatPropertyAddress(selectedProperty),
+    [selectedProperty]
+  );
+
+  const isModerating = useCallback(
+    (id: number) => moderatingIds.has(id),
+    [moderatingIds]
+  );
+
+  const toggleModerating = useCallback((id: number, active: boolean) => {
+    setModeratingIds((previous) => {
+      const updated = new Set(previous);
+      if (active) {
+        updated.add(id);
+      } else {
+        updated.delete(id);
+      }
+      return updated;
+    });
+  }, []);
+
+  const handlePropertyChange = useCallback(
+    (propertyId: string) => {
+      setSelectedPropertyId(propertyId);
+      startTransition(() => {
+        const load = async () => {
+          try {
+            const response = await fetchTenantMessages({
+              propertyId,
+              limit: pageSize,
+              includePropertyMeta: true,
+            });
+
+            setMessages(sortByNewest(response.messages));
+            setCursor(response.nextCursor);
+            setHasMore(response.hasMore);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "Unable to load messages";
+            toast({
+              title: "Failed to load messages",
+              description: message,
+              variant: "destructive",
+            });
+          }
+        };
+
+        void load();
+      });
+    },
+    [pageSize, toast]
+  );
+
+  const handleLoadMore = useCallback(async () => {
+    if (!cursor) {
+      return;
+    }
+
+    setLoadingMore(true);
+
+    try {
+      const response = await fetchTenantMessages({
+        propertyId: selectedPropertyId,
+        limit: pageSize,
+        before: cursor,
+        includePropertyMeta: true,
+      });
+
+      setMessages((previous) =>
+        sortByNewest([...previous, ...response.messages])
+      );
+      setCursor(response.nextCursor);
+      setHasMore(response.hasMore);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to load more messages";
+      toast({
+        title: "Could not load more messages",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [cursor, pageSize, selectedPropertyId, toast]);
+
+  const handlePinToggle = useCallback(
+    async (message: TenantMessageRecord, desiredState: boolean) => {
+      toggleModerating(message.id, true);
+
+      try {
+        const updated = desiredState
+          ? await pinTenantMessage(message.id)
+          : await unpinTenantMessage(message.id);
+
+        setMessages((previous) =>
+          sortByNewest(
+            previous.map((existing) => (existing.id === updated.id ? updated : existing))
+          )
+        );
+
+        toast({ title: desiredState ? "Message pinned" : "Message unpinned" });
+      } catch (error) {
+        const description =
+          error instanceof Error ? error.message : "Unable to update message";
+        toast({
+          title: "Moderation update failed",
+          description,
+          variant: "destructive",
+        });
+      } finally {
+        toggleModerating(message.id, false);
+      }
+    },
+    [toast, toggleModerating]
+  );
+
+  const handleRemovalToggle = useCallback(
+    async (message: TenantMessageRecord, desiredState: boolean) => {
+      toggleModerating(message.id, true);
+
+      try {
+        const updated = desiredState
+          ? await removeTenantMessage(message.id)
+          : await restoreTenantMessage(message.id);
+
+        setMessages((previous) =>
+          sortByNewest(
+            previous.map((existing) => (existing.id === updated.id ? updated : existing))
+          )
+        );
+
+        toast({ title: desiredState ? "Message removed" : "Message restored" });
+      } catch (error) {
+        const description =
+          error instanceof Error ? error.message : "Unable to update message";
+        toast({
+          title: "Moderation update failed",
+          description,
+          variant: "destructive",
+        });
+      } finally {
+        toggleModerating(message.id, false);
+      }
+    },
+    [toast, toggleModerating]
+  );
+
+  return (
+    <Card className="border-border/60 shadow-sm">
+      <CardHeader className="gap-6">
+        <div className="space-y-2">
+          <CardTitle className="text-2xl">Moderate tenant conversations</CardTitle>
+          <CardDescription>
+            Review the latest posts, highlight important updates, and keep community
+            threads on-topic.
+          </CardDescription>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Property</Label>
+            <Select value={selectedPropertyId} onValueChange={handlePropertyChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select a property" />
+              </SelectTrigger>
+              <SelectContent>
+                {properties.map((property) => (
+                  <SelectItem key={property.id} value={property.id}>
+                    {property.name || "Property"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Moderator</Label>
+            <div className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
+              {currentProfile.full_name ?? "Staff"}
+            </div>
+          </div>
+        </div>
+        {propertyAddress ? (
+          <div className="rounded-md border border-dashed bg-muted/40 p-4 text-sm text-muted-foreground">
+            {propertyAddress}
+          </div>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {isLoadingProperty ? (
+          <div className="flex items-center gap-2 rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            Loading property feed…
+          </div>
+        ) : null}
+        {messages.length === 0 ? (
+          <div className="rounded-md border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+            No messages yet for this property.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {messages.map((message) => (
+              <div
+                key={message.id}
+                className={cn(
+                  "rounded-md border bg-card p-5",
+                  message.is_removed ? "opacity-70" : ""
+                )}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center gap-2 text-sm">
+                    <span className="font-medium text-foreground">
+                      {message.author?.full_name ?? "Resident"}
+                    </span>
+                    {message.unit?.label ? (
+                      <Badge variant="outline">Unit {message.unit.label}</Badge>
+                    ) : null}
+                    {message.is_pinned ? (
+                      <Badge variant="secondary" className="gap-1">
+                        <Pin className="size-3" />
+                        Pinned
+                      </Badge>
+                    ) : null}
+                    {message.is_removed ? (
+                      <Badge variant="destructive" className="gap-1">
+                        <AlertTriangle className="size-3" />
+                        Removed
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {formatDistanceToNow(new Date(message.created_at), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                </div>
+                <p
+                  className={cn(
+                    "mt-3 whitespace-pre-line text-sm",
+                    message.is_removed ? "text-muted-foreground" : "text-foreground"
+                  )}
+                >
+                  {message.body}
+                </p>
+                {message.attachments.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {message.attachments.map((attachment) => (
+                      <a
+                        key={attachment.url}
+                        href={attachment.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex max-w-[260px] items-center gap-2 truncate rounded-md border bg-muted px-3 py-1 text-xs text-muted-foreground transition hover:bg-muted/80"
+                      >
+                        <Paperclip className="size-3.5 shrink-0" />
+                        <span className="truncate">{attachment.name}</span>
+                      </a>
+                    ))}
+                  </div>
+                ) : null}
+                <div className="mt-4 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                  <span>
+                    Updated {formatDistanceToNow(new Date(message.updated_at), { addSuffix: true })}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => handlePinToggle(message, !message.is_pinned)}
+                      disabled={isModerating(message.id)}
+                    >
+                      {isModerating(message.id) ? (
+                        <Loader2 className="mr-1 size-3 animate-spin" />
+                      ) : message.is_pinned ? (
+                        <PinOff className="mr-1 size-3" />
+                      ) : (
+                        <Pin className="mr-1 size-3" />
+                      )}
+                      {message.is_pinned ? "Unpin" : "Pin"}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => handleRemovalToggle(message, !message.is_removed)}
+                      disabled={isModerating(message.id)}
+                    >
+                      {isModerating(message.id) ? (
+                        <Loader2 className="mr-1 size-3 animate-spin" />
+                      ) : message.is_removed ? (
+                        <Undo2 className="mr-1 size-3" />
+                      ) : (
+                        <Trash2 className="mr-1 size-3" />
+                      )}
+                      {message.is_removed ? "Restore" : "Remove"}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {hasMore ? (
+          <div className="flex justify-center">
+            <Button
+              variant="outline"
+              onClick={handleLoadMore}
+              disabled={loadingMore}
+              className="w-full sm:w-auto"
+            >
+              {loadingMore ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Loading older messages
+                </>
+              ) : (
+                "Load older messages"
+              )}
+            </Button>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/dashboard/message-board/moderation.tsx
+++ b/app/dashboard/message-board/moderation.tsx
@@ -1,0 +1,73 @@
+import { redirect } from "next/navigation";
+
+import {
+  fetchPropertyDirectory,
+  fetchTenantMessages,
+  fetchUserProfile,
+} from "@/app/(tenant)/message-board/actions";
+import { isStaffRole } from "@/app/(tenant)/message-board/roles";
+
+import ModerationClient from "./moderation-client";
+
+const PAGE_SIZE = 40;
+
+type ModerationPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default async function ModerationPage({ searchParams }: ModerationPageProps) {
+  let profile;
+  try {
+    profile = await fetchUserProfile();
+  } catch (error) {
+    if (error instanceof Error && error.message === "Not authenticated") {
+      redirect("/auth");
+    }
+
+    throw error;
+  }
+
+  if (!isStaffRole(profile.role ?? null)) {
+    redirect("/dashboard");
+  }
+
+  const properties = (await fetchPropertyDirectory()).map(({ units, ...summary }) => summary);
+
+  if (!properties.length) {
+    return (
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 py-12">
+        <div className="rounded-md border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+          No properties are configured yet. Create a property to begin moderating tenant
+          conversations.
+        </div>
+      </div>
+    );
+  }
+
+  const requestedProperty = searchParams?.property;
+  const propertyIds = properties.map((property) => property.id);
+  const selectedPropertyId =
+    typeof requestedProperty === "string" && propertyIds.includes(requestedProperty)
+      ? requestedProperty
+      : properties[0]!.id;
+
+  const messagePage = await fetchTenantMessages({
+    propertyId: selectedPropertyId,
+    limit: PAGE_SIZE,
+    includePropertyMeta: true,
+  });
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 py-8">
+      <ModerationClient
+        currentProfile={profile}
+        properties={properties}
+        initialPropertyId={selectedPropertyId}
+        initialMessages={messagePage.messages}
+        initialCursor={messagePage.nextCursor}
+        initialHasMore={messagePage.hasMore}
+        pageSize={PAGE_SIZE}
+      />
+    </div>
+  );
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -19,6 +19,10 @@ export const siteConfig = {
       href: "/dashboard",
     },
     {
+      title: "Message Board",
+      href: "/message-board",
+    },
+    {
       title: "OpenAI",
       href: "/playground",
     },
@@ -50,5 +54,6 @@ export const siteConfig = {
     signup: "/onboarding",
     contact: "/contact",
     linkedin: "https://linkedin.com/in/robertmoureyjr",
+    messageBoard: "/message-board",
   },
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -450,39 +450,6 @@ export type Database = {
         }
         Relationships: []
       }
-      chat: {
-        Row: {
-          created_at: string
-          id: number
-          messages: string[] | null
-          path: string | null
-          profile_id: string
-          sharepath: string | null
-          title: string | null
-          user_id: string | null
-        }
-        Insert: {
-          created_at: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
-          profile_id: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          created_at?: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
-          profile_id?: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
-        }
-        Relationships: []
-      }
       countries: {
         Row: {
           continent: Database["public"]["Enums"]["continents"] | null
@@ -1289,6 +1256,91 @@ export type Database = {
         }
         Relationships: []
       }
+      properties: {
+        Row: {
+          address_line: string | null
+          city: string | null
+          created_at: string
+          id: string
+          manager_id: string | null
+          name: string
+          postal_code: string | null
+          state: string | null
+          updated_at: string
+        }
+        Insert: {
+          address_line?: string | null
+          city?: string | null
+          created_at?: string
+          id?: string
+          manager_id?: string | null
+          name: string
+          postal_code?: string | null
+          state?: string | null
+          updated_at?: string
+        }
+        Update: {
+          address_line?: string | null
+          city?: string | null
+          created_at?: string
+          id?: string
+          manager_id?: string | null
+          name?: string
+          postal_code?: string | null
+          state?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "properties_manager_id_fkey"
+            columns: ["manager_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      property_units: {
+        Row: {
+          bathrooms: number | null
+          bedrooms: number | null
+          created_at: string
+          id: string
+          label: string
+          property_id: string
+          square_feet: number | null
+          updated_at: string
+        }
+        Insert: {
+          bathrooms?: number | null
+          bedrooms?: number | null
+          created_at?: string
+          id?: string
+          label: string
+          property_id: string
+          square_feet?: number | null
+          updated_at?: string
+        }
+        Update: {
+          bathrooms?: number | null
+          bedrooms?: number | null
+          created_at?: string
+          id?: string
+          label?: string
+          property_id?: string
+          square_feet?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "property_units_property_id_fkey"
+            columns: ["property_id"]
+            isOneToOne: false
+            referencedRelation: "properties"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       reusable_packages: {
         Row: {
           created_at: string | null
@@ -1558,6 +1610,142 @@ export type Database = {
         }
         Relationships: []
       }
+      tenant_messages: {
+        Row: {
+          attachments: Json
+          author_id: string
+          body: string
+          created_at: string
+          id: number
+          is_pinned: boolean
+          is_removed: boolean
+          pinned_at: string | null
+          pinned_by: string | null
+          property_id: string
+          removed_at: string | null
+          removed_by: string | null
+          unit_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          attachments?: Json
+          author_id: string
+          body: string
+          created_at?: string
+          id?: number
+          is_pinned?: boolean
+          is_removed?: boolean
+          pinned_at?: string | null
+          pinned_by?: string | null
+          property_id: string
+          removed_at?: string | null
+          removed_by?: string | null
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          attachments?: Json
+          author_id?: string
+          body?: string
+          created_at?: string
+          id?: number
+          is_pinned?: boolean
+          is_removed?: boolean
+          pinned_at?: string | null
+          pinned_by?: string | null
+          property_id?: string
+          removed_at?: string | null
+          removed_by?: string | null
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_messages_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_pinned_by_fkey"
+            columns: ["pinned_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_property_id_fkey"
+            columns: ["property_id"]
+            isOneToOne: false
+            referencedRelation: "properties"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_removed_by_fkey"
+            columns: ["removed_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_messages_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "property_units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tenant_property_memberships: {
+        Row: {
+          created_at: string
+          id: string
+          profile_id: string
+          property_id: string
+          role: string
+          unit_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          profile_id: string
+          property_id: string
+          role?: string
+          unit_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          profile_id?: string
+          property_id?: string
+          role?: string
+          unit_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_property_memberships_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_property_memberships_property_id_fkey"
+            columns: ["property_id"]
+            isOneToOne: false
+            referencedRelation: "properties"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_property_memberships_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "property_units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       todos: {
         Row: {
           created_at: string
@@ -1598,6 +1786,12 @@ export type Database = {
       }
     }
     Views: {
+      staff_profiles: {
+        Row: {
+          id: string | null
+        }
+        Relationships: []
+      }
       package_utilization: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20240712_tenant_messages.sql
+++ b/supabase/migrations/20240712_tenant_messages.sql
@@ -1,0 +1,244 @@
+create extension if not exists "pgcrypto";
+
+-- Replace legacy chat table with scoped tenant messaging primitives
+drop table if exists public.chat cascade;
+
+create table public.properties (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  address_line text,
+  city text,
+  state text,
+  postal_code text,
+  manager_id uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.property_units (
+  id uuid primary key default gen_random_uuid(),
+  property_id uuid not null references public.properties(id) on delete cascade,
+  label text not null,
+  bedrooms integer,
+  bathrooms integer,
+  square_feet integer,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint property_units_property_label_key unique (property_id, lower(label))
+);
+
+create table public.tenant_property_memberships (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  property_id uuid not null references public.properties(id) on delete cascade,
+  unit_id uuid references public.property_units(id) on delete set null,
+  role text not null default 'tenant',
+  created_at timestamptz not null default now(),
+  constraint tenant_property_memberships_profile_property_unit_key unique (profile_id, property_id, unit_id)
+);
+
+create table public.tenant_messages (
+  id bigint generated always as identity primary key,
+  property_id uuid not null references public.properties(id) on delete cascade,
+  unit_id uuid references public.property_units(id) on delete set null,
+  author_id uuid not null references public.profiles(id) on delete cascade,
+  body text not null,
+  attachments jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  is_pinned boolean not null default false,
+  pinned_at timestamptz,
+  pinned_by uuid references public.profiles(id) on delete set null,
+  is_removed boolean not null default false,
+  removed_at timestamptz,
+  removed_by uuid references public.profiles(id) on delete set null
+);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_properties_updated_at on public.properties;
+create trigger set_properties_updated_at
+before update on public.properties
+for each row execute function public.set_updated_at();
+
+drop trigger if exists set_property_units_updated_at on public.property_units;
+create trigger set_property_units_updated_at
+before update on public.property_units
+for each row execute function public.set_updated_at();
+
+drop trigger if exists set_tenant_messages_updated_at on public.tenant_messages;
+create trigger set_tenant_messages_updated_at
+before update on public.tenant_messages
+for each row execute function public.set_updated_at();
+
+create index if not exists idx_property_units_property on public.property_units(property_id);
+create index if not exists idx_tenant_memberships_profile on public.tenant_property_memberships(profile_id);
+create index if not exists idx_tenant_memberships_property on public.tenant_property_memberships(property_id);
+create index if not exists idx_tenant_messages_property on public.tenant_messages(property_id, unit_id, created_at desc);
+create index if not exists idx_tenant_messages_author on public.tenant_messages(author_id);
+
+alter table public.properties enable row level security;
+alter table public.property_units enable row level security;
+alter table public.tenant_property_memberships enable row level security;
+alter table public.tenant_messages enable row level security;
+
+-- helper predicate for staff checks
+create or replace view public.staff_profiles as
+select id
+from public.profiles
+where lower(coalesce(role, '')) in ('staff', 'admin', 'manager', 'property_manager');
+
+drop policy if exists "Members can view their memberships" on public.tenant_property_memberships;
+create policy "Members can view their memberships"
+  on public.tenant_property_memberships
+  for select
+  using (
+    profile_id = auth.uid()
+    or exists (
+      select 1 from public.staff_profiles sp where sp.id = auth.uid()
+    )
+  );
+
+drop policy if exists "Staff manage memberships" on public.tenant_property_memberships;
+create policy "Staff manage memberships"
+  on public.tenant_property_memberships
+  for all
+  using (
+    exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  )
+  with check (
+    exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  );
+
+drop policy if exists "Tenants can view their properties" on public.properties;
+create policy "Tenants can view their properties"
+  on public.properties
+  for select
+  using (
+    exists (
+      select 1
+      from public.tenant_property_memberships m
+      where m.property_id = public.properties.id
+        and (
+          m.profile_id = auth.uid()
+          or exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+        )
+    )
+  );
+
+drop policy if exists "Staff manage properties" on public.properties;
+create policy "Staff manage properties"
+  on public.properties
+  for all
+  using (
+    exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  )
+  with check (
+    exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  );
+
+drop policy if exists "Tenants can view their units" on public.property_units;
+create policy "Tenants can view their units"
+  on public.property_units
+  for select
+  using (
+    exists (
+      select 1
+      from public.tenant_property_memberships m
+      where m.property_id = public.property_units.property_id
+        and (
+          m.profile_id = auth.uid()
+          or exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+        )
+    )
+  );
+
+drop policy if exists "Staff manage units" on public.property_units;
+create policy "Staff manage units"
+  on public.property_units
+  for all
+  using (
+    exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  )
+  with check (
+    exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  );
+
+drop policy if exists "Tenants can read thread messages" on public.tenant_messages;
+create policy "Tenants can read thread messages"
+  on public.tenant_messages
+  for select
+  using (
+    exists (
+      select 1
+      from public.tenant_property_memberships m
+      where m.profile_id = auth.uid()
+        and m.property_id = public.tenant_messages.property_id
+        and (
+          public.tenant_messages.unit_id is null
+          or m.unit_id is null
+          or m.unit_id = public.tenant_messages.unit_id
+        )
+    )
+    or exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  );
+
+drop policy if exists "Tenants can post to their threads" on public.tenant_messages;
+create policy "Tenants can post to their threads"
+  on public.tenant_messages
+  for insert
+  with check (
+    (
+      exists (
+        select 1
+        from public.tenant_property_memberships m
+        where m.profile_id = auth.uid()
+          and m.property_id = public.tenant_messages.property_id
+          and (
+            public.tenant_messages.unit_id is null
+            or m.unit_id is null
+            or m.unit_id = public.tenant_messages.unit_id
+          )
+      )
+      and auth.uid() = public.tenant_messages.author_id
+    )
+    or exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  );
+
+drop policy if exists "Authors can edit their messages" on public.tenant_messages;
+create policy "Authors can edit their messages"
+  on public.tenant_messages
+  for update
+  using (auth.uid() = public.tenant_messages.author_id)
+  with check (
+    exists (
+      select 1
+      from public.tenant_property_memberships m
+      where m.profile_id = auth.uid()
+        and m.property_id = public.tenant_messages.property_id
+        and (
+          public.tenant_messages.unit_id is null
+          or m.unit_id is null
+          or m.unit_id = public.tenant_messages.unit_id
+        )
+    )
+  );
+
+drop policy if exists "Staff can moderate tenant messages" on public.tenant_messages;
+create policy "Staff can moderate tenant messages"
+  on public.tenant_messages
+  for all
+  using (
+    exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  )
+  with check (
+    exists (select 1 from public.staff_profiles sp where sp.id = auth.uid())
+  );


### PR DESCRIPTION
## Summary
- replace the legacy chat schema with property-aware tenant messaging tables, triggers, and RLS policies
- regenerate Supabase types and add server actions plus realtime helpers for tenant message feeds
- build tenant- and staff-facing message board UIs with moderation tools and surface navigation/CTA links to the feature

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ceea926b60832898456fdad90f5f0c