### PR TITLE
Add visitor workflow test coverage

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { CalendarIcon, PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,18 +8,23 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+                {
+                        href: "/dashboard/visitors",
+                        text: "Visitors",
+                        Icon: CalendarIcon,
+                },
+        ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/visitors/actions/cancel-visitor-request.ts
+++ b/app/dashboard/visitors/actions/cancel-visitor-request.ts
@@ -1,0 +1,69 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+
+import { sendVisitorNotifications } from '@/lib/notifications/visitors'
+import { createClient } from '@/utils/supa-server-actions'
+
+import {
+  cancelVisitorRequestSchema,
+  handleCancelVisitorRequest,
+  type CancelVisitorRequestInput,
+  type VisitorActionState,
+} from './shared'
+import { createCancelDependencies, getProfileById } from './data-access'
+
+export async function cancelVisitorRequest(
+  input: CancelVisitorRequestInput,
+): Promise<VisitorActionState> {
+  const parsed = cancelVisitorRequestSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      status: 'error',
+      message: 'Unable to cancel this visit. Please try again.',
+      issues: parsed.error.flatten().fieldErrors,
+    }
+  }
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    return {
+      status: 'error',
+      message: userError.message,
+    }
+  }
+
+  if (!user) {
+    return {
+      status: 'error',
+      message: 'You must be signed in to cancel a visitor stay.',
+    }
+  }
+
+  const profile = await getProfileById(supabase, user.id)
+  if (!profile) {
+    return {
+      status: 'error',
+      message: 'We could not load your profile.',
+    }
+  }
+
+  const dependencies = createCancelDependencies(supabase, profile)
+
+  return handleCancelVisitorRequest(
+    dependencies,
+    parsed.data,
+    sendVisitorNotifications,
+    {
+      revalidatePath,
+    },
+  )
+}

--- a/app/dashboard/visitors/actions/data-access.ts
+++ b/app/dashboard/visitors/actions/data-access.ts
@@ -1,0 +1,385 @@
+import type { PostgrestSingleResponse } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/supabase'
+import type {
+  ProfileRow,
+  ProfileSummary,
+  VisitorAuditEntryView,
+  VisitorAuditRow,
+  VisitorLogRow,
+  VisitorLogSummary,
+  VisitorLogWithRelations,
+  VisitorRuleRow,
+  VisitorRuleSummary,
+} from '@/types/visitors'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+
+const VISITOR_RULE_COLUMNS =
+  'id, title, description, building_id, unit_id, max_consecutive_nights, max_visits_per_month, require_manager_approval, advance_notice_hours, created_at, updated_at, created_by, active, metadata'
+
+const VISITOR_LOG_COLUMNS =
+  'id, host_profile_id, building_id, unit_id, visitor_name, visitor_email, arrival_date, departure_date, total_nights, reason, status, rule_id, approval_notes, approved_by, approved_at, cancellation_reason, cancelled_at, cancelled_by, metadata, created_at, updated_at'
+
+const VISITOR_LOG_WITH_RELATIONS =
+  `${VISITOR_LOG_COLUMNS}, rule:visitor_rules!visitor_logs_rule_id_fkey(${VISITOR_RULE_COLUMNS}), host:profiles!visitor_logs_host_profile_id_fkey(id, full_name, email, role, building_id, unit_id)`
+
+const AUDIT_COLUMNS = 'id, log_id, actor_profile_id, action, notes, metadata, created_at'
+
+export type VisitorLogInsert = Database['public']['Tables']['visitor_logs']['Insert']
+export type VisitorLogUpdate = Database['public']['Tables']['visitor_logs']['Update']
+export type VisitorAuditInsert = Database['public']['Tables']['visitor_log_audits']['Insert']
+
+function ensureSuccess<T>(response: PostgrestSingleResponse<T>): T {
+  if (response.error) {
+    throw new Error(response.error.message)
+  }
+
+  return response.data as T
+}
+
+export async function getProfileById(
+  client: TypedSupabaseClient,
+  profileId: string,
+): Promise<ProfileSummary | null> {
+  const { data, error } = await client
+    .from('profiles')
+    .select('id, full_name, email, role, building_id, unit_id')
+    .eq('id', profileId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return data as ProfileSummary | null
+}
+
+export async function listRulesForProfile(
+  client: TypedSupabaseClient,
+  profile: ProfileSummary,
+): Promise<VisitorRuleRow[]> {
+  const query = client
+    .from('visitor_rules')
+    .select(VISITOR_RULE_COLUMNS)
+    .eq('active', true)
+    .eq('building_id', profile.building_id)
+
+  if (profile.unit_id) {
+    query.or(`unit_id.eq.${profile.unit_id},unit_id.is.null`)
+  } else {
+    query.is('unit_id', null)
+  }
+
+  const { data, error } = await query.order('unit_id', { ascending: false })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data ?? []) as VisitorRuleRow[]
+}
+
+export async function getRuleForProfile(
+  client: TypedSupabaseClient,
+  profile: ProfileSummary,
+  ruleId?: number | null,
+): Promise<VisitorRuleRow | null> {
+  if (ruleId) {
+    const { data, error } = await client
+      .from('visitor_rules')
+      .select(VISITOR_RULE_COLUMNS)
+      .eq('id', ruleId)
+      .maybeSingle()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    if (!data) return null
+
+    const rule = data as VisitorRuleRow
+    if (
+      rule.building_id !== profile.building_id ||
+      (rule.unit_id && profile.unit_id && rule.unit_id !== profile.unit_id)
+    ) {
+      return null
+    }
+
+    if (rule.unit_id && !profile.unit_id) {
+      return null
+    }
+
+    return rule
+  }
+
+  const rules = await listRulesForProfile(client, profile)
+  if (!rules.length) {
+    return null
+  }
+
+  const unitSpecific = profile.unit_id
+    ? rules.find(rule => rule.unit_id === profile.unit_id)
+    : null
+
+  return unitSpecific ?? rules[0]
+}
+
+export async function insertVisitorLog(
+  client: TypedSupabaseClient,
+  payload: VisitorLogInsert,
+): Promise<VisitorLogRow> {
+  const response = await client
+    .from('visitor_logs')
+    .insert(payload)
+    .select(VISITOR_LOG_COLUMNS)
+    .single()
+
+  return ensureSuccess(response) as VisitorLogRow
+}
+
+export async function updateVisitorLog(
+  client: TypedSupabaseClient,
+  logId: number,
+  changes: VisitorLogUpdate,
+): Promise<VisitorLogRow> {
+  const response = await client
+    .from('visitor_logs')
+    .update(changes)
+    .eq('id', logId)
+    .select(VISITOR_LOG_COLUMNS)
+    .single()
+
+  return ensureSuccess(response) as VisitorLogRow
+}
+
+export async function getVisitorLogWithRelations(
+  client: TypedSupabaseClient,
+  logId: number,
+): Promise<VisitorLogWithRelations | null> {
+  const { data, error } = await client
+    .from('visitor_logs')
+    .select(VISITOR_LOG_WITH_RELATIONS)
+    .eq('id', logId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data as VisitorLogWithRelations | null) ?? null
+}
+
+export async function insertVisitorAudit(
+  client: TypedSupabaseClient,
+  entry: VisitorAuditInsert,
+): Promise<VisitorAuditRow> {
+  const response = await client
+    .from('visitor_log_audits')
+    .insert(entry)
+    .select(AUDIT_COLUMNS)
+    .single()
+
+  return ensureSuccess(response) as VisitorAuditRow
+}
+
+export async function listRoommatesForUnit(
+  client: TypedSupabaseClient,
+  unitId: string,
+  excludeProfileId?: string,
+): Promise<ProfileSummary[]> {
+  const query = client
+    .from('profiles')
+    .select('id, full_name, email, role, building_id, unit_id')
+    .eq('unit_id', unitId)
+    .in('role', ['tenant', 'roommate'])
+
+  if (excludeProfileId) {
+    query.neq('id', excludeProfileId)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data ?? []) as ProfileSummary[]
+}
+
+export async function listManagersForBuilding(
+  client: TypedSupabaseClient,
+  buildingId: string,
+): Promise<ProfileSummary[]> {
+  const { data, error } = await client
+    .from('profiles')
+    .select('id, full_name, email, role, building_id, unit_id')
+    .eq('building_id', buildingId)
+    .in('role', ['property_manager', 'admin'])
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data ?? []) as ProfileSummary[]
+}
+
+export async function listVisitorLogsForUnit(
+  client: TypedSupabaseClient,
+  unitId: string,
+): Promise<VisitorLogWithRelations[]> {
+  const { data, error } = await client
+    .from('visitor_logs')
+    .select(VISITOR_LOG_WITH_RELATIONS)
+    .eq('unit_id', unitId)
+    .order('arrival_date', { ascending: false })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data ?? []) as VisitorLogWithRelations[]
+}
+
+export async function listPendingVisitorLogsForBuilding(
+  client: TypedSupabaseClient,
+  buildingId: string,
+): Promise<VisitorLogWithRelations[]> {
+  const { data, error } = await client
+    .from('visitor_logs')
+    .select(VISITOR_LOG_WITH_RELATIONS)
+    .eq('building_id', buildingId)
+    .eq('status', 'pending')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data ?? []) as VisitorLogWithRelations[]
+}
+
+export async function listAuditEntriesForLogs(
+  client: TypedSupabaseClient,
+  logIds: number[],
+): Promise<VisitorAuditEntryView[]> {
+  if (!logIds.length) return []
+
+  const { data, error } = await client
+    .from('visitor_log_audits')
+    .select(
+      `${AUDIT_COLUMNS}, actor:profiles!visitor_log_audits_actor_profile_id_fkey(full_name, role)`,
+    )
+    .in('log_id', logIds)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data ?? []).map(entry => {
+    const record = entry as VisitorAuditRow & {
+      actor?: Pick<ProfileRow, 'full_name' | 'role'> | null
+    }
+
+    return {
+      id: record.id,
+      logId: record.log_id,
+      action: record.action,
+      notes: record.notes,
+      createdAt: record.created_at,
+      actorName: record.actor?.full_name ?? null,
+      actorRole: record.actor?.role ?? null,
+      metadata: (record.metadata as Record<string, unknown> | null) ?? null,
+    }
+  })
+}
+
+function mapRuleToSummary(rule: VisitorRuleRow): VisitorRuleSummary {
+  return {
+    id: rule.id,
+    title: rule.title,
+    description: rule.description ?? null,
+    buildingId: rule.building_id,
+    unitId: rule.unit_id ?? null,
+    maxConsecutiveNights: rule.max_consecutive_nights,
+    maxVisitsPerMonth: rule.max_visits_per_month ?? null,
+    requireManagerApproval: rule.require_manager_approval,
+    advanceNoticeHours: rule.advance_notice_hours ?? null,
+  }
+}
+
+export function mapLogToSummary(
+  log: VisitorLogWithRelations,
+): VisitorLogSummary {
+  return {
+    id: log.id,
+    visitorName: log.visitor_name,
+    visitorEmail: log.visitor_email ?? null,
+    arrivalDate: log.arrival_date,
+    departureDate: log.departure_date,
+    totalNights: log.total_nights,
+    status: log.status,
+    reason: log.reason ?? null,
+    rule: log.rule ? mapRuleToSummary(log.rule) : null,
+    hostId: log.host_profile_id,
+    hostName: log.host?.full_name ?? null,
+    hostEmail: log.host?.email ?? null,
+    approvalNotes: log.approval_notes ?? null,
+    approvedAt: log.approved_at ?? null,
+    cancellationReason: log.cancellation_reason ?? null,
+    cancelledAt: log.cancelled_at ?? null,
+    createdAt: log.created_at,
+    updatedAt: log.updated_at,
+  }
+}
+
+export function mapRulesToSummaries(rules: VisitorRuleRow[]): VisitorRuleSummary[] {
+  return rules.map(mapRuleToSummary)
+}
+
+export function createVisitorRequestDependencies(
+  client: TypedSupabaseClient,
+  profile: ProfileSummary,
+) {
+  return {
+    profile,
+    fetchRule: (ruleId?: number | null) => getRuleForProfile(client, profile, ruleId),
+    insertLog: (payload: VisitorLogInsert) => insertVisitorLog(client, payload),
+    createAudit: (entry: VisitorAuditInsert) => insertVisitorAudit(client, entry),
+    listRoommates: (unitId: string, exclude?: string) =>
+      listRoommatesForUnit(client, unitId, exclude),
+    listManagers: (buildingId: string) => listManagersForBuilding(client, buildingId),
+  }
+}
+
+export function createCancelDependencies(
+  client: TypedSupabaseClient,
+  actor: ProfileSummary,
+) {
+  return {
+    actor,
+    getLog: (logId: number) => getVisitorLogWithRelations(client, logId),
+    updateLog: (logId: number, changes: VisitorLogUpdate) =>
+      updateVisitorLog(client, logId, changes),
+    createAudit: (entry: VisitorAuditInsert) => insertVisitorAudit(client, entry),
+    listRoommates: (unitId: string, exclude?: string) =>
+      listRoommatesForUnit(client, unitId, exclude),
+    listManagers: (buildingId: string) => listManagersForBuilding(client, buildingId),
+  }
+}
+
+export function createResolveDependencies(
+  client: TypedSupabaseClient,
+  actor: ProfileSummary,
+) {
+  return {
+    actor,
+    getLog: (logId: number) => getVisitorLogWithRelations(client, logId),
+    updateLog: (logId: number, changes: VisitorLogUpdate) =>
+      updateVisitorLog(client, logId, changes),
+    createAudit: (entry: VisitorAuditInsert) => insertVisitorAudit(client, entry),
+    listRoommates: (unitId: string, exclude?: string) =>
+      listRoommatesForUnit(client, unitId, exclude),
+    listManagers: (buildingId: string) => listManagersForBuilding(client, buildingId),
+  }
+}

