### PR TITLE
Add networking Terraform module for multi-environment VPCs

### DIFF
--- a/infra/terraform/networking/README.md
+++ b/infra/terraform/networking/README.md
@@ -1,0 +1,69 @@
+# Networking Terraform Module
+
+This Terraform configuration provisions per-environment networking primitives in AWS. Each environment receives its own VPC spanning three availability zones with public and private subnets, NAT gateways, security groups for applications and databases, and VPC endpoints for frequently used services.
+
+## Features
+
+- One VPC per environment with DNS support enabled.
+- Three public subnets (one per availability zone) for ingress resources such as load balancers and NAT gateways.
+- Three private subnets (one per availability zone) for application and database workloads.
+- Internet gateway, elastic IPs, and per-AZ NAT gateways for outbound access from private subnets.
+- Opinionated security groups that expose HTTP/HTTPS for applications and limit database access to application instances.
+- Gateway VPC endpoints for Amazon S3 and DynamoDB plus interface endpoints for Amazon ECR (`ecr.api` and `ecr.dkr`).
+
+## CIDR Strategy
+
+Provide a parent CIDR block for each environment (for example, `10.10.0.0/20`). When explicit subnet CIDRs are not supplied, the module automatically creates:
+
+- **Public subnets:** the first three `cidrsubnet` slices of the VPC CIDR using `newbits = 4` (e.g., `10.10.0.0/24`, `10.10.1.0/24`, `10.10.2.0/24`).
+- **Private subnets:** the next three slices using the same `newbits = 4` calculation (e.g., `10.10.3.0/24`, `10.10.4.0/24`, `10.10.5.0/24`).
+
+This layout keeps public and private ranges contiguous while leaving space in the VPC for future subnet tiers. If you need different addressing, provide `public_subnet_cidrs` and `private_subnet_cidrs` lists that align with the availability zones specified via `var.azs`.
+
+## Usage
+
+```hcl
+module "networking" {
+  source = "./infra/terraform/networking"
+
+  azs = [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+  ]
+
+  environments = {
+    dev = {
+      cidr_block = "10.10.0.0/20"
+    }
+
+    staging = {
+      cidr_block = "10.20.0.0/20"
+      tags = {
+        Owner = "platform-team"
+      }
+    }
+
+    prod = {
+      cidr_block = "10.30.0.0/20"
+    }
+  }
+
+  common_tags = {
+    Project = "share-house"
+  }
+}
+```
+
+## Outputs
+
+- `vpc_ids` – map of environment names to VPC IDs.
+- `public_subnet_ids` – map of `<env>-<az index>` to public subnet IDs.
+- `private_subnet_ids` – map of `<env>-<az index>` to private subnet IDs.
+- `security_groups` – nested map with application, database, and VPC endpoint security group IDs per environment.
+
+## Notes
+
+- NAT gateways incur hourly and data processing charges in each availability zone.
+- The database security group opens PostgreSQL (5432) to the application security group; adjust as needed for other database engines.
+- Interface VPC endpoints require associated private subnets to have available IP address capacity.

