### PR TITLE
Add identity service with authentication and SCIM APIs

### DIFF
--- a/services/identity/IdentityService.Api/Controllers/AuthController.cs
+++ b/services/identity/IdentityService.Api/Controllers/AuthController.cs
@@ -1,0 +1,294 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using IdentityService.Api.Data;
+using IdentityService.Api.Dtos;
+using IdentityService.Api.Entities;
+using IdentityService.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityService.Api.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly AppDbContext _dbContext;
+    private readonly ITokenService _tokenService;
+    private readonly IMfaService _mfaService;
+    private readonly IPasswordHasher<User> _passwordHasher;
+    private readonly ILogger<AuthController> _logger;
+
+    public AuthController(AppDbContext dbContext, ITokenService tokenService, IMfaService mfaService, IPasswordHasher<User> passwordHasher, ILogger<AuthController> logger)
+    {
+        _dbContext = dbContext;
+        _tokenService = tokenService;
+        _mfaService = mfaService;
+        _passwordHasher = passwordHasher;
+        _logger = logger;
+    }
+
+    [HttpPost("register")]
+    [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Register([FromBody] RegisterRequest request, CancellationToken cancellationToken)
+    {
+        if (await _dbContext.Users.AnyAsync(u => u.Email == request.Email, cancellationToken))
+        {
+            return Conflict(new { message = "Email is already registered." });
+        }
+
+        var user = new User
+        {
+            Email = request.Email,
+            DisplayName = request.DisplayName
+        };
+        user.PasswordHash = _passwordHasher.HashPassword(user, request.Password);
+
+        var refreshToken = _tokenService.CreateRefreshToken(user);
+        user.RefreshTokens.Add(refreshToken);
+
+        await _dbContext.Users.AddAsync(user, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var (accessToken, expiresAt) = _tokenService.CreateAccessToken(user);
+        return Ok(new LoginResponse
+        {
+            AccessToken = accessToken,
+            RefreshToken = refreshToken.Token,
+            ExpiresAt = expiresAt,
+            MfaRequired = false
+        });
+    }
+
+    [HttpPost("login")]
+    [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
+    {
+        var user = await _dbContext.Users
+            .Include(u => u.RefreshTokens)
+            .SingleOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
+
+        if (user is null)
+        {
+            _logger.LogWarning("Login failed for {Email}: user not found", request.Email);
+            return Unauthorized(new { message = "Invalid credentials." });
+        }
+
+        var passwordResult = _passwordHasher.VerifyHashedPassword(user, user.PasswordHash, request.Password);
+        if (passwordResult == PasswordVerificationResult.Failed)
+        {
+            _logger.LogWarning("Login failed for {Email}: invalid password", request.Email);
+            return Unauthorized(new { message = "Invalid credentials." });
+        }
+
+        if (user.MfaEnabled)
+        {
+            if (string.IsNullOrWhiteSpace(request.MfaCode) || !_mfaService.ValidateCode(user.MfaSecret!, request.MfaCode))
+            {
+                _logger.LogInformation("MFA required for user {UserId}", user.Id);
+                return Ok(new LoginResponse { MfaRequired = true });
+            }
+        }
+
+        PruneExpiredRefreshTokens(user);
+
+        var refreshToken = _tokenService.CreateRefreshToken(user);
+        _dbContext.RefreshTokens.Add(refreshToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var (accessToken, expiresAt) = _tokenService.CreateAccessToken(user);
+        return Ok(new LoginResponse
+        {
+            AccessToken = accessToken,
+            RefreshToken = refreshToken.Token,
+            ExpiresAt = expiresAt,
+            MfaRequired = false
+        });
+    }
+
+    [HttpPost("refresh")]
+    [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Refresh([FromBody] RefreshRequest request, CancellationToken cancellationToken)
+    {
+        var refreshToken = await _dbContext.RefreshTokens
+            .Include(t => t.User)
+            .SingleOrDefaultAsync(t => t.Token == request.RefreshToken, cancellationToken);
+
+        if (refreshToken is null || refreshToken.RevokedAt is not null || refreshToken.ExpiresAt < DateTime.UtcNow)
+        {
+            return Unauthorized(new { message = "Refresh token is invalid or expired." });
+        }
+
+        var user = refreshToken.User ?? await _dbContext.Users.FindAsync(new object?[] { refreshToken.UserId }, cancellationToken);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        refreshToken.RevokedAt = DateTime.UtcNow;
+        PruneExpiredRefreshTokens(user);
+
+        var newRefreshToken = _tokenService.CreateRefreshToken(user);
+        _dbContext.RefreshTokens.Add(newRefreshToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var (accessToken, expiresAt) = _tokenService.CreateAccessToken(user);
+        return Ok(new LoginResponse
+        {
+            AccessToken = accessToken,
+            RefreshToken = newRefreshToken.Token,
+            ExpiresAt = expiresAt,
+            MfaRequired = user.MfaEnabled
+        });
+    }
+
+    [HttpPost("password-reset/request")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> RequestPasswordReset([FromBody] PasswordResetRequest request, CancellationToken cancellationToken)
+    {
+        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
+        if (user is null)
+        {
+            return Ok(new { message = "If the email exists, a reset token has been generated." });
+        }
+
+        var token = new PasswordResetToken
+        {
+            Token = Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+            ExpiresAt = DateTime.UtcNow.AddMinutes(30),
+            UserId = user.Id
+        };
+        await _dbContext.PasswordResetTokens.AddAsync(token, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        // In a real system the token would be emailed. For development/testing we return it in the payload.
+        return Ok(new
+        {
+            message = "Password reset token generated.",
+            token = token.Token,
+            expiresAt = token.ExpiresAt
+        });
+    }
+
+    [HttpPost("password-reset/confirm")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ConfirmPasswordReset([FromBody] PasswordResetConfirmRequest request, CancellationToken cancellationToken)
+    {
+        var token = await _dbContext.PasswordResetTokens
+            .Include(t => t.User)
+            .SingleOrDefaultAsync(t => t.Token == request.Token, cancellationToken);
+
+        if (token is null || token.Used || token.ExpiresAt < DateTime.UtcNow)
+        {
+            return BadRequest(new { message = "Token is invalid or expired." });
+        }
+
+        var user = token.User ?? await _dbContext.Users.FindAsync(new object?[] { token.UserId }, cancellationToken);
+        if (user is null)
+        {
+            return BadRequest(new { message = "Associated user not found." });
+        }
+
+        user.PasswordHash = _passwordHasher.HashPassword(user, request.NewPassword);
+        token.Used = true;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return NoContent();
+    }
+
+    [Authorize]
+    [HttpPost("mfa/setup")]
+    [ProducesResponseType(typeof(MfaSetupResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> SetupMfa(CancellationToken cancellationToken)
+    {
+        var user = await GetCurrentUserAsync(cancellationToken);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var secret = _mfaService.GenerateSecretKey();
+        user.MfaSecret = secret;
+        user.MfaEnabled = false;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var uri = _mfaService.GenerateQrCodeUri(user.Email, secret, "ShareHouse Identity");
+        return Ok(new MfaSetupResponse
+        {
+            SharedKey = secret,
+            AuthenticatorUri = uri
+        });
+    }
+
+    [Authorize]
+    [HttpPost("mfa/enable")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> EnableMfa([FromBody] MfaEnableRequest request, CancellationToken cancellationToken)
+    {
+        var user = await GetCurrentUserAsync(cancellationToken);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var secret = request.SharedKey ?? user.MfaSecret;
+        if (string.IsNullOrWhiteSpace(secret) || !_mfaService.ValidateCode(secret!, request.Code))
+        {
+            return BadRequest(new { message = "Invalid MFA verification code." });
+        }
+
+        user.MfaSecret = secret;
+        user.MfaEnabled = true;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    [Authorize]
+    [HttpPost("mfa/disable")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> DisableMfa(CancellationToken cancellationToken)
+    {
+        var user = await GetCurrentUserAsync(cancellationToken);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        user.MfaEnabled = false;
+        user.MfaSecret = null;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    private async Task<User?> GetCurrentUserAsync(CancellationToken cancellationToken)
+    {
+        var subject = User.FindFirstValue(JwtRegisteredClaimNames.Sub) ?? User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            return null;
+        }
+
+        if (!Guid.TryParse(subject, out var userId))
+        {
+            return null;
+        }
+
+        return await _dbContext.Users.Include(u => u.RefreshTokens).SingleOrDefaultAsync(u => u.Id == userId, cancellationToken);
+    }
+
+    private static void PruneExpiredRefreshTokens(User user)
+    {
+        var expired = user.RefreshTokens.Where(t => t.ExpiresAt < DateTime.UtcNow).ToList();
+        foreach (var token in expired)
+        {
+            user.RefreshTokens.Remove(token);
+        }
+    }
+}

--- a/services/identity/IdentityService.Api/Controllers/OAuthController.cs
+++ b/services/identity/IdentityService.Api/Controllers/OAuthController.cs
@@ -1,0 +1,216 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using IdentityService.Api.Data;
+using IdentityService.Api.Dtos;
+using IdentityService.Api.Entities;
+using IdentityService.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityService.Api.Controllers;
+
+[ApiController]
+[Route("oauth")]
+public class OAuthController : ControllerBase
+{
+    private readonly AppDbContext _dbContext;
+    private readonly IOAuthService _oauthService;
+    private readonly ITokenService _tokenService;
+    private readonly ILogger<OAuthController> _logger;
+
+    public OAuthController(AppDbContext dbContext, IOAuthService oauthService, ITokenService tokenService, ILogger<OAuthController> logger)
+    {
+        _dbContext = dbContext;
+        _oauthService = oauthService;
+        _tokenService = tokenService;
+        _logger = logger;
+    }
+
+    [Authorize]
+    [HttpGet("authorize")]
+    [ProducesResponseType(typeof(OAuthAuthorizationResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Authorize(
+        [FromQuery(Name = "response_type")] string responseType,
+        [FromQuery(Name = "client_id")] string clientId,
+        [FromQuery(Name = "redirect_uri")] string redirectUri,
+        [FromQuery] string? scope,
+        [FromQuery] string? state,
+        CancellationToken cancellationToken)
+    {
+        if (!string.Equals(responseType, "code", StringComparison.OrdinalIgnoreCase))
+        {
+            return BadRequest(new { error = "unsupported_response_type" });
+        }
+
+        var client = await _oauthService.ValidateClientAsync(clientId, cancellationToken: cancellationToken);
+        if (client is null)
+        {
+            return BadRequest(new { error = "invalid_client" });
+        }
+
+        if (!string.Equals(client.RedirectUri, redirectUri, StringComparison.OrdinalIgnoreCase))
+        {
+            return BadRequest(new { error = "invalid_redirect_uri" });
+        }
+
+        var user = await GetCurrentUserAsync(cancellationToken);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var scopes = scope?.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var authorizationCode = await _oauthService.CreateAuthorizationCodeAsync(user, client, redirectUri, scopes, cancellationToken);
+        _logger.LogInformation("Issued authorization code for client {ClientId} and user {UserId}", client.ClientId, user.Id);
+
+        return Ok(new OAuthAuthorizationResponse
+        {
+            Code = authorizationCode.Code,
+            RedirectUri = redirectUri,
+            State = state,
+            ExpiresAt = authorizationCode.ExpiresAt
+        });
+    }
+
+    [HttpPost("token")]
+    [ProducesResponseType(typeof(OAuthTokenResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Token([FromForm] OAuthTokenRequest request, CancellationToken cancellationToken)
+    {
+        switch (request.GrantType)
+        {
+            case "authorization_code":
+                return await ExchangeAuthorizationCodeAsync(request, cancellationToken);
+            case "refresh_token":
+                return await ExchangeRefreshTokenAsync(request, cancellationToken);
+            default:
+                return BadRequest(new { error = "unsupported_grant_type" });
+        }
+    }
+
+    [Authorize]
+    [HttpGet("userinfo")]
+    public async Task<IActionResult> UserInfo(CancellationToken cancellationToken)
+    {
+        var user = await GetCurrentUserAsync(cancellationToken);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        return Ok(new
+        {
+            sub = user.Id,
+            name = user.DisplayName,
+            email = user.Email,
+            mfa_enabled = user.MfaEnabled
+        });
+    }
+
+    private async Task<IActionResult> ExchangeAuthorizationCodeAsync(OAuthTokenRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.ClientId) || string.IsNullOrWhiteSpace(request.ClientSecret) ||
+            string.IsNullOrWhiteSpace(request.Code) || string.IsNullOrWhiteSpace(request.RedirectUri))
+        {
+            return BadRequest(new { error = "invalid_request" });
+        }
+
+        var client = await _oauthService.ValidateClientAsync(request.ClientId, request.ClientSecret, cancellationToken);
+        if (client is null)
+        {
+            return BadRequest(new { error = "invalid_client" });
+        }
+
+        var authorizationCode = await _oauthService.RedeemCodeAsync(request.Code, request.RedirectUri, cancellationToken);
+        if (authorizationCode is null)
+        {
+            return BadRequest(new { error = "invalid_grant" });
+        }
+
+        var user = authorizationCode.User ?? await _dbContext.Users.FindAsync(new object?[] { authorizationCode.UserId }, cancellationToken);
+        if (user is null)
+        {
+            return BadRequest(new { error = "invalid_grant" });
+        }
+
+        var scopes = authorizationCode.Scopes?.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var (accessToken, expiresAt) = _tokenService.CreateAccessToken(user, scopes);
+        var refreshToken = _tokenService.CreateRefreshToken(user);
+        user.RefreshTokens.Add(refreshToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var idTokenClaims = new List<Claim>
+        {
+            new("nonce", Guid.NewGuid().ToString())
+        };
+        var idToken = _tokenService.CreateIdToken(user, idTokenClaims);
+
+        _logger.LogInformation("Issued tokens for client {ClientId} and user {UserId}", client.ClientId, user.Id);
+
+        return Ok(new OAuthTokenResponse
+        {
+            AccessToken = accessToken,
+            ExpiresIn = (int)(expiresAt - DateTime.UtcNow).TotalSeconds,
+            RefreshToken = refreshToken.Token,
+            IdToken = idToken
+        });
+    }
+
+    private async Task<IActionResult> ExchangeRefreshTokenAsync(OAuthTokenRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.ClientId) || string.IsNullOrWhiteSpace(request.ClientSecret) ||
+            string.IsNullOrWhiteSpace(request.RefreshToken))
+        {
+            return BadRequest(new { error = "invalid_request" });
+        }
+
+        var client = await _oauthService.ValidateClientAsync(request.ClientId, request.ClientSecret, cancellationToken);
+        if (client is null)
+        {
+            return BadRequest(new { error = "invalid_client" });
+        }
+
+        var refreshToken = await _dbContext.RefreshTokens
+            .Include(t => t.User)
+            .SingleOrDefaultAsync(t => t.Token == request.RefreshToken, cancellationToken);
+
+        if (refreshToken is null || refreshToken.ExpiresAt < DateTime.UtcNow || refreshToken.RevokedAt is not null)
+        {
+            return BadRequest(new { error = "invalid_grant" });
+        }
+
+        var user = refreshToken.User ?? await _dbContext.Users.FindAsync(new object?[] { refreshToken.UserId }, cancellationToken);
+        if (user is null)
+        {
+            return BadRequest(new { error = "invalid_grant" });
+        }
+
+        refreshToken.RevokedAt = DateTime.UtcNow;
+        var (accessToken, expiresAt) = _tokenService.CreateAccessToken(user);
+        var newRefreshToken = _tokenService.CreateRefreshToken(user);
+        user.RefreshTokens.Add(newRefreshToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Rotated refresh token for client {ClientId} and user {UserId}", client.ClientId, user.Id);
+
+        return Ok(new OAuthTokenResponse
+        {
+            AccessToken = accessToken,
+            ExpiresIn = (int)(expiresAt - DateTime.UtcNow).TotalSeconds,
+            RefreshToken = newRefreshToken.Token
+        });
+    }
+
+    private async Task<User?> GetCurrentUserAsync(CancellationToken cancellationToken)
+    {
+        var subject = User.FindFirstValue(JwtRegisteredClaimNames.Sub) ?? User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(subject) || !Guid.TryParse(subject, out var userId))
+        {
+            return null;
+        }
+
+        return await _dbContext.Users.SingleOrDefaultAsync(u => u.Id == userId, cancellationToken);
+    }
+}

--- a/services/identity/IdentityService.Api/Controllers/OidcController.cs
+++ b/services/identity/IdentityService.Api/Controllers/OidcController.cs
@@ -1,0 +1,62 @@
+using System.Text;
+using IdentityService.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace IdentityService.Api.Controllers;
+
+[ApiController]
+[Route(".well-known")]
+public class OidcController : ControllerBase
+{
+    private readonly JwtOptions _jwtOptions;
+
+    public OidcController(IOptions<JwtOptions> jwtOptions)
+    {
+        _jwtOptions = jwtOptions.Value;
+    }
+
+    [HttpGet("openid-configuration")]
+    [Produces("application/json")]
+    public IActionResult GetConfiguration()
+    {
+        var baseUrl = $"{Request.Scheme}://{Request.Host}";
+        var issuer = string.IsNullOrWhiteSpace(_jwtOptions.Issuer) ? baseUrl : _jwtOptions.Issuer;
+        var configuration = new
+        {
+            issuer,
+            authorization_endpoint = baseUrl + "/oauth/authorize",
+            token_endpoint = baseUrl + "/oauth/token",
+            userinfo_endpoint = baseUrl + "/oauth/userinfo",
+            jwks_uri = baseUrl + "/.well-known/jwks.json",
+            response_types_supported = new[] { "code" },
+            subject_types_supported = new[] { "public" },
+            id_token_signing_alg_values_supported = new[] { SecurityAlgorithms.HmacSha256 },
+            scopes_supported = new[] { "openid", "profile" },
+            claims_supported = new[] { "sub", "name", "email" }
+        };
+        return Ok(configuration);
+    }
+
+    [HttpGet("jwks.json")]
+    [Produces("application/json")]
+    public IActionResult GetJwks()
+    {
+        var keyBytes = Encoding.UTF8.GetBytes(_jwtOptions.SigningKey);
+        var jwks = new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    kty = "oct",
+                    alg = SecurityAlgorithms.HmacSha256,
+                    k = Base64UrlEncoder.Encode(keyBytes),
+                    kid = "default"
+                }
+            }
+        };
+        return Ok(jwks);
+    }
+}

--- a/services/identity/IdentityService.Api/Controllers/ScimGroupsController.cs
+++ b/services/identity/IdentityService.Api/Controllers/ScimGroupsController.cs
@@ -1,0 +1,169 @@
+using IdentityService.Api.Data;
+using IdentityService.Api.Dtos;
+using IdentityService.Api.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityService.Api.Controllers;
+
+[ApiController]
+[Route("scim/v2/Groups")]
+[Produces("application/scim+json", "application/json")]
+public class ScimGroupsController : ControllerBase
+{
+    private readonly AppDbContext _dbContext;
+
+    public ScimGroupsController(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Query([FromQuery] int startIndex = 1, [FromQuery] int count = 50, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.ScimGroups.Include(g => g.Members).ThenInclude(m => m.User);
+        var totalResults = await query.CountAsync(cancellationToken);
+        var groups = await query.Skip(Math.Max(startIndex - 1, 0)).Take(Math.Clamp(count, 1, 200)).ToListAsync(cancellationToken);
+        var resources = groups.Select(MapToResource).ToList();
+
+        var response = new
+        {
+            schemas = new[] { "urn:ietf:params:scim:api:messages:2.0:ListResponse" },
+            totalResults,
+            startIndex,
+            itemsPerPage = resources.Count,
+            Resources = resources
+        };
+        return Ok(response);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(string id, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(id, out var groupId))
+        {
+            return NotFound();
+        }
+
+        var group = await _dbContext.ScimGroups
+            .Include(g => g.Members)
+            .ThenInclude(m => m.User)
+            .SingleOrDefaultAsync(g => g.Id == groupId, cancellationToken);
+        if (group is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(MapToResource(group));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] ScimGroupResource resource, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(resource.DisplayName))
+        {
+            return BadRequest(new { message = "DisplayName is required." });
+        }
+
+        var group = new ScimGroup
+        {
+            DisplayName = resource.DisplayName
+        };
+        await _dbContext.ScimGroups.AddAsync(group, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await UpdateMembershipAsync(group, resource.Members, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await _dbContext.Entry(group).Collection(g => g.Members).Query().Include(m => m.User).LoadAsync(cancellationToken);
+
+        return CreatedAtAction(nameof(GetById), new { id = group.Id }, MapToResource(group));
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Replace(string id, [FromBody] ScimGroupResource resource, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(id, out var groupId))
+        {
+            return NotFound();
+        }
+
+        var group = await _dbContext.ScimGroups.Include(g => g.Members).ThenInclude(m => m.User).SingleOrDefaultAsync(g => g.Id == groupId, cancellationToken);
+        if (group is null)
+        {
+            return NotFound();
+        }
+
+        if (!string.IsNullOrWhiteSpace(resource.DisplayName))
+        {
+            group.DisplayName = resource.DisplayName;
+        }
+
+        await UpdateMembershipAsync(group, resource.Members, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await _dbContext.Entry(group).Collection(g => g.Members).Query().Include(m => m.User).LoadAsync(cancellationToken);
+        return Ok(MapToResource(group));
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(id, out var groupId))
+        {
+            return NotFound();
+        }
+
+        var group = await _dbContext.ScimGroups.Include(g => g.Members).SingleOrDefaultAsync(g => g.Id == groupId, cancellationToken);
+        if (group is null)
+        {
+            return NotFound();
+        }
+
+        _dbContext.ScimGroupMembers.RemoveRange(group.Members);
+        _dbContext.ScimGroups.Remove(group);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    private async Task UpdateMembershipAsync(ScimGroup group, IEnumerable<ScimGroupMemberResource>? members, CancellationToken cancellationToken)
+    {
+        _dbContext.ScimGroupMembers.RemoveRange(group.Members);
+        group.Members.Clear();
+
+        if (members is null)
+        {
+            return;
+        }
+
+        foreach (var member in members)
+        {
+            if (!Guid.TryParse(member.Value, out var userId))
+            {
+                continue;
+            }
+
+            var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Id == userId, cancellationToken);
+            if (user is null)
+            {
+                continue;
+            }
+
+            var membership = new ScimGroupMember
+            {
+                GroupId = group.Id,
+                UserId = user.Id
+            };
+            group.Members.Add(membership);
+        }
+    }
+
+    private static ScimGroupResource MapToResource(ScimGroup group) => new()
+    {
+        Id = group.Id.ToString(),
+        DisplayName = group.DisplayName,
+        Members = group.Members.Select(m => new ScimGroupMemberResource
+        {
+            Value = m.UserId.ToString(),
+            Display = m.User?.DisplayName ?? m.User?.Email ?? string.Empty
+        }).ToList()
+    };
+}

--- a/services/identity/IdentityService.Api/Controllers/ScimUsersController.cs
+++ b/services/identity/IdentityService.Api/Controllers/ScimUsersController.cs
@@ -1,0 +1,184 @@
+using IdentityService.Api.Data;
+using IdentityService.Api.Dtos;
+using IdentityService.Api.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityService.Api.Controllers;
+
+[ApiController]
+[Route("scim/v2/Users")]
+[Produces("application/scim+json", "application/json")]
+public class ScimUsersController : ControllerBase
+{
+    private readonly AppDbContext _dbContext;
+    private readonly IPasswordHasher<User> _passwordHasher;
+
+    public ScimUsersController(AppDbContext dbContext, IPasswordHasher<User> passwordHasher)
+    {
+        _dbContext = dbContext;
+        _passwordHasher = passwordHasher;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Query([FromQuery] string? filter, [FromQuery] int startIndex = 1, [FromQuery] int count = 50, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Users.AsQueryable();
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            query = ApplyFilter(query, filter);
+        }
+
+        var totalResults = await query.CountAsync(cancellationToken);
+        var users = await query.Skip(Math.Max(startIndex - 1, 0)).Take(Math.Clamp(count, 1, 200)).ToListAsync(cancellationToken);
+        var resources = users.Select(MapToResource).ToList();
+
+        var response = new
+        {
+            schemas = new[] { "urn:ietf:params:scim:api:messages:2.0:ListResponse" },
+            totalResults,
+            startIndex,
+            itemsPerPage = resources.Count,
+            Resources = resources
+        };
+        return Ok(response);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(string id, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(id, out var userId))
+        {
+            return NotFound();
+        }
+
+        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(MapToResource(user));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] ScimUserResource resource, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(resource.Email) && string.IsNullOrWhiteSpace(resource.UserName))
+        {
+            return BadRequest(new { message = "UserName or Email must be provided." });
+        }
+
+        var email = resource.Email ?? resource.UserName;
+        if (await _dbContext.Users.AnyAsync(u => u.Email == email, cancellationToken))
+        {
+            return Conflict(new { message = "A user with that email already exists." });
+        }
+
+        var user = new User
+        {
+            Email = email!,
+            DisplayName = resource.DisplayName,
+            Active = resource.Active
+        };
+        var password = string.IsNullOrWhiteSpace(resource.Password) ? Guid.NewGuid().ToString("N").Substring(0, 12) : resource.Password!;
+        user.PasswordHash = _passwordHasher.HashPassword(user, password);
+
+        await _dbContext.Users.AddAsync(user, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var createdResource = MapToResource(user);
+        return CreatedAtAction(nameof(GetById), new { id = user.Id }, createdResource);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Replace(string id, [FromBody] ScimUserResource resource, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(id, out var userId))
+        {
+            return NotFound();
+        }
+
+        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        if (!string.IsNullOrWhiteSpace(resource.Email) && !string.Equals(resource.Email, user.Email, StringComparison.OrdinalIgnoreCase))
+        {
+            if (await _dbContext.Users.AnyAsync(u => u.Email == resource.Email && u.Id != userId, cancellationToken))
+            {
+                return Conflict(new { message = "A user with that email already exists." });
+            }
+            user.Email = resource.Email!;
+        }
+
+        user.DisplayName = resource.DisplayName;
+        user.Active = resource.Active;
+
+        if (!string.IsNullOrWhiteSpace(resource.Password))
+        {
+            user.PasswordHash = _passwordHasher.HashPassword(user, resource.Password);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return Ok(MapToResource(user));
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(id, out var userId))
+        {
+            return NotFound();
+        }
+
+        var user = await _dbContext.Users.Include(u => u.RefreshTokens).SingleOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        _dbContext.RefreshTokens.RemoveRange(user.RefreshTokens);
+        _dbContext.Users.Remove(user);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+
+    private static IQueryable<User> ApplyFilter(IQueryable<User> query, string filter)
+    {
+        var segments = filter.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length < 3)
+        {
+            return query;
+        }
+
+        var attribute = segments[0];
+        var operation = segments[1];
+        var value = segments[2].Trim('\"');
+
+        if (!string.Equals(operation, "eq", StringComparison.OrdinalIgnoreCase))
+        {
+            return query;
+        }
+
+        return attribute switch
+        {
+            "userName" => query.Where(u => u.Email == value),
+            "email" => query.Where(u => u.Email == value),
+            "active" => bool.TryParse(value, out var active) ? query.Where(u => u.Active == active) : query,
+            _ => query
+        };
+    }
+
+    private static ScimUserResource MapToResource(User user) => new()
+    {
+        Id = user.Id.ToString(),
+        UserName = user.Email,
+        Email = user.Email,
+        DisplayName = user.DisplayName ?? string.Empty,
+        Active = user.Active
+    };
+}

--- a/services/identity/IdentityService.Api/Data/AppDbContext.cs
+++ b/services/identity/IdentityService.Api/Data/AppDbContext.cs
@@ -1,0 +1,84 @@
+using IdentityService.Api.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityService.Api.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+    public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();
+    public DbSet<OAuthClient> OAuthClients => Set<OAuthClient>();
+    public DbSet<AuthorizationCode> AuthorizationCodes => Set<AuthorizationCode>();
+    public DbSet<ScimGroup> ScimGroups => Set<ScimGroup>();
+    public DbSet<ScimGroupMember> ScimGroupMembers => Set<ScimGroupMember>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<User>()
+            .HasIndex(u => u.Email)
+            .IsUnique();
+
+        modelBuilder.Entity<User>()
+            .HasMany(u => u.RefreshTokens)
+            .WithOne(t => t.User!)
+            .HasForeignKey(t => t.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<User>()
+            .HasMany(u => u.PasswordResetTokens)
+            .WithOne(t => t.User!)
+            .HasForeignKey(t => t.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<User>()
+            .HasMany(u => u.AuthorizationCodes)
+            .WithOne(c => c.User!)
+            .HasForeignKey(c => c.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<OAuthClient>()
+            .HasIndex(c => c.ClientId)
+            .IsUnique();
+
+        modelBuilder.Entity<OAuthClient>()
+            .HasMany(c => c.AuthorizationCodes)
+            .WithOne(code => code.Client!)
+            .HasForeignKey(code => code.OAuthClientId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<ScimGroupMember>()
+            .HasIndex(m => new { m.GroupId, m.UserId })
+            .IsUnique();
+
+        modelBuilder.Entity<ScimGroupMember>()
+            .HasOne(m => m.Group)
+            .WithMany(g => g.Members)
+            .HasForeignKey(m => m.GroupId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<ScimGroupMember>()
+            .HasOne(m => m.User)
+            .WithMany(u => u.GroupMemberships)
+            .HasForeignKey(m => m.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<RefreshToken>()
+            .HasIndex(t => t.Token)
+            .IsUnique();
+
+        modelBuilder.Entity<PasswordResetToken>()
+            .HasIndex(t => t.Token)
+            .IsUnique();
+
+        modelBuilder.Entity<AuthorizationCode>()
+            .HasIndex(c => c.Code)
+            .IsUnique();
+    }
+}

--- a/services/identity/IdentityService.Api/Dtos/LoginRequest.cs
+++ b/services/identity/IdentityService.Api/Dtos/LoginRequest.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Dtos;
+
+public class LoginRequest
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    public string Password { get; set; } = string.Empty;
+
+    public string? MfaCode { get; set; }
+}

--- a/services/identity/IdentityService.Api/Dtos/LoginResponse.cs
+++ b/services/identity/IdentityService.Api/Dtos/LoginResponse.cs
@@ -1,0 +1,9 @@
+namespace IdentityService.Api.Dtos;
+
+public class LoginResponse
+{
+    public bool MfaRequired { get; set; }
+    public string? AccessToken { get; set; }
+    public string? RefreshToken { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+}

--- a/services/identity/IdentityService.Api/Dtos/MfaEnableRequest.cs
+++ b/services/identity/IdentityService.Api/Dtos/MfaEnableRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Dtos;
+
+public class MfaEnableRequest
+{
+    [Required]
+    public string Code { get; set; } = string.Empty;
+
+    public string? SharedKey { get; set; }
+}

--- a/services/identity/IdentityService.Api/Dtos/MfaSetupResponse.cs
+++ b/services/identity/IdentityService.Api/Dtos/MfaSetupResponse.cs
@@ -1,0 +1,7 @@
+namespace IdentityService.Api.Dtos;
+
+public class MfaSetupResponse
+{
+    public string SharedKey { get; set; } = string.Empty;
+    public string AuthenticatorUri { get; set; } = string.Empty;
+}

--- a/services/identity/IdentityService.Api/Dtos/OAuthAuthorizationResponse.cs
+++ b/services/identity/IdentityService.Api/Dtos/OAuthAuthorizationResponse.cs
@@ -1,0 +1,9 @@
+namespace IdentityService.Api.Dtos;
+
+public class OAuthAuthorizationResponse
+{
+    public string Code { get; set; } = string.Empty;
+    public string RedirectUri { get; set; } = string.Empty;
+    public string? State { get; set; }
+    public DateTime ExpiresAt { get; set; }
+}

--- a/services/identity/IdentityService.Api/Dtos/OAuthTokenRequest.cs
+++ b/services/identity/IdentityService.Api/Dtos/OAuthTokenRequest.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace IdentityService.Api.Dtos;
+
+public class OAuthTokenRequest
+{
+    [Required]
+    [JsonPropertyName("grant_type")]
+    public string GrantType { get; set; } = string.Empty;
+
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
+
+    [JsonPropertyName("redirect_uri")]
+    public string? RedirectUri { get; set; }
+
+    [JsonPropertyName("client_id")]
+    public string? ClientId { get; set; }
+
+    [JsonPropertyName("client_secret")]
+    public string? ClientSecret { get; set; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; set; }
+}

--- a/services/identity/IdentityService.Api/Dtos/OAuthTokenResponse.cs
+++ b/services/identity/IdentityService.Api/Dtos/OAuthTokenResponse.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace IdentityService.Api.Dtos;
+
+public class OAuthTokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; set; } = string.Empty;
+
+    [JsonPropertyName("token_type")]
+    public string TokenType { get; set; } = "Bearer";
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; set; }
+
+    [JsonPropertyName("id_token")]
+    public string? IdToken { get; set; }
+}

--- a/services/identity/IdentityService.Api/Dtos/PasswordResetConfirmRequest.cs
+++ b/services/identity/IdentityService.Api/Dtos/PasswordResetConfirmRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Dtos;
+
+public class PasswordResetConfirmRequest
+{
+    [Required]
+    public string Token { get; set; } = string.Empty;
+
+    [Required]
+    [MinLength(6)]
+    public string NewPassword { get; set; } = string.Empty;
+}

--- a/services/identity/IdentityService.Api/Dtos/PasswordResetRequest.cs
+++ b/services/identity/IdentityService.Api/Dtos/PasswordResetRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Dtos;
+
+public class PasswordResetRequest
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+}

--- a/services/identity/IdentityService.Api/Dtos/RefreshRequest.cs
+++ b/services/identity/IdentityService.Api/Dtos/RefreshRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Dtos;
+
+public class RefreshRequest
+{
+    [Required]
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/services/identity/IdentityService.Api/Dtos/RegisterRequest.cs
+++ b/services/identity/IdentityService.Api/Dtos/RegisterRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Dtos;
+
+public class RegisterRequest
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [MinLength(6)]
+    public string Password { get; set; } = string.Empty;
+
+    [MaxLength(128)]
+    public string? DisplayName { get; set; }
+}

--- a/services/identity/IdentityService.Api/Dtos/ScimGroupResource.cs
+++ b/services/identity/IdentityService.Api/Dtos/ScimGroupResource.cs
@@ -1,0 +1,18 @@
+namespace IdentityService.Api.Dtos;
+
+public class ScimGroupResource
+{
+    public string[] Schemas { get; set; } = new[] { "urn:ietf:params:scim:schemas:core:2.0:Group" };
+
+    public string? Id { get; set; }
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public List<ScimGroupMemberResource> Members { get; set; } = new();
+}
+
+public class ScimGroupMemberResource
+{
+    public string Value { get; set; } = string.Empty;
+    public string Display { get; set; } = string.Empty;
+}

--- a/services/identity/IdentityService.Api/Dtos/ScimUserResource.cs
+++ b/services/identity/IdentityService.Api/Dtos/ScimUserResource.cs
@@ -1,0 +1,18 @@
+namespace IdentityService.Api.Dtos;
+
+public class ScimUserResource
+{
+    public string[] Schemas { get; set; } = new[] { "urn:ietf:params:scim:schemas:core:2.0:User" };
+
+    public string? Id { get; set; }
+
+    public string UserName { get; set; } = string.Empty;
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? Email { get; set; }
+
+    public bool Active { get; set; } = true;
+
+    public string? Password { get; set; }
+}

--- a/services/identity/IdentityService.Api/Entities/AuthorizationCode.cs
+++ b/services/identity/IdentityService.Api/Entities/AuthorizationCode.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Entities;
+
+public class AuthorizationCode
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(128)]
+    public string Code { get; set; } = string.Empty;
+
+    [Required]
+    public Guid UserId { get; set; }
+
+    public User? User { get; set; }
+
+    [Required]
+    public Guid OAuthClientId { get; set; }
+
+    public OAuthClient? Client { get; set; }
+
+    [Required]
+    [MaxLength(512)]
+    public string RedirectUri { get; set; } = string.Empty;
+
+    [MaxLength(256)]
+    public string? Scopes { get; set; }
+
+    public DateTime ExpiresAt { get; set; }
+
+    public bool Consumed { get; set; }
+}

--- a/services/identity/IdentityService.Api/Entities/OAuthClient.cs
+++ b/services/identity/IdentityService.Api/Entities/OAuthClient.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Entities;
+
+public class OAuthClient
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(128)]
+    public string ClientId { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(256)]
+    public string ClientSecret { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(512)]
+    public string RedirectUri { get; set; } = string.Empty;
+
+    [MaxLength(128)]
+    public string Name { get; set; } = string.Empty;
+
+    public ICollection<AuthorizationCode> AuthorizationCodes { get; set; } = new List<AuthorizationCode>();
+}

--- a/services/identity/IdentityService.Api/Entities/PasswordResetToken.cs
+++ b/services/identity/IdentityService.Api/Entities/PasswordResetToken.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Entities;
+
+public class PasswordResetToken
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(256)]
+    public string Token { get; set; } = string.Empty;
+
+    public DateTime ExpiresAt { get; set; }
+
+    public bool Used { get; set; }
+
+    public Guid UserId { get; set; }
+
+    public User? User { get; set; }
+}

--- a/services/identity/IdentityService.Api/Entities/RefreshToken.cs
+++ b/services/identity/IdentityService.Api/Entities/RefreshToken.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Entities;
+
+public class RefreshToken
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(512)]
+    public string Token { get; set; } = string.Empty;
+
+    public DateTime ExpiresAt { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime? RevokedAt { get; set; }
+
+    public Guid UserId { get; set; }
+
+    public User? User { get; set; }
+}

--- a/services/identity/IdentityService.Api/Entities/ScimGroup.cs
+++ b/services/identity/IdentityService.Api/Entities/ScimGroup.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Entities;
+
+public class ScimGroup
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(128)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    public ICollection<ScimGroupMember> Members { get; set; } = new List<ScimGroupMember>();
+}

--- a/services/identity/IdentityService.Api/Entities/ScimGroupMember.cs
+++ b/services/identity/IdentityService.Api/Entities/ScimGroupMember.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Entities;
+
+public class ScimGroupMember
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    public Guid GroupId { get; set; }
+
+    public ScimGroup? Group { get; set; }
+
+    [Required]
+    public Guid UserId { get; set; }
+
+    public User? User { get; set; }
+}

--- a/services/identity/IdentityService.Api/Entities/User.cs
+++ b/services/identity/IdentityService.Api/Entities/User.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityService.Api.Entities;
+
+public class User
+{
+    [Key]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(256)]
+    public string Email { get; set; } = string.Empty;
+
+    [MaxLength(128)]
+    public string? DisplayName { get; set; }
+
+    [Required]
+    public string PasswordHash { get; set; } = string.Empty;
+
+    public bool Active { get; set; } = true;
+
+    public bool MfaEnabled { get; set; }
+
+    [MaxLength(512)]
+    public string? MfaSecret { get; set; }
+
+    public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
+
+    public ICollection<PasswordResetToken> PasswordResetTokens { get; set; } = new List<PasswordResetToken>();
+
+    public ICollection<AuthorizationCode> AuthorizationCodes { get; set; } = new List<AuthorizationCode>();
+
+    public ICollection<ScimGroupMember> GroupMemberships { get; set; } = new List<ScimGroupMember>();
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/services/identity/IdentityService.Api/Extensions/HostExtensions.cs
+++ b/services/identity/IdentityService.Api/Extensions/HostExtensions.cs
@@ -1,0 +1,44 @@
+using IdentityService.Api.Data;
+using IdentityService.Api.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+
+namespace IdentityService.Api.Extensions;
+
+public static class HostExtensions
+{
+    public static async Task<IHost> ApplyMigrationsAsync(this IHost host)
+    {
+        using var scope = host.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        if (!await dbContext.OAuthClients.AnyAsync())
+        {
+            var defaultClient = new OAuthClient
+            {
+                ClientId = "sharehouse-web",
+                ClientSecret = "change-me",
+                RedirectUri = "https://localhost:3000/auth/callback",
+                Name = "ShareHouse Web"
+            };
+            dbContext.OAuthClients.Add(defaultClient);
+        }
+
+        if (!await dbContext.Users.AnyAsync())
+        {
+            var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher<User>>();
+            var user = new User
+            {
+                Email = "admin@sharehouse.local",
+                DisplayName = "ShareHouse Admin"
+            };
+            user.PasswordHash = passwordHasher.HashPassword(user, "ChangeMe!123");
+            dbContext.Users.Add(user);
+        }
+
+        await dbContext.SaveChangesAsync();
+        return host;
+    }
+}

--- a/services/identity/IdentityService.Api/IdentityService.Api.csproj
+++ b/services/identity/IdentityService.Api/IdentityService.Api.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.20" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+    <PackageReference Include="Otp.NET" Version="1.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/services/identity/IdentityService.Api/IdentityService.Api.http
+++ b/services/identity/IdentityService.Api/IdentityService.Api.http
@@ -1,0 +1,6 @@
+@IdentityService.Api_HostAddress = http://localhost:5189
+
+GET {{IdentityService.Api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/services/identity/IdentityService.Api/Models/JwtOptions.cs
+++ b/services/identity/IdentityService.Api/Models/JwtOptions.cs
@@ -1,0 +1,10 @@
+namespace IdentityService.Api.Models;
+
+public class JwtOptions
+{
+    public string Issuer { get; set; } = "ShareHouse.Identity";
+    public string Audience { get; set; } = "ShareHouse.Identity.Client";
+    public string SigningKey { get; set; } = string.Empty;
+    public int AccessTokenMinutes { get; set; } = 60;
+    public int RefreshTokenDays { get; set; } = 7;
+}

--- a/services/identity/IdentityService.Api/Program.cs
+++ b/services/identity/IdentityService.Api/Program.cs
@@ -1,0 +1,134 @@
+using System.Text;
+using IdentityService.Api.Data;
+using IdentityService.Api.Entities;
+using IdentityService.Api.Extensions;
+using IdentityService.Api.Models;
+using IdentityService.Api.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Configuration
+var jwtSection = builder.Configuration.GetSection("Jwt");
+var jwtOptions = jwtSection.Get<JwtOptions>() ?? new JwtOptions();
+if (string.IsNullOrWhiteSpace(jwtOptions.SigningKey))
+{
+    jwtOptions.SigningKey = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+    builder.Configuration["Jwt:SigningKey"] = jwtOptions.SigningKey;
+}
+
+builder.Services.Configure<JwtOptions>(opts =>
+{
+    opts.Issuer = jwtOptions.Issuer;
+    opts.Audience = jwtOptions.Audience;
+    opts.SigningKey = jwtOptions.SigningKey;
+    opts.AccessTokenMinutes = jwtOptions.AccessTokenMinutes;
+    opts.RefreshTokenDays = jwtOptions.RefreshTokenDays;
+});
+
+var connectionString = builder.Configuration.GetConnectionString("Default") ?? "Data Source=identity.db";
+builder.Services.AddDbContext<AppDbContext>(options => options.UseSqlite(connectionString));
+
+builder.Services.AddScoped<ITokenService, TokenService>();
+builder.Services.AddSingleton<IMfaService, MfaService>();
+builder.Services.AddScoped<IOAuthService, OAuthService>();
+builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "ShareHouse Identity API",
+        Version = "v1",
+        Description = "Authentication, OAuth, and SCIM provisioning endpoints for the ShareHouse platform."
+    });
+
+    var bearerScheme = new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = JwtBearerDefaults.AuthenticationScheme,
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Provide the access token as: Bearer {token}"
+    };
+    c.AddSecurityDefinition("Bearer", bearerScheme);
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            bearerScheme,
+            new List<string>()
+        }
+    });
+
+    var oauthScheme = new OpenApiSecurityScheme
+    {
+        Type = SecuritySchemeType.OAuth2,
+        Flows = new OpenApiOAuthFlows
+        {
+            AuthorizationCode = new OpenApiOAuthFlow
+            {
+                AuthorizationUrl = new Uri("/oauth/authorize", UriKind.Relative),
+                TokenUrl = new Uri("/oauth/token", UriKind.Relative),
+                Scopes = new Dictionary<string, string>
+                {
+                    { "openid", "OpenID Connect identity scope" },
+                    { "profile", "Access to basic profile information" }
+                }
+            }
+        }
+    };
+    c.AddSecurityDefinition("OAuth2", oauthScheme);
+});
+
+var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.SigningKey));
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = jwtOptions.Issuer,
+        ValidAudience = jwtOptions.Audience,
+        IssuerSigningKey = signingKey,
+        ClockSkew = TimeSpan.FromMinutes(1)
+    };
+});
+
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+await app.ApplyMigrationsAsync();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(options =>
+    {
+        options.SwaggerEndpoint("/swagger/v1/swagger.json", "ShareHouse Identity API");
+        options.OAuthClientId("sharehouse-web");
+        options.OAuthUsePkce();
+    });
+}
+
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program;

