### PR TITLE
Add Terraform module for AWS organization bootstrap

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,41 @@
+# Terraform Infrastructure
+
+This directory holds Terraform configuration used to bootstrap the Share House Platform AWS Organization.
+
+## Bootstrap Instructions
+
+1. **Install prerequisites**
+   - Terraform CLI v1.5.0 or later.
+   - AWS CLI configured with credentials for the management (payer) account that has `organizations:*`, `sso:*`, `config:*`, and `ce:*` permissions.
+2. **Create a backend**
+   - Configure the remote state backend (e.g., S3 + DynamoDB) that will store Terraform state for the management account. Update your `terraform` block as needed before running the module.
+3. **Populate secret variables**
+   - Provide unique email addresses for each child account. These must not already be associated with an AWS account.
+   - Export sensitive values with a `terraform.tfvars` file or environment variables. Example `terraform.tfvars`:
+     ```hcl
+     dev_account_email     = "dev@example.com"
+     staging_account_email = "staging@example.com"
+     prod_account_email    = "prod@example.com"
+     logging_account_email = "logging@example.com"
+     identity_center_admin_group_id = "12345678-90ab-cdef-1234-567890abcdef"
+     config_aggregator_role_arn     = "arn:aws:iam::111122223333:role/ConfigAggregatorRole"
+     ```
+4. **Initialize Terraform**
+   ```bash
+   terraform -chdir=infra/terraform init
+   ```
+5. **Review and apply**
+   ```bash
+   terraform -chdir=infra/terraform plan
+   terraform -chdir=infra/terraform apply
+   ```
+   The `apply` step provisions the AWS Organization accounts, IAM Identity Center configuration, SCPs, AWS Config aggregator, and activates cost allocation tags.
+6. **Post-apply validation**
+   - Confirm the new accounts appear in the AWS Organizations console.
+   - Verify IAM Identity Center assignments for the administrator group.
+   - Ensure the AWS Config aggregator reports healthy status.
+   - Check Cost Explorer to ensure the cost allocation tags are active within 24 hours.
+
+## Module Layout
+
+- [`aws-org/`](./aws-org) – Terraform module that deploys the core AWS Organization scaffold.

--- a/infra/terraform/aws-org/README.md
+++ b/infra/terraform/aws-org/README.md
@@ -1,0 +1,49 @@
+# AWS Organization Module
+
+This module creates the foundational AWS Organization for Share House Platform projects. It provisions workload and security organizational units, production lifecycle accounts, IAM Identity Center access, baseline service control policies (SCPs), AWS Config organization aggregation, and activates standard cost allocation tags.
+
+## Features
+
+- Creates or adopts an AWS Organization with service access for AWS Config, IAM Identity Center, and Tag Policies.
+- Provisions the following accounts beneath dedicated organizational units:
+  - `*-dev`
+  - `*-staging`
+  - `*-prod`
+  - `*-logging` (designated as the delegated administrator for AWS Config)
+- Attaches guardrail SCPs to block root-user usage and require MFA.
+- Optionally configures IAM Identity Center with an Administrator permission set and assignments for all managed accounts.
+- Enables an AWS Config organization aggregator.
+- Activates Cost Explorer cost allocation tags for `Environment`, `Owner`, and `CostCenter` by default.
+
+## Usage
+
+```hcl
+module "aws_org" {
+  source = "./aws-org"
+
+  environment_prefix      = "share-house"
+  dev_account_email       = "dev@example.com"
+  staging_account_email   = "staging@example.com"
+  prod_account_email      = "prod@example.com"
+  logging_account_email   = "logging@example.com"
+  identity_center_region  = "us-east-1"
+  identity_center_admin_group_id = "12345678-90ab-cdef-1234-567890abcdef"
+  config_aggregator_role_arn     = "arn:aws:iam::111122223333:role/ConfigAggregatorRole"
+}
+```
+
+### Optional Configuration
+
+- Disable IAM Identity Center configuration by setting `enable_identity_center = false`.
+- Override the default cost allocation tags with a custom list via `cost_allocation_tags`.
+- Provide `identity_center_admin_relay_state` when you want to deep-link into a central landing page.
+- Set `enable_config_aggregator = false` if an aggregator is managed outside of Terraform.
+
+## Outputs
+
+- `organization_id` – The AWS Organization ID.
+- `account_ids` – Map of environment name to AWS account IDs.
+- `organizational_units` – Workloads and security OU IDs.
+- `scp_policy_ids` – IDs of the guardrail SCPs.
+- `identity_center_permission_set_arn` – Administrator permission set ARN when enabled.
+- `cost_allocation_tags` – The activated cost allocation tag keys.

