### PR TITLE
feat: add digital key management services

### DIFF
--- a/services/keys/README.md
+++ b/services/keys/README.md
@@ -1,0 +1,188 @@
+# Key Management Services
+
+This package contains the domain-level APIs required to manage digital key lifecycles
+and integrate with on-premises key cabinets. It is framework agnostic and can be used
+from React Server Actions, traditional API routes, background jobs, or any other
+TypeScript runtime that provides the Fetch API.
+
+## Overview of modules
+
+- `service.ts` – high-level orchestration for checkout, return, overdue alerts, and
+  policy evaluations.
+- `policies.ts` – reusable policy validator with built-in time window, role, and
+  max duration rules.
+- `connector.ts` – connector contract and default HTTP-based implementation for an
+  on-premise key cabinet.
+- `errors.ts` – strongly typed error hierarchy.
+- `types.ts` – shared DTOs, contracts, and policy definitions.
+
+Importing from `services/keys` re-exports everything you need:
+
+```ts
+import { KeyService, OnPremKeyCabinetConnector, KeyPolicyValidator } from '@/services/keys';
+```
+
+## Digital key APIs
+
+### Checkout a key
+
+Use `KeyService.checkoutKey` to orchestrate validation, persistence, and cabinet
+notifications.
+
+```ts
+const service = new KeyService({
+  repository,
+  notificationService,
+  cabinetConnector,
+});
+
+await service.checkoutKey({
+  keyId: 'front-door',
+  userId: 'resident-123',
+  userRole: 'resident',
+  issuedAt: new Date(),
+  expectedReturnAt: addHours(new Date(), 2),
+  policies: [timeWindowPolicy, rolePolicy],
+});
+```
+
+1. Policies are validated via `KeyPolicyValidator`. Violations surface as
+   `PolicyViolationError` (see below).
+2. `repository.checkout` is invoked to persist the transaction.
+3. When a `KeyCabinetConnector` is configured, the checkout event is forwarded to
+   the physical cabinet.
+
+### Return a key
+
+```ts
+await service.returnKey({
+  transactionId: 'txn-123',
+  keyId: 'front-door',
+  userId: 'resident-123',
+  returnedAt: new Date(),
+});
+```
+
+The repository is responsible for updating the transaction status and return time.
+If a cabinet connector is present the return is synchronised with the cabinet.
+
+### Overdue alerts
+
+Call `KeyService.triggerOverdueAlerts()` on a schedule to notify residents and
+managers of overdue keys. The method returns a summary that indicates successes
+and failures without throwing unless the underlying repository query fails.
+
+```ts
+const summary = await service.triggerOverdueAlerts();
+
+console.log(summary);
+// {
+//   referenceDate: Date,
+//   totalOverdue: number,
+//   alertsSent: number,
+//   failures: Array<{ record, error }>
+// }
+```
+
+Failures are wrapped in `KeyServiceError` instances with the `NOTIFICATION_ERROR`
+code so they can be logged, retried, or escalated.
+
+### Policy validation
+
+`KeyService.validatePolicies` (or `KeyPolicyValidator` directly) can be used to
+pre-flight a request without mutating state.
+
+Supported rule types out of the box:
+
+- `timeWindow`: restricts checkouts to configured hours/days/time zones and
+  optionally a country.
+- `role`: enforces allowed user roles.
+- `maxDuration`: caps the time between issue and expected return.
+- `custom`: plug in arbitrary validation logic with async support.
+
+You can provide contextual data (time zone, custom attributes, etc.) using the
+`context` property on `KeyCheckoutRequest`.
+
+## Error handling contract
+
+All operational errors surface as `KeyServiceError` (or subclasses) with a `code`
+property that allows reliable classification. The following codes are used across
+APIs:
+
+| Code | Meaning |
+| ---- | ------- |
+| `VALIDATION_ERROR` | Unexpected issue while running schema/policy validation. |
+| `POLICY_VIOLATION` | One or more policies failed. Violations are attached. |
+| `REPOSITORY_ERROR` | Persistence or data retrieval failed. |
+| `NOTIFICATION_ERROR` | Downstream notification provider rejected the alert. |
+| `CONNECTOR_ERROR` | The cabinet connector rejected the call or could not be reached. |
+| `CONFIGURATION_ERROR` | Misconfiguration detected (e.g., missing Fetch API implementation). |
+
+`PolicyViolationError` is a specialised `KeyServiceError` that exposes a
+`violations` array and the `PolicyValidationResult` that produced them.
+
+When you need to wrap unexpected exceptions, use `KeyServiceError.from(cause, code, message, details)`.
+This helper automatically preserves existing `KeyServiceError` instances and
+annotates new ones with the original cause.
+
+## On-prem cabinet integration
+
+`OnPremKeyCabinetConnector` is an opinionated HTTP connector that translates
+service events into REST calls:
+
+- `syncInventory()` → `GET /cabinets/:id/inventory`
+- `dispatchCheckout()` → `POST /cabinets/:id/transactions/checkout`
+- `dispatchReturn()` → `POST /cabinets/:id/transactions/return`
+- `streamAlerts()` → long-polls `GET /cabinets/:id/alerts` for audit and tamper
+  events
+
+### Configuration
+
+```ts
+const connector = new OnPremKeyCabinetConnector({
+  baseUrl: 'https://cabinet.local/api',
+  apiKey: process.env.CABINET_API_KEY!,
+  cabinetId: 'cabinet-01',
+  timeoutMs: 5_000,
+  defaultAlertPollIntervalMs: 10_000,
+});
+```
+
+- `baseUrl` should point to the cabinet middleware endpoint.
+- `apiKey` is used for Bearer authentication. Additional headers can be provided
+  via the `fetch` instance passed in `config.fetch`.
+- `timeoutMs` controls how long HTTP calls will wait before aborting.
+- The connector relies on the global `fetch`. Provide a polyfill or custom
+  implementation when running in environments that do not ship with the Fetch API.
+
+### Alert streaming contract
+
+`streamAlerts` returns an async iterator that yields normalised alerts. Use an
+`AbortController` to close the stream gracefully:
+
+```ts
+const abortController = new AbortController();
+
+for await (const alert of connector.streamAlerts({ pollIntervalMs: 5_000, signal: abortController.signal })) {
+  console.log(alert.event, alert.occurredAt);
+  if (shouldStop(alert)) {
+    abortController.abort();
+  }
+}
+```
+
+Alert payloads include the canonical cabinet ID, key ID, slot ID, severity, and
+arbitrary details. Unknown events are mapped to the `unknown` event type so the
+application can decide how to handle them.
+
+## Repository and notification contracts
+
+Implementors must provide:
+
+- `KeyRepository` with methods for checkout, return, and finding overdue
+  transactions.
+- `KeyNotificationService` capable of delivering overdue alerts (email, SMS,
+  push, etc.).
+
+These abstractions enable integration with Supabase, PostgreSQL, or any other
+persistence layer without coupling the service to a specific database driver.

