### PR TITLE
Add facilities operations tables

### DIFF
--- a/docs/attachment-storage.md
+++ b/docs/attachment-storage.md
@@ -1,0 +1,28 @@
+# Attachment Storage & Retention
+
+## Overview
+The `attachments` table acts as a registry for binary artifacts stored in object storage (e.g. AWS S3 or Supabase Storage). Each record tracks the owning entity, where the file lives, and the retention lifecycle metadata so that packages, visitor logs, incidents, and shift reports can share a consistent storage model.
+
+| Column | Purpose |
+| --- | --- |
+| `entity_type` & `entity_id` | Identify the owning record (`package_log`, `package_signature`, `visitor_log`, `incident_report`, `key_transaction`, or `shift_log`). |
+| `s3_bucket` & `s3_key` | Point to the exact object key for retrieval/deletion. |
+| `expires_at` | Optional application-level expiration (for temporary files such as visitor IDs). |
+| `retention_expires_at` | Hard-retention deadline after which files must be purged to satisfy compliance. |
+| `uploaded_by` | Associates uploads with a `profiles.id` for auditing. |
+
+## Storage Guidelines
+- Store files in a private bucket. Grant read access via signed URLs or server-side streaming only after verifying the requesting user has read access to the parent record.
+- Use hierarchical object keys (`{entity_type}/{entity_id}/{timestamp}-{filename}`) to keep namespaces tidy and simplify lifecycle automation.
+- Attachments should be created after the parent record exists to guarantee referential integrity. When cascading deletes are required, remove the object from storage first and then delete the `attachments` row.
+
+## Retention & Cleanup
+1. **Short-term files** – Set `expires_at` for artifacts that should disappear automatically (e.g. temporary visitor IDs). Scheduled jobs can target rows where `expires_at < now()` and purge the related object.
+2. **Compliance retention** – Populate `retention_expires_at` for records subject to minimum retention periods (e.g. incident photos kept 7 years). Do not allow deletion until that timestamp has passed.
+3. **Audit trail** – Preserve `uploaded_by` and timestamps for reporting. Use `attachments` together with `package_logs`, `incident_reports`, `shift_logs`, and other operational tables to reconstruct the full chain of custody.
+4. **Lifecycle automation** – Batch jobs should:
+   - Select attachments that are past their retention deadlines.
+   - Remove the backing object from storage.
+   - Delete the `attachments` row within the same transaction to prevent orphaned metadata.
+
+Following these rules keeps storage costs predictable, enforces compliance, and ensures operational teams always have a clear audit trail for every file stored in S3.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1558,6 +1558,696 @@ export type Database = {
         }
         Relationships: []
       }
