### PR TITLE
feat: add staff operations dashboard

### DIFF
--- a/app/dashboard/staff/page.tsx
+++ b/app/dashboard/staff/page.tsx
@@ -1,0 +1,9 @@
+import { StaffOperationsDashboard } from "@/web/features/staff"
+
+export default function StaffPage() {
+  return (
+    <div className="space-y-6 pb-10">
+      <StaffOperationsDashboard />
+    </div>
+  )
+}

--- a/types/staff.ts
+++ b/types/staff.ts
@@ -1,0 +1,109 @@
+export type PackageStatus = "received" | "notified" | "picked_up"
+
+export type PackageRecord = {
+  id: string
+  trackingNumber: string
+  recipient: string
+  carrier: string
+  location: string
+  status: PackageStatus
+  receivedAt: string
+  notes?: string
+}
+
+export type VisitorStatus = "expected" | "checked_in" | "checked_out"
+
+export type VisitorRecord = {
+  id: string
+  name: string
+  company: string
+  host: string
+  purpose: string
+  badgeNumber: string
+  status: VisitorStatus
+  checkIn: string
+  checkOut?: string
+  contactNumber?: string
+  notes?: string
+}
+
+export type WorkOrderStatus = "new" | "in_progress" | "completed"
+
+export type WorkOrder = {
+  id: string
+  title: string
+  requestedBy: string
+  unit: string
+  priority: "low" | "medium" | "high"
+  category: "maintenance" | "cleaning" | "security" | "other"
+  status: WorkOrderStatus
+  updatedAt: string
+  dueDate?: string
+  details?: string
+}
+
+export type ShiftLogEntry = {
+  id: string
+  author: string
+  role: string
+  timestamp: string
+  type: "handover" | "note" | "alert"
+  summary: string
+  followUp?: string
+}
+
+export type IncidentSeverity = "minor" | "major" | "critical"
+
+export type IncidentReport = {
+  id: string
+  title: string
+  occurredAt: string
+  reportedBy: string
+  location: string
+  severity: IncidentSeverity
+  description: string
+  actionsTaken: string
+  witnesses?: string
+  attachments?: string[]
+}
+
+export type TimeBreak = {
+  id: string
+  startedAt: string
+  endedAt?: string
+}
+
+export type TimeSession = {
+  id: string
+  staffName: string
+  role: string
+  startedAt: string
+  endedAt?: string
+  notes?: string
+  breaks: TimeBreak[]
+}
+
+export type TimeTrackingState = {
+  activeSessions: TimeSession[]
+  history: TimeSession[]
+}
+
+export type ChecklistState = {
+  packageIntake: boolean
+  visitorSignIn: boolean
+  workOrderUpdated: boolean
+  shiftLogUpdated: boolean
+  incidentLogged: boolean
+  timeTracked: boolean
+}
+
+export type StaffOperationsState = {
+  version: number
+  packages: PackageRecord[]
+  visitors: VisitorRecord[]
+  workOrders: Record<WorkOrderStatus, WorkOrder[]>
+  shiftLog: ShiftLogEntry[]
+  incidents: IncidentReport[]
+  timeTracking: TimeTrackingState
+  checklist: ChecklistState
+}

--- a/web/features/staff/StaffOperationsDashboard.tsx
+++ b/web/features/staff/StaffOperationsDashboard.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { StaffOperationsProvider } from "./staff-operations-context"
+import { createSampleStaffOperationsState } from "./sample-data"
+import { IncidentReportForm } from "./components/IncidentReportForm"
+import { PackageIntakePanel } from "./components/PackageIntakePanel"
+import { ShiftLogTimeline } from "./components/ShiftLogTimeline"
+import { TimeTrackingPanel } from "./components/TimeTrackingPanel"
+import { UserAcceptanceChecklist } from "./components/UserAcceptanceChecklist"
+import { VisitorSignInPanel } from "./components/VisitorSignInPanel"
+import { WorkOrderBoard } from "./components/WorkOrderBoard"
+
+export const StaffOperationsDashboard = () => {
+  const initialState = useMemo(() => createSampleStaffOperationsState(), [])
+
+  return (
+    <StaffOperationsProvider initialData={initialState}>
+      <div className="flex flex-col gap-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Front-of-House Operations</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground">
+            A centralized command center for package intake, visitor management,
+            maintenance coordination, and shift accountability. Designed for
+            real-time collaboration across tablets and desktops.
+          </p>
+        </header>
+        <div className="grid gap-6 xl:grid-cols-2">
+          <div className="min-h-[420px]">
+            <PackageIntakePanel />
+          </div>
+          <div className="min-h-[420px]">
+            <VisitorSignInPanel />
+          </div>
+          <div className="xl:col-span-2 min-h-[520px]">
+            <WorkOrderBoard />
+          </div>
+          <div className="min-h-[420px]">
+            <ShiftLogTimeline />
+          </div>
+          <div className="min-h-[420px]">
+            <TimeTrackingPanel />
+          </div>
+          <div className="xl:col-span-2 min-h-[480px]">
+            <IncidentReportForm />
+          </div>
+          <div className="xl:col-span-2 min-h-[260px]">
+            <UserAcceptanceChecklist />
+          </div>
+        </div>
+      </div>
+    </StaffOperationsProvider>
+  )
+}