--- a/infra/terraform/aws-org/SECURITY_REVIEW_CHECKLIST.md
+++ b/infra/terraform/aws-org/SECURITY_REVIEW_CHECKLIST.md
@@ -1,0 +1,22 @@
+# Security Review Verification Checklist
+
+Use this checklist to validate the AWS Organization bootstrap before handing off to the security team.
+
+- [ ] **Organization Guardrails**
+  - [ ] Confirm both `deny_root_access` and `enforce_mfa` SCPs are attached to the Workloads and Security organizational units.
+  - [ ] Verify that the organization feature set is `ALL` and that service control policies are enabled.
+- [ ] **Account Provisioning**
+  - [ ] Ensure the `*-dev`, `*-staging`, `*-prod`, and `*-logging` accounts exist and are placed in the correct OUs.
+  - [ ] Confirm the delegated administrator for AWS Config is the logging account.
+- [ ] **IAM Identity Center**
+  - [ ] Validate that the Administrator permission set exists with the AWS managed `AdministratorAccess` policy attached.
+  - [ ] Confirm the designated administrator group is assigned to each managed account.
+  - [ ] Review the session duration and relay state configuration.
+- [ ] **AWS Config Aggregator**
+  - [ ] Check that the organization aggregator is deployed and reporting data from all regions.
+  - [ ] Confirm the aggregator role ARN matches a trusted IAM role with the necessary permissions.
+- [ ] **Cost Allocation Tags**
+  - [ ] Ensure the `Environment`, `Owner`, and `CostCenter` tags (or customized list) are active in Cost Explorer.
+- [ ] **Audit Artifacts**
+  - [ ] Capture Terraform plan and apply logs for archival.
+  - [ ] Document account IDs, OU IDs, and policy ARNs in the security knowledge base.