--- a/infra/terraform/networking/main.tf
+++ b/infra/terraform/networking/main.tf
@@ -1,0 +1,312 @@
+data "aws_region" "current" {}
+
+locals {
+  env_configs = {
+    for env, cfg in var.environments :
+    env => {
+      cidr_block = cfg.cidr_block
+      tags       = merge(var.common_tags, try(cfg.tags, {}), { Environment = env })
+      public_subnet_cidrs = (
+        try(length(cfg.public_subnet_cidrs), 0) == length(var.azs)
+        ? cfg.public_subnet_cidrs
+        : [for idx in range(length(var.azs)) : cidrsubnet(cfg.cidr_block, 4, idx)]
+      )
+      private_subnet_cidrs = (
+        try(length(cfg.private_subnet_cidrs), 0) == length(var.azs)
+        ? cfg.private_subnet_cidrs
+        : [for idx in range(length(var.azs)) : cidrsubnet(cfg.cidr_block, 4, idx + length(var.azs))]
+      )
+    }
+  }
+
+  public_subnets = {
+    for env, cfg in local.env_configs :
+    for idx, cidr in cfg.public_subnet_cidrs :
+    "${env}-${idx}" => {
+      env   = env
+      index = idx
+      cidr  = cidr
+      az    = element(var.azs, idx)
+    }
+  }
+
+  private_subnets = {
+    for env, cfg in local.env_configs :
+    for idx, cidr in cfg.private_subnet_cidrs :
+    "${env}-${idx}" => {
+      env   = env
+      index = idx
+      cidr  = cidr
+      az    = element(var.azs, idx)
+    }
+  }
+}
+
+resource "aws_vpc" "this" {
+  for_each = local.env_configs
+
+  cidr_block           = each.value.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(each.value.tags, {
+    Name = "${each.key}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  for_each = aws_vpc.this
+
+  vpc_id = each.value.id
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  for_each = local.public_subnets
+
+  vpc_id                  = aws_vpc.this[each.value.env].id
+  cidr_block              = each.value.cidr
+  availability_zone       = each.value.az
+  map_public_ip_on_launch = true
+
+  tags = merge(local.env_configs[each.value.env].tags, {
+    Name = "${each.value.env}-public-${each.value.az}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = local.private_subnets
+
+  vpc_id            = aws_vpc.this[each.value.env].id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+
+  tags = merge(local.env_configs[each.value.env].tags, {
+    Name = "${each.value.env}-private-${each.value.az}"
+    Tier = "private"
+  })
+}
+
+resource "aws_eip" "nat" {
+  for_each = local.public_subnets
+
+  domain = "vpc"
+
+  tags = merge(local.env_configs[each.value.env].tags, {
+    Name = "${each.value.env}-nat-eip-${each.value.az}"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  for_each = local.public_subnets
+
+  allocation_id = aws_eip.nat[each.key].id
+  subnet_id     = aws_subnet.public[each.key].id
+
+  depends_on = [aws_internet_gateway.this[each.value.env]]
+
+  tags = merge(local.env_configs[each.value.env].tags, {
+    Name = "${each.value.env}-nat-${each.value.az}"
+  })
+}
+
+resource "aws_route_table" "public" {
+  for_each = aws_vpc.this
+
+  vpc_id = each.value.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this[each.key].id
+  }
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-public-rt"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = local.public_subnets
+
+  subnet_id      = aws_subnet.public[each.key].id
+  route_table_id = aws_route_table.public[each.value.env].id
+}
+
+resource "aws_route_table" "private" {
+  for_each = local.private_subnets
+
+  vpc_id = aws_vpc.this[each.value.env].id
+
+  tags = merge(local.env_configs[each.value.env].tags, {
+    Name = "${each.value.env}-private-rt-${each.value.az}"
+  })
+}
+
+resource "aws_route" "private_nat" {
+  for_each = local.private_subnets
+
+  route_table_id         = aws_route_table.private[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this["${each.value.env}-${each.value.index}"].id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = local.private_subnets
+
+  subnet_id      = aws_subnet.private[each.key].id
+  route_table_id = aws_route_table.private[each.key].id
+}
+
+resource "aws_security_group" "app" {
+  for_each = aws_vpc.this
+
+  name        = "${each.key}-app-sg"
+  description = "Allow inbound HTTP/S traffic for application services"
+  vpc_id      = each.value.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-app-sg"
+  })
+}
+
+resource "aws_security_group" "db" {
+  for_each = aws_vpc.this
+
+  name        = "${each.key}-db-sg"
+  description = "Allow database access from application security group"
+  vpc_id      = each.value.id
+
+  ingress {
+    description     = "PostgreSQL"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app[each.key].id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-db-sg"
+  })
+}
+
+resource "aws_security_group" "endpoints" {
+  for_each = aws_vpc.this
+
+  name        = "${each.key}-endpoints-sg"
+  description = "Restrict VPC endpoint access to the VPC CIDR"
+  vpc_id      = each.value.id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.this[each.key].cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [aws_vpc.this[each.key].cidr_block]
+  }
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-endpoints-sg"
+  })
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  for_each = aws_vpc.this
+
+  vpc_id            = each.value.id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids = [
+    for key, subnet in local.private_subnets :
+    aws_route_table.private[key].id if subnet.env == each.key
+  ]
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-s3-endpoint"
+  })
+}
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  for_each = aws_vpc.this
+
+  vpc_id            = each.value.id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids = [
+    for key, subnet in local.private_subnets :
+    aws_route_table.private[key].id if subnet.env == each.key
+  ]
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-dynamodb-endpoint"
+  })
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  for_each = aws_vpc.this
+
+  vpc_id              = each.value.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [for key, subnet in local.private_subnets : aws_subnet.private[key].id if subnet.env == each.key]
+  security_group_ids  = [aws_security_group.endpoints[each.key].id]
+  private_dns_enabled = true
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-ecr-api-endpoint"
+  })
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  for_each = aws_vpc.this
+
+  vpc_id              = each.value.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [for key, subnet in local.private_subnets : aws_subnet.private[key].id if subnet.env == each.key]
+  security_group_ids  = [aws_security_group.endpoints[each.key].id]
+  private_dns_enabled = true
+
+  tags = merge(local.env_configs[each.key].tags, {
+    Name = "${each.key}-ecr-dkr-endpoint"
+  })
+}

