### PR TITLE
feat: add notifications service with integrations

### DIFF
--- a/app/api/notifications/events/route.ts
+++ b/app/api/notifications/events/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { notificationMetrics, notificationService } from '@/services/notifications';
+import { SendGridEmailProvider } from '@/services/notifications/channels/email';
+import { TwilioProvider } from '@/services/notifications/channels/sms';
+import { PushNotificationProvider } from '@/services/notifications/channels/push';
+import type { NotificationChannel, NotificationEvent } from '@/services/notifications/types';
+
+export async function GET(request: NextRequest) {
+  const channel = request.nextUrl.searchParams.get('channel');
+  const type = request.nextUrl.searchParams.get('type');
+  const recipient = request.nextUrl.searchParams.get('recipient');
+  const provider = request.nextUrl.searchParams.get('provider');
+
+  if (channel || type || recipient || provider) {
+    const events = notificationMetrics.filterEvents({
+      channel: (channel as NotificationChannel | null) ?? undefined,
+      type: (type as NotificationEvent['type'] | null) ?? undefined,
+      recipient: recipient ?? undefined,
+      provider: provider ?? undefined,
+    });
+
+    return NextResponse.json({ events });
+  }
+
+  return NextResponse.json(notificationMetrics.getSummary());
+}
+
+export async function POST(request: NextRequest) {
+  const provider = request.nextUrl.searchParams.get('provider');
+
+  if (!provider) {
+    return NextResponse.json({ error: 'Provider query parameter is required.' }, { status: 400 });
+  }
+
+  const payload = await request.json().catch(() => undefined);
+
+  if (!payload) {
+    return NextResponse.json({ error: 'Invalid payload.' }, { status: 400 });
+  }
+
+  let events = [];
+
+  switch (provider) {
+    case 'sendgrid':
+      events = SendGridEmailProvider.parseWebhook(payload);
+      break;
+    case 'twilio-sms':
+      events = TwilioProvider.parseWebhook(payload, 'sms');
+      break;
+    case 'twilio-voice':
+      events = TwilioProvider.parseWebhook(payload, 'voice');
+      break;
+    case 'fcm':
+      events = PushNotificationProvider.parseFcmWebhook(payload);
+      break;
+    default:
+      return NextResponse.json({ error: `Unsupported provider: ${provider}` }, { status: 400 });
+  }
+
+  notificationService.recordEvents(events);
+
+  return NextResponse.json({ received: events.length });
+}

--- a/app/api/notifications/preferences/route.ts
+++ b/app/api/notifications/preferences/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { notificationPreferenceCenter } from '@/services/notifications';
+import type { PreferenceUpdate } from '@/services/notifications/types';
+
+export async function GET(request: NextRequest) {
+  const userId = request.nextUrl.searchParams.get('userId');
+
+  if (!userId) {
+    return NextResponse.json({ error: 'userId query parameter is required.' }, { status: 400 });
+  }
+
+  const preferences = notificationPreferenceCenter.getPreferences(userId);
+  return NextResponse.json({ preferences });
+}
+
+export async function PUT(request: NextRequest) {
+  const payload = await request.json().catch(() => undefined);
+
+  if (!payload) {
+    return NextResponse.json({ error: 'Invalid payload.' }, { status: 400 });
+  }
+
+  const updates: PreferenceUpdate[] = Array.isArray(payload) ? payload : [payload];
+  updates.forEach((update) => notificationPreferenceCenter.updatePreference(update));
+
+  return NextResponse.json({ updated: updates.length });
+}