--- a/infra/terraform/aws-org/main.tf
+++ b/infra/terraform/aws-org/main.tf
@@ -1,0 +1,258 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.30"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "management"
+  region = var.management_region
+}
+
+provider "aws" {
+  alias  = "identity_center"
+  region = var.identity_center_region
+}
+
+data "aws_partition" "current" {
+  provider = aws.management
+}
+
+locals {
+  scp_policies = {
+    deny_root_access = jsonencode({
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "DenyRootUserUsage",
+          "Effect" : "Deny",
+          "Action" : "*",
+          "Resource" : "*",
+          "Condition" : {
+            "StringLike" : {
+              "aws:PrincipalArn" : [
+                "arn:${data.aws_partition.current.partition}:iam::*:root"
+              ]
+            }
+          }
+        }
+      ]
+    })
+    enforce_mfa = jsonencode({
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "DenyWithoutMFA",
+          "Effect" : "Deny",
+          "Action" : "*",
+          "Resource" : "*",
+          "Condition" : {
+            "BoolIfExists" : {
+              "aws:MultiFactorAuthPresent" : "false"
+            }
+          }
+        }
+      ]
+    })
+  }
+}
+
+resource "aws_organizations_organization" "this" {
+  aws_service_access_principals = [
+    "config.amazonaws.com",
+    "sso.amazonaws.com",
+    "tagpolicies.tag.amazonaws.com"
+  ]
+
+  enabled_policy_types = [
+    "SERVICE_CONTROL_POLICY",
+    "TAG_POLICY"
+  ]
+
+  feature_set = var.organization_feature_set
+}
+
+resource "aws_organizations_organizational_unit" "workloads" {
+  name      = "workloads"
+  parent_id = aws_organizations_organization.this.roots[0].id
+}
+
+resource "aws_organizations_organizational_unit" "security" {
+  name      = "security"
+  parent_id = aws_organizations_organization.this.roots[0].id
+}
+
+locals {
+  account_definitions = {
+    dev = {
+      name  = "${var.environment_prefix}-dev"
+      email = var.dev_account_email
+      ou    = aws_organizations_organizational_unit.workloads.id
+    }
+    staging = {
+      name  = "${var.environment_prefix}-staging"
+      email = var.staging_account_email
+      ou    = aws_organizations_organizational_unit.workloads.id
+    }
+    prod = {
+      name  = "${var.environment_prefix}-prod"
+      email = var.prod_account_email
+      ou    = aws_organizations_organizational_unit.workloads.id
+    }
+    logging = {
+      name  = "${var.environment_prefix}-logging"
+      email = var.logging_account_email
+      ou    = aws_organizations_organizational_unit.security.id
+    }
+  }
+}
+
+resource "aws_organizations_account" "managed" {
+  for_each = local.account_definitions
+
+  email     = each.value.email
+  name      = each.value.name
+  parent_id = each.value.ou
+  role_name = var.account_access_role
+
+  lifecycle {
+    ignore_changes = [
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_delegated_administrator" "config" {
+  account_id        = aws_organizations_account.managed["logging"].id
+  service_principal = "config.amazonaws.com"
+}
+
+resource "aws_organizations_policy" "scp" {
+  for_each = local.scp_policies
+
+  name    = each.key
+  content = each.value
+  type    = "SERVICE_CONTROL_POLICY"
+}
+
+resource "aws_organizations_policy_attachment" "workloads" {
+  for_each = aws_organizations_policy.scp
+
+  policy_id = each.value.id
+  target_id = aws_organizations_organizational_unit.workloads.id
+}
+
+resource "aws_organizations_policy_attachment" "security" {
+  for_each = aws_organizations_policy.scp
+
+  policy_id = each.value.id
+  target_id = aws_organizations_organizational_unit.security.id
+}
+
+data "aws_ssoadmin_instances" "this" {
+  provider = aws.identity_center
+
+  count = var.enable_identity_center ? 1 : 0
+}
+
+locals {
+  identity_center_instance_arn = var.enable_identity_center ? try(data.aws_ssoadmin_instances.this[0].arns[0], null) : null
+}
+
+resource "aws_ssoadmin_permission_set" "administrator" {
+  provider = aws.identity_center
+
+  count = var.enable_identity_center ? 1 : 0
+
+  name             = "AdministratorAccess"
+  description      = "Grants administrator access to AWS accounts."
+  instance_arn     = local.identity_center_instance_arn
+  session_duration = var.identity_center_admin_session_duration
+  relay_state      = var.identity_center_admin_relay_state
+
+  managed_policies = [
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AdministratorAccess"
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = local.identity_center_instance_arn != null && local.identity_center_instance_arn != ""
+      error_message = "enable_identity_center requires an active IAM Identity Center instance in the target region."
+    }
+  }
+}
+
+resource "aws_ssoadmin_account_assignment" "administrator" {
+  provider = aws.identity_center
+
+  for_each = var.enable_identity_center && var.identity_center_admin_group_id != "" ? aws_organizations_account.managed : {}
+
+  instance_arn       = local.identity_center_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.administrator[0].arn
+  principal_id       = var.identity_center_admin_group_id
+  principal_type     = "GROUP"
+  target_id          = each.value.id
+  target_type        = "AWS_ACCOUNT"
+}
+
+resource "aws_config_configuration_aggregator" "organization" {
+  provider = aws.management
+
+  count = var.enable_config_aggregator ? 1 : 0
+
+  name = var.config_aggregator_name
+
+  organization_aggregation_source {
+    all_regions = true
+    role_arn    = var.config_aggregator_role_arn
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.config_aggregator_role_arn != null && var.config_aggregator_role_arn != ""
+      error_message = "config_aggregator_role_arn must be provided when enable_config_aggregator is true."
+    }
+  }
+}
+
+resource "aws_ce_cost_allocation_tag" "this" {
+  for_each = toset(var.cost_allocation_tags)
+
+  tag_key = each.value
+  status  = "Active"
+}
+
+output "organization_id" {
+  value = aws_organizations_organization.this.id
+}
+
+output "account_ids" {
+  value = { for name, account in aws_organizations_account.managed : name => account.id }
+}
+
+output "organizational_units" {
+  value = {
+    workloads = aws_organizations_organizational_unit.workloads.id
+    security  = aws_organizations_organizational_unit.security.id
+  }
+}
+
+output "scp_policy_ids" {
+  value = { for name, policy in aws_organizations_policy.scp : name => policy.id }
+}
+
+output "identity_center_permission_set_arn" {
+  value       = var.enable_identity_center ? aws_ssoadmin_permission_set.administrator[0].arn : null
+  description = "Administrator permission set ARN when IAM Identity Center is enabled."
+}
+
+output "cost_allocation_tags" {
+  value       = keys(aws_ce_cost_allocation_tag.this)
+  description = "Activated cost allocation tags."
+}

