### PR TITLE
Add traffic protection infrastructure and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frmourey26%2Fonyx%2Ftree%2Fmain)
 
 
+## Traffic protection and observability
+
+- Kubernetes ingress and Helm configuration for strict CORS enforcement, per-IP rate limiting, and request size controls live under `infra/kubernetes` and `infra/helm/share-house-portal`.
+- AWS WAFv2 Terraform definitions for API Gateway, ALB, and the CloudFront SPA distribution live under `infra/aws/waf`.
+- Operational limits, approved origins, and the tuning playbook are documented in [`docs/security/traffic-controls.md`](docs/security/traffic-controls.md).
+
+
 ### Reference/Credit
 - @chensokheng
 

--- a/docs/security/traffic-controls.md
+++ b/docs/security/traffic-controls.md
@@ -1,0 +1,36 @@
+# Traffic Controls and Tuning Guide
+
+This document summarises the cross-platform controls that protect the Share House Portal from abusive traffic and describes the process for tuning them safely.
+
+## Allowed Origins
+
+Only the following origins are permitted to interact with the application through the ingress controller, API surfaces, and the CloudFront distribution:
+
+| Purpose | Origin |
+| --- | --- |
+| Production web application | `https://app.share-house.example` |
+| Internal administration UI | `https://admin.share-house.example` |
+
+Requests that include any other `Origin` header value are rejected by both the NGINX ingress configuration (`infra/kubernetes/ingress.yaml`) and the AWS WAF rules (`infra/aws/waf/main.tf`). Requests without an origin header remain allowed so that server-to-server integrations continue to function.
+
+## Rate Limits and Request Size
+
+| Control layer | Limit | Configuration |
+| --- | --- | --- |
+| NGINX ingress | 10 requests per second and 20 concurrent connections per client IP | `infra/kubernetes/ingress.yaml` and Helm values (`infra/helm/share-house-portal/values.yaml`) |
+| AWS WAF (regional and CloudFront) | 1,200 requests per IP over a five minute window | `infra/aws/waf/main.tf` (`rate_limit` variable) |
+| Request body size | Maximum 2 MiB | `infra/kubernetes/ingress.yaml` (`proxy-body-size`) and `infra/aws/waf/main.tf` (`max_body_size_bytes`) |
+
+These limits were selected to keep burst traffic low enough to protect upstream services while still supporting legitimate user activity.
+
+## Tuning Process
+
+1. **Observe metrics** – Use the CloudWatch metrics emitted by the WAF (`share-house-portal-*-rate-limit`, `*-allowed-origins`, `*-body-size`) and NGINX ingress logs to determine whether legitimate users are being throttled or blocked.
+2. **Engage stakeholders** – Confirm with product and operations teams that adjustments are necessary and understand the expected traffic profile (for example, planned marketing campaigns or API consumers with higher throughput).
+3. **Adjust infrastructure code**:
+   - For ingress limits or origins, update `infra/helm/share-house-portal/values.yaml` and re-render/redeploy the Helm release.
+   - For AWS WAF changes, update the module variables in `infra/aws/waf/variables.tf` or the consuming Terraform workspace and run `terraform apply`.
+4. **Document the change** – Record the new limits and rationale in this document (update the tables above) and in operational runbooks.
+5. **Verify and monitor** – After deployment, review logs and dashboards to confirm the change behaves as expected. Leave temporary alarms in place to catch regressions.
+
+Always perform tuning in non-production environments first when possible, and ensure limits remain consistent across ingress and WAF layers to avoid inconsistent behaviour.

