### PR TITLE
docs: establish repo structure conventions

### DIFF
--- a/agents/AGENTS.template.md
+++ b/agents/AGENTS.template.md
@@ -1,0 +1,65 @@
+# Background Worker Agent Template
+
+> Duplicate this template into `agents/<agent-name>/AGENTS.md` when introducing a new background worker. Update every section with agent-specific details before opening a pull request.
+
+## Overview
+
+- **Agent name:** `<agent-name>`
+- **Team / Owner:** `<team>`
+- **Primary purpose:** Describe what business workflow or automation this worker performs.
+- **Trigger cadence:** e.g., event-driven via queue, cron schedule, or manual dispatch.
+
+## Responsibilities
+
+- List the core jobs or message types the worker processes.
+- Note any upstream dependencies (topics, queues, webhooks) and downstream systems updated.
+
+## Runtime & Deployment
+
+- **Language / Runtime:** e.g., TypeScript (Node 20), Python 3.11, Go 1.21.
+- **Package location:** `<path within monorepo>`
+- **Build command:** `<pnpm turbo run build --filter ...>`
+- **Deploy target:** e.g., AWS ECS service, serverless function, Kubernetes CronJob.
+- **Scaling strategy:** Autoscaling rules, concurrency limits, or worker pool sizing.
+
+## Configuration
+
+- Enumerate required environment variables, secrets, and configuration files.
+- Document feature flags or toggles that affect behavior.
+- Reference configuration sources (e.g., `infra/secrets/<agent>.tf`, Parameter Store path).
+
+## Observability
+
+- **Logging:** Format, correlation IDs, and log destinations.
+- **Metrics:** Key performance indicators emitted (e.g., jobs processed, retry count, latency percentiles) and dashboard links.
+- **Tracing:** How traces are exported and sampling configuration.
+- **Alerts:** Pager or Slack channels notified, and alert thresholds.
+
+## Failure Modes & Recovery
+
+- Known error conditions and mitigation steps.
+- Retry/backoff strategy for transient failures.
+- Runbook links for manual intervention.
+
+## Testing Strategy
+
+- Unit, integration, and end-to-end test coverage expectations.
+- Commands to run tests locally and in CI.
+- How to create fixture data or mocks for external dependencies.
+
+## Release Process
+
+- Checklist for releasing changes, including migration steps or coordination with other teams.
+- Rollback strategy and validation checks after deployment.
+
+## Compliance & Security
+
+- Data classifications handled by the worker (PII, PCI, etc.).
+- Required security reviews or approvals.
+- Access control notes, including least-privilege IAM policies.
+
+## Change Log
+
+| Date | Change | Author |
+| --- | --- | --- |
+| YYYY-MM-DD | Initial version | `<your-name>` |

--- a/docs/adr/0001-repo-structure.md
+++ b/docs/adr/0001-repo-structure.md
@@ -1,0 +1,43 @@
+# ADR 0001: Repository Structure Strategy
+
+- Status: Accepted
+- Deciders: Platform Engineering Guild
+- Date: 2024-04-05
+
+## Context
+
+The Share House platform includes multiple backend services, web and mobile clients, shared libraries, and infrastructure-as-code definitions. Product teams collaborate across these domains, share UI and API contracts, and rely on consistent tooling to deliver features quickly. Historically, related codebases have lived in separate repositories, which increased coordination cost for cross-cutting changes, duplicated CI/CD configuration, and complicated dependency management.
+
+## Decision
+
+We will adopt a **monorepo** for the Share House platform. All product-critical services, clients, infrastructure definitions, and shared packages will live in this repository.
+
+### Rationale
+
+- **Coordinated changes**: Cross-service updates (API contracts, shared libraries, schema migrations) can be implemented and reviewed atomically.
+- **Unified tooling**: Build, lint, and release automation is centralized, reducing duplicated configuration and enabling consistent quality gates.
+- **Discoverability**: Engineers can locate related services, assets, and documentation without traversing multiple repos.
+- **Developer experience**: Local development environments can be orchestrated from a single workspace, simplifying onboarding and reducing context switching.
+
+### Alternatives Considered
+
+- **Polyrepo**: Keeping each service or client in its own repository would isolate release cadences and allow tailored tooling. However, the coordination overhead, fragmented visibility, and duplicated infra outweighed these benefits for our current team size and roadmap.
+
+## Consequences
+
+### Positive
+
+- End-to-end features can be delivered within a single pull request.
+- Shared code evolves faster because teams can co-own packages and see usage sites.
+- Centralized governance makes it easier to enforce security and compliance policies.
+
+### Negative
+
+- The repository will grow large; we must invest in incremental builds, partial CI pipelines, and workspace tooling to keep feedback loops fast.
+- Access controls must be role-based within the repo (e.g., code owners) since repository-level ACLs are no longer granular.
+
+### Follow-up Actions
+
+1. Establish code ownership rules (CODEOWNERS) for critical directories.
+2. Configure workspace-aware tooling (e.g., Turborepo, Nx, or pnpm workspaces) to support selective builds and tests.
+3. Document contribution workflows and release processes for teams sharing the monorepo.

