### PR TITLE
Add Terraform module for secrets management

### DIFF
--- a/docs/security/secrets.md
+++ b/docs/security/secrets.md
@@ -1,0 +1,120 @@
+# Secrets Management
+
+This document describes how the Share House Portal provisions and maintains
+sensitive configuration values in AWS Secrets Manager and Systems Manager
+Parameter Store using Terraform.
+
+## Module overview
+
+All secret primitives are managed by the Terraform module at
+`infra/terraform/security/secrets.tf`. The module exposes three inputs:
+
+- `secrets_manager_secrets` – map of AWS Secrets Manager secrets to create and
+  rotate.
+- `ssm_parameters` – map of Parameter Store entries that back application
+  configuration.
+- `service_access` – map of IAM roles that receive least-privilege read
+  permissions to the required secrets.
+
+The module also exposes outputs for each ARN to simplify downstream IAM and
+application wiring.
+
+## Naming conventions
+
+To keep the secret inventory predictable and environment aware we follow the
+pattern:
+
+```
+/<environment>/<workload>/<purpose>
+```
+
+Examples:
+
+- `/prod/api/database-url`
+- `/staging/worker/sendgrid-key`
+- `/shared/monitoring/pagerduty-routing`
+
+When defining new secrets:
+
+1. Prefer short workload identifiers such as `api`, `worker`, or `jobs`.
+2. Use a hyphenated `purpose` segment that matches the consuming code (for
+   example `database-url`, `jwt-signing-key`).
+3. Align Secrets Manager secret names and Parameter Store paths when both exist
+   for the same concern.
+
+## Rotation workflows
+
+### Secrets Manager
+
+Secrets Manager entries can be rotated automatically by providing a Lambda ARN
+and `rotation_days` interval inside `secrets_manager_secrets`. The module creates
+an `aws_secretsmanager_secret_rotation` resource, which calls the supplied Lambda
+function on the configured cadence. The Lambda is responsible for generating the
+new credential, updating dependent systems, and setting the new secret value
+using the event payload supplied by AWS.
+
+Rotation best practices:
+
+- Always deploy the rotation Lambda with idempotent logic. It may be retried by
+  AWS if failures occur.
+- Grant the Lambda IAM role permissions to update both the secret and the target
+  system (for example, RDS, Redis, or third-party API).
+- Validate Lambda execution with integration tests before assigning it to a
+  production secret.
+
+### Parameter Store
+
+Parameter Store entries accept rotation schedules via EventBridge Scheduler.
+When `rotation_lambda_arn` and `rotation_schedule_expression` are set for a
+parameter, the module creates an `aws_scheduler_schedule` resource that invokes
+the Lambda on the requested cadence with the parameter name in the JSON payload.
+The Lambda should fetch the current value, produce a replacement, and update the
+parameter via the AWS SDK.
+
+For workloads that require flexible execution windows, provide
+`rotation_flexible_time_window` with `mode` (`FLEXIBLE` or `OFF`) and optional
+`maximum_window`/`minimum_window` durations in minutes. Use this to avoid
+coordinated maintenance windows for downstream dependencies.
+
+Rotation best practices:
+
+- Implement concurrency controls in the Lambda to avoid overlapping runs if the
+  rotation window is shorter than the execution time.
+- Emit structured logs describing the rotation status and new version metadata
+  for auditability.
+- Ensure Parameter Store values are encrypted (`SecureString`) unless the value
+  is non-sensitive.
+
+## Least-privilege access
+
+The `service_access` input provisions IAM roles with the minimal read-only
+permissions required by each application component. For example:
+
+```hcl
+service_access = {
+  api = {
+    principal_service            = "ecs-tasks.amazonaws.com"
+    secrets_manager_secret_names = ["/prod/api/database-url"]
+    parameter_names              = ["/prod/api/jwt-secret"]
+  }
+}
+```
+
+The resulting role can be assumed by the ECS tasks running the API. Only the
+listed secrets are included in the IAM policy document, preventing accidental
+leakage of unrelated credentials.
+
+## Operational workflow
+
+1. Define or update secrets within `secrets_manager_secrets` and
+   `ssm_parameters`, including rotation metadata and tagging.
+2. Create or adjust IAM role entries in `service_access` to map workloads to the
+   secrets they require.
+3. Run `terraform plan` and `terraform apply` from the environment-specific root
+   module to roll out the changes.
+4. Monitor the rotation Lambdas and EventBridge Scheduler metrics to ensure
+   execution succeeds, especially after credential updates or infrastructure
+   changes.
+
+Following this approach keeps the secret inventory auditable, enforceable through
+code review, and continuously rotated to minimize credential exposure risk.

