### PR TITLE
Add messaging infrastructure and background worker scaffold

### DIFF
--- a/docs/events/catalog.md
+++ b/docs/events/catalog.md
@@ -1,0 +1,147 @@
+# Event Catalog
+
+This catalog describes the asynchronous domain events that power the Share House Portal platform. Each event is published to Amazon SNS and delivered to consumers through SQS queues with dedicated dead-letter queues (DLQs). The infrastructure backing these channels is provisioned via Terraform in `infra/terraform/messaging`.
+
+## Messaging Topology
+
+| Event | Version | Description | SNS Topic | SQS Queue | DLQ |
+| --- | --- | --- | --- | --- | --- |
+| `tenant.application.submitted` | 1.0.0 | Emitted when a prospective tenant completes an application. | `{environment}-tenant-applications-topic` | `{environment}-tenant-applications-queue` | `{environment}-tenant-applications-queue-dlq` |
+| `maintenance.request.created` | 1.0.0 | Tracks new maintenance requests raised by tenants or staff. | `{environment}-maintenance-requests-topic` | `{environment}-maintenance-requests-queue` | `{environment}-maintenance-requests-queue-dlq` |
+| `rent.payment.received` | 1.0.0 | Indicates a rent payment was processed successfully. | `{environment}-rent-payments-topic` | `{environment}-rent-payments-queue` | `{environment}-rent-payments-queue-dlq` |
+
+> **Note:** Replace `{environment}` with the short environment code used during Terraform deployment (for example, `dev`, `staging`, or `prod`).
+
+## Event Schemas
+
+### Tenant Application Submitted (`tenant.application.submitted`)
+
+- **Topic:** `{environment}-tenant-applications-topic`
+- **Primary Queue:** `{environment}-tenant-applications-queue`
+- **Dead-Letter Queue:** `{environment}-tenant-applications-queue-dlq`
+
+This CloudEvent is produced by the public web application when a prospective tenant completes the onboarding workflow. Consumers can use it to kick off verification, background checks, or CRM updates.
+
+```json
+{
+  "id": "7f5396b6-7fd2-4548-9bba-fab4b5b9d95a",
+  "source": "share-house-portal.applications",
+  "specversion": "1.0",
+  "type": "tenant.application.submitted",
+  "datacontenttype": "application/json",
+  "time": "2024-05-01T16:32:15Z",
+  "data": {
+    "applicationId": "42f3d1b5-9341-4c65-9e0e-0a8752274f50",
+    "applicantId": "2f2d958a-6482-4e5c-9a7d-92f466e7e9fb",
+    "propertyId": "84e3d4a1-929d-4ae2-b886-8eb68f1875ff",
+    "householdSize": 2,
+    "desiredMoveInDate": "2024-06-15",
+    "submittedAt": "2024-05-01T16:32:15Z",
+    "notes": "Looking for a furnished room."
+  }
+}
+```
+
+#### Data Field Reference
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `applicationId` | UUID | Unique identifier for the tenant application. |
+| `applicantId` | UUID | Identifier for the primary applicant profile. |
+| `propertyId` | UUID | Property that the applicant is interested in. |
+| `householdSize` | Integer | Number of occupants represented in the application. |
+| `desiredMoveInDate` | Date (ISO 8601) | Requested move-in date. |
+| `submittedAt` | DateTime (ISO 8601) | Timestamp when the application was submitted. |
+| `notes` | String | Optional free-form context supplied by the applicant. |
+
+### Maintenance Request Created (`maintenance.request.created`)
+
+- **Topic:** `{environment}-maintenance-requests-topic`
+- **Primary Queue:** `{environment}-maintenance-requests-queue`
+- **Dead-Letter Queue:** `{environment}-maintenance-requests-queue-dlq`
+
+This event is emitted whenever a maintenance ticket is opened. Facilities management tools or external vendors can subscribe to automate triage and scheduling.
+
+```json
+{
+  "id": "6dfb6575-1fe9-4d7b-8a2e-d5cce2440f4d",
+  "source": "share-house-portal.maintenance",
+  "specversion": "1.0",
+  "type": "maintenance.request.created",
+  "datacontenttype": "application/json",
+  "time": "2024-05-02T09:20:00Z",
+  "data": {
+    "requestId": "b8fdc89c-8dd2-4a2c-90d4-214c2b975bd0",
+    "propertyId": "84e3d4a1-929d-4ae2-b886-8eb68f1875ff",
+    "reportedByUserId": "f5a601f4-ea63-46ac-98d0-77e51d1b8f13",
+    "category": "Plumbing",
+    "priority": "High",
+    "description": "Leak detected under the kitchen sink.",
+    "reportedAt": "2024-05-02T09:19:55Z",
+    "attachments": [
+      "https://cdn.share-house.example/maintenance/b8fdc89c/photo-1.jpg"
+    ]
+  }
+}
+```
+
+#### Data Field Reference
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `requestId` | UUID | Unique identifier for the maintenance ticket. |
+| `propertyId` | UUID | Property where the issue was reported. |
+| `reportedByUserId` | UUID | User account that opened the ticket. |
+| `category` | String | Functional category used for routing (e.g., Plumbing, Electrical). |
+| `priority` | Enum (`Low`, `Medium`, `High`, `Emergency`) | Urgency classification assigned at creation. |
+| `description` | String | Human-readable description of the issue. |
+| `reportedAt` | DateTime (ISO 8601) | When the request was submitted. |
+| `attachments` | Array of strings | Optional list of URLs pointing to supporting evidence. |
+
+### Rent Payment Received (`rent.payment.received`)
+
+- **Topic:** `{environment}-rent-payments-topic`
+- **Primary Queue:** `{environment}-rent-payments-queue`
+- **Dead-Letter Queue:** `{environment}-rent-payments-queue-dlq`
+
+The billing service emits this event whenever a rent transaction is captured. Accounting systems and analytics pipelines can subscribe to reconcile balances in near real-time.
+
+```json
+{
+  "id": "0b40c75a-1473-44e2-a6cb-c89e7a2f5b5e",
+  "source": "share-house-portal.billing",
+  "specversion": "1.0",
+  "type": "rent.payment.received",
+  "datacontenttype": "application/json",
+  "time": "2024-05-03T14:45:21Z",
+  "data": {
+    "paymentId": "0f7f279b-5d2c-47c1-b77f-74b6aaf60faf",
+    "leaseId": "d94a7b93-7f73-4e53-8a1a-4c0a617f96d9",
+    "tenantId": "2f2d958a-6482-4e5c-9a7d-92f466e7e9fb",
+    "amount": {
+      "currency": "USD",
+      "value": 1250.00
+    },
+    "paidAt": "2024-05-03T14:45:20Z",
+    "coveragePeriodStart": "2024-05-01",
+    "coveragePeriodEnd": "2024-05-31",
+    "paymentMethod": "ACH",
+    "status": "Captured"
+  }
+}
+```
+
+#### Data Field Reference
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `paymentId` | UUID | Unique identifier for the payment transaction. |
+| `leaseId` | UUID | Lease agreement credited by the payment. |
+| `tenantId` | UUID | Account responsible for the payment. |
+| `amount.currency` | ISO 4217 string | Currency code for the transaction. |
+| `amount.value` | Decimal | Monetary amount received. |
+| `paidAt` | DateTime (ISO 8601) | Timestamp when the payment cleared. |
+| `coveragePeriodStart` | Date (ISO 8601) | Beginning of the rent period covered by the payment. |
+| `coveragePeriodEnd` | Date (ISO 8601) | End of the rent period covered. |
+| `paymentMethod` | Enum (`ACH`, `Card`, `Cash`, `Check`, `Other`) | Channel used to collect the payment. |
+| `status` | Enum (`Captured`, `Pending`, `Failed`) | Processing status at the time of publication. |

