### PR TITLE
Add document management UI with reporting

### DIFF
--- a/app/api/documents/[id]/audit/route.ts
+++ b/app/api/documents/[id]/audit/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import {
+  createSupabaseRouteClient,
+  ensureCanViewDocument,
+  getCurrentUserWithProfile,
+  mapAudit,
+} from '../../helpers'
+
+export async function GET(_request: Request, { params }: { params: { id: string } }) {
+  const supabase = createSupabaseRouteClient()
+  const { user, profile, error } = await getCurrentUserWithProfile(supabase)
+
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    await ensureCanViewDocument(supabase, params.id, { id: user.id, profile })
+  } catch (permissionError) {
+    return NextResponse.json({ error: (permissionError as Error).message }, { status: 403 })
+  }
+
+  const { data, error: auditError } = await supabase
+    .from('document_audit_logs')
+    .select('id, document_id, action, actor_id, context, created_at, actor:profiles(id, full_name, email)')
+    .eq('document_id', params.id)
+    .order('created_at', { ascending: false })
+
+  if (auditError) {
+    return NextResponse.json({ error: auditError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ entries: (data ?? []).map(mapAudit) })
+}

--- a/app/api/documents/[id]/permissions/route.ts
+++ b/app/api/documents/[id]/permissions/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server'
+import { z, type ZodType } from 'zod'
+import type { DocumentVisibility } from '@/web/features/documents/types'
+import {
+  createSupabaseRouteClient,
+  ensureCanEditDocument,
+  getCurrentUserWithProfile,
+  logDocumentAudit,
+  mapDocument,
+} from '../../helpers'
+
+const visibilitySchema = z.enum(['private', 'shared', 'public']) as ZodType<DocumentVisibility>
+
+const updateSchema = z.object({
+  visibility: visibilitySchema,
+  allowedRoles: z.array(z.string()).default([]),
+  allowedUsers: z.array(z.string()).default([]),
+})
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  const payload = updateSchema.safeParse(await request.json())
+
+  if (!payload.success) {
+    return NextResponse.json({ error: payload.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = createSupabaseRouteClient()
+  const { user, profile, error } = await getCurrentUserWithProfile(supabase)
+
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let existing
+  try {
+    existing = await ensureCanEditDocument(supabase, params.id, { id: user.id, profile })
+  } catch (permissionError) {
+    return NextResponse.json({ error: (permissionError as Error).message }, { status: 403 })
+  }
+
+  const { data, error: updateError } = await supabase
+    .from('documents')
+    .update({
+      visibility: payload.data.visibility,
+      allowed_roles: payload.data.allowedRoles,
+      allowed_users: payload.data.allowedUsers,
+    })
+    .eq('id', params.id)
+    .select(
+      `id, name, category_id, storage_path, file_size, visibility, allowed_roles, allowed_users, uploaded_by, created_at, updated_at,
+      category:document_categories(id, name, description, visibility, allowed_roles, created_at, updated_at),
+      uploader:profiles(id, full_name, email, role)`,
+    )
+    .single()
+
+  if (updateError || !data) {
+    return NextResponse.json({ error: updateError?.message ?? 'Unable to update permissions' }, { status: 500 })
+  }
+
+  try {
+    await logDocumentAudit(supabase, {
+      documentId: params.id,
+      actorId: user.id,
+      action: 'permission_updated',
+      context: {
+        previousVisibility: existing.visibility,
+        nextVisibility: payload.data.visibility,
+        allowedRoles: payload.data.allowedRoles,
+        allowedUsers: payload.data.allowedUsers,
+      },
+    })
+  } catch (auditError) {
+    return NextResponse.json({ error: (auditError as Error).message }, { status: 500 })
+  }
+
+  return NextResponse.json({ document: mapDocument(data) })
+}

--- a/app/api/documents/helpers.ts
+++ b/app/api/documents/helpers.ts
@@ -1,0 +1,203 @@
+import { cookies } from 'next/headers'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import { createClient } from '@/utils/supa-server-actions'
+import type { DocumentAuditEntry, DocumentCategory, DocumentRecord, DocumentVisibility } from '@/web/features/documents/types'
+import { canEditDocument, canViewDocument, type DocumentPermissionModel, type DocumentUser } from '@/web/features/documents/utils'
+
+export function createSupabaseRouteClient(): TypedSupabaseClient {
+  const cookieStore = cookies()
+  return createClient(cookieStore) as unknown as TypedSupabaseClient
+}
+
+type ProfileRow = {
+  id: string
+  role: string | null
+  full_name: string | null
+  email: string | null
+}
+
+type DocumentCategoryRow = {
+  id: string
+  name: string
+  description: string | null
+  visibility: DocumentVisibility
+  allowed_roles: string[] | null
+  created_at: string
+  updated_at: string | null
+}
+
+type DocumentRow = {
+  id: string
+  name: string
+  category_id: string
+  storage_path: string
+  file_size: number
+  visibility: DocumentVisibility
+  allowed_roles: string[] | null
+  allowed_users: string[] | null
+  uploaded_by: string
+  created_at: string
+  updated_at: string | null
+  category?: DocumentCategoryRow | null
+  uploader?: ProfileRow | null
+}
+
+type AuditRow = {
+  id: string
+  document_id: string
+  action: DocumentAuditEntry['action']
+  actor_id: string
+  context: Record<string, unknown> | null
+  created_at: string
+  actor?: ProfileRow | null
+}
+
+export async function getCurrentUserWithProfile(client: TypedSupabaseClient) {
+  const {
+    data: { user },
+    error,
+  } = await client.auth.getUser()
+
+  if (error || !user) {
+    return { user: null, profile: null as ProfileRow | null, error }
+  }
+
+  const { data: profile } = await client
+    .from('profiles')
+    .select('id, role, full_name, email')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  return { user, profile: profile ?? null, error: null }
+}
+
+export function mapCategory(row: DocumentCategoryRow): DocumentCategory {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    visibility: row.visibility,
+    allowedRoles: row.allowed_roles ?? [],
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+export function mapDocument(row: DocumentRow): DocumentRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    categoryId: row.category_id,
+    categoryName: row.category?.name ?? null,
+    storagePath: row.storage_path,
+    size: row.file_size,
+    visibility: row.visibility,
+    allowedRoles: row.allowed_roles ?? [],
+    allowedUsers: row.allowed_users ?? [],
+    uploadedBy: row.uploaded_by,
+    uploadedByName: row.uploader?.full_name ?? null,
+    uploadedByEmail: row.uploader?.email ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+export function mapAudit(row: AuditRow): DocumentAuditEntry {
+  return {
+    id: row.id,
+    documentId: row.document_id,
+    action: row.action,
+    actorId: row.actor_id,
+    actorName: row.actor?.full_name ?? null,
+    actorEmail: row.actor?.email ?? null,
+    context: row.context,
+    createdAt: row.created_at,
+  }
+}
+
+export function buildPermissionModel(row: DocumentRow): DocumentPermissionModel {
+  return {
+    ownerId: row.uploaded_by,
+    visibility: row.visibility,
+    allowedRoles: row.allowed_roles ?? [],
+    allowedUsers: row.allowed_users ?? [],
+  }
+}
+
+export function buildDocumentUser(user: ProfileRow | null, userId: string): DocumentUser {
+  return {
+    id: userId,
+    role: (user?.role ?? 'user').toString(),
+  }
+}
+
+export async function fetchDocument(client: TypedSupabaseClient, documentId: string) {
+  const { data, error } = await client
+    .from('documents')
+    .select(
+      `id, name, category_id, storage_path, file_size, visibility, allowed_roles, allowed_users, uploaded_by, created_at, updated_at,
+      category:document_categories(id, name, description, visibility, allowed_roles, created_at, updated_at),
+      uploader:profiles(id, full_name, email, role)`,
+    )
+    .eq('id', documentId)
+    .maybeSingle()
+
+  if (error || !data) {
+    throw error ?? new Error('Document not found')
+  }
+
+  return data as DocumentRow
+}
+
+export async function ensureCanViewDocument(
+  client: TypedSupabaseClient,
+  documentId: string,
+  user: { id: string; profile: ProfileRow | null },
+) {
+  const row = await fetchDocument(client, documentId)
+  const permission = buildPermissionModel(row)
+  const actor = buildDocumentUser(user.profile, user.id)
+
+  if (!canViewDocument(actor, permission)) {
+    throw new Error('You do not have permission to view this document')
+  }
+
+  return row
+}
+
+export async function ensureCanEditDocument(
+  client: TypedSupabaseClient,
+  documentId: string,
+  user: { id: string; profile: ProfileRow | null },
+) {
+  const row = await fetchDocument(client, documentId)
+  const permission = buildPermissionModel(row)
+  const actor = buildDocumentUser(user.profile, user.id)
+
+  if (!canEditDocument(actor, permission)) {
+    throw new Error('You do not have permission to modify this document')
+  }
+
+  return row
+}
+
+export async function logDocumentAudit(
+  client: TypedSupabaseClient,
+  entry: {
+    documentId: string
+    actorId: string
+    action: DocumentAuditEntry['action']
+    context?: Record<string, unknown> | null
+  },
+) {
+  const { error } = await client.from('document_audit_logs').insert({
+    document_id: entry.documentId,
+    actor_id: entry.actorId,
+    action: entry.action,
+    context: entry.context ?? null,
+  })
+
+  if (error) {
+    throw error
+  }
+}

--- a/app/api/documents/reports/route.ts
+++ b/app/api/documents/reports/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server'
+import type { DocumentVisibility } from '@/web/features/documents/types'
+import { buildDocumentReport, documentReportToCsv } from '@/web/features/documents/reporting'
+import { createSupabaseRouteClient, getCurrentUserWithProfile, mapDocument } from '../helpers'
+
+export async function GET(request: Request) {
+  const supabase = createSupabaseRouteClient()
+  const { user, profile, error } = await getCurrentUserWithProfile(supabase)
+
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if ((profile?.role ?? 'user').toLowerCase() !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const url = new URL(request.url)
+  const categoryFilters = url.searchParams.getAll('category')
+  const visibilityFilters = url.searchParams.getAll('visibility') as DocumentVisibility[]
+  const start = url.searchParams.get('start')
+  const end = url.searchParams.get('end')
+  const format = url.searchParams.get('format') ?? 'json'
+
+  const { data, error: documentError } = await supabase
+    .from('documents')
+    .select(
+      `id, name, category_id, storage_path, file_size, visibility, allowed_roles, allowed_users, uploaded_by, created_at, updated_at,
+      category:document_categories(id, name, description, visibility, allowed_roles, created_at, updated_at),
+      uploader:profiles(id, full_name, email, role)`,
+    )
+    .order('created_at', { ascending: false })
+
+  if (documentError) {
+    return NextResponse.json({ error: documentError.message }, { status: 500 })
+  }
+
+  const report = buildDocumentReport((data ?? []).map(mapDocument), {
+    categoryIds: categoryFilters.length ? categoryFilters : undefined,
+    visibility: visibilityFilters.length ? visibilityFilters : undefined,
+    startDate: start ? new Date(start) : undefined,
+    endDate: end ? new Date(end) : undefined,
+  })
+
+  if (format === 'csv') {
+    const csv = documentReportToCsv(report)
+    return new NextResponse(csv, {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="documents-report-${Date.now()}.csv"`,
+      },
+    })
+  }
+
+  return NextResponse.json({ report })
+}

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server'
+import { z, type ZodType } from 'zod'
+import type { DocumentVisibility } from '@/web/features/documents/types'
+import { createSupabaseRouteClient, getCurrentUserWithProfile, logDocumentAudit, mapCategory, mapDocument } from './helpers'
+
+const visibilitySchema = z.enum(['private', 'shared', 'public']) as ZodType<DocumentVisibility>
+
+const documentPayloadSchema = z.object({
+  name: z.string().min(1),
+  storagePath: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  categoryId: z.string().min(1),
+  visibility: visibilitySchema,
+  allowedRoles: z.array(z.string()).default([]),
+  allowedUsers: z.array(z.string()).default([]),
+})
+
+export async function GET() {
+  const supabase = createSupabaseRouteClient()
+  const { user, profile, error } = await getCurrentUserWithProfile(supabase)
+
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: categoryRows, error: categoryError } = await supabase
+    .from('document_categories')
+    .select('id, name, description, visibility, allowed_roles, created_at, updated_at')
+    .order('name', { ascending: true })
+
+  if (categoryError) {
+    return NextResponse.json({ error: categoryError.message }, { status: 500 })
+  }
+
+  const { data: documentRows, error: documentError } = await supabase
+    .from('documents')
+    .select(
+      `id, name, category_id, storage_path, file_size, visibility, allowed_roles, allowed_users, uploaded_by, created_at, updated_at,
+      category:document_categories(id, name, description, visibility, allowed_roles, created_at, updated_at),
+      uploader:profiles(id, full_name, email, role)`,
+    )
+    .order('created_at', { ascending: false })
+
+  if (documentError) {
+    return NextResponse.json({ error: documentError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    documents: (documentRows ?? []).map(mapDocument),
+    categories: (categoryRows ?? []).map(mapCategory),
+    currentUser: {
+      id: user.id,
+      role: profile?.role ?? 'user',
+      email: profile?.email ?? null,
+      name: profile?.full_name ?? null,
+    },
+  })
+}
+
+export async function POST(request: Request) {
+  const payload = documentPayloadSchema.safeParse(await request.json())
+
+  if (!payload.success) {
+    return NextResponse.json({ error: payload.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = createSupabaseRouteClient()
+  const { user, profile, error } = await getCurrentUserWithProfile(supabase)
+
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: categoryRow, error: categoryError } = await supabase
+    .from('document_categories')
+    .select('id, name, allowed_roles, visibility')
+    .eq('id', payload.data.categoryId)
+    .maybeSingle()
+
+  if (categoryError) {
+    return NextResponse.json({ error: categoryError.message }, { status: 500 })
+  }
+
+  if (!categoryRow) {
+    return NextResponse.json({ error: 'Category not found' }, { status: 404 })
+  }
+
+  const userRole = (profile?.role ?? 'user').toLowerCase()
+  const allowedRoles = (categoryRow.allowed_roles ?? []).map((role: string) => role.toLowerCase())
+
+  if (allowedRoles.length > 0 && !allowedRoles.includes(userRole)) {
+    return NextResponse.json({ error: 'You are not allowed to upload to this category' }, { status: 403 })
+  }
+
+  const { data, error: insertError } = await supabase
+    .from('documents')
+    .insert({
+      name: payload.data.name,
+      storage_path: payload.data.storagePath,
+      file_size: payload.data.size,
+      category_id: payload.data.categoryId,
+      visibility: payload.data.visibility,
+      allowed_roles: payload.data.allowedRoles,
+      allowed_users: payload.data.allowedUsers,
+      uploaded_by: user.id,
+    })
+    .select(
+      `id, name, category_id, storage_path, file_size, visibility, allowed_roles, allowed_users, uploaded_by, created_at, updated_at,
+      category:document_categories(id, name, description, visibility, allowed_roles, created_at, updated_at),
+      uploader:profiles(id, full_name, email, role)`,
+    )
+    .single()
+
+  if (insertError || !data) {
+    return NextResponse.json({ error: insertError?.message ?? 'Unable to create document record' }, { status: 500 })
+  }
+
+  try {
+    await logDocumentAudit(supabase, {
+      documentId: data.id,
+      actorId: user.id,
+      action: 'uploaded',
+      context: {
+        size: payload.data.size,
+        categoryId: payload.data.categoryId,
+        visibility: payload.data.visibility,
+      },
+    })
+  } catch (auditError) {
+    return NextResponse.json({ error: (auditError as Error).message }, { status: 500 })
+  }
+
+  return NextResponse.json({ document: mapDocument(data) })
+}

--- a/app/api/documents/sign-upload/route.ts
+++ b/app/api/documents/sign-upload/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { buildObjectKey } from '@/web/features/documents/utils'
+import { createSupabaseRouteClient, getCurrentUserWithProfile } from '../helpers'
+
+const signPayloadSchema = z.object({
+  fileName: z.string().min(1),
+  fileType: z.string().min(1),
+  categoryId: z.string().min(1),
+})
+
+export async function POST(request: Request) {
+  const payload = signPayloadSchema.safeParse(await request.json())
+
+  if (!payload.success) {
+    return NextResponse.json({ error: payload.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = createSupabaseRouteClient()
+  const { user, profile, error } = await getCurrentUserWithProfile(supabase)
+
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: categoryRow, error: categoryError } = await supabase
+    .from('document_categories')
+    .select('id, allowed_roles')
+    .eq('id', payload.data.categoryId)
+    .maybeSingle()
+
+  if (categoryError) {
+    return NextResponse.json({ error: categoryError.message }, { status: 500 })
+  }
+
+  if (!categoryRow) {
+    return NextResponse.json({ error: 'Category not found' }, { status: 404 })
+  }
+
+  const userRole = (profile?.role ?? 'user').toLowerCase()
+  const allowedRoles = (categoryRow.allowed_roles ?? []).map((role: string) => role.toLowerCase())
+
+  if (allowedRoles.length > 0 && !allowedRoles.includes(userRole)) {
+    return NextResponse.json({ error: 'You are not allowed to upload to this category' }, { status: 403 })
+  }
+
+  const objectKey = buildObjectKey(payload.data.categoryId, payload.data.fileName, {
+    userId: user.id,
+  })
+
+  const { data, error: signedError } = await supabase.storage.from('documents').createSignedUploadUrl(objectKey)
+
+  if (signedError || !data) {
+    return NextResponse.json({ error: signedError?.message ?? 'Unable to sign upload URL' }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    uploadUrl: data.signedUrl,
+    path: data.path ?? objectKey,
+    token: data.token ?? null,
+  })
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -109,6 +110,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^1.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -306,6 +306,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.14.15)(terser@5.39.0)
 
 packages:
 
@@ -1328,6 +1331,144 @@ packages:
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1409,6 +1550,10 @@ packages:
       '@types/react-dom': ^18.0.11
       react: ^18.2.0
       react-dom: ^18.2.0
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -2323,6 +2468,116 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rushstack/eslint-patch@1.6.1':
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
 
@@ -2337,6 +2592,9 @@ packages:
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
   '@supabase-cache-helpers/postgrest-core@0.3.0':
     resolution: {integrity: sha512-anLCZeyKcTl5ggrn2xyZ7WRq6q1QnHxIemevg7OX+3NOw+xatZ0g0HpBBFrQfRLTz2UD6K5oeqmIKN9EPrNgeA==}
@@ -2489,6 +2747,9 @@ packages:
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/google-one-tap@1.2.6':
     resolution: {integrity: sha512-REmJsXVHvKb/sgI8DF+7IesMbDbcsEokHBqxU01ENZ8d98UPWdRLhUCtxEm9bhNFFg6PJGy7PNFdvovp0hK3jA==}
@@ -2649,6 +2910,21 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
   '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
 
@@ -2746,6 +3022,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
@@ -2758,6 +3038,11 @@ packages:
 
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2804,6 +3089,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -2862,6 +3151,9 @@ packages:
   arraybuffer.prototype.slice@1.0.2:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -3020,6 +3312,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3056,6 +3352,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3084,6 +3384,9 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -3168,6 +3471,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -3315,6 +3621,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -3353,6 +3663,10 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3473,6 +3787,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -3644,6 +3963,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -3780,6 +4103,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.2.2:
     resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
 
@@ -3797,6 +4123,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -3959,6 +4289,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -4141,6 +4475,10 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -4217,6 +4555,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -4314,6 +4655,10 @@ packages:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -4356,6 +4701,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -4543,6 +4891,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -4579,6 +4931,9 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -4678,6 +5033,10 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4722,6 +5081,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -4729,6 +5092,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -4766,6 +5133,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -4780,6 +5151,15 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -4807,6 +5187,9 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   postcss-attribute-case-insensitive@7.0.0:
     resolution: {integrity: sha512-ETMUHIw67Kyv9Q81nden/NuJbRh+4/S963giXpfSLd5eaKK8kd1UdAHMVRV/NG/w/N6Cq8B0qZIZbZZWU/67+A==}
@@ -5040,6 +5423,10 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   prismjs@1.27.0:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
     engines: {node: '>=6'}
@@ -5125,6 +5512,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
@@ -5317,6 +5707,11 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5404,6 +5799,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5474,6 +5872,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
     peerDependencies:
@@ -5482,6 +5883,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -5537,6 +5941,10 @@ packages:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -5544,6 +5952,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -5690,6 +6101,17 @@ packages:
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -5748,6 +6170,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@0.16.0:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
@@ -5775,6 +6201,9 @@ packages:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -5934,6 +6363,67 @@ packages:
   victory-vendor@36.8.6:
     resolution: {integrity: sha512-PH8Wj9b0xIZ4AVfyn0c1SJrOhtxDJ5PNxj1ZDABPg1Gw1vJr1mJVqESPhvsFj7mXLQohVdiKqp4kWZkXlPcRcA==}
 
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.20:
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.4.35:
     resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
     peerDependencies:
@@ -5998,6 +6488,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workbox-background-sync@7.1.0:
@@ -6103,6 +6598,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
@@ -7302,10 +7801,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7400,6 +7899,75 @@ snapshots:
   '@emotion/utils@1.2.1': {}
 
   '@emotion/weak-memoize@0.3.1': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
@@ -7500,6 +8068,10 @@ snapshots:
       '@types/react-dom': 18.3.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
 
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
@@ -8524,6 +9096,72 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
   '@rushstack/eslint-patch@1.6.1': {}
 
   '@scure/base@1.1.5': {}
@@ -8543,6 +9181,8 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@sinclair/typebox@0.27.8': {}
 
   '@supabase-cache-helpers/postgrest-core@0.3.0(@supabase/postgrest-js@1.9.2)(@supabase/supabase-js@2.39.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
@@ -8723,6 +9363,8 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/estree@1.0.8': {}
+
   '@types/google-one-tap@1.2.6': {}
 
   '@types/hast@2.3.10':
@@ -8853,19 +9495,48 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
+
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
 
   '@vue/compiler-core@3.4.35':
     dependencies:
@@ -9022,11 +9693,17 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.14.1
+
   acorn@8.11.3: {}
 
   acorn@8.12.1: {}
 
   acorn@8.14.1: {}
+
+  acorn@8.15.0: {}
 
   agent-base@7.1.3: {}
 
@@ -9068,6 +9745,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
 
@@ -9147,6 +9826,8 @@ snapshots:
       get-intrinsic: 1.2.2
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
+
+  assertion-error@1.1.0: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -9327,6 +10008,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -9359,6 +10042,16 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9383,6 +10076,10 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   chokidar@3.5.3:
     dependencies:
@@ -9466,6 +10163,8 @@ snapshots:
   common-tags@1.8.2: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -9592,6 +10291,10 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -9625,6 +10328,8 @@ snapshots:
       dequal: 2.0.3
 
   didyoumean@1.2.2: {}
+
+  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -9802,6 +10507,32 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
@@ -9815,8 +10546,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +10569,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +10586,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +10607,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10063,6 +10794,18 @@ snapshots:
 
   events@3.3.0: {}
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   expand-template@2.0.3: {}
 
   extend@3.0.2: {}
@@ -10198,6 +10941,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.2.2:
     dependencies:
       function-bind: 1.1.2
@@ -10226,6 +10971,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.0.0:
     dependencies:
@@ -10469,6 +11216,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@5.0.0: {}
+
   idb@7.1.1: {}
 
   ieee754@1.2.1: {}
@@ -10628,6 +11377,8 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  is-stream@3.0.0: {}
+
   is-string@1.0.7:
     dependencies:
       has-tostringtag: 1.0.0
@@ -10715,6 +11466,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -10798,6 +11551,11 @@ snapshots:
 
   loader-runner@4.3.0: {}
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 1.3.1
+
   locate-character@3.0.0:
     optional: true
 
@@ -10829,6 +11587,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -10858,7 +11620,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   markdown-extensions@2.0.0: {}
 
@@ -11199,6 +11960,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@4.0.0: {}
+
   mimic-response@3.1.0: {}
 
   minimatch@3.1.2:
@@ -11229,6 +11992,13 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
+
   ms@2.1.2: {}
 
   ms@2.1.3: {}
@@ -11239,8 +12009,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -11252,13 +12021,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +12037,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11310,6 +12079,10 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   object-assign@4.1.1: {}
 
@@ -11362,6 +12135,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   optionator@0.9.3:
     dependencies:
       '@aashutoshrathi/word-wrap': 1.2.6
@@ -11374,6 +12151,10 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.1
 
   p-locate@5.0.0:
     dependencies:
@@ -11423,6 +12204,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-scurry@1.10.1:
@@ -11437,6 +12220,12 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
+
   peberminta@0.9.0: {}
 
   periscopic@3.1.0:
@@ -11449,14 +12238,19 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
 
   postcss-attribute-case-insensitive@7.0.0(postcss@8.4.32):
     dependencies:
@@ -11711,7 +12505,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -11725,7 +12519,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   potpack@1.0.2: {}
 
@@ -11749,6 +12542,12 @@ snapshots:
   prettier@2.8.8: {}
 
   pretty-bytes@5.6.0: {}
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
 
   prismjs@1.27.0: {}
 
@@ -11827,6 +12626,8 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react-lifecycles-compat@3.0.4: {}
 
@@ -12063,6 +12864,34 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12183,6 +13012,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -12212,8 +13043,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -12236,12 +13066,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
     dependencies:
       '@types/three': 0.176.0
       three: 0.160.0
 
   stats.js@0.17.0: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -12322,9 +13156,15 @@ snapshots:
 
   strip-comments@2.0.1: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-to-object@0.4.4:
     dependencies:
@@ -12334,12 +13174,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 
@@ -12519,6 +13359,12 @@ snapshots:
 
   tiny-invariant@1.3.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -12575,6 +13421,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.1.0: {}
+
   type-fest@0.16.0: {}
 
   type-fest@0.20.2: {}
@@ -12607,6 +13455,8 @@ snapshots:
       is-typed-array: 1.1.12
 
   typescript@5.5.4: {}
+
+  ufo@1.6.1: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -12784,6 +13634,68 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@1.6.1(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.20(@types/node@20.14.15)(terser@5.39.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.20(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.3
+      rollup: 4.52.0
+    optionalDependencies:
+      '@types/node': 20.14.15
+      fsevents: 2.3.3
+      terser: 5.39.0
+
+  vitest@1.6.1(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@20.14.15)(terser@5.39.0)
+      vite-node: 1.6.1(@types/node@20.14.15)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.14.15
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
@@ -12898,6 +13810,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workbox-background-sync@7.1.0:
     dependencies:
@@ -13099,6 +14016,8 @@ snapshots:
   yaml@2.3.4: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.1: {}
 
   zod@3.22.4: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['web/features/documents/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+})

--- a/web/features/documents/DocumentManager.tsx
+++ b/web/features/documents/DocumentManager.tsx
@@ -1,0 +1,898 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import Table from '@/components/ui/Table'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Switch } from '@/components/ui/switch'
+import { useToast } from '@/components/ui/use-toast'
+import { cn } from '@/lib/utils'
+import type {
+  DocumentAuditEntry,
+  DocumentCategory,
+  DocumentPermissionUpdate,
+  DocumentRecord,
+  DocumentReport,
+  DocumentVisibility,
+} from './types'
+import { formatBytes, validateFileBeforeUpload, visibilityLabel } from './utils'
+import type { DocumentReportFilters } from './reporting'
+import { buildDocumentReport, documentReportToCsv } from './reporting'
+
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024
+const DEFAULT_ALLOWED_TYPES = [
+  'application/pdf',
+  'image/',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'text/plain',
+]
+
+export type DocumentManagerProps = {
+  currentUser: {
+    id: string
+    role: string
+    email?: string | null
+    name?: string | null
+  }
+}
+
+type ReportConfigState = {
+  categoryIds: string[]
+  visibility: DocumentVisibility[]
+  startDate: string
+  endDate: string
+}
+
+const INITIAL_REPORT_STATE: ReportConfigState = {
+  categoryIds: [],
+  visibility: [],
+  startDate: '',
+  endDate: '',
+}
+
+function uniqueList(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)))
+}
+
+export function DocumentManager({ currentUser }: DocumentManagerProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const dropRef = useRef<HTMLDivElement | null>(null)
+  const { toast } = useToast()
+
+  const [categories, setCategories] = useState<DocumentCategory[]>([])
+  const [documents, setDocuments] = useState<DocumentRecord[]>([])
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string>('')
+  const [newDocumentVisibility, setNewDocumentVisibility] = useState<DocumentVisibility>('shared')
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const [permissionsDialogOpen, setPermissionsDialogOpen] = useState(false)
+  const [activeDocument, setActiveDocument] = useState<DocumentRecord | null>(null)
+  const [pendingRoles, setPendingRoles] = useState('')
+  const [pendingUsers, setPendingUsers] = useState('')
+  const [pendingVisibility, setPendingVisibility] = useState<DocumentVisibility>('private')
+  const [isSavingPermissions, setIsSavingPermissions] = useState(false)
+  const [auditTrail, setAuditTrail] = useState<DocumentAuditEntry[]>([])
+  const [isAuditLoading, setIsAuditLoading] = useState(false)
+  const [reportState, setReportState] = useState<ReportConfigState>(INITIAL_REPORT_STATE)
+  const [reportPreview, setReportPreview] = useState<DocumentReport | null>(null)
+  const [isReportLoading, setIsReportLoading] = useState(false)
+
+  const isAdmin = currentUser.role.toLowerCase() === 'admin'
+
+  const fetchDashboard = useCallback(async () => {
+    try {
+      const response = await fetch('/api/documents', { cache: 'no-store' })
+      if (!response.ok) {
+        throw new Error('Failed to load documents')
+      }
+
+      const payload: {
+        documents: DocumentRecord[]
+        categories: DocumentCategory[]
+      } = await response.json()
+
+      setCategories(payload.categories)
+      setDocuments(payload.documents)
+
+      if (!selectedCategoryId && payload.categories.length > 0) {
+        setSelectedCategoryId(payload.categories[0].id)
+        setNewDocumentVisibility(payload.categories[0].visibility)
+      }
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Unable to load documents',
+        description: (error as Error).message,
+      })
+    }
+  }, [selectedCategoryId, toast])
+
+  useEffect(() => {
+    fetchDashboard()
+  }, [fetchDashboard])
+
+  useEffect(() => {
+    if (!selectedCategoryId) {
+      return
+    }
+
+    const category = categories.find((item) => item.id === selectedCategoryId)
+    if (category) {
+      setNewDocumentVisibility(category.visibility)
+    }
+  }, [categories, selectedCategoryId])
+
+  useEffect(() => {
+    if (!permissionsDialogOpen || !activeDocument) {
+      return
+    }
+
+    const controller = new AbortController()
+
+    async function loadAuditTrail() {
+      try {
+        setIsAuditLoading(true)
+        const response = await fetch(`/api/documents/${activeDocument.id}/audit`, {
+          signal: controller.signal,
+        })
+        if (!response.ok) {
+          throw new Error('Unable to fetch audit trail')
+        }
+        const payload: { entries: DocumentAuditEntry[] } = await response.json()
+        setAuditTrail(payload.entries)
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') {
+          return
+        }
+        toast({
+          variant: 'destructive',
+          title: 'Audit log unavailable',
+          description: (error as Error).message,
+        })
+      } finally {
+        setIsAuditLoading(false)
+      }
+    }
+
+    loadAuditTrail()
+
+    return () => controller.abort()
+  }, [permissionsDialogOpen, activeDocument, toast])
+
+  const filteredDocuments = useMemo(() => {
+    if (!selectedCategoryId) {
+      return documents
+    }
+    return documents.filter((document) => document.categoryId === selectedCategoryId)
+  }, [documents, selectedCategoryId])
+
+  const handleFiles = useCallback(
+    async (files: FileList | File[]) => {
+      if (!selectedCategoryId) {
+        toast({
+          variant: 'destructive',
+          title: 'Select a category first',
+          description: 'Choose a document category before uploading files.',
+        })
+        return
+      }
+
+      setIsUploading(true)
+      setUploadError(null)
+
+      try {
+        for (const file of Array.from(files)) {
+          const validation = validateFileBeforeUpload(file, {
+            maxFileSizeBytes: MAX_FILE_SIZE_BYTES,
+            allowedMimeTypes: DEFAULT_ALLOWED_TYPES,
+          })
+
+          if (!validation.valid) {
+            toast({
+              variant: 'destructive',
+              title: `Cannot upload ${file.name}`,
+              description: validation.reason,
+            })
+            continue
+          }
+
+          const signResponse = await fetch('/api/documents/sign-upload', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              fileName: file.name,
+              fileType: file.type,
+              categoryId: selectedCategoryId,
+            }),
+          })
+
+          if (!signResponse.ok) {
+            throw new Error(`Unable to create upload request for ${file.name}`)
+          }
+
+          const signPayload: { uploadUrl: string; path: string } = await signResponse.json()
+
+          const uploadResponse = await fetch(signPayload.uploadUrl, {
+            method: 'PUT',
+            body: file,
+          })
+
+          if (!uploadResponse.ok) {
+            throw new Error(`Upload failed for ${file.name}`)
+          }
+
+          const metadataResponse = await fetch('/api/documents', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              name: file.name,
+              storagePath: signPayload.path,
+              size: file.size,
+              categoryId: selectedCategoryId,
+              visibility: newDocumentVisibility,
+              allowedRoles: categories.find((category) => category.id === selectedCategoryId)?.allowedRoles ?? [],
+              allowedUsers: [],
+            }),
+          })
+
+          if (!metadataResponse.ok) {
+            throw new Error(`Unable to register ${file.name}`)
+          }
+
+          const created: { document: DocumentRecord } = await metadataResponse.json()
+          setDocuments((existing) => {
+            const index = existing.findIndex((doc) => doc.id === created.document.id)
+            if (index >= 0) {
+              const updated = [...existing]
+              updated[index] = created.document
+              return updated
+            }
+            return [created.document, ...existing]
+          })
+        }
+
+        toast({
+          title: 'Upload complete',
+          description: 'Your document uploads finished successfully.',
+        })
+      } catch (error) {
+        const message = (error as Error).message
+        setUploadError(message)
+        toast({
+          variant: 'destructive',
+          title: 'Upload failed',
+          description: message,
+        })
+      } finally {
+        setIsUploading(false)
+      }
+    },
+    [categories, newDocumentVisibility, selectedCategoryId, toast],
+  )
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      setIsDragOver(false)
+
+      if (event.dataTransfer?.files?.length) {
+        void handleFiles(event.dataTransfer.files)
+      }
+    },
+    [handleFiles],
+  )
+
+  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (event.currentTarget.contains(event.relatedTarget as Node)) {
+      return
+    }
+    setIsDragOver(false)
+  }, [])
+
+  const onFileInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (event.target.files?.length) {
+        void handleFiles(event.target.files)
+        event.target.value = ''
+      }
+    },
+    [handleFiles],
+  )
+
+  const onSelectCategory = useCallback(
+    (value: string) => {
+      setSelectedCategoryId(value)
+      const category = categories.find((item) => item.id === value)
+      if (category) {
+        setNewDocumentVisibility(category.visibility)
+      }
+    },
+    [categories],
+  )
+
+  const openPermissionsDialog = useCallback((document: DocumentRecord) => {
+    setActiveDocument(document)
+    setPendingRoles(document.allowedRoles.join(', '))
+    setPendingUsers(document.allowedUsers.join(', '))
+    setPendingVisibility(document.visibility)
+    setPermissionsDialogOpen(true)
+  }, [])
+
+  const closePermissionsDialog = useCallback(() => {
+    setPermissionsDialogOpen(false)
+    setActiveDocument(null)
+    setPendingRoles('')
+    setPendingUsers('')
+    setPendingVisibility('private')
+    setAuditTrail([])
+  }, [])
+
+  const savePermissions = useCallback(async () => {
+    if (!activeDocument) {
+      return
+    }
+
+    setIsSavingPermissions(true)
+
+    try {
+      const payload: DocumentPermissionUpdate = {
+        visibility: pendingVisibility,
+        allowedRoles: uniqueList(
+          pendingRoles
+            .split(',')
+            .map((role) => role.trim())
+            .filter(Boolean),
+        ),
+        allowedUsers: uniqueList(
+          pendingUsers
+            .split(',')
+            .map((id) => id.trim())
+            .filter(Boolean),
+        ),
+      }
+
+      const response = await fetch(`/api/documents/${activeDocument.id}/permissions`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+
+      if (!response.ok) {
+        throw new Error('Unable to update permissions')
+      }
+
+      const updated: { document: DocumentRecord } = await response.json()
+      setDocuments((existing) => existing.map((doc) => (doc.id === updated.document.id ? updated.document : doc)))
+      setActiveDocument(updated.document)
+      toast({
+        title: 'Permissions updated',
+        description: `${updated.document.name} permissions were saved successfully`,
+      })
+      setPermissionsDialogOpen(false)
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Unable to update permissions',
+        description: (error as Error).message,
+      })
+    } finally {
+      setIsSavingPermissions(false)
+    }
+  }, [activeDocument, pendingRoles, pendingUsers, pendingVisibility, toast])
+
+  const updateReportState = useCallback(
+    (updater: (state: ReportConfigState) => ReportConfigState) => {
+      setReportState((previous) => updater(previous))
+    },
+    [],
+  )
+
+  const toggleCategoryFilter = useCallback(
+    (categoryId: string) => {
+      updateReportState((previous) => {
+        const set = new Set(previous.categoryIds)
+        if (set.has(categoryId)) {
+          set.delete(categoryId)
+        } else {
+          set.add(categoryId)
+        }
+        return { ...previous, categoryIds: Array.from(set) }
+      })
+    },
+    [updateReportState],
+  )
+
+  const toggleVisibilityFilter = useCallback(
+    (visibility: DocumentVisibility) => {
+      updateReportState((previous) => {
+        const set = new Set(previous.visibility)
+        if (set.has(visibility)) {
+          set.delete(visibility)
+        } else {
+          set.add(visibility)
+        }
+        return { ...previous, visibility: Array.from(set) as DocumentVisibility[] }
+      })
+    },
+    [updateReportState],
+  )
+
+  const updateDateFilter = useCallback(
+    (field: 'startDate' | 'endDate', value: string) => {
+      updateReportState((previous) => ({ ...previous, [field]: value }))
+    },
+    [updateReportState],
+  )
+
+  const requestReport = useCallback(
+    async (format: 'json' | 'csv') => {
+      const filters: DocumentReportFilters = {
+        categoryIds: reportState.categoryIds.length ? reportState.categoryIds : undefined,
+        visibility: reportState.visibility.length ? reportState.visibility : undefined,
+        startDate: reportState.startDate ? new Date(reportState.startDate) : undefined,
+        endDate: reportState.endDate ? new Date(reportState.endDate) : undefined,
+      }
+
+      const params = new URLSearchParams()
+      if (filters.categoryIds) {
+        filters.categoryIds.forEach((id) => params.append('category', id))
+      }
+      if (filters.visibility) {
+        filters.visibility.forEach((value) => params.append('visibility', value))
+      }
+      if (filters.startDate) {
+        params.set('start', filters.startDate.toISOString())
+      }
+      if (filters.endDate) {
+        params.set('end', filters.endDate.toISOString())
+      }
+      params.set('format', format)
+
+      setIsReportLoading(true)
+
+      try {
+        const response = await fetch(`/api/documents/reports?${params.toString()}`, {
+          method: 'GET',
+          headers: {
+            Accept: format === 'csv' ? 'text/csv' : 'application/json',
+          },
+        })
+
+        if (!response.ok) {
+          throw new Error('Unable to build report')
+        }
+
+        if (format === 'csv') {
+          const blob = await response.blob()
+          const url = URL.createObjectURL(blob)
+          const link = document.createElement('a')
+          link.href = url
+          link.download = `documents-report-${Date.now()}.csv`
+          document.body.appendChild(link)
+          link.click()
+          document.body.removeChild(link)
+          URL.revokeObjectURL(url)
+          toast({ title: 'Report downloaded', description: 'Your CSV export is ready.' })
+        } else {
+          const payload: { report: DocumentReport } = await response.json()
+          setReportPreview(payload.report)
+          toast({ title: 'Report ready', description: 'Preview updated with the latest data.' })
+        }
+      } catch (error) {
+        toast({
+          variant: 'destructive',
+          title: 'Unable to generate report',
+          description: (error as Error).message,
+        })
+      } finally {
+        setIsReportLoading(false)
+      }
+    },
+    [reportState, toast],
+  )
+
+  const localReportPreview = useMemo(() => {
+    const filters: DocumentReportFilters = {
+      categoryIds: reportState.categoryIds.length ? reportState.categoryIds : undefined,
+      visibility: reportState.visibility.length ? reportState.visibility : undefined,
+      startDate: reportState.startDate ? new Date(reportState.startDate) : undefined,
+      endDate: reportState.endDate ? new Date(reportState.endDate) : undefined,
+    }
+    return buildDocumentReport(documents, filters)
+  }, [documents, reportState])
+
+  return (
+    <div className="space-y-8">
+      <Card className="p-6">
+        <div className="flex flex-col gap-4">
+          <div>
+            <h2 className="text-lg font-semibold">Upload documents</h2>
+            <p className="text-sm text-muted-foreground">
+              Drag files here or use the picker. Files are uploaded with signed S3 URLs and stored per category.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="w-full sm:w-60">
+              <Label htmlFor="document-category">Category</Label>
+              <Select value={selectedCategoryId} onValueChange={onSelectCategory}>
+                <SelectTrigger id="document-category">
+                  <SelectValue placeholder="Select a category" />
+                </SelectTrigger>
+                <SelectContent>
+                  {categories.map((category) => (
+                    <SelectItem key={category.id} value={category.id}>
+                      {category.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="w-full sm:w-60">
+              <Label htmlFor="document-visibility">Visibility</Label>
+              <Select value={newDocumentVisibility} onValueChange={(value: DocumentVisibility) => setNewDocumentVisibility(value)}>
+                <SelectTrigger id="document-visibility">
+                  <SelectValue placeholder="Visibility" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="private">Private</SelectItem>
+                  <SelectItem value="shared">Shared</SelectItem>
+                  <SelectItem value="public">Public</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label htmlFor="document-picker" className="sr-only">
+                Document picker
+              </Label>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isUploading || !selectedCategoryId}
+              >
+                Choose files
+              </Button>
+              <input
+                ref={fileInputRef}
+                id="document-picker"
+                type="file"
+                multiple
+                className="hidden"
+                onChange={onFileInputChange}
+              />
+            </div>
+          </div>
+
+          <div
+            ref={dropRef}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            className={cn(
+              'flex min-h-[160px] items-center justify-center rounded-md border-2 border-dashed p-6 transition',
+              isDragOver ? 'border-primary bg-primary/5' : 'border-muted-foreground/20',
+            )}
+          >
+            <div className="text-center">
+              <p className="font-medium">Drop files to upload</p>
+              <p className="text-sm text-muted-foreground">
+                Files up to {formatBytes(MAX_FILE_SIZE_BYTES)}. Supported types: PDF, images, documents, text.
+              </p>
+              {isUploading && <p className="mt-2 text-sm text-muted-foreground">Uploading in progress…</p>}
+            </div>
+          </div>
+
+          {uploadError && <p className="text-sm text-destructive">{uploadError}</p>}
+        </div>
+      </Card>
+
+      <Card className="p-6">
+        <div className="mb-4 flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold">Documents</h2>
+            <p className="text-sm text-muted-foreground">
+              Manage uploaded content by category, update permissions, and review the audit trail.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => fetchDashboard()} disabled={isUploading}>
+            Refresh
+          </Button>
+        </div>
+
+        {filteredDocuments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No documents found for the selected category.</p>
+        ) : (
+          <Table headers={['Document', 'Category', 'Visibility', 'Size', 'Actions']}>
+            <div className="mx-2 rounded-sm bg-white dark:bg-inherit">
+              {filteredDocuments.map((document) => (
+                <div
+                  key={document.id}
+                  className="grid grid-cols-5 gap-3 rounded-sm p-3 align-middle text-sm"
+                >
+                  <div>
+                    <p className="font-medium">{document.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Uploaded {new Date(document.createdAt).toLocaleString()} by{' '}
+                      {document.uploadedByName || document.uploadedByEmail || document.uploadedBy}
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Badge variant="secondary" className="w-fit">
+                      {document.categoryName ?? 'Uncategorised'}
+                    </Badge>
+                  </div>
+                  <div>
+                    <Badge className="w-fit" variant={document.visibility === 'public' ? 'default' : 'outline'}>
+                      {visibilityLabel(document.visibility)}
+                    </Badge>
+                  </div>
+                  <div className="font-medium">{formatBytes(document.size)}</div>
+                  <div className="flex items-center gap-2">
+                    <Button variant="outline" size="sm" onClick={() => openPermissionsDialog(document)}>
+                      Manage permissions
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={() => openPermissionsDialog(document)}>
+                      Audit log
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Table>
+        )}
+      </Card>
+
+      {isAdmin && (
+        <Card className="p-6">
+          <div className="mb-4">
+            <h2 className="text-lg font-semibold">Reports &amp; exports</h2>
+            <p className="text-sm text-muted-foreground">
+              Configure filters and export a CSV report or review the generated insights for administrators.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-4">
+              <div>
+                <h3 className="text-sm font-semibold">Categories</h3>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {categories.map((category) => {
+                    const selected = reportState.categoryIds.includes(category.id)
+                    return (
+                      <button
+                        type="button"
+                        key={category.id}
+                        onClick={() => toggleCategoryFilter(category.id)}
+                        className={cn(
+                          'rounded-full border px-3 py-1 text-xs transition',
+                          selected ? 'border-primary bg-primary/10 text-primary' : 'border-muted-foreground/20',
+                        )}
+                      >
+                        {category.name}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-semibold">Visibility</h3>
+                <div className="mt-2 flex flex-wrap gap-3">
+                  {(['private', 'shared', 'public'] satisfies DocumentVisibility[]).map((value) => {
+                    const selected = reportState.visibility.includes(value)
+                    return (
+                      <label key={value} className="flex items-center gap-2 text-sm">
+                        <Switch checked={selected} onCheckedChange={() => toggleVisibilityFilter(value)} />
+                        {visibilityLabel(value)}
+                      </label>
+                    )
+                  })}
+                </div>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <Label htmlFor="report-start">Start date</Label>
+                  <Input
+                    id="report-start"
+                    type="date"
+                    value={reportState.startDate}
+                    onChange={(event) => updateDateFilter('startDate', event.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="report-end">End date</Label>
+                  <Input
+                    id="report-end"
+                    type="date"
+                    value={reportState.endDate}
+                    onChange={(event) => updateDateFilter('endDate', event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <Button disabled={isReportLoading} onClick={() => requestReport('json')}>
+                  Preview report
+                </Button>
+                <Button
+                  variant="outline"
+                  disabled={isReportLoading}
+                  onClick={() => requestReport('csv')}
+                >
+                  Export CSV
+                </Button>
+              </div>
+            </div>
+
+            <div className="rounded-md border bg-muted/30 p-4 text-sm">
+              <h3 className="mb-2 text-sm font-semibold">Report preview</h3>
+              <p className="text-sm text-muted-foreground">
+                Preview updates in real-time as you adjust filters. Use the export option to download a CSV snapshot.
+              </p>
+
+              <div className="mt-4 space-y-3">
+                <div>
+                  <p className="text-xs uppercase text-muted-foreground">Total documents</p>
+                  <p className="text-lg font-semibold">{localReportPreview.totalCount}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase text-muted-foreground">Total storage</p>
+                  <p className="text-lg font-semibold">{formatBytes(localReportPreview.totalSize)}</p>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {Object.entries(localReportPreview.totalsByVisibility).map(([key, value]) => (
+                    <div key={key} className="rounded border bg-background/70 p-3">
+                      <p className="text-xs uppercase text-muted-foreground">{visibilityLabel(key as DocumentVisibility)}</p>
+                      <p className="text-sm font-semibold">{value.count} files</p>
+                      <p className="text-xs text-muted-foreground">{formatBytes(value.size)}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {reportPreview && (
+                <div className="mt-4">
+                  <h4 className="text-sm font-semibold">Last exported snapshot</h4>
+                  <p className="text-xs text-muted-foreground">
+                    {reportPreview.totalCount} files totalling {formatBytes(reportPreview.totalSize)}
+                  </p>
+                  <pre className="mt-2 max-h-48 overflow-auto rounded bg-background/80 p-2 text-xs">
+                    {documentReportToCsv(reportPreview)}
+                  </pre>
+                </div>
+              )}
+            </div>
+          </div>
+        </Card>
+      )}
+
+      <Dialog open={permissionsDialogOpen} onOpenChange={(open) => (open ? setPermissionsDialogOpen(true) : closePermissionsDialog())}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Document permissions</DialogTitle>
+            <DialogDescription>
+              Configure access rules and review the audit history for the selected document.
+            </DialogDescription>
+          </DialogHeader>
+
+          {activeDocument ? (
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <p className="text-sm font-semibold">{activeDocument.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  Uploaded {new Date(activeDocument.createdAt).toLocaleString()} by{' '}
+                  {activeDocument.uploadedByName || activeDocument.uploadedByEmail || activeDocument.uploadedBy}
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="permission-visibility">Visibility</Label>
+                  <Select value={pendingVisibility} onValueChange={(value: DocumentVisibility) => setPendingVisibility(value)}>
+                    <SelectTrigger id="permission-visibility">
+                      <SelectValue placeholder="Select visibility" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="private">Private</SelectItem>
+                      <SelectItem value="shared">Shared</SelectItem>
+                      <SelectItem value="public">Public</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="permission-roles">Allowed roles (comma separated)</Label>
+                  <Input
+                    id="permission-roles"
+                    value={pendingRoles}
+                    onChange={(event) => setPendingRoles(event.target.value)}
+                    placeholder="admin, manager"
+                  />
+                </div>
+
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="permission-users">Allowed user IDs (comma separated)</Label>
+                  <Input
+                    id="permission-users"
+                    value={pendingUsers}
+                    onChange={(event) => setPendingUsers(event.target.value)}
+                    placeholder="uuid-1, uuid-2"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <p className="text-sm font-semibold">Audit history</p>
+                {isAuditLoading ? (
+                  <p className="text-xs text-muted-foreground">Loading audit entries…</p>
+                ) : auditTrail.length > 0 ? (
+                  <div className="max-h-60 space-y-3 overflow-y-auto pr-2">
+                    {auditTrail.map((entry) => (
+                      <div key={entry.id} className="rounded-md border bg-muted/30 p-3">
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm font-medium capitalize">{entry.action.replace(/_/g, ' ')}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {new Date(entry.createdAt).toLocaleString()}
+                          </span>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {entry.actorName || entry.actorEmail || entry.actorId}
+                        </p>
+                        {entry.context && (
+                          <pre className="mt-2 max-h-24 overflow-auto rounded bg-background/80 p-2 text-xs">
+                            {JSON.stringify(entry.context, null, 2)}
+                          </pre>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">No audit entries recorded for this document.</p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Select a document to manage its permissions.</p>
+          )}
+
+          <DialogFooter className="mt-4">
+            <Button variant="outline" onClick={closePermissionsDialog}>
+              Cancel
+            </Button>
+            <Button onClick={() => void savePermissions()} disabled={isSavingPermissions}>
+              Save changes
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+export default DocumentManager

--- a/web/features/documents/index.ts
+++ b/web/features/documents/index.ts
@@ -1,0 +1,4 @@
+export * from './DocumentManager'
+export * from './reporting'
+export * from './types'
+export * from './utils'

--- a/web/features/documents/reporting.test.ts
+++ b/web/features/documents/reporting.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { buildDocumentReport, documentReportToCsv } from './reporting'
+import type { DocumentRecord } from './types'
+
+describe('document reporting', () => {
+  const documents: DocumentRecord[] = [
+    {
+      id: 'doc-1',
+      name: 'Lease Agreement',
+      categoryId: 'cat-lease',
+      categoryName: 'Leases',
+      storagePath: 'cat-lease/doc-1.pdf',
+      size: 10_240,
+      visibility: 'shared',
+      allowedRoles: ['manager'],
+      allowedUsers: [],
+      uploadedBy: 'user-1',
+      uploadedByName: 'Alice',
+      uploadedByEmail: 'alice@example.com',
+      createdAt: '2024-01-15T12:00:00.000Z',
+      updatedAt: null,
+    },
+    {
+      id: 'doc-2',
+      name: 'Utility Bill',
+      categoryId: 'cat-billing',
+      categoryName: 'Billing',
+      storagePath: 'cat-billing/doc-2.pdf',
+      size: 5_120,
+      visibility: 'public',
+      allowedRoles: [],
+      allowedUsers: [],
+      uploadedBy: 'user-2',
+      uploadedByName: 'Bob',
+      uploadedByEmail: 'bob@example.com',
+      createdAt: '2024-02-01T09:30:00.000Z',
+      updatedAt: null,
+    },
+  ]
+
+  it('applies visibility and category filters', () => {
+    const report = buildDocumentReport(documents, {
+      categoryIds: ['cat-lease'],
+      visibility: ['shared'],
+      startDate: new Date('2024-01-01T00:00:00.000Z'),
+      endDate: new Date('2024-03-01T00:00:00.000Z'),
+    })
+
+    expect(report.totalCount).toBe(1)
+    expect(report.totalSize).toBe(10_240)
+    expect(Object.keys(report.totalsByCategory)).toEqual(['cat-lease'])
+    expect(report.totalsByVisibility.shared.count).toBe(1)
+  })
+
+  it('serialises the report to CSV format', () => {
+    const report = buildDocumentReport(documents)
+    const csv = documentReportToCsv(report)
+
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toContain('Document,Category,Visibility,Size (bytes),Uploaded By,Uploaded By Name,Uploaded At')
+    expect(lines).toHaveLength(3)
+    expect(lines[1]).toContain('Lease Agreement')
+  })
+})

--- a/web/features/documents/reporting.ts
+++ b/web/features/documents/reporting.ts
@@ -1,0 +1,123 @@
+import type { DocumentRecord, DocumentReport, DocumentVisibility } from './types'
+
+export type DocumentReportFilters = {
+  categoryIds?: string[]
+  visibility?: DocumentVisibility[]
+  startDate?: Date
+  endDate?: Date
+}
+
+function isWithinRange(date: Date, start?: Date, end?: Date) {
+  if (start && date < start) {
+    return false
+  }
+  if (end && date > end) {
+    return false
+  }
+  return true
+}
+
+export function filterDocuments(
+  documents: DocumentRecord[],
+  filters: DocumentReportFilters,
+): DocumentRecord[] {
+  const visibilitySet = filters.visibility ? new Set(filters.visibility) : null
+  const categorySet = filters.categoryIds ? new Set(filters.categoryIds) : null
+
+  return documents.filter((document) => {
+    if (visibilitySet && !visibilitySet.has(document.visibility)) {
+      return false
+    }
+
+    if (categorySet && !categorySet.has(document.categoryId)) {
+      return false
+    }
+
+    const createdAt = new Date(document.createdAt)
+    if (!isWithinRange(createdAt, filters.startDate, filters.endDate)) {
+      return false
+    }
+
+    return true
+  })
+}
+
+export function buildDocumentReport(
+  documents: DocumentRecord[],
+  filters: DocumentReportFilters = {},
+): DocumentReport {
+  const filtered = filterDocuments(documents, filters)
+
+  const totalsByCategory: DocumentReport['totalsByCategory'] = {}
+  const totalsByVisibility: DocumentReport['totalsByVisibility'] = {
+    private: { count: 0, size: 0 },
+    shared: { count: 0, size: 0 },
+    public: { count: 0, size: 0 },
+  }
+
+  let totalSize = 0
+
+  filtered.forEach((doc) => {
+    totalSize += doc.size
+
+    if (!totalsByCategory[doc.categoryId]) {
+      totalsByCategory[doc.categoryId] = { count: 0, size: 0 }
+    }
+    totalsByCategory[doc.categoryId].count += 1
+    totalsByCategory[doc.categoryId].size += doc.size
+
+    totalsByVisibility[doc.visibility].count += 1
+    totalsByVisibility[doc.visibility].size += doc.size
+  })
+
+  return {
+    rows: filtered.map((doc) => ({
+      id: doc.id,
+      name: doc.name,
+      categoryId: doc.categoryId,
+      categoryName: doc.categoryName,
+      visibility: doc.visibility,
+      size: doc.size,
+      uploadedBy: doc.uploadedBy,
+      uploadedByName: doc.uploadedByName,
+      createdAt: doc.createdAt,
+    })),
+    totalSize,
+    totalCount: filtered.length,
+    totalsByCategory,
+    totalsByVisibility,
+  }
+}
+
+export function documentReportToCsv(report: DocumentReport): string {
+  const header = [
+    'Document',
+    'Category',
+    'Visibility',
+    'Size (bytes)',
+    'Uploaded By',
+    'Uploaded By Name',
+    'Uploaded At',
+  ]
+
+  const rows = report.rows.map((row) => [
+    row.name,
+    row.categoryName ?? row.categoryId,
+    row.visibility,
+    row.size.toString(),
+    row.uploadedBy,
+    row.uploadedByName ?? '',
+    row.createdAt,
+  ])
+
+  return [header, ...rows]
+    .map((columns) =>
+      columns
+        .map((column) => {
+          const safe = column.replace(/"/g, '""')
+          return /[",\n]/.test(safe) ? `"${safe}"` : safe
+        })
+        .join(','),
+    )
+    .join('\n')
+}

--- a/web/features/documents/types.ts
+++ b/web/features/documents/types.ts
@@ -1,0 +1,65 @@
+export type DocumentVisibility = 'private' | 'shared' | 'public'
+
+export type DocumentCategory = {
+  id: string
+  name: string
+  description?: string | null
+  visibility: DocumentVisibility
+  allowedRoles: string[]
+  createdAt: string
+  updatedAt?: string | null
+}
+
+export type DocumentRecord = {
+  id: string
+  name: string
+  categoryId: string
+  categoryName?: string | null
+  storagePath: string
+  size: number
+  visibility: DocumentVisibility
+  allowedRoles: string[]
+  allowedUsers: string[]
+  uploadedBy: string
+  uploadedByName?: string | null
+  uploadedByEmail?: string | null
+  createdAt: string
+  updatedAt?: string | null
+}
+
+export type DocumentAuditEntry = {
+  id: string
+  documentId: string
+  action: 'uploaded' | 'downloaded' | 'permission_updated' | 'deleted' | 'restored' | 'viewed'
+  actorId: string
+  actorName?: string | null
+  actorEmail?: string | null
+  context?: Record<string, unknown> | null
+  createdAt: string
+}
+
+export type DocumentPermissionUpdate = {
+  visibility: DocumentVisibility
+  allowedRoles: string[]
+  allowedUsers: string[]
+}
+
+export type DocumentReportRow = {
+  id: string
+  name: string
+  categoryId: string
+  categoryName?: string | null
+  visibility: DocumentVisibility
+  size: number
+  uploadedBy: string
+  uploadedByName?: string | null
+  createdAt: string
+}
+
+export type DocumentReport = {
+  rows: DocumentReportRow[]
+  totalSize: number
+  totalCount: number
+  totalsByCategory: Record<string, { count: number; size: number }>
+  totalsByVisibility: Record<DocumentVisibility, { count: number; size: number }>
+}

--- a/web/features/documents/utils.test.ts
+++ b/web/features/documents/utils.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildObjectKey,
+  canEditDocument,
+  canViewDocument,
+  formatBytes,
+  normalizeFileName,
+  validateFileBeforeUpload,
+  type DocumentPermissionModel,
+  type DocumentUser,
+} from './utils'
+
+describe('normalizeFileName', () => {
+  it('sanitises whitespace and special characters', () => {
+    expect(normalizeFileName(' Quarterly Report 2024!.PDF ')).toBe('quarterly-report-2024.pdf')
+  })
+
+  it('falls back to default name when value is blank', () => {
+    expect(normalizeFileName('   ')).toBe('file')
+  })
+})
+
+describe('buildObjectKey', () => {
+  it('creates deterministic storage keys using category and user metadata', () => {
+    const key = buildObjectKey('policies', 'handbook.pdf', { userId: 'user-123', timestamp: 123456789 })
+    expect(key).toBe('policies/user-123/21i3v9-handbook.pdf')
+  })
+})
+
+describe('permission helpers', () => {
+  const permissions: DocumentPermissionModel = {
+    ownerId: 'owner-1',
+    visibility: 'shared',
+    allowedRoles: ['manager'],
+    allowedUsers: ['user-2'],
+  }
+
+  const owner: DocumentUser = { id: 'owner-1', role: 'admin' }
+  const manager: DocumentUser = { id: 'user-3', role: 'manager' }
+  const collaborator: DocumentUser = { id: 'user-2', role: 'user' }
+  const outsider: DocumentUser = { id: 'user-4', role: 'user' }
+
+  it('allows owners and granted roles to view', () => {
+    expect(canViewDocument(owner, permissions)).toBe(true)
+    expect(canViewDocument(manager, permissions)).toBe(true)
+    expect(canViewDocument(collaborator, permissions)).toBe(true)
+  })
+
+  it('prevents unauthorised viewers', () => {
+    expect(canViewDocument(outsider, permissions)).toBe(false)
+    expect(canViewDocument(null, permissions)).toBe(false)
+  })
+
+  it('only allows owners or authorised roles to edit', () => {
+    expect(canEditDocument(owner, permissions)).toBe(true)
+    expect(canEditDocument(manager, permissions)).toBe(true)
+    expect(canEditDocument(collaborator, permissions)).toBe(false)
+  })
+})
+
+describe('validateFileBeforeUpload', () => {
+  const config = { maxFileSizeBytes: 2 * 1024 * 1024, allowedMimeTypes: ['application/pdf', 'image/'] }
+
+  it('accepts valid files', () => {
+    const result = validateFileBeforeUpload({ size: 1_000_000, type: 'application/pdf' }, config)
+    expect(result).toEqual({ valid: true })
+  })
+
+  it('rejects files that are too large', () => {
+    const result = validateFileBeforeUpload({ size: 3_000_000, type: 'application/pdf' }, config)
+    expect(result).toMatchObject({ valid: false })
+  })
+
+  it('rejects unsupported mime types', () => {
+    const result = validateFileBeforeUpload({ size: 500_000, type: 'application/zip' }, config)
+    expect(result).toMatchObject({ valid: false })
+  })
+})
+
+describe('formatBytes', () => {
+  it('formats byte counts in a human readable way', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(1024)).toBe('1 KB')
+    expect(formatBytes(1024 * 1024)).toBe('1 MB')
+  })
+})

--- a/web/features/documents/utils.ts
+++ b/web/features/documents/utils.ts
@@ -1,0 +1,171 @@
+import type { DocumentPermissionUpdate, DocumentVisibility } from './types'
+
+export type DocumentUser = {
+  id: string
+  role: string
+}
+
+export type DocumentPermissionModel = DocumentPermissionUpdate & {
+  ownerId: string
+}
+
+const DEFAULT_FILE_NAME = 'file'
+
+export function normalizeFileName(name: string): string {
+  const trimmed = name.trim()
+  if (!trimmed) {
+    return DEFAULT_FILE_NAME
+  }
+
+  const extensionMatch = trimmed.match(/\.([A-Za-z0-9]{1,8})$/)
+  const extension = extensionMatch ? extensionMatch[1].toLowerCase() : null
+  const base = extensionMatch
+    ? trimmed.slice(0, trimmed.length - extensionMatch[0].length)
+    : trimmed
+
+  const normalizedBase = base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-]+|[-]+$/g, '')
+
+  const safeBase = normalizedBase || DEFAULT_FILE_NAME
+
+  if (extension) {
+    return `${safeBase}.${extension}`
+  }
+
+  return safeBase
+}
+
+export function buildObjectKey(
+  categoryId: string,
+  fileName: string,
+  options: { userId?: string; timestamp?: number } = {},
+): string {
+  const safeName = normalizeFileName(fileName)
+  const timestamp = (options.timestamp ?? Date.now()).toString(36)
+  const userSegment = options.userId ? `${options.userId}/` : ''
+  return `${categoryId}/${userSegment}${timestamp}-${safeName}`
+}
+
+export function canViewDocument(
+  user: DocumentUser | null,
+  permissions: DocumentPermissionModel,
+): boolean {
+  if (permissions.visibility === 'public') {
+    return true
+  }
+
+  if (!user) {
+    return false
+  }
+
+  if (user.id === permissions.ownerId) {
+    return true
+  }
+
+  if (permissions.allowedUsers.includes(user.id)) {
+    return true
+  }
+
+  if (
+    permissions.visibility === 'shared' &&
+    permissions.allowedRoles.some((role) => role.toLowerCase() === user.role.toLowerCase())
+  ) {
+    return true
+  }
+
+  return false
+}
+
+export function canEditDocument(
+  user: DocumentUser | null,
+  permissions: DocumentPermissionModel,
+): boolean {
+  if (!user) {
+    return false
+  }
+
+  if (user.id === permissions.ownerId) {
+    return true
+  }
+
+  return permissions.allowedRoles.some((role) => role.toLowerCase() === user.role.toLowerCase())
+}
+
+export type UploadValidationConfig = {
+  maxFileSizeBytes: number
+  allowedMimeTypes: string[]
+}
+
+export function validateFileBeforeUpload(
+  file: { size: number; type: string },
+  config: UploadValidationConfig,
+): { valid: true } | { valid: false; reason: string } {
+  if (file.size > config.maxFileSizeBytes) {
+    return {
+      valid: false,
+      reason: `File exceeds maximum size of ${Math.round(config.maxFileSizeBytes / (1024 * 1024))}MB`,
+    }
+  }
+
+  if (
+    config.allowedMimeTypes.length > 0 &&
+    !config.allowedMimeTypes.some((allowed) => {
+      if (allowed.endsWith('/*')) {
+        return file.type.startsWith(allowed.slice(0, -1))
+      }
+      if (allowed.endsWith('/')) {
+        return file.type.startsWith(allowed)
+      }
+      return file.type === allowed
+    })
+  ) {
+    return {
+      valid: false,
+      reason: 'File type is not allowed for uploads',
+    }
+  }
+
+  return { valid: true }
+}
+
+export function mergePermissionUpdates(
+  existing: DocumentPermissionModel,
+  update: Partial<DocumentPermissionUpdate>,
+): DocumentPermissionModel {
+  return {
+    ownerId: existing.ownerId,
+    visibility: update.visibility ?? existing.visibility,
+    allowedRoles: update.allowedRoles ?? existing.allowedRoles,
+    allowedUsers: update.allowedUsers ?? existing.allowedUsers,
+  }
+}
+
+export function visibilityLabel(visibility: DocumentVisibility): string {
+  switch (visibility) {
+    case 'private':
+      return 'Private (owner only)'
+    case 'shared':
+      return 'Shared (restricted access)'
+    case 'public':
+      return 'Public (everyone in workspace)'
+    default:
+      return visibility
+  }
+}
+
+export function formatBytes(size: number): string {
+  if (Number.isNaN(size) || size <= 0) {
+    return '0 B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const exponent = Math.min(Math.floor(Math.log(size) / Math.log(1024)), units.length - 1)
+  const value = size / 1024 ** exponent
+  const precision = value < 10 && exponent > 0 ? 1 : 0
+  const formatted = value.toFixed(precision)
+  const normalized = precision > 0 ? Number(formatted).toString() : formatted
+  return `${normalized} ${units[exponent]}`
+}


### PR DESCRIPTION
## Summary
- implement a document management surface with drag-and-drop uploads, inline permission management, and audit log viewing
- add document utilities, reporting helpers, and API routes to back signed uploads, metadata storage, and admin CSV exports
- cover permission and file handling logic with new vitest suites to protect upload and reporting behaviour

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ceeff845a88328a08c379efc0a9200