--- a/services/identity/IdentityService.Api/Properties/launchSettings.json
+++ b/services/identity/IdentityService.Api/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:28336",
+      "sslPort": 44353
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5189",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7152;http://localhost:5189",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/services/identity/IdentityService.Api/Services/IMfaService.cs
+++ b/services/identity/IdentityService.Api/Services/IMfaService.cs
@@ -1,0 +1,8 @@
+namespace IdentityService.Api.Services;
+
+public interface IMfaService
+{
+    string GenerateSecretKey();
+    string GenerateQrCodeUri(string email, string secret, string issuer);
+    bool ValidateCode(string secret, string code);
+}

--- a/services/identity/IdentityService.Api/Services/IOAuthService.cs
+++ b/services/identity/IdentityService.Api/Services/IOAuthService.cs
@@ -1,0 +1,10 @@
+using IdentityService.Api.Entities;
+
+namespace IdentityService.Api.Services;
+
+public interface IOAuthService
+{
+    Task<OAuthClient?> ValidateClientAsync(string clientId, string? clientSecret = null, CancellationToken cancellationToken = default);
+    Task<AuthorizationCode> CreateAuthorizationCodeAsync(User user, OAuthClient client, string redirectUri, IEnumerable<string>? scopes, CancellationToken cancellationToken = default);
+    Task<AuthorizationCode?> RedeemCodeAsync(string code, string redirectUri, CancellationToken cancellationToken = default);
+}

