### PR TITLE
Add Terraform RDS SQL Server module and update secrets plan

### DIFF
--- a/docs/operations/secrets-management-plan.md
+++ b/docs/operations/secrets-management-plan.md
@@ -1,0 +1,24 @@
+# Secrets Management Plan
+
+This plan tracks the sensitive configuration required to operate the Share House Portal data platform. Secrets are stored in AWS Secrets Manager with replication across production regions. Each secret entry includes ownership information, rotation requirements, and operational metadata such as maintenance windows and connection coordinates.
+
+## Storage and Access Controls
+
+- **Vault**: AWS Secrets Manager (production account).
+- **Replication**: Single-region with automated backup to cross-region recovery vault.
+- **Access**: IAM roles scoped to the application, data platform engineers, and on-call SREs.
+- **Rotation**: Managed by AWS for credentials that support automatic rotation; manual runbooks exist for all others.
+
+## Secret Inventory
+
+| Secret Name | Purpose | Contents | Rotation | Owner |
+|-------------|---------|----------|----------|-------|
+| `share-house/rds/sqlserver/admin` | Stores the managed master user secret for the Multi-AZ SQL Server instance. | - `master_secret_arn` (from Terraform output)<br>- `endpoint`<br>- `port`<br>- `maintenance_window`<br>- `backup_window` | Automatic (Secrets Manager rotation enabled via `manage_master_user_password`) | Data Platform Team |
+| `share-house/rds/sqlserver/app` | Application credentials for least-privilege connections. | - `username`<br>- `password`<br>- `endpoint`<br>- `port`<br>- `maintenance_window` | Manual rotation every 90 days with runbook `RUNBOOK-DB-04` | Application Team |
+
+## Operational Notes
+
+- The Terraform module exposes the writer endpoint and port through outputs so they can be injected into the secrets at deploy time.
+- Preferred backup window: `02:00-04:00` UTC. Preferred maintenance window: `sun:05:00-sun:07:00` UTC. These values must be mirrored in the secrets to inform scheduling and change freeze decisions.
+- When Performance Insights data is queried, reference the `db_instance_resource_id` output; the identifier is not considered a secret but is documented in deployment runbooks.
+- Any change to maintenance or backup windows requires updating the associated secret entries and notifying the on-call rotation.

