### PR TITLE
Add DNS and CloudFront Terraform networking module

### DIFF
--- a/infra/terraform/networking/README.md
+++ b/infra/terraform/networking/README.md
@@ -1,0 +1,79 @@
+# Networking Terraform Module
+
+This module provisions DNS and edge networking resources for the Share House Portal deployment. It creates the public Route 53 hosted zone, issues ACM certificates for CloudFront, and configures CloudFront distributions for the single-page application (SPA) and media CDN.
+
+## Deployment Prerequisites
+
+Before applying the Terraform configuration:
+
+1. **Buckets**
+   - Create and populate the S3 bucket that will host the compiled SPA assets.
+   - Create the S3 bucket that stores user-uploaded media.
+   - Update each bucket policy to allow the CloudFront Origin Access Controls (OACs) created by this module to read objects. The AWS console wizard or the `aws cloudfront create-origin-access-control` CLI output provides the necessary policy snippets.
+2. **API Origin**
+   - Identify the API endpoint that should receive traffic (for example, an API Gateway custom domain or an Application Load Balancer).
+   - Collect the endpoint's DNS name and hosted zone ID so that Terraform can create an alias record for `api.<root-domain>`.
+3. **Logging (optional)**
+   - If you plan to store CloudFront access logs, create the destination S3 bucket first and provide its `bucket.s3.amazonaws.com` domain in the `access_logs_bucket` variable.
+4. **DNS Ownership**
+   - Ensure the `root_domain` is registered in Route 53 or that you are ready to delegate it from the current registrar to the hosted zone that this module creates.
+
+## Applying the Configuration
+
+1. Populate a Terraform variables file (e.g. `prod.tfvars`) with the required inputs: project name, environment, AWS region, domain names, S3 bucket names, API endpoint details, and optional logging configuration.
+2. Initialize Terraform from the `infra/terraform/networking` directory:
+
+   ```bash
+   terraform init
+   ```
+
+3. Review the plan to confirm the resources and DNS changes:
+
+   ```bash
+   terraform plan -var-file=prod.tfvars
+   ```
+
+4. Apply the configuration when ready:
+
+   ```bash
+   terraform apply -var-file=prod.tfvars
+   ```
+
+Terraform will provision the hosted zone, request and validate ACM certificates, create the CloudFront distributions, and write DNS aliases for the SPA, media, and API endpoints.
+
+## Post-Deployment Validation Checklist
+
+After a successful apply, validate the deployment before cutting over production DNS:
+
+1. **Certificate Validation**
+   - Confirm in the AWS Certificate Manager (us-east-1) console that the certificate issued for the web, media, and API domains is in the `Issued` state.
+2. **CloudFront Status**
+   - Wait for the SPA and media distributions to reach the `Deployed` status and note their domain names.
+   - Test the default CloudFront domain for the SPA (e.g. `dxxxx.cloudfront.net`) to verify that the SPA loads and client-side routing works (refresh deep links and confirm 403/404 responses render the SPA).
+   - Test the `/api/*` routes through CloudFront to ensure they successfully proxy to the API origin.
+   - Test media URLs to confirm caching headers, CORS rules, and object retrieval function as expected.
+3. **Origin Access Controls**
+   - Verify that the S3 buckets deny public access and that objects can only be retrieved through CloudFront by requesting them directly with `curl -I` against the CloudFront domain.
+4. **Monitoring and Logs**
+   - If access logging is enabled, check that log files are written to the target S3 bucket using the configured prefixes.
+5. **Health Checks**
+   - If the API origin exposes a health endpoint, confirm that it is reachable through CloudFront to detect issues before DNS cutover.
+
+## DNS Cutover Plan
+
+1. **Lower TTLs**
+   - At least 24 hours before migration, reduce the TTL of the existing production DNS records (if managed outside Route 53) to a short value such as 60 seconds.
+2. **Pre-Cutover Smoke Test**
+   - Create temporary hosts file entries mapping the new CloudFront alias to the final domain names and perform end-to-end testing, including authentication flows, API calls, and media uploads.
+3. **Update Authoritative DNS**
+   - When ready, either:
+     - Update the registrar to delegate the domain to the name servers generated for the new Route 53 hosted zone, **or**
+     - Modify the existing hosted zone records to alias to the CloudFront distributions and API origin defined by this module.
+4. **Monitor Traffic**
+   - Track application logs, CloudFront metrics, and API health for at least one hour after cutover to ensure traffic is flowing correctly.
+5. **Raise TTLs**
+   - Once satisfied with stability, increase record TTLs to production values (e.g. 300 or 600 seconds) to reduce DNS query volume.
+6. **Rollback Strategy**
+   - Keep the previous DNS configuration details on hand. If critical issues appear, revert the aliases to the prior endpoints or switch the registrar delegation back while investigating.
+
+These steps ensure the Share House Portal deployment is validated and that DNS cutover is orderly with minimal downtime.

