### PR TITLE
feat: add communications hub with moderation and e2e tests

### DIFF
--- a/app/playground/communications/page.tsx
+++ b/app/playground/communications/page.tsx
@@ -1,0 +1,11 @@
+import CommunicationsHub from "@/web/features/communications"
+
+const CommunicationsPlaygroundPage = () => {
+  return (
+    <main className="container mx-auto space-y-6 py-10">
+      <CommunicationsHub />
+    </main>
+  )
+}
+
+export default CommunicationsPlaygroundPage

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "test:e2e": "playwright test",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -100,6 +101,7 @@
     "@types/node": "^20.14.15",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@playwright/test": "^1.45.3",
     "@typescript-eslint/parser": "^5.62.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 60_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:3001",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm exec next start -p 3001",
+    url: "http://127.0.0.1:3001",
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+    env: {
+      ...process.env,
+      NEXT_DISABLE_VERSION_CHECK: "1",
+      NEXT_TELEMETRY_DISABLED: "1",
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -261,6 +261,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@playwright/test':
+        specifier: ^1.45.3
+        version: 1.55.0
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -1570,6 +1573,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -3753,6 +3761,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4807,6 +4820,16 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-attribute-case-insensitive@7.0.0:
     resolution: {integrity: sha512-ETMUHIw67Kyv9Q81nden/NuJbRh+4/S963giXpfSLd5eaKK8kd1UdAHMVRV/NG/w/N6Cq8B0qZIZbZZWU/67+A==}
@@ -7302,10 +7325,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7656,6 +7679,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
 
   '@radix-ui/number@1.0.1':
     dependencies:
@@ -8853,16 +8880,16 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
@@ -9815,8 +9842,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +9865,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +9882,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +9903,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10161,6 +10188,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -11252,13 +11282,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +11298,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11280,6 +11310,7 @@ snapshots:
       '@next/swc-win32-ia32-msvc': 14.2.4
       '@next/swc-win32-x64-msvc': 14.2.4
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.55.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -11457,6 +11488,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-attribute-case-insensitive@7.0.0(postcss@8.4.32):
     dependencies:
@@ -12334,12 +12373,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 

--- a/tests/e2e/communications.spec.ts
+++ b/tests/e2e/communications.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test, type Page } from "@playwright/test"
+
+const communicationsPath = "/playground/communications"
+
+const selectRole = async (page: Page, role: string) => {
+  await page.selectOption('[data-testid="role-selector"]', role)
+}
+
+test.describe("Resident communications hub", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(communicationsPath)
+  })
+
+  test("resident can publish a bulletin post and comment", async ({ page }) => {
+    await selectRole(page, "resident")
+
+    const title = `Pool Party ${Date.now()}`
+    const message = "Join us for a community pool party this weekend!"
+
+    await page.fill('[data-testid="post-title"]', title)
+    await page.fill('[data-testid="post-message"]', message)
+    await page.click('[data-testid="submit-post"]')
+
+    const firstPost = page
+      .locator('[data-testid="published-posts"]')
+      .locator('[data-testid="post-card"]').first()
+
+    await expect(firstPost).toContainText(title)
+    await expect(firstPost).toContainText(message)
+
+    const commentMessage = "Looking forward to it!"
+
+    await firstPost.locator('[data-testid="comment-input"]').fill(commentMessage)
+    await firstPost.locator('[data-testid="comment-submit"]').click()
+
+    await expect(firstPost.locator('[data-testid="post-comments"]')).toContainText(
+      commentMessage
+    )
+  })
+
+  test("moderator can approve filtered submissions", async ({ page }) => {
+    await selectRole(page, "resident")
+
+    const flaggedTitle = `Flagged update ${Date.now()}`
+    const flaggedMessage = "This message contains spam and should be held." // includes banned word
+
+    await page.fill('[data-testid="post-title"]', flaggedTitle)
+    await page.fill('[data-testid="post-message"]', flaggedMessage)
+    await page.click('[data-testid="submit-post"]')
+
+    const queueItem = page
+      .locator('[data-testid="moderation-queue"]')
+      .locator('[data-testid="moderation-item"]', { hasText: flaggedTitle })
+
+    await expect(queueItem).toContainText("Awaiting review")
+
+    await selectRole(page, "moderator")
+    await queueItem.locator('[data-testid="approve-action"]').click()
+
+    const publishedPosts = page
+      .locator('[data-testid="published-posts"]')
+      .locator('[data-testid="post-card"]').first()
+
+    await expect(publishedPosts).toContainText(flaggedTitle)
+    await expect(page.locator('[data-testid="moderation-log"]')).toContainText(
+      "approved"
+    )
+  })
+})

