### PR TITLE
Add Terraform EKS platform with bootstrap docs

### DIFF
--- a/infra/kubernetes/README.md
+++ b/infra/kubernetes/README.md
@@ -1,0 +1,100 @@
+# Kubernetes Platform Bootstrap
+
+This directory documents how to provision and bootstrap the Share House Portal Kubernetes platform on Amazon EKS using the Terraform configuration contained in [`../terraform/eks`](../terraform/eks).
+
+## Prerequisites
+
+Before applying the infrastructure configuration ensure that the following tools and requirements are met:
+
+- Terraform v1.4.0 or newer
+- AWS CLI v2 with credentials that can provision IAM, VPC, EKS, Route53 and related resources
+- kubectl v1.29+ (matches the target cluster version)
+- (Optional) A remote Terraform backend such as S3 + DynamoDB for state locking
+- Access to an existing VPC with private subnets for worker nodes and the ability to create the necessary security groups and load balancers
+
+## Repository Layout
+
+```
+infra/
+├── kubernetes/          # Platform documentation (this file)
+└── terraform/
+    └── eks/             # Terraform modules, providers and Helm releases for the EKS stack
+```
+
+## Bootstrap Workflow
+
+1. **Copy and edit variable definitions.**
+   ```bash
+   cd infra/terraform/eks
+   cp terraform.tfvars.example terraform.tfvars
+   ```
+   Update `terraform.tfvars` with the IDs of the target VPC and subnets, the desired cluster name, and hosted zone ARNs for services such as `external-dns`. Every value in `terraform.tfvars.example` includes inline comments to guide the selection of appropriate IDs and sizing.
+
+2. **Configure Terraform backend (optional).** If you plan to share state between team members, add a `backend` block to `versions.tf` or create a `backend.hcl` file that points at your remote S3 bucket/DynamoDB table before running `terraform init`.
+
+3. **Initialise Terraform providers and modules.**
+   ```bash
+   terraform init
+   ```
+   This downloads the AWS, Kubernetes and Helm providers, the `terraform-aws-modules/eks` module, and the IAM sub-modules required for IRSA roles.
+
+4. **Review the plan.**
+   ```bash
+   terraform plan
+   ```
+   Verify the proposed cluster name, node group sizing, IAM roles, and Helm releases before applying changes.
+
+5. **Apply the infrastructure.**
+   ```bash
+   terraform apply
+   ```
+   The apply step creates the EKS cluster, managed node groups, IAM OIDC provider, and attaches IAM roles for service accounts. Once the control plane is available, Terraform automatically deploys the following Helm charts through the Helm provider:
+
+   - Cluster Autoscaler (auto-discovers node groups)
+   - AWS Load Balancer Controller (required for ALB/NLB integrations)
+   - ingress-nginx (exposes NGINX via an AWS load balancer)
+   - cert-manager (installs CRDs and controller)
+   - external-dns (manages Route53 records)
+
+6. **Update kubeconfig for interactive access.**
+   ```bash
+   aws eks update-kubeconfig --name <your-cluster-name> --region <aws-region>
+   kubectl get nodes
+   ```
+   Confirm nodes are ready and the Helm releases are installed: `kubectl get pods -A`.
+
+## Configuration Overrides
+
+The Terraform module exposes variables for tailoring the deployment without modifying `main.tf`:
+
+- **Cluster and networking**
+  - `cluster_endpoint_public_access`, `cluster_endpoint_private_access`, and `cluster_public_access_cidrs` toggle API server connectivity.
+  - `cluster_additional_security_group_ids` allows you to attach pre-existing security groups to the control plane.
+  - `eks_managed_node_groups` accepts a map of node group definitions. Each entry can set capacity type (`ON_DEMAND`/`SPOT`), labels, and taints. See `terraform.tfvars.example` for multiple pools (e.g., default + spot).
+
+- **Managed add-ons**
+  - Override the default `cluster_addons` map to pin specific versions of `coredns`, `kube-proxy`, or `vpc-cni`, or to inject custom JSON configuration (for example enabling prefix delegation).
+
+- **Helm chart versions and namespaces**
+  - Variables like `cluster_autoscaler_chart_version`, `nginx_ingress_namespace`, `cert_manager_chart_version`, and `external_dns_namespace` allow you to upgrade charts or install them into alternative namespaces.
+  - Set `external_dns_domain_filters`, `external_dns_txt_owner_id`, and `external_dns_hosted_zone_arns` to limit which Route53 zones are modified.
+  - `aws_load_balancer_controller_namespace` and `aws_load_balancer_controller_service_account_name` can be changed if you prefer to co-locate the controller outside `kube-system`.
+
+- **IAM permissions**
+  - `additional_iam_policies` attaches extra managed policy ARNs to every IRSA role (useful for organisation-wide logging or secret access requirements).
+  - `load_balancer_controller_target_group_arns` scopes the load balancer controller permissions to specific target groups if your AWS account enforces least privilege.
+
+- **Ingress behaviour**
+  - The default ingress-nginx chart values expose an internet-facing Network Load Balancer. Adjust or extend the `values` map inside `helm_release.nginx_ingress` if you need an internal load balancer, custom SSL policies, or AWS WAF integration.
+
+If you need to supply more Helm overrides than the provided variables expose, extend the existing `values = [yamlencode({...})]` blocks in `infra/terraform/eks/main.tf` or split them into local variables that read from additional `tfvars` entries. Terraform will automatically reconcile the release with your new settings.
+
+## Post-Provisioning Tasks
+
+- **Certificate Issuers:** Create `ClusterIssuer` or `Issuer` resources for cert-manager (ACME, Route53 DNS01, etc.). If you use Route53 DNS01 challenges, reuse the `external_dns_hosted_zone_arns` and add the same ARNs to a new IAM role created via the IRSA module for cert-manager.
+- **Ingress Definitions:** Deploy application-specific `Ingress` resources that reference either the ingress-nginx controller (`kubernetes.io/ingress.class: nginx`) or the AWS Load Balancer Controller (`ingressClassName: alb`).
+- **Autoscaling Policies:** Fine-tune node group scaling behaviour (`desired_size`, `max_size`) to reflect workload demand, and optionally add `autoscaling_group_tags` by extending the node group configuration map.
+
+## Cleaning Up
+
+Run `terraform destroy` from `infra/terraform/eks` to remove the entire stack. Be aware that dangling load balancers, security groups, or Route53 records created outside Terraform must be deleted manually before destruction can complete.