--- a/infra/aws/waf/README.md
+++ b/infra/aws/waf/README.md
@@ -1,0 +1,54 @@
+# AWS WAF Configuration
+
+This Terraform configuration provisions two AWS WAFv2 Web ACLs:
+
+1. A **regional** Web ACL that attaches to Amazon API Gateway stages and Application Load Balancers backing the Share House Portal APIs.
+2. A **CloudFront** scoped Web ACL used by the single page application (SPA) distribution.
+
+Both ACLs implement the same hardening primitives:
+
+- AWS managed `AWSManagedRulesCommonRuleSet` baseline protections.
+- A shared IP based rate limit (defaults to 1,200 requests per IP per five minute period).
+- Inspection of the `Origin` header to enforce the approved domain allow list.
+- A request body size ceiling (2 MiB) matching the NGINX ingress proxy body size limit.
+
+## Usage
+
+1. Provide the relevant resource ARNs as variables (API Gateway stage ARNs, ALB ARNs, and optionally the CloudFront distribution ARN) in a Terraform workspace.
+2. Run `terraform init` and `terraform apply` inside `infra/aws/waf`.
+
+Example variable definition:
+
+```hcl
+module "waf" {
+  source = "./infra/aws/waf"
+
+  project                 = "share-house-portal"
+  region                  = "us-east-1"
+  api_gateway_stage_arns  = ["arn:aws:apigateway:us-east-1::/restapis/abc123/stages/prod"]
+  alb_arns                = ["arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/share-house/50dc6c495c0c9188"]
+  allowed_origins         = ["https://app.share-house.example", "https://admin.share-house.example"]
+  rate_limit              = 1200
+  max_body_size_bytes     = 2097152
+}
+```
+
+The CloudFront scoped ACL must be deployed from `us-east-1`, which is handled via the provider alias defined in `main.tf`.
+
+## Associating the CloudFront Web ACL
+
+Terraform cannot directly associate a Web ACL to an existing CloudFront distribution without managing the entire distribution resource. After `terraform apply`, attach the ACL by setting the distribution's `web_acl_id` to the output `spa_web_acl_arn`. This can be accomplished with the AWS CLI:
+
+```bash
+aws cloudfront update-distribution \
+  --id YOUR_DISTRIBUTION_ID \
+  --if-match E2ABCDEFGHIJKL \
+  --distribution-config file://distribution-config.json \
+  --web-acl-id $(terraform output -raw spa_web_acl_arn)
+```
+
+Alternatively, update the CloudFront distribution via infrastructure-as-code so that `web_acl_id` references the Terraform output.
+
+## Monitoring and Tuning
+
+All rules emit CloudWatch metrics whose names include the project slug (for example `share-house-portal-api-rate-limit`). Use these metrics in dashboards and alarms to observe rate limiting or origin blocks, and adjust the module variables as documented in `docs/security/traffic-controls.md`.