--- a/web/features/communications/content-filter.ts
+++ b/web/features/communications/content-filter.ts
@@ -1,0 +1,45 @@
+const bannedWordList = [
+  {
+    term: "spam",
+    guidance: "Avoid promotional or repetitive content.",
+  },
+  {
+    term: "scam",
+    guidance: "Potentially fraudulent language detected.",
+  },
+  {
+    term: "offensive",
+    guidance: "Content violates community guidelines.",
+  },
+]
+
+export interface FilterResult {
+  cleanText: string
+  flagged: boolean
+  matches: string[]
+}
+
+const redactTerm = (term: string) => "★".repeat(Math.max(term.length, 3))
+
+export const filterContent = (input: string): FilterResult => {
+  let cleanText = input
+  let flagged = false
+  const matches = new Set<string>()
+
+  bannedWordList.forEach(({ term }) => {
+    const pattern = new RegExp(`\\b${term}\\b`, "gi")
+    if (pattern.test(cleanText)) {
+      flagged = true
+      matches.add(term)
+      cleanText = cleanText.replace(pattern, () => redactTerm(term))
+    }
+  })
+
+  return {
+    cleanText: cleanText.trim(),
+    flagged,
+    matches: Array.from(matches),
+  }
+}
+
+export const bannedWords = bannedWordList