--- a/services/keys/connector.ts
+++ b/services/keys/connector.ts
@@ -1,0 +1,288 @@
+import { KeyServiceError } from './errors';
+import type {
+  KeyCabinetAlert,
+  KeyCabinetAlertStreamOptions,
+  KeyCabinetConnector,
+  KeyCabinetInventorySnapshot,
+  KeyCabinetKeyState,
+  KeyCheckoutRecord,
+  KeyPolicySeverity,
+} from './types';
+
+export interface OnPremKeyCabinetConnectorConfig {
+  baseUrl: string;
+  apiKey: string;
+  cabinetId: string;
+  id?: string;
+  timeoutMs?: number;
+  fetch?: typeof fetch;
+  defaultAlertPollIntervalMs?: number;
+}
+
+type FetchLike = typeof fetch;
+
+interface InventoryResponse {
+  capturedAt: string;
+  keys: Array<
+    Omit<KeyCabinetKeyState, 'lastUpdatedAt'> & {
+      lastUpdatedAt?: string;
+    }
+  >;
+}
+
+interface AlertResponse {
+  keyId: string;
+  slotId: string;
+  event: string;
+  occurredAt: string;
+  severity: KeyPolicySeverity;
+  details?: Record<string, unknown>;
+  cursor?: string;
+}
+
+interface CheckoutPayload {
+  transactionId: string;
+  keyId: string;
+  userId: string;
+  dueAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface ReturnPayload {
+  transactionId: string;
+  keyId: string;
+  userId: string;
+  returnedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export class OnPremKeyCabinetConnector implements KeyCabinetConnector {
+  readonly id: string;
+
+  private readonly baseUrl: string;
+
+  private readonly apiKey: string;
+
+  private readonly fetchImpl: FetchLike;
+
+  private readonly cabinetId: string;
+
+  private readonly timeoutMs: number;
+
+  private readonly defaultAlertPollIntervalMs: number;
+
+  constructor(config: OnPremKeyCabinetConnectorConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.apiKey = config.apiKey;
+    this.cabinetId = config.cabinetId;
+    this.timeoutMs = config.timeoutMs ?? 10000;
+    this.defaultAlertPollIntervalMs = config.defaultAlertPollIntervalMs ?? 15000;
+    this.id = config.id ?? config.cabinetId;
+
+    const fetchImpl = config.fetch ?? globalThis.fetch;
+    if (!fetchImpl) {
+      throw new KeyServiceError('CONFIGURATION_ERROR', 'Fetch API is not available for key cabinet connector');
+    }
+    this.fetchImpl = fetchImpl;
+  }
+
+  async syncInventory(): Promise<KeyCabinetInventorySnapshot> {
+    const response = await this.request<InventoryResponse>(`/cabinets/${this.cabinetId}/inventory`, {
+      method: 'GET',
+    });
+
+    return {
+      cabinetId: this.cabinetId,
+      capturedAt: new Date(response.capturedAt),
+      keys: response.keys.map((key) => ({
+        ...key,
+        lastUpdatedAt: key.lastUpdatedAt ? new Date(key.lastUpdatedAt) : undefined,
+      })),
+    };
+  }
+
+  async dispatchCheckout(record: KeyCheckoutRecord): Promise<void> {
+    const payload: CheckoutPayload = {
+      transactionId: record.id,
+      keyId: record.keyId,
+      userId: record.userId,
+      dueAt: record.dueAt.toISOString(),
+      metadata: record.metadata,
+    };
+
+    await this.request(`/cabinets/${this.cabinetId}/transactions/checkout`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async dispatchReturn(record: KeyCheckoutRecord): Promise<void> {
+    const payload: ReturnPayload = {
+      transactionId: record.id,
+      keyId: record.keyId,
+      userId: record.userId,
+      returnedAt: (record.returnedAt ?? new Date()).toISOString(),
+      metadata: record.metadata,
+    };
+
+    await this.request(`/cabinets/${this.cabinetId}/transactions/return`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async *streamAlerts(options: KeyCabinetAlertStreamOptions = {}): AsyncIterable<KeyCabinetAlert> {
+    const pollInterval = options.pollIntervalMs ?? this.defaultAlertPollIntervalMs;
+    let cursor = options.since?.toISOString();
+
+    while (!options.signal?.aborted) {
+      let alerts: AlertResponse[] | undefined;
+      try {
+        alerts = await this.request<AlertResponse[]>(
+          `/cabinets/${this.cabinetId}/alerts${cursor ? `?since=${encodeURIComponent(cursor)}` : ''}`,
+          {
+            method: 'GET',
+            signal: options.signal,
+          },
+        );
+      } catch (error) {
+        if (options.signal?.aborted) {
+          break;
+        }
+        throw error;
+      }
+
+      for (const alert of alerts ?? []) {
+        cursor = alert.cursor ?? alert.occurredAt;
+        yield {
+          cabinetId: this.cabinetId,
+          keyId: alert.keyId,
+          slotId: alert.slotId,
+          event: normalizeAlertEvent(alert.event),
+          occurredAt: new Date(alert.occurredAt),
+          severity: alert.severity,
+          details: alert.details,
+        };
+      }
+
+      if (options.signal?.aborted) {
+        break;
+      }
+
+      try {
+        await delay(pollInterval, options.signal);
+      } catch (error) {
+        if (options.signal?.aborted) {
+          break;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers = new Headers(init.headers);
+    headers.set('authorization', `Bearer ${this.apiKey}`);
+    if (!headers.has('content-type') && init.body) {
+      headers.set('content-type', 'application/json');
+    }
+
+    const controller = init.signal ? undefined : new AbortController();
+    const timeoutHandle = controller
+      ? setTimeout(() => controller.abort(), this.timeoutMs)
+      : undefined;
+    const signal = init.signal ?? controller?.signal;
+
+    try {
+      const response = await this.fetchImpl(url, {
+        ...init,
+        headers,
+        signal,
+      });
+
+      if (!response.ok) {
+        const body = await safeReadJson(response);
+        throw new KeyServiceError('CONNECTOR_ERROR', 'Key cabinet responded with an error', {
+          details: {
+            status: response.status,
+            path,
+            body,
+          },
+        });
+      }
+
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      const text = await response.text();
+      const trimmed = text.trim();
+      return trimmed ? (JSON.parse(trimmed) as T) : (undefined as T);
+    } catch (error) {
+      if (signal?.aborted) {
+        throw new KeyServiceError('CONNECTOR_ERROR', 'Key cabinet request aborted', {
+          cause: error,
+          details: { path },
+        });
+      }
+
+      throw KeyServiceError.from(error, 'CONNECTOR_ERROR', 'Failed to communicate with key cabinet', {
+        path,
+      });
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  }
+}
+
+const safeReadJson = async (response: Response): Promise<unknown> => {
+  try {
+    const text = await response.text();
+    return text ? JSON.parse(text) : undefined;
+  } catch (error) {
+    return { parseError: error instanceof Error ? error.message : 'unknown error' };
+  }
+};
+
+const normalizeAlertEvent = (event: string): KeyCabinetAlert['event'] => {
+  switch (event) {
+    case 'door_opened':
+    case 'door_forced':
+    case 'power_loss':
+    case 'tamper':
+      return event;
+    default:
+      return 'unknown';
+  }
+};
+
+const delay = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(handle);
+      reject(createAbortError());
+    };
+
+    const handle = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+
+const createAbortError = (): Error => {
+  const error = new Error('Aborted');
+  error.name = 'AbortError';
+  return error;
+};

--- a/services/keys/errors.ts
+++ b/services/keys/errors.ts
@@ -1,0 +1,81 @@
+import type { PolicyValidationResult, PolicyViolation } from './types';
+
+export type KeyServiceErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'POLICY_VIOLATION'
+  | 'REPOSITORY_ERROR'
+  | 'NOTIFICATION_ERROR'
+  | 'CONNECTOR_ERROR'
+  | 'CONFIGURATION_ERROR';
+
+export interface KeyServiceErrorOptions {
+  cause?: unknown;
+  details?: Record<string, unknown>;
+}
+
+export class KeyServiceError extends Error {
+  readonly code: KeyServiceErrorCode;
+
+  readonly details?: Record<string, unknown>;
+
+  override readonly cause?: unknown;
+
+  constructor(code: KeyServiceErrorCode, message: string, options: KeyServiceErrorOptions = {}) {
+    super(message);
+    this.name = 'KeyServiceError';
+    this.code = code;
+    this.details = options.details;
+    if (options.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+
+  static from(
+    cause: unknown,
+    code: KeyServiceErrorCode,
+    message: string,
+    details?: Record<string, unknown>,
+  ): KeyServiceError {
+    if (cause instanceof KeyServiceError) {
+      return cause;
+    }
+
+    let enrichedDetails: Record<string, unknown> | undefined = details
+      ? { ...details }
+      : undefined;
+    if (cause instanceof Error) {
+      if (enrichedDetails) {
+        enrichedDetails.causeMessage = cause.message;
+      } else {
+        enrichedDetails = { causeMessage: cause.message };
+      }
+    }
+
+    return new KeyServiceError(code, message, { cause, details: enrichedDetails });
+  }
+}
+
+export class PolicyViolationError extends KeyServiceError {
+  readonly violations: PolicyViolation[];
+
+  readonly validation?: PolicyValidationResult;
+
+  constructor(
+    violations: PolicyViolation[],
+    validation?: PolicyValidationResult,
+    message = 'Key policy validation failed',
+  ) {
+    super('POLICY_VIOLATION', message, {
+      details: {
+        violations,
+        evaluatedPolicies: validation?.evaluatedPolicies,
+      },
+    });
+    this.name = 'PolicyViolationError';
+    this.violations = violations;
+    this.validation = validation;
+  }
+}
+
+export const isKeyServiceError = (error: unknown): error is KeyServiceError =>
+  error instanceof KeyServiceError;

--- a/services/keys/index.ts
+++ b/services/keys/index.ts
@@ -1,0 +1,5 @@
+export * from './connector';
+export * from './errors';
+export * from './policies';
+export * from './service';
+export * from './types';

--- a/services/keys/policies.ts
+++ b/services/keys/policies.ts
@@ -1,0 +1,241 @@
+import { PolicyViolationError } from './errors';
+import type {
+  CustomPolicyRule,
+  KeyCheckoutRequest,
+  KeyPolicy,
+  KeyPolicyRule,
+  MaxDurationPolicyRule,
+  PolicyEvaluationContext,
+  PolicyValidationResult,
+  PolicyViolation,
+  RolePolicyRule,
+  TimeWindowPolicyRule,
+} from './types';
+
+export interface KeyPolicyValidatorOptions {
+  stopOnFirstViolation?: boolean;
+  timezoneFallback?: string;
+}
+
+export class KeyPolicyValidator {
+  private readonly timezoneFallback: string;
+
+  constructor(private readonly options: KeyPolicyValidatorOptions = {}) {
+    this.timezoneFallback = options.timezoneFallback ?? 'UTC';
+  }
+
+  async validate(request: KeyCheckoutRequest): Promise<PolicyValidationResult> {
+    const policies = request.policies ?? [];
+    const violations: PolicyViolation[] = [];
+    const evaluatedPolicies: string[] = [];
+
+    if (policies.length === 0) {
+      return { passed: true, violations, evaluatedPolicies };
+    }
+
+    const now = request.context?.currentTime ?? new Date();
+
+    for (const policy of policies) {
+      evaluatedPolicies.push(policy.id);
+      const timezone = this.resolveTimezone(policy, request);
+      const evaluationContext: PolicyEvaluationContext = { request, now, timezone };
+      const passed = await this.evaluatePolicy(policy.rule, evaluationContext);
+
+      if (!passed) {
+        violations.push({
+          policyId: policy.id,
+          message: this.resolveViolationMessage(policy, evaluationContext),
+          severity: policy.rule.type === 'custom'
+            ? policy.rule.severity ?? policy.severity ?? 'medium'
+            : policy.severity ?? 'medium',
+        });
+
+        if (this.options.stopOnFirstViolation) {
+          break;
+        }
+      }
+    }
+
+    return { passed: violations.length === 0, violations, evaluatedPolicies };
+  }
+
+  async assertValid(request: KeyCheckoutRequest): Promise<PolicyValidationResult> {
+    const result = await this.validate(request);
+    if (!result.passed) {
+      throw new PolicyViolationError(result.violations, result);
+    }
+    return result;
+  }
+
+  private resolveTimezone(policy: KeyPolicy, request: KeyCheckoutRequest): string {
+    if (policy.rule.type === 'timeWindow' && policy.rule.timeZone) {
+      return policy.rule.timeZone;
+    }
+    return request.context?.timezone ?? this.timezoneFallback;
+  }
+
+  private async evaluatePolicy(
+    rule: KeyPolicyRule,
+    context: PolicyEvaluationContext,
+  ): Promise<boolean> {
+    switch (rule.type) {
+      case 'timeWindow':
+        return this.evaluateTimeWindow(rule, context);
+      case 'role':
+        return this.evaluateRole(rule, context);
+      case 'maxDuration':
+        return this.evaluateMaxDuration(rule, context);
+      case 'custom':
+        return this.evaluateCustom(rule, context);
+      default: {
+        const exhaustiveCheck: never = rule;
+        return exhaustiveCheck;
+      }
+    }
+  }
+
+  private evaluateTimeWindow(rule: TimeWindowPolicyRule, context: PolicyEvaluationContext): boolean {
+    const zoned = zonedDate(context.now, rule.timeZone ?? context.timezone);
+
+    if (rule.countries?.length) {
+      const country = extractCountry(context.request);
+      if (!country || !rule.countries.includes(country)) {
+        return false;
+      }
+    }
+
+    if (rule.allowedWeekdays?.length) {
+      const weekday = zoned.getUTCDay();
+      if (!rule.allowedWeekdays.includes(weekday)) {
+        return false;
+      }
+    }
+
+    const minutes = zoned.getUTCHours() * 60 + zoned.getUTCMinutes();
+    const start = rule.startTime ? parseTimeToMinutes(rule.startTime) : undefined;
+    const end = rule.endTime ? parseTimeToMinutes(rule.endTime) : undefined;
+
+    if (start === undefined && end === undefined) {
+      return true;
+    }
+
+    if (start !== undefined && Number.isNaN(start)) {
+      return false;
+    }
+
+    if (end !== undefined && Number.isNaN(end)) {
+      return false;
+    }
+
+    if (start !== undefined && end !== undefined) {
+      if (start <= end) {
+        return minutes >= start && minutes <= end;
+      }
+      return minutes >= start || minutes <= end;
+    }
+
+    if (start !== undefined) {
+      return minutes >= start;
+    }
+
+    if (end !== undefined) {
+      return minutes <= end;
+    }
+
+    return true;
+  }
+
+  private evaluateRole(rule: RolePolicyRule, context: PolicyEvaluationContext): boolean {
+    return rule.allowedRoles.includes(context.request.userRole);
+  }
+
+  private evaluateMaxDuration(
+    rule: MaxDurationPolicyRule,
+    context: PolicyEvaluationContext,
+  ): boolean {
+    const issuedAt = context.request.issuedAt ?? context.now;
+    const diffMs = context.request.expectedReturnAt.getTime() - issuedAt.getTime();
+    const diffMinutes = diffMs / 60000;
+    return diffMinutes <= rule.maxDurationMinutes;
+  }
+
+  private async evaluateCustom(
+    rule: CustomPolicyRule,
+    context: PolicyEvaluationContext,
+  ): Promise<boolean> {
+    return rule.validate(context);
+  }
+
+  private resolveViolationMessage(policy: KeyPolicy, context: PolicyEvaluationContext): string {
+    if (policy.rule.type === 'custom') {
+      const { message } = policy.rule;
+      if (typeof message === 'function') {
+        return message(context);
+      }
+      if (typeof message === 'string') {
+        return message;
+      }
+    }
+
+    switch (policy.rule.type) {
+      case 'timeWindow':
+        return `Key can only be checked out between ${policy.rule.startTime ?? '00:00'} and ${
+          policy.rule.endTime ?? '23:59'
+        } (${policy.rule.timeZone ?? context.timezone}).`;
+      case 'role':
+        return 'User does not have permission to checkout this key.';
+      case 'maxDuration':
+        return `Key must be returned within ${policy.rule.maxDurationMinutes} minutes.`;
+      case 'custom':
+        return 'Custom policy validation failed.';
+      default:
+        return 'Policy validation failed.';
+    }
+  }
+}
+
+const zonedDate = (input: Date, timeZone: string): Date => {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(input);
+  const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const year = Number(lookup.year);
+  const month = Number(lookup.month) - 1;
+  const day = Number(lookup.day);
+  const hour = Number(lookup.hour ?? 0);
+  const minute = Number(lookup.minute ?? 0);
+  const second = Number(lookup.second ?? 0);
+  return new Date(Date.UTC(year, month, day, hour, minute, second));
+};
+
+const parseTimeToMinutes = (value: string): number => {
+  const [hours, minutes] = value.split(':').map(Number);
+  if (
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return Number.NaN;
+  }
+  return hours * 60 + minutes;
+};
+
+const extractCountry = (request: KeyCheckoutRequest): string | undefined => {
+  const attributeCountry = request.context?.attributes?.country;
+  if (typeof attributeCountry === 'string') {
+    return attributeCountry;
+  }
+  const metadataCountry = request.metadata?.country;
+  return typeof metadataCountry === 'string' ? metadataCountry : undefined;
+};

--- a/services/keys/service.ts
+++ b/services/keys/service.ts
@@ -1,0 +1,162 @@
+import { KeyServiceError, PolicyViolationError } from './errors';
+import { KeyPolicyValidator } from './policies';
+import type {
+  KeyCabinetConnector,
+  KeyCheckoutRecord,
+  KeyCheckoutRequest,
+  KeyNotificationService,
+  KeyRepository,
+  KeyReturnRequest,
+  OverdueAlertPayload,
+  PolicyValidationResult,
+} from './types';
+
+export interface KeyServiceDependencies {
+  repository: KeyRepository;
+  notificationService: KeyNotificationService;
+  policyValidator?: KeyPolicyValidator;
+  cabinetConnector?: KeyCabinetConnector;
+}
+
+export interface OverdueAlertFailure {
+  record: KeyCheckoutRecord;
+  error: KeyServiceError;
+}
+
+export interface OverdueAlertSummary {
+  referenceDate: Date;
+  totalOverdue: number;
+  alertsSent: number;
+  failures: OverdueAlertFailure[];
+}
+
+export class KeyService {
+  private readonly policyValidator: KeyPolicyValidator;
+
+  private readonly repository: KeyRepository;
+
+  private readonly notificationService: KeyNotificationService;
+
+  private readonly cabinetConnector?: KeyCabinetConnector;
+
+  constructor(dependencies: KeyServiceDependencies) {
+    this.repository = dependencies.repository;
+    this.notificationService = dependencies.notificationService;
+    this.policyValidator = dependencies.policyValidator ?? new KeyPolicyValidator();
+    this.cabinetConnector = dependencies.cabinetConnector;
+  }
+
+  async checkoutKey(request: KeyCheckoutRequest): Promise<KeyCheckoutRecord> {
+    let validation: PolicyValidationResult | undefined;
+    try {
+      validation = await this.policyValidator.validate(request);
+      if (!validation.passed) {
+        throw new PolicyViolationError(validation.violations, validation);
+      }
+    } catch (error) {
+      if (error instanceof PolicyViolationError) {
+        throw error;
+      }
+      throw KeyServiceError.from(error, 'VALIDATION_ERROR', 'Failed to validate checkout request', {
+        keyId: request.keyId,
+        userId: request.userId,
+      });
+    }
+
+    let record: KeyCheckoutRecord;
+    try {
+      record = await this.repository.checkout(request);
+    } catch (error) {
+      throw KeyServiceError.from(error, 'REPOSITORY_ERROR', 'Unable to checkout key', {
+        keyId: request.keyId,
+        userId: request.userId,
+      });
+    }
+
+    if (this.cabinetConnector) {
+      try {
+        await this.cabinetConnector.dispatchCheckout(record);
+      } catch (error) {
+        throw KeyServiceError.from(error, 'CONNECTOR_ERROR', 'Failed to notify key cabinet of checkout', {
+          keyId: record.keyId,
+          transactionId: record.id,
+        });
+      }
+    }
+
+    return record;
+  }
+
+  async returnKey(request: KeyReturnRequest): Promise<KeyCheckoutRecord> {
+    let record: KeyCheckoutRecord;
+    try {
+      record = await this.repository.return(request);
+    } catch (error) {
+      throw KeyServiceError.from(error, 'REPOSITORY_ERROR', 'Unable to return key', {
+        keyId: request.keyId,
+        userId: request.userId,
+        transactionId: request.transactionId,
+      });
+    }
+
+    if (this.cabinetConnector) {
+      try {
+        await this.cabinetConnector.dispatchReturn(record);
+      } catch (error) {
+        throw KeyServiceError.from(error, 'CONNECTOR_ERROR', 'Failed to notify key cabinet of return', {
+          keyId: record.keyId,
+          transactionId: record.id,
+        });
+      }
+    }
+
+    return record;
+  }
+
+  async triggerOverdueAlerts(referenceDate = new Date()): Promise<OverdueAlertSummary> {
+    let overdueRecords: KeyCheckoutRecord[];
+    try {
+      overdueRecords = await this.repository.findOverdue(referenceDate);
+    } catch (error) {
+      throw KeyServiceError.from(error, 'REPOSITORY_ERROR', 'Unable to query overdue keys', {
+        referenceDate: referenceDate.toISOString(),
+      });
+    }
+
+    const summary: OverdueAlertSummary = {
+      referenceDate,
+      totalOverdue: overdueRecords.length,
+      alertsSent: 0,
+      failures: [],
+    };
+
+    for (const record of overdueRecords) {
+      const payload: OverdueAlertPayload = {
+        keyId: record.keyId,
+        userId: record.userId,
+        overdueByMs: referenceDate.getTime() - record.dueAt.getTime(),
+        record,
+      };
+
+      try {
+        await this.notificationService.sendOverdueAlert(payload);
+        summary.alertsSent += 1;
+      } catch (error) {
+        summary.failures.push({
+          record,
+          error: KeyServiceError.from(error, 'NOTIFICATION_ERROR', 'Failed to send overdue alert', {
+            keyId: record.keyId,
+            userId: record.userId,
+            transactionId: record.id,
+          }),
+        });
+      }
+    }
+
+    return summary;
+  }
+
+  validatePolicies(request: KeyCheckoutRequest): Promise<PolicyValidationResult> {
+    return this.policyValidator.validate(request);
+  }
+}

--- a/services/keys/types.ts
+++ b/services/keys/types.ts
@@ -1,0 +1,180 @@
+export type KeyCheckoutStatus =
+  | 'pending'
+  | 'checked_out'
+  | 'returned'
+  | 'overdue'
+  | 'failed';
+
+export type KeyPolicySeverity = 'info' | 'low' | 'medium' | 'high' | 'critical';
+
+export interface KeyCheckoutRecord {
+  id: string;
+  keyId: string;
+  userId: string;
+  status: KeyCheckoutStatus;
+  checkedOutAt: Date;
+  dueAt: Date;
+  returnedAt?: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PolicyContext {
+  /**
+   * The point in time that should be used for policy evaluation. Defaults to the
+   * current system time when omitted.
+   */
+  currentTime?: Date;
+  /**
+   * The timezone that should be used for policies that depend on local time. If a
+   * policy provides a timezone it takes precedence over this value.
+   */
+  timezone?: string;
+  /** Arbitrary contextual attributes that policies may inspect. */
+  attributes?: Record<string, unknown>;
+}
+
+export interface KeyCheckoutRequest {
+  keyId: string;
+  userId: string;
+  userRole: string;
+  expectedReturnAt: Date;
+  issuedAt?: Date;
+  locationId?: string;
+  reason?: string;
+  context?: PolicyContext;
+  policies?: KeyPolicy[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface KeyReturnRequest {
+  transactionId: string;
+  keyId: string;
+  userId: string;
+  returnedAt: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OverdueAlertPayload {
+  keyId: string;
+  userId: string;
+  /** Milliseconds that the key is overdue. */
+  overdueByMs: number;
+  record: KeyCheckoutRecord;
+}
+
+export interface KeyRepository {
+  checkout(request: KeyCheckoutRequest): Promise<KeyCheckoutRecord>;
+  return(request: KeyReturnRequest): Promise<KeyCheckoutRecord>;
+  findOverdue(referenceDate: Date): Promise<KeyCheckoutRecord[]>;
+}
+
+export interface KeyNotificationService {
+  sendOverdueAlert(payload: OverdueAlertPayload): Promise<void>;
+}
+
+export interface PolicyViolation {
+  policyId: string;
+  message: string;
+  severity: KeyPolicySeverity;
+}
+
+export interface PolicyValidationResult {
+  passed: boolean;
+  violations: PolicyViolation[];
+  evaluatedPolicies: string[];
+}
+
+export interface TimeWindowPolicyRule {
+  type: 'timeWindow';
+  /** ISO-3166 alpha-2 country codes for which the rule applies, if restricted. */
+  countries?: string[];
+  /**
+   * ISO weekday numbers (0-6) that the checkout is allowed on. When omitted, all
+   * days are permitted.
+   */
+  allowedWeekdays?: number[];
+  /** Time in HH:mm (24h) format. */
+  startTime?: string;
+  /** Time in HH:mm (24h) format. */
+  endTime?: string;
+  /** IANA timezone identifier. */
+  timeZone?: string;
+}
+
+export interface RolePolicyRule {
+  type: 'role';
+  allowedRoles: string[];
+}
+
+export interface MaxDurationPolicyRule {
+  type: 'maxDuration';
+  /** Maximum duration in minutes. */
+  maxDurationMinutes: number;
+}
+
+export interface CustomPolicyRule {
+  type: 'custom';
+  validate: (context: PolicyEvaluationContext) => boolean | Promise<boolean>;
+  message?: string | ((context: PolicyEvaluationContext) => string);
+  severity?: KeyPolicySeverity;
+}
+
+export type KeyPolicyRule =
+  | TimeWindowPolicyRule
+  | RolePolicyRule
+  | MaxDurationPolicyRule
+  | CustomPolicyRule;
+
+export interface KeyPolicy {
+  id: string;
+  name: string;
+  description?: string;
+  severity?: KeyPolicySeverity;
+  rule: KeyPolicyRule;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PolicyEvaluationContext {
+  request: KeyCheckoutRequest;
+  now: Date;
+  timezone: string;
+}
+
+export interface KeyCabinetKeyState {
+  slotId: string;
+  keyId: string;
+  status: 'available' | 'checked_out' | 'maintenance';
+  batteryLevel?: number;
+  lastUpdatedAt?: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface KeyCabinetInventorySnapshot {
+  cabinetId: string;
+  capturedAt: Date;
+  keys: KeyCabinetKeyState[];
+}
+
+export interface KeyCabinetAlert {
+  cabinetId: string;
+  keyId: string;
+  slotId: string;
+  event: 'door_opened' | 'door_forced' | 'power_loss' | 'tamper' | 'unknown';
+  occurredAt: Date;
+  severity: KeyPolicySeverity;
+  details?: Record<string, unknown>;
+}
+
+export interface KeyCabinetAlertStreamOptions {
+  pollIntervalMs?: number;
+  since?: Date;
+  signal?: AbortSignal;
+}
+
+export interface KeyCabinetConnector {
+  readonly id: string;
+  syncInventory(): Promise<KeyCabinetInventorySnapshot>;
+  dispatchCheckout(record: KeyCheckoutRecord): Promise<void>;
+  dispatchReturn(record: KeyCheckoutRecord): Promise<void>;
+  streamAlerts?(options?: KeyCabinetAlertStreamOptions): AsyncIterable<KeyCabinetAlert>;
+}


### PR DESCRIPTION
## Summary
- add shared types and error helpers for key lifecycle orchestration
- implement a key service with checkout/return flows, overdue alerts, and policy validation helpers
- ship an on-prem cabinet connector plus documentation covering integration and error handling contracts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ceefe4940883289fa1c0e579fe5c25