### PR TITLE
Finalize messaging overhaul

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, ChatBubbleIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,10 +8,15 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
+        const links = [
+                {
+                        href: "/dashboard/messages",
+                        text: "Messages",
+                        Icon: ChatBubbleIcon,
+                },
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
 			Icon: PersonIcon,
 		},
 		{

--- a/app/dashboard/messages/actions.ts
+++ b/app/dashboard/messages/actions.ts
@@ -1,0 +1,350 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { createSupbaseServerClient } from "@/utils/supaone"
+import type { Database } from "@/lib/supabase"
+import type { MessageMetadataShape } from "@/types/messages"
+import {
+  MODERATOR_ROLES,
+  resolveBestAssignment,
+} from "@/lib/messages/permissions"
+
+const MESSAGE_METADATA_FIELDS = [
+  "clientRef",
+  "poll",
+  "maintenanceTicketId",
+  "flagged",
+] as const
+
+export type ModerationAction = Database["public"]["Enums"]["moderation_action"]
+
+function sanitizeMetadata(metadata: unknown): MessageMetadataShape {
+  if (!metadata || typeof metadata !== "object") {
+    return {}
+  }
+
+  const payload = metadata as Record<string, unknown>
+  const safe: MessageMetadataShape = {}
+
+  for (const field of MESSAGE_METADATA_FIELDS) {
+    if (field in payload) {
+      safe[field] = payload[field]
+    }
+  }
+
+  return { ...payload, ...safe }
+}
+
+async function getClientWithSession() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session?.user) {
+    throw new Error("Not authenticated")
+  }
+
+  return { supabase, profileId: session.user.id }
+}
+
+async function fetchAssignments(supabase: Awaited<ReturnType<typeof createSupbaseServerClient>>, profileId: string) {
+  const { data, error } = await supabase
+    .from("tenant_assignments")
+    .select("id, building_id, unit_id, role, created_at, profile_id")
+    .eq("profile_id", profileId)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return data ?? []
+}
+
+export async function createThreadAction(input: {
+  title: string
+  buildingId: string
+  unitId?: string | null
+  category?: string
+  metadata?: MessageMetadataShape
+  clientRef?: string
+}) {
+  const { supabase, profileId } = await getClientWithSession()
+  const assignments = await fetchAssignments(supabase, profileId)
+
+  const assignment = resolveBestAssignment(assignments, input.buildingId, input.unitId ?? null)
+  if (!assignment) {
+    throw new Error("You are not assigned to this building or unit")
+  }
+
+  const metadata = {
+    ...(input.metadata ?? {}),
+    clientRef: input.clientRef,
+  }
+
+  const { error, data } = await supabase
+    .from("threads")
+    .insert({
+      building_id: input.buildingId,
+      unit_id: input.unitId ?? null,
+      title: input.title,
+      category: input.category ?? "general",
+      metadata,
+      created_by: profileId,
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  revalidatePath("/dashboard/messages")
+
+  return data
+}
+
+export async function postMessageAction(input: {
+  threadId: string
+  body: string
+  messageType?: string
+  metadata?: MessageMetadataShape
+  parentMessageId?: string | null
+  clientRef?: string
+}) {
+  const { supabase, profileId } = await getClientWithSession()
+
+  const { data: thread, error: threadError } = await supabase
+    .from("threads")
+    .select("id, building_id, unit_id, is_locked")
+    .eq("id", input.threadId)
+    .maybeSingle()
+
+  if (threadError) {
+    throw new Error(threadError.message)
+  }
+
+  if (!thread) {
+    throw new Error("Thread not found")
+  }
+
+  if (thread.is_locked) {
+    throw new Error("Thread is locked")
+  }
+
+  const assignments = await fetchAssignments(supabase, profileId)
+  const assignment = resolveBestAssignment(assignments, thread.building_id, thread.unit_id)
+
+  if (!assignment) {
+    throw new Error("You cannot post to this thread")
+  }
+
+  const metadata = {
+    ...(input.metadata ?? {}),
+    clientRef: input.clientRef,
+  }
+
+  const { data, error } = await supabase
+    .from("messages")
+    .insert({
+      thread_id: input.threadId,
+      parent_message_id: input.parentMessageId ?? null,
+      created_by: profileId,
+      body: input.body,
+      message_type: input.messageType ?? "text",
+      metadata,
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  await supabase
+    .from("threads")
+    .update({ updated_at: new Date().toISOString() })
+    .eq("id", input.threadId)
+
+  return data
+}
+
+export async function toggleReactionAction(input: {
+  messageId: string
+  reactionType: string
+  metadata?: Record<string, unknown>
+}) {
+  const { supabase, profileId } = await getClientWithSession()
+
+  const { data: messageRow, error } = await supabase
+    .from("messages")
+    .select(
+      `
+        id,
+        metadata,
+        message_type,
+        thread:threads!inner (
+          id,
+          building_id,
+          unit_id
+        )
+      `,
+    )
+    .eq("id", input.messageId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!messageRow) {
+    throw new Error("Message not found")
+  }
+
+  const assignments = await fetchAssignments(supabase, profileId)
+  const assignment = resolveBestAssignment(
+    assignments,
+    messageRow.thread.building_id,
+    messageRow.thread.unit_id,
+  )
+
+  if (!assignment) {
+    throw new Error("You cannot react to this message")
+  }
+
+  const { data: existingReaction } = await supabase
+    .from("message_reactions")
+    .select("id")
+    .eq("message_id", input.messageId)
+    .eq("profile_id", profileId)
+    .eq("reaction_type", input.reactionType)
+    .maybeSingle()
+
+  if (existingReaction?.id) {
+    await supabase.from("message_reactions").delete().eq("id", existingReaction.id)
+    return { removed: true }
+  }
+
+  if (input.reactionType.startsWith("poll:")) {
+    const allowMultiple = Boolean(
+      (messageRow.metadata as Record<string, unknown> | null)?.poll?.allowMultiple,
+    )
+
+    if (!allowMultiple) {
+      await supabase
+        .from("message_reactions")
+        .delete()
+        .eq("message_id", input.messageId)
+        .eq("profile_id", profileId)
+        .like("reaction_type", "poll:%")
+    }
+  }
+
+  const { error: insertError } = await supabase.from("message_reactions").insert({
+    message_id: input.messageId,
+    profile_id: profileId,
+    reaction_type: input.reactionType,
+    metadata: input.metadata ?? {},
+  })
+
+  if (insertError) {
+    throw new Error(insertError.message)
+  }
+
+  return { removed: false }
+}
+
+export async function moderateMessageAction(input: {
+  messageId: string
+  action: ModerationAction
+  reason?: string
+}) {
+  const { supabase, profileId } = await getClientWithSession()
+
+  const { data: messageRow, error } = await supabase
+    .from("messages")
+    .select(
+      `
+        id,
+        metadata,
+        is_deleted,
+        thread_id,
+        thread:threads!inner (
+          id,
+          building_id,
+          unit_id,
+          pinned_message_id
+        )
+      `,
+    )
+    .eq("id", input.messageId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!messageRow) {
+    throw new Error("Message not found")
+  }
+
+  const assignments = await fetchAssignments(supabase, profileId)
+  const hasPermission = assignments.some(
+    (assignment) =>
+      assignment.building_id === messageRow.thread.building_id &&
+      MODERATOR_ROLES.includes(assignment.role),
+  )
+
+  if (!hasPermission) {
+    throw new Error("You do not have moderation privileges for this message")
+  }
+
+  const now = new Date().toISOString()
+  const metadata = sanitizeMetadata(messageRow.metadata)
+
+  if (input.action === "pin") {
+    await supabase
+      .from("threads")
+      .update({ pinned_message_id: input.messageId, updated_at: now })
+      .eq("id", messageRow.thread.id)
+  } else if (input.action === "unpin") {
+    await supabase
+      .from("threads")
+      .update({ pinned_message_id: null, updated_at: now })
+      .eq("id", messageRow.thread.id)
+  } else if (input.action === "delete") {
+    await supabase
+      .from("messages")
+      .update({ is_deleted: true, deleted_at: now, metadata })
+      .eq("id", input.messageId)
+  } else if (input.action === "restore") {
+    await supabase
+      .from("messages")
+      .update({ is_deleted: false, deleted_at: null, metadata })
+      .eq("id", input.messageId)
+  } else if (input.action === "flag") {
+    await supabase
+      .from("messages")
+      .update({ metadata: { ...metadata, flagged: true } })
+      .eq("id", input.messageId)
+  } else if (input.action === "resolve_flag") {
+    await supabase
+      .from("messages")
+      .update({ metadata: { ...metadata, flagged: false } })
+      .eq("id", input.messageId)
+  }
+
+  const { error: moderationError } = await supabase.from("message_moderation").insert({
+    message_id: input.messageId,
+    moderator_id: profileId,
+    action: input.action,
+    reason: input.reason ?? null,
+  })
+
+  if (moderationError) {
+    throw new Error(moderationError.message)
+  }
+
+  return { success: true }
+}

--- a/app/dashboard/messages/components/message-composer.tsx
+++ b/app/dashboard/messages/components/message-composer.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { FormEvent, useMemo, useState } from "react"
+import { PlusCircle, Send } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+
+import type { MessageMetadataShape, PollOptionMeta } from "@/types/messages"
+import { useMessagesContext } from "./messages-provider"
+
+interface MessageComposerProps {
+  threadId: string
+  isLocked: boolean
+}
+
+function createOption(): PollOptionMeta {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return { id: crypto.randomUUID(), label: "" }
+  }
+
+  return { id: `option-${Math.random().toString(36).slice(2, 10)}`, label: "" }
+}
+
+export default function MessageComposer({ threadId, isLocked }: MessageComposerProps) {
+  const { sendMessage } = useMessagesContext()
+  const [body, setBody] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isPoll, setIsPoll] = useState(false)
+  const [allowMultiple, setAllowMultiple] = useState(false)
+  const [maintenanceId, setMaintenanceId] = useState("")
+  const [options, setOptions] = useState<PollOptionMeta[]>([createOption(), createOption()])
+
+  const canSubmitPoll = useMemo(
+    () =>
+      options.filter((option) => option.label.trim().length > 0).length >= 2,
+    [options],
+  )
+
+  const resetForm = () => {
+    setBody("")
+    setIsPoll(false)
+    setAllowMultiple(false)
+    setMaintenanceId("")
+    setOptions([createOption(), createOption()])
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (isLocked || isSubmitting) {
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const metadata: MessageMetadataShape = {}
+      if (maintenanceId.trim()) {
+        metadata.maintenanceTicketId = maintenanceId.trim()
+      }
+
+      if (isPoll) {
+        const preparedOptions = options
+          .filter((option) => option.label.trim().length > 0)
+          .map((option) => ({
+            id: option.id,
+            label: option.label.trim(),
+          }))
+
+        if (preparedOptions.length < 2) {
+          return
+        }
+
+        metadata.poll = {
+          options: preparedOptions,
+          allowMultiple,
+        }
+
+        await sendMessage({
+          threadId,
+          body: "",
+          messageType: "poll",
+          metadata,
+        })
+      } else {
+        if (!body.trim()) {
+          return
+        }
+
+        await sendMessage({
+          threadId,
+          body: body.trim(),
+          metadata,
+        })
+      }
+
+      resetForm()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      {isLocked ? (
+        <p className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-500/60 dark:bg-red-950/40 dark:text-red-200">
+          This thread is locked. Only moderators can add new messages.
+        </p>
+      ) : null}
+      {!isPoll ? (
+        <div className="space-y-1">
+          <Label htmlFor="message-body">Message</Label>
+          <Textarea
+            id="message-body"
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            placeholder="Share an update with your roommates"
+            disabled={isLocked}
+          />
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label className="font-semibold">Poll options</Label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setOptions((prev) => [...prev, createOption()])}
+              disabled={options.length >= 6}
+            >
+              <PlusCircle className="mr-2 size-4" /> Add option
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {options.map((option, index) => (
+              <Input
+                key={option.id}
+                value={option.label}
+                onChange={(event) => {
+                  const value = event.target.value
+                  setOptions((prev) =>
+                    prev.map((item) =>
+                      item.id === option.id ? { ...item, label: value } : item,
+                    ),
+                  )
+                }}
+                placeholder={`Option ${index + 1}`}
+              />
+            ))}
+          </div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Switch checked={allowMultiple} onCheckedChange={setAllowMultiple} />
+            Allow multiple selections
+          </div>
+        </div>
+      )}
+      <div className="space-y-1">
+        <Label htmlFor="maintenance-ticket">Maintenance ticket (optional)</Label>
+        <Input
+          id="maintenance-ticket"
+          value={maintenanceId}
+          onChange={(event) => setMaintenanceId(event.target.value)}
+          placeholder="TCK-1234"
+        />
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <Button
+          type="button"
+          variant={isPoll ? "secondary" : "ghost"}
+          onClick={() => setIsPoll((value) => !value)}
+        >
+          {isPoll ? "Switch to message" : "Create poll"}
+        </Button>
+        <Button
+          type="submit"
+          disabled={
+            isLocked ||
+            isSubmitting ||
+            (!isPoll && !body.trim()) ||
+            (isPoll && !canSubmitPoll)
+          }
+        >
+          <Send className="mr-2 size-4" />
+          {isSubmitting ? "Sending" : "Send"}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/app/dashboard/messages/components/message-item.tsx
+++ b/app/dashboard/messages/components/message-item.tsx
@@ -1,0 +1,235 @@
+"use client"
+
+import { formatDistanceToNow } from "date-fns"
+import { Flag } from "lucide-react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+import type { MessageEntity } from "@/lib/messages/state"
+import { ensureMessageMetadata } from "@/lib/messages/state"
+import type { PollOptionMeta } from "@/types/messages"
+import { useMessagesContext } from "./messages-provider"
+import ModerationMenu from "./moderation-menu"
+
+const REACTION_PRESETS = ["👍", "❤️", "🎉"]
+
+interface MessageItemProps {
+  message: MessageEntity
+  depth: number
+  threadId: string
+  canModerate: boolean
+  isPinned?: boolean
+}
+
+function initialsFromName(name: string | null | undefined) {
+  if (!name) {
+    return "?"
+  }
+
+  const parts = name.split(" ")
+  if (parts.length === 1) {
+    return parts[0]?.slice(0, 2).toUpperCase()
+  }
+
+  return `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`.toUpperCase()
+}
+
+function isPollOptionReaction(reactionType: string) {
+  return reactionType.startsWith("poll:")
+}
+
+function getPollOptionId(reactionType: string) {
+  return reactionType.replace(/^poll:/, "")
+}
+
+export default function MessageItem({
+  message,
+  depth,
+  threadId,
+  canModerate,
+  isPinned,
+}: MessageItemProps) {
+  const { profile, toggleReaction, moderateMessage } = useMessagesContext()
+
+  const metadata = ensureMessageMetadata(message.metadata)
+  const pollMetadata = metadata.poll
+  const emojiReactions = message.reactions.filter(
+    (reaction) => !isPollOptionReaction(reaction.reaction_type),
+  )
+  const pollReactions = message.reactions.filter((reaction) =>
+    isPollOptionReaction(reaction.reaction_type),
+  )
+
+  const groupedReactions = emojiReactions.reduce(
+    (acc, reaction) => {
+      const group = acc.get(reaction.reaction_type) ?? []
+      group.push(reaction)
+      acc.set(reaction.reaction_type, group)
+      return acc
+    },
+    new Map<string, typeof emojiReactions>(),
+  )
+
+  const userReactions = new Set(
+    emojiReactions
+      .filter((reaction) => reaction.profile_id === profile.id)
+      .map((reaction) => reaction.reaction_type),
+  )
+
+  const userPollVotes = new Set(
+    pollReactions
+      .filter((reaction) => reaction.profile_id === profile.id)
+      .map((reaction) => getPollOptionId(reaction.reaction_type)),
+  )
+
+  const createdAt = formatDistanceToNow(new Date(message.created_at), {
+    addSuffix: true,
+  })
+
+  const author = message.created_by_profile
+  const isDeleted = message.is_deleted
+  const flagged = Boolean(metadata.flagged)
+
+  const pollOptions: PollOptionMeta[] = pollMetadata?.options ?? []
+  const pollTotalVotes = pollReactions.length
+
+  const handleReaction = async (reactionType: string) => {
+    await toggleReaction({ messageId: message.id, reactionType })
+  }
+
+  const handlePollVote = async (option: PollOptionMeta) => {
+    await toggleReaction({
+      messageId: message.id,
+      reactionType: `poll:${option.id}`,
+      metadata: { optionLabel: option.label },
+    })
+  }
+
+  return (
+    <article
+      className={cn(
+        "rounded-lg border border-transparent bg-background p-3 transition hover:border-border",
+        isPinned && "ring-1 ring-primary",
+      )}
+      style={{ marginLeft: depth ? depth * 16 : undefined }}
+    >
+      <div className="flex items-start gap-3">
+        <Avatar className="size-9">
+          <AvatarImage src={author?.avatar_url ?? undefined} alt={author?.full_name ?? ""} />
+          <AvatarFallback>{initialsFromName(author?.full_name)}</AvatarFallback>
+        </Avatar>
+        <div className="flex-1 space-y-2">
+          <header className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="font-semibold">{author?.full_name ?? "Unknown"}</span>
+            <span className="text-xs text-muted-foreground">{createdAt}</span>
+            {isPinned ? <Badge variant="secondary">Pinned</Badge> : null}
+            {flagged ? (
+              <Badge variant="outline" className="gap-1 text-xs text-red-600 dark:text-red-400">
+                <Flag className="size-3" /> Flagged
+              </Badge>
+            ) : null}
+          </header>
+          <div className="text-sm">
+            {isDeleted ? (
+              <p className="italic text-muted-foreground">This message was removed by a moderator.</p>
+            ) : pollMetadata ? (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-muted-foreground">Poll</p>
+                <div className="space-y-2">
+                  {pollOptions.map((option) => {
+                    const votes = pollReactions.filter(
+                      (reaction) => getPollOptionId(reaction.reaction_type) === option.id,
+                    )
+                    const voteCount = votes.length
+                    const percentage = pollTotalVotes
+                      ? Math.round((voteCount / pollTotalVotes) * 100)
+                      : 0
+                    const isSelected = userPollVotes.has(option.id)
+
+                    return (
+                      <button
+                        type="button"
+                        key={option.id}
+                        onClick={() => handlePollVote(option)}
+                        className={cn(
+                          "w-full rounded-md border p-2 text-left text-sm transition",
+                          isSelected
+                            ? "border-primary bg-primary/10"
+                            : "border-border hover:bg-muted/60",
+                        )}
+                      >
+                        <div className="flex items-center justify-between">
+                          <span>{option.label}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {voteCount} vote{voteCount === 1 ? "" : "s"}
+                          </span>
+                        </div>
+                        <div className="mt-1 h-1.5 rounded-full bg-muted">
+                          <div
+                            className="h-full rounded-full bg-primary"
+                            style={{ width: `${percentage}%` }}
+                          />
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {pollTotalVotes} total vote{pollTotalVotes === 1 ? "" : "s"}
+                  {pollMetadata.allowMultiple ? " • Multiple selections allowed" : null}
+                </p>
+              </div>
+            ) : (
+              <p>{message.body}</p>
+            )}
+          </div>
+          <footer className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <div className="flex flex-wrap items-center gap-2">
+              {Array.from(groupedReactions.entries()).map(([reactionType, reactions]) => {
+                const isActive = userReactions.has(reactionType)
+                return (
+                  <Button
+                    key={reactionType}
+                    type="button"
+                    variant={isActive ? "default" : "outline"}
+                    size="sm"
+                    className="h-7 gap-1"
+                    onClick={() => handleReaction(reactionType)}
+                  >
+                    <span>{reactionType}</span>
+                    <span>{reactions.length}</span>
+                  </Button>
+                )
+              })}
+              {REACTION_PRESETS.filter((preset) => !groupedReactions.has(preset)).map((preset) => (
+                <Button
+                  key={preset}
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7"
+                  onClick={() => handleReaction(preset)}
+                >
+                  {preset}
+                </Button>
+              ))}
+            </div>
+            {canModerate ? (
+              <ModerationMenu
+                messageId={message.id}
+                threadId={threadId}
+                isDeleted={isDeleted}
+                isPinned={Boolean(isPinned)}
+                flagged={flagged}
+                onModerate={moderateMessage}
+              />
+            ) : null}
+          </footer>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/app/dashboard/messages/components/messages-page-content.tsx
+++ b/app/dashboard/messages/components/messages-page-content.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import OfflineBanner from "./offline-banner"
+import ThreadPanel from "./thread-panel"
+import ThreadSidebar from "./thread-sidebar"
+import { MessagesProvider, type MessagesProviderProps } from "./messages-provider"
+
+function MessagesLayout() {
+  return (
+    <div className="flex flex-col gap-4">
+      <OfflineBanner />
+      <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
+        <ThreadSidebar />
+        <ThreadPanel />
+      </div>
+    </div>
+  )
+}
+
+export default function MessagesPageContent(props: MessagesProviderProps) {
+  return (
+    <MessagesProvider {...props}>
+      <MessagesLayout />
+    </MessagesProvider>
+  )
+}

--- a/app/dashboard/messages/components/messages-provider.tsx
+++ b/app/dashboard/messages/components/messages-provider.tsx
@@ -1,0 +1,919 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+
+import type {
+  BuildingRow,
+  ProfileSummary,
+  TenantAssignmentRow,
+  UnitRow,
+} from "@/types/messages"
+import type { ModerationAction } from "../actions"
+import {
+  moderateMessageAction,
+  postMessageAction,
+  toggleReactionAction,
+  createThreadAction,
+} from "../actions"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import {
+  buildInitialState,
+  createOptimisticMessage,
+  ensureMessageMetadata,
+  messagesReducer,
+  type MessageEntity,
+  type MessagesState,
+} from "@/lib/messages/state"
+import type { MessageMetadataShape, ThreadWithRelations } from "@/types/messages"
+import { emitNotification } from "@/lib/notifications"
+import { canModerateThread } from "@/lib/messages/permissions"
+import type { NotificationBridgePayload } from "@/types/messages"
+
+interface PendingOperation {
+  id: string
+  execute: () => Promise<void>
+  description: string
+}
+
+interface SendMessageInput {
+  threadId: string
+  body: string
+  parentMessageId?: string | null
+  metadata?: MessageMetadataShape
+  messageType?: string
+}
+
+interface CreateThreadInput {
+  title: string
+  buildingId: string
+  unitId?: string | null
+  category?: string
+  metadata?: MessageMetadataShape
+}
+
+interface ReactionInput {
+  messageId: string
+  reactionType: string
+  metadata?: Record<string, unknown>
+}
+
+export interface ModerationInput {
+  messageId: string
+  action: ModerationAction
+  reason?: string
+}
+
+interface MessagesContextValue {
+  state: MessagesState
+  selectedThreadId: string | null
+  selectThread: (threadId: string | null) => void
+  sendMessage: (input: SendMessageInput) => Promise<void>
+  createThread: (input: CreateThreadInput) => Promise<void>
+  toggleReaction: (input: ReactionInput) => Promise<void>
+  moderateMessage: (input: ModerationInput) => Promise<void>
+  profile: ProfileSummary
+  assignments: TenantAssignmentRow[]
+  buildings: BuildingRow[]
+  units: UnitRow[]
+  isOnline: boolean
+  pendingCount: number
+  profileCache: Record<string, ProfileSummary>
+}
+
+const THREAD_SELECT = `
+  id,
+  building_id,
+  unit_id,
+  created_at,
+  updated_at,
+  created_by,
+  title,
+  category,
+  metadata,
+  pinned_message_id,
+  is_locked,
+  created_by_profile:profiles!threads_created_by_fkey (
+    id,
+    full_name,
+    avatar_url,
+    role
+  ),
+  messages (
+    id,
+    thread_id,
+    parent_message_id,
+    created_by,
+    body,
+    message_type,
+    metadata,
+    is_deleted,
+    deleted_at,
+    created_at,
+    updated_at,
+    created_by_profile:profiles!messages_created_by_fkey (
+      id,
+      full_name,
+      avatar_url,
+      role
+    ),
+    message_reactions (
+      id,
+      message_id,
+      profile_id,
+      reaction_type,
+      metadata,
+      created_at,
+      reactor_profile:profiles!message_reactions_profile_id_fkey (
+        id,
+        full_name,
+        avatar_url,
+        role
+      )
+    ),
+    message_moderation (
+      id,
+      message_id,
+      moderator_id,
+      action,
+      reason,
+      created_at,
+      moderator_profile:profiles!message_moderation_moderator_id_fkey (
+        id,
+        full_name,
+        avatar_url,
+        role
+      )
+    )
+  )
+`
+
+const MESSAGE_SELECT = `
+  id,
+  thread_id,
+  parent_message_id,
+  created_by,
+  body,
+  message_type,
+  metadata,
+  is_deleted,
+  deleted_at,
+  created_at,
+  updated_at,
+  created_by_profile:profiles!messages_created_by_fkey (
+    id,
+    full_name,
+    avatar_url,
+    role
+  ),
+  message_reactions (
+    id,
+    message_id,
+    profile_id,
+    reaction_type,
+    metadata,
+    created_at,
+    reactor_profile:profiles!message_reactions_profile_id_fkey (
+      id,
+      full_name,
+      avatar_url,
+      role
+    )
+  ),
+  message_moderation (
+    id,
+    message_id,
+    moderator_id,
+    action,
+    reason,
+    created_at,
+    moderator_profile:profiles!message_moderation_moderator_id_fkey (
+      id,
+      full_name,
+      avatar_url,
+      role
+    )
+  )
+`
+
+const MessagesContext = createContext<MessagesContextValue | null>(null)
+
+function generateOptimisticId(prefix: string) {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+
+  return `${prefix}-${Math.random().toString(36).slice(2, 12)}`
+}
+
+function findMessageEntry(state: MessagesState, messageId: string): {
+  threadId: string
+  message: MessageEntity
+} | null {
+  for (const [threadId, entity] of Object.entries(state.threads)) {
+    const message = entity.messages[messageId]
+    if (message) {
+      return { threadId, message }
+    }
+  }
+
+  return null
+}
+
+function summarizeNotification(
+  payload: NotificationBridgePayload,
+  state: MessagesState,
+  buildings: BuildingRow[],
+  units: UnitRow[],
+) {
+  const thread = state.threads[payload.threadId]?.thread
+  const building = buildings.find((entry) => entry.id === payload.buildingId)
+  const unit = payload.unitId
+    ? units.find((entry) => entry.id === payload.unitId)
+    : undefined
+
+  const titleParts = [thread?.title ?? "Thread"]
+  if (building?.name) {
+    titleParts.push(building.name)
+  }
+  if (unit?.label) {
+    titleParts.push(unit.label)
+  }
+
+  const title = titleParts.join(" • ")
+
+  let body = "New activity"
+  if (payload.action === "new_message") {
+    body = "New message received"
+  } else if (payload.action === "moderation") {
+    body = "A moderator updated a message"
+  } else if (payload.action === "status_update") {
+    body = "Thread status changed"
+  }
+
+  return { title, body }
+}
+
+export interface MessagesProviderProps {
+  profile: ProfileSummary
+  assignments: TenantAssignmentRow[]
+  buildings: BuildingRow[]
+  units: UnitRow[]
+  initialThreads: ThreadWithRelations[]
+  children: ReactNode
+}
+
+export function MessagesProvider({
+  profile,
+  assignments,
+  buildings,
+  units,
+  initialThreads,
+  children,
+}: MessagesProviderProps) {
+  const supabase = useSupabaseBrowser()
+  const [state, dispatch] = useReducer(
+    messagesReducer,
+    initialThreads,
+    buildInitialState,
+  )
+  const stateRef = useRef(state)
+  useEffect(() => {
+    stateRef.current = state
+  }, [state])
+
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(() => {
+    const firstThread = state.threadOrder[0]
+    return firstThread ?? null
+  })
+
+  const [isOnline, setIsOnline] = useState<boolean>(() => {
+    if (typeof navigator === "undefined") {
+      return true
+    }
+
+    return navigator.onLine
+  })
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+
+    window.addEventListener("online", handleOnline)
+    window.addEventListener("offline", handleOffline)
+
+    return () => {
+      window.removeEventListener("online", handleOnline)
+      window.removeEventListener("offline", handleOffline)
+    }
+  }, [])
+
+  const pendingRef = useRef<PendingOperation[]>([])
+  const [pendingCount, setPendingCount] = useState(0)
+
+  const enqueueOperation = useCallback((operation: PendingOperation) => {
+    pendingRef.current = [...pendingRef.current, operation]
+    setPendingCount(pendingRef.current.length)
+  }, [])
+
+  const flushQueue = useCallback(async () => {
+    if (!pendingRef.current.length) {
+      return
+    }
+
+    const queue = [...pendingRef.current]
+    for (const operation of queue) {
+      try {
+        await operation.execute()
+        pendingRef.current = pendingRef.current.filter((item) => item.id !== operation.id)
+        setPendingCount(pendingRef.current.length)
+      } catch (error) {
+        console.error("Failed to process pending operation", error)
+        break
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isOnline) {
+      void flushQueue()
+    }
+  }, [isOnline, flushQueue])
+
+  const profileCacheRef = useRef<Record<string, ProfileSummary>>({ [profile.id]: profile })
+
+  useEffect(() => {
+    const cache: Record<string, ProfileSummary> = { [profile.id]: profile }
+
+    for (const entity of Object.values(state.threads)) {
+      const creator = entity.thread.created_by_profile
+      if (creator) {
+        cache[creator.id] = creator
+      }
+
+      for (const messageId of entity.messageOrder) {
+        const message = entity.messages[messageId]
+        if (message.created_by_profile) {
+          cache[message.created_by_profile.id] = message.created_by_profile
+        }
+        for (const reaction of message.reactions) {
+          if (reaction.reactor_profile) {
+            cache[reaction.reactor_profile.id] = reaction.reactor_profile
+          }
+        }
+        for (const moderation of message.moderation) {
+          if (moderation.moderator_profile) {
+            cache[moderation.moderator_profile.id] = moderation.moderator_profile
+          }
+        }
+      }
+    }
+
+    profileCacheRef.current = cache
+  }, [state, profile])
+
+  const buildingIds = useMemo(
+    () => Array.from(new Set(assignments.map((assignment) => assignment.building_id))),
+    [assignments],
+  )
+
+  const bridgeNotification = useCallback(
+    (payload: NotificationBridgePayload) => {
+      const { title, body } = summarizeNotification(
+        payload,
+        stateRef.current,
+        buildings,
+        units,
+      )
+
+      emitNotification({
+        domain: "messages",
+        title,
+        body,
+        metadata: {
+          threadId: payload.threadId,
+          messageId: payload.messageId,
+        },
+      })
+
+      if (payload.maintenanceTicketId) {
+        emitNotification({
+          domain: "maintenance",
+          title: `Ticket ${payload.maintenanceTicketId}`,
+          body: "A new update is available",
+          metadata: {
+            threadId: payload.threadId,
+            messageId: payload.messageId,
+            maintenanceTicketId: payload.maintenanceTicketId,
+          },
+        })
+      }
+    },
+    [buildings, units],
+  )
+
+  const hydrateThread = useCallback(
+    async (threadId: string) => {
+      const { data } = await supabase
+        .from("threads")
+        .select(THREAD_SELECT)
+        .eq("id", threadId)
+        .maybeSingle()
+
+      if (data) {
+        dispatch({ type: "UPSERT_THREAD", thread: data })
+
+        const metadata = ensureMessageMetadata(data.metadata)
+        if (metadata.clientRef) {
+          const optimisticEntry = Object.entries(stateRef.current.threads).find(
+            ([id, entry]) =>
+              id !== data.id && ensureMessageMetadata(entry.thread.metadata).clientRef === metadata.clientRef,
+          )
+
+          if (optimisticEntry) {
+            dispatch({ type: "REMOVE_THREAD", threadId: optimisticEntry[0] })
+          }
+        }
+      }
+    },
+    [supabase],
+  )
+
+  const hydrateMessage = useCallback(
+    async (messageId: string, eventType: "INSERT" | "UPDATE") => {
+      const { data } = await supabase
+        .from("messages")
+        .select(MESSAGE_SELECT)
+        .eq("id", messageId)
+        .maybeSingle()
+
+      if (data) {
+        const creator = data.created_by_profile
+        if (creator) {
+          profileCacheRef.current[creator.id] = creator
+        }
+
+        dispatch({ type: "UPSERT_MESSAGE", message: data })
+
+        const metadata = ensureMessageMetadata(data.metadata)
+        if (metadata.clientRef) {
+          const match = findMessageEntry(stateRef.current, messageId)
+          if (match) {
+            const message = match.message
+            if (ensureMessageMetadata(message.metadata).clientRef === metadata.clientRef) {
+              // Replace optimistic entry by removing the placeholder id if necessary
+              if (message.id !== data.id && message.id.startsWith("optimistic")) {
+                dispatch({
+                  type: "DELETE_MESSAGE",
+                  messageId: message.id,
+                  threadId: match.threadId,
+                })
+              }
+            }
+          }
+        }
+
+        if (eventType === "INSERT") {
+          bridgeNotification({
+            messageId: data.id,
+            threadId: data.thread_id,
+            buildingId: stateRef.current.threads[data.thread_id]?.thread.building_id ?? "",
+            unitId: stateRef.current.threads[data.thread_id]?.thread.unit_id ?? null,
+            action: "new_message",
+            maintenanceTicketId: ensureMessageMetadata(data.metadata).maintenanceTicketId,
+          })
+        }
+      }
+    },
+    [supabase, bridgeNotification],
+  )
+
+  const handleThreadChange = useCallback(
+    async (payload: {
+      eventType: "INSERT" | "UPDATE" | "DELETE"
+      new: { id: string }
+      old: { id: string }
+    }) => {
+      if (payload.eventType === "DELETE") {
+        dispatch({ type: "REMOVE_THREAD", threadId: payload.old.id })
+        return
+      }
+
+      const threadId = payload.new.id
+      await hydrateThread(threadId)
+    },
+    [hydrateThread],
+  )
+
+  const handleMessageChange = useCallback(
+    async (payload: {
+      eventType: "INSERT" | "UPDATE" | "DELETE"
+      new: { id: string; thread_id: string; is_deleted?: boolean; deleted_at?: string | null }
+      old: { id: string; thread_id: string; is_deleted?: boolean; deleted_at?: string | null }
+    }) => {
+      if (payload.eventType === "DELETE") {
+        dispatch({
+          type: "DELETE_MESSAGE",
+          threadId: payload.old.thread_id,
+          messageId: payload.old.id,
+        })
+        return
+      }
+
+      if (payload.eventType === "UPDATE" && payload.new.is_deleted) {
+        dispatch({
+          type: "MARK_MESSAGE_DELETED",
+          threadId: payload.new.thread_id,
+          messageId: payload.new.id,
+          deletedAt: payload.new.deleted_at ?? undefined,
+        })
+      }
+
+      await hydrateMessage(payload.new.id, payload.eventType)
+    },
+    [hydrateMessage],
+  )
+
+  const handleReactionChange = useCallback(
+    async (payload: {
+      eventType: "INSERT" | "UPDATE" | "DELETE"
+      new: { id: string; message_id: string }
+      old: { id: string; message_id: string }
+    }) => {
+      if (payload.eventType === "DELETE") {
+        const entry = findMessageEntry(stateRef.current, payload.old.message_id)
+        if (entry) {
+          dispatch({
+            type: "DELETE_REACTION",
+            reactionId: payload.old.id,
+            threadId: entry.threadId,
+            messageId: payload.old.message_id,
+          })
+        }
+        return
+      }
+
+      const { data } = await supabase
+        .from("message_reactions")
+        .select(
+          `
+            id,
+            message_id,
+            profile_id,
+            reaction_type,
+            metadata,
+            created_at,
+            reactor_profile:profiles!message_reactions_profile_id_fkey (
+              id,
+              full_name,
+              avatar_url,
+              role
+            )
+          `,
+        )
+        .eq("id", payload.new.id)
+        .maybeSingle()
+
+      if (data) {
+        if (data.reactor_profile) {
+          profileCacheRef.current[data.reactor_profile.id] = data.reactor_profile
+        }
+        dispatch({ type: "UPSERT_REACTION", reaction: data })
+      }
+    },
+    [supabase],
+  )
+
+  const handleModerationChange = useCallback(
+    async (payload: {
+      eventType: "INSERT" | "UPDATE" | "DELETE"
+      new: { id: string; message_id: string; action: ModerationAction }
+      old: { id: string; message_id: string }
+    }) => {
+      if (payload.eventType === "DELETE") {
+        return
+      }
+
+      const { data } = await supabase
+        .from("message_moderation")
+        .select(
+          `
+            id,
+            message_id,
+            moderator_id,
+            action,
+            reason,
+            created_at,
+            moderator_profile:profiles!message_moderation_moderator_id_fkey (
+              id,
+              full_name,
+              avatar_url,
+              role
+            )
+          `,
+        )
+        .eq("id", payload.new.id)
+        .maybeSingle()
+
+      if (data) {
+        if (data.moderator_profile) {
+          profileCacheRef.current[data.moderator_profile.id] = data.moderator_profile
+        }
+        dispatch({ type: "UPSERT_MODERATION", moderation: data })
+
+        const messageEntry = findMessageEntry(stateRef.current, data.message_id)
+        if (messageEntry) {
+          bridgeNotification({
+            messageId: data.message_id,
+            threadId: messageEntry.threadId,
+            buildingId: stateRef.current.threads[messageEntry.threadId]?.thread.building_id ?? "",
+            unitId: stateRef.current.threads[messageEntry.threadId]?.thread.unit_id ?? null,
+            action: "moderation",
+          })
+        }
+      }
+    },
+    [supabase, bridgeNotification],
+  )
+
+  useEffect(() => {
+    if (!buildingIds.length) {
+      return
+    }
+
+    const channels = buildingIds.map((buildingId) =>
+      supabase
+        .channel(`messages:${buildingId}`)
+        .on("postgres_changes", { event: "*", schema: "public", table: "threads", filter: `building_id=eq.${buildingId}` }, handleThreadChange)
+        .on("postgres_changes", { event: "*", schema: "public", table: "messages" }, handleMessageChange)
+        .on("postgres_changes", { event: "*", schema: "public", table: "message_reactions" }, handleReactionChange)
+        .on("postgres_changes", { event: "*", schema: "public", table: "message_moderation" }, handleModerationChange)
+        .subscribe(),
+    )
+
+    return () => {
+      channels.forEach((channel) => {
+        void supabase.removeChannel(channel)
+      })
+    }
+  }, [supabase, buildingIds, handleThreadChange, handleMessageChange, handleReactionChange, handleModerationChange])
+
+  const selectThread = useCallback((threadId: string | null) => {
+    setSelectedThreadId(threadId)
+  }, [])
+
+  const createThread = useCallback(
+    async (input: CreateThreadInput) => {
+      const clientRef = generateOptimisticId("thread")
+      const optimisticThread: ThreadWithRelations = {
+        id: `optimistic-thread-${clientRef}`,
+        building_id: input.buildingId,
+        unit_id: input.unitId ?? null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        created_by: profile.id,
+        title: input.title,
+        category: input.category ?? "general",
+        metadata: { ...(input.metadata ?? {}), clientRef },
+        pinned_message_id: null,
+        is_locked: false,
+        created_by_profile: profile,
+        messages: [],
+      }
+
+      dispatch({ type: "UPSERT_THREAD", thread: optimisticThread })
+      setSelectedThreadId(optimisticThread.id)
+
+      const mutation = async () => {
+        await createThreadAction({
+          ...input,
+          metadata: { ...(input.metadata ?? {}), clientRef },
+          clientRef,
+        })
+      }
+
+      if (!isOnline) {
+        enqueueOperation({
+          id: optimisticThread.id,
+          execute: mutation,
+          description: "create-thread",
+        })
+        return
+      }
+
+      try {
+        await mutation()
+      } catch (error) {
+        console.error("Failed to create thread", error)
+      }
+    },
+    [profile, isOnline, enqueueOperation],
+  )
+
+  const sendMessage = useCallback(
+    async (input: SendMessageInput) => {
+      const clientRef = generateOptimisticId("message")
+      const optimisticMessage = createOptimisticMessage({
+        thread_id: input.threadId,
+        parent_message_id: input.parentMessageId ?? null,
+        body: input.body,
+        message_type: input.messageType ?? "text",
+        metadata: { ...(input.metadata ?? {}), clientRef },
+        created_by: profile.id,
+        created_by_profile: profile,
+      })
+
+      dispatch({ type: "UPSERT_MESSAGE", message: optimisticMessage, optimistic: true })
+
+      const mutation = async () => {
+        await postMessageAction({
+          threadId: input.threadId,
+          body: input.body,
+          parentMessageId: input.parentMessageId ?? null,
+          messageType: input.messageType ?? "text",
+          metadata: { ...(input.metadata ?? {}), clientRef },
+          clientRef,
+        })
+      }
+
+      if (!isOnline) {
+        enqueueOperation({
+          id: optimisticMessage.id,
+          execute: mutation,
+          description: "send-message",
+        })
+        return
+      }
+
+      try {
+        await mutation()
+      } catch (error) {
+        console.error("Failed to send message", error)
+      }
+    },
+    [profile, isOnline, enqueueOperation],
+  )
+
+  const toggleReaction = useCallback(
+    async (input: ReactionInput) => {
+      const entry = findMessageEntry(stateRef.current, input.messageId)
+      if (!entry) {
+        return
+      }
+
+      const existing = entry.message.reactions.find(
+        (reaction) =>
+          reaction.profile_id === profile.id && reaction.reaction_type === input.reactionType,
+      )
+
+      if (existing) {
+        dispatch({
+          type: "DELETE_REACTION",
+          reactionId: existing.id,
+          threadId: entry.threadId,
+          messageId: input.messageId,
+        })
+      } else {
+        const optimisticId = generateOptimisticId("reaction")
+        dispatch({
+          type: "UPSERT_REACTION",
+          reaction: {
+            id: optimisticId,
+            message_id: input.messageId,
+            profile_id: profile.id,
+            reaction_type: input.reactionType,
+            metadata: input.metadata ?? {},
+            created_at: new Date().toISOString(),
+            reactor_profile: profile,
+          },
+        })
+      }
+
+      const mutation = async () => {
+        await toggleReactionAction(input)
+      }
+
+      if (!isOnline) {
+        enqueueOperation({
+          id: `reaction-${input.messageId}-${input.reactionType}`,
+          execute: mutation,
+          description: "toggle-reaction",
+        })
+        return
+      }
+
+      try {
+        await mutation()
+      } catch (error) {
+        console.error("Failed to update reaction", error)
+      }
+    },
+    [profile, isOnline, enqueueOperation],
+  )
+
+  const moderateMessage = useCallback(
+    async (input: ModerationInput) => {
+      const entry = findMessageEntry(stateRef.current, input.messageId)
+      if (!entry) {
+        throw new Error("Message not found")
+      }
+
+      const thread = stateRef.current.threads[entry.threadId].thread
+      const canModerate = canModerateThread(thread, assignments)
+      if (!canModerate) {
+        throw new Error("Insufficient permissions")
+      }
+
+      if (input.action === "pin" || input.action === "unpin") {
+        dispatch({ type: "SET_PINNED", threadId: entry.threadId, messageId: input.action === "pin" ? input.messageId : null })
+      }
+
+      if (input.action === "delete") {
+        dispatch({
+          type: "MARK_MESSAGE_DELETED",
+          threadId: entry.threadId,
+          messageId: input.messageId,
+          deletedAt: new Date().toISOString(),
+        })
+      }
+
+      const mutation = async () => {
+        await moderateMessageAction(input)
+      }
+
+      if (!isOnline) {
+        enqueueOperation({
+          id: `moderation-${input.messageId}-${input.action}`,
+          execute: mutation,
+          description: "moderate-message",
+        })
+        return
+      }
+
+      try {
+        await mutation()
+      } catch (error) {
+        console.error("Failed to moderate message", error)
+      }
+    },
+    [assignments, isOnline, enqueueOperation],
+  )
+
+  const contextValue = useMemo<MessagesContextValue>(
+    () => ({
+      state,
+      selectedThreadId,
+      selectThread,
+      sendMessage,
+      createThread,
+      toggleReaction,
+      moderateMessage,
+      profile,
+      assignments,
+      buildings,
+      units,
+      isOnline,
+      pendingCount,
+      profileCache: profileCacheRef.current,
+    }),
+    [
+      state,
+      selectedThreadId,
+      selectThread,
+      sendMessage,
+      createThread,
+      toggleReaction,
+      moderateMessage,
+      profile,
+      assignments,
+      buildings,
+      units,
+      isOnline,
+      pendingCount,
+    ],
+  )
+
+  return <MessagesContext.Provider value={contextValue}>{children}</MessagesContext.Provider>
+}
+
+export function useMessagesContext() {
+  const context = useContext(MessagesContext)
+  if (!context) {
+    throw new Error("MessagesContext must be used within a MessagesProvider")
+  }
+
+  return context
+}

--- a/app/dashboard/messages/components/moderation-menu.tsx
+++ b/app/dashboard/messages/components/moderation-menu.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { useState } from "react"
+import { Flag, MoreHorizontal, Pin, Trash2, Undo2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+import type { ModerationInput } from "./messages-provider"
+
+interface ModerationMenuProps {
+  messageId: string
+  isPinned: boolean
+  isDeleted: boolean
+  flagged: boolean
+  onModerate: (input: ModerationInput) => Promise<void>
+}
+
+export default function ModerationMenu({
+  messageId,
+  isPinned,
+  isDeleted,
+  flagged,
+  onModerate,
+}: ModerationMenuProps) {
+  const [isWorking, setIsWorking] = useState(false)
+
+  const runAction = async (action: ModerationInput["action"]) => {
+    setIsWorking(true)
+    try {
+      await onModerate({ messageId, action })
+    } finally {
+      setIsWorking(false)
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-8">
+          <MoreHorizontal className="size-4" />
+          <span className="sr-only">Moderation actions</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48 text-sm">
+        <DropdownMenuItem disabled={isWorking} onSelect={() => runAction(isPinned ? "unpin" : "pin")}>
+          <Pin className="mr-2 size-4" /> {isPinned ? "Unpin" : "Pin"} message
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem disabled={isWorking} onSelect={() => runAction(isDeleted ? "restore" : "delete")}>
+          {isDeleted ? (
+            <Undo2 className="mr-2 size-4" />
+          ) : (
+            <Trash2 className="mr-2 size-4" />
+          )}
+          {isDeleted ? "Restore" : "Delete"} message
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={isWorking}
+          onSelect={() => runAction(flagged ? "resolve_flag" : "flag")}
+        >
+          <Flag className="mr-2 size-4" /> {flagged ? "Resolve flag" : "Flag message"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/app/dashboard/messages/components/offline-banner.tsx
+++ b/app/dashboard/messages/components/offline-banner.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { WifiOff } from "lucide-react"
+
+import { useMessagesContext } from "./messages-provider"
+
+export default function OfflineBanner() {
+  const { isOnline, pendingCount } = useMessagesContext()
+
+  if (isOnline && pendingCount === 0) {
+    return null
+  }
+
+  const message = !isOnline
+    ? "You are offline. New messages will be queued and sent when you reconnect."
+    : `Syncing ${pendingCount} pending update${pendingCount === 1 ? "" : "s"}...`
+
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-amber-500/60 bg-amber-100/70 p-3 text-sm text-amber-900 shadow-sm dark:border-amber-400/50 dark:bg-amber-900/30 dark:text-amber-200">
+      <WifiOff className="size-4" aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  )
+}

--- a/app/dashboard/messages/components/thread-panel.tsx
+++ b/app/dashboard/messages/components/thread-panel.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useMemo } from "react"
+import { Building2, Lock, Pin } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+
+import { canModerateThread } from "@/lib/messages/permissions"
+import type { MessageEntity } from "@/lib/messages/state"
+
+import { useMessagesContext } from "./messages-provider"
+import MessageComposer from "./message-composer"
+import MessageItem from "./message-item"
+
+function computeDepth(messageId: string, messages: Record<string, MessageEntity>) {
+  let depth = 0
+  let current = messages[messageId]
+  const visited = new Set<string>()
+
+  while (current?.parent_message_id) {
+    if (visited.has(current.parent_message_id)) {
+      break
+    }
+    visited.add(current.parent_message_id)
+    depth += 1
+    current = messages[current.parent_message_id]
+  }
+
+  return depth
+}
+
+export default function ThreadPanel() {
+  const {
+    state,
+    selectedThreadId,
+    assignments,
+    buildings,
+    units,
+  } = useMessagesContext()
+
+  const entity = selectedThreadId ? state.threads[selectedThreadId] : undefined
+  const canModerate = useMemo(() => {
+    if (!entity) {
+      return false
+    }
+    return canModerateThread(entity.thread, assignments)
+  }, [entity, assignments])
+
+  if (!entity) {
+    return (
+      <Card className="flex h-full flex-col items-center justify-center border-dashed bg-muted/30 text-center">
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Select a thread to get started or create a new conversation.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const thread = entity.thread
+  const building = buildings.find((entry) => entry.id === thread.building_id)
+  const unit = thread.unit_id ? units.find((entry) => entry.id === thread.unit_id) : undefined
+  const pinnedMessage = thread.pinned_message_id
+    ? entity.messages[thread.pinned_message_id]
+    : undefined
+
+  const messages = entity.messageOrder.map((id) => entity.messages[id])
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="border-b">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-xl font-semibold">{thread.title}</CardTitle>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1">
+                <Building2 className="size-3.5" aria-hidden="true" />
+                {building?.name ?? "Building"}
+              </span>
+              <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                {thread.category}
+              </Badge>
+              <span>{unit ? unit.label : "Common areas"}</span>
+              {thread.is_locked ? (
+                <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400">
+                  <Lock className="size-3" /> Locked
+                </span>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      {pinnedMessage ? (
+        <div className="border-b bg-muted/50 p-4">
+          <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase text-muted-foreground">
+            <Pin className="size-3.5" aria-hidden="true" /> Pinned message
+          </div>
+          <MessageItem
+            message={pinnedMessage}
+            depth={0}
+            threadId={thread.id}
+            canModerate={canModerate}
+            isPinned
+          />
+        </div>
+      ) : null}
+      <CardContent className="flex-1 space-y-3 overflow-y-auto p-4">
+        {messages.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No messages yet. Say hello!</p>
+        ) : (
+          messages.map((message) => (
+            <MessageItem
+              key={message.id}
+              message={message}
+              depth={computeDepth(message.id, entity.messages)}
+              threadId={thread.id}
+              canModerate={canModerate}
+            />
+          ))
+        )}
+      </CardContent>
+      <Separator />
+      <div className="p-4">
+        <MessageComposer threadId={thread.id} isLocked={thread.is_locked} />
+      </div>
+    </Card>
+  )
+}

--- a/app/dashboard/messages/components/thread-sidebar.tsx
+++ b/app/dashboard/messages/components/thread-sidebar.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import { FormEvent, useMemo, useState } from "react"
+import { MessageCircle, Pin, Plus } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+
+import { useMessagesContext } from "./messages-provider"
+
+const BUILDING_SCOPE_VALUE = "__building__"
+
+export default function ThreadSidebar() {
+  const {
+    state,
+    selectedThreadId,
+    selectThread,
+    buildings,
+    units,
+    assignments,
+    createThread,
+  } = useMessagesContext()
+
+  const [title, setTitle] = useState("")
+  const [category, setCategory] = useState("general")
+  const [isCreating, setIsCreating] = useState(false)
+
+  const defaultBuilding = assignments[0]?.building_id ?? ""
+  const [buildingId, setBuildingId] = useState(defaultBuilding)
+  const [unitSelection, setUnitSelection] = useState<string>(
+    assignments[0]?.unit_id ?? BUILDING_SCOPE_VALUE,
+  )
+
+  const accessibleBuildings = useMemo(() => {
+    const unique = new Map<string, string>()
+    for (const assignment of assignments) {
+      const building = buildings.find((entry) => entry.id === assignment.building_id)
+      unique.set(assignment.building_id, building?.name ?? "Building")
+    }
+    return Array.from(unique.entries())
+  }, [assignments, buildings])
+
+  const availableUnits = useMemo(() => {
+    return units.filter((unit) => unit.building_id === buildingId)
+  }, [units, buildingId])
+
+  const threadOrder = state.threadOrder.map((id) => state.threads[id])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!title.trim() || !buildingId) {
+      return
+    }
+
+    setIsCreating(true)
+    try {
+      await createThread({
+        title: title.trim(),
+        buildingId,
+        unitId: unitSelection === BUILDING_SCOPE_VALUE ? null : unitSelection,
+        category,
+      })
+      setTitle("")
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <Card className="flex-1 overflow-hidden">
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="text-base font-semibold">Threads</CardTitle>
+          <span className="text-xs text-muted-foreground">{threadOrder.length} active</span>
+        </CardHeader>
+        <CardContent className="space-y-2 overflow-y-auto">
+          {threadOrder.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No threads yet. Start a conversation below.</p>
+          ) : (
+            threadOrder.map((entry) => {
+              const { thread } = entry
+              const building = buildings.find((b) => b.id === thread.building_id)
+              const unit = thread.unit_id
+                ? units.find((u) => u.id === thread.unit_id)
+                : undefined
+              const isSelected = selectedThreadId === thread.id
+              return (
+                <button
+                  type="button"
+                  key={thread.id}
+                  onClick={() => selectThread(thread.id)}
+                  className={cn(
+                    "w-full rounded-md border border-transparent p-3 text-left transition hover:border-border hover:bg-muted/60",
+                    isSelected && "border-primary bg-primary/10",
+                  )}
+                >
+                  <div className="flex items-center justify-between text-sm font-medium">
+                    <span className="line-clamp-1 flex items-center gap-1">
+                      <MessageCircle className="size-4 shrink-0 text-muted-foreground" />
+                      {thread.title}
+                    </span>
+                    {thread.pinned_message_id ? (
+                      <Pin className="size-3.5 text-primary" aria-hidden="true" />
+                    ) : null}
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {building?.name ?? "Building"}
+                    {unit ? ` • ${unit.label}` : " • Common"}
+                  </div>
+                  <div className="mt-2 text-xs text-muted-foreground">
+                    {entry.messageOrder.length} message{entry.messageOrder.length === 1 ? "" : "s"}
+                  </div>
+                </button>
+              )
+            })
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base font-semibold">
+            <Plus className="size-4" /> Start a thread
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-3" onSubmit={handleSubmit}>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">Topic</label>
+              <Input
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Appliance repair, rent reminder..."
+                required
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">Building</label>
+              <Select
+                value={buildingId}
+                onValueChange={(value) => {
+                  setBuildingId(value)
+                  const firstUnit = assignments.find(
+                    (assignment) => assignment.building_id === value,
+                  )?.unit_id
+                  setUnitSelection(firstUnit ?? BUILDING_SCOPE_VALUE)
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select building" />
+                </SelectTrigger>
+                <SelectContent>
+                  {accessibleBuildings.map(([id, name]) => (
+                    <SelectItem key={id} value={id}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">Scope</label>
+              <Select value={unitSelection} onValueChange={setUnitSelection}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select unit" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={BUILDING_SCOPE_VALUE}>Whole building</SelectItem>
+                  {availableUnits.map((unit) => (
+                    <SelectItem key={unit.id} value={unit.id}>
+                      {unit.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">Category</label>
+              <Select value={category} onValueChange={setCategory}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Category" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="general">General</SelectItem>
+                  <SelectItem value="maintenance">Maintenance</SelectItem>
+                  <SelectItem value="announcement">Announcement</SelectItem>
+                  <SelectItem value="poll">Poll</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button type="submit" className="w-full" disabled={isCreating || !title.trim()}>
+              {isCreating ? "Creating..." : "Create thread"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/messages/page.tsx
+++ b/app/dashboard/messages/page.tsx
@@ -1,0 +1,166 @@
+import { Metadata } from "next"
+import { redirect } from "next/navigation"
+
+import MessagesPageContent from "./components/messages-page-content"
+import { createSupbaseServerClient } from "@/utils/supaone"
+import type {
+  BuildingRow,
+  ThreadWithRelations,
+  TenantAssignmentRow,
+  UnitRow,
+} from "@/types/messages"
+import { filterThreadsByAssignments, sortThreadsForDisplay } from "@/lib/messages/permissions"
+
+export const metadata: Metadata = {
+  title: "Messages",
+  description: "Collaborate with your roommates and property team in real-time.",
+}
+
+export default async function MessagesPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session?.user) {
+    redirect("/auth")
+  }
+
+  const profileId = session.user.id
+
+  const [{ data: profileData }, { data: assignmentData }] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("id, full_name, avatar_url, role")
+      .eq("id", profileId)
+      .maybeSingle(),
+    supabase
+      .from("tenant_assignments")
+      .select("id, building_id, unit_id, role, created_at, profile_id")
+      .eq("profile_id", profileId),
+  ])
+
+  if (!profileData) {
+    throw new Error("Unable to load profile")
+  }
+
+  const assignments = assignmentData ?? []
+  const buildingIds = Array.from(new Set(assignments.map((assignment) => assignment.building_id)))
+
+  let buildings: BuildingRow[] = []
+  if (buildingIds.length) {
+    const { data: buildingRows } = await supabase
+      .from("buildings")
+      .select("id, name, address, created_at, updated_at")
+      .in("id", buildingIds)
+
+    buildings = buildingRows ?? []
+  }
+
+  let units: UnitRow[] = []
+  const unitIds = Array.from(
+    new Set(assignments.map((assignment) => assignment.unit_id).filter(Boolean) as string[]),
+  )
+
+  if (unitIds.length) {
+    const { data: unitRows } = await supabase
+      .from("units")
+      .select("id, label, building_id, created_at, updated_at")
+      .in("id", unitIds)
+
+    units = unitRows ?? []
+  }
+
+  let threads: ThreadWithRelations[] = []
+
+  if (buildingIds.length) {
+    const { data: threadRows } = await supabase
+      .from("threads")
+      .select(
+        `
+          id,
+          building_id,
+          unit_id,
+          created_at,
+          updated_at,
+          created_by,
+          title,
+          category,
+          metadata,
+          pinned_message_id,
+          is_locked,
+          created_by_profile:profiles!threads_created_by_fkey (
+            id,
+            full_name,
+            avatar_url,
+            role
+          ),
+          messages (
+            id,
+            thread_id,
+            parent_message_id,
+            created_by,
+            body,
+            message_type,
+            metadata,
+            is_deleted,
+            deleted_at,
+            created_at,
+            updated_at,
+            created_by_profile:profiles!messages_created_by_fkey (
+              id,
+              full_name,
+              avatar_url,
+              role
+            ),
+            message_reactions (
+              id,
+              message_id,
+              profile_id,
+              reaction_type,
+              metadata,
+              created_at,
+              reactor_profile:profiles!message_reactions_profile_id_fkey (
+                id,
+                full_name,
+                avatar_url,
+                role
+              )
+            ),
+            message_moderation (
+              id,
+              message_id,
+              moderator_id,
+              action,
+              reason,
+              created_at,
+              moderator_profile:profiles!message_moderation_moderator_id_fkey (
+                id,
+                full_name,
+                avatar_url,
+                role
+              )
+            )
+          )
+        `,
+      )
+      .in("building_id", buildingIds)
+      .order("updated_at", { ascending: false })
+
+    threads = threadRows ?? []
+  }
+
+  const filteredThreads = sortThreadsForDisplay(
+    filterThreadsByAssignments(threads, assignments),
+  )
+
+  const props = {
+    profile: profileData,
+    assignments: assignments as TenantAssignmentRow[],
+    buildings,
+    units,
+    initialThreads: filteredThreads,
+  }
+
+  return <MessagesPageContent {...props} />
+}

--- a/app/dashboard/todo/page.tsx
+++ b/app/dashboard/todo/page.tsx
@@ -1,42 +1,75 @@
+"use client";
 
 import React from "react";
-import CreateForm from "./components/CreateForm";
-import { cn } from "@/lib/utils";
+
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { useNotifications } from "@/hooks/useNotifications";
+
+import CreateForm from "./components/CreateForm";
 
 export default function Todo() {
-	const todos = [
-		{
-			title: "Subscribe",
-			created_by: "091832901830",
-			id: "101981908",
-			completed: false,
-		},
-	];
+        const { notifications, clear } = useNotifications("maintenance");
+        const todos = [
+                {
+                        title: "Subscribe",
+                        created_by: "091832901830",
+                        id: "101981908",
+                        completed: false,
+                },
+        ];
 
-	return (
-		<div className="flex h-screen items-center justify-center">
-			<div className="w-96 space-y-5">
+        return (
+                <div className="flex h-screen items-center justify-center">
+                        <div className="w-96 space-y-5">
+                                <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+                                        <div className="flex items-center justify-between">
+                                                <span className="font-medium uppercase text-muted-foreground">Maintenance activity</span>
+                                                <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="h-6 px-2"
+                                                        onClick={() => clear()}
+                                                >
+                                                        Clear
+                                                </Button>
+                                        </div>
+                                        {notifications.length === 0 ? (
+                                                <p className="mt-2">No recent ticket updates.</p>
+                                        ) : (
+                                                <ul className="mt-2 space-y-2">
+                                                        {notifications.map((notification) => (
+                                                                <li key={notification.id} className="rounded-md bg-background p-2 shadow-sm">
+                                                                        <div className="flex items-center justify-between gap-2">
+                                                                                <span className="text-xs font-semibold">{notification.title}</span>
+                                                                                <Badge variant="outline">New</Badge>
+                                                                        </div>
+                                                                        <p className="mt-1 text-xs text-muted-foreground">{notification.body}</p>
+                                                                </li>
+                                                        ))}
+                                                </ul>
+                                        )}
+                                </div>
+                                <CreateForm />
 
-				<CreateForm />
+                                {todos?.map((todo, index) => {
+                                        return (
+                                                <div key={index} className="flex items-center gap-6">
+                                                        <h1
+                                                                className={cn({
+                                                                        "line-through": todo.completed,
+                                                                })}
+                                                        >
+                                                                {todo.title}
+                                                        </h1>
 
-				{todos?.map((todo, index) => {
-					return (
-						<div key={index} className="flex items-center gap-6">
-							<h1
-								className={cn({
-									"line-through": todo.completed,
-								})}
-							>
-								{todo.title}
-							</h1>
-
-							<Button>delete</Button>
-							<Button>Update</Button>
-						</div>
-					);
-				})}
-			</div>
-		</div>
-	);
+                                                        <Button>delete</Button>
+                                                        <Button>Update</Button>
+                                                </div>
+                                        );
+                                })}
+                        </div>
+                </div>
+        );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,17 +18,17 @@ export default async function IndexPage() {
     return redirect("/dashboard")
   }
   return (
-    <section className="relative max-w-dvw w-full overflow-hidden bg-arctic-gradient pb-16">
-      <div className="container px-4 py-8 mx-auto flex flex-col space-y-16 items-center pb-16 pt-16 sm:pt-16 sm:pb-24">
-        <div className="flex mx-auto flex-col px-4 md:px-6 lg:px-8 w-full items-center gap-y-12">
-          <h1 className="text-4xl sm:text-5xl lg:text-7xl font-extrabold leading-tight tracking-tighter md:text-6xl text-center">
+    <section className="max-w-dvw bg-arctic-gradient relative w-full overflow-hidden pb-16">
+      <div className="container mx-auto flex w-full flex-col items-center space-y-16 px-4 py-16 sm:py-24">
+        <div className="mx-auto flex w-full flex-col items-center gap-y-12 px-4 md:px-6 lg:px-8">
+          <h1 className="text-center text-4xl font-extrabold leading-tight tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl">
             Onyx SaaS PWA Template
           </h1>
 
           {/* The PrismContainer uses dynamic client-side rendering to display the FeaturesAnimation component. I wanted to demo the usage of Fibonacci's Golden Ratio in an interactive 3D component for devs who may be interested in expanding upon the general concept of the animation. Theres a working implementation running NextJS 15 and React 19 at github.com/rmourey26/3d-prism-infographic and 3d-prism-infographic.vercel.app. The Onyx version needs some tinkering to work properly with React 18.3. I should be able to get that done by 05-10-2025. We'll see. 
         <PrismContainer />
       */}
-          <p className="max-w-3xl text-lg lg:text-xl xs:text-justify text-muted-foreground">
+          <p className="xs:text-justify max-w-3xl text-lg text-muted-foreground lg:text-xl">
             Secure user authentication + RBAC, Zod validated Supabase Postgres
             DB CRUD ops, Rust serverless API runtime, TanStack queries with
             Supabase cache helpers, Resend, SID.ai, NextMDX, admin dashboard,
@@ -36,7 +36,7 @@ export default async function IndexPage() {
           </p>
         </div>
         <Cta />
-        <div className="flex gap-6 mb-8">
+        <div className="mb-8 flex gap-6">
           <Link href={siteConfig.links.login} className={buttonVariants()}>
             Login
           </Link>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -27,13 +27,13 @@ export function MobileNav({ isAuthenticated }: MobileNavProps) {
           variant="ghost"
           className="mr-0 px-0 text-base hover:bg-transparent focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 md:hidden"
         >
-          <Icons.menu className="h-6 w-6" />
+          <Icons.menu className="size-6" />
           <span className="sr-only">Toggle Menu</span>
         </Button>
       </SheetTrigger>
       <div className="xs:items-center ml-1 gap-4 md:hidden">
         <Link href="/" className="flex items-center space-x-2">
-          <Icons.logo className="h-6 w-6" />
+          <Icons.logo className="size-6" />
           <span className="font-bold">{siteConfig.name}</span>
         </Link>
       </div>

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,0 +1,37 @@
+"use client"
+
+import { useMemo } from "react"
+import { useSyncExternalStore } from "react"
+
+import {
+  clearNotifications,
+  getNotificationsSnapshot,
+  subscribeToNotifications,
+  type NotificationDomain,
+  type NotificationPayload,
+} from "@/lib/notifications"
+
+export function useNotifications(domain?: NotificationDomain) {
+  const subscribe = useMemo(
+    () =>
+      (callback: () => void) => {
+        const unsubscribe = subscribeToNotifications(callback)
+        return () => unsubscribe()
+      },
+    [],
+  )
+
+  const getSnapshot = useMemo(
+    () => () => getNotificationsSnapshot(domain),
+    [domain],
+  )
+
+  const notifications = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  return {
+    notifications,
+    clear: () => clearNotifications(domain),
+  }
+}
+
+export type { NotificationPayload }

--- a/lib/messages/permissions.ts
+++ b/lib/messages/permissions.ts
@@ -1,0 +1,130 @@
+import type { ThreadWithRelations, TenantAssignmentRow, TenantRole } from "@/types/messages"
+
+export const MODERATOR_ROLES: readonly TenantRole[] = [
+  "property_manager",
+  "admin",
+]
+
+export function normalizeAssignments(assignments: TenantAssignmentRow[]): TenantAssignmentRow[] {
+  return assignments.reduce<TenantAssignmentRow[]>((acc, assignment) => {
+    const hasDuplicate = acc.some(
+      (existing) =>
+        existing.building_id === assignment.building_id &&
+        existing.unit_id === assignment.unit_id &&
+        existing.role === assignment.role,
+    )
+
+    if (!hasDuplicate) {
+      acc.push(assignment)
+    }
+
+    return acc
+  }, [])
+}
+
+export function assignmentCoversThread(
+  assignment: TenantAssignmentRow,
+  thread: ThreadWithRelations,
+): boolean {
+  if (assignment.building_id !== thread.building_id) {
+    return false
+  }
+
+  if (assignment.role === "property_manager" || assignment.role === "admin") {
+    return true
+  }
+
+  if (!thread.unit_id) {
+    return true
+  }
+
+  return assignment.unit_id === thread.unit_id
+}
+
+export function filterThreadsByAssignments(
+  threads: ThreadWithRelations[],
+  assignments: TenantAssignmentRow[],
+): ThreadWithRelations[] {
+  if (!assignments.length) {
+    return []
+  }
+
+  const normalized = normalizeAssignments(assignments)
+
+  return threads.filter((thread) =>
+    normalized.some((assignment) => assignmentCoversThread(assignment, thread)),
+  )
+}
+
+export function canModerateThread(
+  thread: ThreadWithRelations,
+  assignments: TenantAssignmentRow[],
+): boolean {
+  return assignments.some(
+    (assignment) =>
+      assignment.building_id === thread.building_id &&
+      MODERATOR_ROLES.includes(assignment.role),
+  )
+}
+
+export function canCreateThread(
+  assignment: TenantAssignmentRow,
+  targetBuildingId: string,
+  targetUnitId: string | null,
+): boolean {
+  if (assignment.building_id !== targetBuildingId) {
+    return false
+  }
+
+  if (MODERATOR_ROLES.includes(assignment.role)) {
+    return true
+  }
+
+  if (!targetUnitId) {
+    return false
+  }
+
+  return assignment.unit_id === targetUnitId
+}
+
+export function resolveBestAssignment(
+  assignments: TenantAssignmentRow[],
+  buildingId: string,
+  unitId: string | null,
+): TenantAssignmentRow | undefined {
+  return assignments.find((assignment) => {
+    if (assignment.building_id !== buildingId) {
+      return false
+    }
+
+    if (MODERATOR_ROLES.includes(assignment.role)) {
+      return true
+    }
+
+    if (!unitId) {
+      return true
+    }
+
+    return assignment.unit_id === unitId
+  })
+}
+
+export function sortThreadsForDisplay(
+  threads: ThreadWithRelations[],
+): ThreadWithRelations[] {
+  return [...threads].sort((a, b) =>
+    new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+  )
+}
+
+export function isPoll(messageType: string, metadata: unknown): boolean {
+  if (messageType !== "poll") {
+    return false
+  }
+
+  if (!metadata || typeof metadata !== "object") {
+    return false
+  }
+
+  return Array.isArray((metadata as Record<string, unknown>).poll?.options)
+}

--- a/lib/messages/state.ts
+++ b/lib/messages/state.ts
@@ -1,0 +1,465 @@
+import type {
+  MessageMetadataShape,
+  MessageWithRelations,
+  ModerationWithProfile,
+  ReactionWithProfile,
+  ThreadWithRelations,
+} from "@/types/messages"
+
+export interface MessageEntity extends MessageWithRelations {
+  reactions: ReactionWithProfile[]
+  moderation: ModerationWithProfile[]
+  optimistic?: boolean
+}
+
+export interface ThreadEntity {
+  thread: ThreadWithRelations
+  messages: Record<string, MessageEntity>
+  messageOrder: string[]
+}
+
+export interface MessagesState {
+  threads: Record<string, ThreadEntity>
+  threadOrder: string[]
+}
+
+export type MessagesAction =
+  | { type: "HYDRATE"; threads: ThreadWithRelations[] }
+  | { type: "UPSERT_THREAD"; thread: ThreadWithRelations }
+  | { type: "REMOVE_THREAD"; threadId: string }
+  | { type: "UPSERT_MESSAGE"; message: MessageWithRelations; optimistic?: boolean }
+  | { type: "DELETE_MESSAGE"; messageId: string; threadId: string }
+  | { type: "MARK_MESSAGE_DELETED"; messageId: string; threadId: string; deletedAt?: string }
+  | { type: "UPSERT_REACTION"; reaction: ReactionWithProfile }
+  | { type: "DELETE_REACTION"; reactionId: string; messageId: string; threadId: string }
+  | { type: "UPSERT_MODERATION"; moderation: ModerationWithProfile }
+  | { type: "SET_PINNED"; threadId: string; messageId: string | null }
+
+function cloneMessage(base: MessageWithRelations, optimistic = false): MessageEntity {
+  return {
+    ...base,
+    reactions: [...(base.message_reactions ?? [])],
+    moderation: [...(base.message_moderation ?? [])],
+    optimistic,
+  }
+}
+
+function normalizeThread(thread: ThreadWithRelations): ThreadEntity {
+  const messageList = [...(thread.messages ?? [])]
+  const sortedMessages = messageList.sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  )
+
+  const messages: Record<string, MessageEntity> = {}
+  const messageOrder: string[] = []
+
+  for (const message of sortedMessages) {
+    messages[message.id] = cloneMessage(message)
+    messageOrder.push(message.id)
+  }
+
+  return {
+    thread: { ...thread, messages: undefined },
+    messages,
+    messageOrder,
+  }
+}
+
+export function buildInitialState(threads: ThreadWithRelations[]): MessagesState {
+  const normalizedThreads = threads.map(normalizeThread)
+  const threadOrder = [...normalizedThreads]
+    .sort((a, b) => new Date(b.thread.updated_at).getTime() - new Date(a.thread.updated_at).getTime())
+    .map((entry) => entry.thread.id)
+
+  const record: Record<string, ThreadEntity> = {}
+  for (const entry of normalizedThreads) {
+    record[entry.thread.id] = entry
+  }
+
+  return {
+    threads: record,
+    threadOrder,
+  }
+}
+
+function ensureThreadEntity(
+  state: MessagesState,
+  thread: ThreadWithRelations,
+): ThreadEntity {
+  const existing = state.threads[thread.id]
+  if (existing) {
+    return {
+      ...existing,
+      thread: { ...existing.thread, ...thread, messages: undefined },
+    }
+  }
+
+  return normalizeThread(thread)
+}
+
+function upsertThread(state: MessagesState, thread: ThreadWithRelations): MessagesState {
+  const entry = ensureThreadEntity(state, thread)
+  const threads = {
+    ...state.threads,
+    [thread.id]: entry,
+  }
+
+  const existingIndex = state.threadOrder.indexOf(thread.id)
+  let threadOrder: string[]
+
+  if (existingIndex >= 0) {
+    threadOrder = [...state.threadOrder]
+    threadOrder.splice(existingIndex, 1)
+    threadOrder.unshift(thread.id)
+  } else {
+    threadOrder = [thread.id, ...state.threadOrder]
+  }
+
+  return { threads, threadOrder }
+}
+
+function deleteThread(state: MessagesState, threadId: string): MessagesState {
+  if (!state.threads[threadId]) {
+    return state
+  }
+
+  const { [threadId]: _removed, ...rest } = state.threads
+  return {
+    threads: rest,
+    threadOrder: state.threadOrder.filter((id) => id !== threadId),
+  }
+}
+
+function upsertMessage(
+  state: MessagesState,
+  message: MessageWithRelations,
+  optimistic = false,
+): MessagesState {
+  const threadId = message.thread_id
+  const existingThread = state.threads[threadId]
+
+  if (!existingThread) {
+    const placeholderThread: ThreadWithRelations = {
+      building_id: "",
+      category: "general",
+      created_at: new Date().toISOString(),
+      created_by: message.created_by,
+      id: threadId,
+      is_locked: false,
+      metadata: {},
+      pinned_message_id: null,
+      title: "Pending thread",
+      unit_id: null,
+      updated_at: message.created_at,
+    }
+
+    const created = normalizeThread({ ...placeholderThread, messages: [message] })
+    return {
+      threads: { ...state.threads, [threadId]: created },
+      threadOrder: [threadId, ...state.threadOrder],
+    }
+  }
+
+  const existingMessage = existingThread.messages[message.id]
+  const nextMessage = cloneMessage({ ...existingMessage, ...message }, optimistic)
+
+  const messages = {
+    ...existingThread.messages,
+    [message.id]: nextMessage,
+  }
+
+  let messageOrder = existingThread.messageOrder
+  if (!existingMessage) {
+    messageOrder = [...messageOrder, message.id]
+    messageOrder.sort(
+      (a, b) =>
+        new Date(messages[a].created_at).getTime() -
+        new Date(messages[b].created_at).getTime(),
+    )
+  }
+
+  const thread = {
+    ...existingThread,
+    thread: {
+      ...existingThread.thread,
+      updated_at: message.updated_at ?? existingThread.thread.updated_at,
+    },
+    messages,
+    messageOrder,
+  }
+
+  return {
+    threads: {
+      ...state.threads,
+      [threadId]: thread,
+    },
+    threadOrder: state.threadOrder,
+  }
+}
+
+function deleteMessage(
+  state: MessagesState,
+  threadId: string,
+  messageId: string,
+): MessagesState {
+  const thread = state.threads[threadId]
+  if (!thread || !thread.messages[messageId]) {
+    return state
+  }
+
+  const { [messageId]: _removed, ...rest } = thread.messages
+  return {
+    threads: {
+      ...state.threads,
+      [threadId]: {
+        ...thread,
+        messages: rest,
+        messageOrder: thread.messageOrder.filter((id) => id !== messageId),
+      },
+    },
+    threadOrder: state.threadOrder,
+  }
+}
+
+function markMessageDeleted(
+  state: MessagesState,
+  threadId: string,
+  messageId: string,
+  deletedAt?: string,
+): MessagesState {
+  const thread = state.threads[threadId]
+  if (!thread) {
+    return state
+  }
+
+  const message = thread.messages[messageId]
+  if (!message) {
+    return state
+  }
+
+  const updated: MessageEntity = {
+    ...message,
+    is_deleted: true,
+    deleted_at: deletedAt ?? new Date().toISOString(),
+  }
+
+  return {
+    threads: {
+      ...state.threads,
+      [threadId]: {
+        ...thread,
+        messages: {
+          ...thread.messages,
+          [messageId]: updated,
+        },
+      },
+    },
+    threadOrder: state.threadOrder,
+  }
+}
+
+function upsertReaction(
+  state: MessagesState,
+  reaction: ReactionWithProfile,
+): MessagesState {
+  const thread = Object.values(state.threads).find((candidate) =>
+    Boolean(candidate.messages[reaction.message_id]),
+  )
+
+  if (!thread) {
+    return state
+  }
+
+  const message = thread.messages[reaction.message_id]
+  if (!message) {
+    return state
+  }
+
+  const reactions = [...message.reactions]
+  const index = reactions.findIndex((item) => item.id === reaction.id)
+
+  if (index >= 0) {
+    reactions[index] = reaction
+  } else {
+    reactions.push(reaction)
+  }
+
+  return {
+    threads: {
+      ...state.threads,
+      [thread.thread.id]: {
+        ...thread,
+        messages: {
+          ...thread.messages,
+          [message.id]: {
+            ...message,
+            reactions,
+          },
+        },
+      },
+    },
+    threadOrder: state.threadOrder,
+  }
+}
+
+function deleteReaction(
+  state: MessagesState,
+  threadId: string,
+  messageId: string,
+  reactionId: string,
+): MessagesState {
+  const thread = state.threads[threadId]
+  if (!thread) {
+    return state
+  }
+
+  const message = thread.messages[messageId]
+  if (!message) {
+    return state
+  }
+
+  return {
+    threads: {
+      ...state.threads,
+      [threadId]: {
+        ...thread,
+        messages: {
+          ...thread.messages,
+          [messageId]: {
+            ...message,
+            reactions: message.reactions.filter((reaction) => reaction.id !== reactionId),
+          },
+        },
+      },
+    },
+    threadOrder: state.threadOrder,
+  }
+}
+
+function upsertModeration(
+  state: MessagesState,
+  moderation: ModerationWithProfile,
+): MessagesState {
+  const thread = Object.values(state.threads).find((candidate) =>
+    Boolean(candidate.messages[moderation.message_id]),
+  )
+
+  if (!thread) {
+    return state
+  }
+
+  const message = thread.messages[moderation.message_id]
+  if (!message) {
+    return state
+  }
+
+  const moderationEntries = [...message.moderation]
+  const index = moderationEntries.findIndex((item) => item.id === moderation.id)
+
+  if (index >= 0) {
+    moderationEntries[index] = moderation
+  } else {
+    moderationEntries.push(moderation)
+  }
+
+  return {
+    threads: {
+      ...state.threads,
+      [thread.thread.id]: {
+        ...thread,
+        messages: {
+          ...thread.messages,
+          [message.id]: {
+            ...message,
+            moderation: moderationEntries,
+          },
+        },
+      },
+    },
+    threadOrder: state.threadOrder,
+  }
+}
+
+function setPinned(state: MessagesState, threadId: string, messageId: string | null): MessagesState {
+  const thread = state.threads[threadId]
+  if (!thread) {
+    return state
+  }
+
+  return {
+    threads: {
+      ...state.threads,
+      [threadId]: {
+        ...thread,
+        thread: {
+          ...thread.thread,
+          pinned_message_id: messageId,
+        },
+      },
+    },
+    threadOrder: state.threadOrder,
+  }
+}
+
+export function messagesReducer(state: MessagesState, action: MessagesAction): MessagesState {
+  switch (action.type) {
+    case "HYDRATE":
+      return buildInitialState(action.threads)
+    case "UPSERT_THREAD":
+      return upsertThread(state, action.thread)
+    case "REMOVE_THREAD":
+      return deleteThread(state, action.threadId)
+    case "UPSERT_MESSAGE":
+      return upsertMessage(state, action.message, action.optimistic)
+    case "DELETE_MESSAGE":
+      return deleteMessage(state, action.threadId, action.messageId)
+    case "MARK_MESSAGE_DELETED":
+      return markMessageDeleted(state, action.threadId, action.messageId, action.deletedAt)
+    case "UPSERT_REACTION":
+      return upsertReaction(state, action.reaction)
+    case "DELETE_REACTION":
+      return deleteReaction(state, action.threadId, action.messageId, action.reactionId)
+    case "UPSERT_MODERATION":
+      return upsertModeration(state, action.moderation)
+    case "SET_PINNED":
+      return setPinned(state, action.threadId, action.messageId)
+    default:
+      return state
+  }
+}
+
+function generateOptimisticId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+
+  return `optimistic-${Math.random().toString(36).slice(2, 14)}`
+}
+
+export function createOptimisticMessage(base: Partial<MessageWithRelations>): MessageWithRelations {
+  const now = new Date().toISOString()
+  return {
+    body: base.body ?? "",
+    created_at: now,
+    created_by: base.created_by ?? "optimistic",
+    deleted_at: null,
+    id: base.id ?? generateOptimisticId(),
+    is_deleted: false,
+    metadata: base.metadata ?? {},
+    message_type: base.message_type ?? "text",
+    parent_message_id: base.parent_message_id ?? null,
+    thread_id: base.thread_id ?? "",
+    updated_at: now,
+    message_moderation: [],
+    message_reactions: [],
+    created_by_profile: base.created_by_profile,
+  }
+}
+
+export function ensureMessageMetadata(metadata: unknown): MessageMetadataShape {
+  if (!metadata || typeof metadata !== "object") {
+    return {}
+  }
+
+  return metadata as MessageMetadataShape
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,63 @@
+export type NotificationDomain = "messages" | "maintenance" | "system"
+
+export interface NotificationPayload {
+  id: string
+  domain: NotificationDomain
+  title: string
+  body: string
+  createdAt: string
+  link?: string
+  metadata?: Record<string, unknown>
+}
+
+type Listener = () => void
+
+const listeners = new Set<Listener>()
+let notifications: NotificationPayload[] = []
+
+function generateId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+
+  return `notification-${Math.random().toString(36).slice(2, 12)}`
+}
+
+export function emitNotification(payload: Omit<NotificationPayload, "id" | "createdAt"> & {
+  id?: string
+  createdAt?: string
+}) {
+  const entry: NotificationPayload = {
+    id: payload.id ?? generateId(),
+    createdAt: payload.createdAt ?? new Date().toISOString(),
+    ...payload,
+  }
+
+  notifications = [...notifications, entry]
+  listeners.forEach((listener) => listener())
+
+  return entry
+}
+
+export function subscribeToNotifications(listener: Listener) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function getNotificationsSnapshot(domain?: NotificationDomain) {
+  if (!domain) {
+    return notifications
+  }
+
+  return notifications.filter((notification) => notification.domain === domain)
+}
+
+export function clearNotifications(domain?: NotificationDomain) {
+  if (!domain) {
+    notifications = []
+  } else {
+    notifications = notifications.filter((notification) => notification.domain !== domain)
+  }
+
+  listeners.forEach((listener) => listener())
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -450,38 +450,329 @@ export type Database = {
         }
         Relationships: []
       }
-      chat: {
+      buildings: {
         Row: {
+          address: string | null
           created_at: string
-          id: number
-          messages: string[] | null
-          path: string | null
-          profile_id: string
-          sharepath: string | null
-          title: string | null
-          user_id: string | null
+          id: string
+          name: string
+          updated_at: string
         }
         Insert: {
+          address?: string | null
+          created_at?: string
+          id?: string
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          address?: string | null
+          created_at?: string
+          id?: string
+          name?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      message_moderation: {
+        Row: {
+          action: Database["public"]["Enums"]["moderation_action"]
           created_at: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
+          id: string
+          message_id: string
+          moderator_id: string
+          reason: string | null
+        }
+        Insert: {
+          action: Database["public"]["Enums"]["moderation_action"]
+          created_at?: string
+          id?: string
+          message_id: string
+          moderator_id: string
+          reason?: string | null
+        }
+        Update: {
+          action?: Database["public"]["Enums"]["moderation_action"]
+          created_at?: string
+          id?: string
+          message_id?: string
+          moderator_id?: string
+          reason?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "message_moderation_message_id_fkey",
+            columns: ["message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "message_moderation_moderator_id_fkey",
+            columns: ["moderator_id"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      message_reactions: {
+        Row: {
+          created_at: string
+          id: string
+          message_id: string
+          metadata: Json
           profile_id: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
+          reaction_type: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          message_id: string
+          metadata?: Json
+          profile_id: string
+          reaction_type: string
         }
         Update: {
           created_at?: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
+          id?: string
+          message_id?: string
+          metadata?: Json
           profile_id?: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
+          reaction_type?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "message_reactions_message_id_fkey",
+            columns: ["message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "message_reactions_profile_id_fkey",
+            columns: ["profile_id"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      messages: {
+        Row: {
+          body: string | null
+          created_at: string
+          created_by: string
+          deleted_at: string | null
+          id: string
+          is_deleted: boolean
+          metadata: Json
+          message_type: string
+          parent_message_id: string | null
+          thread_id: string
+          updated_at: string
+        }
+        Insert: {
+          body?: string | null
+          created_at?: string
+          created_by: string
+          deleted_at?: string | null
+          id?: string
+          is_deleted?: boolean
+          metadata?: Json
+          message_type?: string
+          parent_message_id?: string | null
+          thread_id: string
+          updated_at?: string
+        }
+        Update: {
+          body?: string | null
+          created_at?: string
+          created_by?: string
+          deleted_at?: string | null
+          id?: string
+          is_deleted?: boolean
+          metadata?: Json
+          message_type?: string
+          parent_message_id?: string | null
+          thread_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "messages_created_by_fkey",
+            columns: ["created_by"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_parent_message_id_fkey",
+            columns: ["parent_message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_thread_id_fkey",
+            columns: ["thread_id"],
+            isOneToOne: false,
+            referencedRelation: "threads",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      tenant_assignments: {
+        Row: {
+          building_id: string
+          created_at: string
+          id: string
+          profile_id: string
+          role: "tenant" | "roommate" | "property_manager" | "admin"
+          unit_id: string | null
+        }
+        Insert: {
+          building_id: string
+          created_at?: string
+          id?: string
+          profile_id: string
+          role: "tenant" | "roommate" | "property_manager" | "admin"
+          unit_id?: string | null
+        }
+        Update: {
+          building_id?: string
+          created_at?: string
+          id?: string
+          profile_id?: string
+          role?: "tenant" | "roommate" | "property_manager" | "admin"
+          unit_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_assignments_building_id_fkey",
+            columns: ["building_id"],
+            isOneToOne: false,
+            referencedRelation: "buildings",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "tenant_assignments_profile_id_fkey",
+            columns: ["profile_id"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "tenant_assignments_unit_id_fkey",
+            columns: ["unit_id"],
+            isOneToOne: false,
+            referencedRelation: "units",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      threads: {
+        Row: {
+          building_id: string
+          category: string
+          created_at: string
+          created_by: string
+          id: string
+          is_locked: boolean
+          metadata: Json
+          pinned_message_id: string | null
+          title: string
+          unit_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          building_id: string
+          category?: string
+          created_at?: string
+          created_by: string
+          id?: string
+          is_locked?: boolean
+          metadata?: Json
+          pinned_message_id?: string | null
+          title: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          building_id?: string
+          category?: string
+          created_at?: string
+          created_by?: string
+          id?: string
+          is_locked?: boolean
+          metadata?: Json
+          pinned_message_id?: string | null
+          title?: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "threads_building_id_fkey",
+            columns: ["building_id"],
+            isOneToOne: false,
+            referencedRelation: "buildings",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_created_by_fkey",
+            columns: ["created_by"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_pinned_message_id_fkey",
+            columns: ["pinned_message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_unit_id_fkey",
+            columns: ["unit_id"],
+            isOneToOne: false,
+            referencedRelation: "units",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      units: {
+        Row: {
+          building_id: string
+          created_at: string
+          id: string
+          label: string
+          updated_at: string
+        }
+        Insert: {
+          building_id: string
+          created_at?: string
+          id?: string
+          label: string
+          updated_at?: string
+        }
+        Update: {
+          building_id?: string
+          created_at?: string
+          id?: string
+          label?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "units_building_id_fkey",
+            columns: ["building_id"],
+            isOneToOne: false,
+            referencedRelation: "buildings",
+            referencedColumns: ["id"],
+          },
+        ]
       }
       countries: {
         Row: {
@@ -1598,6 +1889,15 @@ export type Database = {
       }
     }
     Views: {
+      v_tenant_scoped_roles: {
+        Row: {
+          building_id: string | null
+          profile_id: string | null
+          role: "tenant" | "roommate" | "property_manager" | "admin" | null
+          unit_id: string | null
+        }
+        Relationships: []
+      }
       package_utilization: {
         Row: {
           created_at: string | null
@@ -1774,6 +2074,13 @@ export type Database = {
         | "Oceania"
         | "North America"
         | "South America"
+      moderation_action:
+        | "pin"
+        | "unpin"
+        | "delete"
+        | "restore"
+        | "flag"
+        | "resolve_flag"
       user_role: "user" | "admin"
     }
     CompositeTypes: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -96,6 +97,7 @@
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
     "@types/eslint": "^8.56.2",
+    "@types/jsdom": "^21.1.7",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.14.15",
     "@types/react": "^18.3.3",
@@ -107,8 +109,10 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -264,6 +264,9 @@ importers:
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
@@ -297,6 +300,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -306,6 +312,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.39.0)
 
 packages:
 
@@ -330,6 +339,15 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@asamuzakjp/css-color@4.0.4':
+    resolution: {integrity: sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==}
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    resolution: {integrity: sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -1030,12 +1048,23 @@ packages:
     resolution: {integrity: sha512-CEypeeykO9AN7JWkr1OEOQb0HRzZlPWGwV0Ya6DuVgFdDi6g3ma/cPZ5ZPZM4AWQikDpq/0llnGGlIL+j8afzw==}
     engines: {node: ^14 || ^16 || >=18}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
   '@csstools/css-calc@2.0.0':
     resolution: {integrity: sha512-fxPxNrEVGeej4F35Xt69Q7gPMKa7oEGNxeP1DpA01sWpTF3Yhgux/0slVX3jLHd7dhlszeQlNAUhpAorVxoHdQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.0
       '@csstools/css-tokenizer': ^3.0.0
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-color-parser@3.0.0':
     resolution: {integrity: sha512-F/A1Z3ZXH4fU6+29Up4QAZtewLmWLI4hVz6hyODMFvorx4AEC/03tu+gFq0nMZSDafC0lmapNOj9f4ctHMNaqQ==}
@@ -1044,14 +1073,37 @@ packages:
       '@csstools/css-parser-algorithms': ^3.0.0
       '@csstools/css-tokenizer': ^3.0.0
 
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
   '@csstools/css-parser-algorithms@3.0.0':
     resolution: {integrity: sha512-20hEErXV9GEx15qRbsJVzB91ryayx1F2duHPBrfZXQAHz/dJG0u/611URpr28+sFjm3EI7U17Pj9SVA9NSAGJA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.0
 
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   '@csstools/css-tokenizer@3.0.0':
     resolution: {integrity: sha512-efZvfJyYrqH9hPCKtOBywlTsCXnEzAI9sLHFzUsDpBb+1bQ+bxJnwL9V2bRKv9w4cpIp75yxGeZRaVKoMQnsEg==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
   '@csstools/media-query-list-parser@3.0.0':
@@ -1327,6 +1379,162 @@ packages:
 
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
+
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -2323,6 +2531,116 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rushstack/eslint-patch@1.6.1':
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
 
@@ -2436,6 +2754,9 @@ packages:
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -2466,6 +2787,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
@@ -2490,6 +2814,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/google-one-tap@1.2.6':
     resolution: {integrity: sha512-REmJsXVHvKb/sgI8DF+7IesMbDbcsEokHBqxU01ENZ8d98UPWdRLhUCtxEm9bhNFFg6PJGy7PNFdvovp0hK3jA==}
 
@@ -2498,6 +2825,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2557,6 +2887,9 @@ packages:
 
   '@types/three@0.176.0':
     resolution: {integrity: sha512-FwfPXxCqOtP7EdYMagCFePNKoG1AGBDUEVKtluv2BTVRpSt7b+X27xNsirPCTCqY1pGYsPUzaM3jgWP7dXSxlw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2648,6 +2981,35 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
@@ -2863,6 +3225,10 @@ packages:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -3020,6 +3386,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3056,6 +3426,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3084,6 +3458,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -3227,6 +3605,10 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssdb@8.1.0:
     resolution: {integrity: sha512-BQN57lfS4dYt2iL0LgyrlDbefZKEtUyrO8rbzrbGrqBk6OoyNTQLF+porY9DrpDBjLo4NEvj2IJttC7vf3x+Ew==}
 
@@ -3234,6 +3616,10 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -3285,6 +3671,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
+
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
 
@@ -3305,8 +3695,20 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -3314,6 +3716,10 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3438,6 +3844,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
@@ -3459,6 +3869,9 @@ packages:
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3473,6 +3886,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -3648,6 +4066,10 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -3682,6 +4104,15 @@ packages:
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
@@ -3949,6 +4380,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -3956,9 +4391,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -4117,6 +4560,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
@@ -4218,9 +4664,21 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -4357,6 +4815,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
@@ -4366,6 +4827,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -4424,6 +4889,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
@@ -4751,6 +5219,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -4781,6 +5252,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -4799,6 +5277,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -5017,6 +5499,10 @@ packages:
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   potpack@1.0.2:
@@ -5317,6 +5803,14 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5329,6 +5823,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -5404,6 +5905,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5474,6 +5978,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
     peerDependencies:
@@ -5482,6 +5989,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -5545,6 +6055,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
 
@@ -5596,6 +6109,9 @@ packages:
   svelte@4.2.18:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
@@ -5690,6 +6206,35 @@ packages:
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.15:
+    resolution: {integrity: sha512-YBkp2VfS9VTRMPNL2PA6PMESmxV1JEVoAr5iBlZnB5JG3KUrWzNCB3yNNkRa2FZkqClaBgfNYCp8PgpYmpjkZw==}
+
+  tldts@7.0.15:
+    resolution: {integrity: sha512-heYRCiGLhtI+U/D0V8YM3QRwPfsLJiP+HX+YwiHZTnWzjIKC+ZCxQRYlzvOoTEc6KIP62B1VeAN63diGCng2hg==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -5698,11 +6243,19 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -5934,6 +6487,79 @@ packages:
   victory-vendor@36.8.6:
     resolution: {integrity: sha512-PH8Wj9b0xIZ4AVfyn0c1SJrOhtxDJ5PNxj1ZDABPg1Gw1vJr1mJVqESPhvsFj7mXLQohVdiKqp4kWZkXlPcRcA==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.6:
+    resolution: {integrity: sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.4.35:
     resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
     peerDependencies:
@@ -5941,6 +6567,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
 
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
@@ -5958,6 +6588,10 @@ packages:
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
+
   webpack-sources@1.4.3:
     resolution: {integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==}
 
@@ -5974,6 +6608,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -5998,6 +6644,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workbox-background-sync@7.1.0:
@@ -6082,6 +6733,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -6142,6 +6812,23 @@ snapshots:
       json-schema: 0.4.0
       jsonpointer: 5.0.1
       leven: 3.1.0
+
+  '@asamuzakjp/css-color@4.0.4':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.1
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -7069,10 +7756,17 @@ snapshots:
 
   '@csstools/color-helpers@4.2.1': {}
 
+  '@csstools/color-helpers@5.1.0': {}
+
   '@csstools/css-calc@2.0.0(@csstools/css-parser-algorithms@3.0.0(@csstools/css-tokenizer@3.0.0))(@csstools/css-tokenizer@3.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.0(@csstools/css-tokenizer@3.0.0)
       '@csstools/css-tokenizer': 3.0.0
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-color-parser@3.0.0(@csstools/css-parser-algorithms@3.0.0(@csstools/css-tokenizer@3.0.0))(@csstools/css-tokenizer@3.0.0)':
     dependencies:
@@ -7081,11 +7775,28 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.0(@csstools/css-tokenizer@3.0.0)
       '@csstools/css-tokenizer': 3.0.0
 
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
   '@csstools/css-parser-algorithms@3.0.0(@csstools/css-tokenizer@3.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.0
 
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.4.32)':
+    dependencies:
+      postcss: 8.4.32
+
   '@csstools/css-tokenizer@3.0.0': {}
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@csstools/media-query-list-parser@3.0.0(@csstools/css-parser-algorithms@3.0.0(@csstools/css-tokenizer@3.0.0))(@csstools/css-tokenizer@3.0.0)':
     dependencies:
@@ -7302,10 +8013,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7400,6 +8111,84 @@ snapshots:
   '@emotion/utils@1.2.1': {}
 
   '@emotion/weak-memoize@0.3.1': {}
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
+    optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
@@ -8524,6 +9313,72 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
   '@rushstack/eslint-patch@1.6.1': {}
 
   '@scure/base@1.1.5': {}
@@ -8668,6 +9523,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.5
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -8696,6 +9555,8 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/draco3d@1.4.10': {}
 
   '@types/eslint-scope@3.7.7':
@@ -8723,6 +9584,8 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/estree@1.0.8': {}
+
   '@types/google-one-tap@1.2.6': {}
 
   '@types/hast@2.3.10':
@@ -8732,6 +9595,12 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.2
+
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 20.17.30
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
 
   '@types/json-schema@7.0.15': {}
 
@@ -8794,6 +9663,8 @@ snapshots:
       fflate: 0.8.2
       meshoptimizer: 0.18.1
 
+  '@types/tough-cookie@4.0.5': {}
+
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.10': {}
@@ -8853,19 +9724,61 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.4.35':
     dependencies:
@@ -9148,6 +10061,8 @@ snapshots:
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astring@1.8.6: {}
@@ -9327,6 +10242,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -9359,6 +10276,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9383,6 +10308,8 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -9526,9 +10453,22 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   cssdb@8.1.0: {}
 
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.1(postcss@8.4.32):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.4
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.4.32)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
@@ -9572,6 +10512,11 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+
   date-fns@3.3.1: {}
 
   debug@3.2.7:
@@ -9582,7 +10527,13 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -9591,6 +10542,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -9713,6 +10666,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -9782,6 +10737,8 @@ snapshots:
 
   es-module-lexer@1.6.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -9802,6 +10759,35 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
@@ -9815,8 +10801,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +10824,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +10841,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +10862,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10065,6 +11051,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  expect-type@1.2.2: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@2.0.1: {}
@@ -10096,6 +11084,10 @@ snapshots:
   fault@1.0.4:
     dependencies:
       format: 0.2.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fflate@0.6.10: {}
 
@@ -10447,6 +11439,10 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -10462,12 +11458,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb@7.1.1: {}
 
@@ -10604,6 +11611,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.2:
     dependencies:
       '@types/estree': 1.0.5
@@ -10715,9 +11724,39 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.5
+      cssstyle: 5.3.1(postcss@8.4.32)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   jsesc@0.5.0: {}
 
@@ -10829,6 +11868,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -10837,6 +11878,8 @@ snapshots:
   lru-cache@10.1.0: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -10858,7 +11901,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   markdown-extensions@2.0.0: {}
 
@@ -10965,6 +12007,8 @@ snapshots:
 
   mdn-data@2.0.30:
     optional: true
+
+  mdn-data@2.12.2: {}
 
   merge-anything@5.1.7:
     dependencies:
@@ -11239,8 +12283,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -11252,13 +12295,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +12311,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11412,6 +12455,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -11437,6 +12484,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   peberminta@0.9.0: {}
 
   periscopic@3.1.0:
@@ -11449,10 +12500,11 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -11726,6 +12778,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
     optional: true
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   potpack@1.0.2: {}
 
@@ -12063,6 +13121,36 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12081,6 +13169,12 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -12183,6 +13277,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -12212,8 +13308,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -12236,12 +13331,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
     dependencies:
       '@types/three': 0.176.0
       three: 0.160.0
 
   stats.js@0.17.0: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -12326,6 +13425,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -12334,12 +13437,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 
@@ -12388,6 +13491,8 @@ snapshots:
       magic-string: 0.30.17
       periscopic: 3.1.0
     optional: true
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.2.0:
     dependencies:
@@ -12519,15 +13624,44 @@ snapshots:
 
   tiny-invariant@1.3.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@7.0.15: {}
+
+  tldts@7.0.15:
+    dependencies:
+      tldts-core: 7.0.15
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.15
+
   tr46@0.0.3: {}
 
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -12784,6 +13918,84 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.14.15
+      fsevents: 2.3.3
+      jiti: 1.21.0
+      terser: 5.39.0
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.39.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite-node: 3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.14.15
+      jsdom: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
@@ -12794,6 +14006,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
     optional: true
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   watchpack@2.4.2:
     dependencies:
@@ -12807,6 +14023,8 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@8.0.0: {}
 
   webpack-sources@1.4.3:
     dependencies:
@@ -12845,6 +14063,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -12898,6 +14127,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workbox-background-sync@7.1.0:
     dependencies:
@@ -13085,6 +14319,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/supabase/migrations/20250423_messages.sql
+++ b/supabase/migrations/20250423_messages.sql
@@ -1,0 +1,447 @@
+-- Enable UUID generation
+create extension if not exists "pgcrypto";
+
+-- Drop the legacy chat table when present.
+drop table if exists public.chat cascade;
+
+drop type if exists public.moderation_action cascade;
+
+create table public.buildings (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  address text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.buildings enable row level security;
+
+create table public.units (
+  id uuid primary key default gen_random_uuid(),
+  building_id uuid not null references public.buildings(id) on delete cascade,
+  label text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.units enable row level security;
+
+create table public.tenant_assignments (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  building_id uuid not null references public.buildings(id) on delete cascade,
+  unit_id uuid references public.units(id) on delete cascade,
+  role text not null check (role in ('tenant','roommate','property_manager','admin')),
+  created_at timestamptz not null default now()
+);
+
+create unique index tenant_assignments_unit_unique
+  on public.tenant_assignments(profile_id, unit_id, role)
+  where unit_id is not null;
+
+create unique index tenant_assignments_building_unique
+  on public.tenant_assignments(profile_id, building_id, role)
+  where unit_id is null;
+
+alter table public.tenant_assignments enable row level security;
+
+create table public.threads (
+  id uuid primary key default gen_random_uuid(),
+  building_id uuid not null references public.buildings(id) on delete cascade,
+  unit_id uuid references public.units(id) on delete set null,
+  created_by uuid not null references public.profiles(id) on delete cascade,
+  title text not null,
+  category text not null default 'general',
+  metadata jsonb not null default '{}'::jsonb,
+  pinned_message_id uuid,
+  is_locked boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.threads enable row level security;
+
+create table public.messages (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null references public.threads(id) on delete cascade,
+  parent_message_id uuid references public.messages(id) on delete cascade,
+  created_by uuid not null references public.profiles(id) on delete cascade,
+  body text,
+  message_type text not null default 'text',
+  metadata jsonb not null default '{}'::jsonb,
+  is_deleted boolean not null default false,
+  deleted_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.messages enable row level security;
+
+create table public.message_reactions (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.messages(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  reaction_type text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (message_id, profile_id, reaction_type)
+);
+
+alter table public.message_reactions enable row level security;
+
+create type public.moderation_action as enum (
+  'pin',
+  'unpin',
+  'delete',
+  'restore',
+  'flag',
+  'resolve_flag'
+);
+
+create table public.message_moderation (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.messages(id) on delete cascade,
+  moderator_id uuid not null references public.profiles(id) on delete cascade,
+  action public.moderation_action not null,
+  reason text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.message_moderation enable row level security;
+
+-- Helper view for policy reuse
+create view public.v_tenant_scoped_roles as
+select
+  ta.profile_id,
+  ta.role,
+  ta.building_id,
+  ta.unit_id
+from public.tenant_assignments ta;
+
+-- Building visibility
+create policy "Managers see building" on public.buildings
+  for select using (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = buildings.id
+    )
+  );
+
+create policy "Managers insert building" on public.buildings
+  for insert with check (false);
+
+create policy "Managers update building" on public.buildings
+  for update using (false) with check (false);
+
+create policy "Managers delete building" on public.buildings
+  for delete using (false);
+
+-- Units inherit building access
+create policy "Members read units" on public.units
+  for select using (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = units.building_id
+    )
+  );
+
+create policy "Members insert units" on public.units
+  for insert with check (false);
+
+create policy "Members update units" on public.units
+  for update using (false) with check (false);
+
+create policy "Members delete units" on public.units
+  for delete using (false);
+
+-- Tenant assignments are only visible to authenticated members of a building
+create policy "Assignments readable by members" on public.tenant_assignments
+  for select using (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = tenant_assignments.building_id
+        and (r.unit_id = tenant_assignments.unit_id or r.role in ('property_manager','admin'))
+    )
+  );
+
+create policy "Assignments managed by admins" on public.tenant_assignments
+  for insert with check (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = tenant_assignments.building_id
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+create policy "Assignments update by admins" on public.tenant_assignments
+  for update using (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = tenant_assignments.building_id
+        and r.role in ('property_manager','admin')
+    )
+  ) with check (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = tenant_assignments.building_id
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+create policy "Assignments delete by admins" on public.tenant_assignments
+  for delete using (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = tenant_assignments.building_id
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+-- Thread policies
+create policy "Members read threads" on public.threads
+  for select using (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = threads.building_id
+        and (
+          threads.unit_id is null
+          or r.unit_id = threads.unit_id
+          or r.role in ('property_manager','admin')
+        )
+    )
+  );
+
+create policy "Members create threads" on public.threads
+  for insert with check (
+    created_by = auth.uid()
+    and exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = threads.building_id
+        and (
+          threads.unit_id is null
+          or r.unit_id = threads.unit_id
+          or r.role in ('property_manager','admin')
+        )
+    )
+  );
+
+create policy "Members update threads" on public.threads
+  for update using (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = threads.building_id
+        and r.role in ('property_manager','admin')
+    )
+  ) with check (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = threads.building_id
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+create policy "Members delete threads" on public.threads
+  for delete using (
+    exists (
+      select 1
+      from public.v_tenant_scoped_roles r
+      where r.profile_id = auth.uid()
+        and r.building_id = threads.building_id
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+-- Message policies
+create policy "Members read messages" on public.messages
+  for select using (
+    exists (
+      select 1
+      from public.threads t
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where t.id = messages.thread_id
+        and r.profile_id = auth.uid()
+        and (
+          t.unit_id is null
+          or r.unit_id = t.unit_id
+          or r.role in ('property_manager','admin')
+        )
+    )
+  );
+
+create policy "Members create messages" on public.messages
+  for insert with check (
+    created_by = auth.uid()
+    and exists (
+      select 1
+      from public.threads t
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where t.id = messages.thread_id
+        and r.profile_id = auth.uid()
+        and (
+          t.unit_id is null
+          or r.unit_id = t.unit_id
+          or r.role in ('property_manager','admin')
+        )
+    )
+  );
+
+create policy "Members update own messages" on public.messages
+  for update using (
+    created_by = auth.uid()
+  ) with check (
+    created_by = auth.uid()
+  );
+
+create policy "Managers moderate messages" on public.messages
+  for update using (
+    exists (
+      select 1
+      from public.threads t
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where t.id = messages.thread_id
+        and r.profile_id = auth.uid()
+        and r.role in ('property_manager','admin')
+    )
+  ) with check (
+    exists (
+      select 1
+      from public.threads t
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where t.id = messages.thread_id
+        and r.profile_id = auth.uid()
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+create policy "Managers delete messages" on public.messages
+  for delete using (
+    exists (
+      select 1
+      from public.threads t
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where t.id = messages.thread_id
+        and r.profile_id = auth.uid()
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+-- Reaction policies
+create policy "Members read reactions" on public.message_reactions
+  for select using (
+    exists (
+      select 1
+      from public.messages m
+      join public.threads t on t.id = m.thread_id
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where m.id = message_reactions.message_id
+        and r.profile_id = auth.uid()
+        and (
+          t.unit_id is null
+          or r.unit_id = t.unit_id
+          or r.role in ('property_manager','admin')
+        )
+    )
+  );
+
+create policy "Members create reactions" on public.message_reactions
+  for insert with check (
+    profile_id = auth.uid()
+    and exists (
+      select 1
+      from public.messages m
+      join public.threads t on t.id = m.thread_id
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where m.id = message_reactions.message_id
+        and r.profile_id = auth.uid()
+        and (
+          t.unit_id is null
+          or r.unit_id = t.unit_id
+          or r.role in ('property_manager','admin')
+        )
+    )
+  );
+
+create policy "Members delete own reactions" on public.message_reactions
+  for delete using (
+    profile_id = auth.uid()
+  );
+
+create policy "Managers delete reactions" on public.message_reactions
+  for delete using (
+    exists (
+      select 1
+      from public.messages m
+      join public.threads t on t.id = m.thread_id
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where m.id = message_reactions.message_id
+        and r.profile_id = auth.uid()
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+-- Moderation audit policies
+create policy "Members read moderation" on public.message_moderation
+  for select using (
+    exists (
+      select 1
+      from public.messages m
+      join public.threads t on t.id = m.thread_id
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where m.id = message_moderation.message_id
+        and r.profile_id = auth.uid()
+        and (
+          t.unit_id is null
+          or r.unit_id = t.unit_id
+          or r.role in ('property_manager','admin')
+        )
+    )
+  );
+
+create policy "Managers write moderation" on public.message_moderation
+  for insert with check (
+    moderator_id = auth.uid()
+    and exists (
+      select 1
+      from public.messages m
+      join public.threads t on t.id = m.thread_id
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where m.id = message_moderation.message_id
+        and r.profile_id = auth.uid()
+        and r.role in ('property_manager','admin')
+    )
+  );
+
+create policy "Managers delete moderation" on public.message_moderation
+  for delete using (
+    exists (
+      select 1
+      from public.messages m
+      join public.threads t on t.id = m.thread_id
+      join public.v_tenant_scoped_roles r on r.building_id = t.building_id
+      where m.id = message_moderation.message_id
+        and r.profile_id = auth.uid()
+        and r.role in ('property_manager','admin')
+    )
+  );

--- a/tests/messages-permissions.test.ts
+++ b/tests/messages-permissions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canModerateThread,
+  filterThreadsByAssignments,
+} from "@/lib/messages/permissions"
+import type { TenantAssignmentRow, ThreadWithRelations } from "@/types/messages"
+
+describe("message permissions", () => {
+  const now = new Date().toISOString()
+  const thread: ThreadWithRelations = {
+    id: "thread-1",
+    building_id: "building-1",
+    unit_id: "unit-1",
+    created_at: now,
+    updated_at: now,
+    created_by: "user-1",
+    title: "Kitchen",
+    category: "general",
+    metadata: {},
+    pinned_message_id: null,
+    is_locked: false,
+    created_by_profile: null,
+    messages: [],
+  }
+
+  const tenantAssignment: TenantAssignmentRow = {
+    id: "assign-1",
+    profile_id: "user-2",
+    building_id: "building-1",
+    unit_id: "unit-1",
+    role: "tenant",
+    created_at: now,
+  }
+
+  const managerAssignment: TenantAssignmentRow = {
+    id: "assign-2",
+    profile_id: "manager-1",
+    building_id: "building-1",
+    unit_id: null,
+    role: "property_manager",
+    created_at: now,
+  }
+
+  it("filters threads by assignment", () => {
+    const visible = filterThreadsByAssignments([thread], [tenantAssignment])
+    expect(visible).toHaveLength(1)
+  })
+
+  it("prevents access when assignment is missing", () => {
+    const otherAssignment: TenantAssignmentRow = {
+      ...tenantAssignment,
+      building_id: "other-building",
+    }
+    const visible = filterThreadsByAssignments([thread], [otherAssignment])
+    expect(visible).toHaveLength(0)
+  })
+
+  it("grants moderation rights to property managers", () => {
+    const canModerate = canModerateThread(thread, [managerAssignment])
+    expect(canModerate).toBe(true)
+  })
+
+  it("denies moderation for regular tenants", () => {
+    const canModerate = canModerateThread(thread, [tenantAssignment])
+    expect(canModerate).toBe(false)
+  })
+})

--- a/tests/messages-state.test.ts
+++ b/tests/messages-state.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildInitialState,
+  createOptimisticMessage,
+  messagesReducer,
+} from "@/lib/messages/state"
+import type { MessageWithRelations, ThreadWithRelations } from "@/types/messages"
+
+describe("messages state", () => {
+  const now = new Date().toISOString()
+  const baseThread: ThreadWithRelations = {
+    id: "thread-1",
+    building_id: "building-1",
+    unit_id: "unit-1",
+    created_at: now,
+    updated_at: now,
+    created_by: "user-1",
+    title: "General updates",
+    category: "general",
+    metadata: {},
+    pinned_message_id: null,
+    is_locked: false,
+    created_by_profile: null,
+    messages: [],
+  }
+
+  it("hydrates threads and messages", () => {
+    const state = buildInitialState([baseThread])
+    expect(state.threadOrder).toHaveLength(1)
+    expect(state.threads["thread-1"].thread.title).toBe("General updates")
+  })
+
+  it("upserts messages with optimistic entries", () => {
+    const state = buildInitialState([baseThread])
+    const optimistic = createOptimisticMessage({
+      thread_id: "thread-1",
+      body: "Hello",
+      created_by: "user-1",
+    })
+
+    const withMessage = messagesReducer(state, {
+      type: "UPSERT_MESSAGE",
+      message: optimistic,
+      optimistic: true,
+    })
+
+    expect(withMessage.threads["thread-1"].messageOrder).toContain(optimistic.id)
+  })
+
+  it("marks messages as deleted", () => {
+    const state = buildInitialState([baseThread])
+    const message: MessageWithRelations = {
+      id: "message-1",
+      thread_id: "thread-1",
+      parent_message_id: null,
+      created_by: "user-1",
+      body: "Announcement",
+      message_type: "text",
+      metadata: {},
+      is_deleted: false,
+      deleted_at: null,
+      created_at: now,
+      updated_at: now,
+      message_reactions: [],
+      message_moderation: [],
+      created_by_profile: null,
+    }
+
+    const afterInsert = messagesReducer(state, {
+      type: "UPSERT_MESSAGE",
+      message,
+    })
+
+    const afterDelete = messagesReducer(afterInsert, {
+      type: "MARK_MESSAGE_DELETED",
+      messageId: "message-1",
+      threadId: "thread-1",
+      deletedAt: now,
+    })
+
+    expect(afterDelete.threads["thread-1"].messages["message-1"].is_deleted).toBe(true)
+  })
+})

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -1,0 +1,70 @@
+import type { Database } from "@/lib/supabase"
+
+export type ProfileSummary = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "id" | "full_name" | "avatar_url" | "role"
+>
+
+export type ThreadRow = Database["public"]["Tables"]["threads"]["Row"]
+
+export type ThreadWithRelations = ThreadRow & {
+  created_by_profile?: ProfileSummary | null
+  messages?: MessageWithRelations[] | null
+}
+
+export type MessageRow = Database["public"]["Tables"]["messages"]["Row"]
+
+export type ReactionRow = Database["public"]["Tables"]["message_reactions"]["Row"]
+
+export type ModerationRow = Database["public"]["Tables"]["message_moderation"]["Row"]
+
+export type ReactionWithProfile = ReactionRow & {
+  reactor_profile?: ProfileSummary | null
+}
+
+export type ModerationWithProfile = ModerationRow & {
+  moderator_profile?: ProfileSummary | null
+}
+
+export type MessageWithRelations = MessageRow & {
+  created_by_profile?: ProfileSummary | null
+  message_reactions?: ReactionWithProfile[] | null
+  message_moderation?: ModerationWithProfile[] | null
+}
+
+export type TenantAssignmentRow = Database["public"]["Tables"]["tenant_assignments"]["Row"]
+
+export type BuildingRow = Database["public"]["Tables"]["buildings"]["Row"]
+
+export type UnitRow = Database["public"]["Tables"]["units"]["Row"]
+
+export type TenantRole = TenantAssignmentRow["role"]
+
+export interface PollOptionMeta {
+  id: string
+  label: string
+}
+
+export interface PollMetadata {
+  allowMultiple?: boolean
+  options: PollOptionMeta[]
+}
+
+export interface MessageMetadataShape {
+  clientRef?: string
+  poll?: PollMetadata
+  maintenanceTicketId?: string
+  flagged?: boolean
+  [key: string]: unknown
+}
+
+export type MessageMetadata = MessageMetadataShape | null
+
+export interface NotificationBridgePayload {
+  maintenanceTicketId?: string
+  messageId: string
+  threadId: string
+  buildingId: string
+  unitId?: string | null
+  action: "new_message" | "status_update" | "moderation"
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import path from "node:path"
+import { defineConfig } from "vitest/config"
+
+const rootDir = path.resolve(new URL(".", import.meta.url).pathname)
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["tests/**/*.test.ts"],
+    setupFiles: [],
+    coverage: {
+      reporter: ["text", "html"],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": rootDir,
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- replace the legacy chat table with normalized buildings, units, threads, messages, reactions, and moderation tables plus RLS policies
- add a realtime messaging experience with threads, reactions, polls, moderation controls, and offline handling in `/dashboard/messages`
- integrate messaging notifications with maintenance updates, expose shared state helpers/types, and add vitest coverage

## Testing
- pnpm lint
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68d03aeab07883289a2edf1f1f20e8f3