--- a/web/features/communications/index.tsx
+++ b/web/features/communications/index.tsx
@@ -1,0 +1,1093 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Progress } from "@/components/ui/progress"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+import { bannedWords, filterContent } from "./content-filter"
+import { can, roleDetails } from "./permissions"
+import type {
+  BulletinComment,
+  BulletinPost,
+  BulletinStatus,
+  ModerationAction,
+  ModerationLogEntry,
+  Role,
+  SurveyDefinition,
+} from "./types"
+
+const generateId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID()
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+const initialPosts: BulletinPost[] = [
+  {
+    id: "welcome-post",
+    title: "Welcome to the Share House!",
+    author: "Community Moderator",
+    role: "moderator",
+    message:
+      "Remember to introduce yourself and share community updates here. Keep the tone friendly and inclusive!",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    status: "published",
+    flagged: false,
+    matches: [],
+    comments: [
+      {
+        id: "welcome-comment-1",
+        author: "Resident",
+        role: "resident",
+        message: "Excited to meet everyone at the potluck tonight!",
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString(),
+        status: "published",
+        flagged: false,
+        matches: [],
+      },
+    ],
+  },
+  {
+    id: "maintenance-update",
+    title: "Maintenance Reminder",
+    author: "Building Admin",
+    role: "admin",
+    message:
+      "Routine hallway maintenance happens on Thursday at 10am. Please remove bikes or belongings from shared corridors.",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 6).toISOString(),
+    status: "published",
+    flagged: false,
+    matches: [],
+    comments: [],
+  },
+]
+
+const surveyDefinition: SurveyDefinition = {
+  question: "Which community upgrade should we prioritize next?",
+  closingNote: "Voting closes on Friday at 8pm.",
+  options: [
+    {
+      id: "garden",
+      label: "Rooftop herb garden",
+      description: "Includes shared planters and weekly workshops.",
+      votes: 18,
+    },
+    {
+      id: "workspace",
+      label: "Quiet co-working nook",
+      description: "Sound-dampened booths and upgraded Wi-Fi.",
+      votes: 23,
+    },
+    {
+      id: "movie",
+      label: "Outdoor movie nights",
+      description: "Projector upgrades and seasonal programming.",
+      votes: 15,
+    },
+  ],
+}
+
+const formatDate = (isoString: string) =>
+  new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(isoString))
+
+const excerpt = (text: string, length = 120) =>
+  text.length > length ? `${text.slice(0, length)}…` : text
+
+const defaultCommentDrafts = (posts: BulletinPost[]) =>
+  posts.reduce<Record<string, string>>((acc, post) => {
+    acc[post.id] = ""
+    return acc
+  }, {})
+
+const initialSurveyParticipation: Record<Role, boolean> = {
+  resident: false,
+  moderator: false,
+  admin: false,
+  guest: false,
+}
+
+const statusBadgeVariant = (status: BulletinStatus) => {
+  switch (status) {
+    case "pending":
+      return "secondary" as const
+    case "rejected":
+      return "destructive" as const
+    default:
+      return "default" as const
+  }
+}
+
+const statusLabel = (status: BulletinStatus) => {
+  switch (status) {
+    case "pending":
+      return "Pending review"
+    case "rejected":
+      return "Rejected"
+    default:
+      return "Published"
+  }
+}
+
+const getInitialSurveyOptions = () =>
+  surveyDefinition.options.map((option) => ({ ...option }))
+
+const buildLobbyStats = (options: SurveyDefinition["options"]) => {
+  const totalVotes = options.reduce((sum, option) => sum + option.votes, 0)
+
+  const sortedOptions = [...options].sort((a, b) => b.votes - a.votes)
+  const leader = sortedOptions[0]
+  const leaderShare = totalVotes > 0 ? Math.round((leader.votes / totalVotes) * 100) : 0
+
+  return {
+    totalVotes,
+    leader,
+    leaderShare,
+  }
+}
+
+const findPost = (posts: BulletinPost[], postId: string) =>
+  posts.find((post) => post.id === postId)
+
+const communicationsHighlights = (posts: BulletinPost[]) =>
+  posts
+    .filter((post) => post.status === "published")
+    .slice(0, 3)
+    .map((post) => ({
+      id: post.id,
+      title: post.title,
+      message: excerpt(post.message, 100),
+      createdAt: post.createdAt,
+    }))
+
+const updateCommentDrafts = (
+  drafts: Record<string, string>,
+  postId: string,
+  value: string
+) => ({
+  ...drafts,
+  [postId]: value,
+})
+
+const addCommentToPosts = (
+  posts: BulletinPost[],
+  postId: string,
+  comment: BulletinComment
+) =>
+  posts.map((post) =>
+    post.id === postId
+      ? {
+          ...post,
+          comments: [comment, ...post.comments],
+        }
+      : post
+  )
+
+const updateCommentStatus = (
+  posts: BulletinPost[],
+  postId: string,
+  commentId: string,
+  status: BulletinStatus
+) =>
+  posts.map((post) =>
+    post.id === postId
+      ? {
+          ...post,
+          comments: post.comments.map((comment) =>
+            comment.id === commentId
+              ? {
+                  ...comment,
+                  status,
+                  flagged: status !== "published" ? comment.flagged : false,
+                }
+              : comment
+          ),
+        }
+      : post
+  )
+
+const updatePostStatus = (
+  posts: BulletinPost[],
+  postId: string,
+  status: BulletinStatus
+) =>
+  posts.map((post) =>
+    post.id === postId
+      ? {
+          ...post,
+          status,
+          flagged: status !== "published" ? post.flagged : false,
+        }
+      : post
+  )
+
+const removeRejectedContent = (posts: BulletinPost[]) =>
+  posts.filter((post) => post.status !== "rejected")
+
+const redactMatches = (matches: string[]) =>
+  matches.map((match) => match.toUpperCase()).join(", ")
+
+const mergeDraftsWithPosts = (
+  drafts: Record<string, string>,
+  posts: BulletinPost[]
+) => {
+  const nextDrafts = { ...drafts }
+  posts.forEach((post) => {
+    if (!(post.id in nextDrafts)) {
+      nextDrafts[post.id] = ""
+    }
+  })
+
+  return nextDrafts
+}
+
+const moderationMessage = (
+  action: ModerationAction,
+  title: string,
+  role: Role
+) => {
+  const actor = roleDetails[role].label
+  if (action === "approve") {
+    return `${actor} approved “${title}”.`
+  }
+
+  return `${actor} rejected “${title}”.`
+}
+
+const filterPendingComments = (posts: BulletinPost[]) =>
+  posts.flatMap((post) =>
+    post.comments
+      .filter((comment) => comment.status === "pending")
+      .map((comment) => ({ comment, post }))
+  )
+
+const filterPendingPosts = (posts: BulletinPost[]) =>
+  posts.filter((post) => post.status === "pending")
+
+const filterPublishedPosts = (posts: BulletinPost[]) =>
+  posts.filter((post) => post.status === "published")
+
+const totalSurveyVotes = (options: SurveyDefinition["options"]) =>
+  options.reduce((sum, option) => sum + option.votes, 0)
+
+const calculateVoteShare = (votes: number, total: number) =>
+  total === 0 ? 0 : Math.round((votes / total) * 100)
+
+const commentStatusBadgeVariant = (status: BulletinStatus) => {
+  switch (status) {
+    case "pending":
+      return "secondary" as const
+    case "rejected":
+      return "destructive" as const
+    default:
+      return "outline" as const
+  }
+}
+
+const sortByNewest = <T extends { createdAt: string }>(items: T[]) =>
+  [...items].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  )
+
+const getModerationLogEntry = (
+  targetId: string,
+  targetType: "post" | "comment",
+  action: ModerationAction,
+  moderatorRole: Role,
+  moderatorName: string
+): ModerationLogEntry => ({
+  id: generateId(),
+  targetId,
+  targetType,
+  action,
+  moderatorRole,
+  moderator: moderatorName,
+  timestamp: new Date().toISOString(),
+})
+
+const hasContentRights = (role: Role) => can(role, "createPost") || can(role, "comment")
+
+const CommunicationsHub = () => {
+  const [role, setRole] = useState<Role>("resident")
+  const [posts, setPosts] = useState<BulletinPost[]>(sortByNewest(initialPosts))
+  const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>(
+    defaultCommentDrafts(initialPosts)
+  )
+  const [newPostTitle, setNewPostTitle] = useState("")
+  const [newPostMessage, setNewPostMessage] = useState("")
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [moderationLog, setModerationLog] = useState<ModerationLogEntry[]>([])
+  const [surveyOptions, setSurveyOptions] = useState(getInitialSurveyOptions)
+  const [surveyParticipation, setSurveyParticipation] = useState(
+    initialSurveyParticipation
+  )
+  const [lobbyMode, setLobbyMode] = useState(false)
+  const [surveyFeedback, setSurveyFeedback] = useState<string | null>(null)
+
+  const canCreatePost = can(role, "createPost")
+  const canComment = can(role, "comment")
+  const canModerate = can(role, "moderate")
+  const canVote = can(role, "participateSurvey")
+  const canToggleLobby = can(role, "toggleLobby")
+
+  const publishedPosts = useMemo(
+    () => filterPublishedPosts(posts),
+    [posts]
+  )
+  const pendingPosts = useMemo(() => filterPendingPosts(posts), [posts])
+  const pendingComments = useMemo(() => filterPendingComments(posts), [posts])
+
+  const mergedDrafts = useMemo(
+    () => mergeDraftsWithPosts(commentDrafts, posts),
+    [commentDrafts, posts]
+  )
+
+  const totalVotes = useMemo(() => totalSurveyVotes(surveyOptions), [surveyOptions])
+  const lobbyStats = useMemo(
+    () => buildLobbyStats(surveyOptions),
+    [surveyOptions]
+  )
+
+  const highlights = useMemo(
+    () => communicationsHighlights(posts),
+    [posts]
+  )
+
+  const handleRoleChange = (nextRole: Role) => {
+    setRole(nextRole)
+    setFeedback(null)
+    setSurveyFeedback(null)
+  }
+
+  const handlePostSubmit = () => {
+    if (!canCreatePost) {
+      setFeedback("You do not have permission to post to the bulletin board.")
+      return
+    }
+
+    const trimmedTitle = newPostTitle.trim()
+    const trimmedMessage = newPostMessage.trim()
+
+    if (!trimmedTitle || !trimmedMessage) {
+      setFeedback("Add both a title and message before submitting.")
+      return
+    }
+
+    const filteredTitle = filterContent(trimmedTitle)
+    const filteredMessage = filterContent(trimmedMessage)
+
+    const post: BulletinPost = {
+      id: generateId(),
+      title: filteredTitle.cleanText,
+      author: roleDetails[role].defaultAuthor,
+      role,
+      message: filteredMessage.cleanText,
+      createdAt: new Date().toISOString(),
+      status: filteredTitle.flagged || filteredMessage.flagged ? "pending" : "published",
+      flagged: filteredTitle.flagged || filteredMessage.flagged,
+      matches: Array.from(new Set([...filteredTitle.matches, ...filteredMessage.matches])),
+      comments: [],
+    }
+
+    setPosts((previous) => sortByNewest([post, ...previous]))
+    setCommentDrafts((drafts) => updateCommentDrafts(drafts, post.id, ""))
+
+    if (post.status === "pending") {
+      setFeedback(
+        "Your post was submitted for moderation because it triggered the content filter."
+      )
+    } else {
+      setFeedback("Post published to the community bulletin board.")
+    }
+
+    setNewPostTitle("")
+    setNewPostMessage("")
+  }
+
+  const handleCommentSubmit = (postId: string) => {
+    if (!canComment) {
+      setFeedback("You do not have permission to comment on bulletin posts.")
+      return
+    }
+
+    const draft = mergedDrafts[postId]?.trim() ?? ""
+
+    if (!draft) {
+      setFeedback("Enter a comment before submitting.")
+      return
+    }
+
+    const filteredComment = filterContent(draft)
+
+    const comment: BulletinComment = {
+      id: generateId(),
+      author: roleDetails[role].defaultAuthor,
+      role,
+      message: filteredComment.cleanText,
+      createdAt: new Date().toISOString(),
+      status: filteredComment.flagged ? "pending" : "published",
+      flagged: filteredComment.flagged,
+      matches: filteredComment.matches,
+    }
+
+    setPosts((previous) =>
+      sortByNewest(addCommentToPosts(previous, postId, comment))
+    )
+    setCommentDrafts((drafts) => updateCommentDrafts(drafts, postId, ""))
+
+    if (comment.status === "pending") {
+      setFeedback(
+        "Your comment is awaiting moderation due to restricted language."
+      )
+    } else {
+      setFeedback("Comment published.")
+    }
+  }
+
+  const recordModeration = (
+    action: ModerationAction,
+    targetType: "post" | "comment",
+    targetId: string,
+    label: string
+  ) => {
+    const entry = getModerationLogEntry(
+      targetId,
+      targetType,
+      action,
+      role,
+      roleDetails[role].defaultAuthor
+    )
+
+    setModerationLog((previous) => [entry, ...previous])
+    setFeedback(moderationMessage(action, label, role))
+  }
+
+  const handlePostModeration = (postId: string, action: ModerationAction) => {
+    if (!canModerate) {
+      setFeedback("You do not have permission to moderate content.")
+      return
+    }
+
+    const post = findPost(posts, postId)
+
+    if (!post) {
+      setFeedback("Post could not be found for moderation.")
+      return
+    }
+
+    const nextStatus = action === "approve" ? "published" : "rejected"
+    setPosts((previous) =>
+      action === "reject"
+        ? removeRejectedContent(updatePostStatus(previous, postId, nextStatus))
+        : updatePostStatus(previous, postId, nextStatus)
+    )
+    recordModeration(action, "post", post.id, post.title)
+  }
+
+  const handleCommentModeration = (
+    postId: string,
+    commentId: string,
+    action: ModerationAction
+  ) => {
+    if (!canModerate) {
+      setFeedback("You do not have permission to moderate content.")
+      return
+    }
+
+    const post = findPost(posts, postId)
+    const comment = post?.comments.find((entry) => entry.id === commentId)
+
+    if (!post || !comment) {
+      setFeedback("Comment could not be found for moderation.")
+      return
+    }
+
+    const nextStatus = action === "approve" ? "published" : "rejected"
+
+    setPosts((previous) =>
+      action === "reject"
+        ? updateCommentStatus(previous, postId, commentId, nextStatus).map((entry) => ({
+            ...entry,
+            comments: entry.comments.filter((item) => item.status !== "rejected"),
+          }))
+        : updateCommentStatus(previous, postId, commentId, nextStatus)
+    )
+    recordModeration(action, "comment", comment.id, `comment on ${post.title}`)
+  }
+
+  const handleVote = (optionId: string) => {
+    if (!canVote) {
+      setSurveyFeedback("This role cannot submit survey responses.")
+      return
+    }
+
+    if (surveyParticipation[role]) {
+      setSurveyFeedback("You have already voted in this survey.")
+      return
+    }
+
+    setSurveyOptions((previous) =>
+      previous.map((option) =>
+        option.id === optionId
+          ? { ...option, votes: option.votes + 1 }
+          : option
+      )
+    )
+
+    setSurveyParticipation((previous) => ({
+      ...previous,
+      [role]: true,
+    }))
+    setSurveyFeedback("Thank you for voting! Your response has been recorded.")
+  }
+
+  const handleLobbyToggle = (checked: boolean) => {
+    if (!canToggleLobby) {
+      setFeedback("This role cannot control the lobby display.")
+      return
+    }
+
+    setLobbyMode(checked)
+  }
+
+  const renderModerationNotice = (flagged: boolean, matches: string[]) => {
+    if (!flagged) {
+      return null
+    }
+
+    return (
+      <p className="text-xs text-amber-600 dark:text-amber-400" data-testid="moderation-notice">
+        {`Content filtered: ${redactMatches(matches)}`}
+      </p>
+    )
+  }
+
+  const lobbyDisplay = lobbyMode && (
+    <Card
+      data-testid="lobby-display"
+      className="border-primary/30 bg-primary/5 backdrop-blur"
+    >
+      <CardHeader>
+        <CardTitle>Lobby Display</CardTitle>
+        <CardDescription>
+          Rotating highlights for the entrance display. Content is read-only and
+          auto-refreshes from approved posts and survey data.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-6 md:grid-cols-2">
+        <section>
+          <h4 className="mb-2 font-semibold">Bulletin Highlights</h4>
+          <ul className="space-y-3">
+            {highlights.length === 0 && (
+              <li className="text-sm text-muted-foreground">
+                No approved posts yet. Moderators can approve submissions to
+                populate the lobby display.
+              </li>
+            )}
+            {highlights.map((highlight) => (
+              <li
+                key={highlight.id}
+                className="rounded-lg border border-dashed border-primary/40 p-3"
+              >
+                <p className="font-medium">{highlight.title}</p>
+                <p className="text-xs text-muted-foreground">
+                  {formatDate(highlight.createdAt)}
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {highlight.message}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+        <section>
+          <h4 className="mb-2 font-semibold">Survey Snapshot</h4>
+          <div className="rounded-lg border border-dashed border-primary/40 p-4">
+            <p className="text-sm font-medium">{surveyDefinition.question}</p>
+            <p className="text-xs text-muted-foreground">
+              {surveyDefinition.closingNote}
+            </p>
+            <div className="mt-4 space-y-3">
+              {surveyOptions.map((option) => (
+                <div key={option.id}>
+                  <p className="text-sm font-semibold">{option.label}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {calculateVoteShare(option.votes, totalVotes)}% • {option.votes} votes
+                  </p>
+                </div>
+              ))}
+            </div>
+            {lobbyStats.leader && (
+              <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-primary">
+                Leading: {lobbyStats.leader.label} ({lobbyStats.leaderShare}% of {lobbyStats.totalVotes} votes)
+              </p>
+            )}
+          </div>
+        </section>
+      </CardContent>
+    </Card>
+  )
+
+  return (
+    <div className="space-y-6" data-testid="communications-hub">
+      <Card>
+        <CardHeader className="gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle>Resident Communications Hub</CardTitle>
+            <CardDescription>
+              Manage announcements, conversations, and surveys with built-in
+              safeguards for respectful collaboration.
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">Lobby display</span>
+            <Switch
+              data-testid="lobby-toggle"
+              checked={lobbyMode}
+              onCheckedChange={handleLobbyToggle}
+            />
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <section className="space-y-3">
+            <label className="block text-sm font-semibold" htmlFor="role-selector">
+              Impersonate role
+            </label>
+            <select
+              id="role-selector"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              value={role}
+              data-testid="role-selector"
+              onChange={(event) => handleRoleChange(event.target.value as Role)}
+            >
+              {Object.entries(roleDetails).map(([value, details]) => (
+                <option key={value} value={value}>
+                  {details.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-sm text-muted-foreground">
+              {roleDetails[role].summary}
+            </p>
+            <div className="flex flex-wrap gap-2" data-testid="role-permissions">
+              <Badge variant={canCreatePost ? "default" : "outline"}>
+                Post
+              </Badge>
+              <Badge variant={canComment ? "default" : "outline"}>
+                Comment
+              </Badge>
+              <Badge variant={canModerate ? "default" : "outline"}>
+                Moderate
+              </Badge>
+              <Badge variant={canVote ? "default" : "outline"}>Vote</Badge>
+              <Badge variant={canToggleLobby ? "default" : "outline"}>Lobby</Badge>
+            </div>
+          </section>
+          <section className="space-y-2">
+            <p className="text-sm font-semibold">Content safety filter</p>
+            <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+              {bannedWords.map((entry) => (
+                <li key={entry.term}>
+                  <span className="font-medium uppercase text-muted-foreground/80">
+                    {entry.term}
+                  </span>
+                  : {entry.guidance}
+                </li>
+              ))}
+            </ul>
+            <p className="text-xs text-muted-foreground">
+              Flagged submissions enter the moderation queue until a moderator or
+              admin approves them.
+            </p>
+          </section>
+        </CardContent>
+        {feedback && (
+          <CardFooter>
+            <p className="text-sm text-primary" data-testid="feedback-banner">
+              {feedback}
+            </p>
+          </CardFooter>
+        )}
+      </Card>
+
+      {lobbyDisplay}
+
+      {hasContentRights(role) && (
+        <Card data-testid="bulletin-form">
+          <CardHeader>
+            <CardTitle>Create a bulletin post</CardTitle>
+            <CardDescription>
+              Share updates with housemates. Content is filtered automatically
+              before publishing.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="post-title">
+                Title
+              </label>
+              <Input
+                id="post-title"
+                value={newPostTitle}
+                data-testid="post-title"
+                maxLength={120}
+                onChange={(event) => setNewPostTitle(event.target.value)}
+                placeholder="Community dinner on Saturday"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="post-message">
+                Message
+              </label>
+              <Textarea
+                id="post-message"
+                value={newPostMessage}
+                data-testid="post-message"
+                rows={4}
+                maxLength={800}
+                onChange={(event) => setNewPostMessage(event.target.value)}
+                placeholder="Let everyone know about your update..."
+              />
+            </div>
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="button"
+              data-testid="submit-post"
+              onClick={handlePostSubmit}
+              disabled={!canCreatePost}
+            >
+              Submit update
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Community bulletin</CardTitle>
+          <CardDescription>
+            Approved announcements appear here immediately. Comments inherit the
+            same moderation safeguards as posts.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4" data-testid="published-posts">
+            {publishedPosts.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                No published posts yet. Start the conversation with a new
+                bulletin update.
+              </p>
+            )}
+            {publishedPosts.map((post) => (
+              <article
+                key={post.id}
+                data-testid="post-card"
+                className="rounded-lg border bg-card p-4 shadow-sm"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h3 className="font-semibold">{post.title}</h3>
+                    <p className="text-xs text-muted-foreground">
+                      {post.author} • {formatDate(post.createdAt)}
+                    </p>
+                  </div>
+                  <Badge variant={statusBadgeVariant(post.status)}>
+                    {statusLabel(post.status)}
+                  </Badge>
+                </div>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                  {post.message}
+                </p>
+                {renderModerationNotice(post.flagged, post.matches)}
+                <div className="mt-4 space-y-3" data-testid="post-comments">
+                  {post.comments
+                    .filter((comment) => comment.status === "published")
+                    .map((comment) => (
+                      <div
+                        key={comment.id}
+                        className="rounded-md border border-border/50 bg-muted/50 p-3"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="text-sm font-medium">{comment.author}</p>
+                          <Badge variant={commentStatusBadgeVariant(comment.status)}>
+                            {statusLabel(comment.status)}
+                          </Badge>
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          {comment.message}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatDate(comment.createdAt)}
+                        </p>
+                      </div>
+                    ))}
+                </div>
+                {canComment && (
+                  <form
+                    className="mt-4 space-y-2"
+                    onSubmit={(event) => {
+                      event.preventDefault()
+                      handleCommentSubmit(post.id)
+                    }}
+                  >
+                    <label className="text-sm font-medium" htmlFor={`comment-${post.id}`}>
+                      Add a comment
+                    </label>
+                    <Textarea
+                      id={`comment-${post.id}`}
+                      data-testid="comment-input"
+                      value={mergedDrafts[post.id] ?? ""}
+                      onChange={(event) =>
+                        setCommentDrafts((drafts) =>
+                          updateCommentDrafts(drafts, post.id, event.target.value)
+                        )
+                      }
+                      rows={2}
+                      maxLength={400}
+                      placeholder="Share your thoughts with the community"
+                    />
+                    <Button
+                      type="submit"
+                      data-testid="comment-submit"
+                      disabled={!canComment}
+                    >
+                      Post comment
+                    </Button>
+                  </form>
+                )}
+              </article>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card data-testid="moderation-queue">
+        <CardHeader>
+          <CardTitle>Moderation queue</CardTitle>
+          <CardDescription>
+            Flagged posts and comments are listed here. Moderators approve or
+            reject content to keep the space healthy.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {pendingPosts.length === 0 && pendingComments.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No items need review. Great job keeping the board respectful!
+            </p>
+          )}
+          {pendingPosts.map((post) => (
+            <article
+              key={post.id}
+              data-testid="moderation-item"
+              className="rounded-lg border border-amber-300/60 bg-amber-50 p-4 text-amber-900 dark:border-amber-500/50 dark:bg-amber-950/40 dark:text-amber-100"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <h3 className="font-semibold">{post.title}</h3>
+                  <p className="text-xs uppercase tracking-wide">
+                    Pending bulletin post
+                  </p>
+                </div>
+                <Badge variant="secondary">Awaiting review</Badge>
+              </div>
+              <p className="mt-2 text-sm">{post.message}</p>
+              {renderModerationNotice(post.flagged, post.matches)}
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  data-testid="approve-action"
+                  variant="default"
+                  disabled={!canModerate}
+                  onClick={() => handlePostModeration(post.id, "approve")}
+                >
+                  Approve
+                </Button>
+                <Button
+                  type="button"
+                  data-testid="reject-action"
+                  variant="destructive"
+                  disabled={!canModerate}
+                  onClick={() => handlePostModeration(post.id, "reject")}
+                >
+                  Reject
+                </Button>
+              </div>
+            </article>
+          ))}
+          {pendingComments.map(({ post, comment }) => (
+            <article
+              key={comment.id}
+              data-testid="moderation-item"
+              className="rounded-lg border border-amber-300/60 bg-amber-50 p-4 text-amber-900 dark:border-amber-500/50 dark:bg-amber-950/40 dark:text-amber-100"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <h3 className="font-semibold">Comment on {post.title}</h3>
+                  <p className="text-xs uppercase tracking-wide">
+                    Pending comment
+                  </p>
+                </div>
+                <Badge variant="secondary">Awaiting review</Badge>
+              </div>
+              <p className="mt-2 text-sm">{comment.message}</p>
+              {renderModerationNotice(comment.flagged, comment.matches)}
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  data-testid="approve-action"
+                  variant="default"
+                  disabled={!canModerate}
+                  onClick={() =>
+                    handleCommentModeration(post.id, comment.id, "approve")
+                  }
+                >
+                  Approve
+                </Button>
+                <Button
+                  type="button"
+                  data-testid="reject-action"
+                  variant="destructive"
+                  disabled={!canModerate}
+                  onClick={() =>
+                    handleCommentModeration(post.id, comment.id, "reject")
+                  }
+                >
+                  Reject
+                </Button>
+              </div>
+            </article>
+          ))}
+        </CardContent>
+        {!canModerate && (
+          <CardFooter>
+            <p className="text-xs text-muted-foreground">
+              Only moderators and admins can change the status of queue items.
+            </p>
+          </CardFooter>
+        )}
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Survey participation</CardTitle>
+          <CardDescription>
+            Vote on the next community initiative. Results refresh after every
+            submission.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-6 md:grid-cols-2">
+          <section className="space-y-4">
+            <div>
+              <h3 className="font-semibold">{surveyDefinition.question}</h3>
+              <p className="text-xs text-muted-foreground">
+                {surveyDefinition.closingNote}
+              </p>
+            </div>
+            <div className="space-y-3">
+              {surveyOptions.map((option) => (
+                <Button
+                  key={option.id}
+                  type="button"
+                  variant="outline"
+                  className={cn(
+                    "w-full justify-start border-border bg-background text-left",
+                    !canVote && "pointer-events-none opacity-60"
+                  )}
+                  data-testid={`survey-option-${option.id}`}
+                  disabled={!canVote}
+                  onClick={() => handleVote(option.id)}
+                >
+                  <div>
+                    <p className="font-medium">{option.label}</p>
+                    {option.description && (
+                      <p className="text-xs text-muted-foreground">
+                        {option.description}
+                      </p>
+                    )}
+                  </div>
+                </Button>
+              ))}
+            </div>
+          </section>
+          <section className="space-y-4" data-testid="survey-results">
+            <div className="flex items-center justify-between text-sm font-medium">
+              <span>Real-time results</span>
+              <span>{totalVotes} votes</span>
+            </div>
+            <div className="space-y-4">
+              {surveyOptions.map((option) => (
+                <div key={option.id} className="space-y-2">
+                  <div className="flex items-center justify-between text-sm">
+                    <span>{option.label}</span>
+                    <span>{calculateVoteShare(option.votes, totalVotes)}%</span>
+                  </div>
+                  <Progress value={calculateVoteShare(option.votes, totalVotes)} />
+                </div>
+              ))}
+            </div>
+            {surveyFeedback && (
+              <p className="text-xs text-primary" data-testid="survey-feedback">
+                {surveyFeedback}
+              </p>
+            )}
+          </section>
+        </CardContent>
+      </Card>
+
+      <Card data-testid="moderation-log">
+        <CardHeader>
+          <CardTitle>Moderation activity</CardTitle>
+          <CardDescription>
+            A transparent record of moderation outcomes keeps the community
+            informed and accountable.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {moderationLog.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No moderation actions have been recorded yet.
+            </p>
+          )}
+          {moderationLog.map((entry) => (
+            <div
+              key={entry.id}
+              className="rounded-md border border-border/60 bg-muted/40 p-3 text-sm"
+            >
+              <p>
+                <span className="font-medium">{entry.moderator}</span> ({
+                  roleDetails[entry.moderatorRole].label
+                }) {entry.action === "approve" ? "approved" : "rejected"} a
+                {" "}
+                {entry.targetType}.
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {formatDate(entry.timestamp)}
+              </p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default CommunicationsHub

--- a/web/features/communications/permissions.ts
+++ b/web/features/communications/permissions.ts
@@ -1,0 +1,64 @@
+import type { Role } from "./types"
+
+export type Permission =
+  | "createPost"
+  | "comment"
+  | "moderate"
+  | "participateSurvey"
+  | "toggleLobby"
+
+const rolePermissions: Record<Role, Set<Permission>> = {
+  resident: new Set<Permission>([
+    "createPost",
+    "comment",
+    "participateSurvey",
+    "toggleLobby",
+  ]),
+  moderator: new Set<Permission>([
+    "createPost",
+    "comment",
+    "participateSurvey",
+    "moderate",
+    "toggleLobby",
+  ]),
+  admin: new Set<Permission>([
+    "createPost",
+    "comment",
+    "participateSurvey",
+    "moderate",
+    "toggleLobby",
+  ]),
+  guest: new Set<Permission>(["toggleLobby"]),
+}
+
+export const roleDetails: Record<
+  Role,
+  { label: string; summary: string; defaultAuthor: string }
+> = {
+  resident: {
+    label: "Resident",
+    summary: "Residents can share updates, comment on posts, and participate in surveys.",
+    defaultAuthor: "Resident",
+  },
+  moderator: {
+    label: "Community Moderator",
+    summary:
+      "Moderators review flagged content and keep the bulletin board collaborative and safe.",
+    defaultAuthor: "Moderator",
+  },
+  admin: {
+    label: "Building Admin",
+    summary:
+      "Admins can manage all content streams and ensure community guidelines are followed.",
+    defaultAuthor: "Building Admin",
+  },
+  guest: {
+    label: "Guest Viewer",
+    summary:
+      "Guests can only view the lobby display without contributing content.",
+    defaultAuthor: "Guest",
+  },
+}
+
+export const can = (role: Role, permission: Permission) =>
+  rolePermissions[role]?.has(permission) ?? false

--- a/web/features/communications/types.ts
+++ b/web/features/communications/types.ts
@@ -1,0 +1,53 @@
+export type Role = "resident" | "moderator" | "admin" | "guest"
+
+export type BulletinStatus = "published" | "pending" | "rejected"
+
+export interface BulletinComment {
+  id: string
+  author: string
+  role: Role
+  message: string
+  createdAt: string
+  flagged: boolean
+  matches: string[]
+  status: BulletinStatus
+}
+
+export interface BulletinPost {
+  id: string
+  title: string
+  author: string
+  role: Role
+  message: string
+  createdAt: string
+  status: BulletinStatus
+  flagged: boolean
+  matches: string[]
+  comments: BulletinComment[]
+}
+
+export type ModerationAction = "approve" | "reject"
+
+export interface ModerationLogEntry {
+  id: string
+  targetId: string
+  targetType: "post" | "comment"
+  action: ModerationAction
+  moderator: string
+  moderatorRole: Role
+  timestamp: string
+  notes?: string
+}
+
+export interface SurveyOption {
+  id: string
+  label: string
+  description?: string
+  votes: number
+}
+
+export interface SurveyDefinition {
+  question: string
+  closingNote: string
+  options: SurveyOption[]
+}


### PR DESCRIPTION
## Summary
- implement a resident communications hub with RBAC-aware bulletin posts, comment moderation, survey voting, and lobby display tools, including content filtering and feedback messaging
- expose the hub at /playground/communications for quick access
- configure Playwright and add end-to-end coverage for bulletin submission and moderation flows

## Testing
- pnpm lint
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68ceeff0452483289f3ad52f052052ba