### PR TITLE
feat: add directory services and import endpoint

### DIFF
--- a/app/api/directory/import/route.ts
+++ b/app/api/directory/import/route.ts
@@ -1,0 +1,376 @@
+import { NextRequest } from 'next/server'
+import { parse } from 'csv-parse/sync'
+import {
+  AuthContext,
+  DirectoryRole,
+  SupabaseDirectoryRepository,
+  createBuilding,
+  createResident,
+  createStaff,
+  createUnit,
+  BuildingCreateInput,
+  ResidentCreateInput,
+  StaffCreateInput,
+  UnitCreateInput,
+} from '@/services/directory'
+import { createSupbaseServerClient } from '@/utils/supaone'
+import { UserError } from '@/lib/errors'
+import type { Json } from '@/lib/supabase'
+
+type ImportEntity = 'buildings' | 'units' | 'residents' | 'staff'
+
+interface ImportRequestBody {
+  entity: ImportEntity
+  csv: string
+  tenantId?: string
+  dryRun?: boolean
+}
+
+interface ImportIssue {
+  row: number
+  message: string
+  identifier?: string
+}
+
+interface ImportSummary {
+  total: number
+  inserted: number
+  planned: number
+  duplicates: ImportIssue[]
+  errors: ImportIssue[]
+  dryRun: boolean
+}
+
+const SUPPORTED_ENTITIES: ImportEntity[] = ['buildings', 'units', 'residents', 'staff']
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json()) as ImportRequestBody
+
+  if (!body.entity || !SUPPORTED_ENTITIES.includes(body.entity)) {
+    return Response.json({ error: 'Unsupported entity type.' }, { status: 400 })
+  }
+
+  if (!body.csv || typeof body.csv !== 'string') {
+    return Response.json({ error: 'A CSV payload is required.' }, { status: 400 })
+  }
+
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, role, public_id')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    return Response.json({ error: 'Unable to resolve user profile.' }, { status: 500 })
+  }
+
+  if (!profile) {
+    return Response.json({ error: 'Profile not found.' }, { status: 404 })
+  }
+
+  const tenantId = profile.public_id ?? body.tenantId
+
+  if (!tenantId) {
+    return Response.json({ error: 'A tenant scope is required.' }, { status: 400 })
+  }
+
+  if (body.tenantId && body.tenantId !== tenantId) {
+    return Response.json({ error: 'Tenant scope mismatch.' }, { status: 403 })
+  }
+
+  const context: AuthContext = {
+    role: resolveRole(profile.role),
+    tenantId,
+    userId: user.id,
+  }
+
+  if (context.role !== 'admin' && context.role !== 'manager') {
+    return Response.json(
+      { error: 'Insufficient permissions to import directory data.' },
+      { status: 403 }
+    )
+  }
+
+  const repository = new SupabaseDirectoryRepository(supabase)
+
+  let records: Record<string, string>[]
+
+  try {
+    records = parse(body.csv, {
+      columns: true,
+      skip_empty_lines: true,
+      trim: true,
+    })
+  } catch (error) {
+    return Response.json(
+      { error: 'Failed to parse CSV payload.', details: getErrorMessage(error) },
+      { status: 400 }
+    )
+  }
+
+  const dryRun = Boolean(body.dryRun)
+  const duplicates: ImportIssue[] = []
+  const errors: ImportIssue[] = []
+  let planned = 0
+  let inserted = 0
+
+  for (const [index, row] of records.entries()) {
+    const rowNumber = index + 2
+
+    try {
+      switch (body.entity) {
+        case 'buildings': {
+          const payload = mapBuildingRow(row)
+          const duplicate = await repository.findBuildingByName(context.tenantId, payload.name)
+
+          if (duplicate) {
+            duplicates.push({
+              row: rowNumber,
+              message: 'Building already exists.',
+              identifier: duplicate.id,
+            })
+            continue
+          }
+
+          planned += 1
+          if (!dryRun) {
+            await createBuilding(repository, context, payload)
+            inserted += 1
+          }
+          break
+        }
+        case 'units': {
+          const payload = mapUnitRow(row)
+          const duplicate = await repository.findUnitByNumber(
+            context.tenantId,
+            payload.building_id,
+            payload.unit_number
+          )
+
+          if (duplicate) {
+            duplicates.push({
+              row: rowNumber,
+              message: 'Unit already exists for this building.',
+              identifier: duplicate.id,
+            })
+            continue
+          }
+
+          planned += 1
+          if (!dryRun) {
+            await createUnit(repository, context, payload)
+            inserted += 1
+          }
+          break
+        }
+        case 'residents': {
+          const payload = mapResidentRow(row)
+          const duplicate = await repository.findResidentByEmail(context.tenantId, payload.email)
+
+          if (duplicate) {
+            duplicates.push({
+              row: rowNumber,
+              message: 'Resident already exists for this tenant.',
+              identifier: duplicate.id,
+            })
+            continue
+          }
+
+          planned += 1
+          if (!dryRun) {
+            await createResident(repository, context, payload)
+            inserted += 1
+          }
+          break
+        }
+        case 'staff': {
+          const payload = mapStaffRow(row)
+          const duplicate = await repository.findStaffByEmail(context.tenantId, payload.email)
+
+          if (duplicate) {
+            duplicates.push({
+              row: rowNumber,
+              message: 'Staff member already exists for this tenant.',
+              identifier: duplicate.id,
+            })
+            continue
+          }
+
+          planned += 1
+          if (!dryRun) {
+            await createStaff(repository, context, payload)
+            inserted += 1
+          }
+          break
+        }
+      }
+    } catch (error) {
+      errors.push({ row: rowNumber, message: getErrorMessage(error) })
+    }
+  }
+
+  const summary: ImportSummary = {
+    total: records.length,
+    inserted,
+    planned,
+    duplicates,
+    errors,
+    dryRun,
+  }
+
+  return Response.json(summary)
+}
+
+function resolveRole(role: string | null): DirectoryRole {
+  if (!role) {
+    return 'viewer'
+  }
+
+  if (role === 'admin' || role === 'manager' || role === 'staff' || role === 'viewer') {
+    return role
+  }
+
+  return 'viewer'
+}
+
+function mapBuildingRow(row: Record<string, string>): Omit<BuildingCreateInput, 'tenant_id'> {
+  return {
+    name: required(row, 'name', 'Building name'),
+    address_line1: optional(row, 'address_line1'),
+    address_line2: optional(row, 'address_line2'),
+    city: optional(row, 'city'),
+    state: optional(row, 'state'),
+    postal_code: optional(row, 'postal_code'),
+    country: optional(row, 'country'),
+    status: optional(row, 'status'),
+    metadata: parseJson(row.metadata),
+  }
+}
+
+function mapUnitRow(row: Record<string, string>): Omit<UnitCreateInput, 'tenant_id'> {
+  const bedrooms = optionalNumber(row, 'bedrooms')
+  const bathrooms = optionalNumber(row, 'bathrooms')
+  const squareFeet = optionalNumber(row, 'square_feet')
+
+  return {
+    building_id: required(row, 'building_id', 'Building ID'),
+    unit_number: required(row, 'unit_number', 'Unit number'),
+    floor: optional(row, 'floor'),
+    bedrooms,
+    bathrooms,
+    square_feet: squareFeet,
+    status: optional(row, 'status'),
+    metadata: parseJson(row.metadata),
+  }
+}
+
+function mapResidentRow(row: Record<string, string>): Omit<ResidentCreateInput, 'tenant_id'> {
+  return {
+    building_id: optional(row, 'building_id'),
+    unit_id: optional(row, 'unit_id'),
+    first_name: required(row, 'first_name', 'First name'),
+    last_name: required(row, 'last_name', 'Last name'),
+    email: required(row, 'email', 'Email'),
+    phone: optional(row, 'phone'),
+    status: optional(row, 'status'),
+    move_in_date: optionalDate(row, 'move_in_date'),
+    move_out_date: optionalDate(row, 'move_out_date'),
+    metadata: parseJson(row.metadata),
+  }
+}
+
+function mapStaffRow(row: Record<string, string>): Omit<StaffCreateInput, 'tenant_id'> {
+  return {
+    building_id: optional(row, 'building_id'),
+    first_name: required(row, 'first_name', 'First name'),
+    last_name: required(row, 'last_name', 'Last name'),
+    email: required(row, 'email', 'Email'),
+    phone: optional(row, 'phone'),
+    role: optional(row, 'role'),
+    status: optional(row, 'status'),
+    metadata: parseJson(row.metadata),
+  }
+}
+
+function required(row: Record<string, string>, key: string, label: string) {
+  const value = row[key]
+
+  if (!value || !value.trim()) {
+    throw new UserError(`${label} is required.`)
+  }
+
+  return value.trim()
+}
+
+function optional(row: Record<string, string>, key: string) {
+  const value = row[key]
+  return value && value.trim() ? value.trim() : null
+}
+
+function optionalNumber(row: Record<string, string>, key: string) {
+  const value = optional(row, key)
+
+  if (!value) {
+    return null
+  }
+
+  const parsed = Number(value)
+
+  if (Number.isNaN(parsed)) {
+    throw new UserError(`Invalid numeric value provided for ${key}.`)
+  }
+
+  return parsed
+}
+
+function optionalDate(row: Record<string, string>, key: string) {
+  const value = optional(row, key)
+
+  if (!value) {
+    return null
+  }
+
+  const parsed = new Date(value)
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new UserError(`Invalid date value provided for ${key}.`)
+  }
+
+  return parsed.toISOString()
+}
+
+function parseJson(value: string | undefined): Json | null {
+  const trimmed = value?.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    return JSON.parse(trimmed)
+  } catch (error) {
+    throw new UserError('Invalid metadata JSON payload.')
+  }
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof UserError) {
+    return error.message
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return 'Unknown error'
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -239,6 +239,226 @@ export type Database = {
           },
         ]
       }