--- a/infra/terraform/data/rds-sqlserver/README.md
+++ b/infra/terraform/data/rds-sqlserver/README.md
@@ -1,0 +1,107 @@
+# SQL Server RDS Module
+
+This Terraform module provisions a production-ready Amazon RDS for SQL Server instance that is hardened for availability and operational resilience. The instance is deployed in a Multi-AZ configuration with encrypted storage, automated backups, point-in-time recovery (PITR), and a customizable parameter group so the service can be tuned for Share House Portal workloads.
+
+## Features
+
+- Multi-AZ deployment for high availability and automatic failover.
+- Storage encryption using AWS Key Management Service (KMS).
+- Automated backups with configurable retention and preferred windows to support PITR.
+- Custom parameter group for SQL Server engine tuning.
+- Performance Insights with optional KMS encryption to provide workload visibility.
+- Enhanced monitoring, CloudWatch log exports, and IAM database authentication toggles.
+
+## Usage
+
+```hcl
+module "rds_sqlserver" {
+  source = "./infra/terraform/data/rds-sqlserver"
+
+  identifier              = "share-house-sqlserver"
+  db_subnet_group_name    = aws_db_subnet_group.data.name
+  vpc_security_group_ids  = [aws_security_group.db.id]
+  master_username         = "dbadmin"
+  manage_master_user_password = true
+
+  backup_retention_period = 14
+  backup_window           = "02:00-04:00"
+  maintenance_window      = "sun:05:00-sun:07:00"
+
+  parameters = {
+    "cost threshold for parallelism" = {
+      value        = "50"
+      apply_method = "pending-reboot"
+    }
+  }
+
+  tags = {
+    Environment = "production"
+    Service     = "share-house-portal"
+  }
+}
+```
+
+## Performance Insights
+
+Performance Insights is enabled by default to capture wait events and query metrics for the SQL Server instance. If you need to disable Performance Insights or supply a dedicated KMS key/retention period, use the `performance_insights_enabled`, `performance_insights_kms_key_arn`, and `performance_insights_retention_period` variables.
+
+## Read Replica Strategy
+
+Amazon RDS for SQL Server does not currently support managed read replicas. This module intentionally exposes a placeholder section so the team can document future strategies (for example, Always On availability groups or change data capture pipelines) when AWS adds native support or when an alternative pattern is selected.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `identifier` | Unique identifier for the SQL Server instance. | `string` | n/a | yes |
+| `engine` | Database engine identifier. Defaults to SQL Server Standard Edition. | `string` | `"sqlserver-se"` | no |
+| `engine_version` | Engine version to deploy. | `string` | `"16.00.4105.4.v1"` | no |
+| `instance_class` | Instance class to use for the SQL Server instance. | `string` | `"db.m6i.large"` | no |
+| `license_model` | License model for the SQL Server instance. | `string` | `"license-included"` | no |
+| `allocated_storage` | Initial storage allocated in GiB. | `number` | `200` | no |
+| `max_allocated_storage` | Maximum storage in GiB for autoscaling. Set to null to disable autoscaling. | `number` | `1000` | no |
+| `storage_type` | Storage type to use. | `string` | `"gp3"` | no |
+| `iops` | Provisioned IOPS for storage types that require it. | `number` | `null` | no |
+| `kms_key_arn` | KMS key ARN for storage encryption. | `string` | `null` | no |
+| `auto_minor_version_upgrade` | Whether minor engine upgrades are applied automatically. | `bool` | `true` | no |
+| `allow_major_version_upgrade` | Whether major engine upgrades are allowed. | `bool` | `false` | no |
+| `db_subnet_group_name` | Name of the DB subnet group for the instance. | `string` | n/a | yes |
+| `vpc_security_group_ids` | List of security groups associated with the instance. | `list(string)` | `[]` | no |
+| `preferred_primary_az` | Preferred AZ for the primary instance. Leave null to allow AWS to choose. | `string` | `null` | no |
+| `master_username` | Master username for the SQL Server instance. | `string` | n/a | yes |
+| `master_password` | Master password for the SQL Server instance. Leave null when Secrets Manager is managing the password. | `string` | `null` | no |
+| `manage_master_user_password` | Enable AWS Secrets Manager integration for the master user password. | `bool` | `true` | no |
+| `backup_retention_period` | Number of days to retain automated backups to enable PITR. | `number` | `14` | no |
+| `backup_window` | Preferred backup window. | `string` | `"02:00-04:00"` | no |
+| `maintenance_window` | Preferred maintenance window. | `string` | `"sun:05:00-sun:07:00"` | no |
+| `deletion_protection` | Enable deletion protection on the instance. | `bool` | `true` | no |
+| `publicly_accessible` | Whether the instance is publicly accessible. | `bool` | `false` | no |
+| `port` | Port the instance listens on. | `number` | `1433` | no |
+| `enhanced_monitoring_interval` | Enhanced monitoring interval in seconds. Set to 0 to disable. | `number` | `60` | no |
+| `monitoring_role_arn` | ARN of the IAM role for enhanced monitoring. | `string` | `null` | no |
+| `performance_insights_enabled` | Enable Performance Insights. | `bool` | `true` | no |
+| `performance_insights_kms_key_arn` | KMS key ARN for encrypting Performance Insights data. | `string` | `null` | no |
+| `performance_insights_retention_period` | Retention period (in days) for Performance Insights metrics. | `number` | `7` | no |
+| `cloudwatch_logs_exports` | List of log types to export to CloudWatch Logs. | `list(string)` | `["error", "agent"]` | no |
+| `iam_authentication_enabled` | Enable IAM database authentication. | `bool` | `false` | no |
+| `option_group_name` | Existing option group to associate with the instance. | `string` | `null` | no |
+| `apply_immediately` | Apply modifications immediately instead of during the maintenance window. | `bool` | `false` | no |
+| `ca_cert_identifier` | Identifier of the CA certificate for the DB instance. | `string` | `null` | no |
+| `skip_final_snapshot` | Skip creating a final snapshot before instance deletion. | `bool` | `false` | no |
+| `final_snapshot_identifier` | Name of the final snapshot when the instance is deleted. | `string` | `null` | no |
+| `parameter_group_family` | Family of the SQL Server parameter group. | `string` | `"sqlserver-se-16.0"` | no |
+| `parameter_group_description` | Description for the parameter group. | `string` | `"SQL Server parameter overrides"` | no |
+| `parameters` | Map of parameter overrides for the SQL Server parameter group. | `map(object({ value = string, apply_method = optional(string) }))` | `{}` | no |
+| `tags` | Map of tags to apply to resources. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `db_instance_id` | ID of the SQL Server RDS instance. |
+| `db_instance_arn` | ARN of the SQL Server RDS instance. |
+| `db_instance_endpoint` | Writer endpoint address for the SQL Server RDS instance. |
+| `db_instance_port` | Port number for the SQL Server RDS instance. |
+| `db_instance_resource_id` | RDS resource identifier used for CloudWatch and Performance Insights. |
+| `master_user_secret_arn` | ARN of the Secrets Manager secret that stores the master user password when managed by AWS. |
+| `parameter_group_name` | Name of the custom parameter group applied to the SQL Server instance. |

