### PR TITLE
Add Terraform-managed storage buckets

### DIFF
--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -1,0 +1,44 @@
+# Storage Architecture
+
+The Terraform configuration under `infra/terraform/storage` provisions the Amazon S3
+buckets that back the product's storage needs. Each bucket is encrypted with a
+bucket-specific AWS KMS key and protected by a tailored bucket policy so that
+only the services that need the data are able to access it. Buckets are named
+using the pattern `<bucket_prefix>-<environment>-<purpose>` (for example
+`share-house-portal-prod-documents`).
+
+## Bucket Overview
+
+| Bucket | Purpose | Access pattern | Retention & lifecycle | Notes |
+| --- | --- | --- | --- | --- |
+| `documents` | Source of truth for legal agreements, IDs, leases, and other user-provided paperwork. | Application APIs and internal review tooling require read/write access. Principals should be supplied via `documents_bucket_allowed_principals`. | Current versions are kept in the standard tier. Objects transition to STANDARD_IA after 90 days, move to Glacier as non-current after 180 days, and non-current versions are trimmed after three years. Multipart uploads are auto-aborted after 7 days. | Encrypted with a dedicated KMS key and enforced TLS-only access via bucket policy. |
+| `images` | Stores listing images, floorplans, and marketing assets used by the front-end. | The public web application writes and reads through a media-processing pipeline role passed in `images_bucket_allowed_principals`. | Only the latest image revisions are needed. Non-current versions are purged after 90 days and stalled multipart uploads are aborted after 7 days. | TLS-only access; encryption handled by a dedicated KMS key. |
+| `exports` | Temporary analytics exports and partner data drops. | Analytics export jobs write files while partner ingestion roles (specified in `exports_bucket_allowed_principals`) fetch and delete them. | Files automatically expire after 30 days and incomplete uploads are aborted after 3 days. | Designed for short-lived data. |
+| `artifacts` | CI/CD build outputs, deployment bundles, and other engineering artifacts. | CI and deployment roles listed in `artifacts_bucket_allowed_principals` require read/write access. | Artifacts automatically expire after 180 days and incomplete uploads are aborted after 7 days to cap storage costs. | Tight TLS enforcement; not intended for public distribution. |
+| `backups` | Long-term, immutable backups of databases and configuration. | Only automated backup and recovery tooling principals provided through `backups_bucket_allowed_principals` can read or write. Deletes are intentionally not granted. | Backups transition to Glacier after 30 days, are retained for 10 years, and multipart uploads are aborted after 7 days. Object Lock enforces a 365-day compliance retention period. | Versioning and object lock combine to deliver WORM guarantees for compliance. |
+
+## Access Control & Encryption
+
+- **KMS keys** – Every bucket has a dedicated KMS key with automatic rotation.
+  IAM principals defined in the `*_bucket_allowed_principals` variables are
+  granted Encrypt/Decrypt permissions so they can read and write objects with
+  SSE-KMS.
+- **Bucket policies** – Transport security is enforced by denying non-TLS
+  requests. Additional statements allow the consuming services to perform
+  bucket-level operations (for example, `s3:ListBucket`) and object-level
+  operations (for example, `s3:GetObject`).
+- **Public access** – Each bucket has public access blocks enabled to prevent
+  accidental exposure.
+
+## Retention Expectations
+
+| Data class | Minimum retention | Deletion policy |
+| --- | --- | --- |
+| Legal & compliance documents | 3 years of version history with archival of cold versions to Glacier | Manual purge only after retention satisfied. |
+| Marketing imagery | Latest version kept online; stale versions removed after 90 days | Automatic lifecycle purge. |
+| Analytics exports | 30 days | Automatically expired. |
+| Build artifacts | 180 days | Automatically expired. |
+| Backups | 10 years | Automatic expiry after retention; WORM lock prevents tampering for first year. |
+
+To grant a new service access, add the service's IAM role ARN to the relevant
+`*_bucket_allowed_principals` variable when instantiating the storage module.