--- a/app/dashboard/visitors/actions/resolve-visitor-request.ts
+++ b/app/dashboard/visitors/actions/resolve-visitor-request.ts
@@ -1,0 +1,69 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+
+import { sendVisitorNotifications } from '@/lib/notifications/visitors'
+import { createClient } from '@/utils/supa-server-actions'
+
+import {
+  handleResolveVisitorRequest,
+  resolveVisitorRequestSchema,
+  type ResolveVisitorRequestInput,
+  type VisitorActionState,
+} from './shared'
+import { createResolveDependencies, getProfileById } from './data-access'
+
+export async function resolveVisitorRequest(
+  input: ResolveVisitorRequestInput,
+): Promise<VisitorActionState> {
+  const parsed = resolveVisitorRequestSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      status: 'error',
+      message: 'Unable to update this visitor request. Please try again.',
+      issues: parsed.error.flatten().fieldErrors,
+    }
+  }
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    return {
+      status: 'error',
+      message: userError.message,
+    }
+  }
+
+  if (!user) {
+    return {
+      status: 'error',
+      message: 'You must be signed in to perform this action.',
+    }
+  }
+
+  const profile = await getProfileById(supabase, user.id)
+  if (!profile) {
+    return {
+      status: 'error',
+      message: 'We could not load your profile.',
+    }
+  }
+
+  const dependencies = createResolveDependencies(supabase, profile)
+
+  return handleResolveVisitorRequest(
+    dependencies,
+    parsed.data,
+    sendVisitorNotifications,
+    {
+      revalidatePath,
+    },
+  )
+}

