### PR TITLE
Rebrand navigation and metadata for tenant portal

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
- import type { Metadata, Viewport } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/next"
@@ -21,8 +21,8 @@ export const metadata: Metadata = {
     template: `%s - ${siteConfig.name}`,
   },
   description: siteConfig.description,
-    manifest: 'https://onyx-rho-pink.vercel.app/manifest.json',
-  metadataBase: new URL('https://onyx-rho-pink.vercel.app'),
+  manifest: '/manifest.json',
+  metadataBase: new URL('https://share-house-portal.vercel.app'),
   alternates: {
     canonical: '/',
     languages: {
@@ -37,12 +37,19 @@ export const metadata: Metadata = {
     },
   },
   referrer: 'origin-when-cross-origin',
-  keywords: ['NextJS 14 TypeScript', 'Supabase SSR', 'TanStack React Query', 'vercel', 'openai', 'MVP Template', 'Onyx SaaS PWA template', 'Zod', 'Shadcn-UI', 'Tailwind CSS', 'SaaS', 'NextJS Supabase Postgres Tailwind TanStack', 'NextJS CSP',
-             'PWA', 'NextJS SaaS PWA Template', 'CRUD ops', 'secure headers', 'NextJS templates with user authentication, RBAC, and CRUD ops', 'NextJS templates with data validation and database integration',
-            'Rust API runtime for vercel serverless functions', 'NextJS secure headers', 'NextJS NextMDX'],
-  authors: [{ name: 'Robert Mourey Jr' }],
-  creator: 'Robert Mourey Jr',
-  publisher: 'Robert Mourey Jr', 
+  keywords: [
+    'tenant portal',
+    'rent payments',
+    'shared housing',
+    'roommate communication',
+    'amenities booking',
+    'lease documents',
+    'community message board',
+    'maintenance requests',
+  ],
+  authors: [{ name: 'Share House Team' }],
+  creator: 'Share House Team',
+  publisher: 'Share House Team',
   formatDetection: {
     email: false,
     address: false,
@@ -50,11 +57,10 @@ export const metadata: Metadata = {
   },
   generator: 'NextJS',
   icons: {
-    icon: "/favicon.ico",
-    shortcut: "/favicon-16x16.png",
-    apple: "/apple-touch-icon.png",
+    icon: '/favicon.ico',
+    shortcut: '/favicon-16x16.png',
+    apple: '/apple-touch-icon.png',
   },
-
   robots: {
     index: false,
     follow: true,
@@ -72,42 +78,33 @@ export const metadata: Metadata = {
     title: siteConfig.name,
     description: siteConfig.description,
     siteName: siteConfig.name,
-    url: "https://onyx-rho-pink.vercel.app",
+    url: 'https://share-house-portal.vercel.app',
     images: [
       {
-        url: 'https://onyx-rho-pink.vercel.app/og-image.jpg', // Must be an absolute URL
-        width: 1230,
-        height: 640,
-      },
-      {
-        url: 'https://quantumone.b-cdn.net/onyx/opengraph-image.jpg', // Must be an absolute URL
-        width: 1800,
-        height: 1600,
-        alt: 'blockchain business',
+        url: 'https://share-house-portal.vercel.app/og-image.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'Share House Portal overview with rent, amenities, and messages',
       },
     ],
     locale: 'en_US',
     type: 'website',
   },
-    twitter: {
-         title: siteConfig.name,
-         description: siteConfig.description,
-         site: '@r_mourey_jr',
-         creator: '@r_mourey_jr',
-         images: [
+  twitter: {
+    card: 'summary_large_image',
+    title: siteConfig.name,
+    description: siteConfig.description,
+    images: [
       {
-        url: 'https://onyx-rho-pink.vercel.app/twitter-image.jpg', // Must be an absolute URL
-        width: 1800,
-        height: 900,
+        url: 'https://share-house-portal.vercel.app/twitter-image.jpg',
+        width: 1200,
+        height: 675,
+        alt: 'Share House Portal social preview',
       },
-      {
-        url: 'https://quantumone.b-cdn.net/onyx/twitter-image.jpg',
-        width: 1800,
-        height: 900,
-      },
-     ],
-   },
+    ],
+  },
 }
+
 export const viewport: Viewport =  {
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "white" },

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link"
 import { siteConfig } from "@/config/site"
-import { buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/icons"
 
 export function SiteFooter() {
@@ -8,99 +7,104 @@ export function SiteFooter() {
     <footer className="z-40 border-t">
       <div className="container flex flex-col gap-8 py-8 md:flex-row md:py-12">
         <div className="flex-1 space-y-4">
-         <Link className="ml-0 flex items-center gap-1" href="/" target="_blank"
-              rel="noreferrer">
+         <Link className="ml-0 flex items-center gap-1" href={siteConfig.links.portal}>
           <Icons.logo className="size-6" />
           <span className="inline-block font-bold">{siteConfig.name}</span>
         </Link>
-          <p className="text-sm text-muted-foreground">Pioneering real world asset solutions for the digital age.</p>
+          <p className="text-sm text-muted-foreground">
+            The central hub for residents to coordinate rent, amenities, maintenance, and community life in the shared house.
+          </p>
         </div>
         <div className="grid flex-1 grid-cols-2 gap-12 sm:grid-cols-3">
           <div className="space-y-4">
-            <h3 className="text-sm font-medium">Solutions</h3>
+            <h3 className="text-sm font-medium">Residents</h3>
             <ul className="space-y-3 text-sm">
               <li>
-                <Link href="#" className="text-muted-foreground transition-colors hover:text-primary">
-                  Rewards
-                </Link>
-              </li>
-              <li>
-                <Link href="/contact" className="text-muted-foreground transition-colors hover:text-primary">
-                  Contact
-                </Link>
-              </li>
-            </ul>
-          </div>
-          <div className="space-y-4">
-            <h3 className="text-sm font-medium">Company</h3>
-            <ul className="space-y-3 text-sm">
-              <li>
-                <Link href="/about" className="text-muted-foreground transition-colors hover:text-primary">
-                  About Us
-                </Link>
-              </li>
-              <li>
-                <Link href="/blog" className="text-muted-foreground transition-colors hover:text-primary">
-                  Blog
-                </Link>
-              </li>
-            </ul>
-          </div>
-          <div className="space-y-4">
-            <h3 className="text-sm font-medium">Connect</h3>
-            <div className="flex space-x-4">
-              <Link
-                href={siteConfig.links.github}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <div
-                  className={buttonVariants({
-                    size: "icon",
-                    variant: "ghost",
-                  })}
+                <Link
+                  href={siteConfig.links.payments}
+                  className="text-muted-foreground transition-colors hover:text-primary"
                 >
-                  <Icons.gitHub className="size-5" />
-                  <span className="sr-only">GitHub</span>
-                </div>
-              </Link>
-              <Link
-              href={siteConfig.links.twitter}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <div
-                className={buttonVariants({
-                  size: "icon",
-                  variant: "ghost",
-                })}
-              >
-                <Icons.twitter className="size-4" />
-                <span className="sr-only">Twitter</span>
-              </div>
-            </Link>
-            <Link
-              href={siteConfig.links.linkedin}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <div
-                className={buttonVariants({
-                  size: "icon",
-                  variant: "ghost",
-                })}
-              >
-                <Icons.linkedin className="size-5" />
-                <span className="sr-only">LinkedIn</span>
-              </div>
-            </Link>
-            </div>
+                  Rent Payments
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href={siteConfig.links.documents}
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                >
+                  Documents
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href={siteConfig.links.amenities}
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                >
+                  Amenities
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div className="space-y-4">
+            <h3 className="text-sm font-medium">Community</h3>
+            <ul className="space-y-3 text-sm">
+              <li>
+                <Link
+                  href={siteConfig.links.messageBoard}
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                >
+                  Message Board
+                </Link>
+              </li>
+              <li>
+                <Link href="/schedule" className="text-muted-foreground transition-colors hover:text-primary">
+                  Events Calendar
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href={siteConfig.links.support}
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                >
+                  Maintenance Requests
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div className="space-y-4">
+            <h3 className="text-sm font-medium">Management</h3>
+            <ul className="space-y-3 text-sm">
+              <li>
+                <Link
+                  href={siteConfig.links.leases}
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                >
+                  Lease Library
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href={siteConfig.links.admin}
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                >
+                  Admin Portal
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href={siteConfig.links.support}
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                >
+                  Support
+                </Link>
+              </li>
+            </ul>
           </div>
         </div>
       </div>
       <div className="container border-t py-6">
         <p className="text-center text-sm text-muted-foreground">
-          © {new Date().getFullYear()} Onyx. All Rights Reserved.
+          © {new Date().getFullYear()} {siteConfig.name}. All rights reserved.
         </p>
       </div>
     </footer>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -4,7 +4,6 @@ import { readUserSession } from "@/utils/actions"
 import { siteConfig } from "@/config/site"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
-import { Icons } from "@/components/icons"
 import { MainNav } from "@/components/main-nav"
 import { MobileNav } from "@/components/mobile-nav"
 import { SignOutButton } from "@/components/sign-out-button"
@@ -63,36 +62,33 @@ export async function SiteHeader() {
               </>
             )}
           </div>
-          <nav className="flex items-center space-x-1">
+          <nav className="flex items-center gap-2">
             <Link
-              href={siteConfig.links.github}
-              target="_blank"
-              rel="noreferrer"
+              href={siteConfig.links.support}
+              className={cn(
+                buttonVariants({ variant: "ghost", size: "sm" }),
+                "hidden sm:inline-flex"
+              )}
             >
-              <div
-                className={buttonVariants({
-                  size: "icon",
-                  variant: "ghost",
-                })}
-              >
-                <Icons.gitHub className="size-5" />
-                <span className="sr-only">GitHub</span>
-              </div>
+              Support
             </Link>
             <Link
-              href={siteConfig.links.twitter}
-              target="_blank"
-              rel="noreferrer"
+              href={siteConfig.links.leases}
+              className={cn(
+                buttonVariants({ variant: "ghost", size: "sm" }),
+                "hidden sm:inline-flex"
+              )}
             >
-              <div
-                className={buttonVariants({
-                  size: "icon",
-                  variant: "ghost",
-                })}
-              >
-                <Icons.twitter className="size-4 fill-current" />
-                <span className="sr-only">Twitter</span>
-              </div>
+              Leases
+            </Link>
+            <Link
+              href={siteConfig.links.amenities}
+              className={cn(
+                buttonVariants({ variant: "ghost", size: "sm" }),
+                "hidden sm:inline-flex"
+              )}
+            >
+              Amenities
             </Link>
             <ThemeToggle />
           </nav>

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -8,41 +8,28 @@ interface DocsConfig {
 export const docsConfig: DocsConfig = {
   mainNav: [
     {
-      title: "Home",
-      href: "/",
-    },
-    { 
-      title: "Account",
-      href: "/account",
-    },
-    { 
-      title: "Dashboard",
-      href: "/dashboard",
-    },
-    { 
-      title: "OpenAI",
-      href: "/playground",
-    },
-
-    { 
-      title: "Podcasts",
-      href: "/music",
-    },
-    { 
-      title: "Blog",
-      href: "/blog",
-    },
-    { 
-      title: "RBAC",
-      href: "/dashboard/members",
-    },
-    { 
-      title: "About",
-      href: "/about",
+      title: "Rent Payments",
+      href: "/dashboard/payments",
     },
     {
-      title: "Contact",
-      href: "/contact",
+      title: "Amenities",
+      href: "/amenities",
+    },
+    {
+      title: "Documents",
+      href: "/documents",
+    },
+    {
+      title: "Floorplans",
+      href: "/floorplans",
+    },
+    {
+      title: "Message Board",
+      href: "/message-board",
+    },
+    {
+      title: "Admin",
+      href: "/admin",
     },
   ],
   sidebarNav: [

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,54 +1,46 @@
 export type SiteConfig = typeof siteConfig
 
 export const siteConfig = {
-  name: "Onyx",
+  name: "Share House Portal",
   description:
-    "Onyx SaaS PWA Template with validated CRUD ops, user authentication + RBAC, maximum header security, Rust API runtime, TanStack, and more.",
+    "Share House is the tenant hub for tracking rent payments, booking amenities, reviewing documents, and staying connected with housemates.",
   mainNav: [
     {
-      title: "Home",
-      href: "/",
-    },
-
-    {
-      title: "Account",
-      href: "/account",
+      title: "Rent Payments",
+      href: "/dashboard/payments",
     },
     {
-      title: "Dashboard",
-      href: "/dashboard",
+      title: "Amenities",
+      href: "/amenities",
     },
     {
-      title: "OpenAI",
-      href: "/playground",
+      title: "Documents",
+      href: "/documents",
     },
     {
-      title: "Podcasts",
-      href: "/music",
+      title: "Floorplans",
+      href: "/floorplans",
     },
     {
-      title: "Blog",
-      href: "/blog",
+      title: "Message Board",
+      href: "/message-board",
     },
     {
-      title: "RBAC",
-      href: "/dashboard/members",
-    },
-    {
-      title: "About",
-      href: "/about",
-    },
-    {
-      title: "Contact",
-      href: "/contact",
+      title: "Admin",
+      href: "/admin",
     },
   ],
   links: {
-    twitter: "https://twitter.com/r_mourey_jr",
-    github: "https://github.com/rmourey26/onyx",
+    portal: "/",
+    support: "/contact",
+    amenities: "/amenities",
+    leases: "/documents/leases",
+    documents: "/documents",
+    payments: "/dashboard/payments",
+    messageBoard: "/message-board",
+    admin: "/admin",
     login: "/auth",
     signup: "/onboarding",
     contact: "/contact",
-    linkedin: "https://linkedin.com/in/robertmoureyjr",
   },
 }


### PR DESCRIPTION
## Summary
- rename the site configuration for the Share House Portal and surface tenant-focused navigation targets
- refresh layout metadata to describe the tenant portal brand and remove Onyx-specific URLs and previews
- update the header and footer to highlight support, leases, amenities, and admin resources across desktop and mobile navigation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d036a06f00832887e7528050e4ee12