--- a/infra/terraform/storage/.terraform.lock.hcl
+++ b/infra/terraform/storage/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.14.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:MHSiHnXU6DcXC/suxG00SvfAtPRiNnvVKOkGUAZG39g=",
+    "zh:35bd9514b397e96f40eaf5dea7de007e4105e804db3b246ee83edc31260f3251",
+    "zh:5662381971177f552b44b0f96e5aeb117b8c2e5c118845be41b19d44daed94d7",
+    "zh:58f574a0e83a2914c21995a159b155c0361c62690ebb8690cb28c1a5d9a40e6f",
+    "zh:798dc4a0bdd2da2e871a74f1c8fc64e30b5cd07e1d99255dc93c47dd202dc58b",
+    "zh:8972e3d0610e374f35f4e2f1ecd38ee6c4c0fa0d88bc88e0c138056646517751",
+    "zh:965711c26b0037842ab1a85a1ae38c11c446992b276131aea6fedd25995916bb",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b3c41e233c90d70d465b1e371e7b741d0ce67b7bcedabb87c3467b43c56727c0",
+    "zh:b518daff3eaa800e741103f16a7e2d99958bc3a9dc6a50f71d19dcfe7bcdee71",
+    "zh:bd26f8aecdffdbaab5b4dbe1d996a6bd1d6e53c8e036177f4daabaef8aa5abc3",
+    "zh:c5bf06ee484c693b763c90d3022f93c00e4e16b34c9e7c0440053efbc60b2ece",
+    "zh:d3ea9da36625b322745ec66652131c3f61367b0a7a1862308149e42e4bdf3d90",
+    "zh:d6ba44950eceb4d2ac404ace4260a89880cd0a7524a69191369939a8b7efe74c",
+    "zh:e263e3a5b41e92af5b05840bed8c03de3f8339c7d8ef8fbb21d3c700b31ff7ad",
+    "zh:f847e5db9c6361d6fc9b24c36a3c254c123c393b149c836d8fec6428a59824dd",
+  ]
+}