+      directory_buildings: {
+        Row: {
+          address_line1: string | null
+          address_line2: string | null
+          city: string | null
+          country: string | null
+          created_at: string
+          id: string
+          metadata: Json | null
+          name: string
+          postal_code: string | null
+          state: string | null
+          status: string | null
+          tenant_id: string
+          updated_at: string
+        }
+        Insert: {
+          address_line1?: string | null
+          address_line2?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          name: string
+          postal_code?: string | null
+          state?: string | null
+          status?: string | null
+          tenant_id: string
+          updated_at?: string
+        }
+        Update: {
+          address_line1?: string | null
+          address_line2?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          name?: string
+          postal_code?: string | null
+          state?: string | null
+          status?: string | null
+          tenant_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      directory_residents: {
+        Row: {
+          building_id: string | null
+          created_at: string
+          email: string
+          first_name: string
+          id: string
+          last_name: string
+          metadata: Json | null
+          move_in_date: string | null
+          move_out_date: string | null
+          phone: string | null
+          status: string | null
+          tenant_id: string
+          unit_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          building_id?: string | null
+          created_at?: string
+          email: string
+          first_name: string
+          id?: string
+          last_name: string
+          metadata?: Json | null
+          move_in_date?: string | null
+          move_out_date?: string | null
+          phone?: string | null
+          status?: string | null
+          tenant_id: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          building_id?: string | null
+          created_at?: string
+          email?: string
+          first_name?: string
+          id?: string
+          last_name?: string
+          metadata?: Json | null
+          move_in_date?: string | null
+          move_out_date?: string | null
+          phone?: string | null
+          status?: string | null
+          tenant_id?: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "directory_residents_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "directory_buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "directory_residents_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "directory_units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      directory_staff: {
+        Row: {
+          building_id: string | null
+          created_at: string
+          email: string
+          first_name: string
+          id: string
+          last_name: string
+          metadata: Json | null
+          phone: string | null
+          role: string | null
+          status: string | null
+          tenant_id: string
+          updated_at: string
+        }
+        Insert: {
+          building_id?: string | null
+          created_at?: string
+          email: string
+          first_name: string
+          id?: string
+          last_name: string
+          metadata?: Json | null
+          phone?: string | null
+          role?: string | null
+          status?: string | null
+          tenant_id: string
+          updated_at?: string
+        }
+        Update: {
+          building_id?: string | null
+          created_at?: string
+          email?: string
+          first_name?: string
+          id?: string
+          last_name?: string
+          metadata?: Json | null
+          phone?: string | null
+          role?: string | null
+          status?: string | null
+          tenant_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "directory_staff_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "directory_buildings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      directory_units: {
+        Row: {
+          bathrooms: number | null
+          bedrooms: number | null
+          building_id: string
+          created_at: string
+          floor: string | null
+          id: string
+          metadata: Json | null
+          square_feet: number | null
+          status: string | null
+          tenant_id: string
+          unit_number: string
+          updated_at: string
+        }
+        Insert: {
+          bathrooms?: number | null
+          bedrooms?: number | null
+          building_id: string
+          created_at?: string
+          floor?: string | null
+          id?: string
+          metadata?: Json | null
+          square_feet?: number | null
+          status?: string | null
+          tenant_id: string
+          unit_number: string
+          updated_at?: string
+        }
+        Update: {
+          bathrooms?: number | null
+          bedrooms?: number | null
+          building_id?: string
+          created_at?: string
+          floor?: string | null
+          id?: string
+          metadata?: Json | null
+          square_feet?: number | null
+          status?: string | null
+          tenant_id?: string
+          unit_number?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "directory_units_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "directory_buildings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       ai_analysis_results: {
         Row: {
           agent_id: string | null

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -57,6 +58,7 @@
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
     "clsx": "^2.1.0",
+    "csv-parse": "^5.5.4",
     "cmdk": "^0.2.1",
     "date-fns": "^3.3.1",
     "eventemitter3": "^5.0.1",
@@ -109,6 +111,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^1.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -155,6 +155,9 @@ importers:
       cmdk:
         specifier: ^0.2.1
         version: 0.2.1(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      csv-parse:
+        specifier: ^5.5.4
+        version: 5.6.0
       date-fns:
         specifier: ^3.3.1
         version: 3.3.1
@@ -187,13 +190,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -306,6 +309,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.14.15)(terser@5.39.0)
 
 packages:
 
@@ -1328,6 +1334,144 @@ packages:
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1409,6 +1553,10 @@ packages:
       '@types/react-dom': ^18.0.11
       react: ^18.2.0
       react-dom: ^18.2.0
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -2323,6 +2471,116 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rushstack/eslint-patch@1.6.1':
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
 
@@ -2337,6 +2595,9 @@ packages:
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
   '@supabase-cache-helpers/postgrest-core@0.3.0':
     resolution: {integrity: sha512-anLCZeyKcTl5ggrn2xyZ7WRq6q1QnHxIemevg7OX+3NOw+xatZ0g0HpBBFrQfRLTz2UD6K5oeqmIKN9EPrNgeA==}
@@ -2489,6 +2750,9 @@ packages:
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/google-one-tap@1.2.6':
     resolution: {integrity: sha512-REmJsXVHvKb/sgI8DF+7IesMbDbcsEokHBqxU01ENZ8d98UPWdRLhUCtxEm9bhNFFg6PJGy7PNFdvovp0hK3jA==}
@@ -2649,6 +2913,21 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
   '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
 
@@ -2746,6 +3025,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
@@ -2758,6 +3041,11 @@ packages:
 
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2804,6 +3092,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -2862,6 +3154,9 @@ packages:
   arraybuffer.prototype.slice@1.0.2:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -3020,6 +3315,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3056,6 +3355,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3084,6 +3387,9 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -3169,6 +3475,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
@@ -3237,6 +3546,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  csv-parse@5.6.0:
+    resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -3315,6 +3627,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -3353,6 +3669,10 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3473,6 +3793,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -3644,6 +3969,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -3780,6 +4109,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.2.2:
     resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
 
@@ -3797,6 +4129,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -3959,6 +4295,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -4141,6 +4481,10 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -4217,6 +4561,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -4314,6 +4661,10 @@ packages:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -4356,6 +4707,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -4543,6 +4897,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -4579,6 +4937,9 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -4678,6 +5039,10 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4722,6 +5087,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -4729,6 +5098,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -4766,6 +5139,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -4780,6 +5157,15 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -4807,6 +5193,9 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   postcss-attribute-case-insensitive@7.0.0:
     resolution: {integrity: sha512-ETMUHIw67Kyv9Q81nden/NuJbRh+4/S963giXpfSLd5eaKK8kd1UdAHMVRV/NG/w/N6Cq8B0qZIZbZZWU/67+A==}
@@ -5040,6 +5429,10 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   prismjs@1.27.0:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
     engines: {node: '>=6'}
@@ -5125,6 +5518,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
@@ -5317,6 +5713,11 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5404,6 +5805,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5474,6 +5878,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
     peerDependencies:
@@ -5482,6 +5889,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -5537,6 +5947,10 @@ packages:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -5544,6 +5958,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -5690,6 +6107,17 @@ packages:
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -5748,6 +6176,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@0.16.0:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
@@ -5775,6 +6207,9 @@ packages:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -5934,6 +6369,67 @@ packages:
   victory-vendor@36.8.6:
     resolution: {integrity: sha512-PH8Wj9b0xIZ4AVfyn0c1SJrOhtxDJ5PNxj1ZDABPg1Gw1vJr1mJVqESPhvsFj7mXLQohVdiKqp4kWZkXlPcRcA==}
 
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.20:
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.4.35:
     resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
     peerDependencies:
@@ -5998,6 +6494,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workbox-background-sync@7.1.0:
@@ -6103,6 +6604,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
@@ -7302,10 +7807,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7400,6 +7905,75 @@ snapshots:
   '@emotion/utils@1.2.1': {}
 
   '@emotion/weak-memoize@0.3.1': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
@@ -7500,6 +8074,10 @@ snapshots:
       '@types/react-dom': 18.3.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
 
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
@@ -8524,6 +9102,72 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
   '@rushstack/eslint-patch@1.6.1': {}
 
   '@scure/base@1.1.5': {}
@@ -8543,6 +9187,8 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@sinclair/typebox@0.27.8': {}
 
   '@supabase-cache-helpers/postgrest-core@0.3.0(@supabase/postgrest-js@1.9.2)(@supabase/supabase-js@2.39.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
@@ -8723,6 +9369,8 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/estree@1.0.8': {}
+
   '@types/google-one-tap@1.2.6': {}
 
   '@types/hast@2.3.10':
@@ -8853,19 +9501,48 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
+
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
 
   '@vue/compiler-core@3.4.35':
     dependencies:
@@ -9022,11 +9699,17 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.14.1
+
   acorn@8.11.3: {}
 
   acorn@8.12.1: {}
 
   acorn@8.14.1: {}
+
+  acorn@8.15.0: {}
 
   agent-base@7.1.3: {}
 
@@ -9068,6 +9751,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
 
@@ -9147,6 +9832,8 @@ snapshots:
       get-intrinsic: 1.2.2
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
+
+  assertion-error@1.1.0: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -9327,6 +10014,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -9359,6 +10048,16 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9383,6 +10082,10 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   chokidar@3.5.3:
     dependencies:
@@ -9467,6 +10170,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  confbox@0.1.8: {}
+
   config-chain@1.1.13:
     dependencies:
       ini: 1.3.8
@@ -9532,6 +10237,8 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  csv-parse@5.6.0: {}
+
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
@@ -9592,6 +10299,10 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -9625,6 +10336,8 @@ snapshots:
       dequal: 2.0.3
 
   didyoumean@1.2.2: {}
+
+  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -9802,6 +10515,32 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
@@ -9815,8 +10554,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +10577,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +10594,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +10615,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10063,6 +10802,18 @@ snapshots:
 
   events@3.3.0: {}
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   expand-template@2.0.3: {}
 
   extend@3.0.2: {}
@@ -10198,6 +10949,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.2.2:
     dependencies:
       function-bind: 1.1.2
@@ -10226,6 +10979,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.0.0:
     dependencies:
@@ -10469,6 +11224,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@5.0.0: {}
+
   idb@7.1.1: {}
 
   ieee754@1.2.1: {}
@@ -10628,6 +11385,8 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  is-stream@3.0.0: {}
+
   is-string@1.0.7:
     dependencies:
       has-tostringtag: 1.0.0
@@ -10715,6 +11474,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -10798,6 +11559,11 @@ snapshots:
 
   loader-runner@4.3.0: {}
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 1.3.1
+
   locate-character@3.0.0:
     optional: true
 
@@ -10829,6 +11595,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -10858,7 +11628,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   markdown-extensions@2.0.0: {}
 
@@ -11199,6 +11968,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@4.0.0: {}
+
   mimic-response@3.1.0: {}
 
   minimatch@3.1.2:
@@ -11229,6 +12000,13 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
+
   ms@2.1.2: {}
 
   ms@2.1.3: {}
@@ -11239,8 +12017,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -11252,13 +12029,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +12045,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11310,6 +12087,10 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   object-assign@4.1.1: {}
 
@@ -11362,6 +12143,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   optionator@0.9.3:
     dependencies:
       '@aashutoshrathi/word-wrap': 1.2.6
@@ -11374,6 +12159,10 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.1
 
   p-locate@5.0.0:
     dependencies:
@@ -11423,6 +12212,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-scurry@1.10.1:
@@ -11437,6 +12228,12 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
+
   peberminta@0.9.0: {}
 
   periscopic@3.1.0:
@@ -11449,14 +12246,19 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
 
   postcss-attribute-case-insensitive@7.0.0(postcss@8.4.32):
     dependencies:
@@ -11711,7 +12513,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -11725,7 +12527,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   potpack@1.0.2: {}
 
@@ -11749,6 +12550,12 @@ snapshots:
   prettier@2.8.8: {}
 
   pretty-bytes@5.6.0: {}
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
 
   prismjs@1.27.0: {}
 
@@ -11827,6 +12634,8 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react-lifecycles-compat@3.0.4: {}
 
@@ -12063,6 +12872,34 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12183,6 +13020,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -12212,8 +13051,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -12236,12 +13074,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
     dependencies:
       '@types/three': 0.176.0
       three: 0.160.0
 
   stats.js@0.17.0: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -12322,9 +13164,15 @@ snapshots:
 
   strip-comments@2.0.1: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-to-object@0.4.4:
     dependencies:
@@ -12334,12 +13182,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 
@@ -12519,6 +13367,12 @@ snapshots:
 
   tiny-invariant@1.3.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -12575,6 +13429,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.1.0: {}
+
   type-fest@0.16.0: {}
 
   type-fest@0.20.2: {}
@@ -12607,6 +13463,8 @@ snapshots:
       is-typed-array: 1.1.12
 
   typescript@5.5.4: {}
+
+  ufo@1.6.1: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -12784,6 +13642,68 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@1.6.1(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.20(@types/node@20.14.15)(terser@5.39.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.20(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.3
+      rollup: 4.52.0
+    optionalDependencies:
+      '@types/node': 20.14.15
+      fsevents: 2.3.3
+      terser: 5.39.0
+
+  vitest@1.6.1(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@20.14.15)(terser@5.39.0)
+      vite-node: 1.6.1(@types/node@20.14.15)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.14.15
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
@@ -12898,6 +13818,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workbox-background-sync@7.1.0:
     dependencies:
@@ -13099,6 +14024,8 @@ snapshots:
   yaml@2.3.4: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.1: {}
 
   zod@3.22.4: {}
 

--- a/services/directory/__tests__/directory-controllers.test.ts
+++ b/services/directory/__tests__/directory-controllers.test.ts
@@ -1,0 +1,512 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  createBuilding,
+  createResident,
+  createStaff,
+  createUnit,
+  deleteBuilding,
+  listResidents,
+  listBuildings,
+  listUnits,
+  listStaff,
+  updateBuilding,
+  DirectoryRepository,
+  DirectoryBuilding,
+  DirectoryUnit,
+  DirectoryResident,
+  DirectoryStaff,
+  AuthContext,
+  BuildingCreateInput,
+  UnitCreateInput,
+  ResidentCreateInput,
+  StaffCreateInput,
+} from '../index'
+import { UserError } from '@/lib/errors'
+
+class InMemoryDirectoryRepository implements DirectoryRepository {
+  private buildings: DirectoryBuilding[] = []
+  private units: DirectoryUnit[] = []
+  private residents: DirectoryResident[] = []
+  private staff: DirectoryStaff[] = []
+
+  private nextId(prefix: string) {
+    return `${prefix}_${Math.random().toString(36).slice(2, 10)}`
+  }
+
+  async listBuildings(tenantId: string, params = {}) {
+    const page = (params as any).page ?? 1
+    const pageSize = (params as any).pageSize ?? 25
+    const search = ((params as any).search as string | undefined)?.toLowerCase()
+    const city = (params as any).city as string[] | undefined
+    const status = (params as any).status as string[] | undefined
+
+    let data = this.buildings.filter(item => item.tenant_id === tenantId)
+
+    if (search) {
+      data = data.filter(item =>
+        [
+          item.name,
+          item.city,
+          item.state,
+          item.postal_code,
+          item.country,
+          item.address_line1,
+        ]
+          .filter(Boolean)
+          .some(field => field!.toLowerCase().includes(search))
+      )
+    }
+
+    if (city?.length) {
+      data = data.filter(item => (item.city ? city.includes(item.city) : false))
+    }
+
+    if (status?.length) {
+      data = data.filter(item => (item.status ? status.includes(item.status) : false))
+    }
+
+    const total = data.length
+    const start = (page - 1) * pageSize
+    const end = start + pageSize
+
+    return { data: data.slice(start, end), total, page, pageSize }
+  }
+
+  async getBuilding(tenantId: string, id: string) {
+    return this.buildings.find(item => item.tenant_id === tenantId && item.id === id) ?? null
+  }
+
+  async createBuilding(payload: BuildingCreateInput) {
+    const now = new Date().toISOString()
+    const building: DirectoryBuilding = {
+      ...payload,
+      id: this.nextId('building'),
+      created_at: now,
+      updated_at: now,
+    }
+    this.buildings.push(building)
+    return building
+  }
+
+  async updateBuilding(tenantId: string, id: string, updates: Partial<DirectoryBuilding>) {
+    const existing = await this.getBuilding(tenantId, id)
+
+    if (!existing) {
+      throw new Error('Not found')
+    }
+
+    Object.assign(existing, updates, { updated_at: new Date().toISOString() })
+    return existing
+  }
+
+  async deleteBuilding(tenantId: string, id: string) {
+    this.buildings = this.buildings.filter(item => !(item.tenant_id === tenantId && item.id === id))
+  }
+
+  async findBuildingByName(tenantId: string, name: string) {
+    const lower = name.toLowerCase()
+    return (
+      this.buildings.find(
+        item => item.tenant_id === tenantId && item.name.toLowerCase() === lower
+      ) ?? null
+    )
+  }
+
+  async listUnits(tenantId: string, params = {}) {
+    const page = (params as any).page ?? 1
+    const pageSize = (params as any).pageSize ?? 25
+    const search = ((params as any).search as string | undefined)?.toLowerCase()
+    const buildingIds = (params as any).buildingIds as string[] | undefined
+    const status = (params as any).status as string[] | undefined
+
+    let data = this.units.filter(item => item.tenant_id === tenantId)
+
+    if (search) {
+      data = data.filter(item =>
+        [item.unit_number, item.floor, item.status]
+          .filter(Boolean)
+          .some(field => field!.toLowerCase().includes(search))
+      )
+    }
+
+    if (buildingIds?.length) {
+      data = data.filter(item => buildingIds.includes(item.building_id))
+    }
+
+    if (status?.length) {
+      data = data.filter(item => (item.status ? status.includes(item.status) : false))
+    }
+
+    const total = data.length
+    const start = (page - 1) * pageSize
+    const end = start + pageSize
+
+    return { data: data.slice(start, end), total, page, pageSize }
+  }
+
+  async getUnit(tenantId: string, id: string) {
+    return this.units.find(item => item.tenant_id === tenantId && item.id === id) ?? null
+  }
+
+  async createUnit(payload: UnitCreateInput) {
+    const now = new Date().toISOString()
+    const unit: DirectoryUnit = {
+      ...payload,
+      id: this.nextId('unit'),
+      created_at: now,
+      updated_at: now,
+    }
+    this.units.push(unit)
+    return unit
+  }
+
+  async updateUnit(tenantId: string, id: string, updates: Partial<DirectoryUnit>) {
+    const existing = await this.getUnit(tenantId, id)
+
+    if (!existing) {
+      throw new Error('Not found')
+    }
+
+    Object.assign(existing, updates, { updated_at: new Date().toISOString() })
+    return existing
+  }
+
+  async deleteUnit(tenantId: string, id: string) {
+    this.units = this.units.filter(item => !(item.tenant_id === tenantId && item.id === id))
+  }
+
+  async findUnitByNumber(tenantId: string, buildingId: string, unitNumber: string) {
+    const lower = unitNumber.toLowerCase()
+    return (
+      this.units.find(
+        item =>
+          item.tenant_id === tenantId &&
+          item.building_id === buildingId &&
+          item.unit_number.toLowerCase() === lower
+      ) ?? null
+    )
+  }
+
+  async listResidents(tenantId: string, params = {}) {
+    const page = (params as any).page ?? 1
+    const pageSize = (params as any).pageSize ?? 25
+    const search = ((params as any).search as string | undefined)?.toLowerCase()
+    const unitIds = (params as any).unitIds as string[] | undefined
+    const buildingIds = (params as any).buildingIds as string[] | undefined
+    const status = (params as any).status as string[] | undefined
+
+    let data = this.residents.filter(item => item.tenant_id === tenantId)
+
+    if (search) {
+      data = data.filter(item =>
+        [item.first_name, item.last_name, item.email, item.phone]
+          .filter(Boolean)
+          .some(field => field!.toLowerCase().includes(search))
+      )
+    }
+
+    if (unitIds?.length) {
+      data = data.filter(item => (item.unit_id ? unitIds.includes(item.unit_id) : false))
+    }
+
+    if (buildingIds?.length) {
+      data = data.filter(item => (item.building_id ? buildingIds.includes(item.building_id) : false))
+    }
+
+    if (status?.length) {
+      data = data.filter(item => (item.status ? status.includes(item.status) : false))
+    }
+
+    const total = data.length
+    const start = (page - 1) * pageSize
+    const end = start + pageSize
+
+    return { data: data.slice(start, end), total, page, pageSize }
+  }
+
+  async getResident(tenantId: string, id: string) {
+    return this.residents.find(item => item.tenant_id === tenantId && item.id === id) ?? null
+  }
+
+  async createResident(payload: ResidentCreateInput) {
+    const now = new Date().toISOString()
+    const resident: DirectoryResident = {
+      ...payload,
+      id: this.nextId('resident'),
+      created_at: now,
+      updated_at: now,
+    }
+    this.residents.push(resident)
+    return resident
+  }
+
+  async updateResident(tenantId: string, id: string, updates: Partial<DirectoryResident>) {
+    const existing = await this.getResident(tenantId, id)
+
+    if (!existing) {
+      throw new Error('Not found')
+    }
+
+    Object.assign(existing, updates, { updated_at: new Date().toISOString() })
+    return existing
+  }
+
+  async deleteResident(tenantId: string, id: string) {
+    this.residents = this.residents.filter(item => !(item.tenant_id === tenantId && item.id === id))
+  }
+
+  async findResidentByEmail(tenantId: string, email: string) {
+    const lower = email.toLowerCase()
+    return (
+      this.residents.find(
+        item => item.tenant_id === tenantId && item.email.toLowerCase() === lower
+      ) ?? null
+    )
+  }
+
+  async listStaff(tenantId: string, params = {}) {
+    const page = (params as any).page ?? 1
+    const pageSize = (params as any).pageSize ?? 25
+    const search = ((params as any).search as string | undefined)?.toLowerCase()
+    const buildingIds = (params as any).buildingIds as string[] | undefined
+    const status = (params as any).status as string[] | undefined
+    const roles = (params as any).roles as string[] | undefined
+
+    let data = this.staff.filter(item => item.tenant_id === tenantId)
+
+    if (search) {
+      data = data.filter(item =>
+        [item.first_name, item.last_name, item.email, item.phone, item.role]
+          .filter(Boolean)
+          .some(field => field!.toLowerCase().includes(search))
+      )
+    }
+
+    if (buildingIds?.length) {
+      data = data.filter(item => (item.building_id ? buildingIds.includes(item.building_id) : false))
+    }
+
+    if (status?.length) {
+      data = data.filter(item => (item.status ? status.includes(item.status) : false))
+    }
+
+    if (roles?.length) {
+      data = data.filter(item => (item.role ? roles.includes(item.role) : false))
+    }
+
+    const total = data.length
+    const start = (page - 1) * pageSize
+    const end = start + pageSize
+
+    return { data: data.slice(start, end), total, page, pageSize }
+  }
+
+  async getStaff(tenantId: string, id: string) {
+    return this.staff.find(item => item.tenant_id === tenantId && item.id === id) ?? null
+  }
+
+  async createStaff(payload: StaffCreateInput) {
+    const now = new Date().toISOString()
+    const staff: DirectoryStaff = {
+      ...payload,
+      id: this.nextId('staff'),
+      created_at: now,
+      updated_at: now,
+    }
+    this.staff.push(staff)
+    return staff
+  }
+
+  async updateStaff(tenantId: string, id: string, updates: Partial<DirectoryStaff>) {
+    const existing = await this.getStaff(tenantId, id)
+
+    if (!existing) {
+      throw new Error('Not found')
+    }
+
+    Object.assign(existing, updates, { updated_at: new Date().toISOString() })
+    return existing
+  }
+
+  async deleteStaff(tenantId: string, id: string) {
+    this.staff = this.staff.filter(item => !(item.tenant_id === tenantId && item.id === id))
+  }
+
+  async findStaffByEmail(tenantId: string, email: string) {
+    const lower = email.toLowerCase()
+    return (
+      this.staff.find(item => item.tenant_id === tenantId && item.email.toLowerCase() === lower) ?? null
+    )
+  }
+}
+
+const ADMIN_CONTEXT: AuthContext = {
+  role: 'admin',
+  tenantId: 'tenant-1',
+  userId: 'user-1',
+}
+
+const STAFF_CONTEXT: AuthContext = {
+  role: 'staff',
+  tenantId: 'tenant-1',
+  userId: 'user-2',
+}
+
+const OTHER_TENANT_CONTEXT: AuthContext = {
+  role: 'admin',
+  tenantId: 'tenant-2',
+  userId: 'user-3',
+}
+
+const baseBuilding: Omit<BuildingCreateInput, 'tenant_id'> = {
+  name: 'North Tower',
+  address_line1: '123 Main St',
+  address_line2: null,
+  city: 'Metropolis',
+  state: 'CA',
+  postal_code: '90001',
+  country: 'USA',
+  status: 'active',
+  metadata: null,
+}
+
+const baseUnit: Omit<UnitCreateInput, 'tenant_id'> = {
+  building_id: 'building-1',
+  unit_number: '101A',
+  floor: '10',
+  bedrooms: 2,
+  bathrooms: 2,
+  square_feet: 1000,
+  status: 'occupied',
+  metadata: null,
+}
+
+const baseResident: Omit<ResidentCreateInput, 'tenant_id'> = {
+  building_id: 'building-1',
+  unit_id: 'unit-1',
+  first_name: 'Alice',
+  last_name: 'Liddell',
+  email: 'alice@example.com',
+  phone: '555-0000',
+  status: 'active',
+  move_in_date: null,
+  move_out_date: null,
+  metadata: null,
+}
+
+const baseStaff: Omit<StaffCreateInput, 'tenant_id'> = {
+  building_id: 'building-1',
+  first_name: 'Bob',
+  last_name: 'Builder',
+  email: 'bob@example.com',
+  phone: '555-2222',
+  role: 'maintenance',
+  status: 'active',
+  metadata: null,
+}
+
+describe('Directory controllers', () => {
+  let repository: InMemoryDirectoryRepository
+
+  beforeEach(() => {
+    repository = new InMemoryDirectoryRepository()
+  })
+
+  it('prevents non-admin users from mutating data', async () => {
+    await expect(createBuilding(repository, STAFF_CONTEXT, baseBuilding)).rejects.toBeInstanceOf(UserError)
+  })
+
+  it('scopes created entities to the tenant', async () => {
+    const building = await createBuilding(repository, ADMIN_CONTEXT, baseBuilding)
+    expect(building.tenant_id).toEqual(ADMIN_CONTEXT.tenantId)
+  })
+
+  it('filters residents by tenant and search query', async () => {
+    await createResident(repository, ADMIN_CONTEXT, baseResident)
+    await createResident(repository, {
+      ...ADMIN_CONTEXT,
+      tenantId: 'tenant-1',
+    }, {
+      ...baseResident,
+      email: 'beth@example.com',
+      first_name: 'Beth',
+    })
+
+    await createResident(repository, OTHER_TENANT_CONTEXT, {
+      ...baseResident,
+      email: 'chris@example.com',
+      first_name: 'Chris',
+    })
+
+    const result = await listResidents(repository, ADMIN_CONTEXT, { search: 'beth' })
+
+    expect(result.total).toBe(1)
+    expect(result.data[0].email).toBe('beth@example.com')
+  })
+
+  it('enforces tenant scoping when listing buildings', async () => {
+    await createBuilding(repository, ADMIN_CONTEXT, baseBuilding)
+    await createBuilding(repository, OTHER_TENANT_CONTEXT, {
+      ...baseBuilding,
+      name: 'South Tower',
+    })
+
+    const result = await listBuildings(repository, ADMIN_CONTEXT, {})
+    expect(result.total).toBe(1)
+    expect(result.data[0].name).toBe('North Tower')
+  })
+
+  it('applies building filters when listing units', async () => {
+    const buildingA = await createBuilding(repository, ADMIN_CONTEXT, baseBuilding)
+    const buildingB = await createBuilding(repository, ADMIN_CONTEXT, {
+      ...baseBuilding,
+      name: 'East Wing',
+      city: 'Gotham',
+    })
+
+    await createUnit(repository, ADMIN_CONTEXT, {
+      ...baseUnit,
+      building_id: buildingA.id,
+      unit_number: '101',
+    })
+    await createUnit(repository, ADMIN_CONTEXT, {
+      ...baseUnit,
+      building_id: buildingB.id,
+      unit_number: '202',
+    })
+
+    const result = await listUnits(repository, ADMIN_CONTEXT, {
+      buildingIds: [buildingB.id],
+    })
+
+    expect(result.total).toBe(1)
+    expect(result.data[0].unit_number).toBe('202')
+  })
+
+  it('supports status filters when listing staff', async () => {
+    await createStaff(repository, ADMIN_CONTEXT, baseStaff)
+    await createStaff(repository, ADMIN_CONTEXT, {
+      ...baseStaff,
+      email: 'carol@example.com',
+      first_name: 'Carol',
+      status: 'inactive',
+    })
+
+    const result = await listStaff(repository, ADMIN_CONTEXT, { status: ['inactive'] })
+    expect(result.total).toBe(1)
+    expect(result.data[0].email).toBe('carol@example.com')
+  })
+
+  it('allows administrators to update buildings', async () => {
+    const building = await createBuilding(repository, ADMIN_CONTEXT, baseBuilding)
+    const updated = await updateBuilding(repository, ADMIN_CONTEXT, building.id, { city: 'Gotham' })
+    expect(updated.city).toBe('Gotham')
+  })
+
+  it('allows administrators to delete buildings', async () => {
+    const building = await createBuilding(repository, ADMIN_CONTEXT, baseBuilding)
+    await deleteBuilding(repository, ADMIN_CONTEXT, building.id)
+    const result = await listBuildings(repository, ADMIN_CONTEXT, {})
+    expect(result.total).toBe(0)
+  })
+})

--- a/services/directory/buildings-controller.ts
+++ b/services/directory/buildings-controller.ts
@@ -1,0 +1,71 @@
+import { ApplicationError, UserError } from '@/lib/errors'
+import { assertCanMutate, normalizePagination } from './utils'
+import type {
+  AuthContext,
+  BuildingCreateInput,
+  BuildingListParams,
+  BuildingUpdateInput,
+  DirectoryRepository,
+  PaginatedResult,
+  DirectoryBuilding,
+} from './types'
+
+export async function listBuildings(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  params: BuildingListParams = {}
+): Promise<PaginatedResult<DirectoryBuilding>> {
+  const { page, pageSize } = normalizePagination(params)
+  return repository.listBuildings(context.tenantId, { ...params, page, pageSize })
+}
+
+export async function getBuilding(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string
+) {
+  const building = await repository.getBuilding(context.tenantId, id)
+
+  if (!building) {
+    throw new ApplicationError('Building not found', { id })
+  }
+
+  return building
+}
+
+export async function createBuilding(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  payload: Omit<BuildingCreateInput, 'tenant_id'>
+) {
+  assertCanMutate(context)
+
+  const duplicate = await repository.findBuildingByName(context.tenantId, payload.name)
+
+  if (duplicate) {
+    throw new UserError('A building with this name already exists.', {
+      buildingId: duplicate.id,
+    })
+  }
+
+  return repository.createBuilding({ ...payload, tenant_id: context.tenantId })
+}
+
+export async function updateBuilding(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string,
+  updates: BuildingUpdateInput
+) {
+  assertCanMutate(context)
+  return repository.updateBuilding(context.tenantId, id, updates)
+}
+
+export async function deleteBuilding(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string
+) {
+  assertCanMutate(context)
+  await repository.deleteBuilding(context.tenantId, id)
+}

--- a/services/directory/index.ts
+++ b/services/directory/index.ts
@@ -1,0 +1,8 @@
+export * from './types'
+export * from './repository'
+export * from './utils'
+export * from './buildings-controller'
+export * from './units-controller'
+export * from './residents-controller'
+export * from './staff-controller'
+export { SupabaseDirectoryRepository } from './supabase-repository'

--- a/services/directory/repository.ts
+++ b/services/directory/repository.ts
@@ -1,0 +1,49 @@
+import type {
+  BuildingCreateInput,
+  BuildingListParams,
+  BuildingUpdateInput,
+  DirectoryBuilding,
+  DirectoryResident,
+  DirectoryStaff,
+  DirectoryUnit,
+  PaginatedResult,
+  ResidentCreateInput,
+  ResidentListParams,
+  ResidentUpdateInput,
+  StaffCreateInput,
+  StaffListParams,
+  StaffUpdateInput,
+  UnitCreateInput,
+  UnitListParams,
+  UnitUpdateInput,
+} from './types'
+
+export interface DirectoryRepository {
+  listBuildings(tenantId: string, params?: BuildingListParams): Promise<PaginatedResult<DirectoryBuilding>>
+  getBuilding(tenantId: string, id: string): Promise<DirectoryBuilding | null>
+  createBuilding(payload: BuildingCreateInput): Promise<DirectoryBuilding>
+  updateBuilding(tenantId: string, id: string, updates: BuildingUpdateInput): Promise<DirectoryBuilding>
+  deleteBuilding(tenantId: string, id: string): Promise<void>
+  findBuildingByName(tenantId: string, name: string): Promise<DirectoryBuilding | null>
+
+  listUnits(tenantId: string, params?: UnitListParams): Promise<PaginatedResult<DirectoryUnit>>
+  getUnit(tenantId: string, id: string): Promise<DirectoryUnit | null>
+  createUnit(payload: UnitCreateInput): Promise<DirectoryUnit>
+  updateUnit(tenantId: string, id: string, updates: UnitUpdateInput): Promise<DirectoryUnit>
+  deleteUnit(tenantId: string, id: string): Promise<void>
+  findUnitByNumber(tenantId: string, buildingId: string, unitNumber: string): Promise<DirectoryUnit | null>
+
+  listResidents(tenantId: string, params?: ResidentListParams): Promise<PaginatedResult<DirectoryResident>>
+  getResident(tenantId: string, id: string): Promise<DirectoryResident | null>
+  createResident(payload: ResidentCreateInput): Promise<DirectoryResident>
+  updateResident(tenantId: string, id: string, updates: ResidentUpdateInput): Promise<DirectoryResident>
+  deleteResident(tenantId: string, id: string): Promise<void>
+  findResidentByEmail(tenantId: string, email: string): Promise<DirectoryResident | null>
+
+  listStaff(tenantId: string, params?: StaffListParams): Promise<PaginatedResult<DirectoryStaff>>
+  getStaff(tenantId: string, id: string): Promise<DirectoryStaff | null>
+  createStaff(payload: StaffCreateInput): Promise<DirectoryStaff>
+  updateStaff(tenantId: string, id: string, updates: StaffUpdateInput): Promise<DirectoryStaff>
+  deleteStaff(tenantId: string, id: string): Promise<void>
+  findStaffByEmail(tenantId: string, email: string): Promise<DirectoryStaff | null>
+}

--- a/services/directory/residents-controller.ts
+++ b/services/directory/residents-controller.ts
@@ -1,0 +1,71 @@
+import { ApplicationError, UserError } from '@/lib/errors'
+import { assertCanMutate, normalizePagination } from './utils'
+import type {
+  AuthContext,
+  DirectoryRepository,
+  DirectoryResident,
+  PaginatedResult,
+  ResidentCreateInput,
+  ResidentListParams,
+  ResidentUpdateInput,
+} from './types'
+
+export async function listResidents(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  params: ResidentListParams = {}
+): Promise<PaginatedResult<DirectoryResident>> {
+  const { page, pageSize } = normalizePagination(params)
+  return repository.listResidents(context.tenantId, { ...params, page, pageSize })
+}
+
+export async function getResident(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string
+) {
+  const resident = await repository.getResident(context.tenantId, id)
+
+  if (!resident) {
+    throw new ApplicationError('Resident not found', { id })
+  }
+
+  return resident
+}
+
+export async function createResident(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  payload: Omit<ResidentCreateInput, 'tenant_id'>
+) {
+  assertCanMutate(context)
+
+  const duplicate = await repository.findResidentByEmail(context.tenantId, payload.email)
+
+  if (duplicate) {
+    throw new UserError('A resident with this email already exists.', {
+      residentId: duplicate.id,
+    })
+  }
+
+  return repository.createResident({ ...payload, tenant_id: context.tenantId })
+}
+
+export async function updateResident(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string,
+  updates: ResidentUpdateInput
+) {
+  assertCanMutate(context)
+  return repository.updateResident(context.tenantId, id, updates)
+}
+
+export async function deleteResident(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string
+) {
+  assertCanMutate(context)
+  await repository.deleteResident(context.tenantId, id)
+}

--- a/services/directory/staff-controller.ts
+++ b/services/directory/staff-controller.ts
@@ -1,0 +1,71 @@
+import { ApplicationError, UserError } from '@/lib/errors'
+import { assertCanMutate, normalizePagination } from './utils'
+import type {
+  AuthContext,
+  DirectoryRepository,
+  DirectoryStaff,
+  PaginatedResult,
+  StaffCreateInput,
+  StaffListParams,
+  StaffUpdateInput,
+} from './types'
+
+export async function listStaff(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  params: StaffListParams = {}
+): Promise<PaginatedResult<DirectoryStaff>> {
+  const { page, pageSize } = normalizePagination(params)
+  return repository.listStaff(context.tenantId, { ...params, page, pageSize })
+}
+
+export async function getStaff(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string
+) {
+  const staff = await repository.getStaff(context.tenantId, id)
+
+  if (!staff) {
+    throw new ApplicationError('Staff member not found', { id })
+  }
+
+  return staff
+}
+
+export async function createStaff(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  payload: Omit<StaffCreateInput, 'tenant_id'>
+) {
+  assertCanMutate(context)
+
+  const duplicate = await repository.findStaffByEmail(context.tenantId, payload.email)
+
+  if (duplicate) {
+    throw new UserError('A staff member with this email already exists.', {
+      staffId: duplicate.id,
+    })
+  }
+
+  return repository.createStaff({ ...payload, tenant_id: context.tenantId })
+}
+
+export async function updateStaff(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string,
+  updates: StaffUpdateInput
+) {
+  assertCanMutate(context)
+  return repository.updateStaff(context.tenantId, id, updates)
+}
+
+export async function deleteStaff(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string
+) {
+  assertCanMutate(context)
+  await repository.deleteStaff(context.tenantId, id)
+}

--- a/services/directory/supabase-repository.ts
+++ b/services/directory/supabase-repository.ts
@@ -1,0 +1,519 @@
+import { ApplicationError } from '@/lib/errors'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import { normalizePagination, normalizeSearchTerm } from './utils'
+import type {
+  BuildingCreateInput,
+  BuildingListParams,
+  BuildingUpdateInput,
+  DirectoryBuilding,
+  DirectoryRepository,
+  DirectoryResident,
+  DirectoryStaff,
+  DirectoryUnit,
+  PaginatedResult,
+  ResidentCreateInput,
+  ResidentListParams,
+  ResidentUpdateInput,
+  StaffCreateInput,
+  StaffListParams,
+  StaffUpdateInput,
+  UnitCreateInput,
+  UnitListParams,
+  UnitUpdateInput,
+} from './types'
+
+export class SupabaseDirectoryRepository implements DirectoryRepository {
+  constructor(private readonly client: TypedSupabaseClient) {}
+
+  async listBuildings(
+    tenantId: string,
+    params: BuildingListParams = {}
+  ): Promise<PaginatedResult<DirectoryBuilding>> {
+    const { page, pageSize } = normalizePagination(params)
+    const from = (page - 1) * pageSize
+    const to = from + pageSize - 1
+
+    let query = this.client
+      .from('directory_buildings')
+      .select('*', { count: 'exact' })
+      .eq('tenant_id', tenantId)
+      .order('name', { ascending: true })
+      .range(from, to)
+
+    const search = normalizeSearchTerm(params.search)
+
+    if (search) {
+      query = query.or(
+        ['name', 'city', 'state', 'postal_code', 'country', 'address_line1']
+          .map(column => `${column}.ilike.${search}`)
+          .join(',')
+      )
+    }
+
+    if (params.city?.length) {
+      query = query.in('city', params.city)
+    }
+
+    if (params.status?.length) {
+      query = query.in('status', params.status)
+    }
+
+    const { data, error, count } = await query
+
+    if (error) {
+      throw new ApplicationError('Failed to list buildings', { error })
+    }
+
+    return {
+      data: data ?? [],
+      total: count ?? 0,
+      page,
+      pageSize,
+    }
+  }
+
+  async getBuilding(tenantId: string, id: string) {
+    const { data, error } = await this.client
+      .from('directory_buildings')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to fetch building', { error, id })
+    }
+
+    return data as DirectoryBuilding | null
+  }
+
+  async createBuilding(payload: BuildingCreateInput) {
+    const { data, error } = await this.client
+      .from('directory_buildings')
+      .insert(payload)
+      .select('*')
+      .single()
+
+    if (error) {
+      throw new ApplicationError('Failed to create building', { error })
+    }
+
+    return data as DirectoryBuilding
+  }
+
+  async updateBuilding(tenantId: string, id: string, updates: BuildingUpdateInput) {
+    const { data, error } = await this.client
+      .from('directory_buildings')
+      .update(updates)
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .select('*')
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to update building', { error, id })
+    }
+
+    if (!data) {
+      throw new ApplicationError('Building not found', { id })
+    }
+
+    return data as DirectoryBuilding
+  }
+
+  async deleteBuilding(tenantId: string, id: string) {
+    const { error } = await this.client
+      .from('directory_buildings')
+      .delete()
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+
+    if (error) {
+      throw new ApplicationError('Failed to delete building', { error, id })
+    }
+  }
+
+  async findBuildingByName(tenantId: string, name: string) {
+    const { data, error } = await this.client
+      .from('directory_buildings')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .ilike('name', name)
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to check building duplicate', { error })
+    }
+
+    return data as DirectoryBuilding | null
+  }
+
+  async listUnits(tenantId: string, params: UnitListParams = {}) {
+    const { page, pageSize } = normalizePagination(params)
+    const from = (page - 1) * pageSize
+    const to = from + pageSize - 1
+
+    let query = this.client
+      .from('directory_units')
+      .select('*', { count: 'exact' })
+      .eq('tenant_id', tenantId)
+      .order('unit_number', { ascending: true })
+      .range(from, to)
+
+    const search = normalizeSearchTerm(params.search)
+
+    if (search) {
+      query = query.or(
+        ['unit_number', 'floor', 'status']
+          .map(column => `${column}.ilike.${search}`)
+          .join(',')
+      )
+    }
+
+    if (params.buildingIds?.length) {
+      query = query.in('building_id', params.buildingIds)
+    }
+
+    if (params.status?.length) {
+      query = query.in('status', params.status)
+    }
+
+    const { data, error, count } = await query
+
+    if (error) {
+      throw new ApplicationError('Failed to list units', { error })
+    }
+
+    return {
+      data: data ?? [],
+      total: count ?? 0,
+      page,
+      pageSize,
+    }
+  }
+
+  async getUnit(tenantId: string, id: string) {
+    const { data, error } = await this.client
+      .from('directory_units')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to fetch unit', { error, id })
+    }
+
+    return data as DirectoryUnit | null
+  }
+
+  async createUnit(payload: UnitCreateInput) {
+    const { data, error } = await this.client
+      .from('directory_units')
+      .insert(payload)
+      .select('*')
+      .single()
+
+    if (error) {
+      throw new ApplicationError('Failed to create unit', { error })
+    }
+
+    return data as DirectoryUnit
+  }
+
+  async updateUnit(tenantId: string, id: string, updates: UnitUpdateInput) {
+    const { data, error } = await this.client
+      .from('directory_units')
+      .update(updates)
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .select('*')
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to update unit', { error, id })
+    }
+
+    if (!data) {
+      throw new ApplicationError('Unit not found', { id })
+    }
+
+    return data as DirectoryUnit
+  }
+
+  async deleteUnit(tenantId: string, id: string) {
+    const { error } = await this.client
+      .from('directory_units')
+      .delete()
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+
+    if (error) {
+      throw new ApplicationError('Failed to delete unit', { error, id })
+    }
+  }
+
+  async findUnitByNumber(tenantId: string, buildingId: string, unitNumber: string) {
+    const { data, error } = await this.client
+      .from('directory_units')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('building_id', buildingId)
+      .ilike('unit_number', unitNumber)
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to check unit duplicate', { error })
+    }
+
+    return data as DirectoryUnit | null
+  }
+
+  async listResidents(tenantId: string, params: ResidentListParams = {}) {
+    const { page, pageSize } = normalizePagination(params)
+    const from = (page - 1) * pageSize
+    const to = from + pageSize - 1
+
+    let query = this.client
+      .from('directory_residents')
+      .select('*', { count: 'exact' })
+      .eq('tenant_id', tenantId)
+      .order('last_name', { ascending: true })
+      .range(from, to)
+
+    const search = normalizeSearchTerm(params.search)
+
+    if (search) {
+      query = query.or(
+        ['first_name', 'last_name', 'email', 'phone']
+          .map(column => `${column}.ilike.${search}`)
+          .join(',')
+      )
+    }
+
+    if (params.unitIds?.length) {
+      query = query.in('unit_id', params.unitIds)
+    }
+
+    if (params.buildingIds?.length) {
+      query = query.in('building_id', params.buildingIds)
+    }
+
+    if (params.status?.length) {
+      query = query.in('status', params.status)
+    }
+
+    const { data, error, count } = await query
+
+    if (error) {
+      throw new ApplicationError('Failed to list residents', { error })
+    }
+
+    return {
+      data: data ?? [],
+      total: count ?? 0,
+      page,
+      pageSize,
+    }
+  }
+
+  async getResident(tenantId: string, id: string) {
+    const { data, error } = await this.client
+      .from('directory_residents')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to fetch resident', { error, id })
+    }
+
+    return data as DirectoryResident | null
+  }
+
+  async createResident(payload: ResidentCreateInput) {
+    const { data, error } = await this.client
+      .from('directory_residents')
+      .insert(payload)
+      .select('*')
+      .single()
+
+    if (error) {
+      throw new ApplicationError('Failed to create resident', { error })
+    }
+
+    return data as DirectoryResident
+  }
+
+  async updateResident(tenantId: string, id: string, updates: ResidentUpdateInput) {
+    const { data, error } = await this.client
+      .from('directory_residents')
+      .update(updates)
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .select('*')
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to update resident', { error, id })
+    }
+
+    if (!data) {
+      throw new ApplicationError('Resident not found', { id })
+    }
+
+    return data as DirectoryResident
+  }
+
+  async deleteResident(tenantId: string, id: string) {
+    const { error } = await this.client
+      .from('directory_residents')
+      .delete()
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+
+    if (error) {
+      throw new ApplicationError('Failed to delete resident', { error, id })
+    }
+  }
+
+  async findResidentByEmail(tenantId: string, email: string) {
+    const { data, error } = await this.client
+      .from('directory_residents')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .ilike('email', email)
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to check resident duplicate', { error })
+    }
+
+    return data as DirectoryResident | null
+  }
+
+  async listStaff(tenantId: string, params: StaffListParams = {}) {
+    const { page, pageSize } = normalizePagination(params)
+    const from = (page - 1) * pageSize
+    const to = from + pageSize - 1
+
+    let query = this.client
+      .from('directory_staff')
+      .select('*', { count: 'exact' })
+      .eq('tenant_id', tenantId)
+      .order('last_name', { ascending: true })
+      .range(from, to)
+
+    const search = normalizeSearchTerm(params.search)
+
+    if (search) {
+      query = query.or(
+        ['first_name', 'last_name', 'email', 'phone', 'role']
+          .map(column => `${column}.ilike.${search}`)
+          .join(',')
+      )
+    }
+
+    if (params.buildingIds?.length) {
+      query = query.in('building_id', params.buildingIds)
+    }
+
+    if (params.roles?.length) {
+      query = query.in('role', params.roles)
+    }
+
+    if (params.status?.length) {
+      query = query.in('status', params.status)
+    }
+
+    const { data, error, count } = await query
+
+    if (error) {
+      throw new ApplicationError('Failed to list staff', { error })
+    }
+
+    return {
+      data: data ?? [],
+      total: count ?? 0,
+      page,
+      pageSize,
+    }
+  }
+
+  async getStaff(tenantId: string, id: string) {
+    const { data, error } = await this.client
+      .from('directory_staff')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to fetch staff member', { error, id })
+    }
+
+    return data as DirectoryStaff | null
+  }
+
+  async createStaff(payload: StaffCreateInput) {
+    const { data, error } = await this.client
+      .from('directory_staff')
+      .insert(payload)
+      .select('*')
+      .single()
+
+    if (error) {
+      throw new ApplicationError('Failed to create staff member', { error })
+    }
+
+    return data as DirectoryStaff
+  }
+
+  async updateStaff(tenantId: string, id: string, updates: StaffUpdateInput) {
+    const { data, error } = await this.client
+      .from('directory_staff')
+      .update(updates)
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .select('*')
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to update staff member', { error, id })
+    }
+
+    if (!data) {
+      throw new ApplicationError('Staff member not found', { id })
+    }
+
+    return data as DirectoryStaff
+  }
+
+  async deleteStaff(tenantId: string, id: string) {
+    const { error } = await this.client
+      .from('directory_staff')
+      .delete()
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+
+    if (error) {
+      throw new ApplicationError('Failed to delete staff member', { error, id })
+    }
+  }
+
+  async findStaffByEmail(tenantId: string, email: string) {
+    const { data, error } = await this.client
+      .from('directory_staff')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .ilike('email', email)
+      .maybeSingle()
+
+    if (error) {
+      throw new ApplicationError('Failed to check staff duplicate', { error })
+    }
+
+    return data as DirectoryStaff | null
+  }
+}

--- a/services/directory/types.ts
+++ b/services/directory/types.ts
@@ -1,0 +1,119 @@
+import type { Json } from '@/lib/supabase'
+
+export type DirectoryRole = 'admin' | 'manager' | 'staff' | 'viewer'
+
+export interface AuthContext {
+  userId: string
+  tenantId: string
+  role: DirectoryRole
+}
+
+export interface PaginationOptions {
+  page?: number
+  pageSize?: number
+  search?: string
+}
+
+export interface PaginatedResult<T> {
+  data: T[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+export interface BuildingListParams extends PaginationOptions {
+  city?: string[]
+  status?: string[]
+}
+
+export interface UnitListParams extends PaginationOptions {
+  buildingIds?: string[]
+  status?: string[]
+}
+
+export interface ResidentListParams extends PaginationOptions {
+  buildingIds?: string[]
+  unitIds?: string[]
+  status?: string[]
+}
+
+export interface StaffListParams extends PaginationOptions {
+  buildingIds?: string[]
+  roles?: string[]
+  status?: string[]
+}
+
+export interface DirectoryBuilding {
+  id: string
+  tenant_id: string
+  name: string
+  address_line1: string | null
+  address_line2: string | null
+  city: string | null
+  state: string | null
+  postal_code: string | null
+  country: string | null
+  status: string | null
+  metadata: Json | null
+  created_at: string
+  updated_at: string
+}
+
+export interface DirectoryUnit {
+  id: string
+  tenant_id: string
+  building_id: string
+  unit_number: string
+  floor: string | null
+  bedrooms: number | null
+  bathrooms: number | null
+  square_feet: number | null
+  status: string | null
+  metadata: Json | null
+  created_at: string
+  updated_at: string
+}
+
+export interface DirectoryResident {
+  id: string
+  tenant_id: string
+  building_id: string | null
+  unit_id: string | null
+  first_name: string
+  last_name: string
+  email: string
+  phone: string | null
+  status: string | null
+  move_in_date: string | null
+  move_out_date: string | null
+  metadata: Json | null
+  created_at: string
+  updated_at: string
+}
+
+export interface DirectoryStaff {
+  id: string
+  tenant_id: string
+  building_id: string | null
+  first_name: string
+  last_name: string
+  email: string
+  phone: string | null
+  role: string | null
+  status: string | null
+  metadata: Json | null
+  created_at: string
+  updated_at: string
+}
+
+export type BuildingCreateInput = Omit<DirectoryBuilding, 'id' | 'created_at' | 'updated_at'>
+export type BuildingUpdateInput = Partial<Omit<DirectoryBuilding, 'id' | 'tenant_id' | 'created_at' | 'updated_at'>>
+
+export type UnitCreateInput = Omit<DirectoryUnit, 'id' | 'created_at' | 'updated_at'>
+export type UnitUpdateInput = Partial<Omit<DirectoryUnit, 'id' | 'tenant_id' | 'created_at' | 'updated_at'>>
+
+export type ResidentCreateInput = Omit<DirectoryResident, 'id' | 'created_at' | 'updated_at'>
+export type ResidentUpdateInput = Partial<Omit<DirectoryResident, 'id' | 'tenant_id' | 'created_at' | 'updated_at'>>
+
+export type StaffCreateInput = Omit<DirectoryStaff, 'id' | 'created_at' | 'updated_at'>
+export type StaffUpdateInput = Partial<Omit<DirectoryStaff, 'id' | 'tenant_id' | 'created_at' | 'updated_at'>>

--- a/services/directory/units-controller.ts
+++ b/services/directory/units-controller.ts
@@ -1,0 +1,75 @@
+import { ApplicationError, UserError } from '@/lib/errors'
+import { assertCanMutate, normalizePagination } from './utils'
+import type {
+  AuthContext,
+  DirectoryRepository,
+  DirectoryUnit,
+  PaginatedResult,
+  UnitCreateInput,
+  UnitListParams,
+  UnitUpdateInput,
+} from './types'
+
+export async function listUnits(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  params: UnitListParams = {}
+): Promise<PaginatedResult<DirectoryUnit>> {
+  const { page, pageSize } = normalizePagination(params)
+  return repository.listUnits(context.tenantId, { ...params, page, pageSize })
+}
+
+export async function getUnit(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string
+) {
+  const unit = await repository.getUnit(context.tenantId, id)
+
+  if (!unit) {
+    throw new ApplicationError('Unit not found', { id })
+  }
+
+  return unit
+}
+
+export async function createUnit(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  payload: Omit<UnitCreateInput, 'tenant_id'>
+) {
+  assertCanMutate(context)
+
+  const duplicate = await repository.findUnitByNumber(
+    context.tenantId,
+    payload.building_id,
+    payload.unit_number
+  )
+
+  if (duplicate) {
+    throw new UserError('A unit with this number already exists for the building.', {
+      unitId: duplicate.id,
+    })
+  }
+
+  return repository.createUnit({ ...payload, tenant_id: context.tenantId })
+}
+
+export async function updateUnit(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string,
+  updates: UnitUpdateInput
+) {
+  assertCanMutate(context)
+  return repository.updateUnit(context.tenantId, id, updates)
+}
+
+export async function deleteUnit(
+  repository: DirectoryRepository,
+  context: AuthContext,
+  id: string
+) {
+  assertCanMutate(context)
+  await repository.deleteUnit(context.tenantId, id)
+}

--- a/services/directory/utils.ts
+++ b/services/directory/utils.ts
@@ -1,0 +1,30 @@
+import { UserError } from '@/lib/errors'
+import type { AuthContext, PaginationOptions } from './types'
+
+const DEFAULT_PAGE = 1
+const DEFAULT_PAGE_SIZE = 25
+const MUTATION_ROLES = new Set(['admin', 'manager'] as const)
+
+export function assertCanMutate(context: AuthContext) {
+  if (!MUTATION_ROLES.has(context.role)) {
+    throw new UserError('You are not authorized to perform this action.', {
+      code: 'FORBIDDEN',
+      role: context.role,
+    })
+  }
+}
+
+export function normalizePagination(options: PaginationOptions = {}) {
+  const page = Math.max(options.page ?? DEFAULT_PAGE, 1)
+  const pageSize = Math.max(options.pageSize ?? DEFAULT_PAGE_SIZE, 1)
+
+  return { page, pageSize }
+}
+
+export function normalizeSearchTerm(search?: string) {
+  if (!search) {
+    return undefined
+  }
+
+  return `%${search.trim().replace(/[%_]/g, ch => `\\${ch}`).replace(/\s+/g, '%')}%`
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add directory service layer covering buildings, units, residents, and staff with Supabase-backed repository support
- expose a CSV import API for directory entities that enforces tenant scope, de-duplicates records, and reports row-level issues
- expand Supabase types and add Vitest-based tests to validate RBAC enforcement, search filters, and pagination helpers

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ceefb16dcc83288a160d997b7a6e3f