--- a/infra/terraform/networking/outputs.tf
+++ b/infra/terraform/networking/outputs.tf
@@ -1,0 +1,35 @@
+output "vpc_ids" {
+  description = "VPC identifiers keyed by environment name."
+  value = {
+    for env, vpc in aws_vpc.this :
+    env => vpc.id
+  }
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet identifiers keyed by environment and AZ index."
+  value = {
+    for key, subnet in aws_subnet.public :
+    key => subnet.id
+  }
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet identifiers keyed by environment and AZ index."
+  value = {
+    for key, subnet in aws_subnet.private :
+    key => subnet.id
+  }
+}
+
+output "security_groups" {
+  description = "Security group identifiers for application, database, and endpoint access per environment."
+  value = {
+    for env, _ in aws_vpc.this :
+    env => {
+      app       = aws_security_group.app[env].id
+      database  = aws_security_group.db[env].id
+      endpoints = aws_security_group.endpoints[env].id
+    }
+  }
+}

--- a/infra/terraform/networking/variables.tf
+++ b/infra/terraform/networking/variables.tf
@@ -1,0 +1,35 @@
+variable "azs" {
+  description = "List of availability zones to spread networking resources across."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.azs) >= 3
+    error_message = "At least three availability zones are required."
+  }
+}
+
+variable "environments" {
+  description = <<EOT
+Map of environment names to networking configuration. Each environment must provide a parent VPC CIDR block and can optionally override the computed subnet CIDRs or add extra tags.
+EOT
+  type = map(object({
+    cidr_block           = string
+    public_subnet_cidrs  = optional(list(string))
+    private_subnet_cidrs = optional(list(string))
+    tags                 = optional(map(string), {})
+  }))
+
+  validation {
+    condition = alltrue([
+      for env, cfg in var.environments :
+      tonumber(split(cfg.cidr_block, "/")[1]) <= 24
+    ])
+    error_message = "Each environment VPC CIDR block must allow creation of at least /28 subnets."
+  }
+}
+
+variable "common_tags" {
+  description = "Tags applied to every resource created by this module."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/networking/versions.tf
+++ b/infra/terraform/networking/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable Terraform configuration for creating per-environment VPCs across three availability zones
- provision public/private subnets, NAT gateways, security groups, and VPC endpoints for S3, DynamoDB, and ECR
- document default CIDR partitioning and usage guidance in a module README

## Testing
- `terraform -chdir=infra/terraform/networking fmt` *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceef7edfb4832884850e0359d825c0