--- a/services/identity/IdentityService.Api/Services/ITokenService.cs
+++ b/services/identity/IdentityService.Api/Services/ITokenService.cs
@@ -1,0 +1,12 @@
+using System.Security.Claims;
+using IdentityService.Api.Entities;
+using IdentityService.Api.Models;
+
+namespace IdentityService.Api.Services;
+
+public interface ITokenService
+{
+    (string accessToken, DateTime expiresAt) CreateAccessToken(User user, IEnumerable<string>? scopes = null);
+    RefreshToken CreateRefreshToken(User user);
+    string CreateIdToken(User user, IEnumerable<Claim>? additionalClaims = null);
+}

--- a/services/identity/IdentityService.Api/Services/MfaService.cs
+++ b/services/identity/IdentityService.Api/Services/MfaService.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using OtpNet;
+
+namespace IdentityService.Api.Services;
+
+public class MfaService : IMfaService
+{
+    public string GenerateSecretKey()
+    {
+        var secret = KeyGeneration.GenerateRandomKey(20);
+        return Base32Encoding.ToString(secret);
+    }
+
+    public string GenerateQrCodeUri(string email, string secret, string issuer)
+    {
+        var encodedEmail = Uri.EscapeDataString(email);
+        var encodedIssuer = Uri.EscapeDataString(issuer);
+        return $"otpauth://totp/{encodedIssuer}:{encodedEmail}?secret={secret}&issuer={encodedIssuer}&digits=6";
+    }
+
+    public bool ValidateCode(string secret, string code)
+    {
+        if (string.IsNullOrWhiteSpace(secret) || string.IsNullOrWhiteSpace(code))
+        {
+            return false;
+        }
+
+        try
+        {
+            var totp = new Totp(Base32Encoding.ToBytes(secret));
+            return totp.VerifyTotp(code, out _, VerificationWindow.RfcSpecifiedNetworkDelay);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/services/identity/IdentityService.Api/Services/OAuthService.cs
+++ b/services/identity/IdentityService.Api/Services/OAuthService.cs
@@ -1,0 +1,85 @@
+using IdentityService.Api.Data;
+using IdentityService.Api.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityService.Api.Services;
+
+public class OAuthService : IOAuthService
+{
+    private readonly AppDbContext _dbContext;
+    private readonly ILogger<OAuthService> _logger;
+
+    public OAuthService(AppDbContext dbContext, ILogger<OAuthService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<OAuthClient?> ValidateClientAsync(string clientId, string? clientSecret = null, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(clientId))
+        {
+            return null;
+        }
+
+        var client = await _dbContext.OAuthClients.SingleOrDefaultAsync(c => c.ClientId == clientId, cancellationToken);
+        if (client is null)
+        {
+            _logger.LogWarning("OAuth client {ClientId} not found", clientId);
+            return null;
+        }
+
+        if (clientSecret is not null && client.ClientSecret != clientSecret)
+        {
+            _logger.LogWarning("OAuth client {ClientId} provided invalid secret", clientId);
+            return null;
+        }
+
+        return client;
+    }
+
+    public async Task<AuthorizationCode> CreateAuthorizationCodeAsync(User user, OAuthClient client, string redirectUri, IEnumerable<string>? scopes, CancellationToken cancellationToken = default)
+    {
+        var code = new AuthorizationCode
+        {
+            Code = Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+            UserId = user.Id,
+            OAuthClientId = client.Id,
+            RedirectUri = redirectUri,
+            Scopes = scopes is null ? null : string.Join(' ', scopes),
+            ExpiresAt = DateTime.UtcNow.AddMinutes(5)
+        };
+
+        await _dbContext.AuthorizationCodes.AddAsync(code, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Created authorization code for client {ClientId} and user {UserId}", client.ClientId, user.Id);
+        return code;
+    }
+
+    public async Task<AuthorizationCode?> RedeemCodeAsync(string code, string redirectUri, CancellationToken cancellationToken = default)
+    {
+        var authorizationCode = await _dbContext.AuthorizationCodes
+            .Include(c => c.User)
+            .Include(c => c.Client)
+            .SingleOrDefaultAsync(c => c.Code == code, cancellationToken);
+
+        if (authorizationCode is null)
+        {
+            return null;
+        }
+
+        if (authorizationCode.Consumed || authorizationCode.ExpiresAt < DateTime.UtcNow)
+        {
+            return null;
+        }
+
+        if (!string.Equals(authorizationCode.RedirectUri, redirectUri, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        authorizationCode.Consumed = true;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return authorizationCode;
+    }
+}

--- a/services/identity/IdentityService.Api/Services/TokenService.cs
+++ b/services/identity/IdentityService.Api/Services/TokenService.cs
@@ -1,0 +1,107 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using IdentityService.Api.Entities;
+using IdentityService.Api.Models;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace IdentityService.Api.Services;
+
+public class TokenService : ITokenService
+{
+    private readonly JwtOptions _options;
+    private readonly ILogger<TokenService> _logger;
+    private readonly SigningCredentials _signingCredentials;
+
+    public TokenService(IOptions<JwtOptions> options, ILogger<TokenService> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+        var keyBytes = Encoding.UTF8.GetBytes(_options.SigningKey);
+        _signingCredentials = new SigningCredentials(new SymmetricSecurityKey(keyBytes), SecurityAlgorithms.HmacSha256);
+    }
+
+    public (string accessToken, DateTime expiresAt) CreateAccessToken(User user, IEnumerable<string>? scopes = null)
+    {
+        var expiresAt = DateTime.UtcNow.AddMinutes(_options.AccessTokenMinutes);
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new(JwtRegisteredClaimNames.Iat, DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString())
+        };
+
+        if (!string.IsNullOrWhiteSpace(user.DisplayName))
+        {
+            claims.Add(new Claim(JwtRegisteredClaimNames.Name, user.DisplayName!));
+        }
+
+        if (scopes is not null)
+        {
+            claims.Add(new Claim("scope", string.Join(' ', scopes)));
+        }
+
+        if (user.MfaEnabled)
+        {
+            claims.Add(new Claim("mfa", "true"));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: _options.Issuer,
+            audience: _options.Audience,
+            claims: claims,
+            notBefore: DateTime.UtcNow,
+            expires: expiresAt,
+            signingCredentials: _signingCredentials);
+
+        var handler = new JwtSecurityTokenHandler();
+        var accessToken = handler.WriteToken(token);
+        return (accessToken, expiresAt);
+    }
+
+    public RefreshToken CreateRefreshToken(User user)
+    {
+        var tokenBytes = RandomNumberGenerator.GetBytes(64);
+        var refreshToken = new RefreshToken
+        {
+            Token = Convert.ToBase64String(tokenBytes),
+            ExpiresAt = DateTime.UtcNow.AddDays(_options.RefreshTokenDays),
+            UserId = user.Id
+        };
+
+        _logger.LogDebug("Created refresh token for user {UserId}", user.Id);
+        return refreshToken;
+    }
+
+    public string CreateIdToken(User user, IEnumerable<Claim>? additionalClaims = null)
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email),
+            new(JwtRegisteredClaimNames.AuthTime, DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString())
+        };
+
+        if (!string.IsNullOrEmpty(user.DisplayName))
+        {
+            claims.Add(new Claim("name", user.DisplayName!));
+        }
+
+        if (additionalClaims is not null)
+        {
+            claims.AddRange(additionalClaims);
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: _options.Issuer,
+            audience: _options.Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(_options.AccessTokenMinutes),
+            signingCredentials: _signingCredentials);
+        return handler.WriteToken(token);
+    }
+}

--- a/services/identity/IdentityService.Api/appsettings.Development.json
+++ b/services/identity/IdentityService.Api/appsettings.Development.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  },
+  "Jwt": {
+    "Issuer": "https://localhost:5001",
+    "Audience": "sharehouse-clients",
+    "SigningKey": "local-development-signing-key-change-me",
+    "AccessTokenMinutes": 120,
+    "RefreshTokenDays": 30
+  }
+}