--- a/infra/terraform/data/rds-sqlserver/main.tf
+++ b/infra/terraform/data/rds-sqlserver/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+resource "aws_db_parameter_group" "this" {
+  name_prefix = var.identifier
+  family      = var.parameter_group_family
+  description = var.parameter_group_description
+
+  dynamic "parameter" {
+    for_each = var.parameters
+    content {
+      name         = parameter.key
+      value        = parameter.value.value
+      apply_method = try(parameter.value.apply_method, null)
+    }
+  }
+
+  tags = merge(var.tags, {
+    "Name" = var.identifier
+  })
+}
+
+resource "aws_db_instance" "this" {
+  identifier = var.identifier
+
+  engine         = var.engine
+  engine_version = var.engine_version
+  instance_class = var.instance_class
+
+  license_model               = var.license_model
+  allocated_storage           = var.allocated_storage
+  max_allocated_storage       = var.max_allocated_storage
+  storage_type                = var.storage_type
+  iops                        = var.iops
+  storage_encrypted           = true
+  kms_key_id                  = var.kms_key_arn
+  multi_az                    = true
+  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
+  allow_major_version_upgrade = var.allow_major_version_upgrade
+
+  db_subnet_group_name   = var.db_subnet_group_name
+  vpc_security_group_ids = var.vpc_security_group_ids
+  availability_zone      = var.preferred_primary_az
+
+  username = var.master_username
+  password = var.master_password
+
+  manage_master_user_password = var.manage_master_user_password
+
+  backup_retention_period = var.backup_retention_period
+  backup_window           = var.backup_window
+  maintenance_window      = var.maintenance_window
+  copy_tags_to_snapshot   = true
+  delete_automated_backups = false
+  skip_final_snapshot      = var.skip_final_snapshot
+  final_snapshot_identifier = var.skip_final_snapshot ? null : coalesce(var.final_snapshot_identifier, format("%s-final", var.identifier))
+
+  deletion_protection = var.deletion_protection
+  publicly_accessible = var.publicly_accessible
+  port                = var.port
+
+  monitoring_interval = var.enhanced_monitoring_interval
+  monitoring_role_arn = var.monitoring_role_arn
+
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_kms_key_id       = var.performance_insights_kms_key_arn
+  performance_insights_retention_period = var.performance_insights_retention_period
+
+  enabled_cloudwatch_logs_exports = var.cloudwatch_logs_exports
+  iam_database_authentication_enabled = var.iam_authentication_enabled
+
+  parameter_group_name = aws_db_parameter_group.this.name
+  option_group_name    = var.option_group_name
+
+  apply_immediately = var.apply_immediately
+
+  ca_cert_identifier = var.ca_cert_identifier
+
+  tags = merge(var.tags, {
+    "Name" = var.identifier
+  })
+}
+