--- a/infra/terraform/eks/main.tf
+++ b/infra/terraform/eks/main.tf
@@ -1,0 +1,319 @@
+locals {
+  tags = merge(
+    {
+      ManagedBy = "terraform"
+      Project   = var.project
+    },
+    var.tags
+  )
+
+  node_group_subnet_ids      = length(var.node_group_subnet_ids) > 0 ? var.node_group_subnet_ids : var.subnet_ids
+  control_plane_subnet_ids   = length(var.control_plane_subnet_ids) > 0 ? var.control_plane_subnet_ids : var.subnet_ids
+  external_dns_txt_owner_id  = coalesce(var.external_dns_txt_owner_id, var.cluster_name)
+  additional_policy_map      = { for idx, arn in var.additional_iam_policies : "additional-${idx}" => arn }
+  create_lb_controller_ns    = var.aws_load_balancer_controller_namespace != "kube-system"
+  create_external_dns_ns     = var.external_dns_namespace != "default"
+  create_nginx_ingress_ns    = var.nginx_ingress_namespace != "default"
+  create_cert_manager_ns     = var.cert_manager_namespace != "default"
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.13"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+
+  vpc_id                   = var.vpc_id
+  subnet_ids               = var.subnet_ids
+  control_plane_subnet_ids = local.control_plane_subnet_ids
+
+  cluster_endpoint_private_access = var.cluster_endpoint_private_access
+  cluster_endpoint_public_access  = var.cluster_endpoint_public_access
+  cluster_public_access_cidrs     = var.cluster_public_access_cidrs
+
+  cluster_additional_security_group_ids = var.cluster_additional_security_group_ids
+
+  enable_irsa = true
+
+  cluster_addons = var.cluster_addons
+
+  cluster_tags = local.tags
+  tags         = local.tags
+
+  eks_managed_node_group_defaults = {
+    ami_type  = "AL2023_x86_64_STANDARD"
+    disk_size = var.node_group_disk_size
+    subnet_ids = local.node_group_subnet_ids
+    tags      = local.tags
+  }
+
+  eks_managed_node_groups = {
+    for name, config in var.eks_managed_node_groups :
+    name => {
+      min_size       = config.min_size
+      max_size       = config.max_size
+      desired_size   = config.desired_size
+      instance_types = config.instance_types
+      capacity_type  = config.capacity_type
+      labels         = try(config.labels, {})
+      taints         = try(config.taints, [])
+      tags           = local.tags
+    }
+  }
+}
+
+data "aws_eks_cluster" "this" {
+  name = module.eks.cluster_name
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.this.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
+}
+
+module "iam_irsa_cluster_autoscaler" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 5.38"
+
+  name = "${var.cluster_name}-cluster-autoscaler"
+
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_names = [module.eks.cluster_name]
+
+  oidc_providers = {
+    this = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = [
+        "${var.cluster_autoscaler_namespace}:${var.cluster_autoscaler_service_account_name}"
+      ]
+    }
+  }
+
+  policies = local.additional_policy_map
+  tags     = local.tags
+}
+
+module "iam_irsa_aws_load_balancer_controller" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 5.38"
+
+  name = "${var.cluster_name}-aws-load-balancer-controller"
+
+  attach_load_balancer_controller_policy                    = true
+  load_balancer_controller_targetgroup_arns                 = var.load_balancer_controller_target_group_arns
+
+  oidc_providers = {
+    this = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = [
+        "${var.aws_load_balancer_controller_namespace}:${var.aws_load_balancer_controller_service_account_name}"
+      ]
+    }
+  }
+
+  policies = local.additional_policy_map
+  tags     = local.tags
+}
+
+module "iam_irsa_external_dns" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 5.38"
+
+  name = "${var.cluster_name}-external-dns"
+
+  attach_external_dns_policy = true
+  external_dns_hosted_zone_arns = var.external_dns_hosted_zone_arns
+
+  oidc_providers = {
+    this = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = [
+        "${var.external_dns_namespace}:${var.external_dns_service_account_name}"
+      ]
+    }
+  }
+
+  policies = local.additional_policy_map
+  tags     = local.tags
+}
+
+resource "helm_release" "cluster_autoscaler" {
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = var.cluster_autoscaler_chart_version
+  namespace  = var.cluster_autoscaler_namespace
+
+  timeout          = 600
+  cleanup_on_fail  = true
+  atomic           = true
+
+  values = [
+    yamlencode({
+      autoDiscovery = {
+        clusterName = module.eks.cluster_name
+      }
+      awsRegion = var.region
+      extraArgs = {
+        "balance-similar-node-groups"   = "true"
+        "skip-nodes-with-local-storage" = "false"
+        "skip-nodes-with-system-pods"   = "false"
+      }
+      rbac = {
+        serviceAccount = {
+          create = true
+          name   = var.cluster_autoscaler_service_account_name
+          annotations = {
+            "eks.amazonaws.com/role-arn" = module.iam_irsa_cluster_autoscaler.arn
+          }
+        }
+      }
+    })
+  ]
+
+  depends_on = [
+    module.eks,
+    module.iam_irsa_cluster_autoscaler
+  ]
+}
+
+resource "helm_release" "aws_load_balancer_controller" {
+  name             = "aws-load-balancer-controller"
+  repository       = "https://aws.github.io/eks-charts"
+  chart            = "aws-load-balancer-controller"
+  version          = var.aws_load_balancer_controller_chart_version
+  namespace        = var.aws_load_balancer_controller_namespace
+  create_namespace = local.create_lb_controller_ns
+
+  timeout         = 600
+  cleanup_on_fail = true
+  atomic          = true
+
+  values = [
+    yamlencode({
+      clusterName = module.eks.cluster_name
+      region      = var.region
+      vpcId       = var.vpc_id
+      serviceAccount = {
+        create = true
+        name   = var.aws_load_balancer_controller_service_account_name
+        annotations = {
+          "eks.amazonaws.com/role-arn" = module.iam_irsa_aws_load_balancer_controller.arn
+        }
+      }
+    })
+  ]
+
+  depends_on = [
+    module.eks,
+    module.iam_irsa_aws_load_balancer_controller
+  ]
+}
+
+resource "helm_release" "nginx_ingress" {
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  version          = var.nginx_ingress_chart_version
+  namespace        = var.nginx_ingress_namespace
+  create_namespace = local.create_nginx_ingress_ns
+
+  timeout         = 600
+  cleanup_on_fail = true
+  atomic          = true
+
+  values = [
+    yamlencode({
+      controller = {
+        publishService = {
+          enabled = true
+        }
+        service = {
+          type = "LoadBalancer"
+          annotations = {
+            "service.beta.kubernetes.io/aws-load-balancer-type"   = "nlb"
+            "service.beta.kubernetes.io/aws-load-balancer-scheme" = "internet-facing"
+          }
+        }
+      }
+    })
+  ]
+
+  depends_on = [
+    module.eks,
+    helm_release.aws_load_balancer_controller
+  ]
+}
+
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = var.cert_manager_chart_version
+  namespace        = var.cert_manager_namespace
+  create_namespace = local.create_cert_manager_ns
+
+  timeout         = 600
+  cleanup_on_fail = true
+  atomic          = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+  depends_on = [
+    module.eks
+  ]
+}
+
+resource "helm_release" "external_dns" {
+  name             = "external-dns"
+  repository       = "https://kubernetes-sigs.github.io/external-dns/"
+  chart            = "external-dns"
+  version          = var.external_dns_chart_version
+  namespace        = var.external_dns_namespace
+  create_namespace = local.create_external_dns_ns
+
+  timeout         = 600
+  cleanup_on_fail = true
+  atomic          = true
+
+  values = [
+    yamlencode({
+      provider = "aws"
+      policy   = "sync"
+      txtOwnerId = local.external_dns_txt_owner_id
+      domainFilters = var.external_dns_domain_filters
+      zoneType      = var.external_dns_zone_type
+      sources       = ["service", "ingress"]
+      serviceAccount = {
+        create = true
+        name   = var.external_dns_service_account_name
+        annotations = {
+          "eks.amazonaws.com/role-arn" = module.iam_irsa_external_dns.arn
+        }
+      }
+    })
+  ]
+
+  depends_on = [
+    module.eks,
+    module.iam_irsa_external_dns,
+    helm_release.aws_load_balancer_controller
+  ]
+}