--- a/services/identity/IdentityService.Api/appsettings.json
+++ b/services/identity/IdentityService.Api/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Default": "Data Source=identity.db"
+  },
+  "Jwt": {
+    "Issuer": "https://identity.local",
+    "Audience": "sharehouse-clients",
+    "SigningKey": "super-secret-development-key-change-me",
+    "AccessTokenMinutes": 60,
+    "RefreshTokenDays": 14
+  }
+}

--- a/services/identity/IdentityService.Tests/AuthenticationFlowTests.cs
+++ b/services/identity/IdentityService.Tests/AuthenticationFlowTests.cs
@@ -1,0 +1,146 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using IdentityService.Api.Dtos;
+using IdentityService.Tests.Infrastructure;
+using FluentAssertions;
+using OtpNet;
+
+namespace IdentityService.Tests;
+
+public class AuthenticationFlowTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public AuthenticationFlowTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Register_Then_Login_ReturnsTokens()
+    {
+        var email = $"user_{Guid.NewGuid():N}@example.com";
+        var password = "Password!123";
+
+        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", new RegisterRequest
+        {
+            Email = email,
+            Password = password,
+            DisplayName = "Integration User"
+        });
+
+        registerResponse.EnsureSuccessStatusCode();
+        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        registerPayload.Should().NotBeNull();
+        registerPayload!.AccessToken.Should().NotBeNullOrEmpty();
+        registerPayload.RefreshToken.Should().NotBeNullOrEmpty();
+
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login", new LoginRequest
+        {
+            Email = email,
+            Password = password
+        });
+
+        loginResponse.EnsureSuccessStatusCode();
+        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        loginPayload.Should().NotBeNull();
+        loginPayload!.AccessToken.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task PasswordReset_AllowsLoggingInWithNewPassword()
+    {
+        var email = $"reset_{Guid.NewGuid():N}@example.com";
+        var password = "InitialPass!234";
+        var newPassword = "NewPass!345";
+
+        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", new RegisterRequest
+        {
+            Email = email,
+            Password = password
+        });
+        registerResponse.EnsureSuccessStatusCode();
+
+        var resetRequestResponse = await _client.PostAsJsonAsync("/api/auth/password-reset/request", new PasswordResetRequest
+        {
+            Email = email
+        });
+        resetRequestResponse.EnsureSuccessStatusCode();
+        var resetPayload = await resetRequestResponse.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+        resetPayload.Should().ContainKey("token");
+        var token = resetPayload!["token"];
+
+        var confirmResponse = await _client.PostAsJsonAsync("/api/auth/password-reset/confirm", new PasswordResetConfirmRequest
+        {
+            Token = token,
+            NewPassword = newPassword
+        });
+        confirmResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
+
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login", new LoginRequest
+        {
+            Email = email,
+            Password = newPassword
+        });
+        loginResponse.EnsureSuccessStatusCode();
+        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        loginPayload!.AccessToken.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task MfaEnabled_RequiresCodeDuringLogin()
+    {
+        var email = $"mfa_{Guid.NewGuid():N}@example.com";
+        var password = "MfaTest!678";
+
+        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", new RegisterRequest
+        {
+            Email = email,
+            Password = password
+        });
+        registerResponse.EnsureSuccessStatusCode();
+        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        registerPayload.Should().NotBeNull();
+
+        var accessToken = registerPayload!.AccessToken!;
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        var setupResponse = await _client.PostAsync("/api/auth/mfa/setup", null);
+        setupResponse.EnsureSuccessStatusCode();
+        var setupPayload = await setupResponse.Content.ReadFromJsonAsync<MfaSetupResponse>();
+        setupPayload.Should().NotBeNull();
+        var secret = setupPayload!.SharedKey;
+
+        var totp = new Totp(Base32Encoding.ToBytes(secret));
+        var code = totp.ComputeTotp();
+
+        var enableResponse = await _client.PostAsJsonAsync("/api/auth/mfa/enable", new MfaEnableRequest
+        {
+            Code = code
+        });
+        enableResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
+
+        _client.DefaultRequestHeaders.Authorization = null;
+
+        var loginWithoutMfaResponse = await _client.PostAsJsonAsync("/api/auth/login", new LoginRequest
+        {
+            Email = email,
+            Password = password
+        });
+        loginWithoutMfaResponse.EnsureSuccessStatusCode();
+        var loginWithoutMfaPayload = await loginWithoutMfaResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        loginWithoutMfaPayload!.MfaRequired.Should().BeTrue();
+
+        var validMfaCode = totp.ComputeTotp();
+        var loginWithMfaResponse = await _client.PostAsJsonAsync("/api/auth/login", new LoginRequest
+        {
+            Email = email,
+            Password = password,
+            MfaCode = validMfaCode
+        });
+        loginWithMfaResponse.EnsureSuccessStatusCode();
+        var loginWithMfaPayload = await loginWithMfaResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        loginWithMfaPayload!.AccessToken.Should().NotBeNullOrWhiteSpace();
+        loginWithMfaPayload.MfaRequired.Should().BeFalse();
+    }
+}