--- a/infra/terraform/data/rds-sqlserver/outputs.tf
+++ b/infra/terraform/data/rds-sqlserver/outputs.tf
@@ -1,0 +1,34 @@
+output "db_instance_id" {
+  description = "ID of the SQL Server RDS instance."
+  value       = aws_db_instance.this.id
+}
+
+output "db_instance_arn" {
+  description = "ARN of the SQL Server RDS instance."
+  value       = aws_db_instance.this.arn
+}
+
+output "db_instance_endpoint" {
+  description = "Writer endpoint address for the SQL Server RDS instance."
+  value       = aws_db_instance.this.endpoint
+}
+
+output "db_instance_port" {
+  description = "Port number for the SQL Server RDS instance."
+  value       = aws_db_instance.this.port
+}
+
+output "db_instance_resource_id" {
+  description = "RDS resource identifier used for CloudWatch and Performance Insights."
+  value       = aws_db_instance.this.resource_id
+}
+
+output "master_user_secret_arn" {
+  description = "ARN of the Secrets Manager secret that stores the master user password when managed by AWS."
+  value       = try(aws_db_instance.this.master_user_secret[0].secret_arn, null)
+}
+
+output "parameter_group_name" {
+  description = "Name of the custom parameter group applied to the SQL Server instance."
+  value       = aws_db_parameter_group.this.name
+}