--- a/infra/terraform/networking/dns.tf
+++ b/infra/terraform/networking/dns.tf
@@ -1,0 +1,536 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+variable "project" {
+  description = "Project name used for tagging resources."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. dev, staging, prod)."
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region for region-specific resources."
+  type        = string
+}
+
+variable "root_domain" {
+  description = "Root domain name that will host the application."
+  type        = string
+}
+
+variable "spa_subdomain" {
+  description = "Subdomain used for the SPA front-end."
+  type        = string
+  default     = "app"
+}
+
+variable "www_subdomain" {
+  description = "Marketing alias that should map to the SPA."
+  type        = string
+  default     = "www"
+}
+
+variable "api_subdomain" {
+  description = "Subdomain that should resolve to the API origin."
+  type        = string
+  default     = "api"
+}
+
+variable "media_subdomain" {
+  description = "Subdomain that should resolve to the media CDN."
+  type        = string
+  default     = "media"
+}
+
+variable "tags" {
+  description = "Additional resource tags."
+  type        = map(string)
+  default     = {}
+}
+
+variable "spa_bucket_name" {
+  description = "Name of the S3 bucket containing the compiled SPA assets."
+  type        = string
+}
+
+variable "media_bucket_name" {
+  description = "Name of the S3 bucket that stores uploaded media assets."
+  type        = string
+}
+
+variable "api_origin_domain_name" {
+  description = "Origin domain name that will receive API traffic (e.g. API Gateway, load balancer)."
+  type        = string
+}
+
+variable "api_origin_protocol_policy" {
+  description = "Protocol policy for connecting CloudFront to the API origin."
+  type        = string
+  default     = "https-only"
+  validation {
+    condition     = contains(["https-only", "match-viewer"], var.api_origin_protocol_policy)
+    error_message = "api_origin_protocol_policy must be either https-only or match-viewer."
+  }
+}
+
+variable "api_origin_port" {
+  description = "Port CloudFront should use when connecting to the API origin."
+  type        = number
+  default     = 443
+}
+
+variable "api_origin_path" {
+  description = "Optional origin path prefix for API requests (e.g. /prod)."
+  type        = string
+  default     = ""
+}
+
+variable "api_hosted_zone_id" {
+  description = "Hosted zone ID of the API origin (required for Route53 alias)."
+  type        = string
+}
+
+variable "enable_api_ipv6" {
+  description = "Set to true if the API origin supports IPv6 and should receive an AAAA alias record."
+  type        = bool
+  default     = false
+}
+
+variable "access_logs_bucket" {
+  description = "Optional bucket domain (e.g. bucket.s3.amazonaws.com) that receives CloudFront logs."
+  type        = string
+  default     = ""
+}
+
+variable "spa_logging_prefix" {
+  description = "Prefix to use when writing SPA distribution access logs."
+  type        = string
+  default     = "cloudfront/spa/"
+}
+
+variable "media_logging_prefix" {
+  description = "Prefix to use when writing media distribution access logs."
+  type        = string
+  default     = "cloudfront/media/"
+}
+
+locals {
+  base_tags = merge({
+    Project     = var.project,
+    Environment = var.environment,
+    ManagedBy   = "terraform"
+  }, var.tags)
+
+  web_domain   = "${var.spa_subdomain}.${var.root_domain}"
+  www_domain   = "${var.www_subdomain}.${var.root_domain}"
+  api_domain   = "${var.api_subdomain}.${var.root_domain}"
+  media_domain = "${var.media_subdomain}.${var.root_domain}"
+
+  certificate_domains = distinct([
+    var.root_domain,
+    local.web_domain,
+    local.www_domain,
+    local.api_domain,
+    local.media_domain
+  ])
+}
+
+data "aws_s3_bucket" "spa" {
+  bucket = var.spa_bucket_name
+}
+
+data "aws_s3_bucket" "media" {
+  bucket = var.media_bucket_name
+}
+
+# ---------------------------------------------------------------------------
+# Route 53 Hosted Zone
+# ---------------------------------------------------------------------------
+resource "aws_route53_zone" "primary" {
+  name          = var.root_domain
+  comment       = "${var.project} ${var.environment} public hosted zone"
+  force_destroy = false
+
+  tags = local.base_tags
+}
+
+# ---------------------------------------------------------------------------
+# ACM Certificate (us-east-1) for CloudFront Distributions
+# ---------------------------------------------------------------------------
+resource "aws_acm_certificate" "edge" {
+  provider = aws.us_east_1
+
+  domain_name               = local.web_domain
+  subject_alternative_names = [for domain in local.certificate_domains : domain if domain != local.web_domain]
+  validation_method         = "DNS"
+
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.base_tags
+}
+
+resource "aws_route53_record" "edge_certificate_validation" {
+  for_each = {
+    for option in aws_acm_certificate.edge.domain_validation_options : option.domain_name => {
+      name   = option.resource_record_name
+      type   = option.resource_record_type
+      record = option.resource_record_value
+    }
+  }
+
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "edge" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.edge.arn
+  validation_record_fqdns = [for record in aws_route53_record.edge_certificate_validation : record.fqdn]
+}
+
+# ---------------------------------------------------------------------------
+# Shared CloudFront data sources
+# ---------------------------------------------------------------------------
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer" {
+  name = "Managed-AllViewer"
+}
+
+data "aws_cloudfront_origin_request_policy" "api_gateway" {
+  name = "Managed-CORS-CustomOrigin"
+}
+
+data "aws_cloudfront_response_headers_policy" "security_headers" {
+  name = "Managed-SecurityHeadersPolicy"
+}
+
+# ---------------------------------------------------------------------------
+# SPA Distribution
+# ---------------------------------------------------------------------------
+resource "aws_cloudfront_origin_access_control" "spa" {
+  name                              = "${var.project}-${var.environment}-spa-oac"
+  description                       = "Origin access control for SPA bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "spa" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.project} ${var.environment} SPA distribution"
+  default_root_object = "index.html"
+
+  aliases = [var.root_domain, local.web_domain, local.www_domain]
+
+  origin {
+    origin_id   = "spa-bucket"
+    domain_name = data.aws_s3_bucket.spa.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.spa.id
+  }
+
+  origin {
+    origin_id   = "api-origin"
+    domain_name = var.api_origin_domain_name
+    origin_path = var.api_origin_path
+
+    custom_origin_config {
+      http_port              = var.api_origin_port
+      https_port             = var.api_origin_port
+      origin_protocol_policy = var.api_origin_protocol_policy
+      origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "spa-bucket"
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.all_viewer.id
+    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.security_headers.id
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "api/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "api-origin"
+
+    viewer_protocol_policy = "https-only"
+    compress               = true
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.api_gateway.id
+  }
+
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = aws_acm_certificate_validation.edge.certificate_arn
+    ssl_support_method             = "sni-only"
+    minimum_protocol_version       = "TLSv1.2_2021"
+    cloudfront_default_certificate = false
+  }
+
+  dynamic "logging_config" {
+    for_each = var.access_logs_bucket == "" ? [] : [1]
+
+    content {
+      include_cookies = false
+      bucket          = var.access_logs_bucket
+      prefix          = var.spa_logging_prefix
+    }
+  }
+
+  tags = local.base_tags
+
+  depends_on = [aws_acm_certificate_validation.edge]
+}
+
+resource "aws_route53_record" "spa_alias_ipv4" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.web_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.spa.domain_name
+    zone_id                = aws_cloudfront_distribution.spa.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "spa_alias_ipv6" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.web_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.spa.domain_name
+    zone_id                = aws_cloudfront_distribution.spa.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www_alias_ipv4" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.www_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.spa.domain_name
+    zone_id                = aws_cloudfront_distribution.spa.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www_alias_ipv6" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.www_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.spa.domain_name
+    zone_id                = aws_cloudfront_distribution.spa.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "root_alias_ipv4" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = var.root_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.spa.domain_name
+    zone_id                = aws_cloudfront_distribution.spa.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "root_alias_ipv6" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = var.root_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.spa.domain_name
+    zone_id                = aws_cloudfront_distribution.spa.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Media Distribution
+# ---------------------------------------------------------------------------
+resource "aws_cloudfront_origin_access_control" "media" {
+  name                              = "${var.project}-${var.environment}-media-oac"
+  description                       = "Origin access control for media bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "media" {
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "${var.project} ${var.environment} media distribution"
+
+  aliases = [local.media_domain]
+
+  origin {
+    origin_id   = "media-bucket"
+    domain_name = data.aws_s3_bucket.media.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.media.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "media-bucket"
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.all_viewer.id
+    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.security_headers.id
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = aws_acm_certificate_validation.edge.certificate_arn
+    ssl_support_method             = "sni-only"
+    minimum_protocol_version       = "TLSv1.2_2021"
+    cloudfront_default_certificate = false
+  }
+
+  dynamic "logging_config" {
+    for_each = var.access_logs_bucket == "" ? [] : [1]
+
+    content {
+      include_cookies = false
+      bucket          = var.access_logs_bucket
+      prefix          = var.media_logging_prefix
+    }
+  }
+
+  tags = local.base_tags
+
+  depends_on = [aws_acm_certificate_validation.edge]
+}
+
+resource "aws_route53_record" "media_alias_ipv4" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.media_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.media.domain_name
+    zone_id                = aws_cloudfront_distribution.media.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "media_alias_ipv6" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.media_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.media.domain_name
+    zone_id                = aws_cloudfront_distribution.media.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# ---------------------------------------------------------------------------
+# API DNS records (forwarded to external origin)
+# ---------------------------------------------------------------------------
+resource "aws_route53_record" "api_alias_ipv4" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.api_domain
+  type    = "A"
+
+  alias {
+    name                   = var.api_origin_domain_name
+    zone_id                = var.api_hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "api_alias_ipv6" {
+  count   = var.enable_api_ipv6 ? 1 : 0
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.api_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = var.api_origin_domain_name
+    zone_id                = var.api_hosted_zone_id
+    evaluate_target_health = false
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration for the networking stack covering Route 53, ACM, and CloudFront distributions with origin access controls and DNS aliases
- document prerequisites, validation steps, and DNS cutover procedures for deploying the networking module

## Testing
- terraform fmt (fails: terraform CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceef89f2ac8328b6bb5fc9965cd1bd