--- a/services/identity/IdentityService.Tests/IdentityService.Tests.csproj
+++ b/services/identity/IdentityService.Tests/IdentityService.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Otp.NET" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IdentityService.Api\IdentityService.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/identity/IdentityService.Tests/Infrastructure/CustomWebApplicationFactory.cs
+++ b/services/identity/IdentityService.Tests/Infrastructure/CustomWebApplicationFactory.cs
@@ -1,0 +1,78 @@
+using IdentityService.Api.Data;
+using IdentityService.Api.Entities;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace IdentityService.Tests.Infrastructure;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    private SqliteConnection? _connection;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll(typeof(DbContextOptions<AppDbContext>));
+            services.RemoveAll(typeof(AppDbContext));
+
+            services.AddSingleton(provider =>
+            {
+                _connection ??= new SqliteConnection("Filename=:memory:");
+                _connection.Open();
+                return _connection;
+            });
+
+            services.AddDbContext<AppDbContext>((sp, options) =>
+            {
+                var connection = sp.GetRequiredService<SqliteConnection>();
+                options.UseSqlite(connection);
+            });
+
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher<User>>();
+            dbContext.Database.EnsureCreated();
+
+            if (!dbContext.Users.Any())
+            {
+                var user = new User
+                {
+                    Email = "factory-admin@example.com",
+                    DisplayName = "Factory Admin"
+                };
+                user.PasswordHash = passwordHasher.HashPassword(user, "FactoryPass!123");
+                dbContext.Users.Add(user);
+            }
+
+            if (!dbContext.OAuthClients.Any())
+            {
+                dbContext.OAuthClients.Add(new OAuthClient
+                {
+                    ClientId = "test-client",
+                    ClientSecret = "test-secret",
+                    RedirectUri = "https://localhost/callback",
+                    Name = "Test Client"
+                });
+            }
+
+            dbContext.SaveChanges();
+        });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing)
+        {
+            _connection?.Dispose();
+            _connection = null;
+        }
+    }
+}

