### PR TITLE
Add AWS-backed CI/CD workflows and deployment docs

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -1,0 +1,102 @@
+name: Infrastructure CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra-ci.yml'
+  pull_request:
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra-ci.yml'
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply Terraform changes after a successful plan'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+  TERRAFORM_VERSION: ${{ vars.TERRAFORM_VERSION || '1.6.6' }}
+
+jobs:
+  terraform-plan:
+    name: Terraform plan
+    if: ${{ hashFiles('infra/**/*.tf') != '' }}
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_INFRA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Terraform format check
+        run: terraform -chdir=infra fmt -check
+
+      - name: Terraform init
+        run: terraform -chdir=infra init -input=false
+
+      - name: Terraform validate
+        run: terraform -chdir=infra validate
+
+      - name: Terraform plan
+        id: plan
+        run: terraform -chdir=infra plan -input=false -out=tfplan
+
+      - name: Show plan
+        run: terraform -chdir=infra show -no-color tfplan > terraform-plan.txt
+
+      - name: Upload plan output
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan
+          path: terraform-plan.txt
+
+  terraform-apply:
+    name: Terraform apply
+    needs: terraform-plan
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.apply }}
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_INFRA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Terraform init
+        run: terraform -chdir=infra init -input=false
+
+      - name: Terraform apply
+        run: terraform -chdir=infra apply -input=false -auto-approve

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -1,0 +1,216 @@
+name: Service Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/**'
+      - 'deploy/**'
+      - '.github/workflows/service-ci.yml'
+  pull_request:
+    paths:
+      - 'services/**'
+      - 'deploy/**'
+      - '.github/workflows/service-ci.yml'
+  workflow_dispatch:
+    inputs:
+      service:
+        description: 'Optional service name to build/deploy'
+        required: false
+        type: string
+      environment:
+        description: 'Deployment environment override'
+        required: false
+        default: dev
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+  ECR_REPOSITORY_PREFIX: ${{ vars.ECR_REPOSITORY_PREFIX || '' }}
+  HELM_REPOSITORY_PREFIX: ${{ vars.HELM_REPOSITORY_PREFIX || 'helm-' }}
+  HELM_VERSION: ${{ vars.HELM_VERSION || '3.13.3' }}
+  DEFAULT_ENVIRONMENT: ${{ vars.DEFAULT_DEPLOY_ENV || 'dev' }}
+
+jobs:
+  discover-services:
+    name: Discover services
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.detect.outputs.matrix }}
+      environment: ${{ steps.detect.outputs.environment }}
+    env:
+      TARGET_SERVICE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.service) || '' }}
+      TARGET_ENVIRONMENT: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment) || env.DEFAULT_ENVIRONMENT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect services
+        id: detect
+        run: |
+          set -euo pipefail
+          services='[]'
+          shopt -s nullglob
+          for dockerfile in services/*/Dockerfile services/*/Dockerfile.*; do
+            [ -f "${dockerfile}" ] || continue
+            service_dir=$(dirname "$dockerfile")
+            service_name=$(basename "$service_dir")
+            chart_dir="deploy/charts/${service_name}"
+            if [ ! -f "${chart_dir}/Chart.yaml" ]; then
+              echo "::warning::Skipping ${service_name} because ${chart_dir}/Chart.yaml was not found"
+              continue
+            fi
+            if [ -n "${TARGET_SERVICE}" ] && [ "${TARGET_SERVICE}" != "${service_name}" ]; then
+              continue
+            fi
+            services=$(jq --arg name "$service_name" --arg context "$service_dir" --arg dockerfile "$dockerfile" --arg chartDir "$chart_dir" \
+              '. + [{name: $name, context: $context, dockerfile: $dockerfile, chartDir: $chartDir}]' <<<"${services}")
+          done
+          shopt -u nullglob
+          echo "Detected services: ${services}"
+          echo "matrix=${services}" >> "$GITHUB_OUTPUT"
+          echo "environment=${TARGET_ENVIRONMENT}" >> "$GITHUB_OUTPUT"
+
+  build-package-deploy:
+    name: Build, push, and deploy
+    needs: discover-services
+    if: ${{ needs.discover-services.outputs.matrix != '[]' }}
+    runs-on: ubuntu-latest
+    environment: ${{ needs.discover-services.outputs.environment }}
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.discover-services.outputs.matrix) }}
+    env:
+      DEPLOY_ENVIRONMENT: ${{ needs.discover-services.outputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_SERVICE_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set image metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          IMAGE_TAG="${GITHUB_SHA}"
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            IMAGE_TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "image-tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "environment=${DEPLOY_ENVIRONMENT}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push container image
+        env:
+          IMAGE_TAG: ${{ steps.meta.outputs['image-tag'] }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          SERVICE_NAME='${{ matrix.service.name }}'
+          REPO_NAME="${ECR_REPOSITORY_PREFIX}${SERVICE_NAME}"
+          IMAGE_URI="${ECR_REGISTRY}/${REPO_NAME}:${IMAGE_TAG}"
+          echo "Building ${IMAGE_URI} from ${{ matrix.service.context }}"
+          docker buildx build \
+            --platform linux/amd64 \
+            --file "${{ matrix.service.dockerfile }}" \
+            --tag "${IMAGE_URI}" \
+            --tag "${ECR_REGISTRY}/${REPO_NAME}:${DEPLOY_ENVIRONMENT}" \
+            --push \
+            "${{ matrix.service.context }}"
+          echo "image-uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Login Helm to Amazon ECR (OCI)
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          aws ecr get-login-password --region "${AWS_REGION}" | helm registry login "${ECR_REGISTRY}" --username AWS --password-stdin
+
+      - name: Package Helm chart
+        id: package
+        env:
+          IMAGE_TAG: ${{ steps.meta.outputs['image-tag'] }}
+        run: |
+          set -euo pipefail
+          export HELM_EXPERIMENTAL_OCI=1
+          CHART_DIR='${{ matrix.service.chartDir }}'
+          SERVICE_NAME='${{ matrix.service.name }}'
+          PACKAGE_DIR="packaged-charts/${SERVICE_NAME}"
+          mkdir -p "${PACKAGE_DIR}"
+          helm dependency update "${CHART_DIR}" || true
+          helm package "${CHART_DIR}" \
+            --destination "${PACKAGE_DIR}" \
+            --app-version "${IMAGE_TAG}"
+          chart_package=$(ls "${PACKAGE_DIR}"/*.tgz)
+          echo "chart-package=${chart_package}" >> "$GITHUB_OUTPUT"
+
+      - name: Push Helm chart to ECR OCI registry
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          CHART_PACKAGE: ${{ steps.package.outputs['chart-package'] }}
+        run: |
+          set -euo pipefail
+          export HELM_EXPERIMENTAL_OCI=1
+          SERVICE_NAME='${{ matrix.service.name }}'
+          CHART_REPOSITORY="${HELM_REPOSITORY_PREFIX}${SERVICE_NAME}"
+          helm push "${CHART_PACKAGE}" "oci://${ECR_REGISTRY}/${CHART_REPOSITORY}" --force
+
+      - name: Install Argo CD CLI
+        if: ${{ secrets.ARGOCD_SERVER != '' && secrets.ARGOCD_AUTH_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          ARGOCD_VERSION="${{ vars.ARGOCD_VERSION || 'v2.10.2' }}"
+          curl -sSL -o argocd "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64"
+          sudo install -m 555 argocd /usr/local/bin/argocd
+
+      - name: Trigger Argo CD sync for dev
+        if: ${{ secrets.ARGOCD_SERVER != '' && secrets.ARGOCD_AUTH_TOKEN != '' }}
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+          ARGOCD_APP_NAME: ${{ vars.ARGOCD_APP_NAME || matrix.service.name }}
+          ARGOCD_PROJECT: ${{ vars.ARGOCD_PROJECT || 'default' }}
+          IMAGE_TAG: ${{ steps.meta.outputs['image-tag'] }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SERVICE_NAME: ${{ matrix.service.name }}
+        run: |
+          set -euo pipefail
+          export ARGOCD_OPTS="--server ${ARGOCD_SERVER} --grpc-web"
+          IMAGE_REPOSITORY="${ECR_REGISTRY}/${ECR_REPOSITORY_PREFIX}${SERVICE_NAME}"
+          argocd app set "${ARGOCD_APP_NAME}" ${ARGOCD_OPTS} --auth-token "${ARGOCD_AUTH_TOKEN}" \
+            --parameter image.tag="${IMAGE_TAG}" \
+            --parameter image.repository="${IMAGE_REPOSITORY}"
+          argocd app sync "${ARGOCD_APP_NAME}" ${ARGOCD_OPTS} --auth-token "${ARGOCD_AUTH_TOKEN}" --prune
+          argocd app wait "${ARGOCD_APP_NAME}" ${ARGOCD_OPTS} --auth-token "${ARGOCD_AUTH_TOKEN}" --timeout 300 --health
+
+      - name: Upload Helm package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ format('{0}-chart', matrix.service.name) }}
+          path: ${{ steps.package.outputs['chart-package'] }}

--- a/README.md
+++ b/README.md
@@ -83,3 +83,38 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ### Tips/Support
 <a href="https://www.buymeacoffee.com/rmoureyjr" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="51" width="217"></a>
+
+## CI/CD automation
+
+This template ships with infrastructure and service workflows that rely on GitHub Actions OpenID Connect (OIDC) federation to authenticate with AWS. Provide the required AWS IAM roles and repository secrets/variables before enabling the pipelines.
+
+### Workflows overview
+
+- `.github/workflows/infra-ci.yml` plans Terraform located under `infra/` on every pull request and main branch push. Plans are uploaded as artifacts, and a manual `workflow_dispatch` run with the `apply` input applies the changes. Configure the IAM role ARN in the `AWS_INFRA_ROLE_ARN` repository secret and optionally override the Terraform and AWS versions via repository variables (`TERRAFORM_VERSION`, `AWS_REGION`).
+- `.github/workflows/service-ci.yml` discovers services under `services/<service>` that contain a `Dockerfile` and a matching Helm chart in `deploy/charts/<service>`. For every detected service the workflow builds and pushes container images to Amazon ECR, packages the Helm chart, pushes it to the same registry using OCI support, and optionally triggers a deployment.
+
+### AWS OIDC setup
+
+1. Create IAM roles (one for infrastructure, one for services) with `sts:AssumeRoleWithWebIdentity` trust policies granting access to your GitHub repository (`token.actions.githubusercontent.com`).
+2. Attach the permissions needed for Terraform state management, ECR, and Helm chart publishing to the respective roles.
+3. Store the role ARNs in repository secrets: `AWS_INFRA_ROLE_ARN` for infrastructure and `AWS_SERVICE_ROLE_ARN` for service deployments.
+4. Add repository variables for shared settings such as `AWS_REGION`, `ECR_REPOSITORY_PREFIX` (e.g., `platform-`), `HELM_REPOSITORY_PREFIX` (e.g., `helm-`), and `DEFAULT_DEPLOY_ENV`.
+
+### Service build, publish, and deploy
+
+1. Place service source code in `services/<service>` with a `Dockerfile` (or `Dockerfile.<ext>`), and add a matching Helm chart in `deploy/charts/<service>`.
+2. On pull requests the workflow builds the image, pushes it to ECR tagged with the commit SHA and `<environment>` (default `dev`), packages the Helm chart with the commit SHA as the application version, and uploads the artifact.
+3. Configure Argo CD integration by adding the optional secrets `ARGOCD_SERVER` and `ARGOCD_AUTH_TOKEN`. Repository variables `ARGOCD_APP_NAME`, `ARGOCD_PROJECT`, and `ARGOCD_VERSION` customise the sync behaviour. When present, the workflow installs the Argo CD CLI, updates the service image parameter, and synchronises the application to the target cluster.
+4. If Argo CD is not available, the packaged chart artifact can be used manually with `helm upgrade --install` and the pushed image tag from the workflow summary.
+
+### Promotion strategy
+
+1. Merge to `main` (or run the workflow manually) to produce the dev build, image, chart, and optionally trigger an Argo CD deployment to the dev environment.
+2. Promote builds by re-running the `Service Build and Deploy` workflow via `workflow_dispatch`, selecting the target service and `environment` (`staging` or `prod`). The job re-tags the commit image (e.g., `:staging`) and pushes the chart, allowing Argo CD to pick up the promotion automatically.
+3. Use environment-specific Helm values (`values-dev.yaml`, `values-staging.yaml`, etc.) in your charts to tune configuration per environment. The workflow passes the image repository and tag through chart parameters for Argo CD-managed applications.
+4. Monitor the Argo CD sync or helm upgrade status to confirm the deployment and then proceed with any post-deployment validation.
+
+### Infrastructure changes
+
+- Push Terraform updates under `infra/` to trigger formatting, validation, and planning automatically. The generated plan is attached to the workflow run.
+- To apply changes, dispatch the workflow manually from the Actions tab, enable the `apply` input, and confirm the run. The same AWS role is reused for the apply step.


### PR DESCRIPTION
## Summary
- add infrastructure workflow that authenticates to AWS via OIDC and runs Terraform plan/apply stages
- add service CI/CD workflow that builds images, packages Helm charts, and optionally syncs Argo CD for dev deployments
- document the new automation, configuration requirements, and promotion process in the README

## Testing
- not run (workflow/documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ceef8fe5908328aca9d2c23c9a899e