--- a/infra/terraform/eks/outputs.tf
+++ b/infra/terraform/eks/outputs.tf
@@ -1,0 +1,45 @@
+output "cluster_name" {
+  description = "EKS cluster name."
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster API server endpoint."
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority" {
+  description = "Base64 encoded cluster certificate authority data."
+  value       = module.eks.cluster_certificate_authority_data
+  sensitive   = true
+}
+
+output "cluster_oidc_provider_arn" {
+  description = "ARN of the IAM OIDC provider associated with the cluster."
+  value       = module.eks.oidc_provider_arn
+}
+
+output "managed_node_group_role_arns" {
+  description = "IAM role ARNs associated with managed node groups."
+  value       = module.eks.eks_managed_node_group_iam_role_arns
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ID for the EKS control plane."
+  value       = module.eks.cluster_security_group_id
+}
+
+output "cluster_autoscaler_role_arn" {
+  description = "IAM role ARN used by the Cluster Autoscaler service account."
+  value       = module.iam_irsa_cluster_autoscaler.arn
+}
+
+output "aws_load_balancer_controller_role_arn" {
+  description = "IAM role ARN used by the AWS Load Balancer Controller service account."
+  value       = module.iam_irsa_aws_load_balancer_controller.arn
+}
+
+output "external_dns_role_arn" {
+  description = "IAM role ARN used by the external-dns service account."
+  value       = module.iam_irsa_external_dns.arn
+}