--- a/infra/terraform/aws-org/variables.tf
+++ b/infra/terraform/aws-org/variables.tf
@@ -1,0 +1,101 @@
+variable "management_region" {
+  description = "AWS region to target for the management account provider."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "identity_center_region" {
+  description = "Region where IAM Identity Center is hosted."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment_prefix" {
+  description = "Prefix used when naming provisioned AWS accounts."
+  type        = string
+  default     = "share-house"
+}
+
+variable "organization_feature_set" {
+  description = "Feature set for the AWS Organization (must be ALL for SCPs)."
+  type        = string
+  default     = "ALL"
+}
+
+variable "account_access_role" {
+  description = "The IAM role to create in new accounts for cross-account access."
+  type        = string
+  default     = "OrganizationAccountAccessRole"
+}
+
+variable "dev_account_email" {
+  description = "Email address for the development account root user."
+  type        = string
+}
+
+variable "staging_account_email" {
+  description = "Email address for the staging account root user."
+  type        = string
+}
+
+variable "prod_account_email" {
+  description = "Email address for the production account root user."
+  type        = string
+}
+
+variable "logging_account_email" {
+  description = "Email address for the logging/security tooling account root user."
+  type        = string
+}
+
+variable "enable_identity_center" {
+  description = "Whether to configure IAM Identity Center assignments."
+  type        = bool
+  default     = true
+}
+
+variable "identity_center_admin_group_id" {
+  description = "IAM Identity Center group ID that will receive administrator access."
+  type        = string
+  default     = ""
+}
+
+variable "identity_center_admin_session_duration" {
+  description = "Session duration for the administrator permission set."
+  type        = string
+  default     = "PT8H"
+}
+
+variable "identity_center_admin_relay_state" {
+  description = "Optional relay state URL for the administrator permission set."
+  type        = string
+  default     = null
+}
+
+variable "enable_config_aggregator" {
+  description = "Whether to deploy an AWS Config organization aggregator."
+  type        = bool
+  default     = true
+}
+
+variable "config_aggregator_name" {
+  description = "Name of the AWS Config aggregator."
+  type        = string
+  default     = "organization"
+}
+
+variable "config_aggregator_role_arn" {
+  description = "IAM role ARN assumed by AWS Config to aggregate data across the organization."
+  type        = string
+  default     = null
+}
+
+variable "cost_allocation_tags" {
+  description = "List of cost allocation tag keys to activate."
+  type        = list(string)
+  default     = [
+    "Environment",
+    "Owner",
+    "CostCenter"
+  ]
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.30"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.management_region
+}
+
+module "aws_org" {
+  source = "./aws-org"
+
+  management_region                 = var.management_region
+  identity_center_region            = var.identity_center_region
+  environment_prefix                = var.environment_prefix
+  organization_feature_set          = var.organization_feature_set
+  account_access_role               = var.account_access_role
+  dev_account_email                 = var.dev_account_email
+  staging_account_email             = var.staging_account_email
+  prod_account_email                = var.prod_account_email
+  logging_account_email             = var.logging_account_email
+  enable_identity_center            = var.enable_identity_center
+  identity_center_admin_group_id    = var.identity_center_admin_group_id
+  identity_center_admin_session_duration = var.identity_center_admin_session_duration
+  identity_center_admin_relay_state = var.identity_center_admin_relay_state
+  enable_config_aggregator          = var.enable_config_aggregator
+  config_aggregator_name            = var.config_aggregator_name
+  config_aggregator_role_arn        = var.config_aggregator_role_arn
+  cost_allocation_tags              = var.cost_allocation_tags
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,29 @@
+output "organization_id" {
+  description = "AWS Organization ID."
+  value       = module.aws_org.organization_id
+}
+
+output "account_ids" {
+  description = "Map of managed account IDs."
+  value       = module.aws_org.account_ids
+}
+
+output "organizational_units" {
+  description = "Organizational unit identifiers."
+  value       = module.aws_org.organizational_units
+}
+
+output "scp_policy_ids" {
+  description = "Guardrail service control policy IDs."
+  value       = module.aws_org.scp_policy_ids
+}
+
+output "identity_center_permission_set_arn" {
+  description = "IAM Identity Center administrator permission set ARN (if configured)."
+  value       = module.aws_org.identity_center_permission_set_arn
+}
+
+output "cost_allocation_tags" {
+  description = "Activated cost allocation tag keys."
+  value       = module.aws_org.cost_allocation_tags
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,101 @@
+variable "management_region" {
+  description = "AWS region to target for the management account provider."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "identity_center_region" {
+  description = "Region where IAM Identity Center is hosted."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment_prefix" {
+  description = "Prefix used when naming provisioned AWS accounts."
+  type        = string
+  default     = "share-house"
+}
+
+variable "organization_feature_set" {
+  description = "Feature set for the AWS Organization (must be ALL for SCPs)."
+  type        = string
+  default     = "ALL"
+}
+
+variable "account_access_role" {
+  description = "The IAM role to create in new accounts for cross-account access."
+  type        = string
+  default     = "OrganizationAccountAccessRole"
+}
+
+variable "dev_account_email" {
+  description = "Email address for the development account root user."
+  type        = string
+}
+
+variable "staging_account_email" {
+  description = "Email address for the staging account root user."
+  type        = string
+}
+
+variable "prod_account_email" {
+  description = "Email address for the production account root user."
+  type        = string
+}
+
+variable "logging_account_email" {
+  description = "Email address for the logging/security tooling account root user."
+  type        = string
+}
+
+variable "enable_identity_center" {
+  description = "Whether to configure IAM Identity Center assignments."
+  type        = bool
+  default     = true
+}
+
+variable "identity_center_admin_group_id" {
+  description = "IAM Identity Center group ID that will receive administrator access."
+  type        = string
+  default     = ""
+}
+
+variable "identity_center_admin_session_duration" {
+  description = "Session duration for the administrator permission set."
+  type        = string
+  default     = "PT8H"
+}
+
+variable "identity_center_admin_relay_state" {
+  description = "Optional relay state URL for the administrator permission set."
+  type        = string
+  default     = null
+}
+
+variable "enable_config_aggregator" {
+  description = "Whether to deploy an AWS Config organization aggregator."
+  type        = bool
+  default     = true
+}
+
+variable "config_aggregator_name" {
+  description = "Name of the AWS Config aggregator."
+  type        = string
+  default     = "organization"
+}
+
+variable "config_aggregator_role_arn" {
+  description = "IAM role ARN assumed by AWS Config to aggregate data across the organization."
+  type        = string
+  default     = null
+}
+
+variable "cost_allocation_tags" {
+  description = "List of cost allocation tag keys to activate."
+  type        = list(string)
+  default     = [
+    "Environment",
+    "Owner",
+    "CostCenter"
+  ]
+}


### PR DESCRIPTION
## Summary
- add an aws organization bootstrap module that provisions workload accounts, guardrails, IAM Identity Center, AWS Config, and cost allocation tags
- document bootstrap workflow for running the Terraform and include a security review checklist
- expose a root configuration that wires the repository to the new module and surfaces outputs

## Testing
- `terraform -chdir=infra/terraform fmt -recursive` *(fails: terraform CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceef7dbefc83288af3bc65be772b57