--- a/infra/terraform/messaging/main.tf
+++ b/infra/terraform/messaging/main.tf
@@ -1,0 +1,143 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  base_tags = merge({
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Component   = "messaging"
+  }, var.tags)
+
+  messaging_channels = {
+    tenant_applications = {
+      topic = {
+        name         = "tenant-applications-topic"
+        display_name = "Tenant applications events"
+      }
+
+      queue = {
+        name                       = "tenant-applications-queue"
+        visibility_timeout_seconds = 60
+        max_receive_count          = 5
+        message_retention_seconds  = 1209600
+      }
+    }
+
+    maintenance_requests = {
+      topic = {
+        name         = "maintenance-requests-topic"
+        display_name = "Maintenance requests events"
+      }
+
+      queue = {
+        name                       = "maintenance-requests-queue"
+        visibility_timeout_seconds = 60
+        max_receive_count          = 5
+        message_retention_seconds  = 1209600
+      }
+    }
+
+    rent_payments = {
+      topic = {
+        name         = "rent-payments-topic"
+        display_name = "Rent payment events"
+      }
+
+      queue = {
+        name                       = "rent-payments-queue"
+        visibility_timeout_seconds = 60
+        max_receive_count          = 5
+        message_retention_seconds  = 1209600
+      }
+    }
+  }
+}
+
+resource "aws_sns_topic" "topics" {
+  for_each = local.messaging_channels
+
+  name         = "${var.environment}-${each.value.topic.name}"
+  display_name = each.value.topic.display_name
+
+  tags = local.base_tags
+}
+
+resource "aws_sqs_queue" "dlq" {
+  for_each = local.messaging_channels
+
+  name                       = "${var.environment}-${each.value.queue.name}-dlq"
+  message_retention_seconds  = each.value.queue.message_retention_seconds
+  visibility_timeout_seconds = each.value.queue.visibility_timeout_seconds
+
+  tags = local.base_tags
+}
+
+resource "aws_sqs_queue" "queue" {
+  for_each = local.messaging_channels
+
+  name                       = "${var.environment}-${each.value.queue.name}"
+  visibility_timeout_seconds = each.value.queue.visibility_timeout_seconds
+  message_retention_seconds  = each.value.queue.message_retention_seconds
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.dlq[each.key].arn
+    maxReceiveCount     = each.value.queue.max_receive_count
+  })
+
+  tags = local.base_tags
+}
+
+resource "aws_sns_topic_subscription" "queue" {
+  for_each = local.messaging_channels
+
+  topic_arn = aws_sns_topic.topics[each.key].arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.queue[each.key].arn
+
+  raw_message_delivery = true
+}
+
+data "aws_iam_policy_document" "sns_to_sqs" {
+  for_each = aws_sqs_queue.queue
+
+  statement {
+    sid    = "AllowSNSPublish"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [each.value.arn]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_sns_topic.topics[each.key].arn]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "queue" {
+  for_each = aws_sqs_queue.queue
+
+  queue_url = each.value.url
+  policy    = data.aws_iam_policy_document.sns_to_sqs[each.key].json
+}

--- a/infra/terraform/messaging/outputs.tf
+++ b/infra/terraform/messaging/outputs.tf
@@ -1,0 +1,14 @@
+output "sns_topic_arns" {
+  description = "Map of SNS topic ARNs keyed by logical channel name."
+  value       = { for key, topic in aws_sns_topic.topics : key => topic.arn }
+}
+
+output "sqs_queue_arns" {
+  description = "Map of primary SQS queue ARNs keyed by logical channel name."
+  value       = { for key, queue in aws_sqs_queue.queue : key => queue.arn }
+}
+
+output "sqs_dead_letter_queue_arns" {
+  description = "Map of SQS dead-letter queue ARNs keyed by logical channel name."
+  value       = { for key, queue in aws_sqs_queue.dlq : key => queue.arn }
+}

--- a/infra/terraform/messaging/variables.tf
+++ b/infra/terraform/messaging/variables.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "AWS region to deploy messaging resources in."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment identifier used to namespace resources."
+  type        = string
+  default     = "dev"
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/services/common/background-worker/Program.cs
+++ b/services/common/background-worker/Program.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ShareHousePortal.BackgroundWorker;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((context, services) =>
+    {
+        services.AddHostedService<Worker>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/services/common/background-worker/README.md
+++ b/services/common/background-worker/README.md
@@ -1,0 +1,15 @@
+# Background Worker
+
+This project scaffolds a .NET background worker that can be extended to consume the platform's messaging events.
+
+## Getting Started
+
+1. Ensure the [.NET SDK 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) is installed locally.
+2. Restore dependencies and run the worker:
+
+   ```bash
+   dotnet restore
+   dotnet run
+   ```
+
+The worker currently logs a heartbeat every five seconds and is ready for future integration with the messaging resources defined in Terraform.

--- a/services/common/background-worker/Worker.cs
+++ b/services/common/background-worker/Worker.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ShareHousePortal.BackgroundWorker;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("ShareHousePortal background worker starting up");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Worker heartbeat at: {time}", DateTimeOffset.UtcNow);
+
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+
+        _logger.LogInformation("ShareHousePortal background worker is stopping");
+    }
+}

--- a/services/common/background-worker/appsettings.Development.json
+++ b/services/common/background-worker/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/services/common/background-worker/appsettings.json
+++ b/services/common/background-worker/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/services/common/background-worker/background-worker.csproj
+++ b/services/common/background-worker/background-worker.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add Terraform configuration for SNS topics, SQS queues, and queue policies with per-channel DLQs
- scaffold a .NET background worker template that can subscribe to the messaging topics
- document the initial event catalog and schemas for tenant applications, maintenance, and rent payments

## Testing
- dotnet --version *(fails: command not found in container)*
- terraform version *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceef9d275483288be7a786d5300e1a