--- a/infra/terraform/eks/providers.tf
+++ b/infra/terraform/eks/providers.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile
+
+  default_tags {
+    tags = merge(
+      {
+        ManagedBy = "terraform"
+        Project   = var.project
+      },
+      var.tags
+    )
+  }
+}

--- a/infra/terraform/eks/terraform.tfvars.example
+++ b/infra/terraform/eks/terraform.tfvars.example
@@ -1,0 +1,52 @@
+# Required AWS region and networking IDs
+region   = "us-east-1"
+cluster_name = "share-house-portal-eks"
+vpc_id   = "vpc-xxxxxxxxxxxxxxxxx"
+subnet_ids = [
+  "subnet-aaaaaaaaaaaaaaaaa",
+  "subnet-bbbbbbbbbbbbbbbbb"
+]
+
+# Optionally separate control plane subnets
+# control_plane_subnet_ids = []
+
+cluster_endpoint_public_access  = false
+cluster_endpoint_private_access = true
+
+# Example managed node group definitions
+eks_managed_node_groups = {
+  default = {
+    min_size       = 2
+    max_size       = 5
+    desired_size   = 2
+    instance_types = ["t3.medium"]
+    capacity_type  = "ON_DEMAND"
+    labels = {
+      role = "default"
+    }
+  }
+  spot = {
+    min_size       = 0
+    max_size       = 4
+    desired_size   = 0
+    instance_types = ["t3.large", "t3a.large"]
+    capacity_type  = "SPOT"
+    labels = {
+      lifecycle = "spot"
+    }
+  }
+}
+
+# Allow external-dns to manage Route53 hosted zones and limit to domains you own
+external_dns_hosted_zone_arns = [
+  "arn:aws:route53:::hostedzone/Z1111111111111"
+]
+external_dns_domain_filters = [
+  "example.com"
+]
+external_dns_txt_owner_id = "share-house-portal"
+
+# Provide custom tags for all AWS resources
+# tags = {
+#   Environment = "staging"
+# }