--- a/app/api/notifications/send/route.ts
+++ b/app/api/notifications/send/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { notificationService } from '@/services/notifications';
+import type { SendNotificationRequest } from '@/services/notifications/types';
+
+export async function POST(request: NextRequest) {
+  const payload = await request.json().catch(() => undefined);
+
+  if (!payload) {
+    return NextResponse.json({ error: 'Invalid payload.' }, { status: 400 });
+  }
+
+  try {
+    const summary = await notificationService.send(payload as SendNotificationRequest);
+    return NextResponse.json(summary);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/lib/calendar-service.ts
+++ b/lib/calendar-service.ts
@@ -1,6 +1,8 @@
 import { google } from 'googleapis';
 import { GaxiosError } from 'gaxios'; // Part of googleapis
 
+import { appEventBus } from '@/lib/event-bus';
+
 // Configure the Google OAuth2 client
 const oauth2Client = new google.auth.OAuth2(
   process.env.GOOGLE_CLIENT_ID,
@@ -79,6 +81,14 @@ export async function createGoogleCalendarEvent({
     });
 
     console.log('Google Calendar Event created: %s', response.data.htmlLink);
+    appEventBus.emit('calendar:eventCreated', {
+      summary,
+      description,
+      startTime,
+      endTime,
+      attendeeEmail,
+      attendeeName,
+    });
     return { success: true, eventId: response.data.id, link: response.data.htmlLink };
 
   } catch (error: unknown) {

--- a/lib/event-bus.ts
+++ b/lib/event-bus.ts
@@ -1,0 +1,32 @@
+import EventEmitter from 'eventemitter3';
+
+type NotificationChannel = 'email' | 'sms' | 'voice' | 'push';
+
+export interface CalendarEventCreatedPayload {
+  summary: string;
+  description: string;
+  startTime: string;
+  endTime: string;
+  attendeeEmail: string;
+  attendeeName?: string;
+}
+
+export interface PreferenceChangedPayload {
+  userId: string;
+  channel: NotificationChannel;
+  enabled: boolean;
+  category?: string;
+}
+
+export interface AppEventMap {
+  'calendar:eventCreated': CalendarEventCreatedPayload;
+  'notifications:preferenceChanged': PreferenceChangedPayload;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __appEventBus: EventEmitter<AppEventMap> | undefined;
+}
+
+export const appEventBus: EventEmitter<AppEventMap> =
+  globalThis.__appEventBus ?? (globalThis.__appEventBus = new EventEmitter<AppEventMap>());

--- a/services/notifications/channels/email.ts
+++ b/services/notifications/channels/email.ts
@@ -1,0 +1,233 @@
+import type {
+  ChannelResponse,
+  DeliveryEvent,
+  NotificationEvent,
+  NotificationRecipient,
+  RenderedTemplate,
+  SendNotificationRequest,
+} from '../types';
+
+export interface SendGridConfig {
+  apiKey?: string;
+  fromEmail: string;
+  fromName?: string;
+  replyTo?: string;
+}
+
+interface SendGridPayload {
+  personalizations: Array<{
+    to: Array<{ email: string; name?: string }>;
+    dynamic_template_data?: Record<string, unknown>;
+    custom_args?: Record<string, unknown>;
+  }>;
+  from: { email: string; name?: string };
+  reply_to?: { email: string; name?: string };
+  subject?: string;
+  content?: Array<{ type: string; value: string }>;
+  categories?: string[];
+  tracking_settings?: {
+    click_tracking?: { enable: boolean };
+    open_tracking?: { enable: boolean };
+  };
+}
+
+interface SendGridWebhookEvent {
+  email: string;
+  event: string;
+  timestamp: number;
+  sg_message_id?: string;
+  category?: string | string[];
+  reason?: string;
+  type?: string;
+}
+
+export class SendGridEmailProvider {
+  private readonly endpoint = 'https://api.sendgrid.com/v3/mail/send';
+
+  constructor(private readonly config: SendGridConfig) {}
+
+  async send(
+    rendered: RenderedTemplate,
+    recipient: NotificationRecipient,
+    request: SendNotificationRequest,
+  ): Promise<ChannelResponse> {
+    if (!this.config.apiKey) {
+      return {
+        success: false,
+        status: 'skipped',
+        channel: 'email',
+        recipient,
+        timestamp: new Date(),
+        error: 'SendGrid API key is not configured.',
+        provider: 'sendgrid',
+      } satisfies ChannelResponse;
+    }
+
+    const payload = this.buildPayload(rendered, recipient, request);
+
+    try {
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.config.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        return {
+          success: false,
+          status: 'failed',
+          channel: 'email',
+          recipient,
+          timestamp: new Date(),
+          provider: 'sendgrid',
+          error: `SendGrid error: ${response.status} ${errorBody}`.slice(0, 500),
+        } satisfies ChannelResponse;
+      }
+
+      const messageId = response.headers.get('x-message-id') ?? undefined;
+
+      return {
+        success: true,
+        status: 'sent',
+        channel: 'email',
+        recipient,
+        timestamp: new Date(),
+        provider: 'sendgrid',
+        messageId,
+      } satisfies ChannelResponse;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        status: 'failed',
+        channel: 'email',
+        recipient,
+        timestamp: new Date(),
+        provider: 'sendgrid',
+        error: message,
+      } satisfies ChannelResponse;
+    }
+  }
+
+  private buildPayload(
+    rendered: RenderedTemplate,
+    recipient: NotificationRecipient,
+    request: SendNotificationRequest,
+  ): SendGridPayload {
+    const content: SendGridPayload['content'] = [];
+
+    if (rendered.text) {
+      content.push({ type: 'text/plain', value: rendered.text });
+    }
+
+    if (rendered.html) {
+      content.push({ type: 'text/html', value: rendered.html });
+    }
+
+    if (content.length === 0) {
+      content.push({ type: 'text/plain', value: '' });
+    }
+
+    return {
+      personalizations: [
+        {
+          to: [
+            {
+              email: recipient.address,
+              name: recipient.name,
+            },
+          ],
+          dynamic_template_data: request.context,
+          custom_args: {
+            correlationId: request.correlationId,
+            templateId: request.templateId,
+            userId: recipient.userId,
+            category: request.category,
+          },
+        },
+      ],
+      from: {
+        email: this.config.fromEmail,
+        name: this.config.fromName,
+      },
+      reply_to: this.config.replyTo ? { email: this.config.replyTo } : undefined,
+      subject: rendered.subject,
+      content,
+      categories: request.category ? [request.category] : undefined,
+      tracking_settings: {
+        click_tracking: { enable: request.options?.trackClicks ?? true },
+        open_tracking: { enable: request.options?.trackOpens ?? true },
+      },
+    } satisfies SendGridPayload;
+  }
+
+  static parseWebhook(payload: unknown): NotificationEvent[] {
+    if (!Array.isArray(payload)) {
+      return [];
+    }
+
+    const events: NotificationEvent[] = [];
+
+    (payload as SendGridWebhookEvent[]).forEach((event) => {
+      const timestamp = event.timestamp ? new Date(event.timestamp * 1000) : new Date();
+      const category = Array.isArray(event.category)
+        ? event.category[0]
+        : event.category;
+
+      switch (event.event) {
+        case 'delivered':
+        case 'processed':
+        case 'deferred':
+        case 'open':
+        case 'click': {
+          const mapped: DeliveryEvent = {
+            type:
+              event.event === 'open'
+                ? 'opened'
+                : event.event === 'click'
+                  ? 'clicked'
+                  : event.event === 'processed'
+                    ? 'queued'
+                    : event.event === 'deferred'
+                      ? 'sent'
+                      : 'delivered',
+            channel: 'email',
+            provider: 'sendgrid',
+            recipient: event.email,
+            timestamp,
+            messageId: event.sg_message_id,
+            category: category ?? undefined,
+            data: { raw: event },
+          };
+          events.push(mapped);
+          break;
+        }
+        case 'bounce':
+        case 'dropped':
+        case 'spamreport': {
+          events.push({
+            type: event.event === 'spamreport' ? 'complained' : event.event === 'dropped' ? 'failed' : 'bounced',
+            channel: 'email',
+            provider: 'sendgrid',
+            recipient: event.email,
+            timestamp,
+            messageId: event.sg_message_id,
+            category: category ?? undefined,
+            reason: event.reason,
+            data: { raw: event },
+          });
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    });
+
+    return events;
+  }
+}

--- a/services/notifications/channels/push.ts
+++ b/services/notifications/channels/push.ts
@@ -1,0 +1,319 @@
+import http2 from 'node:http2';
+import { createSign } from 'node:crypto';
+
+import type {
+  ChannelResponse,
+  NotificationEvent,
+  NotificationRecipient,
+  RenderedTemplate,
+  SendNotificationRequest,
+} from '../types';
+
+export interface FcmConfig {
+  serverKey?: string;
+  defaultTitle?: string;
+}
+
+export interface ApnsConfig {
+  keyId?: string;
+  teamId?: string;
+  privateKey?: string;
+  bundleId?: string;
+  topic?: string;
+}
+
+export interface PushProviderConfig {
+  fcm?: FcmConfig;
+  apns?: ApnsConfig;
+}
+
+interface FcmResponse {
+  message_id?: string | number;
+  success?: number;
+  failure?: number;
+  results?: Array<{ message_id?: string; error?: string }>;
+}
+
+export class PushNotificationProvider {
+  constructor(private readonly config: PushProviderConfig) {}
+
+  async send(
+    rendered: RenderedTemplate,
+    recipient: NotificationRecipient,
+    request: SendNotificationRequest,
+  ): Promise<ChannelResponse> {
+    const platform =
+      (request.providerOverrides?.platform as 'fcm' | 'apns' | undefined) ??
+      (recipient.metadata?.platform as 'fcm' | 'apns' | undefined) ??
+      'fcm';
+
+    if (platform === 'apns') {
+      return this.sendApns(rendered, recipient, request);
+    }
+
+    return this.sendFcm(rendered, recipient, request);
+  }
+
+  private async sendFcm(
+    rendered: RenderedTemplate,
+    recipient: NotificationRecipient,
+    request: SendNotificationRequest,
+  ): Promise<ChannelResponse> {
+    const serverKey = this.config.fcm?.serverKey;
+
+    if (!serverKey) {
+      return {
+        success: false,
+        status: 'skipped',
+        channel: 'push',
+        recipient,
+        timestamp: new Date(),
+        provider: 'fcm',
+        error: 'FCM server key is not configured.',
+      } satisfies ChannelResponse;
+    }
+
+    const payload = {
+      to: recipient.address,
+      notification: {
+        title: rendered.subject ?? this.config.fcm?.defaultTitle ?? 'Notification',
+        body: rendered.text ?? rendered.html ?? '',
+      },
+      data: {
+        ...request.context,
+        templateId: request.templateId,
+        category: request.category,
+        correlationId: request.correlationId,
+      },
+    };
+
+    try {
+      const response = await fetch('https://fcm.googleapis.com/fcm/send', {
+        method: 'POST',
+        headers: {
+          Authorization: `key=${serverKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        return {
+          success: false,
+          status: 'failed',
+          channel: 'push',
+          recipient,
+          timestamp: new Date(),
+          provider: 'fcm',
+          error: `FCM error: ${response.status} ${errorBody}`.slice(0, 500),
+        } satisfies ChannelResponse;
+      }
+
+      const json = (await response.json()) as FcmResponse;
+      const messageId = json.message_id ?? json.results?.[0]?.message_id;
+      const status = json.failure && json.failure > 0 ? 'failed' : 'sent';
+
+      return {
+        success: !json.failure,
+        status: status === 'sent' ? 'sent' : 'failed',
+        channel: 'push',
+        recipient,
+        timestamp: new Date(),
+        provider: 'fcm',
+        messageId: messageId ? String(messageId) : undefined,
+        error: json.results?.[0]?.error,
+      } satisfies ChannelResponse;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        status: 'failed',
+        channel: 'push',
+        recipient,
+        timestamp: new Date(),
+        provider: 'fcm',
+        error: message,
+      } satisfies ChannelResponse;
+    }
+  }
+
+  private async sendApns(
+    rendered: RenderedTemplate,
+    recipient: NotificationRecipient,
+    request: SendNotificationRequest,
+  ): Promise<ChannelResponse> {
+    const { apns } = this.config;
+
+    if (!apns?.keyId || !apns.teamId || !apns.privateKey || !apns.bundleId) {
+      return {
+        success: false,
+        status: 'skipped',
+        channel: 'push',
+        recipient,
+        timestamp: new Date(),
+        provider: 'apns',
+        error: 'APNs credentials are not configured.',
+      } satisfies ChannelResponse;
+    }
+
+    const jwt = this.createApnsJwt(apns);
+
+    if (!jwt) {
+      return {
+        success: false,
+        status: 'failed',
+        channel: 'push',
+        recipient,
+        timestamp: new Date(),
+        provider: 'apns',
+        error: 'Failed to sign APNs token.',
+      } satisfies ChannelResponse;
+    }
+
+    const body = JSON.stringify({
+      aps: {
+        alert: {
+          title: rendered.subject ?? 'Notification',
+          body: rendered.text ?? rendered.html ?? '',
+        },
+        sound: 'default',
+      },
+      data: {
+        ...request.context,
+        templateId: request.templateId,
+        category: request.category,
+        correlationId: request.correlationId,
+      },
+    });
+
+    const client = http2.connect('https://api.push.apple.com');
+
+    return await new Promise<ChannelResponse>((resolve) => {
+      const requestHeaders = {
+        ':method': 'POST',
+        ':path': `/3/device/${recipient.address}`,
+        authorization: `bearer ${jwt}`,
+        'apns-topic': apns.topic ?? apns.bundleId,
+        'apns-push-type': 'alert',
+        'content-type': 'application/json',
+      } as http2.ClientSessionRequestOptions['headers'];
+
+      const req = client.request(requestHeaders);
+
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+
+      req.on('response', (headers) => {
+        const status = Number(headers[':status'] ?? 0);
+
+        req.on('end', () => {
+          client.close();
+          const bodyText = Buffer.concat(chunks).toString('utf8');
+          if (status >= 200 && status < 300) {
+            resolve({
+              success: true,
+              status: 'sent',
+              channel: 'push',
+              recipient,
+              timestamp: new Date(),
+              provider: 'apns',
+              messageId: headers['apns-id'] ? String(headers['apns-id']) : undefined,
+            });
+          } else {
+            resolve({
+              success: false,
+              status: 'failed',
+              channel: 'push',
+              recipient,
+              timestamp: new Date(),
+              provider: 'apns',
+              error: `APNs error: ${status} ${bodyText}`.slice(0, 500),
+            });
+          }
+        });
+      });
+
+      req.on('error', (error) => {
+        client.close();
+        resolve({
+          success: false,
+          status: 'failed',
+          channel: 'push',
+          recipient,
+          timestamp: new Date(),
+          provider: 'apns',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      });
+
+      req.end(body);
+    });
+  }
+
+  static parseFcmWebhook(payload: unknown): NotificationEvent[] {
+    if (!payload || typeof payload !== 'object') {
+      return [];
+    }
+
+    const events: NotificationEvent[] = [];
+    const data = payload as { message?: { messageId?: string; token?: string; data?: Record<string, unknown> } };
+
+    if (data.message?.messageId && data.message?.token) {
+      events.push({
+        type: 'delivered',
+        channel: 'push',
+        provider: 'fcm',
+        recipient: data.message.token,
+        timestamp: new Date(),
+        messageId: data.message.messageId,
+        data,
+      });
+    }
+
+    return events;
+  }
+
+  private createApnsJwt(config: ApnsConfig) {
+    try {
+      const header = base64UrlEncode(
+        Buffer.from(
+          JSON.stringify({
+            alg: 'ES256',
+            kid: config.keyId,
+          }),
+        ),
+      );
+      const payload = base64UrlEncode(
+        Buffer.from(
+          JSON.stringify({
+            iss: config.teamId,
+            iat: Math.floor(Date.now() / 1000),
+          }),
+        ),
+      );
+      const unsignedToken = `${header}.${payload}`;
+
+      const signer = createSign('sha256');
+      signer.update(unsignedToken);
+      signer.end();
+
+      const signature = signer.sign({ key: config.privateKey as string, dsaEncoding: 'ieee-p1363' });
+      const signatureEncoded = base64UrlEncode(signature);
+      return `${unsignedToken}.${signatureEncoded}`;
+    } catch (error) {
+      console.error('Failed to create APNs JWT', error);
+      return null;
+    }
+  }
+}
+
+function base64UrlEncode(buffer: Buffer) {
+  return buffer
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}

--- a/services/notifications/channels/sms.ts
+++ b/services/notifications/channels/sms.ts
@@ -1,0 +1,279 @@
+import type {
+  ChannelResponse,
+  NotificationEvent,
+  NotificationRecipient,
+  RenderedTemplate,
+  SendNotificationRequest,
+} from '../types';
+
+export interface TwilioConfig {
+  accountSid?: string;
+  authToken?: string;
+  messagingServiceSid?: string;
+  fromNumber?: string;
+  voiceFromNumber?: string;
+  statusCallbackUrl?: string;
+}
+
+interface TwilioWebhookPayload {
+  MessageStatus?: string;
+  SmsStatus?: string;
+  CallStatus?: string;
+  MessageSid?: string;
+  CallSid?: string;
+  To?: string;
+  ErrorCode?: string;
+  ErrorMessage?: string;
+  EventType?: string;
+}
+
+export class TwilioProvider {
+  constructor(private readonly config: TwilioConfig) {}
+
+  private get baseUrl() {
+    if (!this.config.accountSid) {
+      return '';
+    }
+    return `https://api.twilio.com/2010-04-01/Accounts/${this.config.accountSid}`;
+  }
+
+  private get authHeader() {
+    if (!this.config.accountSid || !this.config.authToken) {
+      return undefined;
+    }
+    const token = Buffer.from(`${this.config.accountSid}:${this.config.authToken}`).toString('base64');
+    return `Basic ${token}`;
+  }
+
+  async sendSms(
+    rendered: RenderedTemplate,
+    recipient: NotificationRecipient,
+    request: SendNotificationRequest,
+  ): Promise<ChannelResponse> {
+    if (!this.authHeader || !this.baseUrl) {
+      return {
+        success: false,
+        status: 'skipped',
+        channel: 'sms',
+        recipient,
+        timestamp: new Date(),
+        provider: 'twilio',
+        error: 'Twilio credentials are not configured.',
+      } satisfies ChannelResponse;
+    }
+
+    const body = new URLSearchParams({
+      To: recipient.address,
+      Body: rendered.text ?? rendered.html ?? '',
+    });
+
+    if (this.config.messagingServiceSid) {
+      body.append('MessagingServiceSid', this.config.messagingServiceSid);
+    } else if (this.config.fromNumber) {
+      body.append('From', this.config.fromNumber);
+    }
+
+    if (this.config.statusCallbackUrl) {
+      body.append('StatusCallback', this.config.statusCallbackUrl);
+    }
+
+    try {
+      const response = await fetch(`${this.baseUrl}/Messages.json`, {
+        method: 'POST',
+        headers: {
+          Authorization: this.authHeader,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        return {
+          success: false,
+          status: 'failed',
+          channel: 'sms',
+          recipient,
+          timestamp: new Date(),
+          provider: 'twilio',
+          error: `Twilio error: ${response.status} ${errorBody}`.slice(0, 500),
+        } satisfies ChannelResponse;
+      }
+
+      const json = (await response.json()) as { sid?: string };
+
+      return {
+        success: true,
+        status: 'queued',
+        channel: 'sms',
+        recipient,
+        timestamp: new Date(),
+        provider: 'twilio',
+        messageId: json.sid,
+      } satisfies ChannelResponse;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        status: 'failed',
+        channel: 'sms',
+        recipient,
+        timestamp: new Date(),
+        provider: 'twilio',
+        error: message,
+      } satisfies ChannelResponse;
+    }
+  }
+
+  async sendVoice(
+    rendered: RenderedTemplate,
+    recipient: NotificationRecipient,
+    request: SendNotificationRequest,
+  ): Promise<ChannelResponse> {
+    if (!this.authHeader || !this.baseUrl) {
+      return {
+        success: false,
+        status: 'skipped',
+        channel: 'voice',
+        recipient,
+        timestamp: new Date(),
+        provider: 'twilio',
+        error: 'Twilio credentials are not configured.',
+      } satisfies ChannelResponse;
+    }
+
+    const voiceMessage = request.providerOverrides?.twiml as string | undefined;
+    const body = new URLSearchParams({
+      To: recipient.address,
+      Twiml:
+        voiceMessage ??
+        `<Response><Say>${rendered.text ?? rendered.html ?? ''}</Say></Response>`,
+    });
+
+    if (this.config.voiceFromNumber) {
+      body.append('From', this.config.voiceFromNumber);
+    } else if (this.config.fromNumber) {
+      body.append('From', this.config.fromNumber);
+    }
+
+    if (this.config.statusCallbackUrl) {
+      body.append('StatusCallback', this.config.statusCallbackUrl);
+    }
+
+    try {
+      const response = await fetch(`${this.baseUrl}/Calls.json`, {
+        method: 'POST',
+        headers: {
+          Authorization: this.authHeader,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        return {
+          success: false,
+          status: 'failed',
+          channel: 'voice',
+          recipient,
+          timestamp: new Date(),
+          provider: 'twilio',
+          error: `Twilio error: ${response.status} ${errorBody}`.slice(0, 500),
+        } satisfies ChannelResponse;
+      }
+
+      const json = (await response.json()) as { sid?: string };
+
+      return {
+        success: true,
+        status: 'queued',
+        channel: 'voice',
+        recipient,
+        timestamp: new Date(),
+        provider: 'twilio',
+        messageId: json.sid,
+      } satisfies ChannelResponse;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        status: 'failed',
+        channel: 'voice',
+        recipient,
+        timestamp: new Date(),
+        provider: 'twilio',
+        error: message,
+      } satisfies ChannelResponse;
+    }
+  }
+
+  static parseWebhook(payload: unknown, channel: 'sms' | 'voice' = 'sms'): NotificationEvent[] {
+    if (!payload) {
+      return [];
+    }
+
+    const data: TwilioWebhookPayload =
+      typeof payload === 'string'
+        ? Object.fromEntries(new URLSearchParams(payload))
+        : (payload as TwilioWebhookPayload);
+
+    const status = data.MessageStatus || data.SmsStatus || data.CallStatus;
+    const sid = data.MessageSid || data.CallSid;
+    const recipient = data.To ?? '';
+
+    if (!status) {
+      return [];
+    }
+
+    const normalizedStatus = status.toLowerCase();
+    const timestamp = new Date();
+
+    switch (normalizedStatus) {
+      case 'delivered':
+      case 'completed':
+        return [
+          {
+            type: 'delivered',
+            channel,
+            provider: 'twilio',
+            recipient,
+            timestamp,
+            messageId: sid,
+            data,
+          },
+        ];
+      case 'queued':
+      case 'sending':
+        return [
+          {
+            type: 'queued',
+            channel,
+            provider: 'twilio',
+            recipient,
+            timestamp,
+            messageId: sid,
+            data,
+          },
+        ];
+      case 'failed':
+      case 'undelivered':
+      case 'busy':
+      case 'no-answer':
+        return [
+          {
+            type: 'failed',
+            channel,
+            provider: 'twilio',
+            recipient,
+            timestamp,
+            messageId: sid,
+            reason: data.ErrorMessage ?? data.ErrorCode,
+            data,
+          },
+        ];
+      default:
+        return [];
+    }
+  }
+}

--- a/services/notifications/config.ts
+++ b/services/notifications/config.ts
@@ -1,0 +1,45 @@
+import type { NotificationServiceConfig } from './types';
+import type { SendGridConfig } from './channels/email';
+import type { TwilioConfig } from './channels/sms';
+import type { PushProviderConfig } from './channels/push';
+
+const cleanPrivateKey = (value?: string | null) => {
+  if (!value) {
+    return undefined;
+  }
+  return value.replace(/\\n/g, '\n');
+};
+
+export const notificationProviderConfig = {
+  sendgrid: {
+    apiKey: process.env.SENDGRID_API_KEY,
+    fromEmail: process.env.NOTIFICATIONS_EMAIL_FROM ?? 'no-reply@example.com',
+    fromName: process.env.NOTIFICATIONS_EMAIL_NAME,
+    replyTo: process.env.NOTIFICATIONS_EMAIL_REPLY_TO,
+  } satisfies SendGridConfig,
+  twilio: {
+    accountSid: process.env.TWILIO_ACCOUNT_SID,
+    authToken: process.env.TWILIO_AUTH_TOKEN,
+    messagingServiceSid: process.env.TWILIO_MESSAGING_SERVICE_SID,
+    fromNumber: process.env.TWILIO_FROM_NUMBER,
+    voiceFromNumber: process.env.TWILIO_VOICE_FROM_NUMBER ?? process.env.TWILIO_FROM_NUMBER,
+    statusCallbackUrl: process.env.TWILIO_STATUS_CALLBACK_URL,
+  } satisfies TwilioConfig,
+  push: {
+    fcm: {
+      serverKey: process.env.FCM_SERVER_KEY,
+      defaultTitle: process.env.FCM_DEFAULT_TITLE,
+    },
+    apns: {
+      keyId: process.env.APNS_KEY_ID,
+      teamId: process.env.APNS_TEAM_ID,
+      privateKey: cleanPrivateKey(process.env.APNS_PRIVATE_KEY),
+      bundleId: process.env.APNS_BUNDLE_ID,
+      topic: process.env.APNS_TOPIC,
+    },
+  } satisfies PushProviderConfig,
+};
+
+export const notificationServiceConfig: NotificationServiceConfig = {
+  dryRun: process.env.NOTIFICATIONS_DRY_RUN === 'true',
+};

--- a/services/notifications/event-consumer.ts
+++ b/services/notifications/event-consumer.ts
@@ -1,0 +1,44 @@
+import EventEmitter from 'eventemitter3';
+
+import type { NotificationService } from './notification-service';
+import type { IntegrationEvent } from './types';
+
+export class NotificationEventConsumer {
+  private readonly subscriptions: Array<() => void> = [];
+
+  constructor(private readonly service: NotificationService) {}
+
+  listenTo<T extends Record<string, unknown>>(
+    emitter: EventEmitter<T>,
+    eventName: keyof T & string,
+    mapper?: (payload: T[keyof T]) => IntegrationEvent | IntegrationEvent[] | null | Promise<IntegrationEvent | IntegrationEvent[] | null>,
+  ) {
+    const handler = async (payload: T[keyof T]) => {
+      try {
+        const mapped = mapper ? await mapper(payload) : (payload as IntegrationEvent | IntegrationEvent[] | null);
+        if (!mapped) {
+          return;
+        }
+        await this.consume(mapped);
+      } catch (error) {
+        console.error('Failed to process integration event', error);
+      }
+    };
+
+    emitter.on(eventName, handler as (payload: T[keyof T]) => void);
+    this.subscriptions.push(() => emitter.off(eventName, handler as (payload: T[keyof T]) => void));
+  }
+
+  async consume(event: IntegrationEvent | IntegrationEvent[]) {
+    const events = Array.isArray(event) ? event : [event];
+
+    for (const item of events) {
+      await this.service.send(item);
+    }
+  }
+
+  detachAll() {
+    this.subscriptions.forEach((unsubscribe) => unsubscribe());
+    this.subscriptions.length = 0;
+  }
+}

--- a/services/notifications/index.ts
+++ b/services/notifications/index.ts
@@ -1,0 +1,160 @@
+import { TemplateEngine } from './template-engine';
+import { PreferenceCenter } from './preference-center';
+import { MetricsStore } from './metrics-store';
+import { SendGridEmailProvider } from './channels/email';
+import { TwilioProvider } from './channels/sms';
+import { PushNotificationProvider } from './channels/push';
+import { NotificationService } from './notification-service';
+import { NotificationEventConsumer } from './event-consumer';
+import { notificationProviderConfig, notificationServiceConfig } from './config';
+import type { IntegrationEvent } from './types';
+import { appEventBus } from '@/lib/event-bus';
+import type { CalendarEventCreatedPayload } from '@/lib/event-bus';
+
+interface NotificationRuntime {
+  service: NotificationService;
+  templateEngine: TemplateEngine;
+  preferenceCenter: PreferenceCenter;
+  metrics: MetricsStore;
+  consumer: NotificationEventConsumer;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __notificationRuntime: NotificationRuntime | undefined;
+}
+
+function registerDefaultTemplates(engine: TemplateEngine) {
+  engine.registerTemplate({
+    id: 'generic-email',
+    channel: 'email',
+    name: 'Generic Email',
+    subject: '{{subject}}',
+    html: '<p>{{message}}</p>',
+    text: '{{message}}',
+    defaultContext: {
+      subject: 'Notification',
+      message: '',
+    },
+  });
+
+  engine.registerTemplate({
+    id: 'generic-sms',
+    channel: 'sms',
+    name: 'Generic SMS',
+    text: '{{message}}',
+    defaultContext: {
+      message: '',
+    },
+  });
+
+  engine.registerTemplate({
+    id: 'generic-voice',
+    channel: 'voice',
+    name: 'Generic Voice',
+    text: '{{message}}',
+    defaultContext: {
+      message: '',
+    },
+  });
+
+  engine.registerTemplate({
+    id: 'generic-push',
+    channel: 'push',
+    name: 'Generic Push',
+    subject: '{{title}}',
+    text: '{{message}}',
+    defaultContext: {
+      title: 'Notification',
+      message: '',
+    },
+  });
+
+  engine.registerTemplate({
+    id: 'calendar-event-created',
+    channel: 'email',
+    name: 'Calendar Event Created',
+    subject: 'You have a new meeting: {{summary}}',
+    html: `
+      <h1>{{summary}}</h1>
+      <p>{{description}}</p>
+      <p><strong>Starts:</strong> {{startTime}}</p>
+      <p><strong>Ends:</strong> {{endTime}}</p>
+    `,
+    text: `Your meeting "{{summary}}" is scheduled for {{startTime}} and ends at {{endTime}}.`,
+    defaultContext: {
+      summary: 'Meeting',
+      description: '',
+      startTime: '',
+      endTime: '',
+    },
+  });
+}
+
+function createRuntime(): NotificationRuntime {
+  const templateEngine = new TemplateEngine();
+  registerDefaultTemplates(templateEngine);
+
+  const preferenceCenter = new PreferenceCenter();
+  const metrics = new MetricsStore();
+
+  const emailProvider = new SendGridEmailProvider(notificationProviderConfig.sendgrid);
+  const twilioProvider = new TwilioProvider(notificationProviderConfig.twilio);
+  const pushProvider = new PushNotificationProvider(notificationProviderConfig.push);
+
+  const service = new NotificationService({
+    templateEngine,
+    preferenceCenter,
+    metrics,
+    emailProvider,
+    smsProvider: twilioProvider,
+    voiceProvider: twilioProvider,
+    pushProvider,
+    config: notificationServiceConfig,
+  });
+
+  const consumer = new NotificationEventConsumer(service);
+
+  preferenceCenter.on('change', (event) => {
+    appEventBus.emit('notifications:preferenceChanged', event);
+  });
+
+  consumer.listenTo(appEventBus, 'calendar:eventCreated', mapCalendarEventToNotification);
+
+  return {
+    service,
+    templateEngine,
+    preferenceCenter,
+    metrics,
+    consumer,
+  } satisfies NotificationRuntime;
+}
+
+function mapCalendarEventToNotification(payload: CalendarEventCreatedPayload): IntegrationEvent {
+  return {
+    channel: 'email',
+    templateId: 'calendar-event-created',
+    recipients: [
+      {
+        userId: payload.attendeeEmail,
+        address: payload.attendeeEmail,
+        name: payload.attendeeName,
+      },
+    ],
+    context: {
+      summary: payload.summary,
+      description: payload.description,
+      startTime: payload.startTime,
+      endTime: payload.endTime,
+    },
+    category: 'calendar',
+  } satisfies IntegrationEvent;
+}
+
+const runtime = globalThis.__notificationRuntime ?? (globalThis.__notificationRuntime = createRuntime());
+
+export const notificationService = runtime.service;
+export const notificationTemplateEngine = runtime.templateEngine;
+export const notificationPreferenceCenter = runtime.preferenceCenter;
+export const notificationMetrics = runtime.metrics;
+export const notificationEventConsumer = runtime.consumer;

--- a/services/notifications/metrics-store.ts
+++ b/services/notifications/metrics-store.ts
@@ -1,0 +1,132 @@
+import type {
+  ChannelResponse,
+  DeliveryEvent,
+  MetricsSummary,
+  NotificationChannel,
+  NotificationEvent,
+} from './types';
+
+const MAX_EVENT_HISTORY = 5000;
+
+export class MetricsStore {
+  private readonly events: NotificationEvent[] = [];
+  private readonly sends: ChannelResponse[] = [];
+  private suppressed = 0;
+
+  recordSend(response: ChannelResponse) {
+    this.sends.push(response);
+    this.trimArray(this.sends);
+  }
+
+  recordSuppressed(count = 1) {
+    this.suppressed += count;
+  }
+
+  recordEvent(event: NotificationEvent) {
+    this.events.push(event);
+    this.trimArray(this.events);
+  }
+
+  getSummary(): MetricsSummary {
+    const summary: MetricsSummary = {
+      totalSent: 0,
+      totalDelivered: 0,
+      totalOpened: 0,
+      totalClicked: 0,
+      totalBounced: 0,
+      totalFailed: 0,
+      totalComplained: 0,
+      suppressed: this.suppressed,
+      byChannel: {
+        email: { sent: 0, delivered: 0, bounced: 0, failed: 0, suppressed: 0 },
+        sms: { sent: 0, delivered: 0, bounced: 0, failed: 0, suppressed: 0 },
+        voice: { sent: 0, delivered: 0, bounced: 0, failed: 0, suppressed: 0 },
+        push: { sent: 0, delivered: 0, bounced: 0, failed: 0, suppressed: 0 },
+      },
+      lastEvents: this.events.slice(-50),
+      updatedAt: null,
+    };
+
+    this.sends.forEach((send) => {
+      if (send.status === 'sent' || send.status === 'queued') {
+        summary.totalSent += 1;
+        summary.byChannel[send.channel].sent += 1;
+      }
+      if (send.status === 'failed') {
+        summary.totalFailed += 1;
+        summary.byChannel[send.channel].failed += 1;
+      }
+      if (send.status === 'skipped') {
+        summary.byChannel[send.channel].suppressed += 1;
+      }
+      summary.updatedAt = send.timestamp;
+    });
+
+    this.events.forEach((event) => {
+      if (isDelivery(event)) {
+        summary.byChannel[event.channel].delivered += 1;
+        if (event.type === 'delivered') {
+          summary.totalDelivered += 1;
+        }
+        if (event.type === 'opened') {
+          summary.totalOpened += 1;
+        }
+        if (event.type === 'clicked') {
+          summary.totalClicked += 1;
+        }
+      } else {
+        summary.byChannel[event.channel].bounced += 1;
+        if (event.type === 'bounced') {
+          summary.totalBounced += 1;
+        }
+        if (event.type === 'failed') {
+          summary.totalFailed += 1;
+        }
+        if (event.type === 'complained') {
+          summary.totalComplained += 1;
+        }
+      }
+      summary.updatedAt = event.timestamp;
+    });
+
+    summary.suppressed += summary.byChannel.email.suppressed +
+      summary.byChannel.sms.suppressed +
+      summary.byChannel.voice.suppressed +
+      summary.byChannel.push.suppressed;
+
+    return summary;
+  }
+
+  filterEvents(filter: {
+    channel?: NotificationChannel;
+    type?: NotificationEvent['type'];
+    provider?: string;
+    recipient?: string;
+  }) {
+    return this.events.filter((event) => {
+      if (filter.channel && event.channel !== filter.channel) {
+        return false;
+      }
+      if (filter.type && event.type !== filter.type) {
+        return false;
+      }
+      if (filter.provider && event.provider !== filter.provider) {
+        return false;
+      }
+      if (filter.recipient && event.recipient !== filter.recipient) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  private trimArray<T>(array: T[]) {
+    if (array.length > MAX_EVENT_HISTORY) {
+      array.splice(0, array.length - MAX_EVENT_HISTORY);
+    }
+  }
+}
+
+function isDelivery(event: NotificationEvent): event is DeliveryEvent {
+  return event.type === 'delivered' || event.type === 'opened' || event.type === 'clicked' || event.type === 'sent' || event.type === 'queued';
+}

--- a/services/notifications/notification-service.ts
+++ b/services/notifications/notification-service.ts
@@ -1,0 +1,144 @@
+import { TemplateEngine } from './template-engine';
+import { PreferenceCenter } from './preference-center';
+import { MetricsStore } from './metrics-store';
+import type {
+  ChannelResponse,
+  NotificationEvent,
+  NotificationSendSummary,
+  SendNotificationRequest,
+} from './types';
+import type { SendGridEmailProvider } from './channels/email';
+import type { TwilioProvider } from './channels/sms';
+import type { PushNotificationProvider } from './channels/push';
+import type { NotificationServiceConfig } from './types';
+
+export interface NotificationServiceDependencies {
+  templateEngine: TemplateEngine;
+  preferenceCenter: PreferenceCenter;
+  metrics: MetricsStore;
+  emailProvider: SendGridEmailProvider;
+  smsProvider: TwilioProvider;
+  voiceProvider: TwilioProvider;
+  pushProvider: PushNotificationProvider;
+  config?: NotificationServiceConfig;
+}
+
+export class NotificationService {
+  constructor(private readonly dependencies: NotificationServiceDependencies) {}
+
+  get templateEngine() {
+    return this.dependencies.templateEngine;
+  }
+
+  get preferenceCenter() {
+    return this.dependencies.preferenceCenter;
+  }
+
+  get metrics() {
+    return this.dependencies.metrics;
+  }
+
+  async send(request: SendNotificationRequest): Promise<NotificationSendSummary> {
+    if (!request.recipients.length) {
+      throw new Error('Notification must target at least one recipient.');
+    }
+
+    const rendered = this.dependencies.templateEngine.render(
+      request.channel,
+      request.templateId,
+      request.context,
+    );
+
+    const { allowed, suppressed } = this.dependencies.preferenceCenter.resolveRecipients(
+      request.channel,
+      request.recipients,
+      request.category,
+    );
+
+    const responses: ChannelResponse[] = [];
+
+    for (const recipient of allowed) {
+      const response = await this.dispatchToChannel(request, rendered, recipient);
+      responses.push(response);
+      this.dependencies.metrics.recordSend(response);
+      if (request.options?.responseHook) {
+        await request.options.responseHook(response);
+      }
+    }
+
+    suppressed.forEach((recipient) => {
+      const response: ChannelResponse = {
+        success: false,
+        status: 'skipped',
+        channel: request.channel,
+        recipient,
+        timestamp: new Date(),
+        provider: this.providerNameForChannel(request.channel),
+        error: 'Suppressed by user preferences.',
+      };
+      responses.push(response);
+      this.dependencies.metrics.recordSend(response);
+    });
+
+    const summary: NotificationSendSummary = {
+      templateId: request.templateId,
+      channel: request.channel,
+      category: request.category,
+      correlationId: request.correlationId,
+      responses,
+      sent: responses.filter((response) => response.status === 'sent' || response.status === 'queued').length,
+      skipped: responses.filter((response) => response.status === 'skipped').length,
+      failed: responses.filter((response) => response.status === 'failed').length,
+      timestamp: new Date(),
+    };
+
+    return summary;
+  }
+
+  recordEvents(events: NotificationEvent[]) {
+    events.forEach((event) => this.dependencies.metrics.recordEvent(event));
+  }
+
+  private async dispatchToChannel(
+    request: SendNotificationRequest,
+    rendered: ReturnType<TemplateEngine['render']>,
+    recipient: SendNotificationRequest['recipients'][number],
+  ) {
+    if (request.options?.dryRun || this.dependencies.config?.dryRun) {
+      return {
+        success: true,
+        status: 'queued',
+        channel: request.channel,
+        recipient,
+        timestamp: new Date(),
+        provider: this.providerNameForChannel(request.channel),
+        meta: { dryRun: true },
+      } satisfies ChannelResponse;
+    }
+
+    switch (request.channel) {
+      case 'email':
+        return this.dependencies.emailProvider.send(rendered, recipient, request);
+      case 'sms':
+        return this.dependencies.smsProvider.sendSms(rendered, recipient, request);
+      case 'voice':
+        return this.dependencies.voiceProvider.sendVoice(rendered, recipient, request);
+      case 'push':
+        return this.dependencies.pushProvider.send(rendered, recipient, request);
+      default:
+        throw new Error(`Unsupported channel: ${request.channel}`);
+    }
+  }
+
+  private providerNameForChannel(channel: SendNotificationRequest['channel']) {
+    switch (channel) {
+      case 'email':
+        return 'sendgrid';
+      case 'sms':
+      case 'voice':
+        return 'twilio';
+      case 'push':
+        return 'push';
+    }
+  }
+}

--- a/services/notifications/preference-center.ts
+++ b/services/notifications/preference-center.ts
@@ -1,0 +1,170 @@
+import EventEmitter from 'eventemitter3';
+
+import type {
+  ChannelPreference,
+  NotificationChannel,
+  NotificationRecipient,
+  PreferenceUpdate,
+  UserNotificationPreferences,
+} from './types';
+
+const DEFAULT_CHANNEL_STATE: ChannelPreference = {
+  enabled: true,
+  categories: {},
+  quietHours: null,
+  lastUpdated: new Date(),
+};
+
+export interface PreferenceChangeEvent {
+  userId: string;
+  channel: NotificationChannel;
+  enabled: boolean;
+  category?: string;
+}
+
+type PreferenceEvents = {
+  change: (event: PreferenceChangeEvent) => void;
+};
+
+export class PreferenceCenter extends EventEmitter<PreferenceEvents> {
+  private readonly store = new Map<string, UserNotificationPreferences>();
+
+  getPreferences(userId: string): UserNotificationPreferences {
+    const existing = this.store.get(userId);
+
+    if (existing) {
+      return existing;
+    }
+
+    const fresh: UserNotificationPreferences = {
+      userId,
+      channels: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    this.store.set(userId, fresh);
+    return fresh;
+  }
+
+  setPreferences(preferences: UserNotificationPreferences) {
+    preferences.updatedAt = new Date();
+    if (!preferences.createdAt) {
+      preferences.createdAt = new Date();
+    }
+    this.store.set(preferences.userId, preferences);
+  }
+
+  updatePreference(update: PreferenceUpdate) {
+    const preferences = this.getPreferences(update.userId);
+    const channelState = { ...DEFAULT_CHANNEL_STATE, ...(preferences.channels[update.channel] ?? {}) };
+
+    channelState.enabled = update.enabled;
+    channelState.lastUpdated = new Date();
+    channelState.quietHours = update.quietHours ?? channelState.quietHours ?? null;
+
+    if (update.category) {
+      channelState.categories = {
+        ...channelState.categories,
+        [update.category]: update.enabled,
+      };
+    }
+
+    preferences.channels = {
+      ...preferences.channels,
+      [update.channel]: channelState,
+    };
+    preferences.updatedAt = new Date();
+
+    this.store.set(update.userId, preferences);
+    this.emit('change', {
+      userId: update.userId,
+      channel: update.channel,
+      enabled: update.enabled,
+      category: update.category,
+    });
+  }
+
+  bulkUpdate(updates: PreferenceUpdate[]) {
+    updates.forEach((update) => this.updatePreference(update));
+  }
+
+  isChannelEnabled(
+    userId: string,
+    channel: NotificationChannel,
+    category?: string,
+    date: Date = new Date(),
+  ) {
+    const preferences = this.getPreferences(userId);
+    const channelPrefs = preferences.channels[channel];
+
+    if (!channelPrefs) {
+      return true;
+    }
+
+    if (!channelPrefs.enabled) {
+      return false;
+    }
+
+    if (category && channelPrefs.categories[category] === false) {
+      return false;
+    }
+
+    if (channelPrefs.quietHours) {
+      const { start, end } = channelPrefs.quietHours;
+      if (start && end) {
+        const [startHour, startMinute] = start.split(':').map(Number);
+        const [endHour, endMinute] = end.split(':').map(Number);
+        const currentMinutes = date.getHours() * 60 + date.getMinutes();
+        const startMinutes = startHour * 60 + startMinute;
+        const endMinutes = endHour * 60 + endMinute;
+
+        const isQuiet =
+          startMinutes < endMinutes
+            ? currentMinutes >= startMinutes && currentMinutes < endMinutes
+            : currentMinutes >= startMinutes || currentMinutes < endMinutes;
+
+        if (isQuiet) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  resolveRecipients(
+    channel: NotificationChannel,
+    recipients: NotificationRecipient[],
+    category?: string,
+  ): { allowed: NotificationRecipient[]; suppressed: NotificationRecipient[] } {
+    const allowed: NotificationRecipient[] = [];
+    const suppressed: NotificationRecipient[] = [];
+
+    recipients.forEach((recipient) => {
+      if (this.isChannelEnabled(recipient.userId, channel, category)) {
+        allowed.push(recipient);
+      } else {
+        suppressed.push(recipient);
+      }
+    });
+
+    return { allowed, suppressed };
+  }
+
+  listSubscribers(channel: NotificationChannel, category?: string) {
+    const matches: string[] = [];
+
+    this.store.forEach((prefs) => {
+      if (this.isChannelEnabled(prefs.userId, channel, category)) {
+        matches.push(prefs.userId);
+      }
+    });
+
+    return matches;
+  }
+
+  exportAll(): UserNotificationPreferences[] {
+    return Array.from(this.store.values()).map((preference) => ({ ...preference }));
+  }
+}

--- a/services/notifications/template-engine.ts
+++ b/services/notifications/template-engine.ts
@@ -1,0 +1,86 @@
+import { template as compileTemplate } from 'lodash';
+
+import type {
+  NotificationChannel,
+  NotificationTemplate,
+  RenderedTemplate,
+  TemplateContext,
+} from './types';
+
+interface TemplateRegistryEntry extends NotificationTemplate {
+  compiledSubject?: (context: TemplateContext) => string;
+  compiledHtml?: (context: TemplateContext) => string;
+  compiledText?: (context: TemplateContext) => string;
+}
+
+export class TemplateEngine {
+  private readonly templates = new Map<string, TemplateRegistryEntry>();
+
+  registerTemplate(template: NotificationTemplate) {
+    const entry: TemplateRegistryEntry = {
+      ...template,
+      compiledSubject: template.subject
+        ? compileTemplate(template.subject, { interpolate: /{{([\s\S]+?)}}/g })
+        : undefined,
+      compiledHtml: template.html
+        ? compileTemplate(template.layout ? template.layout.replace('{{{body}}}', template.html) : template.html, {
+            interpolate: /{{([\s\S]+?)}}/g,
+          })
+        : undefined,
+      compiledText: template.text
+        ? compileTemplate(template.text, { interpolate: /{{([\s\S]+?)}}/g })
+        : undefined,
+    };
+
+    entry.createdAt = entry.createdAt ?? new Date();
+    entry.updatedAt = new Date();
+
+    this.templates.set(this.key(template.channel, template.id), entry);
+  }
+
+  getTemplate(channel: NotificationChannel, templateId: string): NotificationTemplate | null {
+    return this.templates.get(this.key(channel, templateId)) ?? null;
+  }
+
+  render(
+    channel: NotificationChannel,
+    templateId: string,
+    context: TemplateContext = {},
+  ): RenderedTemplate {
+    const template = this.templates.get(this.key(channel, templateId));
+
+    if (!template) {
+      throw new Error(`Template ${templateId} for channel ${channel} not registered`);
+    }
+
+    const mergedContext = {
+      ...(template.defaultContext ?? {}),
+      ...context,
+    } satisfies TemplateContext;
+
+    return {
+      subject: template.compiledSubject ? template.compiledSubject(mergedContext) : template.subject,
+      html: template.compiledHtml ? template.compiledHtml(mergedContext) : template.html,
+      text: template.compiledText ? template.compiledText(mergedContext) : template.text,
+      metadata: {
+        templateId,
+        channel,
+        compiledAt: new Date().toISOString(),
+      },
+    } satisfies RenderedTemplate;
+  }
+
+  listTemplates(channel?: NotificationChannel): NotificationTemplate[] {
+    return Array.from(this.templates.values())
+      .filter((entry) => !channel || entry.channel === channel)
+      .map(({ compiledHtml, compiledSubject, compiledText, ...rest }) => rest);
+  }
+
+  removeTemplate(channel: NotificationChannel, templateId: string) {
+    this.templates.delete(this.key(channel, templateId));
+  }
+
+  private key(channel: NotificationChannel, templateId: string) {
+    return `${channel}:${templateId}`;
+  }
+}

--- a/services/notifications/types.ts
+++ b/services/notifications/types.ts
@@ -1,0 +1,175 @@
+import type EventEmitter from 'eventemitter3';
+
+export type NotificationChannel = 'email' | 'sms' | 'voice' | 'push';
+
+export type TemplateContext = Record<string, unknown>;
+
+export interface NotificationTemplate {
+  id: string;
+  channel: NotificationChannel;
+  name?: string;
+  description?: string;
+  subject?: string;
+  html?: string;
+  text?: string;
+  layout?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  tags?: string[];
+  defaultContext?: TemplateContext;
+}
+
+export interface RenderedTemplate {
+  subject?: string;
+  html?: string;
+  text?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface NotificationRecipient {
+  userId: string;
+  address: string;
+  name?: string;
+  locale?: string;
+  timeZone?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SendNotificationRequest {
+  channel: NotificationChannel;
+  templateId: string;
+  recipients: NotificationRecipient[];
+  context?: TemplateContext;
+  category?: string;
+  correlationId?: string;
+  providerOverrides?: Record<string, unknown>;
+  options?: NotificationDispatchOptions;
+}
+
+export interface NotificationDispatchOptions {
+  trackOpens?: boolean;
+  trackClicks?: boolean;
+  highPriority?: boolean;
+  delayUntil?: Date;
+  dryRun?: boolean;
+  responseHook?: (response: ChannelResponse) => void | Promise<void>;
+}
+
+export interface ChannelResponse {
+  success: boolean;
+  status: 'sent' | 'queued' | 'failed' | 'skipped';
+  channel: NotificationChannel;
+  recipient: NotificationRecipient;
+  messageId?: string;
+  provider?: string;
+  error?: string;
+  timestamp: Date;
+  meta?: Record<string, unknown>;
+}
+
+export interface NotificationSendSummary {
+  templateId: string;
+  channel: NotificationChannel;
+  category?: string;
+  correlationId?: string;
+  responses: ChannelResponse[];
+  sent: number;
+  skipped: number;
+  failed: number;
+  timestamp: Date;
+}
+
+export interface ChannelPreference {
+  enabled: boolean;
+  categories: Record<string, boolean>;
+  quietHours?: {
+    start: string; // HH:mm in 24h
+    end: string; // HH:mm in 24h
+  } | null;
+  lastUpdated: Date;
+  reason?: string;
+}
+
+export interface UserNotificationPreferences {
+  userId: string;
+  locale?: string;
+  timeZone?: string;
+  channels: Partial<Record<NotificationChannel, ChannelPreference>>;
+  updatedAt: Date;
+  createdAt: Date;
+}
+
+export interface PreferenceUpdate {
+  userId: string;
+  channel: NotificationChannel;
+  enabled: boolean;
+  category?: string;
+  reason?: string;
+  quietHours?: ChannelPreference['quietHours'];
+}
+
+export interface DeliveryEvent {
+  type: 'delivered' | 'opened' | 'clicked' | 'sent' | 'queued';
+  channel: NotificationChannel;
+  provider: string;
+  recipient: string;
+  timestamp: Date;
+  messageId?: string;
+  category?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface BounceEvent {
+  type: 'bounced' | 'dropped' | 'failed' | 'complained';
+  channel: NotificationChannel;
+  provider: string;
+  recipient: string;
+  timestamp: Date;
+  messageId?: string;
+  category?: string;
+  reason?: string;
+  data?: Record<string, unknown>;
+}
+
+export type NotificationEvent = DeliveryEvent | BounceEvent;
+
+export interface MetricsSummary {
+  totalSent: number;
+  totalDelivered: number;
+  totalOpened: number;
+  totalClicked: number;
+  totalBounced: number;
+  totalFailed: number;
+  totalComplained: number;
+  suppressed: number;
+  byChannel: Record<NotificationChannel, {
+    sent: number;
+    delivered: number;
+    bounced: number;
+    failed: number;
+    suppressed: number;
+  }>;
+  lastEvents: NotificationEvent[];
+  updatedAt: Date | null;
+}
+
+export interface ProviderWebhookParser {
+  (payload: unknown): NotificationEvent[];
+}
+
+export interface IntegrationEvent {
+  channel: NotificationChannel;
+  templateId: string;
+  recipients: NotificationRecipient[];
+  context?: TemplateContext;
+  category?: string;
+  correlationId?: string;
+  options?: NotificationDispatchOptions;
+}
+
+export type NotificationEventEmitter = EventEmitter<Record<string, unknown>>;
+
+export interface NotificationServiceConfig {
+  dryRun?: boolean;
+}
+


### PR DESCRIPTION
## Summary
- add a comprehensive notifications service with template engine, channel providers, metrics, and preference center
- expose notification preference management, send trigger, and webhook reporting API routes
- integrate calendar service events through a shared app event bus

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceefe41cc483289368c9392880380c