--- a/services/identity/IdentityService.sln
+++ b/services/identity/IdentityService.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityService.Api", "IdentityService.Api\IdentityService.Api.csproj", "{A5B4E828-388F-47F1-A0B4-5C0950E99C3F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityService.Tests", "IdentityService.Tests\IdentityService.Tests.csproj", "{DB186771-4BA0-4586-8966-D94A22354C57}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5B4E828-388F-47F1-A0B4-5C0950E99C3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5B4E828-388F-47F1-A0B4-5C0950E99C3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5B4E828-388F-47F1-A0B4-5C0950E99C3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5B4E828-388F-47F1-A0B4-5C0950E99C3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB186771-4BA0-4586-8966-D94A22354C57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB186771-4BA0-4586-8966-D94A22354C57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB186771-4BA0-4586-8966-D94A22354C57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB186771-4BA0-4586-8966-D94A22354C57}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- scaffolded a new ASP.NET Core identity service wired to EF Core, JWT bearer auth, and documented OAuth/OIDC plus SCIM provisioning controllers
- added entity models, data context configuration, and supporting services for token issuance, MFA, OAuth client flows, and startup seeding
- created end-to-end integration tests exercising registration/login, password reset, and MFA flows via a SQLite-backed test host

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ceef948be8832886490e3607982e59