--- a/infra/terraform/eks/variables.tf
+++ b/infra/terraform/eks/variables.tf
@@ -1,0 +1,260 @@
+variable "region" {
+  description = "AWS region to deploy the EKS cluster into."
+  type        = string
+}
+
+variable "aws_profile" {
+  description = "Optional named AWS CLI profile to use for authentication."
+  type        = string
+  default     = null
+}
+
+variable "project" {
+  description = "Project tag applied to AWS resources."
+  type        = string
+  default     = "share-house-portal"
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster."
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "Desired Kubernetes version for the EKS control plane."
+  type        = string
+  default     = "1.29"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC that hosts the EKS cluster."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs where worker nodes will be launched."
+  type        = list(string)
+}
+
+variable "control_plane_subnet_ids" {
+  description = "Optional list of subnet IDs dedicated to the control plane ENIs. Defaults to \"subnet_ids\" when empty."
+  type        = list(string)
+  default     = []
+}
+
+variable "cluster_endpoint_private_access" {
+  description = "Whether the EKS cluster endpoint is private."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Whether the EKS cluster endpoint is public."
+  type        = bool
+  default     = false
+}
+
+variable "cluster_public_access_cidrs" {
+  description = "List of CIDR blocks that can access the public endpoint when enabled."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "cluster_additional_security_group_ids" {
+  description = "Additional security group IDs attached to the cluster."
+  type        = list(string)
+  default     = []
+}
+
+variable "node_group_disk_size" {
+  description = "EBS volume size in GiB for the default managed node groups."
+  type        = number
+  default     = 50
+}
+
+variable "node_group_subnet_ids" {
+  description = "Override subnet IDs used by managed node groups. Defaults to \"subnet_ids\" when empty."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Additional tags applied to AWS resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "eks_managed_node_groups" {
+  description = "Map of EKS managed node group configurations keyed by node group name."
+  type = map(object({
+    min_size       = number
+    max_size       = number
+    desired_size   = number
+    instance_types = list(string)
+    capacity_type  = optional(string, "ON_DEMAND")
+    labels         = optional(map(string), {})
+    taints = optional(list(object({
+      key    = string
+      value  = string
+      effect = string
+    })), [])
+  }))
+  default = {
+    default = {
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["t3.medium"]
+      capacity_type  = "ON_DEMAND"
+      labels = {
+        role = "default"
+      }
+      taints = []
+    }
+  }
+}
+
+variable "cluster_addons" {
+  description = "Managed EKS cluster add-ons configuration map."
+  type = map(object({
+    addon_version            = optional(string)
+    configuration_values     = optional(string)
+    most_recent              = optional(bool)
+    resolve_conflicts        = optional(string)
+    service_account_role_arn = optional(string)
+    marketplace_customer_config = optional(object({
+      product_id  = string
+      product_code = string
+    }))
+  }))
+  default = {
+    coredns = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+      configuration_values = jsonencode({
+        env = {
+          ENABLE_PREFIX_DELEGATION = "true"
+        }
+      })
+    }
+  }
+}
+
+variable "cluster_autoscaler_namespace" {
+  description = "Namespace where the Cluster Autoscaler chart is installed."
+  type        = string
+  default     = "kube-system"
+}
+
+variable "cluster_autoscaler_service_account_name" {
+  description = "Service account name used by the Cluster Autoscaler release."
+  type        = string
+  default     = "cluster-autoscaler"
+}
+
+variable "cluster_autoscaler_chart_version" {
+  description = "Version of the Cluster Autoscaler Helm chart."
+  type        = string
+  default     = "9.34.1"
+}
+
+variable "aws_load_balancer_controller_namespace" {
+  description = "Namespace where the AWS Load Balancer Controller chart is installed."
+  type        = string
+  default     = "kube-system"
+}
+
+variable "aws_load_balancer_controller_service_account_name" {
+  description = "Service account name for the AWS Load Balancer Controller."
+  type        = string
+  default     = "aws-load-balancer-controller"
+}
+
+variable "aws_load_balancer_controller_chart_version" {
+  description = "Version of the AWS Load Balancer Controller Helm chart."
+  type        = string
+  default     = "1.7.2"
+}
+
+variable "nginx_ingress_namespace" {
+  description = "Namespace where the ingress-nginx chart is installed."
+  type        = string
+  default     = "ingress-nginx"
+}
+
+variable "nginx_ingress_chart_version" {
+  description = "Version of the ingress-nginx Helm chart."
+  type        = string
+  default     = "4.10.0"
+}
+
+variable "cert_manager_namespace" {
+  description = "Namespace where the cert-manager chart is installed."
+  type        = string
+  default     = "cert-manager"
+}
+
+variable "cert_manager_chart_version" {
+  description = "Version of the cert-manager Helm chart."
+  type        = string
+  default     = "1.14.4"
+}
+
+variable "external_dns_namespace" {
+  description = "Namespace where the external-dns chart is installed."
+  type        = string
+  default     = "external-dns"
+}
+
+variable "external_dns_service_account_name" {
+  description = "Service account name for the external-dns release."
+  type        = string
+  default     = "external-dns"
+}
+
+variable "external_dns_chart_version" {
+  description = "Version of the external-dns Helm chart."
+  type        = string
+  default     = "1.14.5"
+}
+
+variable "external_dns_txt_owner_id" {
+  description = "TXT record owner identifier used by external-dns. Defaults to the cluster name when null."
+  type        = string
+  default     = null
+}
+
+variable "external_dns_domain_filters" {
+  description = "Optional list of domain filters for external-dns."
+  type        = list(string)
+  default     = []
+}
+
+variable "external_dns_zone_type" {
+  description = "Route53 zone type managed by external-dns (public or private)."
+  type        = string
+  default     = "public"
+}
+
+variable "external_dns_hosted_zone_arns" {
+  description = "Route53 hosted zone ARNs that external-dns is allowed to manage."
+  type        = list(string)
+  default     = []
+}
+
+variable "load_balancer_controller_target_group_arns" {
+  description = "Restrict the load balancer controller to specific target group ARNs when supplied."
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_iam_policies" {
+  description = "Additional IAM policy ARNs to attach to all service account roles."
+  type        = list(string)
+  default     = []
+}

--- a/infra/terraform/eks/versions.tf
+++ b/infra/terraform/eks/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.11"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration for provisioning an EKS cluster with managed node groups and service-account IAM roles
- manage core platform controllers (cluster autoscaler, AWS Load Balancer Controller, ingress-nginx, cert-manager, external-dns) via Terraform Helm releases
- document bootstrap workflow and configuration options plus provide a terraform.tfvars example

## Testing
- `terraform fmt -recursive infra/terraform/eks` *(fails: terraform not installed in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceef82955483288732ce141ddd7f24