### PR TITLE
Add amenities booking experience with Playwright tests

### DIFF
--- a/app/web/features/amenities/_components/amenities-feature-experience.tsx
+++ b/app/web/features/amenities/_components/amenities-feature-experience.tsx
@@ -1,0 +1,1086 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+import {
+  Ban,
+  CalendarDays,
+  CheckCircle2,
+  Clock,
+  Download,
+  FileText,
+  PartyPopper,
+  Search,
+  ShieldCheck,
+  Users,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react"
+import { format, isWithinInterval, parseISO } from "date-fns"
+import { eachDayOfInterval } from "date-fns/eachDayOfInterval"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Calendar } from "@/components/ui/calendar"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
+import { Input } from "@/components/ui/input"
+import { Progress } from "@/components/ui/progress"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { toast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+
+const CURRENT_MEMBER = "Jordan Lee"
+const DEFAULT_DATE = parseISO("2025-01-15")
+
+type SlotTemplate = {
+  id: string
+  name: string
+  startTime: string
+  endTime: string
+  tags: string[]
+}
+
+type RuleHint = {
+  id: string
+  title: string
+  detail: string
+  icon: LucideIcon
+}
+
+type BlackoutPeriod = {
+  id: string
+  start: Date
+  end: Date
+  reason: string
+}
+
+type Amenity = {
+  id: string
+  name: string
+  description: string
+  dailyQuota: number
+  requiresApproval: boolean
+  rules: RuleHint[]
+  slotTemplates: SlotTemplate[]
+  blackoutPeriods: BlackoutPeriod[]
+}
+
+type BookingStatus = "pending" | "confirmed" | "cancelled"
+
+type Booking = {
+  id: string
+  amenityId: string
+  date: string
+  startTime: string
+  endTime: string
+  attendee: string
+  status: BookingStatus
+  requiresApproval: boolean
+  approvedBy?: string | null
+  notes?: string
+}
+
+type SlotWithState = SlotTemplate & {
+  label: string
+  isBooked: boolean
+  bookedBy?: string
+  isBlackout: boolean
+  blackoutReason?: string
+}
+
+const AMENITIES: Amenity[] = [
+  {
+    id: "sky-lounge",
+    name: "Sky Lounge",
+    description:
+      "Panoramic lounge with gourmet kitchen access, perfect for celebrations and off-sites.",
+    dailyQuota: 3,
+    requiresApproval: true,
+    rules: [
+      {
+        id: "approval",
+        title: "Host approval",
+        detail: "Events over 12 guests require concierge approval at least 48 hours in advance.",
+        icon: ShieldCheck,
+      },
+      {
+        id: "cleanup",
+        title: "Cleanup buffer",
+        detail: "A 30 minute buffer is automatically blocked before and after each event for turnover.",
+        icon: Clock,
+      },
+      {
+        id: "catering",
+        title: "Catering ready",
+        detail: "Kitchen equipment and AV remotes are staged once a booking is approved.",
+        icon: PartyPopper,
+      },
+    ],
+    slotTemplates: [
+      {
+        id: "sunrise-reset",
+        name: "Sunrise Reset",
+        startTime: "08:00",
+        endTime: "10:00",
+        tags: ["quiet", "sunrise"],
+      },
+      {
+        id: "chef-demo",
+        name: "Chef Demo",
+        startTime: "12:00",
+        endTime: "14:00",
+        tags: ["catering", "lunch"],
+      },
+      {
+        id: "sunset-social",
+        name: "Sunset Social",
+        startTime: "16:00",
+        endTime: "18:00",
+        tags: ["sunset", "networking"],
+      },
+      {
+        id: "moonlight-mixer",
+        name: "Moonlight Mixer",
+        startTime: "19:00",
+        endTime: "21:00",
+        tags: ["evening", "music"],
+      },
+    ],
+    blackoutPeriods: [
+      {
+        id: "floor-care",
+        start: parseISO("2025-01-20T00:00:00"),
+        end: parseISO("2025-01-21T23:59:59"),
+        reason: "Floor resealing and chandelier maintenance",
+      },
+      {
+        id: "vip-retreat",
+        start: parseISO("2025-02-05T12:00:00"),
+        end: parseISO("2025-02-07T23:00:00"),
+        reason: "Private corporate retreat",
+      },
+    ],
+  },
+  {
+    id: "maker-lab",
+    name: "Maker Lab",
+    description:
+      "Reservable fabrication studio with laser cutter, VR prototyping rigs, and print farm.",
+    dailyQuota: 4,
+    requiresApproval: false,
+    rules: [
+      {
+        id: "orientation",
+        title: "Orientation required",
+        detail: "Residents must complete the safety orientation before reserving equipment.",
+        icon: Users,
+      },
+      {
+        id: "materials",
+        title: "Supply policy",
+        detail: "Bring your own materials or purchase filament packs from the concierge desk.",
+        icon: FileText,
+      },
+    ],
+    slotTemplates: [
+      {
+        id: "prototype-sprint",
+        name: "Prototype Sprint",
+        startTime: "09:00",
+        endTime: "11:00",
+        tags: ["laser", "cnc"],
+      },
+      {
+        id: "open-build",
+        name: "Open Build",
+        startTime: "11:30",
+        endTime: "13:30",
+        tags: ["print", "robotics"],
+      },
+      {
+        id: "evening-lab",
+        name: "Evening Lab",
+        startTime: "17:30",
+        endTime: "19:30",
+        tags: ["robotics", "team"],
+      },
+    ],
+    blackoutPeriods: [
+      {
+        id: "inventory",
+        start: parseISO("2025-01-22T08:00:00"),
+        end: parseISO("2025-01-22T18:00:00"),
+        reason: "Quarterly equipment calibration",
+      },
+    ],
+  },
+]
+
+const INITIAL_BOOKINGS: Booking[] = [
+  {
+    id: "booking-sky-1",
+    amenityId: "sky-lounge",
+    date: "2025-01-15",
+    startTime: "12:00",
+    endTime: "14:00",
+    attendee: CURRENT_MEMBER,
+    status: "confirmed",
+    requiresApproval: true,
+    approvedBy: "Community Manager",
+    notes: "Product launch lunch",
+  },
+  {
+    id: "booking-sky-2",
+    amenityId: "sky-lounge",
+    date: "2025-01-15",
+    startTime: "19:00",
+    endTime: "21:00",
+    attendee: "Alex Morgan",
+    status: "pending",
+    requiresApproval: true,
+    approvedBy: null,
+    notes: "Birthday celebration",
+  },
+  {
+    id: "booking-lab-1",
+    amenityId: "maker-lab",
+    date: "2025-01-15",
+    startTime: "09:00",
+    endTime: "11:00",
+    attendee: "Priya Patel",
+    status: "confirmed",
+    requiresApproval: false,
+    approvedBy: "Auto-approve",
+    notes: "Prototype sprint",
+  },
+]
+
+function combineDateAndTime(baseDate: Date, time: string) {
+  const [hours, minutes] = time.split(":").map(Number)
+  const combined = new Date(baseDate)
+  combined.setHours(hours, minutes, 0, 0)
+  return combined
+}
+
+function formatRange(start: Date, end: Date) {
+  return `${format(start, "h:mm a")} – ${format(end, "h:mm a")}`
+}
+
+function formatStatus(status: BookingStatus) {
+  switch (status) {
+    case "confirmed":
+      return "Confirmed"
+    case "pending":
+      return "Pending approval"
+    case "cancelled":
+      return "Cancelled"
+  }
+}
+
+function statusBadgeClass(status: BookingStatus) {
+  switch (status) {
+    case "confirmed":
+      return "bg-emerald-100 text-emerald-700 border-emerald-200"
+    case "pending":
+      return "bg-amber-100 text-amber-700 border-amber-200"
+    case "cancelled":
+      return "bg-slate-200 text-slate-600 border-slate-300"
+  }
+}
+
+function formatIcsDate(date: Date) {
+  return date.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z"
+}
+
+function getAmenityById(id: string) {
+  return AMENITIES.find((amenity) => amenity.id === id)
+}
+
+const blackoutModifiers = (dates: Date[]) => ({
+  blackout: dates,
+})
+
+const blackoutStyles = {
+  blackout: {
+    backgroundColor: "rgba(220, 38, 38, 0.18)",
+    color: "#991b1b",
+  },
+}
+
+export default function AmenitiesFeatureExperience() {
+  const [selectedAmenityId, setSelectedAmenityId] = useState<string>(AMENITIES[0]?.id ?? "")
+  const [selectedDate, setSelectedDate] = useState<Date>(DEFAULT_DATE)
+  const [searchTerm, setSearchTerm] = useState("")
+  const [bookings, setBookings] = useState<Booking[]>(INITIAL_BOOKINGS)
+  const [slotDialogOpen, setSlotDialogOpen] = useState(false)
+  const [slotToBook, setSlotToBook] = useState<SlotWithState | null>(null)
+
+  const selectedAmenity = useMemo(
+    () => AMENITIES.find((amenity) => amenity.id === selectedAmenityId) ?? AMENITIES[0],
+    [selectedAmenityId]
+  )
+
+  const selectedDateKey = useMemo(() => format(selectedDate, "yyyy-MM-dd"), [selectedDate])
+
+  const blackoutDates = useMemo(() => {
+    if (!selectedAmenity) {
+      return []
+    }
+    return selectedAmenity.blackoutPeriods.flatMap((period) =>
+      eachDayOfInterval({ start: period.start, end: period.end })
+    )
+  }, [selectedAmenity])
+
+  const dayBlackout = useMemo(() => {
+    if (!selectedAmenity) {
+      return null
+    }
+    return (
+      selectedAmenity.blackoutPeriods.find((period) =>
+        isWithinInterval(selectedDate, { start: period.start, end: period.end })
+      ) ?? null
+    )
+  }, [selectedAmenity, selectedDate])
+
+  const normalizedSearch = searchTerm.trim().toLowerCase()
+
+  const activeBookingsForDay = useMemo(
+    () =>
+      bookings.filter(
+        (booking) =>
+          booking.amenityId === selectedAmenity?.id &&
+          booking.date === selectedDateKey &&
+          booking.status !== "cancelled"
+      ),
+    [bookings, selectedAmenity?.id, selectedDateKey]
+  )
+
+  const isQuotaReached = (selectedAmenity?.dailyQuota ?? 0) <= activeBookingsForDay.length
+
+  const slotsForDate = useMemo(() => {
+    if (!selectedAmenity) {
+      return []
+    }
+
+    return selectedAmenity.slotTemplates.map<SlotWithState>((slot) => {
+      const start = combineDateAndTime(selectedDate, slot.startTime)
+      const end = combineDateAndTime(selectedDate, slot.endTime)
+
+      const conflictingBooking = bookings.find(
+        (booking) =>
+          booking.amenityId === selectedAmenity.id &&
+          booking.date === selectedDateKey &&
+          booking.startTime === slot.startTime &&
+          booking.status !== "cancelled"
+      )
+
+      const blackout = selectedAmenity.blackoutPeriods.find((period) =>
+        isWithinInterval(start, { start: period.start, end: period.end })
+      )
+
+      return {
+        ...slot,
+        label: `${slot.name} · ${formatRange(start, end)}`,
+        isBooked: Boolean(conflictingBooking),
+        bookedBy: conflictingBooking?.attendee,
+        isBlackout: Boolean(blackout),
+        blackoutReason: blackout?.reason,
+      }
+    })
+  }, [bookings, selectedAmenity, selectedDate, selectedDateKey])
+
+  const filteredSlots = useMemo(() => {
+    if (!normalizedSearch) {
+      return slotsForDate
+    }
+
+    return slotsForDate.filter((slot) => {
+      const haystack = [slot.name, slot.label, slot.tags.join(" ")].join(" ").toLowerCase()
+      return haystack.includes(normalizedSearch)
+    })
+  }, [normalizedSearch, slotsForDate])
+
+  const myBookings = useMemo(() => {
+    return bookings
+      .filter(
+        (booking) =>
+          booking.attendee === CURRENT_MEMBER &&
+          booking.amenityId === selectedAmenity?.id
+      )
+      .sort((a, b) => {
+        if (a.date === b.date) {
+          return a.startTime.localeCompare(b.startTime)
+        }
+        return a.date.localeCompare(b.date)
+      })
+  }, [bookings, selectedAmenity?.id])
+
+  const pendingApprovals = useMemo(
+    () =>
+      bookings.filter(
+        (booking) =>
+          booking.amenityId === selectedAmenity?.id &&
+          booking.requiresApproval &&
+          booking.status === "pending"
+      ),
+    [bookings, selectedAmenity?.id]
+  )
+
+  const handleSelectSlot = useCallback((slot: SlotWithState) => {
+    setSlotToBook(slot)
+    setSlotDialogOpen(true)
+  }, [])
+
+  const handleConfirmBooking = useCallback(() => {
+    if (!slotToBook || !selectedAmenity) {
+      return
+    }
+
+    if (slotToBook.isBooked) {
+      toast({
+        title: "Slot already reserved",
+        description: "Choose another window or search for a different amenity.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    if (slotToBook.isBlackout || dayBlackout) {
+      toast({
+        title: "Blackout in effect",
+        description: "This amenity is unavailable during the selected window.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    if (isQuotaReached) {
+      toast({
+        title: "Daily quota reached",
+        description: "Select another day or amenity with availability.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    const bookingId = `booking-${selectedAmenity.id}-${slotToBook.id}-${Date.now()}`
+
+    const newBooking: Booking = {
+      id: bookingId,
+      amenityId: selectedAmenity.id,
+      date: selectedDateKey,
+      startTime: slotToBook.startTime,
+      endTime: slotToBook.endTime,
+      attendee: CURRENT_MEMBER,
+      status: selectedAmenity.requiresApproval ? "pending" : "confirmed",
+      requiresApproval: selectedAmenity.requiresApproval,
+      approvedBy: selectedAmenity.requiresApproval ? null : "Auto-approve",
+      notes: `${slotToBook.name} reservation`,
+    }
+
+    setBookings((prev) => [...prev, newBooking])
+    setSlotDialogOpen(false)
+    setSlotToBook(null)
+
+    toast({
+      title: selectedAmenity.requiresApproval ? "Booking submitted for approval" : "Booking confirmed",
+      description: selectedAmenity.requiresApproval
+        ? "The concierge team will review and approve this reservation shortly."
+        : "Your slot is confirmed and ready to add to your calendar.",
+    })
+  }, [dayBlackout, isQuotaReached, selectedAmenity, selectedDateKey, slotToBook])
+
+  const handleCancelBooking = useCallback((bookingId: string) => {
+    setBookings((prev) =>
+      prev.map((booking) =>
+        booking.id === bookingId ? { ...booking, status: "cancelled" } : booking
+      )
+    )
+    toast({
+      title: "Reservation cancelled",
+      description: "The slot is now released back to the calendar.",
+    })
+  }, [])
+
+  const handleApprove = useCallback((bookingId: string) => {
+    setBookings((prev) =>
+      prev.map((booking) =>
+        booking.id === bookingId
+          ? {
+              ...booking,
+              status: "confirmed",
+              approvedBy: "Community Manager",
+            }
+          : booking
+      )
+    )
+    toast({
+      title: "Booking approved",
+      description: "The resident has been notified and can download their ICS file.",
+    })
+  }, [])
+
+  const handleReject = useCallback((bookingId: string) => {
+    setBookings((prev) =>
+      prev.map((booking) =>
+        booking.id === bookingId
+          ? {
+              ...booking,
+              status: "cancelled",
+              approvedBy: "Community Manager",
+            }
+          : booking
+      )
+    )
+    toast({
+      title: "Booking declined",
+      description: "Residents receive a notification with alternative suggestions.",
+    })
+  }, [])
+
+  const handleDownloadIcs = useCallback((booking: Booking) => {
+    const amenity = getAmenityById(booking.amenityId)
+    if (!amenity) return
+
+    const date = parseISO(booking.date)
+    const start = combineDateAndTime(date, booking.startTime)
+    const end = combineDateAndTime(date, booking.endTime)
+
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Share House Portal//Amenities//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      "BEGIN:VEVENT",
+      `UID:${booking.id}@share-house-portal`,
+      `DTSTAMP:${formatIcsDate(new Date())}`,
+      `DTSTART:${formatIcsDate(start)}`,
+      `DTEND:${formatIcsDate(end)}`,
+      `SUMMARY:${amenity.name} reservation`,
+      `DESCRIPTION:Reserved by ${booking.attendee}${booking.notes ? ` — ${booking.notes}` : ""}`,
+      `LOCATION:${amenity.name}`,
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n")
+
+    const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = `${amenity.name.toLowerCase().replace(/\s+/g, "-")}-${booking.id}.ics`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+
+    toast({
+      title: "Calendar file ready",
+      description: "An .ics file has been generated for your reservation.",
+    })
+  }, [])
+
+  const quotaPercentage = selectedAmenity
+    ? Math.min(100, Math.round((activeBookingsForDay.length / selectedAmenity.dailyQuota) * 100))
+    : 0
+
+  return (
+    <div className="container mx-auto flex max-w-6xl flex-col gap-8 px-4 py-12">
+      <header className="space-y-3 text-center">
+        <Badge variant="outline" className="px-3 py-1 text-sm">
+          Amenities Command Center
+        </Badge>
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+          Calendar-driven amenity reservations
+        </h1>
+        <p className="mx-auto max-w-3xl text-muted-foreground">
+          Explore how residents search for slots, receive instant policy hints, download calendar invites,
+          and how your team keeps control with quotas, blackout periods, and streamlined approvals.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-1">
+            <CardTitle className="text-xl">Amenity selection</CardTitle>
+            <CardDescription>
+              Compare reservation rules, real-time availability, and blackout planning across amenities.
+            </CardDescription>
+          </div>
+          <Select
+            value={selectedAmenity?.id}
+            onValueChange={(value) => {
+              setSelectedAmenityId(value)
+              setSearchTerm("")
+            }}
+          >
+            <SelectTrigger className="w-full min-w-[220px] lg:w-[280px]" data-testid="amenity-select">
+              <SelectValue placeholder="Choose an amenity" />
+            </SelectTrigger>
+            <SelectContent>
+              {AMENITIES.map((amenity) => (
+                <SelectItem key={amenity.id} value={amenity.id}>
+                  {amenity.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
+            <div className="space-y-4">
+              <Card className="border-muted shadow-none">
+                <CardHeader className="pb-3">
+                  <CardTitle className="flex items-center gap-2 text-base font-semibold">
+                    <CalendarDays className="size-5 text-primary" /> Reservation calendar
+                  </CardTitle>
+                  <CardDescription className="text-sm">
+                    Blackout dates display in red so residents can plan around maintenance windows.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <Calendar
+                    mode="single"
+                    defaultMonth={selectedDate}
+                    selected={selectedDate}
+                    onSelect={(date) => date && setSelectedDate(date)}
+                    modifiers={blackoutModifiers(blackoutDates)}
+                    modifiersStyles={blackoutStyles}
+                  />
+                </CardContent>
+              </Card>
+
+              <div className="rounded-lg border border-muted bg-muted/20 p-4 text-sm">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <ShieldCheck className="size-4 text-primary" />
+                  Policy hints
+                </div>
+                <Separator className="my-3" />
+                <div className="flex flex-wrap gap-2">
+                  {selectedAmenity?.rules.map((rule) => (
+                    <HoverCard key={rule.id}>
+                      <HoverCardTrigger asChild>
+                        <Badge variant="outline" className="cursor-help gap-1 px-2 py-1">
+                          <rule.icon className="size-4" />
+                          {rule.title}
+                        </Badge>
+                      </HoverCardTrigger>
+                      <HoverCardContent side="top" className="max-w-xs text-sm">
+                        {rule.detail}
+                      </HoverCardContent>
+                    </HoverCard>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="flex items-center gap-2 rounded-full border border-muted bg-background px-3 py-1 text-sm">
+                  <Users className="size-4 text-primary" />
+                  <span>{selectedAmenity?.requiresApproval ? "Concierge approval required" : "Instant book amenity"}</span>
+                </div>
+                <div className="flex items-center gap-2 rounded-full border border-muted bg-background px-3 py-1 text-sm">
+                  <Clock className="size-4 text-primary" />
+                  <span>
+                    Daily quota {activeBookingsForDay.length}/{selectedAmenity?.dailyQuota}
+                  </span>
+                </div>
+                {dayBlackout ? (
+                  <div className="flex items-center gap-2 rounded-full border border-destructive bg-destructive/10 px-3 py-1 text-sm text-destructive">
+                    <Ban className="size-4" />
+                    <span>Blackout: {dayBlackout.reason}</span>
+                  </div>
+                ) : null}
+              </div>
+
+              <div>
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <h2 className="text-lg font-semibold">Available slots</h2>
+                    <p className="text-sm text-muted-foreground">
+                      Search by experience name, time, or keyword to find the perfect window.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 rounded-md border border-muted px-3 py-2 text-sm">
+                    <Search className="size-4 text-muted-foreground" />
+                    <Input
+                      value={searchTerm}
+                      onChange={(event) => setSearchTerm(event.target.value)}
+                      placeholder="Search slots"
+                      className="h-6 border-0 bg-transparent p-0 text-sm focus-visible:ring-0"
+                      data-testid="slot-search"
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4" data-testid="available-slots">
+                  {filteredSlots.map((slot) => {
+                    const disabled =
+                      slot.isBooked ||
+                      slot.isBlackout ||
+                      isQuotaReached ||
+                      Boolean(dayBlackout)
+
+                    return (
+                      <Card
+                        key={slot.id}
+                        className={cn(
+                          "transition-shadow hover:shadow-md",
+                          slot.isBooked && "border-muted-foreground/30",
+                          slot.isBlackout && "border-destructive text-destructive"
+                        )}
+                        data-testid={`slot-card-${slot.id}`}
+                      >
+                        <CardHeader className="flex flex-col gap-3 pb-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div className="space-y-1">
+                            <CardTitle className="text-base font-semibold">
+                              {slot.name}
+                            </CardTitle>
+                            <CardDescription className="text-sm">{slot.label}</CardDescription>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            {slot.tags.map((tag) => (
+                              <Badge key={tag} variant="outline" className="uppercase tracking-wide">
+                                {tag}
+                              </Badge>
+                            ))}
+                          </div>
+                        </CardHeader>
+                        <CardContent className="flex flex-col gap-3 pt-0 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="flex flex-wrap items-center gap-3 text-sm">
+                            {slot.isBooked ? (
+                              <span className="flex items-center gap-2">
+                              <XCircle className="size-4 text-muted-foreground" />
+                                Reserved by {slot.bookedBy}
+                              </span>
+                            ) : slot.isBlackout ? (
+                              <span className="flex items-center gap-2 text-destructive">
+                              <Ban className="size-4" />
+                                {slot.blackoutReason}
+                              </span>
+                            ) : (
+                              <span className="flex items-center gap-2 text-emerald-600">
+                              <CheckCircle2 className="size-4" />
+                                Open for booking
+                              </span>
+                            )}
+                          </div>
+                          <Button
+                            size="sm"
+                            disabled={disabled}
+                            onClick={() => handleSelectSlot(slot)}
+                            data-testid={`book-slot-${slot.id}`}
+                          >
+                            {slot.isBooked
+                              ? "Unavailable"
+                              : isQuotaReached
+                                ? "Quota reached"
+                                : dayBlackout
+                                  ? "Blackout"
+                                  : `Book ${slot.name}`}
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    )
+                  })}
+
+                  {filteredSlots.length === 0 ? (
+                    <div className="rounded-lg border border-dashed border-muted-foreground/50 p-6 text-center text-sm text-muted-foreground">
+                      No slots match that search. Try a different keyword or switch amenities.
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm font-medium">
+                  <span>Quota utilization</span>
+                  <span>
+                    {activeBookingsForDay.length} of {selectedAmenity?.dailyQuota} bookings
+                  </span>
+                </div>
+                <Progress value={quotaPercentage} className="h-2" />
+              </div>
+
+              <div className="rounded-lg border border-muted p-4 text-sm">
+                <div className="mb-2 flex items-center gap-2 font-medium">
+                  <Ban className="size-4 text-primary" /> Upcoming blackout periods
+                </div>
+                <ul className="space-y-2">
+                  {selectedAmenity?.blackoutPeriods.map((period) => (
+                    <li key={period.id} className="flex items-start gap-2">
+                      <span className="mt-1 inline-flex size-2 flex-none rounded-full bg-destructive" />
+                      <span>
+                        <span className="font-medium">{format(period.start, "MMM d")}</span>
+                        {" – "}
+                        <span className="font-medium">{format(period.end, "MMM d")}</span>
+                        <span className="block text-muted-foreground">{period.reason}</span>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Tabs defaultValue="member" className="space-y-6">
+        <TabsList className="w-full justify-start overflow-x-auto">
+          <TabsTrigger value="member">Resident booking journey</TabsTrigger>
+          <TabsTrigger value="admin">Admin approvals & governance</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="member" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>My reservations</CardTitle>
+              <CardDescription>
+                Residents can view, download, or cancel their amenity bookings in real time.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ScrollArea className="h-full max-h-[320px] pr-4" data-testid="my-bookings">
+                <div className="space-y-4">
+                  {myBookings.map((booking) => {
+                    const amenity = getAmenityById(booking.amenityId)
+                    const statusClass = statusBadgeClass(booking.status)
+
+                    return (
+                      <div
+                        key={booking.id}
+                        className="rounded-lg border border-muted bg-background p-4 shadow-sm"
+                        data-testid={`my-booking-${booking.id}`}
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div>
+                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                              <CalendarDays className="size-4" />
+                              <span>{format(parseISO(booking.date), "MMM d, yyyy")}</span>
+                              <span aria-hidden="true">•</span>
+                              <span>
+                                {formatRange(
+                                  combineDateAndTime(parseISO(booking.date), booking.startTime),
+                                  combineDateAndTime(parseISO(booking.date), booking.endTime)
+                                )}
+                              </span>
+                            </div>
+                            <div className="mt-1 text-base font-semibold">{amenity?.name}</div>
+                            {booking.notes ? (
+                              <p className="text-sm text-muted-foreground">{booking.notes}</p>
+                            ) : null}
+                          </div>
+                          <Badge className={cn("border", statusClass)}>{formatStatus(booking.status)}</Badge>
+                        </div>
+                        <div className="mt-3 flex flex-wrap items-center gap-2">
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            disabled={booking.status !== "confirmed"}
+                            onClick={() => handleDownloadIcs(booking)}
+                            data-testid={`download-ics-${booking.id}`}
+                          >
+                            <Download className="mr-2 size-4" /> Download ICS
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            disabled={booking.status === "cancelled"}
+                            onClick={() => handleCancelBooking(booking.id)}
+                            data-testid={`cancel-booking-${booking.id}`}
+                          >
+                            Cancel booking
+                          </Button>
+                        </div>
+                      </div>
+                    )
+                  })}
+                  {myBookings.length === 0 ? (
+                    <div className="rounded-lg border border-dashed border-muted-foreground/40 p-6 text-center text-sm text-muted-foreground">
+                      No reservations yet. Use the calendar above to reserve your first experience.
+                    </div>
+                  ) : null}
+                </div>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="admin" className="space-y-6">
+          <div className="grid gap-6 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Pending approvals</CardTitle>
+                <CardDescription>
+                  Concierge staff triage requests that exceed capacity rules or require manual review.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4" data-testid="pending-approvals">
+                  {pendingApprovals.length > 0 ? (
+                    pendingApprovals.map((booking) => {
+                      const amenity = getAmenityById(booking.amenityId)
+                      return (
+                        <div
+                          key={booking.id}
+                          className="rounded-lg border border-muted bg-muted/20 p-4"
+                          data-testid={`pending-booking-${booking.id}`}
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                            <div className="font-medium">{amenity?.name}</div>
+                            <span className="text-muted-foreground">
+                              {format(parseISO(booking.date), "MMM d, yyyy")} · {booking.startTime}–{booking.endTime}
+                            </span>
+                          </div>
+                          {booking.notes ? (
+                            <p className="mt-1 text-sm text-muted-foreground">{booking.notes}</p>
+                          ) : null}
+                          <div className="mt-3 flex gap-2">
+                            <Button
+                              size="sm"
+                              onClick={() => handleApprove(booking.id)}
+                              data-testid={`approve-booking-${booking.id}`}
+                            >
+                              Approve
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleReject(booking.id)}
+                              data-testid={`reject-booking-${booking.id}`}
+                            >
+                              Decline
+                            </Button>
+                          </div>
+                        </div>
+                      )
+                    })
+                  ) : (
+                    <div className="rounded-lg border border-dashed border-muted-foreground/40 p-6 text-center text-sm text-muted-foreground">
+                      All caught up — nothing awaiting review.
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>All reservations</CardTitle>
+                <CardDescription>Live state of every booking, including approved and cancelled slots.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ScrollArea className="h-full max-h-[320px] pr-4" data-testid="all-bookings">
+                  <div className="space-y-4">
+                    {bookings
+                      .filter((booking) => booking.amenityId === selectedAmenity?.id)
+                      .sort((a, b) => {
+                        if (a.date === b.date) {
+                          return a.startTime.localeCompare(b.startTime)
+                        }
+                        return a.date.localeCompare(b.date)
+                      })
+                      .map((booking) => {
+                        const amenity = getAmenityById(booking.amenityId)
+                        const statusClass = statusBadgeClass(booking.status)
+                        return (
+                          <div
+                            key={booking.id}
+                            className="rounded-lg border border-muted bg-background p-4"
+                            data-testid={`admin-booking-${booking.id}`}
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-3">
+                              <div>
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                  <CalendarDays className="size-4" />
+                                  <span>{format(parseISO(booking.date), "MMM d, yyyy")}</span>
+                                  <span aria-hidden="true">•</span>
+                                  <span>
+                                    {formatRange(
+                                      combineDateAndTime(parseISO(booking.date), booking.startTime),
+                                      combineDateAndTime(parseISO(booking.date), booking.endTime)
+                                    )}
+                                  </span>
+                                </div>
+                                <div className="mt-1 text-base font-semibold">{amenity?.name}</div>
+                                <p className="text-sm text-muted-foreground">Resident: {booking.attendee}</p>
+                                {booking.notes ? (
+                                  <p className="text-xs text-muted-foreground">{booking.notes}</p>
+                                ) : null}
+                              </div>
+                              <Badge className={cn("border", statusClass)}>{formatStatus(booking.status)}</Badge>
+                            </div>
+                            {booking.approvedBy ? (
+                              <p className="mt-2 text-xs text-muted-foreground">Handled by {booking.approvedBy}</p>
+                            ) : null}
+                          </div>
+                        )
+                      })}
+                  </div>
+                </ScrollArea>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      <Dialog open={slotDialogOpen} onOpenChange={setSlotDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm reservation</DialogTitle>
+            <DialogDescription>
+              Review the reservation details and confirm your booking for the {selectedAmenity?.name}.
+            </DialogDescription>
+          </DialogHeader>
+          {slotToBook ? (
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center gap-2">
+                <CalendarDays className="size-4 text-primary" />
+                <span>{format(selectedDate, "EEEE, MMMM d, yyyy")}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Clock className="size-4 text-primary" />
+                <span>
+                  {formatRange(
+                    combineDateAndTime(selectedDate, slotToBook.startTime),
+                    combineDateAndTime(selectedDate, slotToBook.endTime)
+                  )}
+                </span>
+              </div>
+              {selectedAmenity?.requiresApproval ? (
+                <div className="flex items-center gap-2 text-amber-600">
+                  <ShieldCheck className="size-4" />
+                  This booking routes to concierge for approval.
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-emerald-600">
+                  <CheckCircle2 className="size-4" />
+                  This booking confirms instantly.
+                </div>
+              )}
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSlotDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleConfirmBooking} data-testid="confirm-booking">
+              Confirm booking
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/web/features/amenities/page.tsx
+++ b/app/web/features/amenities/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+import AmenitiesFeatureExperience from "./_components/amenities-feature-experience"
+
+export const metadata: Metadata = {
+  title: "Amenities reservations | Share House Portal",
+  description:
+    "Interactive amenity scheduling demo showcasing quotas, blackout periods, approvals, and ICS exports.",
+}
+
+export default function AmenitiesFeaturePage() {
+  return <AmenitiesFeatureExperience />
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -101,6 +102,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "@playwright/test": "^1.45.1",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.0.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+    viewport: { width: 1280, height: 720 },
+  },
+  webServer: {
+    command: "pnpm start --hostname 127.0.0.1 --port 3000",
+    url: "http://127.0.0.1:3000",
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -261,6 +261,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@playwright/test':
+        specifier: ^1.45.1
+        version: 1.55.0
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -1570,6 +1573,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -3753,6 +3761,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4807,6 +4820,16 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-attribute-case-insensitive@7.0.0:
     resolution: {integrity: sha512-ETMUHIw67Kyv9Q81nden/NuJbRh+4/S963giXpfSLd5eaKK8kd1UdAHMVRV/NG/w/N6Cq8B0qZIZbZZWU/67+A==}
@@ -7302,10 +7325,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7656,6 +7679,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
 
   '@radix-ui/number@1.0.1':
     dependencies:
@@ -8853,16 +8880,16 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
@@ -9815,8 +9842,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +9865,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +9882,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +9903,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10161,6 +10188,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -11252,13 +11282,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +11298,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11280,6 +11310,7 @@ snapshots:
       '@next/swc-win32-ia32-msvc': 14.2.4
       '@next/swc-win32-x64-msvc': 14.2.4
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.55.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -11457,6 +11488,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-attribute-case-insensitive@7.0.0(postcss@8.4.32):
     dependencies:
@@ -12334,12 +12373,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 

--- a/tests/amenities-booking.spec.ts
+++ b/tests/amenities-booking.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test"
+
+test.describe("Amenities booking experience", () => {
+  test("resident can search, book, and cancel a slot", async ({ page }) => {
+    await page.goto("/web/features/amenities")
+
+    await expect(
+      page.getByRole("heading", { name: /calendar-driven amenity reservations/i })
+    ).toBeVisible()
+
+    await expect(page.getByTestId("download-ics-booking-sky-1")).toBeEnabled()
+
+    const searchInput = page.getByTestId("slot-search")
+    await searchInput.fill("Sunset")
+
+    const slotCard = page.getByTestId("slot-card-sunset-social")
+    await expect(slotCard).toBeVisible()
+
+    const bookButton = page.getByTestId("book-slot-sunset-social")
+    await expect(bookButton).toBeEnabled()
+    await bookButton.click()
+
+    await page.getByTestId("confirm-booking").click()
+
+    const myBookings = page.getByTestId("my-bookings")
+    const newBookingCard = myBookings
+      .locator('[data-testid^="my-booking-"]')
+      .filter({ hasText: "Sunset Social reservation" })
+    await expect(newBookingCard).toContainText("Pending approval")
+
+    await newBookingCard.getByRole("button", { name: "Cancel booking" }).click()
+    await expect(newBookingCard).toContainText("Cancelled")
+
+    await expect(page.getByTestId("book-slot-sunset-social")).toBeEnabled()
+  })
+
+  test("admins can approve bookings and view updated status", async ({ page }) => {
+    await page.goto("/web/features/amenities")
+
+    await page.getByRole("tab", { name: "Admin approvals & governance" }).click()
+
+    const pendingCard = page.getByTestId("pending-booking-booking-sky-2")
+    await expect(pendingCard).toContainText("Birthday celebration")
+
+    await page.getByTestId("approve-booking-booking-sky-2").click()
+
+    await expect(page.getByTestId("pending-approvals")).toContainText("All caught up")
+
+    const adminCard = page
+      .getByTestId("all-bookings")
+      .locator('[data-testid^="admin-booking-"]')
+      .filter({ hasText: "Birthday celebration" })
+
+    await expect(adminCard).toContainText("Confirmed")
+    await expect(adminCard).toContainText("Handled by Community Manager")
+  })
+})


### PR DESCRIPTION
## Summary
- add an interactive amenities booking demo with quotas, blackout alerts, approvals, and ICS downloads under `/web/features/amenities`
- expose Playwright configuration and end-to-end coverage for resident booking and admin approval flows
- register a `test:e2e` script and Playwright dependency for running the new browser tests

## Testing
- `pnpm lint`
- `CI=1 pnpm build`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ceefef975083289e7bf2f0c2fcf25f