### PR TITLE
feat: add communications service endpoints

### DIFF
--- a/app/api/services/communications/announcements/route.ts
+++ b/app/api/services/communications/announcements/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supa-server-actions'
+import {
+  createAnnouncement,
+  deleteAnnouncement,
+  getRequestContext,
+  listAnnouncements,
+  normalizeError,
+  updateAnnouncement,
+  type AnnouncementStatus,
+  type CreateAnnouncementInput,
+  type UpdateAnnouncementInput,
+} from '@/services/communications'
+
+const ANNOUNCEMENT_STATUSES: AnnouncementStatus[] = [
+  'draft',
+  'scheduled',
+  'published',
+  'archived',
+]
+
+function toErrorResponse(error: unknown) {
+  const normalized = normalizeError(error)
+
+  return NextResponse.json(
+    { error: normalized.message, details: normalized.details },
+    { status: normalized.status },
+  )
+}
+
+export async function GET(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const { searchParams } = new URL(request.url)
+
+    const statusParam = searchParams.get('status')
+    let status: AnnouncementStatus | undefined
+
+    if (statusParam) {
+      if (!ANNOUNCEMENT_STATUSES.includes(statusParam as AnnouncementStatus)) {
+        return NextResponse.json(
+          { error: 'Invalid announcement status filter' },
+          { status: 400 },
+        )
+      }
+
+      status = statusParam as AnnouncementStatus
+    }
+
+    const includeExpired = searchParams.get('includeExpired') === 'true'
+    const limitParam = searchParams.get('limit')
+    let limit: number | undefined
+
+    if (limitParam) {
+      const parsedLimit = Number.parseInt(limitParam, 10)
+
+      if (Number.isNaN(parsedLimit)) {
+        return NextResponse.json(
+          { error: 'Limit must be a number' },
+          { status: 400 },
+        )
+      }
+
+      limit = parsedLimit
+    }
+
+    const announcements = await listAnnouncements(supabase, context, {
+      status,
+      includeExpired,
+      limit,
+    })
+
+    return NextResponse.json({ data: announcements })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function POST(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const body = (await request.json()) as CreateAnnouncementInput
+
+    if (!body?.title || !body?.body) {
+      return NextResponse.json(
+        { error: 'Title and body are required' },
+        { status: 400 },
+      )
+    }
+
+    if (body.status && !ANNOUNCEMENT_STATUSES.includes(body.status)) {
+      return NextResponse.json(
+        { error: 'Invalid announcement status provided' },
+        { status: 400 },
+      )
+    }
+
+    const announcement = await createAnnouncement(supabase, context, body)
+
+    return NextResponse.json({ data: announcement }, { status: 201 })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function PATCH(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const body = (await request.json()) as UpdateAnnouncementInput
+
+    if (!body?.id) {
+      return NextResponse.json(
+        { error: 'Announcement id is required' },
+        { status: 400 },
+      )
+    }
+
+    if (body.status && !ANNOUNCEMENT_STATUSES.includes(body.status)) {
+      return NextResponse.json(
+        { error: 'Invalid announcement status provided' },
+        { status: 400 },
+      )
+    }
+
+    const announcement = await updateAnnouncement(supabase, context, body)
+
+    return NextResponse.json({ data: announcement })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function DELETE(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const body = (await request.json()) as { id?: number }
+
+    if (!body?.id) {
+      return NextResponse.json(
+        { error: 'Announcement id is required' },
+        { status: 400 },
+      )
+    }
+
+    const announcement = await deleteAnnouncement(supabase, context, body.id)
+
+    return NextResponse.json({ data: announcement })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}

--- a/app/api/services/communications/bulletins/route.ts
+++ b/app/api/services/communications/bulletins/route.ts
@@ -1,0 +1,211 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supa-server-actions'
+import {
+  createBulletin,
+  deleteBulletin,
+  getRequestContext,
+  listBulletins,
+  moderateBulletin,
+  normalizeError,
+  reportBulletinAbuse,
+  type BulletinStatus,
+  type CreateBulletinInput,
+  type ModerationStatus,
+  type ModerateBulletinInput,
+} from '@/services/communications'
+
+const BULLETIN_STATUSES: BulletinStatus[] = [
+  'pending',
+  'approved',
+  'rejected',
+  'escalated',
+  'archived',
+]
+
+const MODERATION_STATUSES: ModerationStatus[] = [
+  'clean',
+  'under_review',
+  'action_required',
+  'resolved',
+]
+
+const MODERATION_ACTIONS: ModerateBulletinInput['action'][] = [
+  'approve',
+  'reject',
+  'escalate',
+  'resolve',
+]
+
+function toErrorResponse(error: unknown) {
+  const normalized = normalizeError(error)
+
+  return NextResponse.json(
+    { error: normalized.message, details: normalized.details },
+    { status: normalized.status },
+  )
+}
+
+export async function GET(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const { searchParams } = new URL(request.url)
+
+    const statusParam = searchParams.get('status')
+    let status: BulletinStatus | undefined
+
+    if (statusParam) {
+      if (!BULLETIN_STATUSES.includes(statusParam as BulletinStatus)) {
+        return NextResponse.json(
+          { error: 'Invalid bulletin status filter' },
+          { status: 400 },
+        )
+      }
+
+      status = statusParam as BulletinStatus
+    }
+
+    const moderationParam = searchParams.get('moderationStatus')
+    let moderationStatus: ModerationStatus | undefined
+
+    if (moderationParam) {
+      if (
+        !MODERATION_STATUSES.includes(moderationParam as ModerationStatus)
+      ) {
+        return NextResponse.json(
+          { error: 'Invalid moderation status filter' },
+          { status: 400 },
+        )
+      }
+
+      moderationStatus = moderationParam as ModerationStatus
+    }
+
+    const mineOnly = searchParams.get('mineOnly') === 'true'
+    const includeAbuse = searchParams.get('includeAbuse') === 'true'
+
+    const result = await listBulletins(supabase, context, {
+      status,
+      moderationStatus,
+      mineOnly,
+      includeAbuse,
+    })
+
+    return NextResponse.json({ data: result })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function POST(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const rawBody = (await request.json()) as Record<string, unknown> | null
+
+    if (rawBody?.action === 'report') {
+      if (
+        typeof rawBody.bulletinId !== 'number' ||
+        rawBody.bulletinId <= 0 ||
+        typeof rawBody.reason !== 'string' ||
+        rawBody.reason.trim().length === 0
+      ) {
+        return NextResponse.json(
+          { error: 'Bulletin id and reason are required to report abuse' },
+          { status: 400 },
+        )
+      }
+
+      const report = await reportBulletinAbuse(supabase, context, {
+        bulletinId: rawBody.bulletinId,
+        reason: rawBody.reason,
+        details:
+          typeof rawBody.details === 'string' ? rawBody.details : undefined,
+      })
+
+      return NextResponse.json({ data: report }, { status: 201 })
+    }
+
+    if (
+      !rawBody ||
+      typeof rawBody.title !== 'string' ||
+      rawBody.title.trim().length === 0 ||
+      typeof rawBody.content !== 'string' ||
+      rawBody.content.trim().length === 0
+    ) {
+      return NextResponse.json(
+        { error: 'Title and content are required' },
+        { status: 400 },
+      )
+    }
+
+    const bulletinInput: CreateBulletinInput = {
+      title: rawBody.title,
+      content: rawBody.content,
+    }
+
+    const bulletin = await createBulletin(supabase, context, bulletinInput)
+
+    return NextResponse.json({ data: bulletin }, { status: 201 })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function PATCH(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const body = (await request.json()) as ModerateBulletinInput
+
+    if (!body?.bulletinId || !body.action) {
+      return NextResponse.json(
+        { error: 'Bulletin id and action are required' },
+        { status: 400 },
+      )
+    }
+
+    if (!MODERATION_ACTIONS.includes(body.action)) {
+      return NextResponse.json(
+        { error: 'Unsupported moderation action' },
+        { status: 400 },
+      )
+    }
+
+    await moderateBulletin(supabase, context, body)
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function DELETE(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const body = (await request.json()) as { id?: number }
+
+    if (!body?.id) {
+      return NextResponse.json(
+        { error: 'Bulletin id is required' },
+        { status: 400 },
+      )
+    }
+
+    const bulletin = await deleteBulletin(supabase, context, body.id)
+
+    return NextResponse.json({ data: bulletin })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}

--- a/app/api/services/communications/reports/route.ts
+++ b/app/api/services/communications/reports/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supa-server-actions'
+import {
+  buildCommunicationsReport,
+  getRequestContext,
+  normalizeError,
+} from '@/services/communications'
+
+function toErrorResponse(error: unknown) {
+  const normalized = normalizeError(error)
+
+  return NextResponse.json(
+    { error: normalized.message, details: normalized.details },
+    { status: normalized.status },
+  )
+}
+
+export async function GET() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const report = await buildCommunicationsReport(supabase, context)
+
+    return NextResponse.json({ data: report })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}

--- a/app/api/services/communications/surveys/route.ts
+++ b/app/api/services/communications/surveys/route.ts
@@ -1,0 +1,209 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supa-server-actions'
+import {
+  aggregateSurveyResponses,
+  createSurvey,
+  exportSurveyResponses,
+  getRequestContext,
+  listSurveys,
+  normalizeError,
+  submitSurveyResponse,
+  updateSurvey,
+  type CreateSurveyInput,
+  type SubmitSurveyResponseInput,
+  type SurveyStatus,
+  type UpdateSurveyInput,
+} from '@/services/communications'
+
+const SURVEY_STATUSES: SurveyStatus[] = [
+  'draft',
+  'open',
+  'closed',
+  'archived',
+]
+
+function toErrorResponse(error: unknown) {
+  const normalized = normalizeError(error)
+
+  return NextResponse.json(
+    { error: normalized.message, details: normalized.details },
+    { status: normalized.status },
+  )
+}
+
+export async function GET(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const { searchParams } = new URL(request.url)
+
+    const statusParam = searchParams.get('status')
+    let status: SurveyStatus | undefined
+
+    if (statusParam) {
+      if (!SURVEY_STATUSES.includes(statusParam as SurveyStatus)) {
+        return NextResponse.json(
+          { error: 'Invalid survey status filter' },
+          { status: 400 },
+        )
+      }
+
+      status = statusParam as SurveyStatus
+    }
+
+    const includeClosed = searchParams.get('includeClosed') === 'true'
+    const createdBy = searchParams.get('createdBy') ?? undefined
+    const surveyIdParam = searchParams.get('surveyId')
+    const aggregate = searchParams.get('aggregate') === 'true'
+    const format = searchParams.get('format')
+
+    if ((aggregate || format === 'csv') && !surveyIdParam) {
+      return NextResponse.json(
+        { error: 'A surveyId is required for aggregation or export' },
+        { status: 400 },
+      )
+    }
+
+    if (surveyIdParam) {
+      const surveyId = Number.parseInt(surveyIdParam, 10)
+
+      if (Number.isNaN(surveyId)) {
+        return NextResponse.json(
+          { error: 'surveyId must be numeric' },
+          { status: 400 },
+        )
+      }
+
+      if (aggregate) {
+        const aggregation = await aggregateSurveyResponses(
+          supabase,
+          context,
+          surveyId,
+        )
+
+        return NextResponse.json({ data: aggregation })
+      }
+
+      if (format === 'csv') {
+        const exportResult = await exportSurveyResponses(
+          supabase,
+          context,
+          surveyId,
+        )
+
+        return new NextResponse(exportResult.content, {
+          status: 200,
+          headers: {
+            'Content-Type': exportResult.mimeType,
+            'Content-Disposition': `attachment; filename="${exportResult.filename}"`,
+          },
+        })
+      }
+    }
+
+    const surveys = await listSurveys(supabase, context, {
+      status,
+      includeClosed,
+      createdBy,
+    })
+
+    if (surveyIdParam) {
+      const surveyId = Number.parseInt(surveyIdParam, 10)
+      if (!Number.isNaN(surveyId)) {
+        return NextResponse.json({
+          data: surveys.filter(survey => survey.id === surveyId),
+        })
+      }
+    }
+
+    return NextResponse.json({ data: surveys })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function POST(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const body = (await request.json()) as CreateSurveyInput
+
+    if (!body?.title || typeof body.questions !== 'object') {
+      return NextResponse.json(
+        { error: 'Survey title and questions are required' },
+        { status: 400 },
+      )
+    }
+
+    if (body.status && !SURVEY_STATUSES.includes(body.status)) {
+      return NextResponse.json(
+        { error: 'Invalid survey status' },
+        { status: 400 },
+      )
+    }
+ 
+    const survey = await createSurvey(supabase, context, body)
+
+    return NextResponse.json({ data: survey }, { status: 201 })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function PUT(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const body = (await request.json()) as SubmitSurveyResponseInput
+
+    if (!body?.surveyId || typeof body.answers !== 'object') {
+      return NextResponse.json(
+        { error: 'Survey id and answers are required' },
+        { status: 400 },
+      )
+    }
+
+    const response = await submitSurveyResponse(supabase, context, body)
+
+    return NextResponse.json({ data: response }, { status: 201 })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+export async function PATCH(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  try {
+    const context = await getRequestContext(supabase)
+    const body = (await request.json()) as UpdateSurveyInput
+
+    if (!body?.id) {
+      return NextResponse.json(
+        { error: 'Survey id is required' },
+        { status: 400 },
+      )
+    }
+
+    if (body.status && !SURVEY_STATUSES.includes(body.status)) {
+      return NextResponse.json(
+        { error: 'Invalid survey status' },
+        { status: 400 },
+      )
+    }
+
+    const survey = await updateSurvey(supabase, context, body)
+
+    return NextResponse.json({ data: survey })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1596,6 +1596,301 @@ export type Database = {
           },
         ]
       }
+      communications_announcements: {
+        Row: {
+          body: string
+          created_at: string
+          created_by: string
+          expire_at: string | null
+          id: number
+          publish_at: string | null
+          status: Database["public"]["Enums"]["announcement_status"]
+          target_roles: string[] | null
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          body: string
+          created_at?: string
+          created_by: string
+          expire_at?: string | null
+          id?: number
+          publish_at?: string | null
+          status?: Database["public"]["Enums"]["announcement_status"]
+          target_roles?: string[] | null
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          body?: string
+          created_at?: string
+          created_by?: string
+          expire_at?: string | null
+          id?: number
+          publish_at?: string | null
+          status?: Database["public"]["Enums"]["announcement_status"]
+          target_roles?: string[] | null
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "communications_announcements_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      communications_bulletins: {
+        Row: {
+          abuse_context: Json | null
+          abuse_reason: string | null
+          author_id: string
+          content: string
+          created_at: string
+          id: number
+          moderation_status: Database["public"]["Enums"]["moderation_status"]
+          moderated_at: string | null
+          moderated_by: string | null
+          status: Database["public"]["Enums"]["bulletin_status"]
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          abuse_context?: Json | null
+          abuse_reason?: string | null
+          author_id: string
+          content: string
+          created_at?: string
+          id?: number
+          moderation_status?: Database["public"]["Enums"]["moderation_status"]
+          moderated_at?: string | null
+          moderated_by?: string | null
+          status?: Database["public"]["Enums"]["bulletin_status"]
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          abuse_context?: Json | null
+          abuse_reason?: string | null
+          author_id?: string
+          content?: string
+          created_at?: string
+          id?: number
+          moderation_status?: Database["public"]["Enums"]["moderation_status"]
+          moderated_at?: string | null
+          moderated_by?: string | null
+          status?: Database["public"]["Enums"]["bulletin_status"]
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "communications_bulletins_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "communications_bulletins_moderated_by_fkey"
+            columns: ["moderated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      communications_bulletin_audits: {
+        Row: {
+          action: Database["public"]["Enums"]["moderation_action"]
+          actor_id: string
+          bulletin_id: number
+          created_at: string
+          id: number
+          metadata: Json | null
+          notes: string | null
+        }
+        Insert: {
+          action: Database["public"]["Enums"]["moderation_action"]
+          actor_id: string
+          bulletin_id: number
+          created_at?: string
+          id?: number
+          metadata?: Json | null
+          notes?: string | null
+        }
+        Update: {
+          action?: Database["public"]["Enums"]["moderation_action"]
+          actor_id?: string
+          bulletin_id?: number
+          created_at?: string
+          id?: number
+          metadata?: Json | null
+          notes?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "communications_bulletin_audits_actor_id_fkey"
+            columns: ["actor_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "communications_bulletin_audits_bulletin_id_fkey"
+            columns: ["bulletin_id"]
+            isOneToOne: false
+            referencedRelation: "communications_bulletins"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      communications_abuse_reports: {
+        Row: {
+          bulletin_id: number
+          created_at: string
+          details: string | null
+          id: number
+          reason: string
+          reporter_id: string
+          resolved_at: string | null
+          resolution_notes: string | null
+          status: Database["public"]["Enums"]["abuse_status"]
+          updated_at: string
+        }
+        Insert: {
+          bulletin_id: number
+          created_at?: string
+          details?: string | null
+          id?: number
+          reason: string
+          reporter_id: string
+          resolved_at?: string | null
+          resolution_notes?: string | null
+          status?: Database["public"]["Enums"]["abuse_status"]
+          updated_at?: string
+        }
+        Update: {
+          bulletin_id?: number
+          created_at?: string
+          details?: string | null
+          id?: number
+          reason?: string
+          reporter_id?: string
+          resolved_at?: string | null
+          resolution_notes?: string | null
+          status?: Database["public"]["Enums"]["abuse_status"]
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "communications_abuse_reports_bulletin_id_fkey"
+            columns: ["bulletin_id"]
+            isOneToOne: false
+            referencedRelation: "communications_bulletins"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "communications_abuse_reports_reporter_id_fkey"
+            columns: ["reporter_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      communications_surveys: {
+        Row: {
+          closes_at: string | null
+          created_at: string
+          created_by: string
+          description: string | null
+          id: number
+          metadata: Json | null
+          questions: Json
+          status: Database["public"]["Enums"]["survey_status"]
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          closes_at?: string | null
+          created_at?: string
+          created_by: string
+          description?: string | null
+          id?: number
+          metadata?: Json | null
+          questions: Json
+          status?: Database["public"]["Enums"]["survey_status"]
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          closes_at?: string | null
+          created_at?: string
+          created_by?: string
+          description?: string | null
+          id?: number
+          metadata?: Json | null
+          questions?: Json
+          status?: Database["public"]["Enums"]["survey_status"]
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "communications_surveys_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      communications_survey_responses: {
+        Row: {
+          answers: Json
+          id: number
+          metadata: Json | null
+          respondent_id: string | null
+          submitted_at: string
+          survey_id: number
+        }
+        Insert: {
+          answers: Json
+          id?: number
+          metadata?: Json | null
+          respondent_id?: string | null
+          submitted_at?: string
+          survey_id: number
+        }
+        Update: {
+          answers?: Json
+          id?: number
+          metadata?: Json | null
+          respondent_id?: string | null
+          submitted_at?: string
+          survey_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "communications_survey_responses_respondent_id_fkey"
+            columns: ["respondent_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "communications_survey_responses_survey_id_fkey"
+            columns: ["survey_id"]
+            isOneToOne: false
+            referencedRelation: "communications_surveys"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       package_utilization: {
@@ -1775,6 +2070,27 @@ export type Database = {
         | "North America"
         | "South America"
       user_role: "user" | "admin"
+      announcement_status: "draft" | "scheduled" | "published" | "archived"
+      bulletin_status:
+        | "pending"
+        | "approved"
+        | "rejected"
+        | "escalated"
+        | "archived"
+      moderation_status:
+        | "clean"
+        | "under_review"
+        | "action_required"
+        | "resolved"
+      abuse_status: "open" | "investigating" | "resolved"
+      survey_status: "draft" | "open" | "closed" | "archived"
+      moderation_action:
+        | "submit"
+        | "approve"
+        | "reject"
+        | "escalate"
+        | "resolve"
+        | "flag"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -2232,6 +2548,19 @@ export const Constants = {
         "Oceania",
         "North America",
         "South America",
+      ],
+      announcement_status: ["draft", "scheduled", "published", "archived"],
+      bulletin_status: ["pending", "approved", "rejected", "escalated", "archived"],
+      moderation_status: ["clean", "under_review", "action_required", "resolved"],
+      abuse_status: ["open", "investigating", "resolved"],
+      survey_status: ["draft", "open", "closed", "archived"],
+      moderation_action: [
+        "submit",
+        "approve",
+        "reject",
+        "escalate",
+        "resolve",
+        "flag",
       ],
       user_role: ["user", "admin"],
     },

--- a/services/communications/announcements.ts
+++ b/services/communications/announcements.ts
@@ -1,0 +1,192 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import { HttpError, throwIfSupabaseError } from './errors'
+import type {
+  AnnouncementFilters,
+  AnnouncementRecord,
+  CreateAnnouncementInput,
+  RequestContext,
+  UpdateAnnouncementInput,
+} from './types'
+import { requireRole } from './auth'
+
+function filterAnnouncementsForContext(
+  context: RequestContext,
+  announcements: AnnouncementRecord[],
+  filters: AnnouncementFilters,
+): AnnouncementRecord[] {
+  const now = new Date()
+  const statusFilter = filters.status
+
+  let result = announcements
+
+  if (statusFilter) {
+    result = result.filter(announcement => announcement.status === statusFilter)
+  }
+
+  if (context.role !== 'admin') {
+    result = result.filter(announcement => {
+      if (announcement.target_roles && announcement.target_roles.length > 0) {
+        return announcement.target_roles.includes(context.role)
+      }
+
+      return true
+    })
+  }
+
+  const applyLifecycleFilter =
+    context.role !== 'admin' || filters.includeExpired === false
+
+  if (applyLifecycleFilter) {
+    result = result.filter(announcement => {
+      if (announcement.expire_at) {
+        const expires = new Date(announcement.expire_at)
+        if (expires.getTime() < now.getTime()) {
+          return false
+        }
+      }
+
+      if (announcement.publish_at) {
+        const publishAt = new Date(announcement.publish_at)
+        if (publishAt.getTime() > now.getTime()) {
+          return false
+        }
+      }
+
+      return true
+    })
+  }
+
+  if (context.role !== 'admin') {
+    result = result.filter(announcement => announcement.status === 'published')
+  }
+
+  if (filters.limit && filters.limit > 0) {
+    result = result.slice(0, filters.limit)
+  }
+
+  return result
+}
+
+export async function listAnnouncements(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  filters: AnnouncementFilters = {},
+): Promise<AnnouncementRecord[]> {
+  const { data, error } = await supabase
+    .from('communications_announcements')
+    .select('*')
+    .order('publish_at', { ascending: false })
+
+  throwIfSupabaseError(error, 'Failed to fetch announcements')
+
+  const announcements = data ?? []
+
+  return filterAnnouncementsForContext(context, announcements, filters)
+}
+
+export async function createAnnouncement(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  input: CreateAnnouncementInput,
+): Promise<AnnouncementRecord> {
+  requireRole(context, ['admin'])
+
+  const payload = {
+    title: input.title.trim(),
+    body: input.body.trim(),
+    status: input.status ?? 'draft',
+    publish_at: input.publishAt ?? null,
+    expire_at: input.expireAt ?? null,
+    target_roles: input.targetRoles ?? null,
+    created_by: context.userId,
+    updated_at: new Date().toISOString(),
+  }
+
+  const { data, error } = await supabase
+    .from('communications_announcements')
+    .insert(payload)
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(error, 'Failed to create announcement')
+
+  if (!data) {
+    throw new HttpError(500, 'Announcement creation returned no data')
+  }
+
+  return data
+}
+
+export async function updateAnnouncement(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  input: UpdateAnnouncementInput,
+): Promise<AnnouncementRecord> {
+  requireRole(context, ['admin'])
+
+  const updates: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  }
+
+  if (typeof input.title === 'string') {
+    updates.title = input.title.trim()
+  }
+
+  if (typeof input.body === 'string') {
+    updates.body = input.body.trim()
+  }
+
+  if (input.status) {
+    updates.status = input.status
+  }
+
+  if ('publishAt' in input) {
+    updates.publish_at = input.publishAt ?? null
+  }
+
+  if ('expireAt' in input) {
+    updates.expire_at = input.expireAt ?? null
+  }
+
+  if ('targetRoles' in input) {
+    updates.target_roles = input.targetRoles ?? null
+  }
+
+  const { data, error } = await supabase
+    .from('communications_announcements')
+    .update(updates)
+    .eq('id', input.id)
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(error, 'Failed to update announcement')
+
+  if (!data) {
+    throw new HttpError(404, 'Announcement not found')
+  }
+
+  return data
+}
+
+export async function deleteAnnouncement(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  id: number,
+): Promise<AnnouncementRecord> {
+  requireRole(context, ['admin'])
+
+  const { data, error } = await supabase
+    .from('communications_announcements')
+    .delete()
+    .eq('id', id)
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(error, 'Failed to delete announcement')
+
+  if (!data) {
+    throw new HttpError(404, 'Announcement not found')
+  }
+
+  return data
+}

--- a/services/communications/auth.ts
+++ b/services/communications/auth.ts
@@ -1,0 +1,59 @@
+import type { User } from '@supabase/supabase-js'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import type { RequestContext } from './types'
+import { HttpError } from './errors'
+
+interface ProfileRow {
+  role?: string | null
+  email?: string | null
+}
+
+export async function getRequestContext(
+  supabase: TypedSupabaseClient,
+): Promise<RequestContext> {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    throw new HttpError(401, 'Authentication required', error)
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('role, email')
+    .eq('id', user.id)
+    .maybeSingle<ProfileRow>()
+
+  if (profileError) {
+    throw new HttpError(500, 'Failed to resolve profile', profileError)
+  }
+
+  const role = (profile?.role ?? 'user') as RequestContext['role']
+
+  return {
+    userId: user.id,
+    role,
+    email: profile?.email ?? user.email,
+  }
+}
+
+export function requireRole(context: RequestContext, roles: string[]) {
+  if (!roles.includes(context.role)) {
+    throw new HttpError(403, 'Insufficient permissions', {
+      role: context.role,
+      required: roles,
+    })
+  }
+}
+
+export function assertAuthenticated(user: User | null) {
+  if (!user) {
+    throw new HttpError(401, 'Authentication required')
+  }
+}
+
+export function isAdmin(context: RequestContext) {
+  return context.role === 'admin'
+}

--- a/services/communications/bulletins.ts
+++ b/services/communications/bulletins.ts
@@ -1,0 +1,376 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import { HttpError, throwIfSupabaseError } from './errors'
+import {
+  type BulletinFilters,
+  type BulletinListResult,
+  type BulletinRecord,
+  type AbuseReportRecord,
+  type CreateBulletinInput,
+  type ModerateBulletinInput,
+  type ReportAbuseInput,
+  type RequestContext,
+} from './types'
+import { isAdmin, requireRole } from './auth'
+
+function filterBulletins(
+  bulletins: BulletinRecord[],
+  context: RequestContext,
+  filters: BulletinFilters,
+): BulletinRecord[] {
+  let result = bulletins
+
+  if (filters.status) {
+    result = result.filter(bulletin => bulletin.status === filters.status)
+  }
+
+  if (filters.moderationStatus) {
+    result = result.filter(
+      bulletin => bulletin.moderation_status === filters.moderationStatus,
+    )
+  }
+
+  if (filters.mineOnly) {
+    result = result.filter(bulletin => bulletin.author_id === context.userId)
+  }
+
+  if (!isAdmin(context)) {
+    result = result.filter(bulletin => {
+      const isOwner = bulletin.author_id === context.userId
+      const isVisible =
+        bulletin.status === 'approved' || bulletin.status === 'escalated'
+
+      return isOwner || isVisible
+    })
+  }
+
+  return result
+}
+
+async function attachAbuseContext(
+  supabase: TypedSupabaseClient,
+  bulletins: BulletinRecord[],
+): Promise<BulletinListResult> {
+  if (bulletins.length === 0) {
+    return { bulletins }
+  }
+
+  const bulletinIds = bulletins.map(bulletin => bulletin.id)
+  const { data: reports, error } = await supabase
+    .from('communications_abuse_reports')
+    .select('*')
+    .in('bulletin_id', bulletinIds)
+
+  throwIfSupabaseError(error, 'Failed to fetch abuse reports')
+
+  if (!reports) {
+    return { bulletins }
+  }
+
+  const summary: BulletinListResult['abuseSummary'] = {}
+  const enhanced = bulletins.map(bulletin => {
+    const related = reports.filter(report => report.bulletin_id === bulletin.id)
+
+    if (related.length === 0) {
+      return bulletin
+    }
+
+    summary[bulletin.id] = related.reduce((acc, report) => {
+      acc[report.status] = (acc[report.status] ?? 0) + 1
+      return acc
+    }, {} as NonNullable<BulletinListResult['abuseSummary']>[number])
+
+    return {
+      ...bulletin,
+      abuseReports: related,
+    }
+  })
+
+  return { bulletins: enhanced, abuseSummary: summary }
+}
+
+export async function listBulletins(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  filters: BulletinFilters = {},
+): Promise<BulletinListResult> {
+  const { data, error } = await supabase
+    .from('communications_bulletins')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  throwIfSupabaseError(error, 'Failed to fetch bulletins')
+
+  const bulletins = filterBulletins(data ?? [], context, filters)
+
+  if (filters.includeAbuse && isAdmin(context)) {
+    return attachAbuseContext(supabase, bulletins)
+  }
+
+  return { bulletins }
+}
+
+export async function createBulletin(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  input: CreateBulletinInput,
+): Promise<BulletinRecord> {
+  const payload = {
+    title: input.title.trim(),
+    content: input.content.trim(),
+    author_id: context.userId,
+    status: 'pending' as BulletinRecord['status'],
+    moderation_status: 'clean' as BulletinRecord['moderation_status'],
+    updated_at: new Date().toISOString(),
+  }
+
+  const { data, error } = await supabase
+    .from('communications_bulletins')
+    .insert(payload)
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(error, 'Failed to create bulletin')
+
+  if (!data) {
+    throw new HttpError(500, 'Bulletin creation returned no data')
+  }
+
+  const { error: auditError } = await supabase
+    .from('communications_bulletin_audits')
+    .insert({
+      bulletin_id: data.id,
+      actor_id: context.userId,
+      action: 'submit',
+      metadata: { title: data.title },
+    })
+
+  throwIfSupabaseError(auditError, 'Failed to record bulletin submission')
+
+  return data
+}
+
+export async function reportBulletinAbuse(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  input: ReportAbuseInput,
+): Promise<AbuseReportRecord> {
+  const { data: bulletin, error: fetchError } = await supabase
+    .from('communications_bulletins')
+    .select('id, author_id, moderation_status')
+    .eq('id', input.bulletinId)
+    .maybeSingle()
+
+  throwIfSupabaseError(fetchError, 'Failed to load bulletin')
+
+  if (!bulletin) {
+    throw new HttpError(404, 'Bulletin not found')
+  }
+
+  if (bulletin.author_id === context.userId) {
+    throw new HttpError(400, 'Authors cannot report their own bulletins')
+  }
+
+  const { data: existingReport, error: existingError } = await supabase
+    .from('communications_abuse_reports')
+    .select('id, status')
+    .eq('bulletin_id', input.bulletinId)
+    .eq('reporter_id', context.userId)
+    .not('status', 'eq', 'resolved')
+    .maybeSingle()
+
+  throwIfSupabaseError(existingError, 'Failed to verify abuse report history')
+
+  if (existingReport) {
+    throw new HttpError(409, 'An open abuse report already exists for this bulletin')
+  }
+
+  const now = new Date().toISOString()
+  const { data: report, error: reportError } = await supabase
+    .from('communications_abuse_reports')
+    .insert({
+      bulletin_id: input.bulletinId,
+      reporter_id: context.userId,
+      reason: input.reason.trim(),
+      details: input.details ?? null,
+      updated_at: now,
+    })
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(reportError, 'Failed to submit abuse report')
+
+  const { error: bulletinUpdateError } = await supabase
+    .from('communications_bulletins')
+    .update({
+      moderation_status: 'under_review',
+      abuse_reason: input.reason,
+      abuse_context: {
+        details: input.details ?? null,
+        reported_at: now,
+        reported_by: context.userId,
+      },
+      updated_at: now,
+    })
+    .eq('id', input.bulletinId)
+
+  throwIfSupabaseError(bulletinUpdateError, 'Failed to update bulletin moderation state')
+
+  const { error: auditError } = await supabase
+    .from('communications_bulletin_audits')
+    .insert({
+      bulletin_id: input.bulletinId,
+      actor_id: context.userId,
+      action: 'flag',
+      notes: input.details ?? undefined,
+    })
+
+  throwIfSupabaseError(auditError, 'Failed to log abuse report action')
+
+  return report
+}
+
+export async function moderateBulletin(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  input: ModerateBulletinInput,
+): Promise<void> {
+  requireRole(context, ['admin'])
+
+  const { data: bulletin, error: fetchError } = await supabase
+    .from('communications_bulletins')
+    .select('*')
+    .eq('id', input.bulletinId)
+    .maybeSingle()
+
+  throwIfSupabaseError(fetchError, 'Failed to load bulletin for moderation')
+
+  if (!bulletin) {
+    throw new HttpError(404, 'Bulletin not found')
+  }
+
+  const now = new Date().toISOString()
+  const updates: Record<string, unknown> = {
+    moderated_by: context.userId,
+    moderated_at: now,
+    updated_at: now,
+  }
+
+  let abuseStatusUpdate: 'resolved' | 'investigating' | null = null
+
+  switch (input.action) {
+    case 'approve':
+      updates.status = 'approved'
+      updates.moderation_status = 'resolved'
+      updates.abuse_reason = null
+      updates.abuse_context = null
+      abuseStatusUpdate = 'resolved'
+      break
+    case 'reject':
+      updates.status = 'rejected'
+      updates.moderation_status = 'action_required'
+      abuseStatusUpdate = 'investigating'
+      break
+    case 'escalate':
+      updates.status = 'escalated'
+      updates.moderation_status = 'under_review'
+      abuseStatusUpdate = 'investigating'
+      break
+    case 'resolve':
+      updates.moderation_status = 'resolved'
+      abuseStatusUpdate = 'resolved'
+      break
+    default:
+      throw new HttpError(400, `Unsupported moderation action: ${input.action}`)
+  }
+
+  const { error: updateError } = await supabase
+    .from('communications_bulletins')
+    .update(updates)
+    .eq('id', input.bulletinId)
+
+  throwIfSupabaseError(updateError, 'Failed to update bulletin status')
+
+  if (abuseStatusUpdate) {
+    const reportUpdate: Record<string, unknown> = {
+      status: abuseStatusUpdate,
+      updated_at: now,
+    }
+
+    if (abuseStatusUpdate === 'resolved') {
+      reportUpdate.resolved_at = now
+      if (input.resolutionNotes) {
+        reportUpdate.resolution_notes = input.resolutionNotes
+      }
+    }
+
+    const { error: abuseUpdateError } = await supabase
+      .from('communications_abuse_reports')
+      .update(reportUpdate)
+      .eq('bulletin_id', input.bulletinId)
+      .neq('status', 'resolved')
+
+    throwIfSupabaseError(abuseUpdateError, 'Failed to update abuse reports')
+  }
+
+  const { error: auditError } = await supabase
+    .from('communications_bulletin_audits')
+    .insert({
+      bulletin_id: input.bulletinId,
+      actor_id: context.userId,
+      action: input.action,
+      notes: input.notes ?? undefined,
+      metadata: input.resolutionNotes
+        ? { resolution_notes: input.resolutionNotes }
+        : undefined,
+    })
+
+  throwIfSupabaseError(auditError, 'Failed to create moderation audit trail')
+}
+
+export async function deleteBulletin(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  id: number,
+): Promise<BulletinRecord> {
+  const { data: existing, error } = await supabase
+    .from('communications_bulletins')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle()
+
+  throwIfSupabaseError(error, 'Failed to load bulletin')
+
+  if (!existing) {
+    throw new HttpError(404, 'Bulletin not found')
+  }
+
+  if (!isAdmin(context) && existing.author_id !== context.userId) {
+    throw new HttpError(403, 'Only admins or authors can remove bulletins')
+  }
+
+  const { data: removed, error: deleteError } = await supabase
+    .from('communications_bulletins')
+    .delete()
+    .eq('id', id)
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(deleteError, 'Failed to delete bulletin')
+
+  if (!removed) {
+    throw new HttpError(500, 'Bulletin removal returned no data')
+  }
+
+  const { error: auditError } = await supabase
+    .from('communications_bulletin_audits')
+    .insert({
+      bulletin_id: id,
+      actor_id: context.userId,
+      action: 'resolve',
+      notes: 'Bulletin deleted',
+    })
+
+  throwIfSupabaseError(auditError, 'Failed to record bulletin deletion')
+
+  return removed
+}

--- a/services/communications/errors.ts
+++ b/services/communications/errors.ts
@@ -1,0 +1,51 @@
+import type { PostgrestError } from '@supabase/supabase-js'
+
+export class HttpError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+    public details?: unknown,
+  ) {
+    super(message)
+    this.name = 'HttpError'
+  }
+}
+
+export function isHttpError(error: unknown): error is HttpError {
+  return error instanceof HttpError
+}
+
+export function assertCondition(condition: unknown, error: HttpError): asserts condition {
+  if (!condition) {
+    throw error
+  }
+}
+
+export function normalizeError(error: unknown): HttpError {
+  if (isHttpError(error)) {
+    return error
+  }
+
+  if (error instanceof Error) {
+    return new HttpError(500, error.message)
+  }
+
+  return new HttpError(500, 'Unexpected error', error)
+}
+
+export function throwIfSupabaseError(
+  error: PostgrestError | null,
+  message: string,
+  status = 500,
+) {
+  if (!error) {
+    return
+  }
+
+  throw new HttpError(status, message, {
+    code: error.code,
+    details: error.details,
+    hint: error.hint,
+    message: error.message,
+  })
+}

--- a/services/communications/index.ts
+++ b/services/communications/index.ts
@@ -1,0 +1,7 @@
+export * from './announcements'
+export * from './auth'
+export * from './bulletins'
+export * from './errors'
+export * from './reports'
+export * from './surveys'
+export * from './types'

--- a/services/communications/reports.ts
+++ b/services/communications/reports.ts
@@ -1,0 +1,96 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import { throwIfSupabaseError } from './errors'
+import { requireRole } from './auth'
+import type { CommunicationsReport, RequestContext } from './types'
+
+function buildCountMap<T extends string | number | null | undefined>(
+  values: T[] | null,
+): Partial<Record<Exclude<T, null | undefined>, number>> {
+  const counts: Partial<Record<Exclude<T, null | undefined>, number>> = {}
+
+  for (const value of values ?? []) {
+    if (value === null || value === undefined) continue
+    const key = value as Exclude<T, null | undefined>
+    counts[key] = (counts[key] ?? 0) + 1
+  }
+
+  return counts
+}
+
+export async function buildCommunicationsReport(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+): Promise<CommunicationsReport> {
+  requireRole(context, ['admin'])
+
+  const [announcementsRes, bulletinsRes, abuseRes, surveysRes, responsesRes] =
+    await Promise.all([
+      supabase.from('communications_announcements').select('status'),
+      supabase
+        .from('communications_bulletins')
+        .select('status, moderation_status'),
+      supabase.from('communications_abuse_reports').select('status'),
+      supabase.from('communications_surveys').select('id, status'),
+      supabase.from('communications_survey_responses').select('survey_id'),
+    ])
+
+  throwIfSupabaseError(
+    announcementsRes.error,
+    'Failed to load announcement reporting data',
+  )
+  throwIfSupabaseError(
+    bulletinsRes.error,
+    'Failed to load bulletin reporting data',
+  )
+  throwIfSupabaseError(abuseRes.error, 'Failed to load abuse reporting data')
+  throwIfSupabaseError(surveysRes.error, 'Failed to load survey reporting data')
+  throwIfSupabaseError(
+    responsesRes.error,
+    'Failed to load survey response reporting data',
+  )
+
+  const announcementCounts = buildCountMap(
+    (announcementsRes.data ?? []).map(item => item.status),
+  )
+  const bulletinStatusCounts = buildCountMap(
+    (bulletinsRes.data ?? []).map(item => item.status),
+  )
+  const bulletinModerationCounts = buildCountMap(
+    (bulletinsRes.data ?? []).map(item => item.moderation_status),
+  )
+  const abuseByStatus = buildCountMap(
+    (abuseRes.data ?? []).map(item => item.status),
+  ) as CommunicationsReport['abuseByStatus']
+  const surveyStatusCounts = buildCountMap(
+    (surveysRes.data ?? []).map(item => item.status),
+  )
+
+  const responseCounts = (responsesRes.data ?? []).reduce(
+    (acc, response) => {
+      acc[response.survey_id] = (acc[response.survey_id] ?? 0) + 1
+      return acc
+    },
+    {} as Record<number, number>,
+  )
+
+  const totalAnnouncements = announcementsRes.data?.length ?? 0
+  const totalSurveys = surveysRes.data?.length ?? 0
+
+  return {
+    announcementCounts: {
+      total: totalAnnouncements,
+      ...announcementCounts,
+    },
+    bulletinStatusCounts,
+    bulletinModerationCounts,
+    abuseByStatus: {
+      open: abuseByStatus.open ?? 0,
+      ...abuseByStatus,
+    },
+    surveySummary: {
+      total: totalSurveys,
+      statusBreakdown: surveyStatusCounts,
+      responseCounts,
+    },
+  }
+}

--- a/services/communications/surveys.ts
+++ b/services/communications/surveys.ts
@@ -1,0 +1,390 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import { HttpError, throwIfSupabaseError } from './errors'
+import {
+  type CreateSurveyInput,
+  type RequestContext,
+  type SubmitSurveyResponseInput,
+  type SurveyAggregationQuestion,
+  type SurveyAggregationResult,
+  type SurveyExportResult,
+  type SurveyFilters,
+  type SurveyRecord,
+  type SurveyResponseRecord,
+  type UpdateSurveyInput,
+} from './types'
+import { isAdmin, requireRole } from './auth'
+
+function normalizeString(input: string | null | undefined) {
+  return typeof input === 'string' ? input.trim() : null
+}
+
+function ensureSurveyVisibility(
+  surveys: SurveyRecord[],
+  context: RequestContext,
+  filters: SurveyFilters,
+): SurveyRecord[] {
+  let result = surveys
+
+  if (filters.status) {
+    result = result.filter(survey => survey.status === filters.status)
+  }
+
+  if (filters.createdBy) {
+    result = result.filter(survey => survey.created_by === filters.createdBy)
+  }
+
+  if (!isAdmin(context)) {
+    result = result.filter(survey => {
+      if (survey.created_by === context.userId) {
+        return true
+      }
+
+      if (survey.status === 'open') {
+        if (survey.closes_at) {
+          return new Date(survey.closes_at).getTime() >= Date.now()
+        }
+
+        return true
+      }
+
+      if (filters.includeClosed) {
+        return survey.status === 'closed'
+      }
+
+      return false
+    })
+  } else if (!filters.includeClosed) {
+    result = result.filter(survey => survey.status !== 'archived')
+  }
+
+  return result
+}
+
+export async function listSurveys(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  filters: SurveyFilters = {},
+): Promise<SurveyRecord[]> {
+  const { data, error } = await supabase
+    .from('communications_surveys')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  throwIfSupabaseError(error, 'Failed to fetch surveys')
+
+  const surveys = ensureSurveyVisibility(data ?? [], context, filters)
+
+  return surveys
+}
+
+export async function createSurvey(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  input: CreateSurveyInput,
+): Promise<SurveyRecord> {
+  requireRole(context, ['admin'])
+
+  const payload = {
+    title: input.title.trim(),
+    description: normalizeString(input.description),
+    questions: input.questions,
+    status: input.status ?? 'draft',
+    created_by: context.userId,
+    closes_at: input.closesAt ?? null,
+    metadata: input.metadata ?? null,
+    updated_at: new Date().toISOString(),
+  }
+
+  const { data, error } = await supabase
+    .from('communications_surveys')
+    .insert(payload)
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(error, 'Failed to create survey')
+
+  if (!data) {
+    throw new HttpError(500, 'Survey creation returned no data')
+  }
+
+  return data
+}
+
+export async function updateSurvey(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  input: UpdateSurveyInput,
+): Promise<SurveyRecord> {
+  requireRole(context, ['admin'])
+
+  const updates: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  }
+
+  if (typeof input.title === 'string') {
+    updates.title = input.title.trim()
+  }
+
+  if ('description' in input) {
+    updates.description = normalizeString(input.description)
+  }
+
+  if ('status' in input && input.status) {
+    updates.status = input.status
+  }
+
+  if ('questions' in input && input.questions) {
+    updates.questions = input.questions
+  }
+
+  if ('closesAt' in input) {
+    updates.closes_at = input.closesAt ?? null
+  }
+
+  if ('metadata' in input) {
+    updates.metadata = input.metadata ?? null
+  }
+
+  const { data, error } = await supabase
+    .from('communications_surveys')
+    .update(updates)
+    .eq('id', input.id)
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(error, 'Failed to update survey')
+
+  if (!data) {
+    throw new HttpError(404, 'Survey not found')
+  }
+
+  return data
+}
+
+export async function submitSurveyResponse(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  input: SubmitSurveyResponseInput,
+): Promise<SurveyResponseRecord> {
+  const { data: survey, error: surveyError } = await supabase
+    .from('communications_surveys')
+    .select('id, status, closes_at, created_by')
+    .eq('id', input.surveyId)
+    .maybeSingle()
+
+  throwIfSupabaseError(surveyError, 'Failed to load survey')
+
+  if (!survey) {
+    throw new HttpError(404, 'Survey not found')
+  }
+
+  if (survey.status !== 'open') {
+    throw new HttpError(400, 'Survey is not accepting responses')
+  }
+
+  if (survey.closes_at && new Date(survey.closes_at).getTime() < Date.now()) {
+    throw new HttpError(400, 'Survey window has closed')
+  }
+
+  const { data, error } = await supabase
+    .from('communications_survey_responses')
+    .insert({
+      survey_id: input.surveyId,
+      respondent_id: context.userId,
+      answers: input.answers,
+      metadata: input.metadata ?? null,
+    })
+    .select('*')
+    .single()
+
+  throwIfSupabaseError(error, 'Failed to submit survey response')
+
+  if (!data) {
+    throw new HttpError(500, 'Survey response insert returned no data')
+  }
+
+  return data
+}
+
+function buildAggregation(
+  survey: SurveyRecord,
+  responses: SurveyResponseRecord[],
+): SurveyAggregationResult {
+  const questions: SurveyAggregationResult['questions'] = {}
+  const respondentIds = new Set<string>()
+  let lastResponseAt: string | null = null
+
+  responses.forEach(response => {
+    if (response.respondent_id) {
+      respondentIds.add(response.respondent_id)
+    }
+
+    if (!lastResponseAt || response.submitted_at > lastResponseAt) {
+      lastResponseAt = response.submitted_at
+    }
+
+    const answers = (response.answers ?? {}) as Record<string, unknown>
+
+    Object.entries(answers).forEach(([questionId, value]) => {
+      if (!questions[questionId]) {
+        questions[questionId] = {
+          totalResponses: 0,
+          counts: {},
+        }
+      }
+
+      const question = questions[questionId] as SurveyAggregationQuestion
+
+      question.totalResponses += 1
+
+      if (Array.isArray(value)) {
+        value.forEach(item => {
+          const key = String(item)
+          question.counts[key] = (question.counts[key] ?? 0) + 1
+        })
+      } else if (typeof value === 'number') {
+        const key = value.toString()
+        question.counts[key] = (question.counts[key] ?? 0) + 1
+        question.numericSum = (question.numericSum ?? 0) + value
+      } else if (typeof value === 'boolean') {
+        const key = value ? 'true' : 'false'
+        question.counts[key] = (question.counts[key] ?? 0) + 1
+      } else if (value !== null && value !== undefined) {
+        const key = String(value)
+        question.counts[key] = (question.counts[key] ?? 0) + 1
+      }
+    })
+  })
+
+  Object.values(questions).forEach(question => {
+    if (question.numericSum !== undefined) {
+      const average = question.numericSum / question.totalResponses
+      question.numericAverage = Number(average.toFixed(4))
+      question.numericSum = Number(question.numericSum.toFixed(4))
+    }
+  })
+
+  return {
+    survey,
+    totalResponses: responses.length,
+    respondents: respondentIds.size,
+    lastResponseAt,
+    questions,
+  }
+}
+
+export async function aggregateSurveyResponses(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  surveyId: number,
+): Promise<SurveyAggregationResult> {
+  const { data: survey, error: surveyError } = await supabase
+    .from('communications_surveys')
+    .select('*')
+    .eq('id', surveyId)
+    .maybeSingle()
+
+  throwIfSupabaseError(surveyError, 'Failed to load survey metadata')
+
+  if (!survey) {
+    throw new HttpError(404, 'Survey not found')
+  }
+
+  if (!isAdmin(context) && survey.created_by !== context.userId) {
+    throw new HttpError(403, 'Only survey owners or admins can aggregate responses')
+  }
+
+  const { data: responses, error: responsesError } = await supabase
+    .from('communications_survey_responses')
+    .select('*')
+    .eq('survey_id', surveyId)
+
+  throwIfSupabaseError(responsesError, 'Failed to load survey responses')
+
+  return buildAggregation(survey, responses ?? [])
+}
+
+function toCsvValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => String(item)).join('; ')
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+
+  return String(value)
+}
+
+function formatCsv(rows: string[][]): string {
+  return rows
+    .map(row =>
+      row
+        .map(cell => {
+          const needsQuotes = /[",\n]/.test(cell)
+          const escaped = cell.replace(/"/g, '""')
+          return needsQuotes ? `"${escaped}"` : escaped
+        })
+        .join(','),
+    )
+    .join('\n')
+}
+
+export async function exportSurveyResponses(
+  supabase: TypedSupabaseClient,
+  context: RequestContext,
+  surveyId: number,
+): Promise<SurveyExportResult> {
+  const aggregation = await aggregateSurveyResponses(supabase, context, surveyId)
+  const { survey } = aggregation
+
+  const { data: responses, error } = await supabase
+    .from('communications_survey_responses')
+    .select('*')
+    .eq('survey_id', surveyId)
+    .order('submitted_at', { ascending: true })
+
+  throwIfSupabaseError(error, 'Failed to load responses for export')
+
+  const allKeys = new Set<string>()
+  ;(responses ?? []).forEach(response => {
+    const answers = (response.answers ?? {}) as Record<string, unknown>
+    Object.keys(answers).forEach(key => allKeys.add(key))
+  })
+
+  const headers = ['response_id', 'respondent_id', 'submitted_at', ...allKeys]
+
+  const rows = [headers]
+
+  ;(responses ?? []).forEach(response => {
+    const answers = (response.answers ?? {}) as Record<string, unknown>
+    const row: string[] = [
+      String(response.id),
+      response.respondent_id ?? '',
+      response.submitted_at,
+    ]
+
+    for (const key of allKeys) {
+      row.push(toCsvValue(answers[key]))
+    }
+
+    rows.push(row)
+  })
+
+  const safeTitle = survey.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  const filename = `${safeTitle || `survey-${surveyId}`}-responses.csv`
+  const content = formatCsv(rows)
+
+  return {
+    filename,
+    mimeType: 'text/csv',
+    content,
+  }
+}

--- a/services/communications/types.ts
+++ b/services/communications/types.ts
@@ -1,0 +1,135 @@
+import type { Database } from '@/lib/supabase'
+
+export type AnnouncementStatus = Database['public']['Enums']['announcement_status']
+export type BulletinStatus = Database['public']['Enums']['bulletin_status']
+export type ModerationStatus = Database['public']['Enums']['moderation_status']
+export type AbuseStatus = Database['public']['Enums']['abuse_status']
+export type SurveyStatus = Database['public']['Enums']['survey_status']
+export type ModerationAction = Database['public']['Enums']['moderation_action']
+
+export type AnnouncementRecord = Database['public']['Tables']['communications_announcements']['Row']
+export type BulletinRecord = Database['public']['Tables']['communications_bulletins']['Row']
+export type AbuseReportRecord = Database['public']['Tables']['communications_abuse_reports']['Row']
+export type SurveyRecord = Database['public']['Tables']['communications_surveys']['Row']
+export type SurveyResponseRecord = Database['public']['Tables']['communications_survey_responses']['Row']
+
+export interface AnnouncementFilters {
+  status?: AnnouncementStatus
+  includeExpired?: boolean
+  limit?: number
+}
+
+export interface BulletinFilters {
+  status?: BulletinStatus
+  moderationStatus?: ModerationStatus
+  mineOnly?: boolean
+  includeAbuse?: boolean
+}
+
+export type BulletinWithRelations = BulletinRecord & {
+  abuseReports?: AbuseReportRecord[]
+}
+
+export interface BulletinListResult {
+  bulletins: BulletinWithRelations[]
+  abuseSummary?: Record<number, Partial<Record<AbuseStatus, number>>>
+}
+
+export interface SurveyFilters {
+  status?: SurveyStatus
+  includeClosed?: boolean
+  createdBy?: string
+}
+
+export interface RequestContext {
+  userId: string
+  role: 'admin' | 'user' | string
+  email?: string | null
+}
+
+export interface SurveyAggregationQuestion {
+  totalResponses: number
+  counts: Record<string, number>
+  numericAverage?: number
+  numericSum?: number
+}
+
+export interface SurveyAggregationResult {
+  survey: SurveyRecord
+  totalResponses: number
+  respondents: number
+  lastResponseAt: string | null
+  questions: Record<string, SurveyAggregationQuestion>
+}
+
+export interface SurveyExportResult {
+  filename: string
+  mimeType: string
+  content: string
+}
+
+export interface CreateAnnouncementInput {
+  title: string
+  body: string
+  status?: AnnouncementStatus
+  publishAt?: string | null
+  expireAt?: string | null
+  targetRoles?: string[] | null
+}
+
+export interface UpdateAnnouncementInput extends Partial<CreateAnnouncementInput> {
+  id: number
+}
+
+export interface CreateBulletinInput {
+  title: string
+  content: string
+}
+
+export interface ModerateBulletinInput {
+  bulletinId: number
+  action: Exclude<ModerationAction, 'submit' | 'flag'>
+  notes?: string
+  resolutionNotes?: string
+}
+
+export interface ReportAbuseInput {
+  bulletinId: number
+  reason: string
+  details?: string
+}
+
+export interface CreateSurveyInput {
+  title: string
+  description?: string | null
+  questions: Record<string, unknown>
+  status?: SurveyStatus
+  closesAt?: string | null
+  metadata?: Record<string, unknown> | null
+}
+
+export interface UpdateSurveyInput extends Partial<CreateSurveyInput> {
+  id: number
+}
+
+export interface SubmitSurveyResponseInput {
+  surveyId: number
+  answers: Record<string, unknown>
+  metadata?: Record<string, unknown> | null
+}
+
+export interface CommunicationsReport {
+  announcementCounts: Partial<Record<AnnouncementStatus, number>> & {
+    total: number
+  }
+  bulletinStatusCounts: Partial<Record<BulletinStatus, number>>
+  bulletinModerationCounts: Partial<Record<ModerationStatus, number>>
+  abuseByStatus: Partial<Record<AbuseStatus, number>> & {
+    open: number
+  }
+  surveySummary: {
+    total: number
+    statusBreakdown: Partial<Record<SurveyStatus, number>>
+    responseCounts: Record<number, number>
+  }
+}

--- a/supabase/migrations/20250409_onyxpwa.sql
+++ b/supabase/migrations/20250409_onyxpwa.sql
@@ -112,6 +112,183 @@ CREATE POLICY "Individuals can view their own todos." ON public.todos FOR SELECT
 CREATE POLICY "Individuals can insert their own todos." ON public.todos FOR INSERT TO authenticated WITH CHECK ((select auth.uid()) = user_id);
 CREATE POLICY "Individuals can update their own todos." ON public.todos FOR UPDATE TO authenticated USING ((select auth.uid()) = user_id) WITH CHECK ((select auth.uid()) = user_id);
 CREATE POLICY "Individuals can delete their own todos." ON public.todos FOR DELETE TO authenticated USING ((select auth.uid()) = user_id);
-```
 
--- Remember to create RLS policies for this table before using it with Supabase APIs.
+-- Communications service domain --------------------------------------------------------
+
+create type public.announcement_status as enum ('draft', 'scheduled', 'published', 'archived');
+create type public.bulletin_status as enum ('pending', 'approved', 'rejected', 'escalated', 'archived');
+create type public.moderation_status as enum ('clean', 'under_review', 'action_required', 'resolved');
+create type public.abuse_status as enum ('open', 'investigating', 'resolved');
+create type public.survey_status as enum ('draft', 'open', 'closed', 'archived');
+create type public.moderation_action as enum ('submit', 'approve', 'reject', 'escalate', 'resolve', 'flag');
+
+CREATE TABLE public.communications_announcements (
+  id bigint primary key generated always as identity,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  title text NOT NULL,
+  body text NOT NULL,
+  status public.announcement_status NOT NULL DEFAULT 'draft',
+  publish_at timestamp with time zone NULL,
+  expire_at timestamp with time zone NULL,
+  created_by uuid NOT NULL,
+  target_roles text[] NULL,
+  CONSTRAINT communications_announcements_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE CASCADE
+) WITH (OIDS=FALSE);
+ALTER TABLE public.communications_announcements ENABLE ROW LEVEL SECURITY;
+CREATE INDEX IF NOT EXISTS idx_communications_announcements_status ON public.communications_announcements(status);
+CREATE INDEX IF NOT EXISTS idx_communications_announcements_publish_at ON public.communications_announcements(publish_at);
+
+CREATE TABLE public.communications_bulletins (
+  id bigint primary key generated always as identity,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  author_id uuid NOT NULL,
+  title text NOT NULL,
+  content text NOT NULL,
+  status public.bulletin_status NOT NULL DEFAULT 'pending',
+  moderation_status public.moderation_status NOT NULL DEFAULT 'clean',
+  abuse_reason text NULL,
+  abuse_context jsonb NULL,
+  moderated_by uuid NULL,
+  moderated_at timestamp with time zone NULL,
+  CONSTRAINT communications_bulletins_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.profiles(id) ON DELETE CASCADE,
+  CONSTRAINT communications_bulletins_moderated_by_fkey FOREIGN KEY (moderated_by) REFERENCES public.profiles(id) ON DELETE SET NULL
+) WITH (OIDS=FALSE);
+ALTER TABLE public.communications_bulletins ENABLE ROW LEVEL SECURITY;
+CREATE INDEX IF NOT EXISTS idx_communications_bulletins_status ON public.communications_bulletins(status);
+CREATE INDEX IF NOT EXISTS idx_communications_bulletins_moderation_status ON public.communications_bulletins(moderation_status);
+
+CREATE TABLE public.communications_bulletin_audits (
+  id bigint primary key generated always as identity,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  bulletin_id bigint NOT NULL,
+  actor_id uuid NOT NULL,
+  action public.moderation_action NOT NULL,
+  notes text NULL,
+  metadata jsonb NULL,
+  CONSTRAINT communications_bulletin_audits_bulletin_id_fkey FOREIGN KEY (bulletin_id) REFERENCES public.communications_bulletins(id) ON DELETE CASCADE,
+  CONSTRAINT communications_bulletin_audits_actor_id_fkey FOREIGN KEY (actor_id) REFERENCES public.profiles(id) ON DELETE CASCADE
+) WITH (OIDS=FALSE);
+ALTER TABLE public.communications_bulletin_audits ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE public.communications_abuse_reports (
+  id bigint primary key generated always as identity,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  bulletin_id bigint NOT NULL,
+  reporter_id uuid NOT NULL,
+  status public.abuse_status NOT NULL DEFAULT 'open',
+  reason text NOT NULL,
+  details text NULL,
+  resolved_at timestamp with time zone NULL,
+  resolution_notes text NULL,
+  CONSTRAINT communications_abuse_reports_bulletin_id_fkey FOREIGN KEY (bulletin_id) REFERENCES public.communications_bulletins(id) ON DELETE CASCADE,
+  CONSTRAINT communications_abuse_reports_reporter_id_fkey FOREIGN KEY (reporter_id) REFERENCES public.profiles(id) ON DELETE CASCADE
+) WITH (OIDS=FALSE);
+ALTER TABLE public.communications_abuse_reports ENABLE ROW LEVEL SECURITY;
+CREATE INDEX IF NOT EXISTS idx_communications_abuse_reports_status ON public.communications_abuse_reports(status);
+
+CREATE TABLE public.communications_surveys (
+  id bigint primary key generated always as identity,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  title text NOT NULL,
+  description text NULL,
+  status public.survey_status NOT NULL DEFAULT 'draft',
+  questions jsonb NOT NULL,
+  created_by uuid NOT NULL,
+  closes_at timestamp with time zone NULL,
+  metadata jsonb NULL,
+  CONSTRAINT communications_surveys_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.profiles(id) ON DELETE CASCADE
+) WITH (OIDS=FALSE);
+ALTER TABLE public.communications_surveys ENABLE ROW LEVEL SECURITY;
+CREATE INDEX IF NOT EXISTS idx_communications_surveys_status ON public.communications_surveys(status);
+
+CREATE TABLE public.communications_survey_responses (
+  id bigint primary key generated always as identity,
+  survey_id bigint NOT NULL,
+  respondent_id uuid NULL,
+  submitted_at timestamp with time zone NOT NULL DEFAULT now(),
+  answers jsonb NOT NULL,
+  metadata jsonb NULL,
+  CONSTRAINT communications_survey_responses_survey_id_fkey FOREIGN KEY (survey_id) REFERENCES public.communications_surveys(id) ON DELETE CASCADE,
+  CONSTRAINT communications_survey_responses_respondent_id_fkey FOREIGN KEY (respondent_id) REFERENCES public.profiles(id) ON DELETE SET NULL
+) WITH (OIDS=FALSE);
+ALTER TABLE public.communications_survey_responses ENABLE ROW LEVEL SECURITY;
+CREATE INDEX IF NOT EXISTS idx_communications_survey_responses_survey_id ON public.communications_survey_responses(survey_id);
+
+-- RBAC aware policies rely on the profiles.role column populated via the application layer.
+CREATE POLICY "Announcements visible to authenticated users" ON public.communications_announcements
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Announcements manageable by admins" ON public.communications_announcements
+  FOR ALL TO authenticated USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Bulletins viewable when authored or approved" ON public.communications_bulletins
+  FOR SELECT TO authenticated USING (
+    author_id = auth.uid()
+    OR status IN ('approved'::public.bulletin_status, 'escalated'::public.bulletin_status)
+  );
+CREATE POLICY "Bulletins insert by authenticated" ON public.communications_bulletins
+  FOR INSERT TO authenticated WITH CHECK (author_id = auth.uid());
+CREATE POLICY "Bulletins managed by admins" ON public.communications_bulletins
+  FOR UPDATE TO authenticated USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Abuse reports readable by admins" ON public.communications_abuse_reports
+  FOR SELECT TO authenticated USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+    )
+    OR reporter_id = auth.uid()
+  );
+CREATE POLICY "Abuse reports insert by authenticated" ON public.communications_abuse_reports
+  FOR INSERT TO authenticated WITH CHECK (reporter_id = auth.uid());
+
+CREATE POLICY "Surveys readable to authenticated" ON public.communications_surveys
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Surveys managed by admins" ON public.communications_surveys
+  FOR ALL TO authenticated USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Survey responses readable to admins or owners" ON public.communications_survey_responses
+  FOR SELECT TO authenticated USING (
+    respondent_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+    )
+  );
+CREATE POLICY "Survey responses insert by authenticated" ON public.communications_survey_responses
+  FOR INSERT TO authenticated WITH CHECK (true);
+
+-- Remember to create any additional RLS policies tailored to your environment before using these tables with Supabase APIs.

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,8 +1,12 @@
 import { type CookieOptions, createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import type { Database } from '@/lib/supabase'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
 
-export function createClient(cookieStore: ReturnType<typeof cookies>) {
-  return createServerClient(
+export function createClient(
+  cookieStore: ReturnType<typeof cookies>,
+): TypedSupabaseClient {
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {


### PR DESCRIPTION
## Summary
- add database schema, Supabase types, and service layer for communications workflows (announcements, bulletins, surveys)
- create API routes for communications operations including moderation, abuse handling, aggregation, and export
- wire up typed Supabase server client and reporting utilities for RBAC-aware communications reporting

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceefc5db44832885fff71befaf4b4e