### PR TITLE
Add floorplan overlays schema and tenant/manager tooling

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { CrumpledPaperIcon, DrawingPinIcon, PersonIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,16 +8,21 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/floorplans",
+                        text: "Floorplans",
+                        Icon: DrawingPinIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
 		},
 	];
 

--- a/app/dashboard/floorplans/actions.ts
+++ b/app/dashboard/floorplans/actions.ts
@@ -1,0 +1,452 @@
+"use server"
+
+import { randomUUID } from "crypto"
+import { revalidatePath } from "next/cache"
+import { z } from "zod"
+
+import { canManageBuilding, canManageFloorplan } from "@/lib/floorplans/access"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export type ActionState = {
+  status: "idle" | "success" | "error"
+  message?: string
+}
+
+export const initialActionState: ActionState = { status: "idle" }
+
+const floorplanSchema = z.object({
+  buildingId: z.string().uuid(),
+  unitId: z.string().uuid().nullable(),
+  name: z.string().min(1).max(120),
+  description: z.string().max(500).optional(),
+})
+
+const annotationSchema = z.object({
+  annotationId: z.string().uuid().optional(),
+  floorplanId: z.string().uuid(),
+  label: z.string().min(1).max(160),
+  annotationType: z.enum(["storage", "chore", "note", "other"]),
+  profileId: z.string().uuid().nullable(),
+  geometry: z.any(),
+  metadata: z.any().optional(),
+})
+
+const createErrorState = (message: string): ActionState => ({ status: "error", message })
+
+const successState = (message: string): ActionState => ({ status: "success", message })
+
+const ensureFileIsValid = (value: FormDataEntryValue | null): File | null => {
+  if (!(value instanceof File)) {
+    return null
+  }
+
+  if (value.size === 0) {
+    return null
+  }
+
+  return value
+}
+
+const parseJsonField = (value: FormDataEntryValue | null) => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    return undefined
+  }
+}
+
+async function getProfileAndAssignments(supabase: Awaited<ReturnType<typeof createSupbaseServerClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { error: "You must be signed in to manage floorplans." }
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, role")
+    .eq("id", user.id)
+    .maybeSingle()
+
+  if (profileError || !profile) {
+    return { error: "Unable to load your profile." }
+  }
+
+  let managedBuildingIds: string[] = []
+
+  if (profile.role === "property_manager") {
+    const { data: assignments, error: assignmentsError } = await supabase
+      .from("property_manager_buildings")
+      .select("building_id")
+      .eq("manager_id", profile.id)
+
+    if (assignmentsError) {
+      return { error: "Unable to load your building assignments." }
+    }
+
+    managedBuildingIds = (assignments ?? []).map((assignment) => assignment.building_id)
+  }
+
+  return { profile, managedBuildingIds }
+}
+
+export async function createFloorplan(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const supabase = await createSupbaseServerClient()
+  const context = await getProfileAndAssignments(supabase)
+
+  if ("error" in context) {
+    return createErrorState(context.error)
+  }
+
+  const buildingIdInput = formData.get("buildingId")
+  const unitIdInput = formData.get("unitId")
+  const nameInput = formData.get("name")
+  const descriptionInput = formData.get("description")
+  const file = ensureFileIsValid(formData.get("file"))
+
+  if (!file) {
+    return createErrorState("A floorplan image or SVG file is required.")
+  }
+
+  const normalizedUnitId = typeof unitIdInput === "string" && unitIdInput.length > 0 ? unitIdInput : null
+
+  const parsed = floorplanSchema.safeParse({
+    buildingId: typeof buildingIdInput === "string" ? buildingIdInput : undefined,
+    unitId: normalizedUnitId,
+    name: typeof nameInput === "string" ? nameInput : undefined,
+    description: typeof descriptionInput === "string" ? descriptionInput : undefined,
+  })
+
+  if (!parsed.success) {
+    return createErrorState(parsed.error.errors[0]?.message ?? "Invalid floorplan details.")
+  }
+
+  const { profile, managedBuildingIds } = context
+
+  if (!canManageBuilding(profile.role, parsed.data.buildingId, managedBuildingIds)) {
+    return createErrorState("You do not have permission to manage this building.")
+  }
+
+  const allowedTypes = new Set(["image/png", "image/jpeg", "image/svg+xml", "image/webp"])
+
+  const contentType = file.type || "application/octet-stream"
+
+  if (file.type && !allowedTypes.has(file.type)) {
+    return createErrorState("Unsupported file type. Please upload an SVG or image file.")
+  }
+
+  const arrayBuffer = await file.arrayBuffer()
+  const buffer = Buffer.from(arrayBuffer)
+  const extension = (() => {
+    const originalName = file.name || ""
+    const parts = originalName.split(".")
+    const suffix = parts.length > 1 ? parts.pop() ?? "" : ""
+
+    if (/^[a-z0-9]+$/i.test(suffix)) {
+      return `.${suffix.toLowerCase()}`
+    }
+
+    switch (contentType) {
+      case "image/png":
+        return ".png"
+      case "image/jpeg":
+        return ".jpg"
+      case "image/webp":
+        return ".webp"
+      case "image/svg+xml":
+        return ".svg"
+      default:
+        return ""
+    }
+  })()
+
+  const storagePath = `${profile.id}/${randomUUID()}${extension}`
+
+  const { error: uploadError } = await supabase.storage
+    .from("floorplans")
+    .upload(storagePath, buffer, {
+      cacheControl: "3600",
+      upsert: true,
+      contentType,
+    })
+
+  if (uploadError) {
+    return createErrorState("Unable to upload the floorplan asset. Please try again.")
+  }
+
+  const { error: insertError } = await supabase.from("floorplans").insert({
+    building_id: parsed.data.buildingId,
+    unit_id: parsed.data.unitId,
+    name: parsed.data.name,
+    description: parsed.data.description ?? null,
+    storage_path: storagePath,
+    media_type: contentType,
+    created_by: profile.id,
+  })
+
+  if (insertError) {
+    await supabase.storage.from("floorplans").remove([storagePath])
+    return createErrorState("Unable to save the floorplan record. Please try again.")
+  }
+
+  revalidatePath("/dashboard/floorplans")
+
+  return successState("Floorplan uploaded successfully.")
+}
+
+export async function deleteFloorplan(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const supabase = await createSupbaseServerClient()
+  const context = await getProfileAndAssignments(supabase)
+
+  if ("error" in context) {
+    return createErrorState(context.error)
+  }
+
+  const floorplanIdValue = formData.get("floorplanId")
+
+  if (typeof floorplanIdValue !== "string") {
+    return createErrorState("A floorplan identifier is required.")
+  }
+
+  const { data: floorplan, error: floorplanError } = await supabase
+    .from("floorplans")
+    .select("id, building_id, storage_path")
+    .eq("id", floorplanIdValue)
+    .maybeSingle()
+
+  if (floorplanError || !floorplan) {
+    return createErrorState("The requested floorplan could not be found.")
+  }
+
+  const { profile, managedBuildingIds } = context
+
+  if (!canManageFloorplan(profile.role, floorplan, managedBuildingIds)) {
+    return createErrorState("You are not allowed to delete this floorplan.")
+  }
+
+  const { error: deleteError } = await supabase
+    .from("floorplans")
+    .delete()
+    .eq("id", floorplan.id)
+
+  if (deleteError) {
+    return createErrorState("Unable to delete the floorplan. Please try again.")
+  }
+
+  if (floorplan.storage_path) {
+    await supabase.storage.from("floorplans").remove([floorplan.storage_path])
+  }
+
+  revalidatePath("/dashboard/floorplans")
+
+  return successState("Floorplan deleted.")
+}
+
+const parseAnnotationForm = (formData: FormData, requireAnnotationId = false) => {
+  const annotationIdValue = formData.get("annotationId")
+  const floorplanIdValue = formData.get("floorplanId")
+  const labelValue = formData.get("label")
+  const annotationTypeValue = formData.get("annotationType")
+  const profileIdValue = formData.get("profileId")
+
+  const geometryValue = parseJsonField(formData.get("geometry"))
+  const metadataValue = parseJsonField(formData.get("metadata"))
+
+  const normalizedProfileId =
+    typeof profileIdValue === "string" && profileIdValue.length > 0 && profileIdValue !== "unassigned"
+      ? profileIdValue
+      : null
+
+  const parsed = annotationSchema.safeParse({
+    annotationId:
+      requireAnnotationId && typeof annotationIdValue === "string" ? annotationIdValue : undefined,
+    floorplanId: typeof floorplanIdValue === "string" ? floorplanIdValue : undefined,
+    label: typeof labelValue === "string" ? labelValue : undefined,
+    annotationType: typeof annotationTypeValue === "string" ? annotationTypeValue : undefined,
+    profileId: normalizedProfileId,
+    geometry: geometryValue,
+    metadata: metadataValue,
+  })
+
+  if (!parsed.success) {
+    return { error: parsed.error.errors[0]?.message ?? "Invalid annotation details." }
+  }
+
+  return { data: parsed.data }
+}
+
+export async function createAnnotation(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const supabase = await createSupbaseServerClient()
+  const context = await getProfileAndAssignments(supabase)
+
+  if ("error" in context) {
+    return createErrorState(context.error)
+  }
+
+  const parsed = parseAnnotationForm(formData)
+
+  if ("error" in parsed) {
+    return createErrorState(parsed.error)
+  }
+
+  const { data } = parsed
+
+  if (data.geometry == null || typeof data.geometry !== "object") {
+    return createErrorState("Geometry must be valid JSON.")
+  }
+
+  const { data: floorplan, error: floorplanError } = await supabase
+    .from("floorplans")
+    .select("id, building_id")
+    .eq("id", data.floorplanId)
+    .maybeSingle()
+
+  if (floorplanError || !floorplan) {
+    return createErrorState("Unable to locate the referenced floorplan.")
+  }
+
+  const { profile, managedBuildingIds } = context
+
+  if (!canManageFloorplan(profile.role, floorplan, managedBuildingIds)) {
+    return createErrorState("You are not allowed to annotate this floorplan.")
+  }
+
+  const { error: insertError } = await supabase.from("floorplan_annotations").insert({
+    floorplan_id: data.floorplanId,
+    label: data.label,
+    annotation_type: data.annotationType,
+    profile_id: data.profileId ?? null,
+    geometry: data.geometry,
+    metadata: data.metadata ?? null,
+    created_by: profile.id,
+  })
+
+  if (insertError) {
+    return createErrorState("Unable to create the annotation. Please try again.")
+  }
+
+  revalidatePath("/dashboard/floorplans")
+
+  return successState("Annotation created.")
+}
+
+export async function updateAnnotation(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const supabase = await createSupbaseServerClient()
+  const context = await getProfileAndAssignments(supabase)
+
+  if ("error" in context) {
+    return createErrorState(context.error)
+  }
+
+  const parsed = parseAnnotationForm(formData, true)
+
+  if ("error" in parsed || !parsed.data?.annotationId) {
+    return createErrorState(parsed.error ?? "Invalid annotation details.")
+  }
+
+  const { data } = parsed
+
+  if (data.geometry == null || typeof data.geometry !== "object") {
+    return createErrorState("Geometry must be valid JSON.")
+  }
+
+  const { data: annotation, error: annotationError } = await supabase
+    .from("floorplan_annotations")
+    .select("id, floorplan_id, floorplan:floorplan_id ( id, building_id )")
+    .eq("id", data.annotationId)
+    .maybeSingle()
+
+  if (annotationError || !annotation || !annotation.floorplan) {
+    return createErrorState("Unable to locate the annotation for update.")
+  }
+
+  const { profile, managedBuildingIds } = context
+
+  if (!canManageFloorplan(profile.role, annotation.floorplan, managedBuildingIds)) {
+    return createErrorState("You are not allowed to update this annotation.")
+  }
+
+  const { error: updateError } = await supabase
+    .from("floorplan_annotations")
+    .update({
+      label: data.label,
+      annotation_type: data.annotationType,
+      profile_id: data.profileId ?? null,
+      geometry: data.geometry,
+      metadata: data.metadata ?? null,
+    })
+    .eq("id", data.annotationId)
+
+  if (updateError) {
+    return createErrorState("Unable to update the annotation. Please try again.")
+  }
+
+  revalidatePath("/dashboard/floorplans")
+
+  return successState("Annotation updated.")
+}
+
+export async function deleteAnnotation(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const supabase = await createSupbaseServerClient()
+  const context = await getProfileAndAssignments(supabase)
+
+  if ("error" in context) {
+    return createErrorState(context.error)
+  }
+
+  const annotationIdValue = formData.get("annotationId")
+
+  if (typeof annotationIdValue !== "string") {
+    return createErrorState("An annotation identifier is required.")
+  }
+
+  const { data: annotation, error: annotationError } = await supabase
+    .from("floorplan_annotations")
+    .select("id, floorplan_id, floorplan:floorplan_id ( id, building_id )")
+    .eq("id", annotationIdValue)
+    .maybeSingle()
+
+  if (annotationError || !annotation || !annotation.floorplan) {
+    return createErrorState("Unable to locate the annotation for deletion.")
+  }
+
+  const { profile, managedBuildingIds } = context
+
+  if (!canManageFloorplan(profile.role, annotation.floorplan, managedBuildingIds)) {
+    return createErrorState("You are not allowed to delete this annotation.")
+  }
+
+  const { error: deleteError } = await supabase
+    .from("floorplan_annotations")
+    .delete()
+    .eq("id", annotation.id)
+
+  if (deleteError) {
+    return createErrorState("Unable to delete the annotation. Please try again.")
+  }
+
+  revalidatePath("/dashboard/floorplans")
+
+  return successState("Annotation deleted.")
+}