--- a/infra/terraform/storage/main.tf
+++ b/infra/terraform/storage/main.tf
@@ -1,0 +1,404 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  bucket_prefix = lower("${var.bucket_prefix}-${var.environment}")
+
+  common_tags = {
+    Application = var.bucket_prefix
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+
+  bucket_definitions = {
+    documents = {
+      description        = "Long-lived user and business documents (leases, agreements, IDs)."
+      kms_description    = "KMS key for encrypting documents bucket objects."
+      allowed_principals = var.documents_bucket_allowed_principals
+      bucket_actions     = ["s3:GetBucketLocation", "s3:ListBucket"]
+      object_actions     = ["s3:GetObject", "s3:GetObjectVersion", "s3:PutObject", "s3:DeleteObject", "s3:DeleteObjectVersion"]
+      lifecycle_rules = [
+        {
+          id                                     = "documents-archive"
+          status                                 = "Enabled"
+          transitions                            = [{ days = 90, storage_class = "STANDARD_IA" }]
+          noncurrent_transitions                 = [{ days = 180, storage_class = "GLACIER" }]
+          noncurrent_expiration_days             = 1095
+          abort_incomplete_multipart_upload_days = 7
+        }
+      ]
+      object_lock = null
+    }
+
+    images = {
+      description        = "Listing and marketing imagery served by the web experience."
+      kms_description    = "KMS key for encrypting images bucket objects."
+      allowed_principals = var.images_bucket_allowed_principals
+      bucket_actions     = ["s3:GetBucketLocation", "s3:ListBucket"]
+      object_actions     = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:DeleteObjectVersion"]
+      lifecycle_rules = [
+        {
+          id                                     = "images-trim-versions"
+          status                                 = "Enabled"
+          noncurrent_expiration_days             = 90
+          abort_incomplete_multipart_upload_days = 7
+        }
+      ]
+      object_lock = null
+    }
+
+    exports = {
+      description        = "Short-lived analytics exports shared with partners and operators."
+      kms_description    = "KMS key for encrypting exports bucket objects."
+      allowed_principals = var.exports_bucket_allowed_principals
+      bucket_actions     = ["s3:ListBucket"]
+      object_actions     = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+      lifecycle_rules = [
+        {
+          id                                     = "exports-expire"
+          status                                 = "Enabled"
+          expiration_days                        = 30
+          abort_incomplete_multipart_upload_days = 3
+        }
+      ]
+      object_lock = null
+    }
+
+    artifacts = {
+      description        = "Build artifacts and deployment bundles from CI/CD pipelines."
+      kms_description    = "KMS key for encrypting artifacts bucket objects."
+      allowed_principals = var.artifacts_bucket_allowed_principals
+      bucket_actions     = ["s3:GetBucketLocation", "s3:ListBucket"]
+      object_actions     = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"]
+      lifecycle_rules = [
+        {
+          id                                     = "artifacts-cleanup"
+          status                                 = "Enabled"
+          expiration_days                        = 180
+          abort_incomplete_multipart_upload_days = 7
+        }
+      ]
+      object_lock = null
+    }
+
+    backups = {
+      description        = "Immutable database and configuration backups for compliance."
+      kms_description    = "KMS key for encrypting backups bucket objects."
+      allowed_principals = var.backups_bucket_allowed_principals
+      bucket_actions     = ["s3:ListBucket"]
+      object_actions     = ["s3:GetObject", "s3:PutObject"]
+      lifecycle_rules = [
+        {
+          id                                     = "backups-archive"
+          status                                 = "Enabled"
+          transitions                            = [{ days = 30, storage_class = "GLACIER" }]
+          expiration_days                        = 3650
+          abort_incomplete_multipart_upload_days = 7
+        }
+      ]
+      object_lock = {
+        mode = "COMPLIANCE"
+        days = 365
+      }
+    }
+  }
+}
+
+locals {
+  bucket_names = { for bucket_key, _ in local.bucket_definitions : bucket_key => "${local.bucket_prefix}-${bucket_key}" }
+}
+
+data "aws_iam_policy_document" "kms_default" {
+  for_each = local.bucket_definitions
+
+  statement {
+    sid     = "AllowRootAccount"
+    effect  = "Allow"
+    actions = ["kms:*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowS3Service"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:GenerateDataKey"
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "kms_principals" {
+  for_each = { for k, v in local.bucket_definitions : k => v if length(v.allowed_principals) > 0 }
+
+  statement {
+    sid    = "AllowBucketConsumers${title(each.key)}"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:ReEncryptFrom",
+      "kms:ReEncryptTo"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = each.value.allowed_principals
+    }
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "kms_with_principals" {
+  for_each = data.aws_iam_policy_document.kms_principals
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_default[each.key].json,
+    data.aws_iam_policy_document.kms_principals[each.key].json
+  ]
+}
+
+resource "aws_kms_key" "bucket" {
+  for_each = local.bucket_definitions
+
+  description             = each.value.kms_description
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  policy                  = try(data.aws_iam_policy_document.kms_with_principals[each.key].json, data.aws_iam_policy_document.kms_default[each.key].json)
+
+  tags = merge(local.common_tags, {
+    "Bucket"      = each.key,
+    "DataPurpose" = each.value.description
+  })
+}
+
+resource "aws_kms_alias" "bucket" {
+  for_each = local.bucket_definitions
+
+  name          = "alias/${local.bucket_names[each.key]}"
+  target_key_id = aws_kms_key.bucket[each.key].key_id
+}
+
+resource "aws_s3_bucket" "bucket" {
+  for_each = local.bucket_definitions
+
+  bucket              = local.bucket_names[each.key]
+  force_destroy       = false
+  object_lock_enabled = each.value.object_lock != null
+
+  tags = merge(local.common_tags, {
+    "Bucket"      = each.key,
+    "DataPurpose" = each.value.description
+  })
+}
+
+resource "aws_s3_bucket_versioning" "bucket" {
+  for_each = aws_s3_bucket.bucket
+
+  bucket = each.value.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
+  for_each = aws_s3_bucket.bucket
+
+  bucket = each.value.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.bucket[each.key].arn
+      sse_algorithm     = "aws:kms"
+    }
+
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "bucket" {
+  for_each = aws_s3_bucket.bucket
+
+  bucket = each.value.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "bucket" {
+  for_each = { for k, v in local.bucket_definitions : k => v if v.object_lock != null }
+
+  bucket = aws_s3_bucket.bucket[each.key].id
+
+  rule {
+    default_retention {
+      mode = each.value.object_lock.mode
+      days = lookup(each.value.object_lock, "days", null)
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.bucket]
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
+  for_each = aws_s3_bucket.bucket
+
+  bucket = each.value.id
+
+  dynamic "rule" {
+    for_each = lookup(local.bucket_definitions[each.key], "lifecycle_rules", [])
+
+    content {
+      id     = rule.value.id
+      status = rule.value.status
+
+      filter {
+        prefix = lookup(rule.value, "prefix", "")
+      }
+
+      dynamic "transition" {
+        for_each = lookup(rule.value, "transitions", [])
+
+        content {
+          days          = transition.value.days
+          storage_class = transition.value.storage_class
+        }
+      }
+
+      dynamic "noncurrent_version_transition" {
+        for_each = lookup(rule.value, "noncurrent_transitions", [])
+
+        content {
+          noncurrent_days = noncurrent_version_transition.value.days
+          storage_class   = noncurrent_version_transition.value.storage_class
+        }
+      }
+
+      dynamic "expiration" {
+        for_each = lookup(rule.value, "expiration_days", null) == null ? [] : [lookup(rule.value, "expiration_days", null)]
+
+        content {
+          days = expiration.value
+        }
+      }
+
+      dynamic "noncurrent_version_expiration" {
+        for_each = lookup(rule.value, "noncurrent_expiration_days", null) == null ? [] : [lookup(rule.value, "noncurrent_expiration_days", null)]
+
+        content {
+          noncurrent_days = noncurrent_version_expiration.value
+        }
+      }
+
+      dynamic "abort_incomplete_multipart_upload" {
+        for_each = lookup(rule.value, "abort_incomplete_multipart_upload_days", null) == null ? [] : [lookup(rule.value, "abort_incomplete_multipart_upload_days", null)]
+
+        content {
+          days_after_initiation = abort_incomplete_multipart_upload.value
+        }
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "bucket_base" {
+  for_each = aws_s3_bucket.bucket
+
+  statement {
+    sid     = "EnforceTLS"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      aws_s3_bucket.bucket[each.key].arn,
+      "${aws_s3_bucket.bucket[each.key].arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "bucket_consumers" {
+  for_each = { for k, v in local.bucket_definitions : k => v if length(v.allowed_principals) > 0 }
+
+  statement {
+    sid     = "AllowBucketLevelAccess"
+    effect  = "Allow"
+    actions = lookup(each.value, "bucket_actions", [])
+
+    principals {
+      type        = "AWS"
+      identifiers = each.value.allowed_principals
+    }
+
+    resources = [aws_s3_bucket.bucket[each.key].arn]
+  }
+
+  statement {
+    sid     = "AllowObjectLevelAccess"
+    effect  = "Allow"
+    actions = lookup(each.value, "object_actions", [])
+
+    principals {
+      type        = "AWS"
+      identifiers = each.value.allowed_principals
+    }
+
+    resources = ["${aws_s3_bucket.bucket[each.key].arn}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  for_each = aws_s3_bucket.bucket
+
+  source_policy_documents = compact([
+    data.aws_iam_policy_document.bucket_base[each.key].json,
+    try(data.aws_iam_policy_document.bucket_consumers[each.key].json, null)
+  ])
+}
+
+resource "aws_s3_bucket_policy" "bucket" {
+  for_each = data.aws_iam_policy_document.bucket_policy
+
+  bucket = aws_s3_bucket.bucket[each.key].id
+  policy = data.aws_iam_policy_document.bucket_policy[each.key].json
+}

--- a/infra/terraform/storage/outputs.tf
+++ b/infra/terraform/storage/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_names" {
+  description = "S3 bucket names keyed by logical bucket identifier."
+  value       = { for key, bucket in aws_s3_bucket.bucket : key => bucket.bucket }
+}
+
+output "bucket_arns" {
+  description = "S3 bucket ARNs keyed by logical bucket identifier."
+  value       = { for key, bucket in aws_s3_bucket.bucket : key => bucket.arn }
+}
+
+output "kms_key_arns" {
+  description = "KMS key ARNs protecting each storage bucket."
+  value       = { for key, key_resource in aws_kms_key.bucket : key => key_resource.arn }
+}

--- a/infra/terraform/storage/variables.tf
+++ b/infra/terraform/storage/variables.tf
@@ -1,0 +1,41 @@
+variable "bucket_prefix" {
+  description = "Prefix applied to all storage buckets (e.g. organisation or application name)."
+  type        = string
+  default     = "share-house-portal"
+}
+
+variable "environment" {
+  description = "Deployment environment identifier used as part of the bucket name (e.g. dev, staging, prod)."
+  type        = string
+  default     = "dev"
+}
+
+variable "documents_bucket_allowed_principals" {
+  description = "IAM principals (roles, users, or accounts) that require read/write access to the documents bucket."
+  type        = list(string)
+  default     = []
+}
+
+variable "images_bucket_allowed_principals" {
+  description = "IAM principals permitted to manage listing and marketing imagery."
+  type        = list(string)
+  default     = []
+}
+
+variable "exports_bucket_allowed_principals" {
+  description = "IAM principals permitted to write analytics exports and retrieve generated files."
+  type        = list(string)
+  default     = []
+}
+
+variable "artifacts_bucket_allowed_principals" {
+  description = "IAM principals (generally CI/CD roles) permitted to store and fetch build artifacts."
+  type        = list(string)
+  default     = []
+}
+
+variable "backups_bucket_allowed_principals" {
+  description = "IAM principals (backup automation, disaster recovery tooling) permitted to write or read immutable backups."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- add a Terraform storage module that provisions S3 buckets for documents, images, exports, artifacts, and backups with SSE-KMS, lifecycle management, and object lock where required
- configure bucket and KMS policies that grant access to consuming service principals supplied via module variables and expose helpful outputs
- document access patterns and retention expectations for each bucket in docs/storage/README.md

## Testing
- /tmp/terraform fmt infra/terraform/storage
- /tmp/terraform -chdir=infra/terraform/storage validate

------
https://chatgpt.com/codex/tasks/task_e_68ceef888b3483289ff2e7df8a15b1ef