--- a/app/dashboard/visitors/actions/shared.ts
+++ b/app/dashboard/visitors/actions/shared.ts
@@ -1,0 +1,569 @@
+import { differenceInCalendarDays, parseISO } from 'date-fns'
+import { z } from 'zod'
+
+import type {
+  ProfileSummary,
+  VisitorAuditRow,
+  VisitorLogRow,
+  VisitorLogWithRelations,
+  VisitorRuleRow,
+} from '@/types/visitors'
+import type { Database } from '@/lib/supabase'
+
+export const visitorRequestFormSchema = z.object({
+  visitorName: z
+    .string()
+    .min(2, { message: 'Visitor name must be at least 2 characters.' })
+    .max(120, { message: 'Visitor name must be 120 characters or fewer.' }),
+  visitorEmail: z
+    .string()
+    .email({ message: 'Enter a valid email address.' })
+    .max(254, { message: 'Email must be 254 characters or fewer.' })
+    .optional()
+    .or(z.literal('')),
+  arrivalDate: z.string().min(1, { message: 'Arrival date is required.' }),
+  departureDate: z.string().min(1, { message: 'Departure date is required.' }),
+  reason: z
+    .string()
+    .min(3, { message: 'Please describe the reason for the visit.' })
+    .max(500, { message: 'Reason must be 500 characters or fewer.' }),
+  ruleId: z.number().int().positive().optional(),
+})
+
+export const cancelVisitorRequestSchema = z.object({
+  logId: z.number().int().positive(),
+  reason: z
+    .string()
+    .max(500, { message: 'Cancellation notes must be 500 characters or fewer.' })
+    .optional(),
+})
+
+export const resolveVisitorRequestSchema = z.object({
+  logId: z.number().int().positive(),
+  decision: z.enum(['approved', 'denied']),
+  notes: z
+    .string()
+    .max(500, { message: 'Notes must be 500 characters or fewer.' })
+    .optional(),
+})
+
+export type SubmitVisitorRequestInput = z.infer<typeof visitorRequestFormSchema>
+export type CancelVisitorRequestInput = z.infer<typeof cancelVisitorRequestSchema>
+export type ResolveVisitorRequestInput = z.infer<typeof resolveVisitorRequestSchema>
+
+export type VisitorActionState = {
+  status: 'idle' | 'success' | 'error'
+  message?: string
+  issues?: Record<string, string[]>
+  logId?: number
+}
+
+export const visitorActionInitialState: VisitorActionState = { status: 'idle' }
+
+type VisitorLogInsert = Database['public']['Tables']['visitor_logs']['Insert']
+type VisitorLogUpdate = Database['public']['Tables']['visitor_logs']['Update']
+type VisitorAuditInsert = Database['public']['Tables']['visitor_log_audits']['Insert']
+
+export interface VisitorNotificationPayload {
+  event: 'request_submitted' | 'request_cancelled' | 'status_changed'
+  log: VisitorLogRow
+  host: ProfileSummary
+  rule: VisitorRuleRow | null
+  roommates: ProfileSummary[]
+  managers: ProfileSummary[]
+  actor?: ProfileSummary
+  decision?: 'approved' | 'denied'
+  cancellationReason?: string | null
+}
+
+export type VisitorNotificationHandler = (
+  payload: VisitorNotificationPayload,
+) => Promise<void>
+
+export interface VisitorRecipientDependencies {
+  listRoommates(unitId: string, excludeProfileId?: string): Promise<ProfileSummary[]>
+  listManagers(buildingId: string): Promise<ProfileSummary[]>
+}
+
+export interface VisitorRequestDependencies extends VisitorRecipientDependencies {
+  profile: ProfileSummary
+  fetchRule(ruleId?: number | null): Promise<VisitorRuleRow | null>
+  insertLog(payload: VisitorLogInsert): Promise<VisitorLogRow>
+  createAudit(entry: VisitorAuditInsert): Promise<VisitorAuditRow>
+}
+
+export interface CancelVisitorDependencies extends VisitorRecipientDependencies {
+  actor: ProfileSummary
+  getLog(logId: number): Promise<VisitorLogWithRelations | null>
+  updateLog(logId: number, changes: VisitorLogUpdate): Promise<VisitorLogRow>
+  createAudit(entry: VisitorAuditInsert): Promise<VisitorAuditRow>
+}
+
+export interface ResolveVisitorDependencies extends VisitorRecipientDependencies {
+  actor: ProfileSummary
+  getLog(logId: number): Promise<VisitorLogWithRelations | null>
+  updateLog(logId: number, changes: VisitorLogUpdate): Promise<VisitorLogRow>
+  createAudit(entry: VisitorAuditInsert): Promise<VisitorAuditRow>
+}
+
+export interface HandlerOptions {
+  revalidatePath?: (path: string) => void
+  revalidatePaths?: string[]
+}
+
+const DEFAULT_REVALIDATE_PATHS = ['/dashboard/visitors', '/dashboard/visitors/manage']
+
+function runRevalidate(options?: HandlerOptions) {
+  if (!options?.revalidatePath) {
+    return
+  }
+
+  const paths = options.revalidatePaths?.length
+    ? options.revalidatePaths
+    : DEFAULT_REVALIDATE_PATHS
+
+  const unique = Array.from(new Set(paths))
+  for (const path of unique) {
+    options.revalidatePath(path)
+  }
+}
+
+function normaliseEmail(value: string | null | undefined) {
+  if (!value) return null
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : null
+}
+
+export async function handleCreateVisitorRequest(
+  deps: VisitorRequestDependencies,
+  input: SubmitVisitorRequestInput,
+  notify: VisitorNotificationHandler,
+  options?: HandlerOptions,
+): Promise<VisitorActionState> {
+  const { profile } = deps
+
+  if (!profile.building_id || !profile.unit_id) {
+    return {
+      status: 'error',
+      message: 'Your profile is missing a building or unit assignment. Please contact your property manager.',
+    }
+  }
+
+  const arrival = parseISO(input.arrivalDate)
+  const departure = parseISO(input.departureDate)
+
+  if (Number.isNaN(arrival.getTime()) || Number.isNaN(departure.getTime())) {
+    return {
+      status: 'error',
+      message: 'We could not understand the arrival or departure date. Please try again.',
+    }
+  }
+
+  const diffDays = differenceInCalendarDays(departure, arrival)
+  if (diffDays < 0) {
+    return {
+      status: 'error',
+      message: 'Departure must be on or after the arrival date.',
+      issues: {
+        departureDate: ['Departure must be on or after arrival.'],
+      },
+    }
+  }
+
+  const totalNights = diffDays + 1
+
+  try {
+    const rule = await deps.fetchRule(input.ruleId ?? null)
+    if (!rule) {
+      return {
+        status: 'error',
+        message: 'No visitor policy is configured for your unit. Please reach out to your property manager.',
+      }
+    }
+
+    if (
+      rule.building_id !== profile.building_id ||
+      (rule.unit_id && rule.unit_id !== profile.unit_id)
+    ) {
+      return {
+        status: 'error',
+        message: 'The selected visitor policy does not apply to your unit.',
+      }
+    }
+
+    if (totalNights > rule.max_consecutive_nights) {
+      return {
+        status: 'error',
+        message: `This stay exceeds the ${rule.max_consecutive_nights}-night limit defined by your visitor policy.`,
+        issues: {
+          departureDate: [
+            `Visitor stays are limited to ${rule.max_consecutive_nights} consecutive nights.`,
+          ],
+        },
+      }
+    }
+
+    const now = new Date().toISOString()
+    const visitorEmail = normaliseEmail(input.visitorEmail)
+    const status = rule.require_manager_approval ? 'pending' : 'approved'
+
+    const inserted = await deps.insertLog({
+      arrival_date: input.arrivalDate,
+      departure_date: input.departureDate,
+      building_id: profile.building_id,
+      unit_id: profile.unit_id,
+      host_profile_id: profile.id,
+      visitor_name: input.visitorName.trim(),
+      visitor_email: visitorEmail,
+      total_nights: totalNights,
+      reason: input.reason.trim(),
+      status,
+      rule_id: rule.id,
+      metadata: {
+        submission_source: 'dashboard',
+        requested_at: now,
+      },
+      approved_by: status === 'approved' ? profile.id : null,
+      approved_at: status === 'approved' ? now : null,
+      approval_notes:
+        status === 'approved' ? 'Auto-approved per published visitor policy.' : null,
+    })
+
+    await deps.createAudit({
+      log_id: inserted.id,
+      actor_profile_id: profile.id,
+      action: 'created',
+      notes: input.reason.trim(),
+      metadata: {
+        total_nights: totalNights,
+        rule_id: rule.id,
+        status,
+      },
+    })
+
+    if (status === 'approved') {
+      await deps.createAudit({
+        log_id: inserted.id,
+        actor_profile_id: profile.id,
+        action: 'approved',
+        notes: 'Automatically approved based on unit policy.',
+        metadata: {
+          auto_approved: true,
+        },
+      })
+    }
+
+    const [roommates, managers] = await Promise.all([
+      deps.listRoommates(profile.unit_id, profile.id),
+      deps.listManagers(profile.building_id),
+    ])
+
+    try {
+      await notify({
+        event: 'request_submitted',
+        log: inserted,
+        host: profile,
+        rule,
+        roommates,
+        managers,
+      })
+
+      await deps.createAudit({
+        log_id: inserted.id,
+        actor_profile_id: profile.id,
+        action: 'notification',
+        notes: 'Visitor submission notifications dispatched.',
+        metadata: {
+          event: 'request_submitted',
+          recipient_count: roommates.length + managers.length,
+        },
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await deps.createAudit({
+        log_id: inserted.id,
+        actor_profile_id: profile.id,
+        action: 'notification',
+        notes: 'Failed to deliver visitor submission notifications.',
+        metadata: {
+          event: 'request_submitted',
+          error: message,
+        },
+      })
+
+      return {
+        status: 'error',
+        message:
+          'Guest request saved, but notifications could not be delivered. Please inform your roommates and manager directly.',
+        logId: inserted.id,
+      }
+    }
+
+    runRevalidate(options)
+
+    return {
+      status: 'success',
+      message: `Guest stay submitted for ${totalNights} night${totalNights > 1 ? 's' : ''}.`,
+      logId: inserted.id,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error creating visitor request.'
+    return {
+      status: 'error',
+      message,
+    }
+  }
+}
+
+export async function handleCancelVisitorRequest(
+  deps: CancelVisitorDependencies,
+  input: CancelVisitorRequestInput,
+  notify: VisitorNotificationHandler,
+  options?: HandlerOptions,
+): Promise<VisitorActionState> {
+  try {
+    const log = await deps.getLog(input.logId)
+    if (!log) {
+      return {
+        status: 'error',
+        message: 'We could not find that visitor request.',
+      }
+    }
+
+    if (log.host_profile_id !== deps.actor.id) {
+      return {
+        status: 'error',
+        message: 'Only the host that created this request can cancel it.',
+      }
+    }
+
+    if (!['pending', 'approved'].includes(log.status)) {
+      return {
+        status: 'error',
+        message: 'Only pending or approved visits can be cancelled.',
+      }
+    }
+
+    const timestamp = new Date().toISOString()
+    const updated = await deps.updateLog(log.id, {
+      status: 'cancelled',
+      cancelled_by: deps.actor.id,
+      cancelled_at: timestamp,
+      cancellation_reason: input.reason ?? null,
+      updated_at: timestamp,
+    })
+
+    await deps.createAudit({
+      log_id: log.id,
+      actor_profile_id: deps.actor.id,
+      action: 'cancelled',
+      notes: input.reason ?? null,
+      metadata: {
+        previous_status: log.status,
+      },
+    })
+
+    const [roommates, managers] = await Promise.all([
+      deps.listRoommates(updated.unit_id, deps.actor.id),
+      deps.listManagers(updated.building_id),
+    ])
+
+    try {
+      await notify({
+        event: 'request_cancelled',
+        log: updated,
+        host: deps.actor,
+        rule: log.rule ?? null,
+        roommates,
+        managers,
+        cancellationReason: input.reason ?? null,
+      })
+
+      await deps.createAudit({
+        log_id: log.id,
+        actor_profile_id: deps.actor.id,
+        action: 'notification',
+        notes: 'Cancellation notifications dispatched.',
+        metadata: {
+          event: 'request_cancelled',
+          recipient_count: roommates.length + managers.length,
+        },
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await deps.createAudit({
+        log_id: log.id,
+        actor_profile_id: deps.actor.id,
+        action: 'notification',
+        notes: 'Failed to dispatch cancellation notifications.',
+        metadata: {
+          event: 'request_cancelled',
+          error: message,
+        },
+      })
+
+      return {
+        status: 'error',
+        message:
+          'The visit was cancelled, but notifications failed. Please alert your roommates and manager manually.',
+        logId: log.id,
+      }
+    }
+
+    runRevalidate(options)
+
+    return {
+      status: 'success',
+      message: 'Guest stay cancelled.',
+      logId: log.id,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error cancelling visitor request.'
+    return {
+      status: 'error',
+      message,
+    }
+  }
+}
+
+export async function handleResolveVisitorRequest(
+  deps: ResolveVisitorDependencies,
+  input: ResolveVisitorRequestInput,
+  notify: VisitorNotificationHandler,
+  options?: HandlerOptions,
+): Promise<VisitorActionState> {
+  try {
+    const log = await deps.getLog(input.logId)
+    if (!log) {
+      return {
+        status: 'error',
+        message: 'Visitor request not found.',
+      }
+    }
+
+    const actorRole = deps.actor.role ?? ''
+    if (!['property_manager', 'admin'].includes(actorRole)) {
+      return {
+        status: 'error',
+        message: 'You do not have permission to update visitor requests.',
+      }
+    }
+
+    if (
+      actorRole === 'property_manager' &&
+      deps.actor.building_id &&
+      deps.actor.building_id !== log.building_id
+    ) {
+      return {
+        status: 'error',
+        message: 'This request belongs to a different building.',
+      }
+    }
+
+    if (!['pending', 'approved', 'denied'].includes(log.status)) {
+      return {
+        status: 'error',
+        message: 'Only pending or previously reviewed requests can be updated.',
+      }
+    }
+
+    const newStatus = input.decision === 'approved' ? 'approved' : 'denied'
+    const timestamp = new Date().toISOString()
+
+    const updated = await deps.updateLog(log.id, {
+      status: newStatus,
+      approved_by: deps.actor.id,
+      approved_at: timestamp,
+      approval_notes: input.notes ?? null,
+      updated_at: timestamp,
+    })
+
+    await deps.createAudit({
+      log_id: log.id,
+      actor_profile_id: deps.actor.id,
+      action: input.decision,
+      notes: input.notes ?? null,
+      metadata: {
+        previous_status: log.status,
+      },
+    })
+
+    const hostSummary: ProfileSummary =
+      log.host ?? {
+        id: log.host_profile_id,
+        full_name: null,
+        email: null,
+        role: null,
+        building_id: log.building_id,
+        unit_id: log.unit_id,
+      }
+
+    const [roommates, managers] = await Promise.all([
+      deps.listRoommates(updated.unit_id, log.host_profile_id),
+      deps.listManagers(updated.building_id),
+    ])
+
+    try {
+      await notify({
+        event: 'status_changed',
+        log: updated,
+        host: hostSummary,
+        rule: log.rule ?? null,
+        roommates,
+        managers,
+        actor: deps.actor,
+        decision: input.decision,
+      })
+
+      await deps.createAudit({
+        log_id: log.id,
+        actor_profile_id: deps.actor.id,
+        action: 'notification',
+        notes: 'Status update notifications dispatched.',
+        metadata: {
+          event: 'status_changed',
+          decision: input.decision,
+          recipient_count:
+            roommates.length + managers.length + (hostSummary.email ? 1 : 0),
+        },
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await deps.createAudit({
+        log_id: log.id,
+        actor_profile_id: deps.actor.id,
+        action: 'notification',
+        notes: 'Failed to dispatch status update notifications.',
+        metadata: {
+          event: 'status_changed',
+          decision: input.decision,
+          error: message,
+        },
+      })
+
+      return {
+        status: 'error',
+        message:
+          'Decision saved, but notifications could not be delivered. Please follow up with the residents manually.',
+        logId: log.id,
+      }
+    }
+
+    runRevalidate(options)
+
+    return {
+      status: 'success',
+      message:
+        input.decision === 'approved'
+          ? 'Visitor request approved.'
+          : 'Visitor request denied.',
+      logId: log.id,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error updating visitor request.'
+    return {
+      status: 'error',
+      message,
+    }
+  }
+}

--- a/app/dashboard/visitors/actions/submit-visitor-request.ts
+++ b/app/dashboard/visitors/actions/submit-visitor-request.ts
@@ -1,0 +1,98 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+
+import { sendVisitorNotifications } from '@/lib/notifications/visitors'
+import { createClient } from '@/utils/supa-server-actions'
+
+import {
+  handleCreateVisitorRequest,
+  visitorActionInitialState,
+  visitorRequestFormSchema,
+  type VisitorActionState,
+} from './shared'
+import {
+  createVisitorRequestDependencies,
+  getProfileById,
+} from './data-access'
+
+function parseRuleId(value: FormDataEntryValue | null): number | undefined {
+  if (typeof value !== 'string' || !value.trim()) {
+    return undefined
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+export async function submitVisitorRequest(
+  _prevState: VisitorActionState = visitorActionInitialState,
+  formData?: FormData,
+): Promise<VisitorActionState> {
+  if (!formData) {
+    return {
+      status: 'error',
+      message: 'No form data received.',
+    }
+  }
+
+  const raw = {
+    visitorName: formData.get('visitorName'),
+    visitorEmail: formData.get('visitorEmail'),
+    arrivalDate: formData.get('arrivalDate'),
+    departureDate: formData.get('departureDate'),
+    reason: formData.get('reason'),
+    ruleId: parseRuleId(formData.get('ruleId')),
+  }
+
+  const parsed = visitorRequestFormSchema.safeParse(raw)
+  if (!parsed.success) {
+    return {
+      status: 'error',
+      message: 'Please correct the highlighted issues and try again.',
+      issues: parsed.error.flatten().fieldErrors,
+    }
+  }
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    return {
+      status: 'error',
+      message: userError.message,
+    }
+  }
+
+  if (!user) {
+    return {
+      status: 'error',
+      message: 'You must be signed in to request overnight visitors.',
+    }
+  }
+
+  const profile = await getProfileById(supabase, user.id)
+  if (!profile) {
+    return {
+      status: 'error',
+      message: 'We could not locate your profile. Please contact support.',
+    }
+  }
+
+  const dependencies = createVisitorRequestDependencies(supabase, profile)
+
+  return handleCreateVisitorRequest(
+    dependencies,
+    parsed.data,
+    sendVisitorNotifications,
+    {
+      revalidatePath,
+    },
+  )
+}

--- a/app/dashboard/visitors/components/ManagerVisitorQueue.tsx
+++ b/app/dashboard/visitors/components/ManagerVisitorQueue.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+import { format, parseISO } from 'date-fns'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Textarea } from '@/components/ui/textarea'
+import { toast } from '@/components/ui/use-toast'
+import type { VisitorAuditEntryView, VisitorLogSummary } from '@/types/visitors'
+
+import { resolveVisitorRequest } from '../actions/resolve-visitor-request'
+import { VisitorAuditTrail } from './VisitorAuditTrail'
+
+function formatDate(value: string) {
+  try {
+    return format(parseISO(value), 'MMM d, yyyy')
+  } catch {
+    return value
+  }
+}
+
+interface ManagerVisitorQueueProps {
+  logs: VisitorLogSummary[]
+  auditLogMap: Record<number, VisitorAuditEntryView[]>
+}
+
+type DecisionState = {
+  logId: number
+  decision: 'approved' | 'denied'
+}
+
+export function ManagerVisitorQueue({ logs, auditLogMap }: ManagerVisitorQueueProps) {
+  const [dialogState, setDialogState] = useState<DecisionState | null>(null)
+  const [notes, setNotes] = useState('')
+  const [isPending, startTransition] = useTransition()
+
+  const activeLog = useMemo(
+    () => (dialogState ? logs.find(log => log.id === dialogState.logId) ?? null : null),
+    [dialogState, logs],
+  )
+
+  const openDialog = (logId: number, decision: 'approved' | 'denied') => {
+    setDialogState({ logId, decision })
+    setNotes('')
+  }
+
+  const onDecision = () => {
+    if (!dialogState) return
+
+    startTransition(async () => {
+      const result = await resolveVisitorRequest({
+        logId: dialogState.logId,
+        decision: dialogState.decision,
+        notes: notes.trim() ? notes.trim() : undefined,
+      })
+
+      toast({
+        title:
+          result.status === 'success'
+            ? `Request ${dialogState.decision}`
+            : 'Unable to update visitor request',
+        description: result.message,
+        variant: result.status === 'success' ? 'default' : 'destructive',
+      })
+
+      if (result.status === 'success') {
+        setDialogState(null)
+      }
+    })
+  }
+
+  if (!logs.length) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Pending visitor approvals</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            All caught up! There are no visitor requests waiting for review.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {logs.map(log => {
+        const auditEntries = auditLogMap[log.id] ?? []
+        return (
+          <Card key={log.id}>
+            <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle className="text-lg">{log.visitorName}</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  {formatDate(log.arrivalDate)} – {formatDate(log.departureDate)} · {log.totalNights}{' '}
+                  night{log.totalNights > 1 ? 's' : ''}
+                </p>
+              </div>
+              <Badge className="w-fit uppercase" variant="secondary">
+                {log.status}
+              </Badge>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                <span className="font-medium text-foreground">Host:</span> {log.hostName ?? 'Unknown host'}
+              </p>
+              {log.hostEmail ? (
+                <p>
+                  <span className="font-medium text-foreground">Contact:</span>{' '}
+                  <a className="underline" href={`mailto:${log.hostEmail}`}>
+                    {log.hostEmail}
+                  </a>
+                </p>
+              ) : null}
+              {log.reason ? (
+                <p>
+                  <span className="font-medium text-foreground">Reason:</span> {log.reason}
+                </p>
+              ) : null}
+              {log.rule ? (
+                <p>
+                  <span className="font-medium text-foreground">Policy:</span> {log.rule.title}
+                </p>
+              ) : null}
+              <div>
+                <p className="font-medium text-foreground">Recent activity</p>
+                <VisitorAuditTrail entries={auditEntries} />
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-3 border-t bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                Review the request and notify residents if you deny the visit.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => openDialog(log.id, 'denied')}
+                  disabled={isPending}
+                >
+                  Deny
+                </Button>
+                <Button onClick={() => openDialog(log.id, 'approved')} disabled={isPending}>
+                  Approve
+                </Button>
+                <AlertDialog
+                  open={Boolean(dialogState && dialogState.logId === log.id)}
+                  onOpenChange={open => {
+                    if (!open) {
+                      setDialogState(null)
+                    }
+                  }}
+                >
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        {dialogState?.decision === 'approved' ? 'Approve visitor stay?' : 'Deny visitor stay?'}
+                      </AlertDialogTitle>
+                    </AlertDialogHeader>
+                    <p className="text-sm text-muted-foreground">
+                      {dialogState?.decision === 'approved'
+                        ? 'Approving will notify the residents that this stay is confirmed.'
+                        : 'Share a short note so residents understand why the request was denied.'}
+                    </p>
+                    <Textarea
+                      value={notes}
+                      onChange={event => setNotes(event.target.value)}
+                      placeholder="Add notes for the residents"
+                      rows={3}
+                      disabled={isPending}
+                      className="mt-4"
+                    />
+                    <AlertDialogFooter className="pt-4">
+                      <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+                      <AlertDialogAction onClick={onDecision} disabled={isPending}>
+                        {isPending ? 'Saving…' : dialogState?.decision === 'approved' ? 'Approve' : 'Deny'}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            </CardFooter>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/dashboard/visitors/components/VisitorAuditTrail.tsx
+++ b/app/dashboard/visitors/components/VisitorAuditTrail.tsx
@@ -1,0 +1,55 @@
+import { formatDistanceToNow, parseISO } from 'date-fns'
+
+import type { VisitorAuditEntryView } from '@/types/visitors'
+
+interface VisitorAuditTrailProps {
+  entries: VisitorAuditEntryView[]
+}
+
+export function VisitorAuditTrail({ entries }: VisitorAuditTrailProps) {
+  if (!entries.length) {
+    return (
+      <p className="text-sm text-muted-foreground">No recent actions recorded for this request.</p>
+    )
+  }
+
+  return (
+    <ul className="space-y-3 text-sm text-muted-foreground">
+      {entries.map(entry => {
+        const decision =
+          entry.metadata && typeof entry.metadata === 'object'
+            ? (entry.metadata as Record<string, unknown>).decision
+            : undefined
+
+        let actionLabel = entry.action
+        if (entry.action === 'status_change' && typeof decision === 'string') {
+          actionLabel = `status ${decision}`
+        }
+
+        return (
+          <li key={entry.id} className="rounded-md border bg-muted/30 p-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="font-medium text-foreground capitalize">{actionLabel}</span>
+              <span>
+                {formatDistanceToNow(parseISO(entry.createdAt), { addSuffix: true })}
+              </span>
+            </div>
+            <div className="mt-1 space-y-1">
+              {entry.actorName ? (
+                <p>
+                  <span className="font-medium text-foreground">By:</span> {entry.actorName}
+                  {entry.actorRole ? ` (${entry.actorRole})` : ''}
+                </p>
+              ) : null}
+              {entry.notes ? (
+                <p>
+                  <span className="font-medium text-foreground">Notes:</span> {entry.notes}
+                </p>
+              ) : null}
+            </div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/app/dashboard/visitors/components/VisitorLogList.tsx
+++ b/app/dashboard/visitors/components/VisitorLogList.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+import { format, parseISO } from 'date-fns'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Textarea } from '@/components/ui/textarea'
+import { toast } from '@/components/ui/use-toast'
+import type { VisitorLogSummary } from '@/types/visitors'
+
+import { cancelVisitorRequest } from '../actions/cancel-visitor-request'
+
+function formatDate(value: string) {
+  try {
+    return format(parseISO(value), 'MMM d, yyyy')
+  } catch {
+    return value
+  }
+}
+
+function statusVariant(status: string) {
+  switch (status) {
+    case 'approved':
+      return 'default'
+    case 'pending':
+      return 'secondary'
+    case 'denied':
+      return 'destructive'
+    case 'cancelled':
+      return 'outline'
+    default:
+      return 'secondary'
+  }
+}
+
+function canCancel(log: VisitorLogSummary, currentProfileId: string) {
+  if (log.hostId !== currentProfileId) return false
+  return log.status === 'pending' || log.status === 'approved'
+}
+
+interface VisitorLogListProps {
+  logs: VisitorLogSummary[]
+  currentProfileId: string
+}
+
+export function VisitorLogList({ logs, currentProfileId }: VisitorLogListProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [cancelReason, setCancelReason] = useState('')
+  const [activeLogId, setActiveLogId] = useState<number | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const activeLog = useMemo(
+    () => logs.find(log => log.id === activeLogId) ?? null,
+    [logs, activeLogId],
+  )
+
+  const handleOpen = (logId: number) => {
+    setActiveLogId(logId)
+    setCancelReason('')
+    setDialogOpen(true)
+  }
+
+  const handleCancel = () => {
+    if (!activeLog) return
+    startTransition(async () => {
+      const result = await cancelVisitorRequest({
+        logId: activeLog.id,
+        reason: cancelReason.trim() ? cancelReason.trim() : undefined,
+      })
+
+      toast({
+        title: result.status === 'success' ? 'Visit cancelled' : 'Unable to cancel visit',
+        description: result.message,
+        variant: result.status === 'success' ? 'default' : 'destructive',
+      })
+
+      if (result.status === 'success') {
+        setDialogOpen(false)
+      }
+    })
+  }
+
+  if (!logs.length) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Visitor history</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No visitor requests yet. Submit your first request to keep roommates and property managers in sync.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {logs.map(log => {
+        const showCancel = canCancel(log, currentProfileId)
+        return (
+          <Card key={log.id}>
+            <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle className="text-lg">{log.visitorName}</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  {formatDate(log.arrivalDate)} – {formatDate(log.departureDate)} · {log.totalNights}{' '}
+                  night{log.totalNights > 1 ? 's' : ''}
+                </p>
+              </div>
+              <Badge variant={statusVariant(log.status)} className="w-fit uppercase">
+                {log.status}
+              </Badge>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              {log.reason ? (
+                <p>
+                  <span className="font-medium text-foreground">Reason:</span> {log.reason}
+                </p>
+              ) : null}
+              {log.hostName ? (
+                <p>
+                  <span className="font-medium text-foreground">Host:</span> {log.hostName}
+                </p>
+              ) : null}
+              {log.rule ? (
+                <p>
+                  <span className="font-medium text-foreground">Policy:</span> {log.rule.title}
+                </p>
+              ) : null}
+              {log.cancellationReason ? (
+                <p>
+                  <span className="font-medium text-foreground">Cancellation notes:</span> {log.cancellationReason}
+                </p>
+              ) : null}
+              {log.approvalNotes && log.status !== 'pending' ? (
+                <p>
+                  <span className="font-medium text-foreground">Manager notes:</span> {log.approvalNotes}
+                </p>
+              ) : null}
+            </CardContent>
+            {showCancel ? (
+              <div className="flex justify-end px-6 pb-4">
+                <AlertDialog open={dialogOpen && activeLogId === log.id} onOpenChange={setDialogOpen}>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="ghost" onClick={() => handleOpen(log.id)}>
+                      Cancel stay
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Cancel visitor stay?</AlertDialogTitle>
+                    </AlertDialogHeader>
+                    <p className="text-sm text-muted-foreground">
+                      Let your roommates and property manager know why you’re cancelling. This note is optional but
+                      helpful context for the team.
+                    </p>
+                    <Textarea
+                      value={cancelReason}
+                      onChange={event => setCancelReason(event.target.value)}
+                      placeholder="Share a quick reason"
+                      disabled={isPending}
+                      className="mt-4"
+                    />
+                    <AlertDialogFooter className="pt-4">
+                      <AlertDialogCancel disabled={isPending}>Close</AlertDialogCancel>
+                      <AlertDialogAction onClick={handleCancel} disabled={isPending}>
+                        {isPending ? 'Cancelling…' : 'Confirm cancel'}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            ) : null}
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/dashboard/visitors/components/VisitorPolicySummary.tsx
+++ b/app/dashboard/visitors/components/VisitorPolicySummary.tsx
@@ -1,0 +1,70 @@
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import type { VisitorRuleSummary } from '@/types/visitors'
+
+interface VisitorPolicySummaryProps {
+  rule: VisitorRuleSummary | null
+  unitLabel: string
+  buildingLabel?: string | null
+}
+
+export function VisitorPolicySummary({
+  rule,
+  unitLabel,
+  buildingLabel,
+}: VisitorPolicySummaryProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <span>Visitor policy</span>
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">Unit:</span>
+            <Badge variant="secondary">{unitLabel}</Badge>
+            {buildingLabel ? (
+              <>
+                <span className="font-medium text-foreground">Building:</span>
+                <Badge variant="outline">{buildingLabel}</Badge>
+              </>
+            ) : null}
+          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {rule ? (
+          <>
+            <p className="text-sm text-muted-foreground">
+              {rule.description ?? 'Policy details for overnight visitors.'}
+            </p>
+            <ul className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-2">
+              <li>
+                <span className="font-medium text-foreground">Max consecutive nights:</span>{' '}
+                {rule.maxConsecutiveNights}
+              </li>
+              <li>
+                <span className="font-medium text-foreground">Requires manager approval:</span>{' '}
+                {rule.requireManagerApproval ? 'Yes' : 'No'}
+              </li>
+              <li>
+                <span className="font-medium text-foreground">Monthly visitor allowance:</span>{' '}
+                {rule.maxVisitsPerMonth ?? 'Not specified'}
+              </li>
+              <li>
+                <span className="font-medium text-foreground">Advance notice:</span>{' '}
+                {rule.advanceNoticeHours != null
+                  ? `${rule.advanceNoticeHours} hour${rule.advanceNoticeHours === 1 ? '' : 's'}`
+                  : 'Not specified'}
+              </li>
+            </ul>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No visitor policy has been configured for your unit yet. Please contact your property manager for
+            assistance.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/visitors/components/VisitorRequestForm.tsx
+++ b/app/dashboard/visitors/components/VisitorRequestForm.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useFormState, useFormStatus } from 'react-dom'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+
+import type { VisitorRuleSummary } from '@/types/visitors'
+import { submitVisitorRequest } from '../actions/submit-visitor-request'
+import { visitorActionInitialState, type VisitorActionState } from '../actions/shared'
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null
+  return <p className="text-sm text-destructive">{message}</p>
+}
+
+function SubmitButton({ disabled }: { disabled: boolean }) {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" disabled={disabled || pending} className="w-full sm:w-auto">
+      {pending ? 'Submitting…' : 'Submit request'}
+    </Button>
+  )
+}
+
+type SubmitAction = (
+  prevState: VisitorActionState,
+  formData?: FormData,
+) => Promise<VisitorActionState>
+
+interface VisitorRequestFormProps {
+  activeRule: VisitorRuleSummary | null
+  submitAction?: SubmitAction
+}
+
+export function VisitorRequestForm({ activeRule, submitAction }: VisitorRequestFormProps) {
+  const formRef = useRef<HTMLFormElement>(null)
+  const [state, formAction] = useFormState<VisitorActionState, FormData>(
+    submitAction ?? submitVisitorRequest,
+    visitorActionInitialState,
+  )
+
+  useEffect(() => {
+    if (state.status === 'success') {
+      formRef.current?.reset()
+    }
+  }, [state.status])
+
+  const disabled = !activeRule
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Request an overnight visitor</CardTitle>
+      </CardHeader>
+      <form ref={formRef} action={formAction} className="space-y-4">
+        <CardContent className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="visitorName">Visitor name</Label>
+            <Input id="visitorName" name="visitorName" placeholder="Guest full name" disabled={disabled} />
+            <FieldError message={state.issues?.visitorName?.[0]} />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="visitorEmail">Visitor email (optional)</Label>
+            <Input
+              id="visitorEmail"
+              name="visitorEmail"
+              type="email"
+              placeholder="guest@example.com"
+              disabled={disabled}
+            />
+            <FieldError message={state.issues?.visitorEmail?.[0]} />
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2 sm:gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="arrivalDate">Arrival date</Label>
+              <Input id="arrivalDate" name="arrivalDate" type="date" disabled={disabled} />
+              <FieldError message={state.issues?.arrivalDate?.[0]} />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="departureDate">Departure date</Label>
+              <Input id="departureDate" name="departureDate" type="date" disabled={disabled} />
+              <FieldError message={state.issues?.departureDate?.[0]} />
+            </div>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="reason">Reason for stay</Label>
+            <Textarea
+              id="reason"
+              name="reason"
+              placeholder="Share any context or house rules for your roommates and manager."
+              rows={4}
+              disabled={disabled}
+            />
+            <FieldError message={state.issues?.reason?.[0]} />
+          </div>
+          {activeRule ? <input type="hidden" name="ruleId" value={activeRule.id} /> : null}
+          {state.status !== 'idle' ? (
+            <p
+              className={`text-sm ${state.status === 'success' ? 'text-emerald-600' : 'text-destructive'}`}
+            >
+              {state.message}
+            </p>
+          ) : null}
+        </CardContent>
+        <CardFooter className="justify-end">
+          <SubmitButton disabled={disabled} />
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/app/dashboard/visitors/manage/page.tsx
+++ b/app/dashboard/visitors/manage/page.tsx
@@ -1,0 +1,75 @@
+import { redirect } from 'next/navigation'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { createSupbaseServerClient } from '@/utils/supaone'
+
+import {
+  getProfileById,
+  listAuditEntriesForLogs,
+  listPendingVisitorLogsForBuilding,
+  mapLogToSummary,
+} from '../actions/data-access'
+import { ManagerVisitorQueue } from '../components/ManagerVisitorQueue'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ManageVisitorsPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth')
+  }
+
+  const profile = await getProfileById(supabase, user.id)
+  if (!profile) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center text-sm text-muted-foreground">
+          We could not load your profile. Please contact support.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const isManager = profile.role === 'property_manager' || profile.role === 'admin'
+  if (!isManager) {
+    redirect('/dashboard/visitors')
+  }
+
+  if (!profile.building_id) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center text-sm text-muted-foreground">
+          You are not assigned to a building. Assign a building to review visitor requests.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const pendingLogs = await listPendingVisitorLogsForBuilding(
+    supabase,
+    profile.building_id,
+  )
+  const summaries = pendingLogs.map(mapLogToSummary)
+  const auditEntries = await listAuditEntriesForLogs(
+    supabase,
+    summaries.map(log => log.id),
+  )
+  const auditMap = summaries.reduce<Record<number, typeof auditEntries[number][]>>(
+    (acc, log) => {
+      acc[log.id] = auditEntries.filter(entry => entry.logId === log.id)
+      return acc
+    },
+    {},
+  )
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Pending visitor approvals</h1>
+      <ManagerVisitorQueue logs={summaries} auditLogMap={auditMap} />
+    </div>
+  )
+}

--- a/app/dashboard/visitors/page.tsx
+++ b/app/dashboard/visitors/page.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { createSupbaseServerClient } from '@/utils/supaone'
+
+import {
+  getProfileById,
+  getRuleForProfile,
+  listVisitorLogsForUnit,
+  mapLogToSummary,
+  mapRulesToSummaries,
+} from './actions/data-access'
+import { VisitorLogList } from './components/VisitorLogList'
+import { VisitorPolicySummary } from './components/VisitorPolicySummary'
+import { VisitorRequestForm } from './components/VisitorRequestForm'
+
+export const dynamic = 'force-dynamic'
+
+export default async function VisitorsPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center text-sm text-muted-foreground">
+          We couldn’t verify your session. Please sign in again to manage visitor requests.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const profile = await getProfileById(supabase, user.id)
+  if (!profile) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center text-sm text-muted-foreground">
+          We could not load your profile. Contact your property manager for assistance.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const activeRule = await getRuleForProfile(supabase, profile)
+  const activeRuleSummary = activeRule ? mapRulesToSummaries([activeRule])[0] : null
+  const logs =
+    profile.unit_id ? await listVisitorLogsForUnit(supabase, profile.unit_id) : []
+  const logSummaries = logs.map(mapLogToSummary)
+
+  const unitLabel = profile.unit_id ?? 'Unassigned'
+  const buildingLabel = profile.building_id ?? null
+  const isManager = profile.role === 'property_manager' || profile.role === 'admin'
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Visitor stays</h1>
+        {isManager ? (
+          <Button asChild variant="outline">
+            <Link href="/dashboard/visitors/manage">Review pending requests</Link>
+          </Button>
+        ) : null}
+      </div>
+      <VisitorPolicySummary
+        rule={activeRuleSummary}
+        unitLabel={unitLabel}
+        buildingLabel={buildingLabel}
+      />
+      <VisitorRequestForm activeRule={activeRuleSummary} />
+      <VisitorLogList logs={logSummaries} currentProfileId={profile.id} />
+    </div>
+  )
+}

--- a/app/test-utils/visitors/page.tsx
+++ b/app/test-utils/visitors/page.tsx
@@ -1,0 +1,181 @@
+import { notFound } from 'next/navigation'
+
+import { VisitorRequestForm } from '@/app/dashboard/visitors/components/VisitorRequestForm'
+import {
+  handleCreateVisitorRequest,
+  visitorActionInitialState,
+  visitorRequestFormSchema,
+  type VisitorActionState,
+} from '@/app/dashboard/visitors/actions/shared'
+import type {
+  ProfileSummary,
+  VisitorAuditRow,
+  VisitorLogRow,
+  VisitorRuleRow,
+  VisitorRuleSummary,
+} from '@/types/visitors'
+
+const hostProfile: ProfileSummary = {
+  id: 'host-1',
+  full_name: 'Host One',
+  email: 'host@example.com',
+  role: 'tenant',
+  building_id: 'building-1',
+  unit_id: 'unit-1',
+}
+
+const ruleRow: VisitorRuleRow = {
+  id: 99,
+  title: 'Test policy',
+  description: 'Guests may stay up to three consecutive nights.',
+  building_id: 'building-1',
+  unit_id: 'unit-1',
+  max_consecutive_nights: 3,
+  max_visits_per_month: null,
+  require_manager_approval: true,
+  advance_notice_hours: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  created_by: hostProfile.id,
+  active: true,
+  metadata: {},
+}
+
+const ruleSummary: VisitorRuleSummary = {
+  id: ruleRow.id,
+  title: ruleRow.title,
+  description: ruleRow.description,
+  buildingId: ruleRow.building_id,
+  unitId: ruleRow.unit_id,
+  maxConsecutiveNights: ruleRow.max_consecutive_nights,
+  maxVisitsPerMonth: ruleRow.max_visits_per_month,
+  requireManagerApproval: ruleRow.require_manager_approval,
+  advanceNoticeHours: ruleRow.advance_notice_hours,
+}
+
+const roommates: ProfileSummary[] = [
+  {
+    id: 'roommate-2',
+    full_name: 'Roommate Two',
+    email: 'roomie@example.com',
+    role: 'tenant',
+    building_id: 'building-1',
+    unit_id: 'unit-1',
+  },
+]
+
+const managers: ProfileSummary[] = [
+  {
+    id: 'manager-1',
+    full_name: 'Manager One',
+    email: 'manager@example.com',
+    role: 'property_manager',
+    building_id: 'building-1',
+    unit_id: null,
+  },
+]
+
+const logs: VisitorLogRow[] = []
+const audits: VisitorAuditRow[] = []
+
+async function submitTestVisitorRequest(
+  _prevState: VisitorActionState = visitorActionInitialState,
+  formData?: FormData,
+): Promise<VisitorActionState> {
+  'use server'
+
+  if (!formData) {
+    return {
+      status: 'error',
+      message: 'No form data received.',
+    }
+  }
+
+  const raw = {
+    visitorName: formData.get('visitorName'),
+    visitorEmail: formData.get('visitorEmail'),
+    arrivalDate: formData.get('arrivalDate'),
+    departureDate: formData.get('departureDate'),
+    reason: formData.get('reason'),
+    ruleId: Number(formData.get('ruleId')), // hidden input ensures this exists
+  }
+
+  const parsed = visitorRequestFormSchema.safeParse(raw)
+  if (!parsed.success) {
+    return {
+      status: 'error',
+      message: 'Please correct the highlighted issues and try again.',
+      issues: parsed.error.flatten().fieldErrors,
+    }
+  }
+
+  return handleCreateVisitorRequest(
+    {
+      profile: hostProfile,
+      fetchRule: async () => ruleRow,
+      insertLog: async payload => {
+        const now = new Date().toISOString()
+        const record: VisitorLogRow = {
+          id: logs.length + 1,
+          created_at: now,
+          updated_at: now,
+          host_profile_id: payload.host_profile_id ?? hostProfile.id,
+          building_id: payload.building_id ?? hostProfile.building_id!,
+          unit_id: payload.unit_id ?? hostProfile.unit_id!,
+          visitor_name: payload.visitor_name,
+          visitor_email: payload.visitor_email,
+          arrival_date: payload.arrival_date,
+          departure_date: payload.departure_date,
+          total_nights: payload.total_nights ?? 0,
+          reason: payload.reason ?? null,
+          status: payload.status ?? 'pending',
+          rule_id: payload.rule_id ?? ruleRow.id,
+          approval_notes: payload.approval_notes ?? null,
+          approved_by: payload.approved_by ?? null,
+          approved_at: payload.approved_at ?? null,
+          cancelled_by: payload.cancelled_by ?? null,
+          cancelled_at: payload.cancelled_at ?? null,
+          cancellation_reason: payload.cancellation_reason ?? null,
+          metadata: (payload.metadata as Record<string, unknown>) ?? {},
+        }
+        logs.unshift(record)
+        return record
+      },
+      createAudit: async entry => {
+        const audit: VisitorAuditRow = {
+          id: audits.length + 1,
+          log_id: entry.log_id,
+          actor_profile_id: entry.actor_profile_id,
+          action: entry.action,
+          notes: entry.notes ?? null,
+          metadata: (entry.metadata as Record<string, unknown>) ?? {},
+          created_at: new Date().toISOString(),
+        }
+        audits.push(audit)
+        return audit
+      },
+      listRoommates: async () => roommates,
+      listManagers: async () => managers,
+    },
+    parsed.data,
+    async () => {},
+  )
+}
+
+export default function VisitorFlowTestPage() {
+  if (process.env.NODE_ENV === 'production') {
+    notFound()
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col gap-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">Visitor request test harness</h1>
+        <p className="text-sm text-muted-foreground">
+          Use this page to exercise the overnight visitor request form during automated tests.
+        </p>
+      </div>
+      <VisitorRequestForm activeRule={ruleSummary} submitAction={submitTestVisitorRequest} />
+    </main>
+  )
+}

--- a/lib/notifications/visitors.ts
+++ b/lib/notifications/visitors.ts
@@ -1,0 +1,136 @@
+import { format, parseISO } from 'date-fns'
+import { Resend } from 'resend'
+
+import type { ProfileSummary } from '@/types/visitors'
+import type { VisitorNotificationPayload } from '@/app/dashboard/visitors/actions/shared'
+
+function gatherRecipients(payload: VisitorNotificationPayload): string[] {
+  const recipients = new Set<string>()
+
+  const add = (profiles: ProfileSummary[]) => {
+    for (const profile of profiles) {
+      const email = profile.email?.trim()
+      if (email) {
+        recipients.add(email)
+      }
+    }
+  }
+
+  switch (payload.event) {
+    case 'request_submitted':
+      add(payload.roommates)
+      add(payload.managers)
+      break
+    case 'request_cancelled':
+      add(payload.roommates)
+      add(payload.managers)
+      break
+    case 'status_changed':
+      add(payload.roommates)
+      add(payload.managers)
+      if (payload.host.email) {
+        recipients.add(payload.host.email)
+      }
+      break
+    default:
+      break
+  }
+
+  return Array.from(recipients)
+}
+
+function safeFormatDate(value: string): string {
+  try {
+    return format(parseISO(value), 'MMM d, yyyy')
+  } catch {
+    return value
+  }
+}
+
+function buildMessage(payload: VisitorNotificationPayload) {
+  const arrival = safeFormatDate(payload.log.arrival_date)
+  const departure = safeFormatDate(payload.log.departure_date)
+  const nights = payload.log.total_nights
+  const visitorName = payload.log.visitor_name
+  const hostName = payload.host.full_name ?? 'A roommate'
+  const unitLabel = payload.host.unit_id ?? 'the unit'
+  const ruleSummary = payload.rule
+    ? `Max consecutive nights: ${payload.rule.max_consecutive_nights}. Requires manager approval: ${payload.rule.require_manager_approval ? 'Yes' : 'No'}.`
+    : 'Refer to the published visitor policy for details.'
+
+  if (payload.event === 'request_submitted') {
+    return {
+      subject: `Visitor request from ${hostName}`,
+      text: [
+        `${hostName} submitted a guest request for ${visitorName}.`,
+        `Stay dates: ${arrival} to ${departure} (${nights} night${nights > 1 ? 's' : ''}).`,
+        `Unit: ${unitLabel}.`,
+        payload.log.reason ? `Reason: ${payload.log.reason}.` : null,
+        ruleSummary,
+        'Please review the request in the Share House Portal.',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    }
+  }
+
+  if (payload.event === 'request_cancelled') {
+    return {
+      subject: `Visitor stay cancelled by ${hostName}`,
+      text: [
+        `${hostName} cancelled the guest stay for ${visitorName}.`,
+        `Originally scheduled for ${arrival} to ${departure} (${nights} night${nights > 1 ? 's' : ''}).`,
+        payload.cancellationReason ? `Cancellation notes: ${payload.cancellationReason}.` : null,
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    }
+  }
+
+  const decisionText = payload.decision === 'approved' ? 'approved' : 'denied'
+  const actorName = payload.actor?.full_name ?? 'A manager'
+
+  return {
+    subject: `Visitor request ${decisionText}: ${visitorName}`,
+    text: [
+      `${actorName} ${decisionText} the visit requested by ${hostName}.`,
+      `Dates: ${arrival} to ${departure} (${nights} night${nights > 1 ? 's' : ''}).`,
+      payload.log.approval_notes ? `Notes: ${payload.log.approval_notes}.` : null,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  }
+}
+
+export async function sendVisitorNotifications(
+  payload: VisitorNotificationPayload,
+): Promise<void> {
+  const recipients = gatherRecipients(payload)
+  if (!recipients.length) {
+    return
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY
+  if (!resendApiKey) {
+    console.warn('RESEND_API_KEY is not configured; skipping visitor notifications.')
+    return
+  }
+
+  const resend = new Resend(resendApiKey)
+  const fromAddress =
+    process.env.RESEND_VISITOR_FROM ?? 'Onyx Visitors <visitors@resend.dev>'
+
+  const { subject, text } = buildMessage(payload)
+
+  const { error } = await resend.emails.send({
+    from: fromAddress,
+    to: recipients,
+    subject,
+    text,
+  })
+
+  if (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(message)
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1229,6 +1229,7 @@ export type Database = {
       profiles: {
         Row: {
           avatar_url: string | null
+          building_id: string | null
           card_style: Json | null
           card_styles: string | null
           company: string | null
@@ -1241,6 +1242,7 @@ export type Database = {
           linkedin_url: string | null
           public_id: string | null
           role: string | null
+          unit_id: string | null
           updated_at: string | null
           username: string | null
           waddress: string | null
@@ -1249,6 +1251,7 @@ export type Database = {
         }
         Insert: {
           avatar_url?: string | null
+          building_id?: string | null
           card_style?: Json | null
           card_styles?: string | null
           company?: string | null
@@ -1261,6 +1264,7 @@ export type Database = {
           linkedin_url?: string | null
           public_id?: string | null
           role?: string | null
+          unit_id?: string | null
           updated_at?: string | null
           username?: string | null
           waddress?: string | null
@@ -1269,6 +1273,7 @@ export type Database = {
         }
         Update: {
           avatar_url?: string | null
+          building_id?: string | null
           card_style?: Json | null
           card_styles?: string | null
           company?: string | null
@@ -1281,6 +1286,7 @@ export type Database = {
           linkedin_url?: string | null
           public_id?: string | null
           role?: string | null
+          unit_id?: string | null
           updated_at?: string | null
           username?: string | null
           waddress?: string | null
@@ -1593,6 +1599,211 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "members_table"
             referencedColumns: ["member_id"]
+          },
+        ]
+      }
+      visitor_log_audits: {
+        Row: {
+          action: string
+          actor_profile_id: string | null
+          created_at: string
+          id: number
+          log_id: number
+          metadata: Json
+          notes: string | null
+        }
+        Insert: {
+          action: string
+          actor_profile_id?: string | null
+          created_at?: string
+          id?: number
+          log_id: number
+          metadata?: Json
+          notes?: string | null
+        }
+        Update: {
+          action?: string
+          actor_profile_id?: string | null
+          created_at?: string
+          id?: number
+          log_id?: number
+          metadata?: Json
+          notes?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "visitor_log_audits_actor_profile_id_fkey"
+            columns: ["actor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_log_audits_log_id_fkey"
+            columns: ["log_id"]
+            isOneToOne: false
+            referencedRelation: "visitor_logs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      visitor_logs: {
+        Row: {
+          approval_notes: string | null
+          approved_at: string | null
+          approved_by: string | null
+          arrival_date: string
+          building_id: string
+          cancellation_reason: string | null
+          cancelled_at: string | null
+          cancelled_by: string | null
+          created_at: string
+          host_profile_id: string
+          id: number
+          metadata: Json
+          reason: string | null
+          rule_id: number | null
+          status: string
+          total_nights: number
+          unit_id: string
+          updated_at: string
+          visitor_email: string | null
+          visitor_name: string
+          departure_date: string
+        }
+        Insert: {
+          approval_notes?: string | null
+          approved_at?: string | null
+          approved_by?: string | null
+          arrival_date: string
+          building_id: string
+          cancellation_reason?: string | null
+          cancelled_at?: string | null
+          cancelled_by?: string | null
+          created_at?: string
+          host_profile_id: string
+          id?: number
+          metadata?: Json
+          reason?: string | null
+          rule_id?: number | null
+          status?: string
+          total_nights: number
+          unit_id: string
+          updated_at?: string
+          visitor_email?: string | null
+          visitor_name: string
+          departure_date: string
+        }
+        Update: {
+          approval_notes?: string | null
+          approved_at?: string | null
+          approved_by?: string | null
+          arrival_date?: string
+          building_id?: string
+          cancellation_reason?: string | null
+          cancelled_at?: string | null
+          cancelled_by?: string | null
+          created_at?: string
+          host_profile_id?: string
+          id?: number
+          metadata?: Json
+          reason?: string | null
+          rule_id?: number | null
+          status?: string
+          total_nights?: number
+          unit_id?: string
+          updated_at?: string
+          visitor_email?: string | null
+          visitor_name?: string
+          departure_date?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "visitor_logs_approved_by_fkey"
+            columns: ["approved_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_logs_cancelled_by_fkey"
+            columns: ["cancelled_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_logs_host_profile_id_fkey"
+            columns: ["host_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_logs_rule_id_fkey"
+            columns: ["rule_id"]
+            isOneToOne: false
+            referencedRelation: "visitor_rules"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      visitor_rules: {
+        Row: {
+          active: boolean
+          advance_notice_hours: number | null
+          building_id: string
+          created_at: string
+          created_by: string
+          description: string | null
+          id: number
+          max_consecutive_nights: number
+          max_visits_per_month: number | null
+          metadata: Json
+          require_manager_approval: boolean
+          title: string
+          unit_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          active?: boolean
+          advance_notice_hours?: number | null
+          building_id: string
+          created_at?: string
+          created_by: string
+          description?: string | null
+          id?: number
+          max_consecutive_nights?: number
+          max_visits_per_month?: number | null
+          metadata?: Json
+          require_manager_approval?: boolean
+          title?: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          active?: boolean
+          advance_notice_hours?: number | null
+          building_id?: string
+          created_at?: string
+          created_by?: string
+          description?: string | null
+          id?: number
+          max_consecutive_nights?: number
+          max_visits_per_month?: number | null
+          metadata?: Json
+          require_manager_approval?: boolean
+          title?: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "visitor_rules_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
         ]
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -101,6 +104,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "@playwright/test": "^1.46.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.0.4",
@@ -109,6 +113,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^1.6.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = process.env.PLAYWRIGHT_PORT ? Number(process.env.PLAYWRIGHT_PORT) : 3100
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: `pnpm dev --hostname 0.0.0.0 --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      NODE_ENV: 'development',
+      NEXT_TELEMETRY_DISABLED: '1',
+      NEXT_PUBLIC_TEST_MODE: 'true',
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -261,6 +261,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@playwright/test':
+        specifier: ^1.46.0
+        version: 1.55.0
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -306,6 +309,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.14.15)(terser@5.39.0)
 
 packages:
 
@@ -1328,6 +1334,144 @@ packages:
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1409,6 +1553,10 @@ packages:
       '@types/react-dom': ^18.0.11
       react: ^18.2.0
       react-dom: ^18.2.0
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -1570,6 +1718,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -2323,6 +2476,116 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rushstack/eslint-patch@1.6.1':
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
 
@@ -2337,6 +2600,9 @@ packages:
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
   '@supabase-cache-helpers/postgrest-core@0.3.0':
     resolution: {integrity: sha512-anLCZeyKcTl5ggrn2xyZ7WRq6q1QnHxIemevg7OX+3NOw+xatZ0g0HpBBFrQfRLTz2UD6K5oeqmIKN9EPrNgeA==}
@@ -2489,6 +2755,9 @@ packages:
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/google-one-tap@1.2.6':
     resolution: {integrity: sha512-REmJsXVHvKb/sgI8DF+7IesMbDbcsEokHBqxU01ENZ8d98UPWdRLhUCtxEm9bhNFFg6PJGy7PNFdvovp0hK3jA==}
@@ -2649,6 +2918,21 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
   '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
 
@@ -2746,6 +3030,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
@@ -2758,6 +3046,11 @@ packages:
 
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2804,6 +3097,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -2862,6 +3159,9 @@ packages:
   arraybuffer.prototype.slice@1.0.2:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -3020,6 +3320,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3056,6 +3360,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3084,6 +3392,9 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -3168,6 +3479,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -3315,6 +3629,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -3353,6 +3671,10 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3473,6 +3795,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -3644,6 +3971,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -3753,6 +4084,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3780,6 +4116,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.2.2:
     resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
 
@@ -3797,6 +4136,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -3959,6 +4302,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -4141,6 +4488,10 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -4217,6 +4568,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -4314,6 +4668,10 @@ packages:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -4356,6 +4714,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -4543,6 +4904,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -4579,6 +4944,9 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -4678,6 +5046,10 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4722,6 +5094,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -4729,6 +5105,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -4766,6 +5146,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -4780,6 +5164,15 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -4807,6 +5200,19 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-attribute-case-insensitive@7.0.0:
     resolution: {integrity: sha512-ETMUHIw67Kyv9Q81nden/NuJbRh+4/S963giXpfSLd5eaKK8kd1UdAHMVRV/NG/w/N6Cq8B0qZIZbZZWU/67+A==}
@@ -5040,6 +5446,10 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   prismjs@1.27.0:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
     engines: {node: '>=6'}
@@ -5125,6 +5535,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
@@ -5317,6 +5730,11 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5404,6 +5822,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5474,6 +5895,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
     peerDependencies:
@@ -5482,6 +5906,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -5537,6 +5964,10 @@ packages:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -5544,6 +5975,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -5690,6 +6124,17 @@ packages:
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -5748,6 +6193,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@0.16.0:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
@@ -5775,6 +6224,9 @@ packages:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -5934,6 +6386,67 @@ packages:
   victory-vendor@36.8.6:
     resolution: {integrity: sha512-PH8Wj9b0xIZ4AVfyn0c1SJrOhtxDJ5PNxj1ZDABPg1Gw1vJr1mJVqESPhvsFj7mXLQohVdiKqp4kWZkXlPcRcA==}
 
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.20:
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.4.35:
     resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
     peerDependencies:
@@ -5998,6 +6511,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workbox-background-sync@7.1.0:
@@ -6103,6 +6621,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
@@ -7302,10 +7824,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7400,6 +7922,75 @@ snapshots:
   '@emotion/utils@1.2.1': {}
 
   '@emotion/weak-memoize@0.3.1': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
@@ -7500,6 +8091,10 @@ snapshots:
       '@types/react-dom': 18.3.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
 
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
@@ -7656,6 +8251,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
 
   '@radix-ui/number@1.0.1':
     dependencies:
@@ -8524,6 +9123,72 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
   '@rushstack/eslint-patch@1.6.1': {}
 
   '@scure/base@1.1.5': {}
@@ -8543,6 +9208,8 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@sinclair/typebox@0.27.8': {}
 
   '@supabase-cache-helpers/postgrest-core@0.3.0(@supabase/postgrest-js@1.9.2)(@supabase/supabase-js@2.39.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
@@ -8723,6 +9390,8 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/estree@1.0.8': {}
+
   '@types/google-one-tap@1.2.6': {}
 
   '@types/hast@2.3.10':
@@ -8853,19 +9522,48 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
+
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
 
   '@vue/compiler-core@3.4.35':
     dependencies:
@@ -9022,11 +9720,17 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.14.1
+
   acorn@8.11.3: {}
 
   acorn@8.12.1: {}
 
   acorn@8.14.1: {}
+
+  acorn@8.15.0: {}
 
   agent-base@7.1.3: {}
 
@@ -9068,6 +9772,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
 
@@ -9147,6 +9853,8 @@ snapshots:
       get-intrinsic: 1.2.2
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
+
+  assertion-error@1.1.0: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -9327,6 +10035,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -9359,6 +10069,16 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9383,6 +10103,10 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   chokidar@3.5.3:
     dependencies:
@@ -9466,6 +10190,8 @@ snapshots:
   common-tags@1.8.2: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -9592,6 +10318,10 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -9625,6 +10355,8 @@ snapshots:
       dequal: 2.0.3
 
   didyoumean@1.2.2: {}
+
+  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -9802,6 +10534,32 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
@@ -9815,8 +10573,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +10596,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +10613,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +10634,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10063,6 +10821,18 @@ snapshots:
 
   events@3.3.0: {}
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   expand-template@2.0.3: {}
 
   extend@3.0.2: {}
@@ -10162,6 +10932,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -10198,6 +10971,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.2.2:
     dependencies:
       function-bind: 1.1.2
@@ -10226,6 +11001,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.0.0:
     dependencies:
@@ -10469,6 +11246,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@5.0.0: {}
+
   idb@7.1.1: {}
 
   ieee754@1.2.1: {}
@@ -10628,6 +11407,8 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  is-stream@3.0.0: {}
+
   is-string@1.0.7:
     dependencies:
       has-tostringtag: 1.0.0
@@ -10715,6 +11496,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -10798,6 +11581,11 @@ snapshots:
 
   loader-runner@4.3.0: {}
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 1.3.1
+
   locate-character@3.0.0:
     optional: true
 
@@ -10829,6 +11617,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -10858,7 +11650,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   markdown-extensions@2.0.0: {}
 
@@ -11199,6 +11990,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@4.0.0: {}
+
   mimic-response@3.1.0: {}
 
   minimatch@3.1.2:
@@ -11229,6 +12022,13 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
+
   ms@2.1.2: {}
 
   ms@2.1.3: {}
@@ -11239,8 +12039,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -11252,13 +12051,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +12067,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11280,6 +12079,7 @@ snapshots:
       '@next/swc-win32-ia32-msvc': 14.2.4
       '@next/swc-win32-x64-msvc': 14.2.4
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.55.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -11310,6 +12110,10 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   object-assign@4.1.1: {}
 
@@ -11362,6 +12166,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   optionator@0.9.3:
     dependencies:
       '@aashutoshrathi/word-wrap': 1.2.6
@@ -11374,6 +12182,10 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.1
 
   p-locate@5.0.0:
     dependencies:
@@ -11423,6 +12235,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-scurry@1.10.1:
@@ -11437,6 +12251,12 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
+
   peberminta@0.9.0: {}
 
   periscopic@3.1.0:
@@ -11449,14 +12269,27 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-attribute-case-insensitive@7.0.0(postcss@8.4.32):
     dependencies:
@@ -11711,7 +12544,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -11725,7 +12558,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   potpack@1.0.2: {}
 
@@ -11749,6 +12581,12 @@ snapshots:
   prettier@2.8.8: {}
 
   pretty-bytes@5.6.0: {}
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
 
   prismjs@1.27.0: {}
 
@@ -11827,6 +12665,8 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react-lifecycles-compat@3.0.4: {}
 
@@ -12063,6 +12903,34 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12183,6 +13051,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -12212,8 +13082,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -12236,12 +13105,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
     dependencies:
       '@types/three': 0.176.0
       three: 0.160.0
 
   stats.js@0.17.0: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -12322,9 +13195,15 @@ snapshots:
 
   strip-comments@2.0.1: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-to-object@0.4.4:
     dependencies:
@@ -12334,12 +13213,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 
@@ -12519,6 +13398,12 @@ snapshots:
 
   tiny-invariant@1.3.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -12575,6 +13460,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.1.0: {}
+
   type-fest@0.16.0: {}
 
   type-fest@0.20.2: {}
@@ -12607,6 +13494,8 @@ snapshots:
       is-typed-array: 1.1.12
 
   typescript@5.5.4: {}
+
+  ufo@1.6.1: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -12784,6 +13673,68 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@1.6.1(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.20(@types/node@20.14.15)(terser@5.39.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.20(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.3
+      rollup: 4.52.0
+    optionalDependencies:
+      '@types/node': 20.14.15
+      fsevents: 2.3.3
+      terser: 5.39.0
+
+  vitest@1.6.1(@types/node@20.14.15)(terser@5.39.0):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@20.14.15)(terser@5.39.0)
+      vite-node: 1.6.1(@types/node@20.14.15)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.14.15
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
@@ -12898,6 +13849,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workbox-background-sync@7.1.0:
     dependencies:
@@ -13099,6 +14055,8 @@ snapshots:
   yaml@2.3.4: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.1: {}
 
   zod@3.22.4: {}
 

--- a/supabase/migrations/20250712_add_visitor_tables.sql
+++ b/supabase/migrations/20250712_add_visitor_tables.sql
@@ -1,0 +1,226 @@
+-- Visitor logs and policy tables
+
+-- Ensure profiles have building and unit metadata to scope policies
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS building_id uuid,
+  ADD COLUMN IF NOT EXISTS unit_id uuid;
+
+-- Helper function for policy checks
+CREATE OR REPLACE FUNCTION public.has_role(roles text[])
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.id = auth.uid()
+      AND p.role = ANY (roles)
+  );
+$$;
+
+-- Rules that govern overnight visitors per building/unit
+CREATE TABLE IF NOT EXISTS public.visitor_rules (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  building_id uuid NOT NULL,
+  unit_id uuid,
+  title text NOT NULL DEFAULT 'Visitor Policy',
+  description text,
+  max_consecutive_nights integer NOT NULL DEFAULT 3 CHECK (max_consecutive_nights > 0),
+  max_visits_per_month integer CHECK (max_visits_per_month IS NULL OR max_visits_per_month > 0),
+  require_manager_approval boolean NOT NULL DEFAULT true,
+  advance_notice_hours integer CHECK (advance_notice_hours IS NULL OR advance_notice_hours >= 0),
+  created_by uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  active boolean NOT NULL DEFAULT true,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS visitor_rules_building_unit_active_idx
+  ON public.visitor_rules (building_id, unit_id)
+  WHERE active IS TRUE;
+
+-- Log of individual visitor stays per tenant
+CREATE TABLE IF NOT EXISTS public.visitor_logs (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  host_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  building_id uuid NOT NULL,
+  unit_id uuid NOT NULL,
+  visitor_name text NOT NULL,
+  visitor_email text,
+  arrival_date date NOT NULL,
+  departure_date date NOT NULL,
+  total_nights integer NOT NULL CHECK (total_nights > 0),
+  reason text,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'denied', 'cancelled', 'completed')),
+  rule_id bigint REFERENCES public.visitor_rules(id) ON DELETE SET NULL,
+  approval_notes text,
+  approved_by uuid REFERENCES public.profiles(id),
+  approved_at timestamptz,
+  cancelled_by uuid REFERENCES public.profiles(id),
+  cancelled_at timestamptz,
+  cancellation_reason text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT visitor_logs_date_range CHECK (departure_date >= arrival_date)
+);
+
+CREATE INDEX IF NOT EXISTS visitor_logs_host_idx ON public.visitor_logs (host_profile_id);
+CREATE INDEX IF NOT EXISTS visitor_logs_unit_idx ON public.visitor_logs (unit_id);
+CREATE INDEX IF NOT EXISTS visitor_logs_status_idx ON public.visitor_logs (status);
+
+-- Audit log entries for compliance retention
+CREATE TABLE IF NOT EXISTS public.visitor_log_audits (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  log_id bigint NOT NULL REFERENCES public.visitor_logs(id) ON DELETE CASCADE,
+  actor_profile_id uuid REFERENCES public.profiles(id),
+  action text NOT NULL CHECK (action IN ('created', 'updated', 'status_change', 'approved', 'denied', 'cancelled', 'notification')),
+  notes text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS visitor_log_audits_log_idx ON public.visitor_log_audits (log_id);
+
+-- Enable RLS and policies for multi-tenant separation
+ALTER TABLE public.visitor_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.visitor_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.visitor_log_audits ENABLE ROW LEVEL SECURITY;
+
+-- Visitor rule visibility and management
+CREATE POLICY IF NOT EXISTS "tenants-can-read-applicable-visitor-rules"
+  ON public.visitor_rules
+  FOR SELECT
+  USING (
+    public.has_role(ARRAY['property_manager', 'admin'])
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.building_id = visitor_rules.building_id
+        AND (
+          visitor_rules.unit_id IS NULL
+          OR visitor_rules.unit_id = p.unit_id
+        )
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "managers-maintain-visitor-rules"
+  ON public.visitor_rules
+  FOR ALL
+  USING (public.has_role(ARRAY['property_manager', 'admin']))
+  WITH CHECK (public.has_role(ARRAY['property_manager', 'admin']));
+
+-- Visitor log policies
+CREATE POLICY IF NOT EXISTS "residents-can-view-unit-visitor-logs"
+  ON public.visitor_logs
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND (
+          p.id = visitor_logs.host_profile_id
+          OR (p.unit_id IS NOT NULL AND p.unit_id = visitor_logs.unit_id)
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+        AND (p.role = 'admin' OR p.building_id = visitor_logs.building_id)
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "hosts-create-visitor-logs"
+  ON public.visitor_logs
+  FOR INSERT
+  WITH CHECK (auth.uid() = host_profile_id);
+
+CREATE POLICY IF NOT EXISTS "hosts-update-own-visitor-logs"
+  ON public.visitor_logs
+  FOR UPDATE
+  USING (auth.uid() = host_profile_id)
+  WITH CHECK (auth.uid() = host_profile_id);
+
+CREATE POLICY IF NOT EXISTS "managers-update-visitor-logs"
+  ON public.visitor_logs
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+        AND (p.role = 'admin' OR p.building_id = visitor_logs.building_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+        AND (p.role = 'admin' OR p.building_id = visitor_logs.building_id)
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "admins-can-delete-visitor-logs"
+  ON public.visitor_logs
+  FOR DELETE
+  USING (public.has_role(ARRAY['admin']));
+
+-- Audit log policies
+CREATE POLICY IF NOT EXISTS "stakeholders-view-visitor-audits"
+  ON public.visitor_log_audits
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.visitor_logs l
+      JOIN public.profiles p ON p.id = auth.uid()
+      WHERE l.id = visitor_log_audits.log_id
+        AND (
+          p.role = 'admin'
+          OR (p.role = 'property_manager' AND p.building_id = l.building_id)
+          OR (p.unit_id IS NOT NULL AND p.unit_id = l.unit_id)
+        )
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "actors-log-visitor-audits"
+  ON public.visitor_log_audits
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.visitor_logs l
+      WHERE l.id = visitor_log_audits.log_id
+        AND (
+          l.host_profile_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.profiles p
+            WHERE p.id = auth.uid()
+              AND p.role IN ('property_manager', 'admin')
+              AND (p.role = 'admin' OR p.building_id = l.building_id)
+          )
+        )
+    )
+  );
+
+-- Managers and admins can maintain audit records if needed
+CREATE POLICY IF NOT EXISTS "managers-update-visitor-audits"
+  ON public.visitor_log_audits
+  FOR UPDATE
+  USING (public.has_role(ARRAY['property_manager', 'admin']))
+  WITH CHECK (public.has_role(ARRAY['property_manager', 'admin']));
+
+CREATE POLICY IF NOT EXISTS "admins-delete-visitor-audits"
+  ON public.visitor_log_audits
+  FOR DELETE
+  USING (public.has_role(ARRAY['admin']));

--- a/tests/e2e/visitor-flow.spec.ts
+++ b/tests/e2e/visitor-flow.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+
+const arrivalSelector = 'input[name="arrivalDate"]'
+const departureSelector = 'input[name="departureDate"]'
+
+test.describe('Visitor request flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-utils/visitors')
+  })
+
+  test('allows tenants to submit valid guest requests', async ({ page }) => {
+    await page.fill('input[name="visitorName"]', 'Playwright Guest')
+    await page.fill('input[name="visitorEmail"]', 'guest@example.com')
+    await page.fill(arrivalSelector, '2024-04-10')
+    await page.fill(departureSelector, '2024-04-11')
+    await page.fill('textarea[name="reason"]', 'Visiting for the weekend.')
+
+    await page.getByRole('button', { name: 'Submit request' }).click()
+
+    await expect(page.getByText('Guest stay submitted for 2 nights.')).toBeVisible()
+    await expect(page.locator('input[name="visitorName"]')).toHaveValue('')
+  })
+
+  test('blocks requests that exceed the consecutive night policy', async ({ page }) => {
+    await page.fill('input[name="visitorName"]', 'Policy Breaker')
+    await page.fill(arrivalSelector, '2024-04-10')
+    await page.fill(departureSelector, '2024-04-20')
+    await page.fill('textarea[name="reason"]', 'Attempting a long stay.')
+
+    await page.getByRole('button', { name: 'Submit request' }).click()
+
+    await expect(
+      page.getByText('This stay exceeds the 3-night limit defined by your visitor policy.'),
+    ).toBeVisible()
+    await expect(
+      page.getByText('Visitor stays are limited to 3 consecutive nights.'),
+    ).toBeVisible()
+  })
+})

--- a/tests/server-actions/visitor-actions.test.ts
+++ b/tests/server-actions/visitor-actions.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import type {
+  ProfileSummary,
+  VisitorAuditRow,
+  VisitorLogRow,
+  VisitorLogWithRelations,
+  VisitorRuleRow,
+} from '@/types/visitors'
+
+import {
+  handleCancelVisitorRequest,
+  handleCreateVisitorRequest,
+  handleResolveVisitorRequest,
+} from '@/app/dashboard/visitors/actions/shared'
+
+const hostProfile: ProfileSummary = {
+  id: 'host-1',
+  full_name: 'Host One',
+  email: 'host@example.com',
+  role: 'tenant',
+  building_id: 'building-1',
+  unit_id: 'unit-1',
+}
+
+const managerProfile: ProfileSummary = {
+  id: 'manager-1',
+  full_name: 'Manager',
+  email: 'manager@example.com',
+  role: 'property_manager',
+  building_id: 'building-1',
+  unit_id: null,
+}
+
+function createRule(overrides: Partial<VisitorRuleRow> = {}): VisitorRuleRow {
+  const now = new Date().toISOString()
+  return {
+    id: 1,
+    title: 'Unit policy',
+    description: null,
+    building_id: 'building-1',
+    unit_id: 'unit-1',
+    max_consecutive_nights: 3,
+    max_visits_per_month: null,
+    require_manager_approval: true,
+    advance_notice_hours: null,
+    created_at: now,
+    updated_at: now,
+    created_by: hostProfile.id,
+    active: true,
+    metadata: {},
+    ...overrides,
+  }
+}
+
+function createLog(overrides: Partial<VisitorLogRow> = {}): VisitorLogRow {
+  const now = new Date().toISOString()
+  return {
+    id: 10,
+    created_at: now,
+    updated_at: now,
+    host_profile_id: hostProfile.id,
+    building_id: hostProfile.building_id!,
+    unit_id: hostProfile.unit_id!,
+    visitor_name: 'Guest',
+    visitor_email: 'guest@example.com',
+    arrival_date: '2024-01-01',
+    departure_date: '2024-01-03',
+    total_nights: 3,
+    reason: 'Vacation',
+    status: 'pending',
+    rule_id: 1,
+    approval_notes: null,
+    approved_by: null,
+    approved_at: null,
+    cancelled_by: null,
+    cancelled_at: null,
+    cancellation_reason: null,
+    metadata: {},
+    ...overrides,
+  }
+}
+
+function createAuditRow(overrides: Partial<VisitorAuditRow> = {}): VisitorAuditRow {
+  const now = new Date().toISOString()
+  return {
+    id: 1,
+    log_id: 10,
+    actor_profile_id: hostProfile.id,
+    action: 'created',
+    notes: null,
+    metadata: {},
+    created_at: now,
+    ...overrides,
+  }
+}
+
+function createLogWithRelations(
+  overrides: Partial<VisitorLogWithRelations> = {},
+): VisitorLogWithRelations {
+  const { rule, host, ...logOverrides } = overrides
+  return {
+    ...createLog(logOverrides as Partial<VisitorLogRow>),
+    rule: rule ?? createRule(),
+    host: host ?? hostProfile,
+  }
+}
+
+describe('visitor server actions', () => {
+  test('rejects requests that exceed consecutive night policy', async () => {
+    const rule = createRule()
+    const insertLogSpy = vi.fn()
+    const createAuditSpy = vi.fn()
+
+    const result = await handleCreateVisitorRequest(
+      {
+        profile: hostProfile,
+        fetchRule: async () => rule,
+        insertLog: async payload => {
+          insertLogSpy(payload)
+          return createLog(payload as Partial<VisitorLogRow>)
+        },
+        createAudit: async entry => {
+          createAuditSpy(entry)
+          return createAuditRow()
+        },
+        listRoommates: async () => [],
+        listManagers: async () => [],
+      },
+      {
+        visitorName: 'Guest',
+        visitorEmail: 'guest@example.com',
+        arrivalDate: '2024-01-01',
+        departureDate: '2024-01-10',
+        reason: 'Vacation',
+        ruleId: rule.id,
+      },
+      vi.fn(),
+    )
+
+    expect(result.status).toBe('error')
+    expect(result.message).toContain('exceeds')
+    expect(insertLogSpy).not.toHaveBeenCalled()
+    expect(createAuditSpy).not.toHaveBeenCalled()
+  })
+
+  test('creates a visitor log and sends notifications', async () => {
+    const rule = createRule({ max_consecutive_nights: 5, require_manager_approval: true })
+    const insertLogSpy = vi.fn(async (payload: Partial<VisitorLogRow>) => createLog(payload))
+    const createAuditSpy = vi.fn()
+    const notify = vi.fn(async () => {})
+
+    const result = await handleCreateVisitorRequest(
+      {
+        profile: hostProfile,
+        fetchRule: async () => rule,
+        insertLog: async payload => insertLogSpy(payload as Partial<VisitorLogRow>),
+        createAudit: async entry => {
+          createAuditSpy(entry)
+          return createAuditRow()
+        },
+        listRoommates: async () => [
+          {
+            id: 'roommate-2',
+            full_name: 'Roommate',
+            email: 'roomie@example.com',
+            role: 'tenant',
+            building_id: hostProfile.building_id,
+            unit_id: hostProfile.unit_id,
+          },
+        ],
+        listManagers: async () => [
+          {
+            id: 'manager-1',
+            full_name: 'Manager',
+            email: 'manager@example.com',
+            role: 'property_manager',
+            building_id: hostProfile.building_id,
+            unit_id: null,
+          },
+        ],
+      },
+      {
+        visitorName: 'Guest',
+        visitorEmail: 'guest@example.com',
+        arrivalDate: '2024-01-01',
+        departureDate: '2024-01-03',
+        reason: 'Vacation',
+        ruleId: rule.id,
+      },
+      notify,
+    )
+
+    expect(result.status).toBe('success')
+    expect(result.logId).toBeDefined()
+    expect(insertLogSpy).toHaveBeenCalledTimes(1)
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(createAuditSpy).toHaveBeenCalled()
+  })
+
+  test('cancels visitor requests and alerts stakeholders', async () => {
+    const notify = vi.fn(async () => {})
+    const updateLog = vi.fn(async () =>
+      createLog({ status: 'cancelled', cancelled_at: new Date().toISOString() }),
+    )
+    const createAuditSpy = vi.fn()
+
+    const result = await handleCancelVisitorRequest(
+      {
+        actor: hostProfile,
+        getLog: async () =>
+          createLogWithRelations({
+            status: 'approved',
+          }),
+        updateLog: async (_, changes) => updateLog(createLog(changes as Partial<VisitorLogRow>)),
+        createAudit: async entry => {
+          createAuditSpy(entry)
+          return createAuditRow()
+        },
+        listRoommates: async () => [],
+        listManagers: async () => [],
+      },
+      {
+        logId: 10,
+        reason: 'Plans changed',
+      },
+      notify,
+    )
+
+    expect(result.status).toBe('success')
+    expect(updateLog).toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'request_cancelled' }),
+    )
+    expect(createAuditSpy).toHaveBeenCalled()
+  })
+
+  test('approves a visitor request', async () => {
+    const notify = vi.fn(async () => {})
+    const updateLog = vi.fn(async () =>
+      createLog({ status: 'approved', approved_by: managerProfile.id }),
+    )
+    const createAuditSpy = vi.fn()
+
+    const result = await handleResolveVisitorRequest(
+      {
+        actor: managerProfile,
+        getLog: async () =>
+          createLogWithRelations({
+            status: 'pending',
+          }),
+        updateLog: async (_, changes) => updateLog(createLog(changes as Partial<VisitorLogRow>)),
+        createAudit: async entry => {
+          createAuditSpy(entry)
+          return createAuditRow()
+        },
+        listRoommates: async () => [],
+        listManagers: async () => [],
+      },
+      {
+        logId: 10,
+        decision: 'approved',
+        notes: 'Enjoy your stay',
+      },
+      notify,
+    )
+
+    expect(result.status).toBe('success')
+    expect(updateLog).toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'status_changed', decision: 'approved' }),
+    )
+    expect(createAuditSpy).toHaveBeenCalled()
+  })
+})

--- a/types/visitors.ts
+++ b/types/visitors.ts
@@ -1,0 +1,60 @@
+import type { Database } from '@/lib/supabase'
+
+export type ProfileRow = Database['public']['Tables']['profiles']['Row']
+export type VisitorRuleRow = Database['public']['Tables']['visitor_rules']['Row']
+export type VisitorLogRow = Database['public']['Tables']['visitor_logs']['Row']
+export type VisitorAuditRow = Database['public']['Tables']['visitor_log_audits']['Row']
+
+export type ProfileSummary = Pick<
+  ProfileRow,
+  'id' | 'full_name' | 'email' | 'role' | 'building_id' | 'unit_id'
+>
+
+export type VisitorRuleSummary = {
+  id: number
+  title: string
+  description: string | null
+  buildingId: string
+  unitId: string | null
+  maxConsecutiveNights: number
+  maxVisitsPerMonth: number | null
+  requireManagerApproval: boolean
+  advanceNoticeHours: number | null
+}
+
+export type VisitorLogSummary = {
+  id: number
+  visitorName: string
+  visitorEmail: string | null
+  arrivalDate: string
+  departureDate: string
+  totalNights: number
+  status: string
+  reason: string | null
+  rule: VisitorRuleSummary | null
+  hostId: string
+  hostName: string | null
+  hostEmail: string | null
+  approvalNotes: string | null
+  approvedAt: string | null
+  cancellationReason: string | null
+  cancelledAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type VisitorAuditEntryView = {
+  id: number
+  logId: number
+  action: string
+  notes: string | null
+  createdAt: string
+  actorName: string | null
+  actorRole: string | null
+  metadata: Record<string, unknown> | null
+}
+
+export type VisitorLogWithRelations = VisitorLogRow & {
+  rule?: VisitorRuleRow | null
+  host?: ProfileSummary | null
+}

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,8 +1,13 @@
 import { type CookieOptions, createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
-export function createClient(cookieStore: ReturnType<typeof cookies>) {
-  return createServerClient(
+import type { Database } from '@/lib/supabase'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+
+export function createClient(
+  cookieStore: ReturnType<typeof cookies>,
+): TypedSupabaseClient {
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['tests/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary
- finish visitor server action test coverage for create, cancel, and resolve flows
- add vitest/playwright configs, scripts, and mock test harness for visitor request UI
- introduce Playwright e2e spec validating policy enforcement and successful submissions

## Testing
- pnpm lint
- pnpm test
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d03ae645388328ac86bcd69e33acfe