--- a/infra/terraform/security/secrets.tf
+++ b/infra/terraform/security/secrets.tf
@@ -1,0 +1,324 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix applied to created resources such as IAM roles."
+  type        = string
+  default     = "share-house"
+}
+
+variable "default_tags" {
+  description = "Tags applied to all managed resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secrets_manager_secrets" {
+  description = <<-EOT
+  Map of Secrets Manager secrets to create. The key is the secret name, and the value
+  controls configuration, tags, rotation, and optional initial value.
+  EOT
+  type = map(object({
+    description          = optional(string)
+    kms_key_id           = optional(string)
+    secret_string        = optional(string)
+    tags                 = optional(map(string))
+    recovery_window_days = optional(number)
+    rotation_lambda_arn  = optional(string)
+    rotation_days        = optional(number)
+  }))
+  default = {}
+}
+
+variable "ssm_parameters" {
+  description = <<-EOT
+  Map of SSM Parameter Store entries to create. Each key is the parameter name and
+  rotation is implemented through an EventBridge schedule that invokes the supplied
+  Lambda function.
+  EOT
+  type = map(object({
+    value                        = string
+    type                         = optional(string, "SecureString")
+    description                  = optional(string)
+    key_id                       = optional(string)
+    tier                         = optional(string)
+    allowed_pattern              = optional(string)
+    data_type                    = optional(string)
+    tags                         = optional(map(string))
+    rotation_lambda_arn          = optional(string)
+    rotation_schedule_expression = optional(string)
+    rotation_flexible_time_window = optional(object({
+      mode           = string
+      maximum_window = optional(number)
+      minimum_window = optional(number)
+    }))
+  }))
+  default = {}
+}
+
+variable "service_access" {
+  description = <<-EOT
+  Map describing IAM roles that can read specific secrets. Each object defines the
+  AWS service principal, the secrets and parameters the service needs access to, and
+  optional tagging.
+  EOT
+  type = map(object({
+    role_name                    = optional(string)
+    description                  = optional(string)
+    principal_service            = string
+    secrets_manager_secret_names = optional(list(string))
+    secret_arns                  = optional(list(string))
+    parameter_names              = optional(list(string))
+    parameter_arns               = optional(list(string))
+    tags                         = optional(map(string))
+  }))
+  default = {}
+}
+
+locals {
+  secrets_with_rotation = {
+    for name, cfg in var.secrets_manager_secrets :
+    name => cfg
+    if try(coalesce(cfg.rotation_lambda_arn, ""), "") != "" && try(cfg.rotation_days, 0) > 0
+  }
+
+  parameters_with_rotation = {
+    for name, cfg in var.ssm_parameters :
+    name => cfg
+    if try(coalesce(cfg.rotation_lambda_arn, ""), "") != "" && try(coalesce(cfg.rotation_schedule_expression, ""), "") != ""
+  }
+}
+
+
+resource "aws_secretsmanager_secret" "this" {
+  for_each = var.secrets_manager_secrets
+
+  name        = each.key
+  description = try(each.value.description, null)
+  kms_key_id  = try(each.value.kms_key_id, null)
+  recovery_window_in_days = try(each.value.recovery_window_days, null)
+
+  tags = merge(var.default_tags, coalesce(try(each.value.tags, null), {}))
+}
+
+resource "aws_secretsmanager_secret_version" "initial" {
+  for_each = {
+    for name, cfg in var.secrets_manager_secrets :
+    name => cfg if try(cfg.secret_string, null) != null
+  }
+
+  secret_id     = aws_secretsmanager_secret.this[each.key].id
+  secret_string = each.value.secret_string
+}
+
+resource "aws_secretsmanager_secret_rotation" "this" {
+  for_each = local.secrets_with_rotation
+
+  secret_id          = aws_secretsmanager_secret.this[each.key].id
+  rotation_lambda_arn = each.value.rotation_lambda_arn
+
+  rotation_rules {
+    automatically_after_days = each.value.rotation_days
+  }
+}
+
+resource "aws_ssm_parameter" "this" {
+  for_each = var.ssm_parameters
+
+  name        = each.key
+  description = try(each.value.description, null)
+  type        = try(each.value.type, "SecureString")
+  value       = each.value.value
+  key_id      = try(each.value.key_id, null)
+  tier        = try(each.value.tier, null)
+  allowed_pattern = try(each.value.allowed_pattern, null)
+  data_type       = try(each.value.data_type, null)
+
+  tags = merge(var.default_tags, coalesce(try(each.value.tags, null), {}))
+}
+
+resource "aws_scheduler_schedule" "parameter_rotation" {
+  for_each = {
+    for name, cfg in local.parameters_with_rotation :
+    name => cfg if try(cfg.rotation_flexible_time_window, null) == null
+  }
+
+  name       = "ssm-rotation-${substr(md5(each.key), 0, 12)}"
+  group_name = "default"
+
+  schedule_expression = each.value.rotation_schedule_expression
+
+  target {
+    arn   = each.value.rotation_lambda_arn
+    input = jsonencode({
+      parameter_name = aws_ssm_parameter.this[each.key].name
+    })
+  }
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  tags = merge(var.default_tags, coalesce(try(each.value.tags, null), {}))
+}
+
+resource "aws_scheduler_schedule" "parameter_rotation_flexible" {
+  for_each = {
+    for name, cfg in local.parameters_with_rotation :
+    name => cfg if try(cfg.rotation_flexible_time_window, null) != null
+  }
+
+  name       = "ssm-rotation-${substr(md5(each.key), 0, 12)}"
+  group_name = "default"
+
+  schedule_expression = each.value.rotation_schedule_expression
+
+  target {
+    arn   = each.value.rotation_lambda_arn
+    input = jsonencode({
+      parameter_name = aws_ssm_parameter.this[each.key].name
+    })
+  }
+
+  flexible_time_window {
+    mode            = each.value.rotation_flexible_time_window.mode
+    maximum_window_in_minutes = try(each.value.rotation_flexible_time_window.maximum_window, null)
+    minimum_window_in_minutes = try(each.value.rotation_flexible_time_window.minimum_window, null)
+  }
+
+  tags = merge(var.default_tags, coalesce(try(each.value.tags, null), {}))
+}
+
+resource "aws_lambda_permission" "parameter_rotation" {
+  for_each = local.parameters_with_rotation
+
+  statement_id  = "AllowScheduler-${substr(md5(each.key), 0, 12)}"
+  action        = "lambda:InvokeFunction"
+  function_name = each.value.rotation_lambda_arn
+  principal     = "scheduler.amazonaws.com"
+  source_arn = try(
+    aws_scheduler_schedule.parameter_rotation[each.key].arn,
+    aws_scheduler_schedule.parameter_rotation_flexible[each.key].arn
+  )
+}
+
+locals {
+  secret_arns_by_name = { for name, secret in aws_secretsmanager_secret.this : name => secret.arn }
+  parameter_arns_by_name = { for name, param in aws_ssm_parameter.this : name => param.arn }
+
+  service_secret_arns = {
+    for service, cfg in var.service_access :
+    service => concat(
+      [
+        for secret_name in coalesce(try(cfg.secrets_manager_secret_names, null), []) :
+        local.secret_arns_by_name[secret_name]
+      ],
+      coalesce(try(cfg.secret_arns, null), [])
+    )
+  }
+
+  service_parameter_arns = {
+    for service, cfg in var.service_access :
+    service => concat(
+      [
+        for parameter_name in coalesce(try(cfg.parameter_names, null), []) :
+        local.parameter_arns_by_name[parameter_name]
+      ],
+      coalesce(try(cfg.parameter_arns, null), [])
+    )
+  }
+}
+
+data "aws_iam_policy_document" "service_assume" {
+  for_each = var.service_access
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = [each.value.principal_service]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "service_read" {
+  for_each = var.service_access
+
+  dynamic "statement" {
+    for_each = length(local.service_secret_arns[each.key]) > 0 ? [true] : []
+
+    content {
+      sid     = "SecretsManagerRead"
+      effect  = "Allow"
+      actions = [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue"
+      ]
+      resources = local.service_secret_arns[each.key]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(local.service_parameter_arns[each.key]) > 0 ? [true] : []
+
+    content {
+      sid     = "SSMParameterRead"
+      effect  = "Allow"
+      actions = [
+        "ssm:GetParameter",
+        "ssm:GetParameterHistory",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath"
+      ]
+      resources = local.service_parameter_arns[each.key]
+    }
+  }
+}
+
+resource "aws_iam_role" "service" {
+  for_each = var.service_access
+
+  name        = try(each.value.role_name, "${var.name_prefix}-${each.key}-secrets")
+  description = try(each.value.description, null)
+
+  assume_role_policy = data.aws_iam_policy_document.service_assume[each.key].json
+
+  tags = merge(var.default_tags, coalesce(try(each.value.tags, null), {}))
+}
+
+resource "aws_iam_role_policy" "service_read" {
+  for_each = {
+    for key, cfg in var.service_access :
+    key => cfg if length(local.service_secret_arns[key]) + length(local.service_parameter_arns[key]) > 0
+  }
+
+  name   = "${var.name_prefix}-${each.key}-secret-read"
+  role   = aws_iam_role.service[each.key].id
+  policy = data.aws_iam_policy_document.service_read[each.key].json
+}
+
+output "secretsmanager_secret_arns" {
+  description = "ARNs of the Secrets Manager secrets created by this module."
+  value       = { for name, secret in aws_secretsmanager_secret.this : name => secret.arn }
+}
+
+output "ssm_parameter_arns" {
+  description = "ARNs of the Parameter Store entries created by this module."
+  value       = { for name, param in aws_ssm_parameter.this : name => param.arn }
+}
+
+output "service_role_arns" {
+  description = "IAM role ARNs provisioned for service access to secrets."
+  value       = { for name, role in aws_iam_role.service : name => role.arn }
+}


### PR DESCRIPTION
## Summary
- add a Terraform module that provisions Secrets Manager secrets, Parameter Store parameters, and rotation schedules alongside least-privilege IAM roles
- document naming conventions and operational workflows for managing secrets across the platform

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ceef8e9b648328ba774596a052bc72