--- a/infra/terraform/data/rds-sqlserver/variables.tf
+++ b/infra/terraform/data/rds-sqlserver/variables.tf
@@ -1,0 +1,244 @@
+variable "identifier" {
+  description = "Unique identifier for the SQL Server instance."
+  type        = string
+}
+
+variable "engine" {
+  description = "Database engine identifier. Defaults to SQL Server Standard Edition."
+  type        = string
+  default     = "sqlserver-se"
+}
+
+variable "engine_version" {
+  description = "Engine version to deploy."
+  type        = string
+  default     = "16.00.4105.4.v1"
+}
+
+variable "instance_class" {
+  description = "Instance class to use for the SQL Server instance."
+  type        = string
+  default     = "db.m6i.large"
+}
+
+variable "license_model" {
+  description = "License model for the SQL Server instance."
+  type        = string
+  default     = "license-included"
+}
+
+variable "allocated_storage" {
+  description = "Initial storage allocated in GiB."
+  type        = number
+  default     = 200
+}
+
+variable "max_allocated_storage" {
+  description = "Maximum storage in GiB for autoscaling. Set to null to disable autoscaling."
+  type        = number
+  default     = 1000
+}
+
+variable "storage_type" {
+  description = "Storage type to use."
+  type        = string
+  default     = "gp3"
+}
+
+variable "iops" {
+  description = "Provisioned IOPS for storage types that require it."
+  type        = number
+  default     = null
+}
+
+variable "kms_key_arn" {
+  description = "KMS key ARN for storage encryption."
+  type        = string
+  default     = null
+}
+
+variable "auto_minor_version_upgrade" {
+  description = "Whether minor engine upgrades are applied automatically."
+  type        = bool
+  default     = true
+}
+
+variable "allow_major_version_upgrade" {
+  description = "Whether major engine upgrades are allowed."
+  type        = bool
+  default     = false
+}
+
+variable "db_subnet_group_name" {
+  description = "Name of the DB subnet group for the instance."
+  type        = string
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of security groups associated with the instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "preferred_primary_az" {
+  description = "Preferred AZ for the primary instance. Leave null to allow AWS to choose."
+  type        = string
+  default     = null
+}
+
+variable "master_username" {
+  description = "Master username for the SQL Server instance."
+  type        = string
+}
+
+variable "master_password" {
+  description = "Master password for the SQL Server instance. Leave null when Secrets Manager is managing the password."
+  type        = string
+  default     = null
+
+  validation {
+    condition = var.manage_master_user_password ? (var.master_password == null || var.master_password == "") : (var.master_password != null && var.master_password != "")
+    error_message = "Provide master_password only when manage_master_user_password is disabled."
+  }
+}
+
+variable "manage_master_user_password" {
+  description = "Enable AWS Secrets Manager integration for the master user password."
+  type        = bool
+  default     = true
+}
+
+variable "backup_retention_period" {
+  description = "Number of days to retain automated backups to enable PITR."
+  type        = number
+  default     = 14
+}
+
+variable "backup_window" {
+  description = "Preferred backup window."
+  type        = string
+  default     = "02:00-04:00"
+}
+
+variable "maintenance_window" {
+  description = "Preferred maintenance window."
+  type        = string
+  default     = "sun:05:00-sun:07:00"
+}
+
+variable "deletion_protection" {
+  description = "Enable deletion protection on the instance."
+  type        = bool
+  default     = true
+}
+
+variable "publicly_accessible" {
+  description = "Whether the instance is publicly accessible."
+  type        = bool
+  default     = false
+}
+
+variable "port" {
+  description = "Port the instance listens on."
+  type        = number
+  default     = 1433
+}
+
+variable "enhanced_monitoring_interval" {
+  description = "Enhanced monitoring interval in seconds. Set to 0 to disable."
+  type        = number
+  default     = 60
+}
+
+variable "monitoring_role_arn" {
+  description = "ARN of the IAM role for enhanced monitoring."
+  type        = string
+  default     = null
+}
+
+variable "performance_insights_enabled" {
+  description = "Enable Performance Insights."
+  type        = bool
+  default     = true
+}
+
+variable "performance_insights_kms_key_arn" {
+  description = "KMS key ARN for encrypting Performance Insights data."
+  type        = string
+  default     = null
+}
+
+variable "performance_insights_retention_period" {
+  description = "Retention period (in days) for Performance Insights metrics."
+  type        = number
+  default     = 7
+}
+
+variable "cloudwatch_logs_exports" {
+  description = "List of log types to export to CloudWatch Logs."
+  type        = list(string)
+  default     = ["error", "agent"]
+}
+
+variable "iam_authentication_enabled" {
+  description = "Enable IAM database authentication."
+  type        = bool
+  default     = false
+}
+
+variable "option_group_name" {
+  description = "Existing option group to associate with the instance."
+  type        = string
+  default     = null
+}
+
+variable "apply_immediately" {
+  description = "Apply modifications immediately instead of during the maintenance window."
+  type        = bool
+  default     = false
+}
+
+variable "ca_cert_identifier" {
+  description = "Identifier of the CA certificate for the DB instance."
+  type        = string
+  default     = null
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip creating a final snapshot before instance deletion."
+  type        = bool
+  default     = false
+}
+
+variable "final_snapshot_identifier" {
+  description = "Name of the final snapshot when the instance is deleted."
+  type        = string
+  default     = null
+}
+
+variable "parameter_group_family" {
+  description = "Family of the SQL Server parameter group."
+  type        = string
+  default     = "sqlserver-se-16.0"
+}
+
+variable "parameter_group_description" {
+  description = "Description for the parameter group."
+  type        = string
+  default     = "SQL Server parameter overrides"
+}
+
+variable "parameters" {
+  description = "Map of parameter overrides for the SQL Server parameter group."
+  type = map(object({
+    value        = string
+    apply_method = optional(string)
+  }))
+  default = {}
+}
+
+variable "tags" {
+  description = "Map of tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add a Terraform module under `infra/terraform/data/rds-sqlserver` that provisions a Multi-AZ SQL Server instance with encryption, automated backups, PITR, parameter groups, and Performance Insights controls
- document module usage, variables, and placeholders for a future read-replica strategy
- record connection details and maintenance windows for the database in the secrets management plan

## Testing
- not run (terraform CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceef83bd6c83288fe32ce4d5eaaa1a