### PR TITLE
Add Terraform backend configuration and tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.92.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_tflint

--- a/infra/terraform/CONTRIBUTING.md
+++ b/infra/terraform/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Terraform Contributor Guide
+
+This directory contains the infrastructure as code configuration for the Share House Portal. The goal of this guide is to help you ship changes safely by standardising tooling, remote state, and workflow conventions.
+
+## Prerequisites
+
+Before making any changes ensure the following tools are installed:
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.6
+- [TFLint](https://github.com/terraform-linters/tflint) (installed automatically by the pre-commit hook)
+- [pre-commit](https://pre-commit.com/#install) >= 3.0
+- Access to the AWS account with profiles that match the values configured in [`main.tf`](./main.tf)
+
+## Remote state backend
+
+Terraform state is stored remotely in Amazon S3 with state locking provided by DynamoDB. The backend is configured in [`main.tf`](./main.tf) and expects the following to exist before you run `terraform init`:
+
+- S3 bucket: `share-house-portal-terraform-state`
+- DynamoDB table: `share-house-portal-terraform-locks`
+
+If the resources do not exist yet, create them manually (once per account) or coordinate with the platform team.
+
+To initialise the backend run:
+
+```bash
+terraform init
+```
+
+The configuration uses the `workspace_key_prefix` feature so that each Terraform workspace receives its own state file under `env/<workspace>/terraform.tfstate`.
+
+## Working with environments (workspaces)
+
+Terraform workspaces map to the environments defined in [`main.tf`](./main.tf). The default mapping is:
+
+- `dev`
+- `staging`
+- `prod`
+
+If you run commands in the default workspace Terraform will transparently use the `dev` configuration. Select a workspace before applying changes:
+
+```bash
+terraform workspace select dev   # or staging / prod
+```
+
+Create a workspace the first time you target a new environment:
+
+```bash
+terraform workspace new staging
+```
+
+The active workspace is exposed to modules through the `environment_settings` output in [`main.tf`](./main.tf). Extend the `environment_definitions` local map if you need additional per-environment configuration.
+
+## Making changes
+
+1. Select the correct workspace.
+2. Run `terraform plan` to review proposed changes.
+3. Apply the plan when you are satisfied:
+
+   ```bash
+   terraform apply
+   ```
+
+4. Commit your changes and open a pull request.
+
+## Pre-commit hooks
+
+Pre-commit hooks are required to keep the Terraform configuration linted and validated. After cloning the repository run:
+
+```bash
+pre-commit install
+```
+
+The following checks will run automatically before each commit and can also be triggered manually with `pre-commit run --all-files`:
+
+- `terraform fmt` for formatting
+- `terraform validate` for static analysis
+- `tflint` for best-practice linting
+
+Running these checks locally before pushing helps align results with CI and prevents simple mistakes from landing in the main branch.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket               = "share-house-portal-terraform-state"
+    key                  = "global/terraform.tfstate"
+    workspace_key_prefix = "env"
+    region               = "us-east-1"
+    dynamodb_table       = "share-house-portal-terraform-locks"
+    encrypt              = true
+  }
+}
+
+locals {
+  environment_definitions = {
+    dev = {
+      aws_profile = "share-house-dev"
+      aws_region  = "us-east-1"
+      stack       = "development"
+    }
+
+    staging = {
+      aws_profile = "share-house-staging"
+      aws_region  = "us-east-1"
+      stack       = "staging"
+    }
+
+    prod = {
+      aws_profile = "share-house-prod"
+      aws_region  = "us-east-1"
+      stack       = "production"
+    }
+  }
+
+  default_environment = "dev"
+
+  workspace = terraform.workspace == "default" ? local.default_environment : terraform.workspace
+
+  current_environment = lookup(
+    local.environment_definitions,
+    local.workspace,
+    {
+      aws_profile = null
+      aws_region  = null
+      stack       = local.workspace
+    }
+  )
+}
+
+output "workspace" {
+  description = "Normalized workspace name used for selecting environment-specific settings."
+  value       = local.workspace
+}
+
+output "environment_settings" {
+  description = "Environment-specific configuration derived from the current Terraform workspace."
+  value       = local.current_environment
+  sensitive   = false
+}


### PR DESCRIPTION
## Summary
- configure Terraform to use an S3 backend with DynamoDB state locking and expose workspace-derived settings
- add contributor documentation for working with Terraform environments and required tooling
- introduce Terraform formatting, validation, and tflint checks via pre-commit

## Testing
- `pre-commit run`


------
https://chatgpt.com/codex/tasks/task_e_68ceef8f75608328a012925aa18e6e37