### PR TITLE
Add EF Core schema for service management

### DIFF
--- a/backend/ShareHousePortal.sln
+++ b/backend/ShareHousePortal.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33424.131
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShareHousePortal.Domain", "src/ShareHousePortal.Domain/ShareHousePortal.Domain.csproj", "{EC02A6F6-F961-4767-BB39-1DB4F9B21B5E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShareHousePortal.Infrastructure", "src/ShareHousePortal.Infrastructure/ShareHousePortal.Infrastructure.csproj", "{A26B162B-8D27-43EF-B2C6-D3AD082EABE4}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {EC02A6F6-F961-4767-BB39-1DB4F9B21B5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {EC02A6F6-F961-4767-BB39-1DB4F9B21B5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {EC02A6F6-F961-4767-BB39-1DB4F9B21B5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {EC02A6F6-F961-4767-BB39-1DB4F9B21B5E}.Release|Any CPU.Build.0 = Release|Any CPU
+        {A26B162B-8D27-43EF-B2C6-D3AD082EABE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {A26B162B-8D27-43EF-B2C6-D3AD082EABE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {A26B162B-8D27-43EF-B2C6-D3AD082EABE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {A26B162B-8D27-43EF-B2C6-D3AD082EABE4}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/backend/src/ShareHousePortal.Domain/Entities/Building.cs
+++ b/backend/src/ShareHousePortal.Domain/Entities/Building.cs
@@ -1,0 +1,15 @@
+namespace ShareHousePortal.Domain.Entities;
+
+public class Building
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? AddressLine1 { get; set; }
+    public string? AddressLine2 { get; set; }
+    public string? City { get; set; }
+    public string? State { get; set; }
+    public string? PostalCode { get; set; }
+
+    public ICollection<ServiceRequest> ServiceRequests { get; set; } = new List<ServiceRequest>();
+    public ICollection<WorkOrder> WorkOrders { get; set; } = new List<WorkOrder>();
+}

--- a/backend/src/ShareHousePortal.Domain/Entities/ServiceLevelAgreementTarget.cs
+++ b/backend/src/ShareHousePortal.Domain/Entities/ServiceLevelAgreementTarget.cs
@@ -1,0 +1,13 @@
+namespace ShareHousePortal.Domain.Entities;
+
+public class ServiceLevelAgreementTarget
+{
+    public Guid Id { get; set; }
+    public Guid ServiceRequestId { get; set; }
+    public int ResponseHours { get; set; }
+    public int ResolutionHours { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? EffectiveUntil { get; set; }
+
+    public ServiceRequest ServiceRequest { get; set; } = null!;
+}

--- a/backend/src/ShareHousePortal.Domain/Entities/ServiceRequest.cs
+++ b/backend/src/ShareHousePortal.Domain/Entities/ServiceRequest.cs
@@ -1,0 +1,25 @@
+using ShareHousePortal.Domain.Enums;
+
+namespace ShareHousePortal.Domain.Entities;
+
+public class ServiceRequest
+{
+    public Guid Id { get; set; }
+    public Guid BuildingId { get; set; }
+    public string ReferenceNumber { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public ServiceRequestStatus Status { get; set; } = ServiceRequestStatus.Draft;
+    public ServiceRequestPriority Priority { get; set; } = ServiceRequestPriority.Medium;
+    public DateTime RequestedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? DueBy { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public string RequestedBy { get; set; } = string.Empty;
+    public string? RequestedByEmail { get; set; }
+    public string? Notes { get; set; }
+
+    public Building Building { get; set; } = null!;
+    public ICollection<WorkOrder> WorkOrders { get; set; } = new List<WorkOrder>();
+    public ICollection<ServiceRequestStatusHistory> StatusHistory { get; set; } = new List<ServiceRequestStatusHistory>();
+    public ServiceLevelAgreementTarget? SlaTarget { get; set; }
+}

--- a/backend/src/ShareHousePortal.Domain/Entities/ServiceRequestStatusHistory.cs
+++ b/backend/src/ShareHousePortal.Domain/Entities/ServiceRequestStatusHistory.cs
@@ -1,0 +1,16 @@
+using ShareHousePortal.Domain.Enums;
+
+namespace ShareHousePortal.Domain.Entities;
+
+public class ServiceRequestStatusHistory
+{
+    public Guid Id { get; set; }
+    public Guid ServiceRequestId { get; set; }
+    public ServiceRequestStatus FromStatus { get; set; }
+    public ServiceRequestStatus ToStatus { get; set; }
+    public string ChangedBy { get; set; } = string.Empty;
+    public DateTime ChangedAt { get; set; } = DateTime.UtcNow;
+    public string? Comment { get; set; }
+
+    public ServiceRequest ServiceRequest { get; set; } = null!;
+}

--- a/backend/src/ShareHousePortal.Domain/Entities/WorkOrder.cs
+++ b/backend/src/ShareHousePortal.Domain/Entities/WorkOrder.cs
@@ -1,0 +1,21 @@
+using ShareHousePortal.Domain.Enums;
+
+namespace ShareHousePortal.Domain.Entities;
+
+public class WorkOrder
+{
+    public Guid Id { get; set; }
+    public Guid ServiceRequestId { get; set; }
+    public Guid BuildingId { get; set; }
+    public string WorkOrderNumber { get; set; } = string.Empty;
+    public WorkOrderStatus Status { get; set; } = WorkOrderStatus.Pending;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? ScheduledFor { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public string? Summary { get; set; }
+    public string? Notes { get; set; }
+
+    public ServiceRequest ServiceRequest { get; set; } = null!;
+    public Building Building { get; set; } = null!;
+    public ICollection<WorkOrderAssignment> Assignments { get; set; } = new List<WorkOrderAssignment>();
+}

--- a/backend/src/ShareHousePortal.Domain/Entities/WorkOrderAssignment.cs
+++ b/backend/src/ShareHousePortal.Domain/Entities/WorkOrderAssignment.cs
@@ -1,0 +1,16 @@
+namespace ShareHousePortal.Domain.Entities;
+
+public class WorkOrderAssignment
+{
+    public Guid Id { get; set; }
+    public Guid WorkOrderId { get; set; }
+    public string AssigneeId { get; set; } = string.Empty;
+    public string AssigneeName { get; set; } = string.Empty;
+    public string? Role { get; set; }
+    public DateTime AssignedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? AcknowledgedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public string? Notes { get; set; }
+
+    public WorkOrder WorkOrder { get; set; } = null!;
+}

--- a/backend/src/ShareHousePortal.Domain/Enums/ServiceRequestPriority.cs
+++ b/backend/src/ShareHousePortal.Domain/Enums/ServiceRequestPriority.cs
@@ -1,0 +1,9 @@
+namespace ShareHousePortal.Domain.Enums;
+
+public enum ServiceRequestPriority
+{
+    Low = 0,
+    Medium = 1,
+    High = 2,
+    Critical = 3
+}

--- a/backend/src/ShareHousePortal.Domain/Enums/ServiceRequestStatus.cs
+++ b/backend/src/ShareHousePortal.Domain/Enums/ServiceRequestStatus.cs
@@ -1,0 +1,12 @@
+namespace ShareHousePortal.Domain.Enums;
+
+public enum ServiceRequestStatus
+{
+    Draft = 0,
+    Submitted = 1,
+    InReview = 2,
+    InProgress = 3,
+    Completed = 4,
+    Cancelled = 5,
+    OnHold = 6
+}

--- a/backend/src/ShareHousePortal.Domain/Enums/WorkOrderStatus.cs
+++ b/backend/src/ShareHousePortal.Domain/Enums/WorkOrderStatus.cs
@@ -1,0 +1,11 @@
+namespace ShareHousePortal.Domain.Enums;
+
+public enum WorkOrderStatus
+{
+    Pending = 0,
+    Assigned = 1,
+    Scheduled = 2,
+    InProgress = 3,
+    Completed = 4,
+    Cancelled = 5
+}

--- a/backend/src/ShareHousePortal.Domain/Repositories/IServiceRequestRepository.cs
+++ b/backend/src/ShareHousePortal.Domain/Repositories/IServiceRequestRepository.cs
@@ -1,0 +1,16 @@
+using ShareHousePortal.Domain.Entities;
+using ShareHousePortal.Domain.Enums;
+
+namespace ShareHousePortal.Domain.Repositories;
+
+public interface IServiceRequestRepository
+{
+    Task<ServiceRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ServiceRequest>> GetByBuildingAsync(Guid buildingId, ServiceRequestStatus? status = null, CancellationToken cancellationToken = default);
+    Task AddAsync(ServiceRequest request, CancellationToken cancellationToken = default);
+    Task UpdateAsync(ServiceRequest request, CancellationToken cancellationToken = default);
+    Task AddWorkOrderAsync(Guid requestId, WorkOrder workOrder, CancellationToken cancellationToken = default);
+    Task AddStatusHistoryAsync(ServiceRequestStatusHistory statusHistory, CancellationToken cancellationToken = default);
+    Task AddWorkOrderAssignmentAsync(Guid workOrderId, WorkOrderAssignment assignment, CancellationToken cancellationToken = default);
+    Task UpsertSlaTargetAsync(ServiceLevelAgreementTarget slaTarget, CancellationToken cancellationToken = default);
+}

--- a/backend/src/ShareHousePortal.Domain/ShareHousePortal.Domain.csproj
+++ b/backend/src/ShareHousePortal.Domain/ShareHousePortal.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/backend/src/ShareHousePortal.Infrastructure/Data/ShareHousePortalDbContext.cs
+++ b/backend/src/ShareHousePortal.Infrastructure/Data/ShareHousePortalDbContext.cs
@@ -1,0 +1,212 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using ShareHousePortal.Domain.Entities;
+using ShareHousePortal.Domain.Enums;
+
+namespace ShareHousePortal.Infrastructure.Data;
+
+public class ShareHousePortalDbContext : DbContext
+{
+    public ShareHousePortalDbContext(DbContextOptions<ShareHousePortalDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Building> Buildings => Set<Building>();
+    public DbSet<ServiceRequest> ServiceRequests => Set<ServiceRequest>();
+    public DbSet<WorkOrder> WorkOrders => Set<WorkOrder>();
+    public DbSet<WorkOrderAssignment> WorkOrderAssignments => Set<WorkOrderAssignment>();
+    public DbSet<ServiceLevelAgreementTarget> ServiceLevelAgreementTargets => Set<ServiceLevelAgreementTarget>();
+    public DbSet<ServiceRequestStatusHistory> ServiceRequestStatusHistory => Set<ServiceRequestStatusHistory>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        ConfigureBuilding(modelBuilder);
+        ConfigureServiceRequest(modelBuilder);
+        ConfigureWorkOrder(modelBuilder);
+        ConfigureWorkOrderAssignment(modelBuilder);
+        ConfigureServiceLevelAgreementTarget(modelBuilder);
+        ConfigureServiceRequestStatusHistory(modelBuilder);
+    }
+
+    private static void ConfigureBuilding(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Building>(builder =>
+        {
+            builder.ToTable("Buildings");
+            builder.HasKey(b => b.Id);
+            builder.Property(b => b.Name)
+                .IsRequired()
+                .HasMaxLength(200);
+            builder.Property(b => b.AddressLine1)
+                .HasMaxLength(200);
+            builder.Property(b => b.AddressLine2)
+                .HasMaxLength(200);
+            builder.Property(b => b.City)
+                .HasMaxLength(100);
+            builder.Property(b => b.State)
+                .HasMaxLength(100);
+            builder.Property(b => b.PostalCode)
+                .HasMaxLength(20);
+        });
+    }
+
+    private static void ConfigureServiceRequest(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ServiceRequest>(builder =>
+        {
+            builder.ToTable("ServiceRequests");
+            builder.HasKey(sr => sr.Id);
+
+            builder.Property(sr => sr.ReferenceNumber)
+                .IsRequired()
+                .HasMaxLength(50);
+            builder.HasIndex(sr => sr.ReferenceNumber)
+                .IsUnique();
+
+            builder.Property(sr => sr.Title)
+                .IsRequired()
+                .HasMaxLength(250);
+            builder.Property(sr => sr.Description)
+                .HasMaxLength(2000);
+
+            builder.Property(sr => sr.Status)
+                .HasConversion(new EnumToStringConverter<ServiceRequestStatus>())
+                .HasMaxLength(64)
+                .IsRequired();
+            builder.HasIndex(sr => sr.Status);
+
+            builder.Property(sr => sr.Priority)
+                .HasConversion(new EnumToStringConverter<ServiceRequestPriority>())
+                .HasMaxLength(32)
+                .IsRequired();
+
+            builder.Property(sr => sr.RequestedBy)
+                .IsRequired()
+                .HasMaxLength(150);
+            builder.Property(sr => sr.RequestedByEmail)
+                .HasMaxLength(320);
+
+            builder.HasIndex(sr => sr.BuildingId);
+
+            builder.HasOne(sr => sr.Building)
+                .WithMany(b => b.ServiceRequests)
+                .HasForeignKey(sr => sr.BuildingId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasOne(sr => sr.SlaTarget)
+                .WithOne(st => st.ServiceRequest)
+                .HasForeignKey<ServiceLevelAgreementTarget>(st => st.ServiceRequestId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+
+    private static void ConfigureWorkOrder(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<WorkOrder>(builder =>
+        {
+            builder.ToTable("WorkOrders");
+            builder.HasKey(wo => wo.Id);
+
+            builder.Property(wo => wo.WorkOrderNumber)
+                .IsRequired()
+                .HasMaxLength(50);
+            builder.HasIndex(wo => wo.WorkOrderNumber)
+                .IsUnique();
+
+            builder.Property(wo => wo.Status)
+                .HasConversion(new EnumToStringConverter<WorkOrderStatus>())
+                .HasMaxLength(64)
+                .IsRequired();
+            builder.HasIndex(wo => wo.Status);
+            builder.HasIndex(wo => wo.BuildingId);
+
+            builder.Property(wo => wo.Summary)
+                .HasMaxLength(500);
+
+            builder.HasOne(wo => wo.ServiceRequest)
+                .WithMany(sr => sr.WorkOrders)
+                .HasForeignKey(wo => wo.ServiceRequestId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasOne(wo => wo.Building)
+                .WithMany(b => b.WorkOrders)
+                .HasForeignKey(wo => wo.BuildingId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+    }
+
+    private static void ConfigureWorkOrderAssignment(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<WorkOrderAssignment>(builder =>
+        {
+            builder.ToTable("WorkOrderAssignments");
+            builder.HasKey(woa => woa.Id);
+
+            builder.Property(woa => woa.AssigneeId)
+                .IsRequired()
+                .HasMaxLength(100);
+            builder.Property(woa => woa.AssigneeName)
+                .IsRequired()
+                .HasMaxLength(200);
+            builder.Property(woa => woa.Role)
+                .HasMaxLength(150);
+
+            builder.HasIndex(woa => woa.WorkOrderId);
+
+            builder.HasOne(woa => woa.WorkOrder)
+                .WithMany(wo => wo.Assignments)
+                .HasForeignKey(woa => woa.WorkOrderId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+
+    private static void ConfigureServiceLevelAgreementTarget(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ServiceLevelAgreementTarget>(builder =>
+        {
+            builder.ToTable("ServiceLevelAgreementTargets");
+            builder.HasKey(st => st.Id);
+
+            builder.Property(st => st.ResponseHours)
+                .IsRequired();
+            builder.Property(st => st.ResolutionHours)
+                .IsRequired();
+
+            builder.HasIndex(st => st.ServiceRequestId)
+                .IsUnique();
+        });
+    }
+
+    private static void ConfigureServiceRequestStatusHistory(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ServiceRequestStatusHistory>(builder =>
+        {
+            builder.ToTable("ServiceRequestStatusHistory");
+            builder.HasKey(h => h.Id);
+
+            builder.Property(h => h.FromStatus)
+                .HasConversion(new EnumToStringConverter<ServiceRequestStatus>())
+                .HasMaxLength(64)
+                .IsRequired();
+            builder.Property(h => h.ToStatus)
+                .HasConversion(new EnumToStringConverter<ServiceRequestStatus>())
+                .HasMaxLength(64)
+                .IsRequired();
+            builder.Property(h => h.ChangedBy)
+                .IsRequired()
+                .HasMaxLength(150);
+            builder.Property(h => h.Comment)
+                .HasMaxLength(1000);
+
+            builder.HasIndex(h => h.ServiceRequestId);
+
+            builder.HasOne(h => h.ServiceRequest)
+                .WithMany(sr => sr.StatusHistory)
+                .HasForeignKey(h => h.ServiceRequestId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+}

--- a/backend/src/ShareHousePortal.Infrastructure/Migrations/20240506120000_AddServiceManagementSchema.cs
+++ b/backend/src/ShareHousePortal.Infrastructure/Migrations/20240506120000_AddServiceManagementSchema.cs
@@ -1,0 +1,235 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShareHousePortal.Infrastructure.Migrations
+{
+    public partial class AddServiceManagementSchema : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Buildings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    AddressLine1 = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    AddressLine2 = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    City = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    State = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    PostalCode = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Buildings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ServiceRequests",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    BuildingId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ReferenceNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Priority = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    RequestedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DueBy = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    RequestedBy = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: false),
+                    RequestedByEmail = table.Column<string>(type: "nvarchar(320)", maxLength: 320, nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServiceRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ServiceRequests_Buildings_BuildingId",
+                        column: x => x.BuildingId,
+                        principalTable: "Buildings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkOrders",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServiceRequestId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    BuildingId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WorkOrderNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ScheduledFor = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Summary = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkOrders", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorkOrders_Buildings_BuildingId",
+                        column: x => x.BuildingId,
+                        principalTable: "Buildings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_WorkOrders_ServiceRequests_ServiceRequestId",
+                        column: x => x.ServiceRequestId,
+                        principalTable: "ServiceRequests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ServiceLevelAgreementTargets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServiceRequestId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ResponseHours = table.Column<int>(type: "int", nullable: false),
+                    ResolutionHours = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    EffectiveUntil = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServiceLevelAgreementTargets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ServiceLevelAgreementTargets_ServiceRequests_ServiceRequestId",
+                        column: x => x.ServiceRequestId,
+                        principalTable: "ServiceRequests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ServiceRequestStatusHistory",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ServiceRequestId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    FromStatus = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    ToStatus = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    ChangedBy = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: false),
+                    ChangedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Comment = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServiceRequestStatusHistory", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ServiceRequestStatusHistory_ServiceRequests_ServiceRequestId",
+                        column: x => x.ServiceRequestId,
+                        principalTable: "ServiceRequests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkOrderAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    WorkOrderId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssigneeId = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    AssigneeName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Role = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: true),
+                    AssignedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    AcknowledgedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkOrderAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorkOrderAssignments_WorkOrders_WorkOrderId",
+                        column: x => x.WorkOrderId,
+                        principalTable: "WorkOrders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceLevelAgreementTargets_ServiceRequestId",
+                table: "ServiceLevelAgreementTargets",
+                column: "ServiceRequestId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceRequestStatusHistory_ServiceRequestId",
+                table: "ServiceRequestStatusHistory",
+                column: "ServiceRequestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceRequests_BuildingId",
+                table: "ServiceRequests",
+                column: "BuildingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceRequests_ReferenceNumber",
+                table: "ServiceRequests",
+                column: "ReferenceNumber",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceRequests_Status",
+                table: "ServiceRequests",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkOrderAssignments_WorkOrderId",
+                table: "WorkOrderAssignments",
+                column: "WorkOrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkOrders_BuildingId",
+                table: "WorkOrders",
+                column: "BuildingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkOrders_ServiceRequestId",
+                table: "WorkOrders",
+                column: "ServiceRequestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkOrders_Status",
+                table: "WorkOrders",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkOrders_WorkOrderNumber",
+                table: "WorkOrders",
+                column: "WorkOrderNumber",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ServiceLevelAgreementTargets");
+
+            migrationBuilder.DropTable(
+                name: "ServiceRequestStatusHistory");
+
+            migrationBuilder.DropTable(
+                name: "WorkOrderAssignments");
+
+            migrationBuilder.DropTable(
+                name: "WorkOrders");
+
+            migrationBuilder.DropTable(
+                name: "ServiceRequests");
+
+            migrationBuilder.DropTable(
+                name: "Buildings");
+        }
+    }
+}

--- a/backend/src/ShareHousePortal.Infrastructure/Migrations/ShareHousePortalDbContextModelSnapshot.cs
+++ b/backend/src/ShareHousePortal.Infrastructure/Migrations/ShareHousePortalDbContextModelSnapshot.cs
@@ -1,0 +1,361 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using ShareHousePortal.Infrastructure.Data;
+
+#nullable disable
+
+namespace ShareHousePortal.Infrastructure.Migrations
+{
+    [DbContext(typeof(ShareHousePortalDbContext))]
+    partial class ShareHousePortalDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.4")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.Building", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("AddressLine1")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("AddressLine2")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("City")
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<string>("PostalCode")
+                    .HasMaxLength(20)
+                    .HasColumnType("nvarchar(20)");
+
+                b.Property<string>("State")
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.HasKey("Id");
+
+                b.ToTable("Buildings");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.ServiceLevelAgreementTarget", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("EffectiveUntil")
+                    .HasColumnType("datetime2");
+
+                b.Property<int>("ResolutionHours")
+                    .HasColumnType("int");
+
+                b.Property<int>("ResponseHours")
+                    .HasColumnType("int");
+
+                b.Property<Guid>("ServiceRequestId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime>("CreatedAt")
+                    .HasColumnType("datetime2");
+
+                b.HasKey("Id");
+
+                b.HasIndex("ServiceRequestId")
+                    .IsUnique();
+
+                b.ToTable("ServiceLevelAgreementTargets");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.ServiceRequest", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("BuildingId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("CompletedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Description")
+                    .HasMaxLength(2000)
+                    .HasColumnType("nvarchar(2000)");
+
+                b.Property<DateTime?>("DueBy")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Priority")
+                    .IsRequired()
+                    .HasMaxLength(32)
+                    .HasColumnType("nvarchar(32)");
+
+                b.Property<DateTime>("RequestedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("RequestedBy")
+                    .IsRequired()
+                    .HasMaxLength(150)
+                    .HasColumnType("nvarchar(150)");
+
+                b.Property<string>("RequestedByEmail")
+                    .HasMaxLength(320)
+                    .HasColumnType("nvarchar(320)");
+
+                b.Property<string>("ReferenceNumber")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(64)
+                    .HasColumnType("nvarchar(64)");
+
+                b.Property<string>("Title")
+                    .IsRequired()
+                    .HasMaxLength(250)
+                    .HasColumnType("nvarchar(250)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("BuildingId");
+
+                b.HasIndex("ReferenceNumber")
+                    .IsUnique();
+
+                b.HasIndex("Status");
+
+                b.ToTable("ServiceRequests");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.ServiceRequestStatusHistory", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime>("ChangedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("ChangedBy")
+                    .IsRequired()
+                    .HasMaxLength(150)
+                    .HasColumnType("nvarchar(150)");
+
+                b.Property<string>("Comment")
+                    .HasMaxLength(1000)
+                    .HasColumnType("nvarchar(1000)");
+
+                b.Property<string>("FromStatus")
+                    .IsRequired()
+                    .HasMaxLength(64)
+                    .HasColumnType("nvarchar(64)");
+
+                b.Property<Guid>("ServiceRequestId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("ToStatus")
+                    .IsRequired()
+                    .HasMaxLength(64)
+                    .HasColumnType("nvarchar(64)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("ServiceRequestId");
+
+                b.ToTable("ServiceRequestStatusHistory");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.WorkOrder", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid>("BuildingId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("CompletedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime>("CreatedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<Guid>("ServiceRequestId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("ScheduledFor")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(64)
+                    .HasColumnType("nvarchar(64)");
+
+                b.Property<string>("Summary")
+                    .HasMaxLength(500)
+                    .HasColumnType("nvarchar(500)");
+
+                b.Property<string>("WorkOrderNumber")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("nvarchar(50)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("BuildingId");
+
+                b.HasIndex("ServiceRequestId");
+
+                b.HasIndex("Status");
+
+                b.HasIndex("WorkOrderNumber")
+                    .IsUnique();
+
+                b.ToTable("WorkOrders");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.WorkOrderAssignment", b =>
+            {
+                b.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime?>("AcknowledgedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<DateTime>("AssignedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("AssigneeId")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<string>("AssigneeName")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<DateTime?>("CompletedAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Role")
+                    .HasMaxLength(150)
+                    .HasColumnType("nvarchar(150)");
+
+                b.Property<Guid>("WorkOrderId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.HasIndex("WorkOrderId");
+
+                b.ToTable("WorkOrderAssignments");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.ServiceLevelAgreementTarget", b =>
+            {
+                b.HasOne("ShareHousePortal.Domain.Entities.ServiceRequest", "ServiceRequest")
+                    .WithOne("SlaTarget")
+                    .HasForeignKey("ShareHousePortal.Domain.Entities.ServiceLevelAgreementTarget", "ServiceRequestId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("ServiceRequest");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.ServiceRequest", b =>
+            {
+                b.HasOne("ShareHousePortal.Domain.Entities.Building", "Building")
+                    .WithMany("ServiceRequests")
+                    .HasForeignKey("BuildingId")
+                    .OnDelete(DeleteBehavior.Restrict)
+                    .IsRequired();
+
+                b.Navigation("Building");
+                b.Navigation("SlaTarget");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.ServiceRequestStatusHistory", b =>
+            {
+                b.HasOne("ShareHousePortal.Domain.Entities.ServiceRequest", "ServiceRequest")
+                    .WithMany("StatusHistory")
+                    .HasForeignKey("ServiceRequestId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("ServiceRequest");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.WorkOrder", b =>
+            {
+                b.HasOne("ShareHousePortal.Domain.Entities.Building", "Building")
+                    .WithMany("WorkOrders")
+                    .HasForeignKey("BuildingId")
+                    .OnDelete(DeleteBehavior.Restrict)
+                    .IsRequired();
+
+                b.HasOne("ShareHousePortal.Domain.Entities.ServiceRequest", "ServiceRequest")
+                    .WithMany("WorkOrders")
+                    .HasForeignKey("ServiceRequestId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Building");
+                b.Navigation("ServiceRequest");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.WorkOrderAssignment", b =>
+            {
+                b.HasOne("ShareHousePortal.Domain.Entities.WorkOrder", "WorkOrder")
+                    .WithMany("Assignments")
+                    .HasForeignKey("WorkOrderId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("WorkOrder");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.Building", b =>
+            {
+                b.Navigation("ServiceRequests");
+                b.Navigation("WorkOrders");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.ServiceRequest", b =>
+            {
+                b.Navigation("StatusHistory");
+                b.Navigation("WorkOrders");
+            });
+
+            modelBuilder.Entity("ShareHousePortal.Domain.Entities.WorkOrder", b =>
+            {
+                b.Navigation("Assignments");
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/backend/src/ShareHousePortal.Infrastructure/Repositories/ServiceRequestRepository.cs
+++ b/backend/src/ShareHousePortal.Infrastructure/Repositories/ServiceRequestRepository.cs
@@ -1,0 +1,112 @@
+using Microsoft.EntityFrameworkCore;
+using ShareHousePortal.Domain.Entities;
+using ShareHousePortal.Domain.Enums;
+using ShareHousePortal.Domain.Repositories;
+using ShareHousePortal.Infrastructure.Data;
+
+namespace ShareHousePortal.Infrastructure.Repositories;
+
+public class ServiceRequestRepository : IServiceRequestRepository
+{
+    private readonly ShareHousePortalDbContext _dbContext;
+
+    public ServiceRequestRepository(ShareHousePortalDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<ServiceRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.ServiceRequests
+            .Include(sr => sr.Building)
+            .Include(sr => sr.WorkOrders)
+                .ThenInclude(wo => wo.Assignments)
+            .Include(sr => sr.StatusHistory)
+            .Include(sr => sr.SlaTarget)
+            .FirstOrDefaultAsync(sr => sr.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<ServiceRequest>> GetByBuildingAsync(Guid buildingId, ServiceRequestStatus? status = null, CancellationToken cancellationToken = default)
+    {
+        IQueryable<ServiceRequest> query = _dbContext.ServiceRequests
+            .Include(sr => sr.SlaTarget)
+            .Include(sr => sr.WorkOrders)
+            .Include(sr => sr.StatusHistory)
+            .Where(sr => sr.BuildingId == buildingId)
+            .OrderByDescending(sr => sr.RequestedAt);
+
+        if (status.HasValue)
+        {
+            query = query.Where(sr => sr.Status == status);
+        }
+
+        return await query.ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(ServiceRequest request, CancellationToken cancellationToken = default)
+    {
+        _dbContext.ServiceRequests.Add(request);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(ServiceRequest request, CancellationToken cancellationToken = default)
+    {
+        _dbContext.ServiceRequests.Update(request);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task AddWorkOrderAsync(Guid requestId, WorkOrder workOrder, CancellationToken cancellationToken = default)
+    {
+        var serviceRequest = await _dbContext.ServiceRequests
+            .Include(sr => sr.WorkOrders)
+            .FirstOrDefaultAsync(sr => sr.Id == requestId, cancellationToken);
+
+        if (serviceRequest is null)
+        {
+            throw new InvalidOperationException($"Service request {requestId} was not found.");
+        }
+
+        serviceRequest.WorkOrders.Add(workOrder);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task AddStatusHistoryAsync(ServiceRequestStatusHistory statusHistory, CancellationToken cancellationToken = default)
+    {
+        _dbContext.ServiceRequestStatusHistory.Add(statusHistory);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task AddWorkOrderAssignmentAsync(Guid workOrderId, WorkOrderAssignment assignment, CancellationToken cancellationToken = default)
+    {
+        var workOrder = await _dbContext.WorkOrders
+            .Include(wo => wo.Assignments)
+            .FirstOrDefaultAsync(wo => wo.Id == workOrderId, cancellationToken);
+
+        if (workOrder is null)
+        {
+            throw new InvalidOperationException($"Work order {workOrderId} was not found.");
+        }
+
+        workOrder.Assignments.Add(assignment);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpsertSlaTargetAsync(ServiceLevelAgreementTarget slaTarget, CancellationToken cancellationToken = default)
+    {
+        var existing = await _dbContext.ServiceLevelAgreementTargets
+            .FirstOrDefaultAsync(st => st.ServiceRequestId == slaTarget.ServiceRequestId, cancellationToken);
+
+        if (existing is null)
+        {
+            _dbContext.ServiceLevelAgreementTargets.Add(slaTarget);
+        }
+        else
+        {
+            existing.ResponseHours = slaTarget.ResponseHours;
+            existing.ResolutionHours = slaTarget.ResolutionHours;
+            existing.EffectiveUntil = slaTarget.EffectiveUntil;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/src/ShareHousePortal.Infrastructure/ShareHousePortal.Infrastructure.csproj
+++ b/backend/src/ShareHousePortal.Infrastructure/ShareHousePortal.Infrastructure.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ShareHousePortal.Domain/ShareHousePortal.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a backend .NET solution with domain entities for buildings, service requests, work orders, assignments, SLA targets, and status history
- configure EF Core DbContext mappings with relational constraints and indexes on status and building identifiers
- scaffold an initial migration and repository implementation to persist and query the new service management tables

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceefa774308328a9bf59751ec967b7