--- a/infra/aws/waf/main.tf
+++ b/infra/aws/waf/main.tf
@@ -1,0 +1,325 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+locals {
+  project_tag = {
+    Project = var.project
+  }
+}
+
+resource "aws_wafv2_web_acl" "api" {
+  name        = "${var.project}-api"
+  description = "Regional Web ACL protecting API Gateway stages and ALBs for the Share House Portal APIs."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project}-api-web-acl"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWSManagedCommonRules"
+    priority = 0
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-api-managed-common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimitPerIp"
+    priority = 10
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type = "IP"
+        limit              = var.rate_limit
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-api-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "EnforceRequestBodySize"
+    priority = 20
+
+    action {
+      block {}
+    }
+
+    statement {
+      size_constraint_statement {
+        comparison_operator = "GT"
+        size                = var.max_body_size_bytes
+
+        field_to_match {
+          body {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-api-body-size"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "EnforceAllowedOrigins"
+    priority = 30
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          size_constraint_statement {
+            comparison_operator = "GT"
+            size                = 0
+
+            field_to_match {
+              single_header {
+                name = "origin"
+              }
+            }
+
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              or_statement {
+                dynamic "statement" {
+                  for_each = var.allowed_origins
+
+                  content {
+                    byte_match_statement {
+                      search_string          = statement.value
+                      positional_constraint  = "EXACTLY"
+
+                      field_to_match {
+                        single_header {
+                          name = "origin"
+                        }
+                      }
+
+                      text_transformation {
+                        priority = 0
+                        type     = "NONE"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-api-allowed-origins"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  tags = local.project_tag
+}
+
+resource "aws_wafv2_web_acl_association" "api_gateway" {
+  for_each     = { for idx, arn in var.api_gateway_stage_arns : idx => arn if arn != "" }
+  resource_arn = each.value
+  web_acl_arn  = aws_wafv2_web_acl.api.arn
+}
+
+resource "aws_wafv2_web_acl_association" "alb" {
+  for_each     = { for idx, arn in var.alb_arns : idx => arn if arn != "" }
+  resource_arn = each.value
+  web_acl_arn  = aws_wafv2_web_acl.api.arn
+}
+
+resource "aws_wafv2_web_acl" "spa" {
+  provider    = aws.us_east_1
+  name        = "${var.project}-spa"
+  description = "CloudFront Web ACL protecting the Share House Portal single page application distribution."
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project}-spa-web-acl"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWSManagedCommonRules"
+    priority = 0
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-spa-managed-common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimitPerIp"
+    priority = 10
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type = "IP"
+        limit              = var.rate_limit
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-spa-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "EnforceAllowedOrigins"
+    priority = 20
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          size_constraint_statement {
+            comparison_operator = "GT"
+            size                = 0
+
+            field_to_match {
+              single_header {
+                name = "origin"
+              }
+            }
+
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              or_statement {
+                dynamic "statement" {
+                  for_each = var.allowed_origins
+
+                  content {
+                    byte_match_statement {
+                      search_string         = statement.value
+                      positional_constraint = "EXACTLY"
+
+                      field_to_match {
+                        single_header {
+                          name = "origin"
+                        }
+                      }
+
+                      text_transformation {
+                        priority = 0
+                        type     = "NONE"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.project}-spa-allowed-origins"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  tags = local.project_tag
+}

--- a/infra/aws/waf/outputs.tf
+++ b/infra/aws/waf/outputs.tf
@@ -1,0 +1,14 @@
+output "api_web_acl_arn" {
+  description = "ARN of the regional Web ACL applied to API Gateway stages and ALBs."
+  value       = aws_wafv2_web_acl.api.arn
+}
+
+output "spa_web_acl_arn" {
+  description = "ARN of the CloudFront scoped Web ACL that must be attached to the SPA distribution."
+  value       = aws_wafv2_web_acl.spa.arn
+}
+
+output "cloudfront_distribution_arn" {
+  description = "CloudFront distribution ARN expected to be associated with the SPA Web ACL."
+  value       = var.cloudfront_distribution_arn
+}

--- a/infra/aws/waf/variables.tf
+++ b/infra/aws/waf/variables.tf
@@ -1,0 +1,50 @@
+variable "project" {
+  description = "Short name used for tagging and resource names."
+  type        = string
+  default     = "share-house-portal"
+}
+
+variable "region" {
+  description = "AWS region where regional resources (API Gateway, ALB) are deployed."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "api_gateway_stage_arns" {
+  description = "List of API Gateway stage ARNs to associate with the regional web ACL."
+  type        = list(string)
+  default     = []
+}
+
+variable "alb_arns" {
+  description = "List of Application Load Balancer ARNs to associate with the regional web ACL."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_origins" {
+  description = "Exact Origin header values allowed to reach the application."
+  type        = list(string)
+  default = [
+    "https://app.share-house.example",
+    "https://admin.share-house.example",
+  ]
+}
+
+variable "rate_limit" {
+  description = "Number of requests per five-minute period allowed from a single IP before blocking."
+  type        = number
+  default     = 1200
+}
+
+variable "max_body_size_bytes" {
+  description = "Maximum payload size in bytes permitted before blocking. Aligns with ingress proxy body size."
+  type        = number
+  default     = 2097152
+}
+
+variable "cloudfront_distribution_arn" {
+  description = "ARN of the CloudFront distribution serving the SPA. Used for reference when attaching the CloudFront scoped Web ACL."
+  type        = string
+  default     = ""
+}

--- a/infra/helm/share-house-portal/Chart.yaml
+++ b/infra/helm/share-house-portal/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: share-house-portal
+version: 0.1.0
+appVersion: "1.0.0"
+description: Helm chart for deploying the Share House Portal web application with hardened ingress controls.
+type: application

--- a/infra/helm/share-house-portal/templates/_helpers.tpl
+++ b/infra/helm/share-house-portal/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "share-house-portal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "share-house-portal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "share-house-portal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "share-house-portal.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "share-house-portal.labels" -}}
+helm.sh/chart: {{ include "share-house-portal.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/infra/helm/share-house-portal/templates/ingress.yaml
+++ b/infra/helm/share-house-portal/templates/ingress.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "share-house-portal.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $cors := .Values.ingress.cors | default (dict) -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "share-house-portal.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | quote }}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.requestSizeLimit | default "2m" | quote }}
+{{- with .Values.ingress.rateLimits.connections }}
+    nginx.ingress.kubernetes.io/limit-connections: {{ . | quote }}
+{{- end }}
+{{- with .Values.ingress.rateLimits.rps }}
+    nginx.ingress.kubernetes.io/limit-rps: {{ . | quote }}
+{{- end }}
+{{- with .Values.ingress.rateLimits.burstMultiplier }}
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: {{ . | quote }}
+{{- end }}
+{{- if $cors.enabled }}
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: {{ ($cors.allowCredentials | default true) | toString | quote }}
+{{- with $cors.allowOrigins }}
+    nginx.ingress.kubernetes.io/cors-allow-origin: {{ join "," . | quote }}
+{{- end }}
+{{- with $cors.allowMethods }}
+    nginx.ingress.kubernetes.io/cors-allow-methods: {{ join "," . | quote }}
+{{- end }}
+{{- with $cors.allowHeaders }}
+    nginx.ingress.kubernetes.io/cors-allow-headers: {{ join "," . | quote }}
+{{- end }}
+{{- with $cors.exposeHeaders }}
+    nginx.ingress.kubernetes.io/cors-expose-headers: {{ join "," . | quote }}
+{{- end }}
+{{- with $cors.maxAge }}
+    nginx.ingress.kubernetes.io/cors-max-age: {{ . | quote }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      set $cors_allowed 0;
+      if ($http_origin = "") {
+        set $cors_allowed 1;
+      }
+{{- range $origin := $cors.allowOrigins | default (list) }}
+      if ($http_origin = "{{ $origin }}") {
+        set $cors_allowed 1;
+      }
+{{- end }}
+      if ($cors_allowed != 1) {
+        return 403;
+      }
+{{- else }}
+    nginx.ingress.kubernetes.io/enable-cors: "false"
+{{- end }}
+spec:
+  rules:
+{{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+{{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
+{{- end }}
+{{- end }}
+{{- with .Values.ingress.tls }}
+  tls:
+{{- range . }}
+    - secretName: {{ .secretName | quote }}
+      hosts:
+{{- range .hosts }}
+        - {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/infra/helm/share-house-portal/values.yaml
+++ b/infra/helm/share-house-portal/values.yaml
@@ -1,0 +1,55 @@
+image:
+  repository: ghcr.io/share-house-portal/web
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: app.share-house.example
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: share-house-portal-tls
+      hosts:
+        - app.share-house.example
+  rateLimits:
+    connections: 20
+    rps: 10
+    burstMultiplier: 3
+  requestSizeLimit: 2m
+  cors:
+    enabled: true
+    allowCredentials: true
+    allowOrigins:
+      - https://app.share-house.example
+      - https://admin.share-house.example
+    allowMethods:
+      - GET
+      - POST
+      - PUT
+      - PATCH
+      - DELETE
+      - OPTIONS
+    allowHeaders:
+      - Authorization
+      - Content-Type
+      - X-Requested-With
+    exposeHeaders:
+      - X-Request-Id
+      - X-Trace-Id
+    maxAge: 600
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/infra/kubernetes/ingress.yaml
+++ b/infra/kubernetes/ingress.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: share-house-portal
+  namespace: web
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://app.share-house.example,https://admin.share-house.example"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization,Content-Type,X-Requested-With"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+    nginx.ingress.kubernetes.io/cors-max-age: "600"
+    nginx.ingress.kubernetes.io/limit-connections: "20"
+    nginx.ingress.kubernetes.io/limit-rps: "10"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
+    nginx.ingress.kubernetes.io/proxy-body-size: "2m"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      set $cors_allowed 0;
+      if ($http_origin = "") {
+        set $cors_allowed 1;
+      }
+      if ($http_origin ~* "^https://(app|admin)\\.share-house\\.example$") {
+        set $cors_allowed 1;
+      }
+      if ($cors_allowed != 1) {
+        return 403;
+      }
+spec:
+  rules:
+    - host: app.share-house.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: share-house-portal
+                port:
+                  number: 3000
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - app.share-house.example
+      secretName: share-house-portal-tls


### PR DESCRIPTION
## Summary
- add hardened NGINX ingress manifest and Helm chart values for rate limiting, request size, and CORS controls
- provision AWS WAFv2 Terraform configuration for API Gateway/ALB and CloudFront with shared limits and origin enforcement
- document approved origins, traffic controls, and tuning workflow and link from the README

## Testing
- not run (infrastructure and documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68ceef9b6c508328944898ba03153c08