--- a/web/features/staff/components/IncidentReportForm.tsx
+++ b/web/features/staff/components/IncidentReportForm.tsx
@@ -1,0 +1,252 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMemo } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { IncidentReport, IncidentSeverity } from "@/types/staff"
+
+import { nowIsoString } from "../utils"
+import { useStaffOperations } from "../staff-operations-context"
+
+const incidentSchema = z.object({
+  actionsTaken: z.string().min(2, "Actions required"),
+  description: z.string().min(10, "Incident description required"),
+  location: z.string().min(2, "Location required"),
+  occurredAt: z.string().min(1, "Date/time required"),
+  reportedBy: z.string().min(2, "Reporter name required"),
+  severity: z.enum(["minor", "major", "critical"]),
+  title: z.string().min(4, "Title required"),
+  witnesses: z.string().optional(),
+})
+
+type IncidentFormValues = z.infer<typeof incidentSchema>
+
+const severityTone: Record<IncidentSeverity, string> = {
+  critical: "bg-red-600/20 text-red-700 dark:text-red-200",
+  major: "bg-amber-500/20 text-amber-700 dark:text-amber-200",
+  minor: "bg-slate-500/20 text-slate-700 dark:text-slate-200",
+}
+
+export const IncidentReportForm = () => {
+  const { addIncident, state } = useStaffOperations()
+
+  const form = useForm<IncidentFormValues>({
+    defaultValues: {
+      actionsTaken: "",
+      description: "",
+      location: "",
+      occurredAt: nowIsoString().slice(0, 16),
+      reportedBy: "",
+      severity: "minor",
+      title: "",
+      witnesses: "",
+    },
+    resolver: zodResolver(incidentSchema),
+  })
+
+  const incidents = useMemo(() => state.incidents.slice(0, 6), [state.incidents])
+
+  const handleSubmit = (values: IncidentFormValues) => {
+    const incident: IncidentReport = {
+      id: `incident-${Date.now()}`,
+      attachments: [],
+      occurredAt: values.occurredAt,
+      ...values,
+    }
+    addIncident(incident)
+    form.reset({ ...values, actionsTaken: "", description: "", title: "", witnesses: "" })
+  }
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-xl">Incident Reporting</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Capture critical events with mandatory follow-up information. All
+          submissions feed the operations audit trail automatically.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="grid gap-4 md:grid-cols-6">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem className="md:col-span-3">
+                  <FormLabel>Incident Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Short headline" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="severity"
+              render={({ field }) => (
+                <FormItem className="md:col-span-1">
+                  <FormLabel>Severity</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Severity" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent align="start">
+                      <SelectItem value="minor">Minor</SelectItem>
+                      <SelectItem value="major">Major</SelectItem>
+                      <SelectItem value="critical">Critical</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="occurredAt"
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel>Occurred</FormLabel>
+                  <FormControl>
+                    <Input type="datetime-local" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="location"
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel>Location</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Lobby, unit, parking" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="reportedBy"
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel>Reported By</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Staff name" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="witnesses"
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel>Witnesses</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Optional" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem className="md:col-span-6">
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Chronological account of what happened"
+                      className="min-h-[100px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="actionsTaken"
+              render={({ field }) => (
+                <FormItem className="md:col-span-6">
+                  <FormLabel>Immediate Actions</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Who was notified and what steps were taken"
+                      className="min-h-[80px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="md:col-span-6 flex flex-col gap-3 md:flex-row md:items-center">
+              <Button type="submit" className="md:w-48">
+                Submit Incident
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                Critical incidents trigger additional alerts via the shared realtime
+                channel.
+              </p>
+            </div>
+          </form>
+        </Form>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold">Recent Reports</h3>
+            <span className="text-sm text-muted-foreground">Latest 6</span>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {incidents.map((incident) => (
+              <article key={incident.id} className="rounded-lg border p-4 shadow-sm">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h4 className="font-semibold leading-tight">{incident.title}</h4>
+                    <p className="text-xs text-muted-foreground">
+                      {new Date(incident.occurredAt).toLocaleString()} · {incident.location}
+                    </p>
+                  </div>
+                  <Badge className={severityTone[incident.severity]}>{incident.severity}</Badge>
+                </div>
+                <p className="mt-3 text-sm">{incident.description}</p>
+                <p className="mt-2 rounded-md bg-muted/60 p-2 text-xs text-muted-foreground">
+                  Actions: {incident.actionsTaken}
+                </p>
+                {incident.witnesses ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Witnesses: {incident.witnesses}
+                  </p>
+                ) : null}
+              </article>
+            ))}
+            {incidents.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                No incidents logged yet. Submit the form above to test the reporting
+                workflow.
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/features/staff/components/PackageIntakePanel.tsx
+++ b/web/features/staff/components/PackageIntakePanel.tsx
@@ -1,0 +1,266 @@
+"use client"
+
+import { useMemo } from "react"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import type { PackageRecord, PackageStatus } from "@/types/staff"
+
+import { nowIsoString } from "../utils"
+import { useStaffOperations } from "../staff-operations-context"
+
+const packageSchema = z.object({
+  carrier: z.string().min(2, "Carrier required"),
+  location: z.string().min(2, "Location required"),
+  notes: z.string().optional(),
+  recipient: z.string().min(2, "Recipient required"),
+  trackingNumber: z.string().min(5, "Tracking number required"),
+})
+
+type PackageFormValues = z.infer<typeof packageSchema>
+
+const statusLabels: Record<PackageStatus, string> = {
+  notified: "Notified",
+  picked_up: "Picked Up",
+  received: "Received",
+}
+
+const statusIntent: Record<PackageStatus, string> = {
+  notified: "bg-amber-500/20 text-amber-700 dark:text-amber-200",
+  picked_up: "bg-emerald-500/20 text-emerald-700 dark:text-emerald-200",
+  received: "bg-slate-500/20 text-slate-700 dark:text-slate-200",
+}
+
+export const PackageIntakePanel = () => {
+  const { addPackage, state, updatePackageStatus } = useStaffOperations()
+
+  const form = useForm<PackageFormValues>({
+    defaultValues: {
+      carrier: "",
+      location: "Front Desk",
+      notes: "",
+      recipient: "",
+      trackingNumber: "",
+    },
+    mode: "onBlur",
+    resolver: zodResolver(packageSchema),
+  })
+
+  const packages = useMemo(() => state.packages.slice(0, 10), [state.packages])
+
+  const handleSubmit = (values: PackageFormValues) => {
+    const newPackage: PackageRecord = {
+      id: values.trackingNumber,
+      receivedAt: nowIsoString(),
+      status: "received",
+      ...values,
+    }
+    addPackage(newPackage)
+    form.reset()
+  }
+
+  const handleSimulatedScan = () => {
+    const simulatedCode = `PKG-${Math.random().toString(36).slice(2, 8).toUpperCase()}`
+    form.setValue("trackingNumber", simulatedCode, { shouldValidate: true })
+  }
+
+  const handleStatusChange = (id: string, status: PackageStatus) => {
+    updatePackageStatus(id, status)
+  }
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-xl">Package Intake</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Scan and manage incoming deliveries. Optimized for quick tablet entry
+          with large touch targets and inline status updates.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-6">
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="grid gap-4 md:grid-cols-2"
+          >
+            <FormField
+              control={form.control}
+              name="trackingNumber"
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel>Tracking Number</FormLabel>
+                  <div className="flex flex-col gap-3 md:flex-row">
+                    <FormControl>
+                      <Input
+                        placeholder="Scan or enter tracking number"
+                        {...field}
+                        className="text-base md:text-lg"
+                      />
+                    </FormControl>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={handleSimulatedScan}
+                      className="md:w-48"
+                    >
+                      Simulate Scan
+                    </Button>
+                  </div>
+                  <FormDescription>
+                    Compatible with keyboard wedge scanners. Use the simulator when
+                    testing without hardware.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="recipient"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Recipient</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Resident or team member" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="carrier"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Carrier</FormLabel>
+                  <FormControl>
+                    <Input placeholder="USPS, UPS, FedEx" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="location"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Storage Location</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Package room shelf" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel>Notes</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Damage, oversized handling, or delivery instructions"
+                      className="min-h-[80px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="md:col-span-2 flex flex-col gap-3 md:flex-row md:items-center">
+              <Button type="submit" className="md:w-40">
+                Add Package
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                Submissions instantly sync with connected tablets through
+                BroadcastChannel/WebSocket fallbacks.
+              </p>
+            </div>
+          </form>
+        </Form>
+        <Separator />
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold">Recent Packages</h3>
+            <span className="text-sm text-muted-foreground">Showing latest 10</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {packages.map((packageItem) => (
+              <div
+                key={packageItem.id}
+                className="rounded-lg border p-4 shadow-sm transition hover:border-primary md:p-5"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium">{packageItem.trackingNumber}</p>
+                    <p className="text-xs text-muted-foreground">{packageItem.carrier}</p>
+                  </div>
+                  <Badge className={statusIntent[packageItem.status]}>
+                    {statusLabels[packageItem.status]}
+                  </Badge>
+                </div>
+                <dl className="mt-3 space-y-1 text-sm">
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Recipient</dt>
+                    <dd>{packageItem.recipient}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Location</dt>
+                    <dd>{packageItem.location}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Received</dt>
+                    <dd>{new Date(packageItem.receivedAt).toLocaleString()}</dd>
+                  </div>
+                </dl>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {(["received", "notified", "picked_up"] as PackageStatus[]).map((status) => (
+                    <Button
+                      key={status}
+                      variant={packageItem.status === status ? "default" : "outline"}
+                      size="sm"
+                      className="flex-1"
+                      onClick={() => handleStatusChange(packageItem.id, status)}
+                    >
+                      {statusLabels[status]}
+                    </Button>
+                  ))}
+                </div>
+                {packageItem.notes ? (
+                  <p className="mt-3 rounded-md bg-muted p-2 text-xs text-muted-foreground">
+                    {packageItem.notes}
+                  </p>
+                ) : null}
+              </div>
+            ))}
+            {packages.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                No packages logged yet today. Use the form above to intake the first
+                delivery.
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/features/staff/components/ShiftLogTimeline.tsx
+++ b/web/features/staff/components/ShiftLogTimeline.tsx
@@ -1,0 +1,197 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMemo } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { ShiftLogEntry } from "@/types/staff"
+
+import { nowIsoString } from "../utils"
+import { useStaffOperations } from "../staff-operations-context"
+
+const shiftSchema = z.object({
+  author: z.string().min(2, "Name required"),
+  followUp: z.string().optional(),
+  role: z.string().min(2, "Role required"),
+  summary: z.string().min(4, "Summary required"),
+  type: z.enum(["handover", "note", "alert"]),
+})
+
+type ShiftFormValues = z.infer<typeof shiftSchema>
+
+const typeCopy: Record<ShiftLogEntry["type"], { label: string; tone: string }> = {
+  alert: { label: "Alert", tone: "bg-red-500/20 text-red-700 dark:text-red-200" },
+  handover: { label: "Handover", tone: "bg-emerald-500/20 text-emerald-700 dark:text-emerald-200" },
+  note: { label: "Note", tone: "bg-slate-500/20 text-slate-700 dark:text-slate-200" },
+}
+
+export const ShiftLogTimeline = () => {
+  const { addShiftEntry, state } = useStaffOperations()
+
+  const form = useForm<ShiftFormValues>({
+    defaultValues: {
+      author: "",
+      followUp: "",
+      role: "",
+      summary: "",
+      type: "handover",
+    },
+    resolver: zodResolver(shiftSchema),
+  })
+
+  const timeline = useMemo(() => state.shiftLog.slice(0, 12), [state.shiftLog])
+
+  const handleSubmit = (values: ShiftFormValues) => {
+    const entry: ShiftLogEntry = {
+      id: `shift-${Date.now()}`,
+      timestamp: nowIsoString(),
+      ...values,
+    }
+    addShiftEntry(entry)
+    form.reset({ ...values, summary: "", followUp: "" })
+  }
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-xl">Shift Log Timeline</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Maintain a chronological record of every handoff, alert, and important
+          note. Entries automatically roll into the incident checklist.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="grid gap-4 md:grid-cols-5">
+            <FormField
+              control={form.control}
+              name="author"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Team Member</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Name" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Front desk, security" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Entry Type</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="handover">Handover</SelectItem>
+                      <SelectItem value="note">Note</SelectItem>
+                      <SelectItem value="alert">Alert</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="summary"
+              render={({ field }) => (
+                <FormItem className="md:col-span-5">
+                  <FormLabel>Summary</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Key details shared at shift change"
+                      className="min-h-[70px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="followUp"
+              render={({ field }) => (
+                <FormItem className="md:col-span-5">
+                  <FormLabel>Follow Up Tasks</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Outstanding actions or watch-outs"
+                      className="min-h-[60px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="md:col-span-5 flex flex-col gap-3 md:flex-row md:items-center">
+              <Button type="submit" className="md:w-44">
+                Log Entry
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                Timeline is instantly synced across active shifts with our
+                BroadcastChannel/WebSocket bridge.
+              </p>
+            </div>
+          </form>
+        </Form>
+        <ol className="relative space-y-4 border-s border-dashed px-4 py-2 md:px-8">
+          {timeline.map((entry) => (
+            <li key={entry.id} className="space-y-2 ps-6">
+              <span className="absolute -ms-1 mt-2 h-2 w-2 rounded-full bg-primary" aria-hidden />
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="font-medium leading-tight">
+                    {entry.author} · <span className="text-muted-foreground">{entry.role}</span>
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {new Date(entry.timestamp).toLocaleString()}
+                  </p>
+                </div>
+                <Badge className={typeCopy[entry.type].tone}>{typeCopy[entry.type].label}</Badge>
+              </div>
+              <p className="rounded-md bg-muted/60 p-3 text-sm">{entry.summary}</p>
+              {entry.followUp ? (
+                <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+                  Follow up: {entry.followUp}
+                </p>
+              ) : null}
+            </li>
+          ))}
+          {timeline.length === 0 ? (
+            <li className="ps-6 text-sm text-muted-foreground">No shift notes logged yet.</li>
+          ) : null}
+        </ol>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/features/staff/components/TimeTrackingPanel.tsx
+++ b/web/features/staff/components/TimeTrackingPanel.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMemo } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import type { TimeSession } from "@/types/staff"
+
+import { nowIsoString } from "../utils"
+import { useStaffOperations } from "../staff-operations-context"
+
+const startShiftSchema = z.object({
+  notes: z.string().optional(),
+  role: z.string().min(2, "Role required"),
+  staffName: z.string().min(2, "Staff name required"),
+})
+
+type StartShiftValues = z.infer<typeof startShiftSchema>
+
+export const TimeTrackingPanel = () => {
+  const { startSession, state, stopSession, toggleBreak } = useStaffOperations()
+
+  const form = useForm<StartShiftValues>({
+    defaultValues: {
+      notes: "",
+      role: "",
+      staffName: "",
+    },
+    resolver: zodResolver(startShiftSchema),
+  })
+
+  const activeSessions = useMemo(() => state.timeTracking.activeSessions, [state.timeTracking.activeSessions])
+  const recentSessions = useMemo(() => state.timeTracking.history.slice(0, 5), [state.timeTracking.history])
+
+  const handleStartShift = (values: StartShiftValues) => {
+    const session: TimeSession = {
+      id: `shift-${values.staffName}-${Date.now()}`,
+      breaks: [],
+      notes: values.notes,
+      role: values.role,
+      staffName: values.staffName,
+      startedAt: nowIsoString(),
+    }
+    startSession(session)
+    form.reset({ ...values, notes: "" })
+  }
+
+  const handleEndShift = (session: TimeSession) => {
+    stopSession({ id: session.id, endedAt: nowIsoString(), notes: session.notes })
+  }
+
+  const handleBreakToggle = (session: TimeSession) => {
+    toggleBreak({ id: session.id, timestamp: nowIsoString() })
+  }
+
+  const isOnBreak = (session: TimeSession) => session.breaks.some((entry) => !entry.endedAt)
+
+  const formatBreakSummary = (session: TimeSession) => {
+    if (session.breaks.length === 0) {
+      return "None"
+    }
+    const labels = session.breaks
+      .map((breakEntry) => {
+        if (!breakEntry.endedAt) {
+          return "Active"
+        }
+        const minutes = Math.round(
+          (new Date(breakEntry.endedAt).getTime() - new Date(breakEntry.startedAt).getTime()) /
+            60000,
+        )
+        return `${minutes}m`
+      })
+      .join(", ")
+    return `${session.breaks.length} (${labels})`
+  }
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-xl">Time Tracking</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Manage shift clocks and breaks directly from a shared device. All events
+          sync instantly with other connected tablets.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleStartShift)} className="grid gap-4 md:grid-cols-3">
+            <FormField
+              control={form.control}
+              name="staffName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Team Member</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Name" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Front desk, maintenance" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem className="md:col-span-3">
+                  <FormLabel>Shift Notes</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Optional context or tasks"
+                      className="min-h-[60px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="md:col-span-3 flex flex-col gap-3 md:flex-row md:items-center">
+              <Button type="submit" className="md:w-48">
+                Start Shift
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                Shifts are tracked locally with BroadcastChannel sync fallback.
+              </p>
+            </div>
+          </form>
+        </Form>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <section className="space-y-3">
+            <header className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold">Active Sessions</h3>
+              <Badge variant="secondary">{activeSessions.length}</Badge>
+            </header>
+            <div className="space-y-3">
+              {activeSessions.map((session) => (
+                <article key={session.id} className="rounded-lg border p-4 shadow-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <h4 className="font-semibold leading-tight">{session.staffName}</h4>
+                      <p className="text-xs text-muted-foreground">{session.role}</p>
+                    </div>
+                    <Badge>{isOnBreak(session) ? "On Break" : "Clocked In"}</Badge>
+                  </div>
+                  <dl className="mt-3 space-y-1 text-sm">
+                    <div className="flex items-center justify-between">
+                      <dt className="text-muted-foreground">Started</dt>
+                      <dd>{new Date(session.startedAt).toLocaleTimeString()}</dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt className="text-muted-foreground">Breaks</dt>
+                      <dd>{formatBreakSummary(session)}</dd>
+                    </div>
+                  </dl>
+                  {session.notes ? (
+                    <p className="mt-3 rounded-md bg-muted/60 p-2 text-xs text-muted-foreground">
+                      {session.notes}
+                    </p>
+                  ) : null}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => handleBreakToggle(session)}
+                    >
+                      {isOnBreak(session) ? "Resume" : "Break"}
+                    </Button>
+                    <Button type="button" size="sm" onClick={() => handleEndShift(session)}>
+                      End Shift
+                    </Button>
+                  </div>
+                </article>
+              ))}
+              {activeSessions.length === 0 ? (
+                <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  Nobody is clocked in. Use the form above to start a session.
+                </div>
+              ) : null}
+            </div>
+          </section>
+          <section className="space-y-3">
+            <header className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold">Completed Sessions</h3>
+              <Badge variant="secondary">{recentSessions.length}</Badge>
+            </header>
+            <div className="space-y-3">
+              {recentSessions.map((session) => (
+                <article key={session.id} className="rounded-lg border p-4 shadow-sm">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h4 className="font-semibold leading-tight">{session.staffName}</h4>
+                      <p className="text-xs text-muted-foreground">{session.role}</p>
+                    </div>
+                    <Badge variant="outline">{session.breaks.length} breaks</Badge>
+                  </div>
+                  <dl className="mt-3 space-y-1 text-sm">
+                    <div className="flex items-center justify-between">
+                      <dt className="text-muted-foreground">Start</dt>
+                      <dd>{new Date(session.startedAt).toLocaleString()}</dd>
+                    </div>
+                    {session.endedAt ? (
+                      <div className="flex items-center justify-between">
+                        <dt className="text-muted-foreground">End</dt>
+                        <dd>{new Date(session.endedAt).toLocaleString()}</dd>
+                      </div>
+                    ) : null}
+                  </dl>
+                  {session.notes ? (
+                    <p className="mt-3 rounded-md bg-muted/60 p-2 text-xs text-muted-foreground">
+                      {session.notes}
+                    </p>
+                  ) : null}
+                </article>
+              ))}
+              {recentSessions.length === 0 ? (
+                <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  No completed sessions yet today.
+                </div>
+              ) : null}
+            </div>
+          </section>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/features/staff/components/UserAcceptanceChecklist.tsx
+++ b/web/features/staff/components/UserAcceptanceChecklist.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import type { ChecklistState } from "@/types/staff"
+
+import { useStaffOperations } from "../staff-operations-context"
+
+const checklistConfig: { key: keyof ChecklistState; label: string; description: string }[] = [
+  {
+    description: "Add a new package and advance it to another status.",
+    key: "packageIntake",
+    label: "Package intake flow",
+  },
+  {
+    description: "Sign in a visitor and confirm they appear in the ledger.",
+    key: "visitorSignIn",
+    label: "Visitor sign-in flow",
+  },
+  {
+    description: "Create a work order and move it across at least one column.",
+    key: "workOrderUpdated",
+    label: "Work order board",
+  },
+  {
+    description: "Log a shift note to confirm the timeline updates.",
+    key: "shiftLogUpdated",
+    label: "Shift timeline",
+  },
+  {
+    description: "Submit an incident report with required details.",
+    key: "incidentLogged",
+    label: "Incident reporting",
+  },
+  {
+    description: "Start and end a shift session to capture time tracking.",
+    key: "timeTracked",
+    label: "Time tracking",
+  },
+]
+
+export const UserAcceptanceChecklist = () => {
+  const { state } = useStaffOperations()
+
+  const completedCount = useMemo(() => {
+    return checklistConfig.filter((item) => state.checklist[item.key]).length
+  }, [state.checklist])
+
+  const progress = Math.round((completedCount / checklistConfig.length) * 100)
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-xl">User Acceptance Checklist</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Confirm each core workflow has been exercised. Progress updates as flows
+          are completed, ensuring a reliable demo script.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-6">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">Progress</span>
+            <Badge variant={progress === 100 ? "default" : "secondary"}>{progress}%</Badge>
+          </div>
+          <Progress value={progress} className="h-3" />
+        </div>
+        <div className="space-y-3">
+          {checklistConfig.map((item) => (
+            <div
+              key={item.key}
+              className="flex items-start justify-between gap-3 rounded-lg border p-4"
+            >
+              <div className="space-y-1">
+                <p className="text-sm font-medium leading-tight">{item.label}</p>
+                <p className="text-xs text-muted-foreground">{item.description}</p>
+              </div>
+              <Badge variant={state.checklist[item.key] ? "default" : "outline"}>
+                {state.checklist[item.key] ? "Complete" : "Pending"}
+              </Badge>
+            </div>
+          ))}
+        </div>
+        <div className="mt-auto space-y-2 rounded-md bg-muted/60 p-4 text-sm text-muted-foreground">
+          <p>
+            Tip: broadcast updates propagate through WebSockets when configured via
+            <code className="mx-1 rounded bg-background px-1 py-0.5 text-xs">NEXT_PUBLIC_STAFF_SOCKET_URL</code>
+            and fall back to shared storage polling.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              if (typeof window !== "undefined") {
+                window.print()
+              }
+            }}
+          >
+            Export Checklist
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/features/staff/components/VisitorSignInPanel.tsx
+++ b/web/features/staff/components/VisitorSignInPanel.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMemo } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import type { VisitorRecord, VisitorStatus } from "@/types/staff"
+
+import { nowIsoString } from "../utils"
+import { useStaffOperations } from "../staff-operations-context"
+
+const visitorSchema = z.object({
+  badgeNumber: z.string().min(1, "Badge number required"),
+  company: z.string().min(1, "Company required"),
+  contactNumber: z.string().optional(),
+  host: z.string().min(1, "Host required"),
+  name: z.string().min(2, "Visitor name required"),
+  notes: z.string().optional(),
+  purpose: z.string().min(2, "Purpose required"),
+})
+
+type VisitorFormValues = z.infer<typeof visitorSchema>
+
+const visitorStatusTone: Record<VisitorStatus, string> = {
+  checked_in: "bg-emerald-500/20 text-emerald-700 dark:text-emerald-200",
+  checked_out: "bg-slate-500/20 text-slate-700 dark:text-slate-200",
+  expected: "bg-amber-500/20 text-amber-700 dark:text-amber-200",
+}
+
+const visitorStatusLabel: Record<VisitorStatus, string> = {
+  checked_in: "On Site",
+  checked_out: "Checked Out",
+  expected: "Expected",
+}
+
+export const VisitorSignInPanel = () => {
+  const { addVisitor, state, updateVisitorStatus } = useStaffOperations()
+
+  const form = useForm<VisitorFormValues>({
+    defaultValues: {
+      badgeNumber: "",
+      company: "",
+      contactNumber: "",
+      host: "",
+      name: "",
+      notes: "",
+      purpose: "Meeting",
+    },
+    resolver: zodResolver(visitorSchema),
+  })
+
+  const visitors = useMemo(() => state.visitors.slice(0, 10), [state.visitors])
+  const activeVisitors = visitors.filter((visitor) => visitor.status === "checked_in")
+
+  const handleSubmit = (values: VisitorFormValues) => {
+    const visitor: VisitorRecord = {
+      id: `${values.badgeNumber}-${Date.now()}`,
+      status: "checked_in",
+      checkIn: nowIsoString(),
+      ...values,
+    }
+    addVisitor(visitor)
+    form.reset({ ...values, badgeNumber: "", company: "", host: "", name: "", notes: "" })
+  }
+
+  const handleCheckOut = (id: string) => {
+    updateVisitorStatus(id, "checked_out")
+  }
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-xl">Visitor Sign-In</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Capture arrivals in real time and keep track of active badges. Designed
+          for lobby tablets with spacious form controls.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="grid gap-4 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Visitor Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Full name" {...field} className="text-base" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="company"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Company</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Organization" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="host"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Host</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Resident or team member" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="purpose"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Purpose</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Meeting, delivery, interview" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="badgeNumber"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Badge</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Badge ID" {...field} className="uppercase" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="contactNumber"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Contact Number</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Optional" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel>Notes</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Special instructions or follow-up"
+                      className="min-h-[80px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="md:col-span-2 flex flex-col gap-3 md:flex-row md:items-center">
+              <Button type="submit" className="md:w-48">
+                Sign In Visitor
+              </Button>
+              <div className="flex flex-1 flex-wrap gap-3 text-sm text-muted-foreground">
+                <span>{activeVisitors.length} on site</span>
+                <span>Badges ready: {visitors.length}</span>
+                <span>Checklist sync via realtime channel</span>
+              </div>
+            </div>
+          </form>
+        </Form>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold">Visitor Ledger</h3>
+            <span className="text-sm text-muted-foreground">Latest 10 entries</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {visitors.map((visitor) => (
+              <div key={visitor.id} className="rounded-lg border p-4 shadow-sm">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{visitor.name}</p>
+                    <p className="text-xs text-muted-foreground">{visitor.company}</p>
+                  </div>
+                  <Badge className={visitorStatusTone[visitor.status]}>
+                    {visitorStatusLabel[visitor.status]}
+                  </Badge>
+                </div>
+                <dl className="mt-3 space-y-1 text-sm">
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Host</dt>
+                    <dd>{visitor.host}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Badge</dt>
+                    <dd>{visitor.badgeNumber}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Check-In</dt>
+                    <dd>{new Date(visitor.checkIn).toLocaleTimeString()}</dd>
+                  </div>
+                  {visitor.checkOut ? (
+                    <div className="flex items-center justify-between">
+                      <dt className="text-muted-foreground">Check-Out</dt>
+                      <dd>{new Date(visitor.checkOut).toLocaleTimeString()}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={visitor.status !== "checked_in"}
+                    className="md:w-32"
+                    onClick={() => handleCheckOut(visitor.id)}
+                  >
+                    Complete Visit
+                  </Button>
+                </div>
+                {visitor.notes ? (
+                  <p className="mt-3 rounded-md bg-muted p-2 text-xs text-muted-foreground">
+                    {visitor.notes}
+                  </p>
+                ) : null}
+              </div>
+            ))}
+            {visitors.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                No visitors signed in. Complete the tablet workflow above to verify
+                the checklist.
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/features/staff/components/WorkOrderBoard.tsx
+++ b/web/features/staff/components/WorkOrderBoard.tsx
@@ -1,0 +1,295 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMemo } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { WorkOrder, WorkOrderStatus } from "@/types/staff"
+
+import { nowIsoString } from "../utils"
+import { useStaffOperations } from "../staff-operations-context"
+
+const workOrderSchema = z.object({
+  category: z.enum(["maintenance", "cleaning", "security", "other"]),
+  details: z.string().optional(),
+  priority: z.enum(["low", "medium", "high"]),
+  requestedBy: z.string().min(2, "Requester required"),
+  title: z.string().min(2, "Title required"),
+  unit: z.string().min(1, "Unit required"),
+})
+
+type WorkOrderFormValues = z.infer<typeof workOrderSchema>
+
+const statusDefinitions: { key: WorkOrderStatus; label: string; description: string }[] = [
+  { key: "new", label: "New", description: "Requests awaiting triage" },
+  { key: "in_progress", label: "In Progress", description: "Active assignments" },
+  { key: "completed", label: "Completed", description: "Ready to close" },
+]
+
+const priorityColor: Record<WorkOrder["priority"], string> = {
+  high: "bg-red-500/20 text-red-700 dark:text-red-200",
+  low: "bg-slate-500/20 text-slate-700 dark:text-slate-200",
+  medium: "bg-amber-500/20 text-amber-700 dark:text-amber-200",
+}
+
+export const WorkOrderBoard = () => {
+  const { addWorkOrder, moveWorkOrder, state } = useStaffOperations()
+
+  const form = useForm<WorkOrderFormValues>({
+    defaultValues: {
+      category: "maintenance",
+      details: "",
+      priority: "medium",
+      requestedBy: "",
+      title: "",
+      unit: "",
+    },
+    resolver: zodResolver(workOrderSchema),
+  })
+
+  const workOrders = useMemo(() => state.workOrders, [state.workOrders])
+
+  const handleSubmit = (values: WorkOrderFormValues) => {
+    const workOrder: WorkOrder = {
+      id: `wo-${Date.now()}`,
+      status: "new",
+      updatedAt: nowIsoString(),
+      ...values,
+    }
+    addWorkOrder(workOrder)
+    form.reset({ ...values, details: "", requestedBy: "", title: "", unit: "" })
+  }
+
+  const handleDrop = (status: WorkOrderStatus, event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    const identifier = event.dataTransfer.getData("application/work-order")
+    if (!identifier) {
+      return
+    }
+    moveWorkOrder(identifier, status)
+  }
+
+  const handleDragStart = (id: string, event: React.DragEvent<HTMLDivElement>) => {
+    event.dataTransfer.setData("application/work-order", id)
+    event.dataTransfer.effectAllowed = "move"
+  }
+
+  const cycleStatus = (order: WorkOrder) => {
+    const flow: WorkOrderStatus[] = ["new", "in_progress", "completed"]
+    const currentIndex = flow.indexOf(order.status)
+    const nextStatus = flow[Math.min(currentIndex + 1, flow.length - 1)]
+    if (nextStatus !== order.status) {
+      moveWorkOrder(order.id, nextStatus)
+    }
+  }
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-xl">Work Order Board</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Drag-and-drop requests between queues or tap the quick action button on
+          touch devices. Updates broadcast immediately across consoles.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-6">
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="grid gap-4 md:grid-cols-6"
+          >
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Short summary" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="unit"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Unit</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Apt 3B" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="requestedBy"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Requested By</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Resident" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="priority"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Priority</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Priority" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent align="start">
+                      <SelectItem value="low">Low</SelectItem>
+                      <SelectItem value="medium">Medium</SelectItem>
+                      <SelectItem value="high">High</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="category"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Category</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Category" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent align="start">
+                      <SelectItem value="maintenance">Maintenance</SelectItem>
+                      <SelectItem value="cleaning">Cleaning</SelectItem>
+                      <SelectItem value="security">Security</SelectItem>
+                      <SelectItem value="other">Other</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="details"
+              render={({ field }) => (
+                <FormItem className="md:col-span-6">
+                  <FormLabel>Details</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Steps taken, vendor contact, or escalation notes"
+                      className="min-h-[70px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="md:col-span-6 flex flex-col gap-3 md:flex-row md:items-center">
+              <Button type="submit" className="md:w-44">
+                Add Request
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                Drag cards to reprioritize or tap “Advance Stage” to move them on
+                touch-only devices.
+              </p>
+            </div>
+          </form>
+        </Form>
+        <div className="grid gap-4 lg:grid-cols-3">
+          {statusDefinitions.map((status) => (
+            <section
+              key={status.key}
+              className="flex flex-1 flex-col rounded-lg border bg-card"
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={(event) => handleDrop(status.key, event)}
+            >
+              <header className="flex items-center justify-between rounded-t-lg bg-muted/60 p-4">
+                <div>
+                  <h3 className="font-semibold">{status.label}</h3>
+                  <p className="text-xs text-muted-foreground">{status.description}</p>
+                </div>
+                <Badge variant="secondary">{workOrders[status.key].length}</Badge>
+              </header>
+              <div className="flex flex-1 flex-col gap-3 p-4">
+                {workOrders[status.key].map((order) => (
+                  <article
+                    key={order.id}
+                    draggable
+                    onDragStart={(event) => handleDragStart(order.id, event)}
+                    className="touch-manipulation rounded-lg border bg-background p-4 shadow-sm transition hover:border-primary focus-within:ring-2 focus-within:ring-primary"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <h4 className="text-sm font-semibold">{order.title}</h4>
+                        <p className="text-xs text-muted-foreground">{order.unit}</p>
+                      </div>
+                      <Badge className={priorityColor[order.priority]}>{order.priority}</Badge>
+                    </div>
+                    <dl className="mt-3 space-y-1 text-xs md:text-sm">
+                      <div className="flex items-center justify-between">
+                        <dt className="text-muted-foreground">Requested by</dt>
+                        <dd>{order.requestedBy}</dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt className="text-muted-foreground">Category</dt>
+                        <dd className="capitalize">{order.category}</dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt className="text-muted-foreground">Updated</dt>
+                        <dd>{new Date(order.updatedAt).toLocaleString()}</dd>
+                      </div>
+                    </dl>
+                    {order.details ? (
+                      <p className="mt-2 rounded-md bg-muted/60 p-2 text-xs text-muted-foreground">
+                        {order.details}
+                      </p>
+                    ) : null}
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="flex-1"
+                        variant="secondary"
+                        onClick={() => cycleStatus(order)}
+                      >
+                        Advance Stage
+                      </Button>
+                    </div>
+                  </article>
+                ))}
+                {workOrders[status.key].length === 0 ? (
+                  <div className="flex flex-1 items-center justify-center rounded-md border border-dashed p-6 text-center text-xs text-muted-foreground">
+                    Drop items here or use the form above to seed this lane.
+                  </div>
+                ) : null}
+              </div>
+            </section>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/features/staff/index.ts
+++ b/web/features/staff/index.ts
@@ -1,0 +1,3 @@
+export { StaffOperationsDashboard } from "./StaffOperationsDashboard"
+export { StaffOperationsProvider, useStaffOperations } from "./staff-operations-context"
+export { createSampleStaffOperationsState } from "./sample-data"

--- a/web/features/staff/sample-data.ts
+++ b/web/features/staff/sample-data.ts
@@ -1,0 +1,119 @@
+import type { StaffOperationsState } from "@/types/staff"
+
+import { nowIsoString } from "./utils"
+
+export const createSampleStaffOperationsState = (): StaffOperationsState => {
+  const now = new Date()
+  const isoNow = nowIsoString()
+  return {
+    version: 1,
+    checklist: {
+      incidentLogged: false,
+      packageIntake: false,
+      shiftLogUpdated: false,
+      timeTracked: false,
+      visitorSignIn: false,
+      workOrderUpdated: false,
+    },
+    incidents: [
+      {
+        actionsTaken: "Reset fire panel and notified facilities director.",
+        description: "Smoke detector triggered in laundry room due to dryer lint build up.",
+        id: "incident-seed-1",
+        location: "Laundry Room",
+        occurredAt: new Date(now.getTime() - 1000 * 60 * 45).toISOString(),
+        reportedBy: "Jordan",
+        severity: "minor",
+        title: "Laundry smoke alert",
+        witnesses: "Resident #204",
+        attachments: [],
+      },
+    ],
+    packages: [
+      {
+        carrier: "UPS",
+        id: "1Z999AA10123456784",
+        location: "Package Room Shelf B",
+        notes: "Oversized box, request dolly for pickup.",
+        recipient: "Alex Rivera",
+        receivedAt: new Date(now.getTime() - 1000 * 60 * 30).toISOString(),
+        status: "received",
+        trackingNumber: "1Z999AA10123456784",
+      },
+      {
+        carrier: "USPS",
+        id: "9400-1111-2222-3333",
+        location: "Locker 3",
+        recipient: "Jamie Chen",
+        receivedAt: new Date(now.getTime() - 1000 * 60 * 90).toISOString(),
+        status: "notified",
+        trackingNumber: "9400-1111-2222-3333",
+      },
+    ],
+    shiftLog: [
+      {
+        author: "Taylor",
+        followUp: "Confirm HVAC tech arrival ETA at 11:00.",
+        id: "shift-seed-1",
+        role: "Night Supervisor",
+        summary: "Quiet overnight. Received two package deliveries for 5A/12C.",
+        timestamp: new Date(now.getTime() - 1000 * 60 * 50).toISOString(),
+        type: "handover",
+      },
+    ],
+    timeTracking: {
+      activeSessions: [
+        {
+          breaks: [],
+          id: "session-seed-1",
+          notes: "Covering lobby + package intake",
+          role: "Front Desk",
+          staffName: "Morgan",
+          startedAt: new Date(now.getTime() - 1000 * 60 * 25).toISOString(),
+        },
+      ],
+      history: [],
+    },
+    visitors: [
+      {
+        badgeNumber: "A17",
+        checkIn: new Date(now.getTime() - 1000 * 60 * 20).toISOString(),
+        company: "Bright Cleaners",
+        host: "Unit 8D",
+        id: "visitor-seed-1",
+        name: "Pat Lee",
+        purpose: "Weekly housekeeping",
+        status: "checked_in",
+      },
+    ],
+    workOrders: {
+      completed: [],
+      in_progress: [
+        {
+          category: "maintenance",
+          details: "Awaiting part delivery from supplier. Residents updated via email.",
+          id: "work-order-seed-1",
+          priority: "high",
+          requestedBy: "Unit 3C",
+          status: "in_progress",
+          title: "HVAC not cooling",
+          unit: "3C",
+          updatedAt: new Date(now.getTime() - 1000 * 60 * 60).toISOString(),
+        },
+      ],
+      new: [
+        {
+          category: "cleaning",
+          details: "Spill reported near elevators, needs mop bucket.",
+          id: "work-order-seed-2",
+          priority: "medium",
+          requestedBy: "Security",
+          status: "new",
+          title: "Clean elevator lobby",
+          unit: "Lobby",
+          updatedAt: isoNow,
+        },
+      ],
+    },
+  }
+}

--- a/web/features/staff/staff-operations-context.tsx
+++ b/web/features/staff/staff-operations-context.tsx
@@ -1,0 +1,438 @@
+"use client"
+
+import { createContext, useContext, useEffect, useMemo, useReducer, useRef } from "react"
+
+import type {
+  ChecklistState,
+  IncidentReport,
+  PackageRecord,
+  PackageStatus,
+  ShiftLogEntry,
+  StaffOperationsState,
+  TimeSession,
+  VisitorRecord,
+  VisitorStatus,
+  WorkOrder,
+  WorkOrderStatus,
+} from "@/types/staff"
+
+const STORAGE_KEY = "staff-operations-state"
+const CHANNEL_NAME = "staff-operations"
+
+const initialChecklist: ChecklistState = {
+  incidentLogged: false,
+  packageIntake: false,
+  shiftLogUpdated: false,
+  timeTracked: false,
+  visitorSignIn: false,
+  workOrderUpdated: false,
+}
+
+const initialState: StaffOperationsState = {
+  checklist: initialChecklist,
+  incidents: [],
+  packages: [],
+  shiftLog: [],
+  timeTracking: {
+    activeSessions: [],
+    history: [],
+  },
+  version: 0,
+  visitors: [],
+  workOrders: {
+    completed: [],
+    in_progress: [],
+    new: [],
+  },
+}
+
+type StaffOperationsAction =
+  | { type: "hydrate"; payload: StaffOperationsState }
+  | { type: "addPackage"; payload: PackageRecord }
+  | {
+      type: "updatePackageStatus"
+      payload: { id: string; status: PackageStatus; notes?: string }
+    }
+  | { type: "addVisitor"; payload: VisitorRecord }
+  | { type: "updateVisitorStatus"; payload: { id: string; status: VisitorStatus } }
+  | { type: "addWorkOrder"; payload: WorkOrder }
+  | { type: "moveWorkOrder"; payload: { id: string; status: WorkOrderStatus } }
+  | { type: "addShiftEntry"; payload: ShiftLogEntry }
+  | { type: "addIncident"; payload: IncidentReport }
+  | { type: "startSession"; payload: TimeSession }
+  | {
+      type: "stopSession"
+      payload: { id: string; endedAt: string; notes?: string }
+    }
+  | { type: "toggleBreak"; payload: { id: string; timestamp: string } }
+
+const incrementVersion = (state: StaffOperationsState): StaffOperationsState => ({
+  ...state,
+  version: state.version + 1,
+})
+
+const updateChecklist = <K extends keyof ChecklistState>(
+  state: StaffOperationsState,
+  key: K,
+): StaffOperationsState => ({
+  ...state,
+  checklist: {
+    ...state.checklist,
+    [key]: true,
+  },
+})
+
+const staffOperationsReducer = (
+  state: StaffOperationsState,
+  action: StaffOperationsAction,
+): StaffOperationsState => {
+  switch (action.type) {
+    case "hydrate": {
+      if (action.payload.version <= state.version) {
+        return state
+      }
+      return action.payload
+    }
+    case "addPackage": {
+      const nextState = incrementVersion(state)
+      return updateChecklist(
+        {
+          ...nextState,
+          packages: [action.payload, ...nextState.packages],
+        },
+        "packageIntake",
+      )
+    }
+    case "updatePackageStatus": {
+      const nextState = incrementVersion(state)
+      return {
+        ...nextState,
+        packages: nextState.packages.map((item) =>
+          item.id === action.payload.id
+            ? { ...item, status: action.payload.status, notes: action.payload.notes }
+            : item,
+        ),
+      }
+    }
+    case "addVisitor": {
+      const nextState = incrementVersion(state)
+      return updateChecklist(
+        {
+          ...nextState,
+          visitors: [action.payload, ...nextState.visitors],
+        },
+        "visitorSignIn",
+      )
+    }
+    case "updateVisitorStatus": {
+      const nextState = incrementVersion(state)
+      return {
+        ...nextState,
+        visitors: nextState.visitors.map((visitor) =>
+          visitor.id === action.payload.id
+            ? {
+                ...visitor,
+                status: action.payload.status,
+                checkOut:
+                  action.payload.status === "checked_out"
+                    ? new Date().toISOString()
+                    : visitor.checkOut,
+              }
+            : visitor,
+        ),
+      }
+    }
+    case "addWorkOrder": {
+      const nextState = incrementVersion(state)
+      const nextWorkOrders = {
+        ...nextState.workOrders,
+        [action.payload.status]: [
+          action.payload,
+          ...nextState.workOrders[action.payload.status],
+        ],
+      }
+      return updateChecklist({ ...nextState, workOrders: nextWorkOrders }, "workOrderUpdated")
+    }
+    case "moveWorkOrder": {
+      const nextState = incrementVersion(state)
+      const { id, status } = action.payload
+      const currentStatus = (Object.keys(nextState.workOrders) as WorkOrderStatus[]).find((key) =>
+        nextState.workOrders[key].some((order) => order.id === id),
+      )
+      if (!currentStatus) {
+        return nextState
+      }
+      const movedOrder = nextState.workOrders[currentStatus].find((order) => order.id === id)
+      if (!movedOrder) {
+        return nextState
+      }
+      const updatedCurrent = nextState.workOrders[currentStatus].filter((order) => order.id !== id)
+      const updatedTarget: WorkOrder[] = [
+        { ...movedOrder, status, updatedAt: new Date().toISOString() },
+        ...nextState.workOrders[status],
+      ]
+      return updateChecklist(
+        {
+          ...nextState,
+          workOrders: {
+            ...nextState.workOrders,
+            [currentStatus]: updatedCurrent,
+            [status]: updatedTarget,
+          },
+        },
+        "workOrderUpdated",
+      )
+    }
+    case "addShiftEntry": {
+      const nextState = incrementVersion(state)
+      return updateChecklist(
+        {
+          ...nextState,
+          shiftLog: [action.payload, ...nextState.shiftLog],
+        },
+        "shiftLogUpdated",
+      )
+    }
+    case "addIncident": {
+      const nextState = incrementVersion(state)
+      return updateChecklist(
+        {
+          ...nextState,
+          incidents: [action.payload, ...nextState.incidents],
+        },
+        "incidentLogged",
+      )
+    }
+    case "startSession": {
+      const nextState = incrementVersion(state)
+      const existing = nextState.timeTracking.activeSessions.filter(
+        (session) => session.staffName !== action.payload.staffName,
+      )
+      return updateChecklist(
+        {
+          ...nextState,
+          timeTracking: {
+            ...nextState.timeTracking,
+            activeSessions: [action.payload, ...existing],
+          },
+        },
+        "timeTracked",
+      )
+    }
+    case "stopSession": {
+      const nextState = incrementVersion(state)
+      const session = nextState.timeTracking.activeSessions.find(
+        (item) => item.id === action.payload.id,
+      )
+      if (!session) {
+        return nextState
+      }
+      const closedBreaks = session.breaks.map((entry) =>
+        entry.endedAt ? entry : { ...entry, endedAt: action.payload.endedAt },
+      )
+      const completedSession: TimeSession = {
+        ...session,
+        breaks: closedBreaks,
+        endedAt: action.payload.endedAt,
+        notes: action.payload.notes ?? session.notes,
+      }
+      return updateChecklist(
+        {
+          ...nextState,
+          timeTracking: {
+            activeSessions: nextState.timeTracking.activeSessions.filter(
+              (item) => item.id !== action.payload.id,
+            ),
+            history: [completedSession, ...nextState.timeTracking.history],
+          },
+        },
+        "timeTracked",
+      )
+    }
+    case "toggleBreak": {
+      const nextState = incrementVersion(state)
+      const updatedSessions = nextState.timeTracking.activeSessions.map((session) => {
+        if (session.id !== action.payload.id) {
+          return session
+        }
+        const hasOpenBreak = session.breaks.some((entry) => !entry.endedAt)
+        if (hasOpenBreak) {
+          return {
+            ...session,
+            breaks: session.breaks.map((entry) =>
+              entry.endedAt ? entry : { ...entry, endedAt: action.payload.timestamp },
+            ),
+          }
+        }
+        return {
+          ...session,
+          breaks: [
+            ...session.breaks,
+            { id: `${session.id}-break-${session.breaks.length + 1}`, startedAt: action.payload.timestamp },
+          ],
+        }
+      })
+      return updateChecklist(
+        {
+          ...nextState,
+          timeTracking: {
+            ...nextState.timeTracking,
+            activeSessions: updatedSessions,
+          },
+        },
+        "timeTracked",
+      )
+    }
+    default:
+      return state
+  }
+}
+
+type StaffOperationsContextValue = {
+  state: StaffOperationsState
+  addPackage: (packageRecord: PackageRecord) => void
+  updatePackageStatus: (id: string, status: PackageStatus, notes?: string) => void
+  addVisitor: (visitor: VisitorRecord) => void
+  updateVisitorStatus: (id: string, status: VisitorStatus) => void
+  addWorkOrder: (workOrder: WorkOrder) => void
+  moveWorkOrder: (id: string, status: WorkOrderStatus) => void
+  addShiftEntry: (entry: ShiftLogEntry) => void
+  addIncident: (incident: IncidentReport) => void
+  startSession: (session: TimeSession) => void
+  stopSession: (payload: { id: string; endedAt: string; notes?: string }) => void
+  toggleBreak: (payload: { id: string; timestamp: string }) => void
+}
+
+const StaffOperationsContext = createContext<StaffOperationsContextValue | undefined>(
+  undefined,
+)
+
+export const StaffOperationsProvider = ({
+  children,
+  initialData,
+}: {
+  children: React.ReactNode
+  initialData?: StaffOperationsState
+}) => {
+  const [state, dispatch] = useReducer(
+    staffOperationsReducer,
+    initialData ?? initialState,
+  )
+  const broadcastChannelRef = useRef<BroadcastChannel | null>(null)
+  const skipBroadcastRef = useRef(false)
+  const stateRef = useRef(state)
+
+  useEffect(() => {
+    stateRef.current = state
+  }, [state])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const handleIncomingState = (payload: StaffOperationsState) => {
+      if (payload.version <= stateRef.current.version) {
+        return
+      }
+      skipBroadcastRef.current = true
+      dispatch({ type: "hydrate", payload })
+    }
+
+    if ("BroadcastChannel" in window) {
+      const channel = new BroadcastChannel(CHANNEL_NAME)
+      broadcastChannelRef.current = channel
+      channel.addEventListener("message", (event) => {
+        if (event?.data) {
+          handleIncomingState(event.data as StaffOperationsState)
+        }
+      })
+      return () => channel.close()
+    }
+
+    const poll = window.setInterval(() => {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (!raw) {
+        return
+      }
+      try {
+        const parsed = JSON.parse(raw) as StaffOperationsState
+        handleIncomingState(parsed)
+      } catch (error) {
+        console.error("Failed to parse stored staff state", error)
+      }
+    }, 5000)
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY || !event.newValue) {
+        return
+      }
+      try {
+        const parsed = JSON.parse(event.newValue) as StaffOperationsState
+        handleIncomingState(parsed)
+      } catch (error) {
+        console.error("Failed to parse storage event", error)
+      }
+    }
+
+    window.addEventListener("storage", handleStorage)
+
+    return () => {
+      window.clearInterval(poll)
+      window.removeEventListener("storage", handleStorage)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+    if (skipBroadcastRef.current) {
+      skipBroadcastRef.current = false
+      return
+    }
+    try {
+      const serialized = JSON.stringify(state)
+      window.localStorage.setItem(STORAGE_KEY, serialized)
+      broadcastChannelRef.current?.postMessage(state)
+    } catch (error) {
+      console.error("Failed to persist staff operations state", error)
+    }
+  }, [state])
+
+  const contextValue = useMemo<StaffOperationsContextValue>(() => {
+    return {
+      state,
+      addIncident: (incident) => dispatch({ type: "addIncident", payload: incident }),
+      addPackage: (packageRecord) => dispatch({ type: "addPackage", payload: packageRecord }),
+      addShiftEntry: (entry) => dispatch({ type: "addShiftEntry", payload: entry }),
+      addVisitor: (visitor) => dispatch({ type: "addVisitor", payload: visitor }),
+      addWorkOrder: (workOrder) => dispatch({ type: "addWorkOrder", payload: workOrder }),
+      moveWorkOrder: (id, status) => dispatch({ type: "moveWorkOrder", payload: { id, status } }),
+      startSession: (session) => dispatch({ type: "startSession", payload: session }),
+      stopSession: (payload) => dispatch({ type: "stopSession", payload }),
+      toggleBreak: (payload) => dispatch({ type: "toggleBreak", payload }),
+      updatePackageStatus: (id, status, notes) =>
+        dispatch({ type: "updatePackageStatus", payload: { id, status, notes } }),
+      updateVisitorStatus: (id, status) =>
+        dispatch({ type: "updateVisitorStatus", payload: { id, status } }),
+    }
+  }, [state])
+
+  return (
+    <StaffOperationsContext.Provider value={contextValue}>
+      {children}
+    </StaffOperationsContext.Provider>
+  )
+}
+
+export const useStaffOperations = () => {
+  const context = useContext(StaffOperationsContext)
+  if (!context) {
+    throw new Error("useStaffOperations must be used within StaffOperationsProvider")
+  }
+  return context
+}
+
+export const getInitialStaffOperationsState = () => initialState

--- a/web/features/staff/utils.ts
+++ b/web/features/staff/utils.ts
@@ -1,0 +1,14 @@
+export const generateId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2)
+}
+
+export const nowIsoString = () => new Date().toISOString()
+
+export const formatTime = (value: string) =>
+  new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))


### PR DESCRIPTION
## Summary
- add a staff operations dashboard surfaced at /dashboard/staff that bundles package intake, visitor sign-in, maintenance board, shift log, incident reporting, and time tracking workflows
- implement a shared staff operations context with BroadcastChannel/polling based realtime sync, seed sample data, and add UX optimizations for tablet workflows
- provide a user acceptance checklist component to validate each flow end-to-end

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceeff7f45083288c3f48421f7f409a