--- a/app/dashboard/floorplans/components/ManagerSection.tsx
+++ b/app/dashboard/floorplans/components/ManagerSection.tsx
@@ -1,0 +1,429 @@
+"use client"
+
+import Image from "next/image"
+import { useEffect, useMemo, useRef, useState, type ComponentProps, type ReactNode } from "react"
+import { useFormState, useFormStatus } from "react-dom"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+import {
+  createAnnotation,
+  createFloorplan,
+  deleteAnnotation,
+  deleteFloorplan,
+  initialActionState,
+  updateAnnotation,
+  type ActionState,
+} from "../actions"
+import type { AnnotationClientModel, BuildingOption, FloorplanClientModel } from "../types"
+
+const annotationTypes = [
+  { value: "storage", label: "Storage" },
+  { value: "chore", label: "Chore" },
+  { value: "note", label: "Note" },
+  { value: "other", label: "Other" },
+] as const
+
+type ManagerSectionProps = {
+  floorplans: FloorplanClientModel[]
+  buildingOptions: BuildingOption[]
+}
+
+const formatMessage = (state: ActionState) => {
+  if (state.status === "error" || state.status === "success") {
+    return state.message
+  }
+
+  return undefined
+}
+
+export default function ManagerSection({ floorplans, buildingOptions }: ManagerSectionProps) {
+  const [createState, createAction] = useFormState(createFloorplan, initialActionState)
+  const formRef = useRef<HTMLFormElement>(null)
+  const [selectedBuildingId, setSelectedBuildingId] = useState<string>(buildingOptions[0]?.id ?? "")
+  const [selectedUnitId, setSelectedUnitId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (createState.status === "success") {
+      formRef.current?.reset()
+      setSelectedUnitId(null)
+    }
+  }, [createState.status])
+
+  const unitOptions = useMemo(() => {
+    const building = buildingOptions.find((option) => option.id === selectedBuildingId)
+    return building?.units ?? []
+  }, [buildingOptions, selectedBuildingId])
+
+  useEffect(() => {
+    if (unitOptions.length === 0) {
+      setSelectedUnitId(null)
+    }
+  }, [unitOptions])
+
+  return (
+    <section className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Upload a floorplan</CardTitle>
+          <CardDescription>
+            Property managers can upload SVG or image files and associate them with specific units.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            ref={formRef}
+            className="grid gap-4 md:grid-cols-2"
+            action={createAction}
+            encType="multipart/form-data"
+          >
+            <div className="space-y-2">
+              <Label htmlFor="buildingId">Building</Label>
+              <Select
+                name="buildingId"
+                value={selectedBuildingId}
+                onValueChange={(value) => {
+                  setSelectedBuildingId(value)
+                  setSelectedUnitId(null)
+                }}
+              >
+                <SelectTrigger id="buildingId">
+                  <SelectValue placeholder="Select a building" />
+                </SelectTrigger>
+                <SelectContent>
+                  {buildingOptions.length === 0 && <SelectItem value="">No buildings available</SelectItem>}
+                  {buildingOptions.map((building) => (
+                    <SelectItem key={building.id} value={building.id}>
+                      {building.name ?? "Unnamed building"}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="unitId">Unit</Label>
+              <Select
+                name="unitId"
+                value={selectedUnitId ?? ""}
+                onValueChange={(value) => setSelectedUnitId(value.length > 0 ? value : null)}
+              >
+                <SelectTrigger id="unitId">
+                  <SelectValue placeholder="Applies to entire building" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">Entire building</SelectItem>
+                  {unitOptions.map((unit) => (
+                    <SelectItem key={unit.id} value={unit.id}>
+                      {unit.unitNumber ?? "Unit"}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input id="name" name="name" placeholder="Kitchen & Living" required />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea id="description" name="description" rows={3} placeholder="Optional notes" />
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <Label htmlFor="file">Floorplan file</Label>
+              <Input id="file" name="file" type="file" accept=".svg,.png,.jpg,.jpeg,.webp" required />
+              <p className="text-xs text-muted-foreground">
+                SVG files allow precise overlays. Images are supported for quick uploads.
+              </p>
+            </div>
+
+            <SubmitButton className="md:col-span-2">Upload floorplan</SubmitButton>
+
+            {formatMessage(createState) && (
+              <p
+                className={cn(
+                  "text-sm md:col-span-2",
+                  createState.status === "error" ? "text-red-500" : "text-green-600",
+                )}
+              >
+                {createState.message}
+              </p>
+            )}
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-4">
+        {floorplans.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>No floorplans yet</CardTitle>
+              <CardDescription>Upload a floorplan to start creating overlays for tenants.</CardDescription>
+            </CardHeader>
+          </Card>
+        ) : (
+          floorplans.map((floorplan) => (
+            <Card key={floorplan.id}>
+              <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <CardTitle>{floorplan.name}</CardTitle>
+                  <CardDescription>
+                    {floorplan.building.name ?? "Unnamed building"}
+                    {floorplan.unit ? ` • Unit ${floorplan.unit.unitNumber ?? ""}` : " • Building wide"}
+                  </CardDescription>
+                </div>
+                <DeleteFloorplanForm floorplanId={floorplan.id} />
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="overflow-hidden rounded-lg border">
+                  {floorplan.signedUrl ? (
+                    <Image
+                      src={floorplan.signedUrl}
+                      alt={`${floorplan.name} floorplan`}
+                      width={1600}
+                      height={1200}
+                      className="max-h-[420px] w-full object-contain"
+                      sizes="(min-width: 768px) 420px, 100vw"
+                    />
+                  ) : (
+                    <div className="flex h-64 items-center justify-center bg-muted">
+                      <p className="text-sm text-muted-foreground">No preview available</p>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <AnnotationDialog
+                    floorplanId={floorplan.id}
+                    availableProfiles={floorplan.availableProfiles}
+                    mode="create"
+                    triggerLabel="Add overlay"
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="space-y-3">
+                  {floorplan.annotations.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No overlays created yet.</p>
+                  ) : (
+                    floorplan.annotations.map((annotation) => (
+                      <div
+                        key={annotation.id}
+                        className="flex flex-col gap-3 rounded-lg border p-4 md:flex-row md:items-center md:justify-between"
+                      >
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-2">
+                            <Badge variant="outline">{labelFromType(annotation.annotationType)}</Badge>
+                            <p className="font-medium">{annotation.label}</p>
+                          </div>
+                          <p className="text-sm text-muted-foreground">
+                            Assigned to {annotation.assigneeName ?? "all roommates"}
+                          </p>
+                        </div>
+                        <div className="flex gap-2">
+                          <AnnotationDialog
+                            floorplanId={floorplan.id}
+                            availableProfiles={floorplan.availableProfiles}
+                            mode="edit"
+                            annotation={annotation}
+                            triggerLabel="Edit"
+                          />
+                          <DeleteAnnotationForm annotationId={annotation.id} />
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </section>
+  )
+}
+
+const labelFromType = (type: AnnotationClientModel["annotationType"]) => {
+  const match = annotationTypes.find((entry) => entry.value === type)
+  return match?.label ?? type
+}
+
+type AnnotationDialogProps = {
+  floorplanId: string
+  availableProfiles: { id: string; name: string | null }[]
+  mode: "create" | "edit"
+  triggerLabel: string
+  annotation?: AnnotationClientModel
+}
+
+function AnnotationDialog({ floorplanId, availableProfiles, mode, triggerLabel, annotation }: AnnotationDialogProps) {
+  const action = mode === "create" ? createAnnotation : updateAnnotation
+  const [state, formAction] = useFormState(action, initialActionState)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (state.status === "success") {
+      setOpen(false)
+    }
+  }, [state.status])
+
+  const geometryDefault = annotation?.geometry ? JSON.stringify(annotation.geometry, null, 2) : ""
+  const metadataDefault = annotation?.metadata ? JSON.stringify(annotation.metadata, null, 2) : ""
+  const selectedType = annotation?.annotationType ?? annotationTypes[0].value
+  const selectedProfile = annotation?.profileId ?? ""
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant={mode === "create" ? "default" : "outline"}>{triggerLabel}</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{mode === "create" ? "Add overlay" : "Edit overlay"}</DialogTitle>
+        </DialogHeader>
+        <form className="space-y-4" action={formAction}>
+          <input type="hidden" name="floorplanId" value={floorplanId} />
+          {mode === "edit" && annotation && <input type="hidden" name="annotationId" value={annotation.id} />}
+
+          <div className="space-y-2">
+            <Label htmlFor="label">Label</Label>
+            <Input id="label" name="label" defaultValue={annotation?.label ?? ""} required />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="annotationType">Category</Label>
+            <Select name="annotationType" defaultValue={selectedType}>
+              <SelectTrigger id="annotationType">
+                <SelectValue placeholder="Select a category" />
+              </SelectTrigger>
+              <SelectContent>
+                {annotationTypes.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="profileId">Assigned roommate</Label>
+            <Select name="profileId" defaultValue={selectedProfile}>
+              <SelectTrigger id="profileId">
+                <SelectValue placeholder="All roommates" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">All roommates</SelectItem>
+                <SelectItem value="unassigned">Unassigned</SelectItem>
+                {availableProfiles.map((profile) => (
+                  <SelectItem key={profile.id} value={profile.id}>
+                    {profile.name ?? "Roommate"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="geometry">Geometry JSON</Label>
+            <Textarea
+              id="geometry"
+              name="geometry"
+              rows={4}
+              defaultValue={geometryDefault || '{"type":"rect","x":0.1,"y":0.1,"width":0.3,"height":0.25}'}
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              Provide normalised coordinates between 0 and 1. Example shown for rectangular overlays.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="metadata">Metadata JSON</Label>
+            <Textarea id="metadata" name="metadata" rows={3} defaultValue={metadataDefault} />
+            <p className="text-xs text-muted-foreground">
+              Optional details such as color or notes. Leave blank for default styling.
+            </p>
+          </div>
+
+          {formatMessage(state) && (
+            <p className={`text-sm ${state.status === "error" ? "text-red-500" : "text-green-600"}`}>{state.message}</p>
+          )}
+
+          <DialogFooter className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <SubmitButton>{mode === "create" ? "Create overlay" : "Save changes"}</SubmitButton>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+type DeleteAnnotationFormProps = {
+  annotationId: string
+}
+
+function DeleteAnnotationForm({ annotationId }: DeleteAnnotationFormProps) {
+  const [state, formAction] = useFormState(deleteAnnotation, initialActionState)
+
+  return (
+    <form action={formAction} className="flex flex-col items-start gap-1">
+      <input type="hidden" name="annotationId" value={annotationId} />
+      <SubmitButton variant="destructive">Delete</SubmitButton>
+      {state.status === "error" && <p className="text-sm text-red-500">{state.message}</p>}
+    </form>
+  )
+}
+
+type DeleteFloorplanFormProps = {
+  floorplanId: string
+}
+
+function DeleteFloorplanForm({ floorplanId }: DeleteFloorplanFormProps) {
+  const [state, formAction] = useFormState(deleteFloorplan, initialActionState)
+
+  return (
+    <form action={formAction} className="flex flex-col items-end gap-2">
+      <input type="hidden" name="floorplanId" value={floorplanId} />
+      <SubmitButton variant="destructive">Delete floorplan</SubmitButton>
+      {state.status === "error" && <p className="text-sm text-red-500">{state.message}</p>}
+    </form>
+  )
+}
+
+type SubmitButtonProps = {
+  children: ReactNode
+  className?: string
+  variant?: ComponentProps<typeof Button>["variant"]
+}
+
+function SubmitButton({ children, className, variant }: SubmitButtonProps) {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button
+      type="submit"
+      variant={variant ?? "default"}
+      className={className}
+      disabled={pending}
+    >
+      {pending ? "Saving..." : children}
+    </Button>
+  )
+}

--- a/app/dashboard/floorplans/components/TenantSection.tsx
+++ b/app/dashboard/floorplans/components/TenantSection.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import Image from "next/image"
+import { useEffect, useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+import type { AnnotationType, FloorplanClientModel, MembershipClientModel } from "../types"
+
+const annotationTypeLabels: Record<AnnotationType, string> = {
+  storage: "Storage",
+  chore: "Chore",
+  note: "Note",
+  other: "Other",
+}
+
+const annotationColors: Record<AnnotationType, string> = {
+  storage: "#2563eb",
+  chore: "#16a34a",
+  note: "#eab308",
+  other: "#a855f7",
+}
+
+type TenantSectionProps = {
+  floorplans: FloorplanClientModel[]
+  memberships: MembershipClientModel[]
+  profileId: string
+}
+
+type RoommateFilter = "all" | "self" | "unassigned" | string
+
+type RoommateOption = {
+  id: string
+  label: string
+}
+
+export default function TenantSection({ floorplans, memberships, profileId }: TenantSectionProps) {
+  const roommateOptions = useMemo<RoommateOption[]>(() => {
+    const unique = new Map<string, string>()
+
+    unique.set("all", "All roommates")
+    unique.set("self", "My overlays")
+    unique.set("unassigned", "Unassigned overlays")
+
+    for (const membership of memberships) {
+      const id = membership.profile?.id
+      if (!id) {
+        continue
+      }
+      const label = membership.profile?.fullName ?? "Roommate"
+      unique.set(id, label)
+    }
+
+    return Array.from(unique.entries()).map(([id, label]) => ({ id, label }))
+  }, [memberships])
+
+  const allTypes = useMemo(() => {
+    const typeSet = new Set<AnnotationType>()
+    for (const floorplan of floorplans) {
+      for (const annotation of floorplan.annotations) {
+        typeSet.add(annotation.annotationType)
+      }
+    }
+    return Array.from(typeSet)
+  }, [floorplans])
+
+  const [roommateFilter, setRoommateFilter] = useState<RoommateFilter>("all")
+  const [activeTypes, setActiveTypes] = useState<Set<AnnotationType>>(new Set(allTypes))
+
+  useEffect(() => {
+    setActiveTypes(new Set(allTypes))
+  }, [allTypes])
+
+  const toggleType = (type: AnnotationType) => {
+    setActiveTypes((current) => {
+      const next = new Set(current)
+      if (next.has(type)) {
+        next.delete(type)
+      } else {
+        next.add(type)
+      }
+      return next
+    })
+  }
+
+  const filteredFloorplans = useMemo(() => {
+    return floorplans.map((floorplan) => {
+      let annotations = floorplan.annotations
+
+      if (roommateFilter === "self") {
+        annotations = annotations.filter((annotation) => annotation.profileId === profileId)
+      } else if (roommateFilter === "unassigned") {
+        annotations = annotations.filter((annotation) => annotation.profileId == null)
+      } else if (roommateFilter !== "all") {
+        annotations = annotations.filter((annotation) => annotation.profileId === roommateFilter)
+      }
+
+      if (activeTypes.size > 0) {
+        annotations = annotations.filter((annotation) => activeTypes.has(annotation.annotationType))
+      } else {
+        annotations = []
+      }
+
+      return {
+        ...floorplan,
+        annotations,
+      }
+    })
+  }, [activeTypes, floorplans, profileId, roommateFilter])
+
+  return (
+    <section className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Roommate overlays</CardTitle>
+          <CardDescription>
+            Toggle overlays to see storage assignments, chores, and roommate notes for your home.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="roommate-filter">Roommate</Label>
+            <Select
+              value={roommateFilter}
+              onValueChange={(value) => setRoommateFilter(value as RoommateFilter)}
+            >
+              <SelectTrigger id="roommate-filter">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {roommateOptions.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Categories</Label>
+            <div className="flex flex-wrap gap-2">
+              {allTypes.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No overlays available yet.</p>
+              ) : (
+                allTypes.map((type) => {
+                  const isActive = activeTypes.has(type)
+                  return (
+                    <Button
+                      key={type}
+                      type="button"
+                      variant={isActive ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => toggleType(type)}
+                    >
+                      {annotationTypeLabels[type]}
+                    </Button>
+                  )
+                })
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {filteredFloorplans.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No floorplans available</CardTitle>
+            <CardDescription>Once your property manager uploads floorplans, they will appear here.</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        filteredFloorplans.map((floorplan) => (
+          <Card key={floorplan.id}>
+            <CardHeader>
+              <CardTitle>{floorplan.name}</CardTitle>
+              <CardDescription>
+                {floorplan.building.name ?? "Unnamed building"}
+                {floorplan.unit ? ` • Unit ${floorplan.unit.unitNumber ?? ""}` : " • Building wide"}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="relative overflow-hidden rounded-lg border">
+                {floorplan.signedUrl ? (
+                  <Image
+                    src={floorplan.signedUrl}
+                    alt={`${floorplan.name} preview`}
+                    width={1600}
+                    height={1200}
+                    className="h-auto w-full object-contain"
+                    sizes="(min-width: 768px) 420px, 100vw"
+                  />
+                ) : (
+                  <div className="flex h-64 items-center justify-center bg-muted">
+                    <p className="text-sm text-muted-foreground">No preview available</p>
+                  </div>
+                )}
+
+                {floorplan.annotations.map((annotation) => {
+                  if (!annotation.geometry || annotation.geometry.type !== "rect") {
+                    return null
+                  }
+
+                  const { x, y, width, height } = annotation.geometry
+                  const color = annotationColors[annotation.annotationType]
+
+                  return (
+                    <div
+                      key={annotation.id}
+                      className="absolute rounded border-2"
+                      style={{
+                        left: `${x * 100}%`,
+                        top: `${y * 100}%`,
+                        width: `${width * 100}%`,
+                        height: `${height * 100}%`,
+                        borderColor: color,
+                        backgroundColor: `${color}22`,
+                      }}
+                    >
+                      <span className="absolute bottom-1 left-1 rounded bg-black/70 px-1 text-xs text-white">
+                        {annotation.label}
+                      </span>
+                    </div>
+                  )
+                })}
+              </div>
+
+              <div className="space-y-3">
+                {floorplan.annotations.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No overlays match your filters.</p>
+                ) : (
+                  floorplan.annotations.map((annotation) => (
+                    <div key={annotation.id} className="rounded border p-3">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <Badge variant="outline">{annotationTypeLabels[annotation.annotationType]}</Badge>
+                            <span className="font-medium">{annotation.label}</span>
+                          </div>
+                          <p className="text-sm text-muted-foreground">
+                            {annotation.assigneeName ?? "Shared by everyone"}
+                          </p>
+                        </div>
+                        {annotation.metadata && Object.keys(annotation.metadata).length > 0 && (
+                          <div className="text-xs text-muted-foreground">
+                            {Object.entries(annotation.metadata).map(([key, value]) => (
+                              <div key={key}>
+                                <span className="font-medium">{key}:</span> {String(value)}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        ))
+      )}
+    </section>
+  )
+}

--- a/app/dashboard/floorplans/page.tsx
+++ b/app/dashboard/floorplans/page.tsx
@@ -1,0 +1,311 @@
+import { redirect } from "next/navigation"
+
+import { normalizeGeometry } from "@/lib/floorplans/access"
+import type { Database } from "@/lib/supabase"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+import ManagerSection from "./components/ManagerSection"
+import TenantSection from "./components/TenantSection"
+import type {
+  AnnotationClientModel,
+  BuildingOption,
+  FloorplanClientModel,
+  MembershipClientModel,
+} from "./types"
+
+const SIGNED_URL_TTL_SECONDS = 60 * 60
+
+export default async function FloorplansPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return redirect("/auth")
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, role, full_name")
+    .eq("id", user.id)
+    .maybeSingle()
+
+  if (profileError || !profile) {
+    return redirect("/auth")
+  }
+
+  const isManager = profile.role === "property_manager" || profile.role === "admin"
+  const isTenant = profile.role === "tenant" || profile.role === "roommate"
+
+  type SupabaseFloorplan = Database["public"]["Tables"]["floorplans"]["Row"] & {
+    building: (Database["public"]["Tables"]["buildings"]["Row"] & {
+      units: (Database["public"]["Tables"]["units"]["Row"] & {
+        unit_memberships: (Database["public"]["Tables"]["unit_memberships"]["Row"] & {
+          profile: Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "full_name"> | null
+        })[]
+      })[]
+    }) | null
+    unit: (Database["public"]["Tables"]["units"]["Row"] & {
+      unit_memberships: (Database["public"]["Tables"]["unit_memberships"]["Row"] & {
+        profile: Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "full_name"> | null
+      })[]
+    }) | null
+    floorplan_annotations: (Database["public"]["Tables"]["floorplan_annotations"]["Row"] & {
+      profile: Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "full_name"> | null
+    })[]
+  }
+
+  const { data: floorplansData } = await supabase
+    .from("floorplans")
+    .select(
+      `
+        id,
+        name,
+        description,
+        storage_path,
+        media_type,
+        building_id,
+        unit_id,
+        created_at,
+        updated_at,
+        building:building_id (
+          id,
+          name,
+          units (
+            id,
+            unit_number,
+            unit_memberships (
+              id,
+              profile_id,
+              membership_role,
+              profile:profile_id ( id, full_name )
+            )
+          )
+        ),
+        unit:unit_id (
+          id,
+          unit_number,
+          building_id,
+          unit_memberships (
+            id,
+            profile_id,
+            membership_role,
+            profile:profile_id ( id, full_name )
+          )
+        ),
+        floorplan_annotations (
+          id,
+          floorplan_id,
+          label,
+          annotation_type,
+          profile_id,
+          geometry,
+          metadata,
+          created_at,
+          updated_at,
+          profile:profile_id ( id, full_name )
+        )
+      `
+    )
+    .order("created_at", { ascending: false })
+
+  const storageClient = supabase.storage.from("floorplans")
+
+  const floorplans: FloorplanClientModel[] = []
+
+  const rawFloorplans = (floorplansData as SupabaseFloorplan[] | null) ?? []
+
+  for (const item of rawFloorplans) {
+    const profileMap = new Map<string, { id: string; name: string | null }>()
+
+    const appendProfile = (input: { profile_id: string | null; profile: { id: string; full_name: string | null } | null }) => {
+      if (!input.profile_id) {
+        return
+      }
+
+      const name = input.profile?.full_name ?? "Roommate"
+
+      if (!profileMap.has(input.profile_id)) {
+        profileMap.set(input.profile_id, { id: input.profile_id, name })
+      }
+    }
+
+    if (item.unit?.unit_memberships) {
+      for (const membership of item.unit.unit_memberships) {
+        appendProfile(membership)
+      }
+    }
+
+    if (!item.unit && item.building?.units) {
+      for (const unit of item.building.units) {
+        for (const membership of unit.unit_memberships ?? []) {
+          appendProfile(membership)
+        }
+      }
+    }
+
+    const availableProfiles = Array.from(profileMap.values())
+
+    const annotations: AnnotationClientModel[] = (item.floorplan_annotations ?? []).map((annotation) => ({
+      id: annotation.id,
+      floorplanId: annotation.floorplan_id,
+      label: annotation.label,
+      annotationType: annotation.annotation_type,
+      profileId: annotation.profile_id,
+      assigneeName: annotation.profile?.full_name ?? null,
+      geometry: normalizeGeometry(annotation.geometry),
+      metadata: (annotation.metadata && typeof annotation.metadata === "object") ? (annotation.metadata as Record<string, unknown>) : null,
+      createdAt: annotation.created_at,
+      updatedAt: annotation.updated_at,
+    }))
+
+    let signedUrl: string | null = null
+
+    if (item.storage_path) {
+      const { data: signed } = await storageClient.createSignedUrl(item.storage_path, SIGNED_URL_TTL_SECONDS)
+      signedUrl = signed?.signedUrl ?? null
+    }
+
+    floorplans.push({
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      storagePath: item.storage_path,
+      mediaType: item.media_type,
+      signedUrl,
+      annotations,
+      availableProfiles,
+      building: {
+        id: item.building?.id ?? item.building_id,
+        name: item.building?.name ?? null,
+      },
+      unit: item.unit
+        ? {
+            id: item.unit.id,
+            unitNumber: item.unit.unit_number,
+            buildingId: item.unit.building_id,
+          }
+        : null,
+      createdAt: item.created_at,
+    })
+  }
+
+  let buildingOptions: BuildingOption[] = []
+
+  if (profile.role === "admin") {
+    const { data: buildingsData } = await supabase
+      .from("buildings")
+      .select(
+        `
+          id,
+          name,
+          units (
+            id,
+            unit_number
+          )
+        `
+      )
+      .order("name")
+
+    buildingOptions = (buildingsData ?? []).map((building) => ({
+      id: building.id,
+      name: building.name,
+      units: (building.units ?? []).map((unit) => ({
+        id: unit.id,
+        unitNumber: unit.unit_number,
+      })),
+    }))
+  } else if (profile.role === "property_manager") {
+    const { data: assignments } = await supabase
+      .from("property_manager_buildings")
+      .select(
+        `
+          building:building_id (
+            id,
+            name,
+            units (
+              id,
+              unit_number
+            )
+          )
+        `
+      )
+      .eq("manager_id", profile.id)
+
+    buildingOptions = (assignments ?? [])
+      .map((assignment) => assignment.building)
+      .filter((building): building is NonNullable<typeof building> => Boolean(building))
+      .map((building) => ({
+        id: building.id,
+        name: building.name,
+        units: (building.units ?? []).map((unit) => ({
+          id: unit.id,
+          unitNumber: unit.unit_number,
+        })),
+      }))
+  }
+
+  let memberships: MembershipClientModel[] = []
+
+  if (isTenant) {
+    const { data: membershipsData } = await supabase
+      .from("unit_memberships")
+      .select(
+        `
+          id,
+          unit_id,
+          membership_role,
+          profile:profile_id ( id, full_name ),
+          unit:unit_id (
+            id,
+            unit_number,
+            building_id,
+            building:building_id ( id, name )
+          )
+        `
+      )
+
+    memberships = (membershipsData ?? []).map((membership) => ({
+      id: membership.id,
+      unitId: membership.unit_id,
+      membershipRole: membership.membership_role,
+      profile: membership.profile
+        ? { id: membership.profile.id, fullName: membership.profile.full_name }
+        : null,
+      unit: membership.unit
+        ? {
+            id: membership.unit.id,
+            unitNumber: membership.unit.unit_number,
+            buildingId: membership.unit.building_id,
+            building: membership.unit.building
+              ? { id: membership.unit.building.id, name: membership.unit.building.name }
+              : null,
+          }
+        : null,
+    }))
+  }
+
+  const pageTitle = "Floorplans"
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">{pageTitle}</h1>
+        <p className="text-muted-foreground">
+          View and manage annotated layouts for your shared spaces.
+        </p>
+      </div>
+
+      {isManager && (
+        <ManagerSection floorplans={floorplans} buildingOptions={buildingOptions} />
+      )}
+
+      <TenantSection
+        floorplans={floorplans}
+        memberships={memberships}
+        profileId={profile.id}
+      />
+    </div>
+  )
+}

--- a/app/dashboard/floorplans/types.ts
+++ b/app/dashboard/floorplans/types.ts
@@ -1,0 +1,57 @@
+import type { NormalizedGeometry } from "@/lib/floorplans/access"
+import type { Database } from "@/lib/supabase"
+
+export type AnnotationType = Database["public"]["Enums"]["floorplan_annotation_type"]
+
+export type AnnotationClientModel = {
+  id: string
+  floorplanId: string
+  label: string
+  annotationType: AnnotationType
+  profileId: string | null
+  assigneeName: string | null
+  geometry: NormalizedGeometry | null
+  metadata: Record<string, unknown> | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export type FloorplanClientModel = {
+  id: string
+  name: string
+  description: string | null
+  building: {
+    id: string
+    name: string | null
+  }
+  unit: {
+    id: string
+    unitNumber: string | null
+    buildingId: string
+  } | null
+  storagePath: string
+  mediaType: string
+  signedUrl: string | null
+  annotations: AnnotationClientModel[]
+  availableProfiles: { id: string; name: string | null }[]
+  createdAt: string | null
+}
+
+export type BuildingOption = {
+  id: string
+  name: string | null
+  units: { id: string; unitNumber: string | null }[]
+}
+
+export type MembershipClientModel = {
+  id: string
+  unitId: string
+  membershipRole: Database["public"]["Enums"]["unit_membership_role"]
+  profile: { id: string; fullName: string | null } | null
+  unit: {
+    id: string
+    unitNumber: string | null
+    buildingId: string
+    building: { id: string; name: string | null } | null
+  } | null
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,17 +18,17 @@ export default async function IndexPage() {
     return redirect("/dashboard")
   }
   return (
-    <section className="relative max-w-dvw w-full overflow-hidden bg-arctic-gradient pb-16">
-      <div className="container px-4 py-8 mx-auto flex flex-col space-y-16 items-center pb-16 pt-16 sm:pt-16 sm:pb-24">
-        <div className="flex mx-auto flex-col px-4 md:px-6 lg:px-8 w-full items-center gap-y-12">
-          <h1 className="text-4xl sm:text-5xl lg:text-7xl font-extrabold leading-tight tracking-tighter md:text-6xl text-center">
+    <section className="max-w-dvw bg-arctic-gradient relative w-full overflow-hidden pb-16">
+      <div className="container mx-auto flex w-full flex-col items-center space-y-16 px-4 py-16 sm:pb-24 sm:pt-16">
+        <div className="mx-auto flex w-full flex-col items-center gap-y-12 px-4 md:px-6 lg:px-8">
+          <h1 className="text-center text-4xl font-extrabold leading-tight tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl">
             Onyx SaaS PWA Template
           </h1>
 
           {/* The PrismContainer uses dynamic client-side rendering to display the FeaturesAnimation component. I wanted to demo the usage of Fibonacci's Golden Ratio in an interactive 3D component for devs who may be interested in expanding upon the general concept of the animation. Theres a working implementation running NextJS 15 and React 19 at github.com/rmourey26/3d-prism-infographic and 3d-prism-infographic.vercel.app. The Onyx version needs some tinkering to work properly with React 18.3. I should be able to get that done by 05-10-2025. We'll see. 
         <PrismContainer />
       */}
-          <p className="max-w-3xl text-lg lg:text-xl xs:text-justify text-muted-foreground">
+          <p className="xs:text-justify max-w-3xl text-lg text-muted-foreground lg:text-xl">
             Secure user authentication + RBAC, Zod validated Supabase Postgres
             DB CRUD ops, Rust serverless API runtime, TanStack queries with
             Supabase cache helpers, Resend, SID.ai, NextMDX, admin dashboard,
@@ -36,7 +36,7 @@ export default async function IndexPage() {
           </p>
         </div>
         <Cta />
-        <div className="flex gap-6 mb-8">
+        <div className="mb-8 flex gap-6">
           <Link href={siteConfig.links.login} className={buttonVariants()}>
             Login
           </Link>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -27,13 +27,13 @@ export function MobileNav({ isAuthenticated }: MobileNavProps) {
           variant="ghost"
           className="mr-0 px-0 text-base hover:bg-transparent focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 md:hidden"
         >
-          <Icons.menu className="h-6 w-6" />
+          <Icons.menu className="size-6" />
           <span className="sr-only">Toggle Menu</span>
         </Button>
       </SheetTrigger>
       <div className="xs:items-center ml-1 gap-4 md:hidden">
         <Link href="/" className="flex items-center space-x-2">
-          <Icons.logo className="h-6 w-6" />
+          <Icons.logo className="size-6" />
           <span className="font-bold">{siteConfig.name}</span>
         </Link>
       </div>

--- a/lib/__tests__/floorplans.test.ts
+++ b/lib/__tests__/floorplans.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildAnnotationTypeSet,
+  canManageBuilding,
+  canManageFloorplan,
+  canViewFloorplan,
+  collectMembershipSummary,
+  filterAnnotationsByRoommate,
+  filterAnnotationsByTypes,
+  normalizeGeometry,
+  type FloorplanRow,
+  type MembershipSummary,
+} from "@/lib/floorplans/access"
+
+const mockFloorplan = (overrides: Partial<FloorplanRow> = {}) => ({
+  building_id: "building-1",
+  created_at: null,
+  created_by: null,
+  description: null,
+  id: "floorplan-1",
+  media_type: "image/png",
+  name: "Main Floor",
+  storage_path: "path",
+  unit_id: "unit-1",
+  updated_at: null,
+  ...overrides,
+})
+
+describe("membership summary", () => {
+  it("collects unique unit and building identifiers", () => {
+    const summary = collectMembershipSummary([
+      { unit_id: "unit-1", unit: { building_id: "building-1" } },
+      { unit_id: "unit-2", unit: { building_id: "building-1" } },
+      { unit_id: "unit-1", unit: { building_id: "building-1" } },
+      { unit_id: "unit-3", unit: { building_id: "building-2" } },
+    ])
+
+    expect(summary.unitIds.sort()).toEqual(["unit-1", "unit-2", "unit-3"].sort())
+    expect(summary.buildingIds.sort()).toEqual(["building-1", "building-2"].sort())
+  })
+})
+
+describe("management permissions", () => {
+  it("allows admins to manage any building", () => {
+    expect(canManageBuilding("admin", "building-1", [])).toBe(true)
+  })
+
+  it("allows property managers for assigned buildings", () => {
+    expect(canManageBuilding("property_manager", "building-2", ["building-2"]))
+      .toBe(true)
+    expect(canManageBuilding("property_manager", "building-3", ["building-2"]))
+      .toBe(false)
+  })
+
+  it("evaluates floorplan permissions", () => {
+    const floorplan = mockFloorplan({ building_id: "building-2" })
+    expect(canManageFloorplan("admin", floorplan, [])).toBe(true)
+    expect(canManageFloorplan("property_manager", floorplan, ["building-2"])).toBe(true)
+    expect(canManageFloorplan("property_manager", floorplan, ["building-1"])).toBe(false)
+  })
+})
+
+describe("view permissions", () => {
+  const membershipSummary: MembershipSummary = {
+    unitIds: ["unit-1"],
+    buildingIds: ["building-1"],
+  }
+
+  it("allows tenants to view their unit floorplans", () => {
+    const floorplan = mockFloorplan()
+    expect(
+      canViewFloorplan("tenant", floorplan, membershipSummary, [])
+    ).toBe(true)
+  })
+
+  it("prevents tenants from other buildings", () => {
+    const floorplan = mockFloorplan({ unit_id: "unit-2", building_id: "building-2" })
+    expect(
+      canViewFloorplan("tenant", floorplan, membershipSummary, [])
+    ).toBe(false)
+  })
+
+  it("allows building-wide floorplans for the same building", () => {
+    const floorplan = mockFloorplan({ unit_id: null, building_id: "building-1" })
+    expect(
+      canViewFloorplan("roommate", floorplan, membershipSummary, [])
+    ).toBe(true)
+  })
+})
+
+describe("geometry normalisation", () => {
+  it("normalises rectangle geometry", () => {
+    const geometry = normalizeGeometry({ type: "rect", x: 1.2, y: -0.5, width: 0.4, height: 0.6 })
+    expect(geometry).toEqual({ type: "rect", x: 1, y: 0, width: 0.4, height: 0.6 })
+  })
+
+  it("rejects invalid geometry", () => {
+    expect(normalizeGeometry(null)).toBeNull()
+    expect(normalizeGeometry({})).toBeNull()
+    expect(normalizeGeometry({ type: "rect" })).toBeNull()
+  })
+})
+
+describe("annotation helpers", () => {
+  const annotations = [
+    { annotation_type: "storage", profile_id: "a" },
+    { annotation_type: "note", profile_id: "b" },
+    { annotation_type: "chore", profile_id: null },
+  ] as const
+
+  it("builds annotation type sets", () => {
+    const typeSet = buildAnnotationTypeSet(Array.from(annotations))
+    expect(Array.from(typeSet).sort()).toEqual(["storage", "note", "chore"].sort())
+  })
+
+  it("filters by roommate", () => {
+    expect(filterAnnotationsByRoommate(Array.from(annotations), "all").length).toBe(3)
+    expect(filterAnnotationsByRoommate(Array.from(annotations), "a").length).toBe(1)
+    expect(filterAnnotationsByRoommate(Array.from(annotations), "unassigned").length).toBe(1)
+  })
+
+  it("filters by type set", () => {
+    const visible = filterAnnotationsByTypes(Array.from(annotations), new Set(["storage", "chore"]))
+    expect(visible.length).toBe(2)
+
+    const none = filterAnnotationsByTypes(Array.from(annotations), new Set())
+    expect(none).toEqual([])
+  })
+})

--- a/lib/floorplans/access.ts
+++ b/lib/floorplans/access.ts
@@ -1,0 +1,211 @@
+import type { Database, Json } from "@/lib/supabase"
+
+export type FloorplanRow = Database["public"]["Tables"]["floorplans"]["Row"]
+export type FloorplanAnnotationRow = Database["public"]["Tables"]["floorplan_annotations"]["Row"]
+export type UnitMembershipRow = Database["public"]["Tables"]["unit_memberships"]["Row"]
+
+export type RoleString = string | null
+
+export type RectGeometry = {
+  type: "rect"
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export type NormalizedGeometry =
+  | RectGeometry
+  | ({
+      type: string
+      [key: string]: number | string | boolean | null
+    } & Record<string, number | string | boolean | null>)
+
+export type MembershipSummary = {
+  unitIds: string[]
+  buildingIds: string[]
+}
+
+export type RoommateFilterValue = "all" | "unassigned" | string | null
+
+export function collectMembershipSummary(
+  memberships: Array<
+    Pick<UnitMembershipRow, "unit_id"> & {
+      unit?: { building_id: string | null } | null
+    }
+  >
+): MembershipSummary {
+  const unitIds = new Set<string>()
+  const buildingIds = new Set<string>()
+
+  for (const membership of memberships) {
+    if (membership.unit_id) {
+      unitIds.add(membership.unit_id)
+    }
+
+    const buildingId = membership.unit?.building_id
+    if (buildingId) {
+      buildingIds.add(buildingId)
+    }
+  }
+
+  return {
+    unitIds: Array.from(unitIds),
+    buildingIds: Array.from(buildingIds),
+  }
+}
+
+export function canManageBuilding(
+  role: RoleString,
+  buildingId: string,
+  managedBuildingIds: readonly string[]
+): boolean {
+  if (role === "admin") {
+    return true
+  }
+
+  if (role === "property_manager") {
+    return managedBuildingIds.includes(buildingId)
+  }
+
+  return false
+}
+
+export function canManageFloorplan(
+  role: RoleString,
+  floorplan: Pick<FloorplanRow, "building_id">,
+  managedBuildingIds: readonly string[]
+): boolean {
+  return canManageBuilding(role, floorplan.building_id, managedBuildingIds)
+}
+
+export function canViewFloorplan(
+  role: RoleString,
+  floorplan: Pick<FloorplanRow, "unit_id" | "building_id">,
+  membershipSummary: MembershipSummary,
+  managedBuildingIds: readonly string[]
+): boolean {
+  if (role === "admin") {
+    return true
+  }
+
+  if (role === "property_manager") {
+    return managedBuildingIds.includes(floorplan.building_id)
+  }
+
+  if (role === "tenant" || role === "roommate") {
+    if (floorplan.unit_id) {
+      return membershipSummary.unitIds.includes(floorplan.unit_id)
+    }
+
+    return membershipSummary.buildingIds.includes(floorplan.building_id)
+  }
+
+  return false
+}
+
+const CLAMP_MIN = 0
+const CLAMP_MAX = 1
+
+const clamp = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  if (value < CLAMP_MIN) {
+    return CLAMP_MIN
+  }
+
+  if (value > CLAMP_MAX) {
+    return CLAMP_MAX
+  }
+
+  return value
+}
+
+export function normalizeGeometry(input: Json | null): NormalizedGeometry | null {
+  if (!input || typeof input !== "object") {
+    return null
+  }
+
+  const maybeGeometry = input as Record<string, unknown>
+  const type = maybeGeometry.type
+
+  if (typeof type !== "string") {
+    return null
+  }
+
+  if (type === "rect") {
+    const rawValues = [maybeGeometry.x, maybeGeometry.y, maybeGeometry.width, maybeGeometry.height].map((value) =>
+      typeof value === "number" || typeof value === "string" ? Number(value) : Number.NaN,
+    )
+
+    if (rawValues.some((value) => !Number.isFinite(value))) {
+      return null
+    }
+
+    const [x, y, width, height] = rawValues.map((value) => clamp(value))
+
+    return {
+      type: "rect",
+      x,
+      y,
+      width,
+      height,
+    }
+  }
+
+  const sanitized: Record<string, number | string | boolean | null> = {}
+
+  for (const [key, value] of Object.entries(maybeGeometry)) {
+    if (key === "type") {
+      continue
+    }
+
+    if (typeof value === "number" || typeof value === "string" || typeof value === "boolean") {
+      sanitized[key] = value
+    } else if (value === null) {
+      sanitized[key] = null
+    }
+  }
+
+  sanitized.type = type
+
+  return sanitized as NormalizedGeometry
+}
+
+export function filterAnnotationsByRoommate<T extends { profile_id: string | null }>(
+  annotations: T[],
+  roommate: RoommateFilterValue
+): T[] {
+  if (!roommate || roommate === "all") {
+    return annotations
+  }
+
+  if (roommate === "unassigned") {
+    return annotations.filter((annotation) => annotation.profile_id == null)
+  }
+
+  return annotations.filter((annotation) => annotation.profile_id === roommate)
+}
+
+export function filterAnnotationsByTypes<T extends { annotation_type: Database["public"]["Enums"]["floorplan_annotation_type"] }>(
+  annotations: T[],
+  visibleTypes: ReadonlySet<Database["public"]["Enums"]["floorplan_annotation_type"]>
+): T[] {
+  if (visibleTypes.size === 0) {
+    return []
+  }
+
+  return annotations.filter((annotation) => visibleTypes.has(annotation.annotation_type))
+}
+
+type AnnotationWithType = {
+  annotation_type: Database["public"]["Enums"]["floorplan_annotation_type"]
+}
+
+export function buildAnnotationTypeSet(
+  annotations: AnnotationWithType[]
+): Set<Database["public"]["Enums"]["floorplan_annotation_type"]> {
+  return new Set(annotations.map((annotation) => annotation.annotation_type))
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1596,6 +1596,278 @@ export type Database = {
           },
         ]
       }
+      buildings: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          slug: string | null
+          street_address: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          name: string
+          slug?: string | null
+          street_address?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          slug?: string | null
+          street_address?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      floorplan_annotations: {
+        Row: {
+          annotation_type: Database["public"]["Enums"]["floorplan_annotation_type"]
+          created_at: string | null
+          created_by: string | null
+          floorplan_id: string
+          geometry: Json
+          id: string
+          label: string
+          metadata: Json | null
+          profile_id: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          annotation_type?: Database["public"]["Enums"]["floorplan_annotation_type"]
+          created_at?: string | null
+          created_by?: string | null
+          floorplan_id: string
+          geometry: Json
+          id?: string
+          label: string
+          metadata?: Json | null
+          profile_id?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          annotation_type?: Database["public"]["Enums"]["floorplan_annotation_type"]
+          created_at?: string | null
+          created_by?: string | null
+          floorplan_id?: string
+          geometry?: Json
+          id?: string
+          label?: string
+          metadata?: Json | null
+          profile_id?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "floorplan_annotations_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "floorplan_annotations_floorplan_id_fkey"
+            columns: ["floorplan_id"]
+            isOneToOne: false
+            referencedRelation: "floorplans"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "floorplan_annotations_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      floorplans: {
+        Row: {
+          building_id: string
+          created_at: string | null
+          created_by: string | null
+          description: string | null
+          id: string
+          media_type: string
+          name: string
+          storage_path: string
+          unit_id: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          building_id: string
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          media_type?: string
+          name: string
+          storage_path: string
+          unit_id?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          building_id?: string
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          media_type?: string
+          name?: string
+          storage_path?: string
+          unit_id?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "floorplans_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "floorplans_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "floorplans_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      property_manager_buildings: {
+        Row: {
+          building_id: string
+          created_at: string | null
+          id: string
+          manager_id: string
+        }
+        Insert: {
+          building_id: string
+          created_at?: string | null
+          id?: string
+          manager_id: string
+        }
+        Update: {
+          building_id?: string
+          created_at?: string | null
+          id?: string
+          manager_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "property_manager_buildings_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "property_manager_buildings_manager_id_fkey"
+            columns: ["manager_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      unit_memberships: {
+        Row: {
+          created_at: string | null
+          id: string
+          invited_by: string | null
+          membership_role: Database["public"]["Enums"]["unit_membership_role"]
+          profile_id: string
+          unit_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          invited_by?: string | null
+          membership_role?: Database["public"]["Enums"]["unit_membership_role"]
+          profile_id: string
+          unit_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          invited_by?: string | null
+          membership_role?: Database["public"]["Enums"]["unit_membership_role"]
+          profile_id?: string
+          unit_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "unit_memberships_invited_by_fkey"
+            columns: ["invited_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "unit_memberships_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "unit_memberships_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      units: {
+        Row: {
+          bathrooms: number | null
+          bedrooms: number | null
+          building_id: string
+          created_at: string | null
+          id: string
+          unit_number: string
+          updated_at: string | null
+        }
+        Insert: {
+          bathrooms?: number | null
+          bedrooms?: number | null
+          building_id: string
+          created_at?: string | null
+          id?: string
+          unit_number: string
+          updated_at?: string | null
+        }
+        Update: {
+          bathrooms?: number | null
+          bedrooms?: number | null
+          building_id?: string
+          created_at?: string | null
+          id?: string
+          unit_number?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "units_building_id_fkey"
+            columns: ["building_id"]
+            isOneToOne: false
+            referencedRelation: "buildings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       package_utilization: {
@@ -1774,7 +2046,9 @@ export type Database = {
         | "Oceania"
         | "North America"
         | "South America"
+      floorplan_annotation_type: "storage" | "chore" | "note" | "other"
       user_role: "user" | "admin"
+      unit_membership_role: "tenant" | "roommate" | "property_manager"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,10 @@ const ContentSecurityPolicy = `
   form-action 'self';
 `
 
+const supabaseHostname = process.env.NEXT_PUBLIC_SUPABASE_URL
+  ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
+  : "*.supabase.co"
+
 const securityHeaders = [
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
   {
@@ -69,52 +73,55 @@ const nextConfig = {
   experimental: {
     mdxRs: true,
   },
-    images : {
-      remotePatterns: [
+  images: {
+    remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'quantumone.b-cdn.net',
-        port: '',
-        pathname: '/onyx/**',
+        protocol: "https",
+        hostname: "quantumone.b-cdn.net",
+        port: "",
+        pathname: "/onyx/**",
       },
       {
-        protocol: 'https',
-        hostname: 'unpkg.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "unpkg.com",
+        port: "",
+        pathname: "/**",
       },
       {
-        protocol: 'https',
-        hostname: 'lh3.googleusercontent.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        port: "",
+        pathname: "/**",
       },
       {
-        protocol: 'https',
-        hostname: 'youtube.com',
-        port: '',
-        pathname: '/embed/HR6a2aHhY_c?si=L2O3Cf7pQ-0HHhsP',
-      },
-
-      {
-        protocol: 'https',
-        hostname: 'quantumone.b-cdn.net',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "youtube.com",
+        port: "",
+        pathname: "/embed/HR6a2aHhY_c?si=L2O3Cf7pQ-0HHhsP",
       },
       {
-        protocol: 'https',
-        hostname: 'images.unsplash.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "quantumone.b-cdn.net",
+        port: "",
+        pathname: "/**",
       },
-
       {
-
-        protocol: 'https',
-        hostname: 'api.web3modal.com',
-        port: '',
-      
+        protocol: "https",
+        hostname: "images.unsplash.com",
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "api.web3modal.com",
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: supabaseHostname,
+        port: "",
+        pathname: "/**",
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -97,7 +98,7 @@
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
     "@types/eslint": "^8.56.2",
     "@types/lodash": "^4.14.202",
-    "@types/node": "^20.14.15",
+    "@types/node": "^20.19.17",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/parser": "^5.62.0",
@@ -109,6 +110,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -268,8 +268,8 @@ importers:
         specifier: ^4.14.202
         version: 4.14.202
       '@types/node':
-        specifier: ^20.14.15
-        version: 20.14.15
+        specifier: ^20.19.17
+        version: 20.19.17
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
@@ -306,6 +306,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
 
 packages:
 
@@ -1328,6 +1331,162 @@ packages:
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2323,6 +2482,116 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rushstack/eslint-patch@1.6.1':
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
 
@@ -2436,6 +2705,9 @@ packages:
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -2466,6 +2738,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
@@ -2487,8 +2762,8 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/google-one-tap@1.2.6':
     resolution: {integrity: sha512-REmJsXVHvKb/sgI8DF+7IesMbDbcsEokHBqxU01ENZ8d98UPWdRLhUCtxEm9bhNFFg6PJGy7PNFdvovp0hK3jA==}
@@ -2517,11 +2792,11 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@20.14.15':
-    resolution: {integrity: sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==}
-
   '@types/node@20.17.30':
     resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
+
+  '@types/node@20.19.17':
+    resolution: {integrity: sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==}
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
@@ -2648,6 +2923,35 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
@@ -2863,6 +3167,10 @@ packages:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -3020,6 +3328,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3056,6 +3368,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3084,6 +3400,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -3305,6 +3625,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
@@ -3314,6 +3643,10 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3456,8 +3789,8 @@ packages:
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
 
-  es-module-lexer@1.6.0:
-    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3473,6 +3806,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -3648,6 +3986,10 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -3682,6 +4024,15 @@ packages:
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
@@ -4218,6 +4569,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -4356,6 +4710,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -4781,6 +5138,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -4799,6 +5163,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -5015,8 +5383,8 @@ packages:
     resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   potpack@1.0.2:
@@ -5317,6 +5685,11 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5404,6 +5777,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5474,6 +5850,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
     peerDependencies:
@@ -5482,6 +5861,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -5544,6 +5926,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -5690,6 +6075,28 @@ packages:
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -5779,11 +6186,11 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -5934,6 +6341,79 @@ packages:
   victory-vendor@36.8.6:
     resolution: {integrity: sha512-PH8Wj9b0xIZ4AVfyn0c1SJrOhtxDJ5PNxj1ZDABPg1Gw1vJr1mJVqESPhvsFj7mXLQohVdiKqp4kWZkXlPcRcA==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.6:
+    resolution: {integrity: sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.4.35:
     resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
     peerDependencies:
@@ -5998,6 +6478,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workbox-background-sync@7.1.0:
@@ -7302,10 +7787,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7400,6 +7885,84 @@ snapshots:
   '@emotion/utils@1.2.1': {}
 
   '@emotion/weak-memoize@0.3.1': {}
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
+    optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
@@ -8524,6 +9087,72 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
   '@rushstack/eslint-patch@1.6.1': {}
 
   '@scure/base@1.1.5': {}
@@ -8668,6 +9297,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.5
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -8696,16 +9329,18 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/draco3d@1.4.10': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.12
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   '@types/eslint@8.56.12':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/eslint@8.56.2':
@@ -8721,7 +9356,7 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
-  '@types/estree@1.0.7': {}
+  '@types/estree@1.0.8': {}
 
   '@types/google-one-tap@1.2.6': {}
 
@@ -8747,13 +9382,13 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@20.14.15':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.17.30':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/node@20.19.17':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/offscreencanvas@2019.7.3': {}
 
@@ -8804,7 +9439,7 @@ snapshots:
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 20.14.15
+      '@types/node': 20.19.17
 
   '@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4)':
     dependencies:
@@ -8853,19 +9488,61 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.4.35':
     dependencies:
@@ -8891,7 +9568,7 @@ snapshots:
       '@vue/shared': 3.4.35
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
     optional: true
 
@@ -9148,6 +9825,8 @@ snapshots:
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astring@1.8.6: {}
@@ -9327,6 +10006,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -9359,6 +10040,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9383,6 +10072,8 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -9423,7 +10114,7 @@ snapshots:
   code-red@1.0.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -9582,6 +10273,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.0.2:
@@ -9591,6 +10286,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -9780,7 +10477,7 @@ snapshots:
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
 
-  es-module-lexer@1.6.0: {}
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -9802,6 +10499,35 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
@@ -9815,8 +10541,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +10564,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +10581,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +10602,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10065,6 +10791,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  expect-type@1.2.2: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@2.0.1: {}
@@ -10096,6 +10824,10 @@ snapshots:
   fault@1.0.4:
     dependencies:
       format: 0.2.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fflate@0.6.10: {}
 
@@ -10610,7 +11342,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
     optional: true
 
   is-regex@1.1.4:
@@ -10714,6 +11446,8 @@ snapshots:
   js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -10829,6 +11563,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -10858,7 +11594,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   markdown-extensions@2.0.0: {}
 
@@ -11239,8 +11974,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -11252,13 +11986,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +12002,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11437,6 +12171,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   peberminta@0.9.0: {}
 
   periscopic@3.1.0:
@@ -11449,10 +12187,11 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -11720,12 +12459,11 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  postcss@8.5.3:
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   potpack@1.0.2: {}
 
@@ -12063,6 +12801,34 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12183,6 +12949,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -12212,8 +12980,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -12236,12 +13003,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
     dependencies:
       '@types/three': 0.176.0
       three: 0.160.0
 
   stats.js@0.17.0: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -12326,6 +13097,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -12334,12 +13109,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 
@@ -12376,7 +13151,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -12519,6 +13294,21 @@ snapshots:
 
   tiny-invariant@1.3.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -12615,9 +13405,9 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  undici-types@5.26.5: {}
-
   undici-types@6.19.8: {}
+
+  undici-types@6.21.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -12784,6 +13574,83 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.17
+      fsevents: 2.3.3
+      jiti: 1.21.0
+      terser: 5.39.0
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+      vite-node: 3.2.4(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
@@ -12818,7 +13685,7 @@ snapshots:
   webpack@5.93.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
@@ -12827,7 +13694,7 @@ snapshots:
       browserslist: 4.23.3
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
+      es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -12898,6 +13765,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workbox-background-sync@7.1.0:
     dependencies:

--- a/supabase/migrations/20250715_floorplans_overlays.sql
+++ b/supabase/migrations/20250715_floorplans_overlays.sql
@@ -1,0 +1,455 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+INSERT INTO storage.buckets (id, name, public)
+SELECT 'floorplans', 'floorplans', false
+WHERE NOT EXISTS (
+  SELECT 1 FROM storage.buckets WHERE id = 'floorplans'
+);
+
+CREATE TYPE public.floorplan_annotation_type AS ENUM ('storage', 'chore', 'note', 'other');
+CREATE TYPE public.unit_membership_role AS ENUM ('tenant', 'roommate', 'property_manager');
+
+CREATE TABLE public.buildings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  slug text UNIQUE,
+  street_address text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE public.units (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  building_id uuid NOT NULL REFERENCES public.buildings(id) ON DELETE CASCADE,
+  unit_number text NOT NULL,
+  bedrooms smallint,
+  bathrooms smallint,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (building_id, unit_number)
+);
+
+CREATE TABLE public.unit_memberships (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  unit_id uuid NOT NULL REFERENCES public.units(id) ON DELETE CASCADE,
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  membership_role public.unit_membership_role NOT NULL DEFAULT 'tenant',
+  invited_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE (unit_id, profile_id)
+);
+
+CREATE TABLE public.property_manager_buildings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  manager_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  building_id uuid NOT NULL REFERENCES public.buildings(id) ON DELETE CASCADE,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE (manager_id, building_id)
+);
+
+CREATE TABLE public.floorplans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  building_id uuid NOT NULL REFERENCES public.buildings(id) ON DELETE CASCADE,
+  unit_id uuid REFERENCES public.units(id) ON DELETE SET NULL,
+  name text NOT NULL,
+  description text,
+  storage_path text NOT NULL,
+  media_type text NOT NULL DEFAULT 'image/svg+xml',
+  created_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (building_id, unit_id, name)
+);
+
+CREATE TABLE public.floorplan_annotations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  floorplan_id uuid NOT NULL REFERENCES public.floorplans(id) ON DELETE CASCADE,
+  profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  label text NOT NULL,
+  annotation_type public.floorplan_annotation_type NOT NULL DEFAULT 'other',
+  geometry jsonb NOT NULL,
+  metadata jsonb,
+  created_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX floorplan_annotations_floorplan_id_idx ON public.floorplan_annotations (floorplan_id);
+CREATE INDEX floorplan_annotations_profile_id_idx ON public.floorplan_annotations (profile_id);
+
+ALTER TABLE public.buildings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.units ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.unit_memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.property_manager_buildings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.floorplans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.floorplan_annotations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS storage.objects ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins manage buildings" ON public.buildings
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ));
+
+CREATE POLICY "Members view assigned buildings" ON public.buildings
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.unit_memberships um
+      JOIN public.units u ON u.id = um.unit_id
+      WHERE um.profile_id = auth.uid()
+        AND u.building_id = buildings.id
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      WHERE pmb.manager_id = auth.uid()
+        AND pmb.building_id = buildings.id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins manage units" ON public.units
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ));
+
+CREATE POLICY "Managers manage assigned units" ON public.units
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      WHERE pmb.manager_id = auth.uid()
+        AND pmb.building_id = units.building_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      WHERE pmb.manager_id = auth.uid()
+        AND pmb.building_id = units.building_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Residents view units" ON public.units
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.unit_memberships um
+      WHERE um.profile_id = auth.uid()
+        AND um.unit_id = units.id
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      WHERE pmb.manager_id = auth.uid()
+        AND pmb.building_id = units.building_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins manage unit memberships" ON public.unit_memberships
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ));
+
+CREATE POLICY "Managers manage unit memberships" ON public.unit_memberships
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      JOIN public.units u ON u.building_id = pmb.building_id
+      WHERE pmb.manager_id = auth.uid()
+        AND u.id = unit_memberships.unit_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      JOIN public.units u ON u.building_id = pmb.building_id
+      WHERE pmb.manager_id = auth.uid()
+        AND u.id = unit_memberships.unit_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Members view shared unit memberships" ON public.unit_memberships
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.unit_memberships um
+      WHERE um.unit_id = unit_memberships.unit_id
+        AND um.profile_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      JOIN public.units u ON u.building_id = pmb.building_id
+      WHERE pmb.manager_id = auth.uid()
+        AND u.id = unit_memberships.unit_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins manage manager assignments" ON public.property_manager_buildings
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ));
+
+CREATE POLICY "Managers view building assignments" ON public.property_manager_buildings
+  FOR SELECT
+  TO authenticated
+  USING (
+    property_manager_buildings.manager_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins manage floorplans" ON public.floorplans
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ));
+
+CREATE POLICY "Managers manage assigned floorplans" ON public.floorplans
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      WHERE pmb.manager_id = auth.uid()
+        AND pmb.building_id = floorplans.building_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      WHERE pmb.manager_id = auth.uid()
+        AND pmb.building_id = floorplans.building_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Residents view unit floorplans" ON public.floorplans
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.unit_memberships um
+      JOIN public.units u ON u.id = um.unit_id
+      WHERE um.profile_id = auth.uid()
+        AND (
+          floorplans.unit_id = um.unit_id
+          OR (floorplans.unit_id IS NULL AND u.building_id = floorplans.building_id)
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.property_manager_buildings pmb
+      WHERE pmb.manager_id = auth.uid()
+        AND pmb.building_id = floorplans.building_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins manage floorplan annotations" ON public.floorplan_annotations
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.role = 'admin'
+  ));
+
+CREATE POLICY "Managers manage assigned annotations" ON public.floorplan_annotations
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.floorplans fp
+      JOIN public.property_manager_buildings pmb ON pmb.building_id = fp.building_id
+      WHERE fp.id = floorplan_annotations.floorplan_id
+        AND pmb.manager_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.floorplans fp
+      JOIN public.property_manager_buildings pmb ON pmb.building_id = fp.building_id
+      WHERE fp.id = floorplan_annotations.floorplan_id
+        AND pmb.manager_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Residents view floorplan annotations" ON public.floorplan_annotations
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.floorplans fp
+      JOIN public.unit_memberships um ON um.unit_id = fp.unit_id
+      WHERE fp.id = floorplan_annotations.floorplan_id
+        AND fp.unit_id IS NOT NULL
+        AND um.profile_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.floorplans fp
+      JOIN public.units u ON u.building_id = fp.building_id
+      JOIN public.unit_memberships um ON um.unit_id = u.id
+      WHERE fp.id = floorplan_annotations.floorplan_id
+        AND fp.unit_id IS NULL
+        AND um.profile_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.floorplans fp
+      JOIN public.property_manager_buildings pmb ON pmb.building_id = fp.building_id
+      WHERE fp.id = floorplan_annotations.floorplan_id
+        AND pmb.manager_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY "Managers maintain floorplan assets" ON storage.objects
+  FOR ALL
+  TO authenticated
+  USING (
+    bucket_id = 'floorplans'
+    AND EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+    )
+  )
+  WITH CHECK (
+    bucket_id = 'floorplans'
+    AND EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Members view floorplan assets" ON storage.objects
+  FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'floorplans'
+    AND (
+      EXISTS (
+        SELECT 1
+        FROM public.floorplans fp
+        JOIN public.unit_memberships um ON um.unit_id = fp.unit_id
+        WHERE fp.storage_path = storage.objects.name
+          AND fp.unit_id IS NOT NULL
+          AND um.profile_id = auth.uid()
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM public.floorplans fp
+        JOIN public.units u ON u.building_id = fp.building_id
+        JOIN public.unit_memberships um ON um.unit_id = u.id
+        WHERE fp.storage_path = storage.objects.name
+          AND fp.unit_id IS NULL
+          AND um.profile_id = auth.uid()
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM public.floorplans fp
+        JOIN public.property_manager_buildings pmb ON pmb.building_id = fp.building_id
+        WHERE fp.storage_path = storage.objects.name
+          AND pmb.manager_id = auth.uid()
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'
+      )
+    )
+  );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const projectRoot = fileURLToPath(new URL(".", import.meta.url))
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["lib/__tests__/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(projectRoot, "."),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add Supabase storage, schema, and RLS policies for floorplans and annotation overlays
- build shared floorplan helpers, server actions, and dashboard UI for managers and tenants
- wire up vitest configuration, unit tests, and remote image support for Supabase assets

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d03ae79e1883288500c7074dbf9cf1