+      attachments: {
+        Row: {
+          content_type: string | null
+          created_at: string
+          entity_id: number
+          entity_type: string
+          expires_at: string | null
+          file_name: string | null
+          file_size: number | null
+          id: number
+          notes: string | null
+          retention_expires_at: string | null
+          s3_bucket: string
+          s3_key: string
+          uploaded_by: string | null
+        }
+        Insert: {
+          content_type?: string | null
+          created_at?: string
+          entity_id: number
+          entity_type: string
+          expires_at?: string | null
+          file_name?: string | null
+          file_size?: number | null
+          id?: number
+          notes?: string | null
+          retention_expires_at?: string | null
+          s3_bucket: string
+          s3_key: string
+          uploaded_by?: string | null
+        }
+        Update: {
+          content_type?: string | null
+          created_at?: string
+          entity_id?: number
+          entity_type?: string
+          expires_at?: string | null
+          file_name?: string | null
+          file_size?: number | null
+          id?: number
+          notes?: string | null
+          retention_expires_at?: string | null
+          s3_bucket?: string
+          s3_key?: string
+          uploaded_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "attachments_uploaded_by_fkey"
+            columns: ["uploaded_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      buildings: {
+        Row: {
+          address_line1: string | null
+          address_line2: string | null
+          city: string | null
+          country: string | null
+          created_at: string
+          description: string | null
+          id: number
+          name: string
+          postal_code: string | null
+          state: string | null
+          timezone: string | null
+          updated_at: string
+        }
+        Insert: {
+          address_line1?: string | null
+          address_line2?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          description?: string | null
+          id?: number
+          name: string
+          postal_code?: string | null
+          state?: string | null
+          timezone?: string | null
+          updated_at?: string
+        }
+        Update: {
+          address_line1?: string | null
+          address_line2?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          description?: string | null
+          id?: number
+          name?: string
+          postal_code?: string | null
+          state?: string | null
+          timezone?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      carriers: {
+        Row: {
+          contact_email: string | null
+          contact_phone: string | null
+          created_at: string
+          id: number
+          name: string
+          notes: string | null
+          updated_at: string
+          website: string | null
+        }
+        Insert: {
+          contact_email?: string | null
+          contact_phone?: string | null
+          created_at?: string
+          id?: number
+          name: string
+          notes?: string | null
+          updated_at?: string
+          website?: string | null
+        }
+        Update: {
+          contact_email?: string | null
+          contact_phone?: string | null
+          created_at?: string
+          id?: number
+          name?: string
+          notes?: string | null
+          updated_at?: string
+          website?: string | null
+        }
+        Relationships: []
+      }
+      incident_reports: {
+        Row: {
+          actions_taken: string | null
+          building_id: number
+          closed_at: string | null
+          created_at: string
+          description: string
+          follow_up_actions: string | null
+          follow_up_at: string | null
+          id: number
+          incident_time: string | null
+          incident_type: string | null
+          notes: string | null
+          reported_at: string
+          reported_by: string | null
+          severity: string | null
+          shift_log_id: number | null
+          status: string
+          unit_id: number | null
+          updated_at: string
+        }
+        Insert: {
+          actions_taken?: string | null
+          building_id: number
+          closed_at?: string | null
+          created_at?: string
+          description: string
+          follow_up_actions?: string | null
+          follow_up_at?: string | null
+          id?: number
+          incident_time?: string | null
+          incident_type?: string | null
+          notes?: string | null
+          reported_at?: string
+          reported_by?: string | null
+          severity?: string | null
+          shift_log_id?: number | null
+          status?: string
+          unit_id?: number | null
+          updated_at?: string
+        }
+        Update: {
+          actions_taken?: string | null
+          building_id?: number
+          closed_at?: string | null
+          created_at?: string
+          description?: string
+          follow_up_actions?: string | null
+          follow_up_at?: string | null
+          id?: number
+          incident_time?: string | null
+          incident_type?: string | null
+          notes?: string | null
+          reported_at?: string
+          reported_by?: string | null
+          severity?: string | null
+          shift_log_id?: number | null
+          status?: string
+          unit_id?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "incident_reports_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "incident_reports_reported_by_fkey"
+            columns: ["reported_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "incident_reports_shift_log_id_fkey"
+            columns: ["shift_log_id"]
+            isOneToOne: false
+            referencedRelation: "shift_logs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "incident_reports_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      key_transactions: {
+        Row: {
+          building_id: number | null
+          created_at: string
+          due_at: string | null
+          handled_by: string | null
+          id: number
+          key_id: number
+          notes: string | null
+          occurred_at: string
+          recipient_contact: string | null
+          recipient_name: string | null
+          returned_at: string | null
+          transaction_type: string
+          unit_id: number | null
+          updated_at: string
+        }
+        Insert: {
+          building_id?: number | null
+          created_at?: string
+          due_at?: string | null
+          handled_by?: string | null
+          id?: number
+          key_id: number
+          notes?: string | null
+          occurred_at?: string
+          recipient_contact?: string | null
+          recipient_name?: string | null
+          returned_at?: string | null
+          transaction_type: string
+          unit_id?: number | null
+          updated_at?: string
+        }
+        Update: {
+          building_id?: number | null
+          created_at?: string
+          due_at?: string | null
+          handled_by?: string | null
+          id?: number
+          key_id?: number
+          notes?: string | null
+          occurred_at?: string
+          recipient_contact?: string | null
+          recipient_name?: string | null
+          returned_at?: string | null
+          transaction_type?: string
+          unit_id?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "key_transactions_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "key_transactions_handled_by_fkey"
+            columns: ["handled_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "key_transactions_key_id_fkey"
+            columns: ["key_id"]
+            isOneToOne: false
+            referencedRelation: "keys"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "key_transactions_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      keys: {
+        Row: {
+          building_id: number
+          created_at: string
+          description: string | null
+          id: number
+          label: string
+          serial_number: string | null
+          status: string
+          storage_location: string | null
+          unit_id: number | null
+          updated_at: string
+        }
+        Insert: {
+          building_id: number
+          created_at?: string
+          description?: string | null
+          id?: number
+          label: string
+          serial_number?: string | null
+          status?: string
+          storage_location?: string | null
+          unit_id?: number | null
+          updated_at?: string
+        }
+        Update: {
+          building_id?: number
+          created_at?: string
+          description?: string | null
+          id?: number
+          label?: string
+          serial_number?: string | null
+          status?: string
+          storage_location?: string | null
+          unit_id?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "keys_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "keys_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      package_logs: {
+        Row: {
+          building_id: number
+          carrier_id: number | null
+          created_at: string
+          delivered_at: string | null
+          id: number
+          notes: string | null
+          notified_at: string | null
+          picked_up_at: string | null
+          picked_up_by: string | null
+          picked_up_contact: string | null
+          received_at: string
+          received_by: string | null
+          recipient_name: string
+          status: string
+          tracking_number: string | null
+          unit_id: number | null
+          updated_at: string
+        }
+        Insert: {
+          building_id: number
+          carrier_id?: number | null
+          created_at?: string
+          delivered_at?: string | null
+          id?: number
+          notes?: string | null
+          notified_at?: string | null
+          picked_up_at?: string | null
+          picked_up_by?: string | null
+          picked_up_contact?: string | null
+          received_at?: string
+          received_by?: string | null
+          recipient_name: string
+          status?: string
+          tracking_number?: string | null
+          unit_id?: number | null
+          updated_at?: string
+        }
+        Update: {
+          building_id?: number
+          carrier_id?: number | null
+          created_at?: string
+          delivered_at?: string | null
+          id?: number
+          notes?: string | null
+          notified_at?: string | null
+          picked_up_at?: string | null
+          picked_up_by?: string | null
+          picked_up_contact?: string | null
+          received_at?: string
+          received_by?: string | null
+          recipient_name?: string
+          status?: string
+          tracking_number?: string | null
+          unit_id?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "package_logs_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "package_logs_carrier_id_fkey"
+            columns: ["carrier_id"]
+            isOneToOne: false
+            referencedRelation: "carriers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "package_logs_received_by_fkey"
+            columns: ["received_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "package_logs_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      package_signatures: {
+        Row: {
+          captured_by: string | null
+          id: number
+          package_log_id: number
+          signed_at: string
+          signature_notes: string | null
+          signer_name: string
+          signer_type: string | null
+        }
+        Insert: {
+          captured_by?: string | null
+          id?: number
+          package_log_id: number
+          signed_at?: string
+          signature_notes?: string | null
+          signer_name: string
+          signer_type?: string | null
+        }
+        Update: {
+          captured_by?: string | null
+          id?: number
+          package_log_id?: number
+          signed_at?: string
+          signature_notes?: string | null
+          signer_name?: string
+          signer_type?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "package_signatures_captured_by_fkey"
+            columns: ["captured_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "package_signatures_package_log_id_fkey"
+            columns: ["package_log_id"]
+            isOneToOne: false
+            referencedRelation: "package_logs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      shift_logs: {
+        Row: {
+          building_id: number
+          created_at: string
+          handoff_notes: string | null
+          handoff_profile_id: string | null
+          id: number
+          issues: string | null
+          shift_date: string
+          shift_end: string | null
+          shift_start: string | null
+          staff_profile_id: string | null
+          summary: string | null
+          updated_at: string
+        }
+        Insert: {
+          building_id: number
+          created_at?: string
+          handoff_notes?: string | null
+          handoff_profile_id?: string | null
+          id?: number
+          issues?: string | null
+          shift_date: string
+          shift_end?: string | null
+          shift_start?: string | null
+          staff_profile_id?: string | null
+          summary?: string | null
+          updated_at?: string
+        }
+        Update: {
+          building_id?: number
+          created_at?: string
+          handoff_notes?: string | null
+          handoff_profile_id?: string | null
+          id?: number
+          issues?: string | null
+          shift_date?: string
+          shift_end?: string | null
+          shift_start?: string | null
+          staff_profile_id?: string | null
+          summary?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "shift_logs_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shift_logs_handoff_profile_id_fkey"
+            columns: ["handoff_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shift_logs_staff_profile_id_fkey"
+            columns: ["staff_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      units: {
+        Row: {
+          bathroom_count: number | null
+          bedroom_count: number | null
+          building_id: number
+          created_at: string
+          floor: string | null
+          id: number
+          square_feet: number | null
+          status: string
+          unit_number: string
+          updated_at: string
+        }
+        Insert: {
+          bathroom_count?: number | null
+          bedroom_count?: number | null
+          building_id: number
+          created_at?: string
+          floor?: string | null
+          id?: number
+          square_feet?: number | null
+          status?: string
+          unit_number: string
+          updated_at?: string
+        }
+        Update: {
+          bathroom_count?: number | null
+          bedroom_count?: number | null
+          building_id?: number
+          created_at?: string
+          floor?: string | null
+          id?: number
+          square_feet?: number | null
+          status?: string
+          unit_number?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "units_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      visitor_logs: {
+        Row: {
+          building_id: number
+          check_in: string
+          check_out: string | null
+          contact_information: string | null
+          created_at: string
+          created_by: string | null
+          government_id_number: string | null
+          government_id_type: string | null
+          host_contact: string | null
+          host_name: string | null
+          id: number
+          notes: string | null
+          purpose: string | null
+          unit_id: number | null
+          updated_at: string
+          visitor_name: string
+          visitor_type: string | null
+        }
+        Insert: {
+          building_id: number
+          check_in?: string
+          check_out?: string | null
+          contact_information?: string | null
+          created_at?: string
+          created_by?: string | null
+          government_id_number?: string | null
+          government_id_type?: string | null
+          host_contact?: string | null
+          host_name?: string | null
+          id?: number
+          notes?: string | null
+          purpose?: string | null
+          unit_id?: number | null
+          updated_at?: string
+          visitor_name: string
+          visitor_type?: string | null
+        }
+        Update: {
+          building_id?: number
+          check_in?: string
+          check_out?: string | null
+          contact_information?: string | null
+          created_at?: string
+          created_by?: string | null
+          government_id_number?: string | null
+          government_id_type?: string | null
+          host_contact?: string | null
+          host_name?: string | null
+          id?: number
+          notes?: string | null
+          purpose?: string | null
+          unit_id?: number | null
+          updated_at?: string
+          visitor_name?: string
+          visitor_type?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "visitor_logs_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_logs_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_logs_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       todos: {
         Row: {
           created_at: string

--- a/supabase/migrations/20250521_facility_operations.sql
+++ b/supabase/migrations/20250521_facility_operations.sql
@@ -1,0 +1,213 @@
+BEGIN;
+
+CREATE TABLE public.buildings (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  name text NOT NULL,
+  description text NULL,
+  address_line1 text NULL,
+  address_line2 text NULL,
+  city text NULL,
+  state text NULL,
+  postal_code text NULL,
+  country text NULL,
+  timezone text NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+ALTER TABLE public.buildings ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE public.units (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  building_id bigint NOT NULL REFERENCES public.buildings(id) ON DELETE CASCADE,
+  unit_number text NOT NULL,
+  floor text NULL,
+  bedroom_count integer NULL,
+  bathroom_count integer NULL,
+  square_feet integer NULL,
+  status text NOT NULL DEFAULT 'active',
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT units_unique_per_building UNIQUE (building_id, unit_number)
+);
+ALTER TABLE public.units ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_units_building_id ON public.units (building_id);
+
+CREATE TABLE public.carriers (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  name text NOT NULL,
+  contact_phone text NULL,
+  contact_email text NULL,
+  website text NULL,
+  notes text NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+ALTER TABLE public.carriers ENABLE ROW LEVEL SECURITY;
+CREATE UNIQUE INDEX idx_carriers_name_lower ON public.carriers ((lower(name)));
+
+CREATE TABLE public.package_logs (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  building_id bigint NOT NULL REFERENCES public.buildings(id) ON DELETE RESTRICT,
+  unit_id bigint NULL REFERENCES public.units(id) ON DELETE SET NULL,
+  carrier_id bigint NULL REFERENCES public.carriers(id) ON DELETE SET NULL,
+  tracking_number text NULL,
+  recipient_name text NOT NULL,
+  received_by uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  status text NOT NULL DEFAULT 'received',
+  received_at timestamp with time zone NOT NULL DEFAULT now(),
+  delivered_at timestamp with time zone NULL,
+  notified_at timestamp with time zone NULL,
+  picked_up_by text NULL,
+  picked_up_contact text NULL,
+  picked_up_at timestamp with time zone NULL,
+  notes text NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT package_logs_status_check CHECK (status IN ('received', 'in_storage', 'notified', 'picked_up', 'returned'))
+);
+ALTER TABLE public.package_logs ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_package_logs_building_id ON public.package_logs (building_id);
+CREATE INDEX idx_package_logs_unit_id ON public.package_logs (unit_id);
+CREATE INDEX idx_package_logs_tracking_number ON public.package_logs (tracking_number);
+
+CREATE TABLE public.package_signatures (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  package_log_id bigint NOT NULL REFERENCES public.package_logs(id) ON DELETE CASCADE,
+  signer_name text NOT NULL,
+  signer_type text NULL,
+  signed_at timestamp with time zone NOT NULL DEFAULT now(),
+  signature_notes text NULL,
+  captured_by uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL
+);
+ALTER TABLE public.package_signatures ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_package_signatures_package_log_id ON public.package_signatures (package_log_id);
+
+CREATE TABLE public.visitor_logs (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  building_id bigint NOT NULL REFERENCES public.buildings(id) ON DELETE RESTRICT,
+  unit_id bigint NULL REFERENCES public.units(id) ON DELETE SET NULL,
+  visitor_name text NOT NULL,
+  visitor_type text NULL,
+  contact_information text NULL,
+  government_id_type text NULL,
+  government_id_number text NULL,
+  check_in timestamp with time zone NOT NULL DEFAULT now(),
+  check_out timestamp with time zone NULL,
+  host_name text NULL,
+  host_contact text NULL,
+  purpose text NULL,
+  created_by uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  notes text NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+ALTER TABLE public.visitor_logs ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_visitor_logs_building_id ON public.visitor_logs (building_id);
+CREATE INDEX idx_visitor_logs_unit_id ON public.visitor_logs (unit_id);
+CREATE INDEX idx_visitor_logs_check_in ON public.visitor_logs (check_in);
+
+CREATE TABLE public.keys (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  building_id bigint NOT NULL REFERENCES public.buildings(id) ON DELETE RESTRICT,
+  unit_id bigint NULL REFERENCES public.units(id) ON DELETE SET NULL,
+  label text NOT NULL,
+  description text NULL,
+  status text NOT NULL DEFAULT 'available',
+  serial_number text NULL,
+  storage_location text NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT keys_status_check CHECK (status IN ('available', 'checked_out', 'lost', 'retired'))
+);
+ALTER TABLE public.keys ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_keys_building_id ON public.keys (building_id);
+CREATE INDEX idx_keys_unit_id ON public.keys (unit_id);
+CREATE UNIQUE INDEX idx_keys_building_label ON public.keys (building_id, label);
+
+CREATE TABLE public.key_transactions (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  key_id bigint NOT NULL REFERENCES public.keys(id) ON DELETE CASCADE,
+  building_id bigint NULL REFERENCES public.buildings(id) ON DELETE SET NULL,
+  unit_id bigint NULL REFERENCES public.units(id) ON DELETE SET NULL,
+  transaction_type text NOT NULL,
+  occurred_at timestamp with time zone NOT NULL DEFAULT now(),
+  handled_by uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  recipient_name text NULL,
+  recipient_contact text NULL,
+  due_at timestamp with time zone NULL,
+  returned_at timestamp with time zone NULL,
+  notes text NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT key_transactions_transaction_type_check CHECK (transaction_type IN ('checkout', 'return', 'audit', 'other'))
+);
+ALTER TABLE public.key_transactions ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_key_transactions_key_id ON public.key_transactions (key_id);
+CREATE INDEX idx_key_transactions_building_id ON public.key_transactions (building_id);
+CREATE INDEX idx_key_transactions_unit_id ON public.key_transactions (unit_id);
+
+CREATE TABLE public.shift_logs (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  building_id bigint NOT NULL REFERENCES public.buildings(id) ON DELETE RESTRICT,
+  shift_date date NOT NULL,
+  shift_start timestamp with time zone NULL,
+  shift_end timestamp with time zone NULL,
+  staff_profile_id uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  handoff_profile_id uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  summary text NULL,
+  handoff_notes text NULL,
+  issues text NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+ALTER TABLE public.shift_logs ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_shift_logs_building_id ON public.shift_logs (building_id);
+CREATE INDEX idx_shift_logs_shift_date ON public.shift_logs (shift_date);
+
+CREATE TABLE public.incident_reports (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  building_id bigint NOT NULL REFERENCES public.buildings(id) ON DELETE RESTRICT,
+  unit_id bigint NULL REFERENCES public.units(id) ON DELETE SET NULL,
+  shift_log_id bigint NULL REFERENCES public.shift_logs(id) ON DELETE SET NULL,
+  reported_by uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  reported_at timestamp with time zone NOT NULL DEFAULT now(),
+  incident_time timestamp with time zone NULL,
+  incident_type text NULL,
+  severity text NULL,
+  description text NOT NULL,
+  actions_taken text NULL,
+  follow_up_actions text NULL,
+  status text NOT NULL DEFAULT 'open',
+  closed_at timestamp with time zone NULL,
+  follow_up_at timestamp with time zone NULL,
+  notes text NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT incident_reports_status_check CHECK (status IN ('open', 'in_progress', 'closed'))
+);
+ALTER TABLE public.incident_reports ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_incident_reports_building_id ON public.incident_reports (building_id);
+CREATE INDEX idx_incident_reports_unit_id ON public.incident_reports (unit_id);
+
+CREATE TABLE public.attachments (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  entity_type text NOT NULL,
+  entity_id bigint NOT NULL,
+  s3_bucket text NOT NULL,
+  s3_key text NOT NULL,
+  file_name text NULL,
+  content_type text NULL,
+  file_size bigint NULL,
+  uploaded_by uuid NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  expires_at timestamp with time zone NULL,
+  retention_expires_at timestamp with time zone NULL,
+  notes text NULL,
+  CONSTRAINT attachments_entity_type_check CHECK (entity_type IN ('package_log', 'package_signature', 'visitor_log', 'incident_report', 'key_transaction', 'shift_log')),
+  CONSTRAINT attachments_s3_key_key UNIQUE (s3_key)
+);
+ALTER TABLE public.attachments ENABLE ROW LEVEL SECURITY;
+CREATE INDEX idx_attachments_entity ON public.attachments (entity_type, entity_id);
+CREATE INDEX idx_attachments_uploaded_by ON public.attachments (uploaded_by);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add building and unit tables plus facility operations tables for carriers, packages, visitors, keys, shifts, incidents, and attachments with indexes and constraints
- wire building/unit foreign keys into the new schema and extend the generated Supabase TypeScript definitions
- document attachment storage workflow and retention expectations for S3-backed objects

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceefb0e0288328a8385b5fef0167fb