--- a/docs/engineering/conventions.md
+++ b/docs/engineering/conventions.md
@@ -1,0 +1,69 @@
+# Engineering Conventions
+
+This document summarizes the agreed structure for the Share House monorepo and the coding standards all teams follow when contributing to it.
+
+## Top-level Folder Structure
+
+The repository is organized to keep infrastructure, services, clients, and shared assets discoverable. New projects should align with these conventions.
+
+| Directory | Description |
+| --- | --- |
+| `infra/` | Infrastructure as code modules, pipeline definitions, Terraform/Terragrunt stacks, and environment specific configuration. Each subfolder should own its deployment documentation and automation scripts. |
+| `services/` | Backend services (REST, GraphQL, background workers, cron jobs). Each service keeps its own README, deployment manifests, and service-level tests. |
+| `apps/web/` | Web clients and portals built with Next.js or other frontend frameworks. Feature apps sit under `apps/web/<app-name>/` and share UI kits from `packages/ui`. |
+| `apps/mobile/` | React Native or native mobile clients. Each mobile app must define build configuration, platform-specific assets, and release checklists in its own subfolder. |
+| `packages/` | Shared libraries used across services and clients (e.g., domain models, API SDKs, UI component libraries, lint configs). Packages should be published via workspaces and versioned with semantic releases. |
+| `tools/` | Developer tooling such as code generators, database migration CLIs, and integration test harnesses. |
+| `docs/` | Architecture decision records, onboarding guides, runbooks, and engineering policies. |
+
+> **Note:** Legacy directories (`app/`, `components/`, etc.) will be migrated into the structure above. New code must follow the structure immediately.
+
+## Coding Standards
+
+### General Principles
+
+- Prefer readability over cleverness; optimize for maintainability and clarity in code reviews.
+- Keep functions small and focused. Extract shared logic into well-named helpers or packages.
+- Write self-documenting code and complement with inline comments only when business logic is non-obvious.
+- Every directory must contain a README outlining purpose, setup, and test instructions.
+
+### TypeScript / JavaScript
+
+- Use TypeScript by default for frontend and Node.js services.
+- Enforce strict compiler options (`"strict": true`) and rely on ESLint/Prettier configurations defined in the repository root.
+- Follow functional component patterns with hooks in React. Avoid legacy class components unless required by dependencies.
+- Group tests alongside implementation files using the `.test.ts(x)` suffix.
+- Favor named exports; use default exports only for Next.js page components.
+
+### Go (Backend Services)
+
+- Organize modules with `cmd/<service>` for entrypoints and `internal/` for shared implementation details.
+- Use `golangci-lint` with the shared configuration from `packages/config/golangci.yml`.
+- Provide unit tests covering core business rules and integration tests for external systems.
+- Keep configuration in environment variables, parsed via a dedicated config package.
+
+### Python (Data / Automation)
+
+- Target Python 3.11+ and manage dependencies with Poetry. Lock files must be committed.
+- Format code with `black`, lint with `ruff`, and type-check with `mypy` using shared configs from `packages/config`.
+- Store notebooks in `notebooks/` with clear metadata and export production code into reusable modules.
+
+### Testing and CI
+
+- All new features require automated tests. Failing tests block merges.
+- CI pipelines should leverage workspace-aware tooling (e.g., Turborepo) to run only affected tasks.
+- Include contract tests when changing API schemas or shared libraries.
+
+### Documentation
+
+- Update relevant ADRs, READMEs, and runbooks when architecture or operational behavior changes.
+- Each service must expose health-check endpoints and document observability dashboards.
+- Pull requests must reference related Jira tickets and include release notes when user-facing changes occur.
+
+### Security & Compliance
+
+- Secrets must never be committed; use the centralized secret manager integration referenced in `infra/secrets/`.
+- Follow least-privilege principles when defining IAM roles or service accounts.
+- Ensure dependency scanning and container image scanning steps succeed before requesting review.
+
+These conventions will evolve with the platform. Propose updates via a new ADR or an update to this document and circulate it in the Platform Engineering Guild for approval.


### PR DESCRIPTION
## Summary
- record ADR choosing a monorepo structure for the platform
- codify top-level folder layout and engineering conventions
- add a background worker agent documentation template

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ceef7ab73c832881a9fc3c20bbcc34