### PR TITLE
feat: overhaul messaging threads and realtime sync

### DIFF
--- a/app/dashboard/components/recent-sales.tsx
+++ b/app/dashboard/components/recent-sales.tsx
@@ -1,71 +1,68 @@
-import {
-    Avatar,
-    AvatarFallback,
-    AvatarImage,
-  } from "@/components/ui/avatar"
-  
-  export function RecentSales() {
+"use client"
+
+import { useMemo } from "react"
+import { formatDistanceToNow } from "date-fns"
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { useNotificationFeed } from "@/hooks/use-notification-feed"
+
+const TYPE_EMOJI: Record<string, string> = {
+  "message:new": "💬",
+  "message:moderated": "🛡️",
+  "maintenance:update": "🛠️",
+}
+
+const formatTimestamp = (timestamp: string) => {
+  try {
+    return formatDistanceToNow(new Date(timestamp), { addSuffix: true })
+  } catch (error) {
+    console.error("Failed to format timestamp", error)
+    return "just now"
+  }
+}
+
+export function RecentSales() {
+  const notifications = useNotificationFeed()
+  const items = useMemo(() => notifications.slice(0, 5), [notifications])
+
+  if (items.length === 0) {
     return (
-      <div className="space-y-8">
-        <div className="flex items-center">
-          <Avatar className="size-9">
-            <AvatarImage src="/avatars/01.png" alt="Avatar" />
-            <AvatarFallback>OM</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">Olivia Martin</p>
-            <p className="text-sm text-muted-foreground">
-              olivia.martin@email.com
-            </p>
-          </div>
-          <div className="ml-auto font-medium">+$1,999.00</div>
-        </div>
-        <div className="flex items-center">
-          <Avatar className="flex size-9 items-center justify-center space-y-0 border">
-            <AvatarImage src="/avatars/02.png" alt="Avatar" />
-            <AvatarFallback>JL</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">Jackson Lee</p>
-            <p className="text-sm text-muted-foreground">jackson.lee@email.com</p>
-          </div>
-          <div className="ml-auto font-medium">+$39.00</div>
-        </div>
-        <div className="flex items-center">
-          <Avatar className="size-9">
-            <AvatarImage src="/avatars/03.png" alt="Avatar" />
-            <AvatarFallback>IN</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">Isabella Nguyen</p>
-            <p className="text-sm text-muted-foreground">
-              isabella.nguyen@email.com
-            </p>
-          </div>
-          <div className="ml-auto font-medium">+$299.00</div>
-        </div>
-        <div className="flex items-center">
-          <Avatar className="size-9">
-            <AvatarImage src="/avatars/04.png" alt="Avatar" />
-            <AvatarFallback>WK</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">William Kim</p>
-            <p className="text-sm text-muted-foreground">will@email.com</p>
-          </div>
-          <div className="ml-auto font-medium">+$99.00</div>
-        </div>
-        <div className="flex items-center">
-          <Avatar className="size-9">
-            <AvatarImage src="/avatars/05.png" alt="Avatar" />
-            <AvatarFallback>SD</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">Sofia Davis</p>
-            <p className="text-sm text-muted-foreground">sofia.davis@email.com</p>
-          </div>
-          <div className="ml-auto font-medium">+$39.00</div>
-        </div>
+      <div className="space-y-2 text-sm text-muted-foreground">
+        <p>No activity yet.</p>
+        <p>Notifications from messaging and maintenance will appear here.</p>
       </div>
     )
   }
+
+  return (
+    <div className="space-y-6">
+      {items.map((notification) => {
+        const emoji = TYPE_EMOJI[notification.type] ?? "💡"
+        return (
+          <div key={notification.id} className="flex items-start gap-3">
+            <Avatar className="size-9">
+              <AvatarFallback>{emoji}</AvatarFallback>
+            </Avatar>
+            <div className="flex-1 space-y-1">
+              <p className="text-sm font-medium leading-none">{notification.title}</p>
+              {notification.description && (
+                <p className="text-sm text-muted-foreground">
+                  {notification.description}
+                </p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                {formatTimestamp(notification.createdAt)}
+              </p>
+            </div>
+            {notification.status && (
+              <Badge variant="secondary" className="whitespace-nowrap">
+                {notification.status}
+              </Badge>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/dashboard/messages/actions.ts
+++ b/app/dashboard/messages/actions.ts
@@ -1,0 +1,474 @@
+"use server"
+
+import { z } from "zod"
+
+import { THREAD_WITH_MESSAGES_SELECT, MESSAGE_WITH_RELATIONS_SELECT } from "@/lib/messages/queries"
+import { mapMessage, mapThread } from "@/lib/messages/mappers"
+import { canAccessThread, canModerate, isStaffRole } from "@/lib/messages/permissions"
+import type { MessageWithRelations, ThreadWithRelations, ProfileSummary, PollMetadata } from "@/types/messages"
+import type { Database } from "@/lib/supabase"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+const messageInputSchema = z.object({
+  threadId: z.string().uuid(),
+  parentMessageId: z.string().uuid().optional(),
+  content: z.string().min(1),
+  messageType: z.enum(["text", "poll"]).default("text"),
+  metadata: z.any().optional(),
+  clientId: z.string().optional(),
+})
+
+const pollOptionSchema = z.object({
+  id: z.string().uuid(),
+  label: z.string().min(1),
+})
+
+const createThreadSchema = z.object({
+  title: z.string().min(3),
+  unitId: z.string().uuid().nullable().optional(),
+  initialMessage: z
+    .object({
+      content: z.string().min(1),
+      messageType: z.enum(["text", "poll"]).default("text"),
+      metadata: z.any().optional(),
+      parentMessageId: z.string().uuid().optional(),
+      clientId: z.string().optional(),
+    })
+    .optional(),
+})
+
+const reactionSchema = z.object({
+  messageId: z.string().uuid(),
+  reaction: z.string().min(1),
+})
+
+const voteSchema = z.object({
+  messageId: z.string().uuid(),
+  optionId: z.string().uuid(),
+})
+
+const moderationSchema = z.object({
+  messageId: z.string().uuid(),
+  action: z.enum(["pin", "unpin", "flag", "unflag", "delete", "restore"]),
+  reason: z.string().max(500).optional(),
+})
+
+type SupabaseClient = Awaited<ReturnType<typeof createSupbaseServerClient>>
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"]
+type ThreadRow = Database["public"]["Tables"]["threads"]["Row"]
+type MessageRow = Database["public"]["Tables"]["messages"]["Row"]
+
+type MessageInsertPayload = z.infer<typeof messageInputSchema>
+
+type MessageResult = {
+  message: MessageWithRelations
+  thread: Pick<ThreadRow, "id" | "last_message_at" | "pinned_message_id" | "pinned_at" | "pinned_by" | "updated_at">
+}
+
+const toProfileSummary = (profile: ProfileRow): ProfileSummary => ({
+  id: profile.id,
+  full_name: profile.full_name,
+  avatar_url: profile.avatar_url,
+  role: profile.role,
+  building_id: profile.building_id,
+  unit_id: profile.unit_id,
+})
+
+async function getSupabaseWithProfile() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+  if (userError) {
+    throw new Error(userError.message)
+  }
+  if (!user) {
+    throw new Error("Not authenticated")
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, full_name, avatar_url, role, building_id, unit_id")
+    .eq("id", user.id)
+    .single()
+
+  if (profileError) {
+    throw new Error(profileError.message)
+  }
+  if (!profile) {
+    throw new Error("Profile not found")
+  }
+  if (!profile.building_id) {
+    throw new Error("Profile is missing a building assignment")
+  }
+
+  return { supabase, profile }
+}
+
+async function fetchThreadScope(
+  supabase: SupabaseClient,
+  threadId: string
+): Promise<Pick<ThreadRow, "id" | "building_id" | "unit_id">> {
+  const { data, error } = await supabase
+    .from("threads")
+    .select("id, building_id, unit_id")
+    .eq("id", threadId)
+    .single()
+  if (error || !data) {
+    throw new Error("Thread not found")
+  }
+  return data
+}
+
+async function fetchThreadWithMessages(
+  supabase: SupabaseClient,
+  threadId: string
+): Promise<ThreadWithRelations> {
+  const { data, error } = await supabase
+    .from("threads")
+    .select(THREAD_WITH_MESSAGES_SELECT)
+    .eq("id", threadId)
+    .single()
+  if (error || !data) {
+    throw new Error(error?.message ?? "Unable to load thread")
+  }
+  return mapThread(data)
+}
+
+async function fetchMessageWithRelations(
+  supabase: SupabaseClient,
+  messageId: string
+): Promise<MessageWithRelations> {
+  const { data, error } = await supabase
+    .from("messages")
+    .select(MESSAGE_WITH_RELATIONS_SELECT)
+    .eq("id", messageId)
+    .single()
+  if (error || !data) {
+    throw new Error(error?.message ?? "Unable to load message")
+  }
+  return mapMessage(data)
+}
+
+function normalisePollMetadata(metadata: unknown): PollMetadata {
+  const base = (metadata ?? {}) as PollMetadata
+  const optionsRaw = base.poll_options ?? []
+  const options = Array.isArray(optionsRaw) ? optionsRaw : []
+  const parsedOptions = options
+    .map((option) => pollOptionSchema.safeParse(option))
+    .filter((result): result is z.SafeParseSuccess<{ id: string; label: string }> => result.success)
+    .map((result) => result.data)
+
+  if (parsedOptions.length < 2) {
+    throw new Error("Poll messages require at least two options")
+  }
+
+  const votes = base.poll_votes ?? {}
+  return {
+    ...base,
+    poll_options: parsedOptions,
+    poll_votes: votes,
+  }
+}
+
+async function sendMessageInternal({
+  supabase,
+  profile,
+  payload,
+  skipAccessCheck = false,
+}: {
+  supabase: SupabaseClient
+  profile: ProfileSummary
+  payload: MessageInsertPayload
+  skipAccessCheck?: boolean
+}): Promise<MessageResult> {
+  const threadScope = await fetchThreadScope(supabase, payload.threadId)
+
+  if (!skipAccessCheck && !canAccessThread(profile, threadScope)) {
+    throw new Error("You do not have permission to post in this thread")
+  }
+
+  let metadata: PollMetadata | undefined
+  if (payload.messageType === "poll") {
+    metadata = normalisePollMetadata(payload.metadata)
+  } else if (payload.metadata) {
+    metadata = payload.metadata as PollMetadata
+  }
+
+  const { data: inserted, error } = await supabase
+    .from("messages")
+    .insert({
+      thread_id: payload.threadId,
+      parent_message_id: payload.parentMessageId ?? null,
+      author_id: profile.id,
+      content: payload.content,
+      message_type: payload.messageType,
+      metadata,
+      client_id: payload.clientId ?? null,
+    })
+    .select(MESSAGE_WITH_RELATIONS_SELECT)
+    .single()
+
+  if (error || !inserted) {
+    throw new Error(error?.message ?? "Unable to send message")
+  }
+
+  const message = mapMessage(inserted)
+
+  const { data: threadMeta, error: threadError } = await supabase
+    .from("threads")
+    .select("id, last_message_at, pinned_message_id, pinned_at, pinned_by, updated_at")
+    .eq("id", payload.threadId)
+    .single()
+
+  if (threadError || !threadMeta) {
+    throw new Error(threadError?.message ?? "Unable to load thread metadata")
+  }
+
+  return {
+    message,
+    thread: threadMeta,
+  }
+}
+
+export async function createThreadAction(rawInput: unknown) {
+  const input = createThreadSchema.parse(rawInput)
+  const { supabase, profile } = await getSupabaseWithProfile()
+  const targetUnitId = isStaffRole(profile.role)
+    ? input.unitId ?? null
+    : profile.unit_id ?? null
+
+  if (!isStaffRole(profile.role) && targetUnitId !== profile.unit_id) {
+    throw new Error("You can only create threads for your assigned unit")
+  }
+
+  const { data: insertedThread, error: insertError } = await supabase
+    .from("threads")
+    .insert({
+      title: input.title,
+      building_id: profile.building_id!,
+      unit_id: targetUnitId,
+      created_by: profile.id,
+    })
+    .select("id")
+    .single()
+
+  if (insertError || !insertedThread) {
+    throw new Error(insertError?.message ?? "Unable to create thread")
+  }
+
+  try {
+    if (input.initialMessage) {
+      await sendMessageInternal({
+        supabase,
+        profile: toProfileSummary(profile),
+        payload: messageInputSchema.parse({
+          ...input.initialMessage,
+          threadId: insertedThread.id,
+        }),
+        skipAccessCheck: true,
+      })
+    }
+  } catch (error) {
+    await supabase.from("threads").delete().eq("id", insertedThread.id)
+    throw error
+  }
+
+  return fetchThreadWithMessages(supabase, insertedThread.id)
+}
+
+export async function sendMessageAction(rawInput: unknown): Promise<MessageResult> {
+  const payload = messageInputSchema.parse(rawInput)
+  const { supabase, profile } = await getSupabaseWithProfile()
+  return sendMessageInternal({
+    supabase,
+    profile: toProfileSummary(profile),
+    payload,
+  })
+}
+
+export async function toggleReactionAction(rawInput: unknown): Promise<MessageWithRelations> {
+  const input = reactionSchema.parse(rawInput)
+  const { supabase, profile } = await getSupabaseWithProfile()
+
+  const { data: existing } = await supabase
+    .from("message_reactions")
+    .select("id")
+    .eq("message_id", input.messageId)
+    .eq("profile_id", profile.id)
+    .eq("reaction", input.reaction)
+    .maybeSingle()
+
+  if (existing?.id) {
+    await supabase.from("message_reactions").delete().eq("id", existing.id)
+  } else {
+    const { error } = await supabase.from("message_reactions").insert({
+      message_id: input.messageId,
+      profile_id: profile.id,
+      reaction: input.reaction,
+    })
+    if (error) {
+      throw new Error(error.message)
+    }
+  }
+
+  return fetchMessageWithRelations(supabase, input.messageId)
+}
+
+export async function voteOnPollAction(rawInput: unknown): Promise<MessageWithRelations> {
+  const input = voteSchema.parse(rawInput)
+  const { supabase, profile } = await getSupabaseWithProfile()
+
+  const message = await fetchMessageWithRelations(supabase, input.messageId)
+
+  if (message.message_type !== "poll") {
+    throw new Error("Only poll messages support voting")
+  }
+
+  if (!canAccessThread(toProfileSummary(profile), message)) {
+    throw new Error("You cannot vote on this poll")
+  }
+
+  const metadata = (message.metadata ?? {}) as PollMetadata
+  const options = metadata.poll_options ?? []
+  if (!options.some((option) => option.id === input.optionId)) {
+    throw new Error("Poll option not found")
+  }
+
+  const votes = metadata.poll_votes ?? {}
+  const updatedVotes: Record<string, string[]> = {}
+  for (const [optionId, voters] of Object.entries(votes)) {
+    const filtered = (voters ?? []).filter((id) => id !== profile.id)
+    if (optionId === input.optionId) {
+      updatedVotes[optionId] = [...new Set([...filtered, profile.id])]
+    } else {
+      updatedVotes[optionId] = filtered
+    }
+  }
+  if (!updatedVotes[input.optionId]) {
+    updatedVotes[input.optionId] = [profile.id]
+  }
+
+  const { error } = await supabase
+    .from("messages")
+    .update({ metadata: { ...metadata, poll_votes: updatedVotes } })
+    .eq("id", message.id)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return fetchMessageWithRelations(supabase, message.id)
+}
+
+export async function moderateMessageAction(rawInput: unknown): Promise<MessageResult> {
+  const input = moderationSchema.parse(rawInput)
+  const { supabase, profile } = await getSupabaseWithProfile()
+
+  if (!canModerate(profile.role)) {
+    throw new Error("You do not have permission to moderate messages")
+  }
+
+  const message = await fetchMessageWithRelations(supabase, input.messageId)
+
+  if (!message.thread_id) {
+    throw new Error("Message missing thread context")
+  }
+
+  const now = new Date().toISOString()
+  const updates: Partial<MessageRow> = {}
+  const moderationMetadata: Record<string, unknown> = {}
+
+  switch (input.action) {
+    case "flag":
+      updates.status = "flagged"
+      moderationMetadata.status = "flagged"
+      if (input.reason) {
+        moderationMetadata.reason = input.reason
+      }
+      break
+    case "unflag":
+      updates.status = "active"
+      moderationMetadata.status = "active"
+      break
+    case "delete":
+      updates.status = "deleted"
+      updates.deleted_at = now
+      moderationMetadata.status = "deleted"
+      break
+    case "restore":
+      updates.status = "active"
+      updates.deleted_at = null
+      moderationMetadata.status = "active"
+      break
+    case "pin":
+    case "unpin":
+      break
+    default:
+      break
+  }
+
+  if (Object.keys(updates).length > 0) {
+    const { error: updateError } = await supabase
+      .from("messages")
+      .update(updates)
+      .eq("id", message.id)
+    if (updateError) {
+      throw new Error(updateError.message)
+    }
+  }
+
+  if (input.action === "pin") {
+    const { error } = await supabase
+      .from("threads")
+      .update({
+        pinned_message_id: message.id,
+        pinned_at: now,
+        pinned_by: profile.id,
+      })
+      .eq("id", message.thread_id)
+    if (error) {
+      throw new Error(error.message)
+    }
+  }
+
+  if (input.action === "unpin") {
+    const { error } = await supabase
+      .from("threads")
+      .update({ pinned_message_id: null, pinned_at: null, pinned_by: null })
+      .eq("id", message.thread_id)
+    if (error) {
+      throw new Error(error.message)
+    }
+  }
+
+  const { error: moderationError } = await supabase.from("message_moderation").insert({
+    message_id: message.id,
+    thread_id: message.thread_id,
+    building_id: message.building_id,
+    action: input.action,
+    reason: input.reason,
+    performed_by: profile.id,
+    metadata: moderationMetadata,
+  })
+  if (moderationError) {
+    throw new Error(moderationError.message)
+  }
+
+  const refreshedMessage = await fetchMessageWithRelations(supabase, message.id)
+  const { data: threadMeta, error: threadError } = await supabase
+    .from("threads")
+    .select("id, last_message_at, pinned_message_id, pinned_at, pinned_by, updated_at")
+    .eq("id", message.thread_id)
+    .single()
+
+  if (threadError || !threadMeta) {
+    throw new Error(threadError?.message ?? "Unable to refresh thread metadata")
+  }
+
+  return {
+    message: refreshedMessage,
+    thread: threadMeta,
+  }
+}

--- a/app/dashboard/messages/message-board.tsx
+++ b/app/dashboard/messages/message-board.tsx
@@ -1,0 +1,1495 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { formatDistanceToNow } from "date-fns"
+import {
+  ArrowRight,
+  Flag,
+  MessageCircle,
+  MoreHorizontal,
+  Pin,
+  Plus,
+  Send,
+  ShieldAlert,
+  Undo2,
+} from "lucide-react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/components/ui/use-toast"
+import { mergeMessageChange, mergeReactionChange } from "@/lib/messages/realtime"
+import { isStaffRole, canModerate } from "@/lib/messages/permissions"
+import {
+  MESSAGE_WITH_RELATIONS_SELECT,
+  THREAD_WITH_MESSAGES_SELECT,
+} from "@/lib/messages/queries"
+import { mapMessage, mapThread } from "@/lib/messages/mappers"
+import { pushNotification } from "@/lib/notifications/store"
+import type {
+  MessageWithRelations,
+  PollMetadata,
+  ProfileSummary,
+  ThreadWithRelations,
+  MessageReactionRow,
+} from "@/types/messages"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+import {
+  createThreadAction,
+  moderateMessageAction,
+  sendMessageAction,
+  toggleReactionAction,
+  voteOnPollAction,
+} from "./actions"
+
+const REACTIONS = ["👍", "🎉", "❤️", "👀"]
+const QUEUE_KEY = "share-house-message-queue"
+
+type MessageBoardProps = {
+  initialThreads: ThreadWithRelations[]
+  profile: ProfileSummary
+  initialThreadId?: string
+}
+
+type SendMessageInput = {
+  threadId: string
+  content: string
+  messageType?: "text" | "poll"
+  metadata?: PollMetadata
+  parentMessageId?: string | null
+  clientId?: string
+}
+
+type PendingAction = {
+  id: string
+  type: "send-message"
+  payload: SendMessageInput
+}
+
+type PollOptionDraft = {
+  id: string
+  label: string
+}
+
+const generateId = () =>
+  typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2)
+
+const sortMessages = (messages: MessageWithRelations[]) =>
+  [...messages].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  )
+
+const MessageBoard = ({
+  initialThreads,
+  profile,
+  initialThreadId,
+}: MessageBoardProps) => {
+  const supabase = useSupabaseBrowser()
+  const { toast } = useToast()
+
+  const [threads, setThreads] = useState<ThreadWithRelations[]>(() =>
+    [...initialThreads]
+      .map((thread) => ({ ...thread, messages: [] }))
+      .sort(
+        (a, b) =>
+          new Date(b.last_message_at ?? b.created_at).getTime() -
+          new Date(a.last_message_at ?? a.created_at).getTime()
+      )
+  )
+  const [messagesByThread, setMessagesByThread] = useState<
+    Record<string, MessageWithRelations[]>
+  >(() => {
+    const next: Record<string, MessageWithRelations[]> = {}
+    initialThreads.forEach((thread) => {
+      next[thread.id] = sortMessages(thread.messages ?? [])
+    })
+    return next
+  })
+  const [activeThreadId, setActiveThreadId] = useState<string | undefined>(() => {
+    if (initialThreadId && initialThreads.some((thread) => thread.id === initialThreadId)) {
+      return initialThreadId
+    }
+    return initialThreads[0]?.id
+  })
+  const [replyTo, setReplyTo] = useState<MessageWithRelations | null>(null)
+  const [isOffline, setIsOffline] = useState(
+    typeof navigator !== "undefined" ? !navigator.onLine : false
+  )
+  const [pendingQueue, setPendingQueue] = useState<PendingAction[]>([])
+  const [isProcessingQueue, setIsProcessingQueue] = useState(false)
+  const [isSubmittingThread, setIsSubmittingThread] = useState(false)
+  const [composerState, setComposerState] = useState({
+    content: "",
+    type: "text" as "text" | "poll",
+    pollOptions: [
+      { id: generateId(), label: "" },
+      { id: generateId(), label: "" },
+    ],
+  })
+  const [isComposerBusy, setIsComposerBusy] = useState(false)
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
+  const [newThreadTitle, setNewThreadTitle] = useState("")
+  const [newThreadMessage, setNewThreadMessage] = useState("")
+  const [newThreadType, setNewThreadType] = useState<"text" | "poll">("text")
+  const [newThreadPollOptions, setNewThreadPollOptions] = useState<PollOptionDraft[]>([
+    { id: generateId(), label: "" },
+    { id: generateId(), label: "" },
+  ])
+  const [newThreadScope, setNewThreadScope] = useState<"unit" | "building">(
+    isStaffRole(profile.role) ? "building" : "unit"
+  )
+  const [newThreadUnitId, setNewThreadUnitId] = useState(profile.unit_id ?? "")
+  const activeThreadIdRef = useRef<string | undefined>(activeThreadId)
+
+  const persistQueue = useCallback((queue: PendingAction[]) => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(QUEUE_KEY, JSON.stringify(queue))
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+    try {
+      const raw = window.localStorage.getItem(QUEUE_KEY)
+      if (raw) {
+        const parsed = JSON.parse(raw) as PendingAction[]
+        if (Array.isArray(parsed)) {
+          setPendingQueue(parsed)
+        }
+      }
+    } catch (error) {
+      console.error("Failed to restore message queue", error)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+    const handleStatus = () => setIsOffline(!navigator.onLine)
+    handleStatus()
+    window.addEventListener("online", handleStatus)
+    window.addEventListener("offline", handleStatus)
+    return () => {
+      window.removeEventListener("online", handleStatus)
+      window.removeEventListener("offline", handleStatus)
+    }
+  }, [])
+  useEffect(() => {
+    activeThreadIdRef.current = activeThreadId
+  }, [activeThreadId])
+  const processQueue = useCallback(async () => {
+    if (
+      isProcessingQueue ||
+      (typeof navigator !== "undefined" && !navigator.onLine)
+    ) {
+      return
+    }
+    if (pendingQueue.length === 0) {
+      return
+    }
+    setIsProcessingQueue(true)
+    let remaining = [...pendingQueue]
+    for (const action of pendingQueue) {
+      try {
+        if (action.type === "send-message") {
+          const result = await sendMessageAction(action.payload)
+          setMessagesByThread((prev) => {
+            const current = prev[action.payload.threadId] ?? []
+            const updated = mergeMessageChange(
+              current,
+              {
+                eventType: "INSERT",
+                new: result.message as any,
+                old: null,
+                schema: "public",
+                table: "messages",
+              },
+              (row) => mapMessage({ ...row })
+            )
+            return {
+              ...prev,
+              [action.payload.threadId]: sortMessages(updated),
+            }
+          })
+          setThreads((prev) =>
+            prev.map((thread) =>
+              thread.id === action.payload.threadId
+                ? { ...thread, ...result.thread }
+                : thread
+            )
+          )
+        }
+        remaining = remaining.filter((item) => item.id !== action.id)
+        setPendingQueue(remaining)
+        persistQueue(remaining)
+      } catch (error) {
+        console.error("Failed to process queued message", error)
+        break
+      }
+    }
+    setIsProcessingQueue(false)
+  }, [isProcessingQueue, pendingQueue, persistQueue])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+    processQueue()
+    const handleOnline = () => {
+      processQueue().catch((error) => console.error(error))
+    }
+    window.addEventListener("online", handleOnline)
+    return () => window.removeEventListener("online", handleOnline)
+  }, [processQueue])
+
+  useEffect(() => {
+    if (!profile.building_id) {
+      return
+    }
+    const filter = `building_id=eq.${profile.building_id}`
+    const allowMessage = (message: Partial<MessageWithRelations>) => {
+      if (isStaffRole(profile.role)) {
+        return true
+      }
+      return !message.unit_id || message.unit_id === profile.unit_id
+    }
+
+    const channel = supabase
+      .channel(`messages:${profile.building_id}`)
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "messages", filter },
+        async (payload) => {
+          const row = (payload.new ?? payload.old) as MessageWithRelations | null
+          if (!row || !row.thread_id || !allowMessage(row)) {
+            return
+          }
+          setMessagesByThread((prev) => {
+            const current = prev[row.thread_id] ?? []
+            const updated = mergeMessageChange(
+              current,
+              payload as any,
+              (incoming) => mapMessage({ ...incoming })
+            )
+            return { ...prev, [row.thread_id]: sortMessages(updated) }
+          })
+          if (payload.eventType === "INSERT") {
+            try {
+              const { data, error } = await supabase
+                .from("messages")
+                .select(MESSAGE_WITH_RELATIONS_SELECT)
+                .eq("id", row.id)
+                .single()
+              if (!error && data) {
+                setMessagesByThread((prev) => {
+                  const current = prev[row.thread_id] ?? []
+                  const updated = mergeMessageChange(
+                    current,
+                    {
+                      eventType: "UPDATE",
+                      new: data as any,
+                      old: null,
+                      schema: "public",
+                      table: "messages",
+                    },
+                    (incoming) => mapMessage({ ...incoming })
+                  )
+                  return { ...prev, [row.thread_id]: sortMessages(updated) }
+                })
+              }
+            } catch (error) {
+              console.error("Failed to hydrate realtime message", error)
+            }
+          }
+          if (payload.eventType === "INSERT" || payload.eventType === "UPDATE") {
+            setThreads((prev) => {
+              const next = prev.map((thread) =>
+                thread.id === row.thread_id
+                  ? {
+                      ...thread,
+                      last_message_at:
+                        payload.eventType === "INSERT"
+                          ? row.created_at
+                          : thread.last_message_at,
+                    }
+                  : thread
+              )
+              return next.sort(
+                (a, b) =>
+                  new Date(b.last_message_at ?? b.created_at).getTime() -
+                  new Date(a.last_message_at ?? a.created_at).getTime()
+              )
+            })
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "message_reactions", filter },
+        (payload) => {
+          const reaction = (payload.new ?? payload.old) as MessageReactionRow | null
+          if (!reaction || !allowMessage({ unit_id: reaction.unit_id })) {
+            return
+          }
+          setMessagesByThread((prev) => {
+            let targetThreadId: string | null = null
+            let current: MessageWithRelations[] | undefined
+            for (const [threadId, list] of Object.entries(prev)) {
+              if (list.some((message) => message.id === reaction.message_id)) {
+                targetThreadId = threadId
+                current = list
+                break
+              }
+            }
+            if (!targetThreadId || !current) {
+              return prev
+            }
+            const updated = mergeReactionChange(current, payload as any)
+            return {
+              ...prev,
+              [targetThreadId]: updated,
+            }
+          })
+        }
+      )
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "message_moderation", filter },
+        (payload) => {
+          const moderation = payload.new as {
+            message_id: string
+            thread_id: string
+            action: string
+            created_at: string
+          }
+          if (moderation.action === "pin") {
+            setThreads((prev) =>
+              prev.map((thread) =>
+                thread.id === moderation.thread_id
+                  ? {
+                      ...thread,
+                      pinned_message_id: moderation.message_id,
+                      pinned_at: moderation.created_at,
+                    }
+                  : thread
+              )
+            )
+          }
+          if (moderation.action === "unpin") {
+            setThreads((prev) =>
+              prev.map((thread) =>
+                thread.id === moderation.thread_id
+                  ? { ...thread, pinned_message_id: null, pinned_at: null }
+                  : thread
+              )
+            )
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "threads", filter },
+        async (payload) => {
+          const threadRow = (payload.new ?? payload.old) as
+            | ({ id: string; building_id: string; unit_id: string | null } & Partial<ThreadWithRelations>)
+            | null
+          if (!threadRow) {
+            return
+          }
+          if (!allowMessage({ unit_id: threadRow.unit_id ?? undefined })) {
+            return
+          }
+
+          if (payload.eventType === "DELETE") {
+            setThreads((prev) => {
+              const filtered = prev.filter((thread) => thread.id !== threadRow.id)
+              if (activeThreadIdRef.current === threadRow.id) {
+                setActiveThreadId(filtered[0]?.id)
+              }
+              return filtered
+            })
+            setMessagesByThread((prev) => {
+              if (!prev[threadRow.id]) {
+                return prev
+              }
+              const next = { ...prev }
+              delete next[threadRow.id]
+              return next
+            })
+            return
+          }
+
+          if (payload.eventType === "INSERT") {
+            try {
+              const { data, error } = await supabase
+                .from("threads")
+                .select(THREAD_WITH_MESSAGES_SELECT)
+                .eq("id", threadRow.id)
+                .single()
+              if (!error && data) {
+                const mapped = mapThread(data)
+                if (!allowMessage({ unit_id: mapped.unit_id ?? undefined })) {
+                  return
+                }
+                setThreads((prev) => {
+                  const next = [{ ...mapped, messages: [] }, ...prev.filter((thread) => thread.id !== mapped.id)]
+                  return next.sort(
+                    (a, b) =>
+                      new Date(b.last_message_at ?? b.created_at).getTime() -
+                      new Date(a.last_message_at ?? a.created_at).getTime()
+                  )
+                })
+                setMessagesByThread((prev) => ({
+                  ...prev,
+                  [mapped.id]: sortMessages(mapped.messages ?? []),
+                }))
+              }
+            } catch (error) {
+              console.error("Failed to hydrate thread", error)
+            }
+            return
+          }
+
+          if (payload.eventType === "UPDATE") {
+            setThreads((prev) => {
+              const next = prev.map((thread) =>
+                thread.id === threadRow.id
+                  ? {
+                      ...thread,
+                      ...threadRow,
+                    }
+                  : thread
+              )
+              return next.sort(
+                (a, b) =>
+                  new Date(b.last_message_at ?? b.created_at).getTime() -
+                  new Date(a.last_message_at ?? a.created_at).getTime()
+              )
+            })
+          }
+        }
+      )
+
+    channel.subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [profile.building_id, profile.role, profile.unit_id, supabase])
+
+  const activeThread = useMemo(
+    () => threads.find((thread) => thread.id === activeThreadId),
+    [threads, activeThreadId]
+  )
+
+  const activeMessages = useMemo(
+    () => (activeThreadId ? messagesByThread[activeThreadId] ?? [] : []),
+    [activeThreadId, messagesByThread]
+  )
+  const handleSendMessage = useCallback(
+    async (
+      threadId: string,
+      content: string,
+      messageType: "text" | "poll" = "text",
+      metadata?: PollMetadata,
+      parentMessageId?: string | null
+    ) => {
+      const trimmed = content.trim()
+      if (!trimmed) {
+        return
+      }
+      const clientId = generateId()
+      const optimistic: MessageWithRelations = {
+        id: clientId,
+        thread_id: threadId,
+        parent_message_id: parentMessageId ?? null,
+        author_id: profile.id,
+        content: trimmed,
+        message_type: messageType,
+        metadata: metadata ?? {},
+        status: "active",
+        client_id: clientId,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        deleted_at: null,
+        building_id: profile.building_id!,
+        unit_id: profile.unit_id ?? null,
+        author: profile,
+        reactions: [],
+        moderation: [],
+      }
+      setMessagesByThread((prev) => {
+        const current = prev[threadId] ?? []
+        return { ...prev, [threadId]: sortMessages([...current, optimistic]) }
+      })
+      setThreads((prev) =>
+        prev
+          .map((thread) =>
+            thread.id === threadId
+              ? { ...thread, last_message_at: optimistic.created_at }
+              : thread
+          )
+          .sort(
+            (a, b) =>
+              new Date(b.last_message_at ?? b.created_at).getTime() -
+              new Date(a.last_message_at ?? a.created_at).getTime()
+          )
+      )
+
+      const payload: SendMessageInput = {
+        threadId,
+        content: trimmed,
+        messageType,
+        metadata,
+        parentMessageId: parentMessageId ?? undefined,
+        clientId,
+      }
+
+      if (typeof navigator !== "undefined" && !navigator.onLine) {
+        const queued: PendingAction = { id: clientId, type: "send-message", payload }
+        setPendingQueue((prev) => {
+          const next = [...prev, queued]
+          persistQueue(next)
+          return next
+        })
+        toast({
+          title: "Message queued",
+          description: "We'll send this once you're back online.",
+        })
+        return
+      }
+
+      setIsComposerBusy(true)
+      try {
+        const result = await sendMessageAction(payload)
+        setMessagesByThread((prev) => {
+          const current = prev[threadId] ?? []
+          const updated = mergeMessageChange(
+            current,
+            {
+              eventType: "UPDATE",
+              new: result.message as any,
+              old: null,
+              schema: "public",
+              table: "messages",
+            },
+            (row) => mapMessage({ ...row })
+          )
+          return { ...prev, [threadId]: sortMessages(updated) }
+        })
+        setThreads((prev) =>
+          prev.map((thread) =>
+            thread.id === threadId ? { ...thread, ...result.thread } : thread
+          )
+        )
+        pushNotification({
+          id: result.message.id,
+          type: "message:new",
+          title: messageType === "poll" ? "Poll sent" : "Message sent",
+          description: trimmed.slice(0, 120),
+          createdAt: result.message.created_at,
+          link: `/dashboard/messages?thread=${threadId}`,
+          status: result.message.status,
+          threadId,
+          messageId: result.message.id,
+        })
+      } catch (error) {
+        console.error(error)
+        setMessagesByThread((prev) => {
+          const current = prev[threadId] ?? []
+          return {
+            ...prev,
+            [threadId]: current.map((message) =>
+              message.id === clientId
+                ? {
+                    ...message,
+                    status: "flagged",
+                    metadata: {
+                      ...(message.metadata ?? {}),
+                      error: (error as Error).message,
+                    },
+                  }
+                : message
+            ),
+          }
+        })
+        toast({
+          title: "Unable to send message",
+          description: (error as Error).message,
+          variant: "destructive",
+        })
+      } finally {
+        setIsComposerBusy(false)
+      }
+    },
+    [persistQueue, profile, toast]
+  )
+
+  const handleReaction = useCallback(
+    async (threadId: string, message: MessageWithRelations, emoji: string) => {
+      const hasReaction = message.reactions.some(
+        (reaction) =>
+          reaction.profile_id === profile.id && reaction.reaction === emoji
+      )
+      setMessagesByThread((prev) => {
+        const current = prev[threadId] ?? []
+        const updated = current.map((item) => {
+          if (item.id !== message.id) {
+            return item
+          }
+          if (hasReaction) {
+            return {
+              ...item,
+              reactions: item.reactions.filter(
+                (reaction) =>
+                  !(
+                    reaction.profile_id === profile.id &&
+                    reaction.reaction === emoji
+                  )
+              ),
+            }
+          }
+          return {
+            ...item,
+            reactions: [
+              ...item.reactions,
+              {
+                id: generateId(),
+                message_id: message.id,
+                profile_id: profile.id,
+                reaction: emoji,
+                created_at: new Date().toISOString(),
+                building_id: profile.building_id!,
+                unit_id: profile.unit_id ?? null,
+                profile,
+              },
+            ],
+          }
+        })
+        return { ...prev, [threadId]: updated }
+      })
+      try {
+        const result = await toggleReactionAction({
+          messageId: message.id,
+          reaction: emoji,
+        })
+        setMessagesByThread((prev) => ({
+          ...prev,
+          [threadId]: prev[threadId]?.map((item) =>
+            item.id === result.id ? result : item
+          ),
+        }))
+      } catch (error) {
+        setMessagesByThread((prev) => ({
+          ...prev,
+          [threadId]: prev[threadId]?.map((item) =>
+            item.id === message.id ? { ...item, reactions: message.reactions } : item
+          ),
+        }))
+        toast({
+          title: "Unable to update reaction",
+          description: (error as Error).message,
+          variant: "destructive",
+        })
+      }
+    },
+    [profile, toast]
+  )
+
+  const handleVote = useCallback(
+    async (threadId: string, message: MessageWithRelations, optionId: string) => {
+      try {
+        const result = await voteOnPollAction({
+          messageId: message.id,
+          optionId,
+        })
+        setMessagesByThread((prev) => ({
+          ...prev,
+          [threadId]: prev[threadId]?.map((item) =>
+            item.id === result.id ? result : item
+          ),
+        }))
+      } catch (error) {
+        toast({
+          title: "Unable to record vote",
+          description: (error as Error).message,
+          variant: "destructive",
+        })
+      }
+    },
+    [toast]
+  )
+
+  const handleModeration = useCallback(
+    async (
+      threadId: string,
+      message: MessageWithRelations,
+      action: "pin" | "unpin" | "flag" | "unflag" | "delete" | "restore",
+      reason?: string
+    ) => {
+      try {
+        const result = await moderateMessageAction({
+          messageId: message.id,
+          action,
+          reason,
+        })
+        setMessagesByThread((prev) => ({
+          ...prev,
+          [threadId]: prev[threadId]?.map((item) =>
+            item.id === result.message.id ? result.message : item
+          ),
+        }))
+        setThreads((prev) =>
+          prev.map((thread) =>
+            thread.id === threadId ? { ...thread, ...result.thread } : thread
+          )
+        )
+        toast({
+          title: "Moderation applied",
+          description: `Message ${action} successfully`,
+        })
+      } catch (error) {
+        toast({
+          title: "Unable to update message",
+          description: (error as Error).message,
+          variant: "destructive",
+        })
+      }
+    },
+    [toast]
+  )
+
+  const handleCreateThread = useCallback(async () => {
+    if (!newThreadTitle.trim()) {
+      toast({
+        title: "Thread title required",
+        description: "Please provide a title before creating a thread.",
+      })
+      return
+    }
+    if (newThreadType === "poll") {
+      const filled = newThreadPollOptions.filter((option) => option.label.trim())
+      if (filled.length < 2) {
+        toast({
+          title: "Add poll options",
+          description: "Polls require at least two options.",
+          variant: "destructive",
+        })
+        return
+      }
+    }
+    setIsSubmittingThread(true)
+    try {
+      const payload: Record<string, unknown> = {
+        title: newThreadTitle.trim(),
+      }
+      if (isStaffRole(profile.role)) {
+        payload.unitId = newThreadScope === "building" ? null : newThreadUnitId || null
+      }
+      if (newThreadMessage.trim()) {
+        payload.initialMessage = {
+          content: newThreadMessage.trim(),
+          messageType: newThreadType,
+          metadata:
+            newThreadType === "poll"
+              ? {
+                  poll_options: newThreadPollOptions
+                    .filter((option) => option.label.trim())
+                    .map((option) => ({
+                      id: option.id,
+                      label: option.label.trim(),
+                    })),
+                }
+              : undefined,
+        }
+      }
+      const thread = await createThreadAction(payload)
+      setThreads((prev) => {
+        const next = [
+          { ...thread, messages: [] },
+          ...prev.filter((existing) => existing.id !== thread.id),
+        ]
+        return next.sort(
+          (a, b) =>
+            new Date(b.last_message_at ?? b.created_at).getTime() -
+            new Date(a.last_message_at ?? a.created_at).getTime()
+        )
+      })
+      setMessagesByThread((prev) => ({
+        ...prev,
+        [thread.id]: sortMessages(thread.messages ?? []),
+      }))
+      setActiveThreadId(thread.id)
+      setIsCreateDialogOpen(false)
+      setNewThreadTitle("")
+      setNewThreadMessage("")
+      setNewThreadType("text")
+      setNewThreadPollOptions([
+        { id: generateId(), label: "" },
+        { id: generateId(), label: "" },
+      ])
+      toast({
+        title: "Thread created",
+        description: "Your new thread is ready for conversation.",
+      })
+    } catch (error) {
+      toast({
+        title: "Unable to create thread",
+        description: (error as Error).message,
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmittingThread(false)
+    }
+  }, [
+    newThreadMessage,
+    newThreadPollOptions,
+    newThreadScope,
+    newThreadTitle,
+    newThreadType,
+    newThreadUnitId,
+    profile.role,
+    toast,
+  ])
+
+  const pinnedMessage = useMemo(() => {
+    if (!activeThread?.pinned_message_id) {
+      return null
+    }
+    return activeMessages.find(
+      (message) => message.id === activeThread.pinned_message_id
+    )
+  }, [activeMessages, activeThread])
+
+  const renderMessageContent = (message: MessageWithRelations) => {
+    if (message.status === "deleted") {
+      return (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <ShieldAlert className="size-4" /> Message removed by moderation
+        </div>
+      )
+    }
+    if (message.message_type === "poll") {
+      const metadata = (message.metadata ?? {}) as PollMetadata
+      const options = metadata.poll_options ?? []
+      const votes = metadata.poll_votes ?? {}
+      const totalVotes = options.reduce(
+        (total, option) => total + (votes[option.id]?.length ?? 0),
+        0
+      )
+      const currentVote = options.find((option) =>
+        (votes[option.id] ?? []).includes(profile.id)
+      )
+      return (
+        <div className="space-y-2">
+          <p className="font-medium">{message.content}</p>
+          <div className="space-y-2">
+            {options.map((option) => {
+              const optionVotes = votes[option.id]?.length ?? 0
+              const percentage = totalVotes
+                ? Math.round((optionVotes / totalVotes) * 100)
+                : 0
+              const isSelected = currentVote?.id === option.id
+              return (
+                <Button
+                  key={option.id}
+                  variant={isSelected ? "default" : "outline"}
+                  className="flex w-full items-center justify-between"
+                  onClick={() => handleVote(message.thread_id, message, option.id)}
+                >
+                  <span>{option.label}</span>
+                  <span className="text-sm text-muted-foreground">
+                    {optionVotes} vote{optionVotes === 1 ? "" : "s"} ({percentage}%)
+                  </span>
+                </Button>
+              )
+            })}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {totalVotes} vote{totalVotes === 1 ? "" : "s"} cast
+          </p>
+        </div>
+      )
+    }
+    if (message.status === "flagged" && message.metadata?.error) {
+      return (
+        <div className="space-y-2">
+          <p>{message.content}</p>
+          <p className="text-xs text-destructive">{String(message.metadata.error)}</p>
+        </div>
+      )
+    }
+    return <p>{message.content}</p>
+  }
+  const repliesMap = useMemo(() => {
+    const map = new Map<string, MessageWithRelations[]>()
+    activeMessages.forEach((message) => {
+      if (message.parent_message_id) {
+        const list = map.get(message.parent_message_id) ?? []
+        list.push(message)
+        map.set(message.parent_message_id, list)
+      }
+    })
+    for (const list of map.values()) {
+      list.sort(
+        (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+      )
+    }
+    return map
+  }, [activeMessages])
+  return (
+    <div className="grid gap-6 lg:grid-cols-[340px,1fr]">
+      <Card className="h-full">
+        <CardHeader className="flex flex-row items-center justify-between gap-2">
+          <div>
+            <CardTitle>Threads</CardTitle>
+            <CardDescription>Conversations across your property</CardDescription>
+          </div>
+          <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <Plus className="mr-2 size-4" /> New thread
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-lg">
+              <DialogHeader>
+                <DialogTitle>Create thread</DialogTitle>
+                <DialogDescription>
+                  Start a new conversation with your roommates or building staff.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Title</label>
+                  <Input
+                    value={newThreadTitle}
+                    onChange={(event) => setNewThreadTitle(event.target.value)}
+                    placeholder="Maintenance updates"
+                  />
+                </div>
+                {isStaffRole(profile.role) && (
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Scope</label>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        variant={newThreadScope === "building" ? "default" : "outline"}
+                        onClick={() => setNewThreadScope("building")}
+                      >
+                        Building wide
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={newThreadScope === "unit" ? "default" : "outline"}
+                        onClick={() => setNewThreadScope("unit")}
+                      >
+                        Specific unit
+                      </Button>
+                    </div>
+                    {newThreadScope === "unit" && (
+                      <Input
+                        value={newThreadUnitId}
+                        onChange={(event) => setNewThreadUnitId(event.target.value)}
+                        placeholder="Unit ID"
+                      />
+                    )}
+                  </div>
+                )}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Initial message</label>
+                  <Textarea
+                    value={newThreadMessage}
+                    onChange={(event) => setNewThreadMessage(event.target.value)}
+                    placeholder="Share context with your roommates"
+                    rows={4}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Message type</label>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant={newThreadType === "text" ? "default" : "outline"}
+                      onClick={() => setNewThreadType("text")}
+                    >
+                      Standard
+                    </Button>
+                    <Button
+                      type="button"
+                      variant={newThreadType === "poll" ? "default" : "outline"}
+                      onClick={() => setNewThreadType("poll")}
+                    >
+                      Poll
+                    </Button>
+                  </div>
+                  {newThreadType === "poll" && (
+                    <div className="space-y-2">
+                      {newThreadPollOptions.map((option, index) => (
+                        <Input
+                          key={option.id}
+                          value={option.label}
+                          onChange={(event) => {
+                            const next = [...newThreadPollOptions]
+                            next[index] = {
+                              ...option,
+                              label: event.target.value,
+                            }
+                            setNewThreadPollOptions(next)
+                          }}
+                          placeholder={`Option ${index + 1}`}
+                        />
+                      ))}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          setNewThreadPollOptions((prev) => [
+                            ...prev,
+                            { id: generateId(), label: "" },
+                          ])
+                        }
+                      >
+                        Add option
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                <Button onClick={handleCreateThread} disabled={isSubmittingThread}>
+                  {isSubmittingThread ? "Creating…" : "Create thread"}
+                </Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isOffline && (
+            <div className="rounded-md border border-dashed border-yellow-500 bg-yellow-500/10 p-3 text-sm text-yellow-800">
+              You&apos;re offline. Messages will be queued until your connection
+              returns.
+            </div>
+          )}
+          {pendingQueue.length > 0 && (
+            <div className="rounded-md border border-dashed border-blue-500 bg-blue-500/10 p-3 text-sm text-blue-800">
+              {pendingQueue.length} message
+              {pendingQueue.length === 1 ? "" : "s"} waiting to send
+            </div>
+          )}
+          <ScrollArea className="h-[520px] pr-4">
+            <div className="space-y-2">
+              {threads.map((thread) => {
+                const messages = messagesByThread[thread.id] ?? []
+                const latest = messages[messages.length - 1]
+                const isActive = thread.id === activeThreadId
+                return (
+                  <Button
+                    key={thread.id}
+                    variant={isActive ? "default" : "ghost"}
+                    className="h-auto w-full justify-start text-left"
+                    onClick={() => {
+                      setActiveThreadId(thread.id)
+                      setReplyTo(null)
+                    }}
+                  >
+                    <div className="flex w-full flex-col gap-1">
+                      <div className="flex items-center justify-between">
+                        <span className="font-semibold">{thread.title}</span>
+                        {thread.pinned_message_id && (
+                  <Badge variant="secondary" className="flex items-center gap-1">
+                    <Pin className="size-3" /> Pinned
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {thread.unit?.name ?? "All units"}
+                      </div>
+                      {latest && (
+                        <div className="flex items-center justify-between text-xs text-muted-foreground">
+                          <span className="truncate">
+                            {latest.author?.full_name ?? "Unknown"}: {latest.content}
+                          </span>
+                          <span>
+                            {formatDistanceToNow(new Date(latest.created_at), {
+                              addSuffix: true,
+                            })}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </Button>
+                )
+              })}
+            </div>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+      <div className="space-y-4">
+        {activeThread ? (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle>{activeThread.title}</CardTitle>
+                <CardDescription>
+                  {activeThread.unit?.name ?? "All building members"}
+                </CardDescription>
+              </CardHeader>
+              {pinnedMessage && (
+                <CardContent>
+                  <div className="rounded-md border border-dashed border-blue-300 bg-blue-50 p-3">
+                    <div className="flex items-center gap-2 text-sm font-medium">
+                      <Pin className="size-4" /> Pinned message
+                    </div>
+                    <p className="mt-2 text-sm">{pinnedMessage.content}</p>
+                  </div>
+                </CardContent>
+              )}
+            </Card>
+            <Card>
+              <CardContent className="space-y-4">
+                <ScrollArea className="h-[480px] pr-4">
+                  <div className="space-y-4">
+                    {activeMessages.length === 0 ? (
+                      <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                        No messages yet. Start the conversation below.
+                      </div>
+                    ) : (
+                      activeMessages
+                        .filter((message) => !message.parent_message_id)
+                        .map((message) => {
+                          const replies = repliesMap.get(message.id) ?? []
+                          const userHasReacted = (emoji: string) =>
+                            message.reactions.some(
+                              (reaction) =>
+                                reaction.profile_id === profile.id &&
+                                reaction.reaction === emoji
+                            )
+                          const reactionGroups = message.reactions.reduce(
+                            (acc, reaction) => {
+                              const existing = acc.get(reaction.reaction) ?? []
+                              existing.push(reaction.profile_id)
+                              acc.set(reaction.reaction, existing)
+                              return acc
+                            },
+                            new Map<string, string[]>()
+                          )
+                          const renderReplies = (parentId: string, depth = 1) => {
+                            const nested = repliesMap.get(parentId) ?? []
+                            return nested.map((reply) => (
+                              <div
+                                key={reply.id}
+                                className="space-y-2 border-l pl-4"
+                                style={{ marginLeft: depth * 12 }}
+                              >
+                                {renderMessageNode(reply, depth)}
+                                {renderReplies(reply.id, depth + 1)}
+                              </div>
+                            ))
+                          }
+                          const renderMessageNode = (
+                            currentMessage: MessageWithRelations,
+                            depth = 0
+                          ) => (
+                            <div className="space-y-2" key={currentMessage.id}>
+                              <div className="flex items-start gap-3">
+                                <Avatar className="size-10">
+                                  <AvatarImage src={currentMessage.author?.avatar_url ?? undefined} />
+                                  <AvatarFallback>
+                                    {currentMessage.author?.full_name?.slice(0, 2).toUpperCase() ?? "??"}
+                                  </AvatarFallback>
+                                </Avatar>
+                                <div className="flex-1 space-y-2">
+                                  <div className="flex items-center gap-2">
+                                    <span className="font-semibold">
+                                      {currentMessage.author?.full_name ?? "Unknown"}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">
+                                      {formatDistanceToNow(new Date(currentMessage.created_at), {
+                                        addSuffix: true,
+                                      })}
+                                    </span>
+                                    {currentMessage.status === "flagged" && (
+                                      <Badge variant="destructive" className="flex items-center gap-1">
+                                        <Flag className="size-3" /> Flagged
+                                      </Badge>
+                                    )}
+                                  </div>
+                                  {renderMessageContent(currentMessage)}
+                                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                    <Button
+                                      type="button"
+                                      size="xs"
+                                      variant="ghost"
+                                      onClick={() => setReplyTo(currentMessage)}
+                                    >
+                                      <MessageCircle className="mr-1 size-3" /> Reply
+                                    </Button>
+                                    {REACTIONS.map((emoji) => (
+                                      <Button
+                                        key={emoji}
+                                        type="button"
+                                        size="xs"
+                                        variant={userHasReacted(emoji) ? "default" : "ghost"}
+                                        onClick={() => handleReaction(currentMessage.thread_id, currentMessage, emoji)}
+                                      >
+                                        {emoji}
+                                        {reactionGroups.get(emoji)?.length ? ` ${reactionGroups.get(emoji)?.length}` : ""}
+                                      </Button>
+                                    ))}
+                                    {canModerate(profile.role) && (
+                                      <DropdownMenu>
+                                        <DropdownMenuTrigger asChild>
+                                          <Button size="xs" variant="ghost">
+                                            <MoreHorizontal className="size-3" />
+                                          </Button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent align="end">
+                                          <DropdownMenuLabel>Moderation</DropdownMenuLabel>
+                                          <DropdownMenuItem
+                                            onClick={() =>
+                                              handleModeration(
+                                                currentMessage.thread_id,
+                                                currentMessage,
+                                                currentMessage.status === "flagged" ? "unflag" : "flag"
+                                              )
+                                            }
+                                          >
+                                            {currentMessage.status === "flagged" ? "Remove flag" : "Flag message"}
+                                          </DropdownMenuItem>
+                                          <DropdownMenuItem
+                                            onClick={() =>
+                                              handleModeration(
+                                                currentMessage.thread_id,
+                                                currentMessage,
+                                                currentMessage.status === "deleted" ? "restore" : "delete"
+                                              )
+                                            }
+                                          >
+                                            {currentMessage.status === "deleted" ? "Restore" : "Delete"}
+                                          </DropdownMenuItem>
+                                          {activeThread?.pinned_message_id === currentMessage.id ? (
+                                            <DropdownMenuItem
+                                              onClick={() =>
+                                                handleModeration(
+                                                  currentMessage.thread_id,
+                                                  currentMessage,
+                                                  "unpin"
+                                                )
+                                              }
+                                            >
+                                              Unpin message
+                                            </DropdownMenuItem>
+                                          ) : (
+                                            <DropdownMenuItem
+                                              onClick={() =>
+                                                handleModeration(
+                                                  currentMessage.thread_id,
+                                                  currentMessage,
+                                                  "pin"
+                                                )
+                                              }
+                                            >
+                                              Pin message
+                                            </DropdownMenuItem>
+                                          )}
+                                          <DropdownMenuSeparator />
+                                          <DropdownMenuItem disabled>
+                                            ID: {currentMessage.id.slice(0, 8)}
+                                          </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                      </DropdownMenu>
+                                    )}
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          )
+
+                          return (
+                            <div key={message.id} className="space-y-3">
+                              {renderMessageNode(message)}
+                              {renderReplies(message.id)}
+                              <Separator />
+                            </div>
+                          )
+                        })
+                    )}
+                  </div>
+                </ScrollArea>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="space-y-4">
+                {replyTo && (
+                  <div className="flex items-center justify-between rounded-md border bg-muted/50 p-3 text-sm">
+                    <div className="flex items-center gap-2">
+                      <ArrowRight className="size-3" /> Replying to {replyTo.author?.full_name ?? "Unknown"}
+                    </div>
+                    <Button
+                      type="button"
+                      size="xs"
+                      variant="ghost"
+                      onClick={() => setReplyTo(null)}
+                    >
+                      <Undo2 className="mr-1 size-3" /> Cancel
+                    </Button>
+                  </div>
+                )}
+                <Textarea
+                  value={composerState.content}
+                  onChange={(event) =>
+                    setComposerState((prev) => ({ ...prev, content: event.target.value }))
+                  }
+                  placeholder="Share an update with your housemates"
+                  rows={4}
+                />
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={composerState.type === "text" ? "default" : "outline"}
+                      onClick={() => setComposerState((prev) => ({ ...prev, type: "text" }))}
+                    >
+                      Message
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={composerState.type === "poll" ? "default" : "outline"}
+                      onClick={() =>
+                        setComposerState((prev) => ({
+                          ...prev,
+                          type: "poll",
+                          pollOptions: prev.pollOptions.length
+                            ? prev.pollOptions
+                            : [
+                                { id: generateId(), label: "" },
+                                { id: generateId(), label: "" },
+                              ],
+                        }))
+                      }
+                    >
+                      Poll
+                    </Button>
+                  </div>
+                  <Button
+                    type="button"
+                    onClick={async () => {
+                      await handleSendMessage(
+                        activeThread.id,
+                        composerState.content,
+                        composerState.type,
+                        composerState.type === "poll"
+                          ? {
+                              poll_options: composerState.pollOptions
+                                .filter((option) => option.label.trim())
+                                .map((option) => ({
+                                  id: option.id,
+                                  label: option.label.trim(),
+                                })),
+                            }
+                          : undefined,
+                        replyTo?.id ?? null
+                      )
+                      setComposerState((prev) => ({
+                        ...prev,
+                        content: "",
+                        pollOptions:
+                          prev.type === "poll"
+                            ? [
+                                { id: generateId(), label: "" },
+                                { id: generateId(), label: "" },
+                              ]
+                            : prev.pollOptions,
+                      }))
+                      setReplyTo(null)
+                    }}
+                    disabled={isComposerBusy || !composerState.content.trim()}
+                  >
+                    {isComposerBusy ? "Sending…" : <><Send className="mr-2 size-4" /> Send</>}
+                  </Button>
+                </div>
+                {composerState.type === "poll" && (
+                  <div className="space-y-2 rounded-md border p-3">
+                    <p className="text-sm font-medium">Poll options</p>
+                    {composerState.pollOptions.map((option, index) => (
+                      <Input
+                        key={option.id}
+                        value={option.label}
+                        onChange={(event) =>
+                          setComposerState((prev) => {
+                            const next = [...prev.pollOptions]
+                            next[index] = {
+                              ...option,
+                              label: event.target.value,
+                            }
+                            return { ...prev, pollOptions: next }
+                          })
+                        }
+                        placeholder={`Option ${index + 1}`}
+                      />
+                    ))}
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        setComposerState((prev) => ({
+                          ...prev,
+                          pollOptions: [...prev.pollOptions, { id: generateId(), label: "" }],
+                        }))
+                      }
+                    >
+                      Add option
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        ) : (
+          <Card>
+            <CardContent className="p-10 text-center text-sm text-muted-foreground">
+              Select a thread from the left or create a new one to get started.
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default MessageBoard

--- a/app/dashboard/messages/page.tsx
+++ b/app/dashboard/messages/page.tsx
@@ -1,0 +1,78 @@
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { THREAD_WITH_MESSAGES_SELECT } from "@/lib/messages/queries"
+import { mapThread } from "@/lib/messages/mappers"
+import { isStaffRole } from "@/lib/messages/permissions"
+import type { ProfileSummary, ThreadWithRelations } from "@/types/messages"
+import useSupabaseServer from "@/utils/supabase-server"
+
+import MessageBoard from "./message-board"
+
+type PageProps = {
+  searchParams?: { [key: string]: string | string[] | undefined }
+}
+
+const toProfileSummary = (profile: any): ProfileSummary => ({
+  id: profile.id,
+  full_name: profile.full_name,
+  avatar_url: profile.avatar_url,
+  role: profile.role,
+  building_id: profile.building_id,
+  unit_id: profile.unit_id,
+})
+
+export default async function MessagesPage({ searchParams }: PageProps) {
+  const cookieStore = cookies()
+  const supabase = useSupabaseServer(cookieStore)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, full_name, avatar_url, role, building_id, unit_id")
+    .eq("id", user.id)
+    .single()
+
+  if (profileError) {
+    throw new Error(profileError.message)
+  }
+
+  if (!profile?.building_id) {
+    redirect("/onboarding")
+  }
+
+  const threadQuery = supabase
+    .from("threads")
+    .select(THREAD_WITH_MESSAGES_SELECT)
+    .eq("building_id", profile.building_id)
+    .order("last_message_at", { ascending: false })
+    .limit(20)
+
+  if (!isStaffRole(profile.role)) {
+    const unitFilter = profile.unit_id ? `unit_id.eq.${profile.unit_id},unit_id.is.null` : `unit_id.is.null`
+    threadQuery.or(unitFilter)
+  }
+
+  const { data: threadsData, error: threadsError } = await threadQuery
+
+  if (threadsError) {
+    throw new Error(threadsError.message)
+  }
+
+  const threads: ThreadWithRelations[] = (threadsData ?? []).map(mapThread)
+  const initialThreadId = typeof searchParams?.thread === "string" ? searchParams.thread : undefined
+
+  return (
+    <MessageBoard
+      initialThreads={threads}
+      profile={toProfileSummary(profile)}
+      initialThreadId={initialThreadId}
+    />
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { CookieButton } from "@/components/cookie-button"
 import { fontSans } from "@/lib/font"
 import { siteConfig } from '@/config/site'
 import { ReactQueryClientProvider } from '@/components/react-query-client-provider'
+import NotificationHydrator from '@/components/notification-hydrator'
 import { Toaster } from "@/components/ui/toaster"
 import { SiteHeader } from "@/components/site-header"
 import { SiteFooter } from "@/components/site-footer"
@@ -151,6 +152,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
           >
              <div className="relative flex min-h-screen flex-col">
               <SiteHeader />
+              <NotificationHydrator />
               <div className="flex-1">{children}<Toaster/><Analytics/><SpeedInsights/></div>
               
    </div>           

--- a/components/notification-hydrator.tsx
+++ b/components/notification-hydrator.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { isStaffRole } from "@/lib/messages/permissions"
+import { pushNotification } from "@/lib/notifications/store"
+import type { MessageRow, TenantRole } from "@/types/messages"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+const NotificationHydrator = () => {
+  const supabase = useSupabaseBrowser()
+
+  useEffect(() => {
+    let cancelled = false
+    const setup = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user || cancelled) {
+        return
+      }
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("id, role, building_id, unit_id")
+        .eq("id", user.id)
+        .single()
+      if (!profile || !profile.building_id || cancelled) {
+        return
+      }
+
+      const filter = `building_id=eq.${profile.building_id}`
+      const allowMessage = (message?: Partial<MessageRow> | null) => {
+        if (!message) {
+          return false
+        }
+        if (isStaffRole(profile.role as TenantRole)) {
+          return true
+        }
+        return !message.unit_id || message.unit_id === profile.unit_id
+      }
+
+      const channel = supabase
+        .channel(`notifications:${profile.building_id}`)
+        .on(
+          "postgres_changes",
+          { event: "INSERT", schema: "public", table: "messages", filter },
+          (payload) => {
+            const message = payload.new as MessageRow
+            if (!allowMessage(message)) {
+              return
+            }
+            pushNotification({
+              id: message.id,
+              type: "message:new",
+              title: message.message_type === "poll" ? "New poll" : "New message",
+              description: message.content?.slice(0, 160),
+              createdAt: message.created_at,
+              link: `/dashboard/messages?thread=${message.thread_id}`,
+              status: message.status,
+              threadId: message.thread_id,
+              messageId: message.id,
+            })
+          }
+        )
+        .on(
+          "postgres_changes",
+          { event: "UPDATE", schema: "public", table: "messages", filter },
+          (payload) => {
+            const message = payload.new as MessageRow
+            const previous = payload.old as MessageRow | null
+            if (!allowMessage(message)) {
+              return
+            }
+            if (previous && message.status !== previous.status) {
+              const statusId = `${message.id}:${message.status}`
+              pushNotification({
+                id: statusId,
+                type: "message:moderated",
+                title: `Message ${message.status}`,
+                description: message.content?.slice(0, 160),
+                createdAt: message.updated_at ?? message.created_at,
+                link: `/dashboard/messages?thread=${message.thread_id}&message=${message.id}`,
+                status: message.status,
+                threadId: message.thread_id,
+                messageId: message.id,
+              })
+              if (message.status === "flagged") {
+                pushNotification({
+                  id: `${statusId}:maintenance`,
+                  type: "maintenance:update",
+                  title: "Maintenance follow-up flagged",
+                  description: message.content?.slice(0, 160),
+                  createdAt: message.updated_at ?? message.created_at,
+                  link: `/dashboard/messages?thread=${message.thread_id}&message=${message.id}`,
+                  status: message.status,
+                  threadId: message.thread_id,
+                  messageId: message.id,
+                })
+              }
+            }
+          }
+        )
+        .on(
+          "postgres_changes",
+          { event: "INSERT", schema: "public", table: "message_moderation", filter },
+          (payload) => {
+            const moderation = payload.new as { message_id: string; thread_id: string; action: string; created_at: string; reason?: string | null }
+            pushNotification({
+              id: `${moderation.message_id}:${moderation.created_at}:${moderation.action}`,
+              type: "message:moderated",
+              title: `Message ${moderation.action}`,
+              description: moderation.reason ?? undefined,
+              createdAt: moderation.created_at,
+              link: `/dashboard/messages?thread=${moderation.thread_id}&message=${moderation.message_id}`,
+              status: moderation.action,
+              threadId: moderation.thread_id,
+              messageId: moderation.message_id,
+              metadata: { action: moderation.action, reason: moderation.reason },
+            })
+          }
+        )
+
+      const subscription = channel.subscribe()
+
+      return () => {
+        supabase.removeChannel(channel)
+        subscription.unsubscribe?.()
+      }
+    }
+
+    const teardown = setup()
+
+    return () => {
+      cancelled = true
+      teardown.then((cleanup) => {
+        if (typeof cleanup === "function") {
+          cleanup()
+        }
+      })
+    }
+  }, [supabase])
+
+  return null
+}
+
+export default NotificationHydrator

--- a/hooks/use-notification-feed.ts
+++ b/hooks/use-notification-feed.ts
@@ -1,0 +1,23 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import {
+  getNotifications,
+  subscribeNotifications,
+  type NotificationItem,
+} from "@/lib/notifications/store"
+
+export const useNotificationFeed = () => {
+  const [notifications, setNotifications] = useState<NotificationItem[]>(() =>
+    getNotifications()
+  )
+
+  useEffect(() => {
+    setNotifications(getNotifications())
+    const unsubscribe = subscribeNotifications((items) => setNotifications(items))
+    return () => unsubscribe()
+  }, [])
+
+  return notifications
+}

--- a/lib/messages/__tests__/permissions.test.ts
+++ b/lib/messages/__tests__/permissions.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canAccessThread,
+  canModerate,
+  isStaffRole,
+} from "@/lib/messages/permissions"
+import type { ProfileSummary, ThreadWithRelations } from "@/types/messages"
+
+describe("permissions", () => {
+  const staffProfile: ProfileSummary = {
+    id: "staff-1",
+    full_name: "Manager",
+    avatar_url: null,
+    role: "property_manager",
+    building_id: "building-1",
+    unit_id: null,
+  }
+
+  const tenantProfile: ProfileSummary = {
+    id: "tenant-1",
+    full_name: "Tenant",
+    avatar_url: null,
+    role: "tenant",
+    building_id: "building-1",
+    unit_id: "unit-1",
+  }
+
+  const thread: Pick<ThreadWithRelations, "building_id" | "unit_id"> = {
+    building_id: "building-1",
+    unit_id: "unit-1",
+  }
+
+  it("identifies staff roles", () => {
+    expect(isStaffRole("property_manager")).toBe(true)
+    expect(isStaffRole("admin")).toBe(true)
+    expect(isStaffRole("tenant")).toBe(false)
+  })
+
+  it("allows staff to moderate", () => {
+    expect(canModerate(staffProfile.role)).toBe(true)
+    expect(canModerate(tenantProfile.role)).toBe(false)
+  })
+
+  it("restricts thread access by unit", () => {
+    expect(canAccessThread(tenantProfile, thread)).toBe(true)
+    expect(canAccessThread(tenantProfile, { ...thread, unit_id: "unit-2" })).toBe(false)
+    expect(
+      canAccessThread(
+        tenantProfile,
+        {
+          building_id: thread.building_id,
+          unit_id: null,
+        }
+      )
+    ).toBe(true)
+  })
+
+  it("prevents access for mismatched buildings", () => {
+    expect(
+      canAccessThread(tenantProfile, {
+        building_id: "building-2",
+        unit_id: thread.unit_id,
+      })
+    ).toBe(false)
+  })
+
+  it("allows staff to access any unit in the building", () => {
+    expect(canAccessThread(staffProfile, thread)).toBe(true)
+    expect(
+      canAccessThread(staffProfile, {
+        building_id: thread.building_id,
+        unit_id: "different-unit",
+      })
+    ).toBe(true)
+  })
+})

--- a/lib/messages/__tests__/realtime.test.ts
+++ b/lib/messages/__tests__/realtime.test.ts
@@ -1,0 +1,200 @@
+import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js"
+import { describe, expect, it } from "vitest"
+
+import {
+  mergeMessageChange,
+  mergeReactionChange,
+} from "@/lib/messages/realtime"
+import type {
+  MessageWithRelations,
+  ReactionWithProfile,
+} from "@/types/messages"
+
+const baseMessage: MessageWithRelations = {
+  id: "message-1",
+  thread_id: "thread-1",
+  parent_message_id: null,
+  building_id: "building-1",
+  unit_id: "unit-1",
+  author_id: "author-1",
+  content: "Hello",
+  message_type: "text",
+  metadata: {},
+  status: "active",
+  client_id: null,
+  created_at: "2024-01-01T00:00:00.000Z",
+  updated_at: "2024-01-01T00:00:00.000Z",
+  deleted_at: null,
+  author: null,
+  reactions: [],
+  moderation: [],
+}
+
+const mapRow = (row: any): MessageWithRelations => ({
+  ...row,
+  author: row.author ?? null,
+  reactions: row.reactions ?? [],
+  moderation: row.moderation ?? [],
+})
+
+const toRowPayload = (
+  eventType: "INSERT" | "UPDATE" | "DELETE",
+  message: MessageWithRelations
+): RealtimePostgresChangesPayload<any> => {
+  const { reactions, moderation, author, ...row } = message
+  return {
+    eventType,
+    schema: "public",
+    table: "messages",
+    new: eventType === "DELETE" ? null : row,
+    old: eventType === "DELETE" ? row : null,
+  }
+}
+
+describe("mergeMessageChange", () => {
+  it("inserts messages in chronological order", () => {
+    const existing = [
+      {
+        ...baseMessage,
+        id: "message-early",
+        created_at: "2024-01-01T00:00:00.000Z",
+      },
+    ]
+    const incoming: MessageWithRelations = {
+      ...baseMessage,
+      id: "message-late",
+      created_at: "2024-01-02T00:00:00.000Z",
+    }
+
+    const result = mergeMessageChange(
+      existing,
+      toRowPayload("INSERT", incoming),
+      mapRow
+    )
+
+    expect(result.map((message) => message.id)).toEqual([
+      "message-early",
+      "message-late",
+    ])
+  })
+
+  it("updates an existing message while preserving reactions", () => {
+    const existing: MessageWithRelations[] = [
+      {
+        ...baseMessage,
+        reactions: [
+          {
+            id: "reaction-1",
+            message_id: baseMessage.id,
+            profile_id: "profile-1",
+            reaction: "👍",
+            created_at: baseMessage.created_at,
+            building_id: baseMessage.building_id,
+            unit_id: baseMessage.unit_id,
+            profile: null,
+          },
+        ],
+      },
+    ]
+    const incoming: MessageWithRelations = {
+      ...baseMessage,
+      content: "Updated",
+      reactions: [],
+    }
+
+    const result = mergeMessageChange(
+      existing,
+      toRowPayload("UPDATE", incoming),
+      mapRow
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toBe("Updated")
+    expect(result[0].reactions).toHaveLength(1)
+  })
+
+  it("removes a message on delete", () => {
+    const existing = [baseMessage]
+
+    const result = mergeMessageChange(
+      existing,
+      toRowPayload("DELETE", baseMessage),
+      mapRow
+    )
+
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe("mergeReactionChange", () => {
+  const reactionBase: ReactionWithProfile = {
+    id: "reaction-1",
+    message_id: baseMessage.id,
+    profile_id: "profile-1",
+    reaction: "👍",
+    created_at: "2024-01-01T00:00:00.000Z",
+    building_id: baseMessage.building_id,
+    unit_id: baseMessage.unit_id,
+    profile: null,
+  }
+
+  const toReactionPayload = (
+    eventType: "INSERT" | "UPDATE" | "DELETE",
+    reaction: ReactionWithProfile
+  ): RealtimePostgresChangesPayload<ReactionWithProfile> => ({
+    eventType,
+    schema: "public",
+    table: "message_reactions",
+    new: eventType === "DELETE" ? null : reaction,
+    old: eventType === "DELETE" ? reaction : null,
+  })
+
+  it("adds new reactions", () => {
+    const existing = [baseMessage]
+
+    const result = mergeReactionChange(
+      existing,
+      toReactionPayload("INSERT", reactionBase)
+    )
+
+    expect(result[0].reactions).toHaveLength(1)
+    expect(result[0].reactions[0].reaction).toBe("👍")
+  })
+
+  it("updates existing reactions", () => {
+    const updatedReaction: ReactionWithProfile = {
+      ...reactionBase,
+      reaction: "❤️",
+    }
+    const existing: MessageWithRelations[] = [
+      {
+        ...baseMessage,
+        reactions: [reactionBase],
+      },
+    ]
+
+    const result = mergeReactionChange(
+      existing,
+      toReactionPayload("UPDATE", updatedReaction)
+    )
+
+    expect(result[0].reactions).toHaveLength(1)
+    expect(result[0].reactions[0].reaction).toBe("❤️")
+  })
+
+  it("removes reactions on delete", () => {
+    const existing: MessageWithRelations[] = [
+      {
+        ...baseMessage,
+        reactions: [reactionBase],
+      },
+    ]
+
+    const result = mergeReactionChange(
+      existing,
+      toReactionPayload("DELETE", reactionBase)
+    )
+
+    expect(result[0].reactions).toHaveLength(0)
+  })
+})

--- a/lib/messages/mappers.ts
+++ b/lib/messages/mappers.ts
@@ -1,0 +1,31 @@
+import type { MessageWithRelations, ThreadWithRelations, PollMetadata } from "@/types/messages"
+
+export const mapMessage = (row: any): MessageWithRelations => ({
+  ...row,
+  metadata: (row.metadata ?? {}) as PollMetadata,
+  author: row.author ?? null,
+  reactions: Array.isArray(row.reactions)
+    ? row.reactions.map((reaction: any) => ({
+        ...reaction,
+        profile: reaction.profile ?? null,
+      }))
+    : [],
+  moderation: Array.isArray(row.moderation)
+    ? row.moderation.map((entry: any) => ({
+        ...entry,
+        performed_by_profile: entry.performed_by_profile ?? null,
+      }))
+    : [],
+})
+
+export const mapThread = (row: any): ThreadWithRelations => ({
+  ...row,
+  metadata: row.metadata ?? {},
+  created_by_profile: row.created_by_profile ?? null,
+  pinned_by_profile: row.pinned_by_profile ?? null,
+  unit: row.unit ?? null,
+  building: row.building ?? null,
+  messages: Array.isArray(row.messages)
+    ? row.messages.map((message: any) => mapMessage(message))
+    : [],
+})

--- a/lib/messages/permissions.ts
+++ b/lib/messages/permissions.ts
@@ -1,0 +1,32 @@
+import type { ThreadWithRelations, ProfileSummary, TenantRole } from "@/types/messages"
+
+const STAFF_ROLES: TenantRole[] = ["property_manager", "admin"]
+
+export const isStaffRole = (role?: TenantRole | null): boolean =>
+  !!role && STAFF_ROLES.includes(role)
+
+export const canModerate = (role?: TenantRole | null): boolean => isStaffRole(role)
+
+export const canAccessThread = (
+  profile: ProfileSummary,
+  thread: Pick<ThreadWithRelations, "building_id" | "unit_id">
+): boolean => {
+  if (!profile.building_id || profile.building_id !== thread.building_id) {
+    return false
+  }
+
+  if (isStaffRole(profile.role)) {
+    return true
+  }
+
+  if (!thread.unit_id) {
+    return true
+  }
+
+  return !!profile.unit_id && profile.unit_id === thread.unit_id
+}
+
+export const canPostInThread = (
+  profile: ProfileSummary,
+  thread: Pick<ThreadWithRelations, "building_id" | "unit_id">
+): boolean => canAccessThread(profile, thread)

--- a/lib/messages/queries.ts
+++ b/lib/messages/queries.ts
@@ -1,0 +1,149 @@
+export const THREAD_WITH_MESSAGES_SELECT = `
+  id,
+  title,
+  building_id,
+  unit_id,
+  created_at,
+  updated_at,
+  last_message_at,
+  metadata,
+  pinned_message_id,
+  pinned_at,
+  pinned_by,
+  created_by,
+  created_by_profile:profiles!threads_created_by_fkey (
+    id,
+    full_name,
+    avatar_url,
+    role,
+    building_id,
+    unit_id
+  ),
+  pinned_by_profile:profiles!threads_pinned_by_fkey (
+    id,
+    full_name,
+    avatar_url,
+    role,
+    building_id,
+    unit_id
+  ),
+  unit:units (
+    id,
+    name
+  ),
+  building:buildings (
+    id,
+    name
+  ),
+  messages:messages(limit:50, order:created_at.asc) (
+    id,
+    thread_id,
+    parent_message_id,
+    author_id,
+    content,
+    message_type,
+    metadata,
+    status,
+    client_id,
+    created_at,
+    updated_at,
+    deleted_at,
+    building_id,
+    unit_id,
+    author:profiles!messages_author_id_fkey (
+      id,
+      full_name,
+      avatar_url,
+      role,
+      building_id,
+      unit_id
+    ),
+    reactions:message_reactions (
+      id,
+      message_id,
+      profile_id,
+      reaction,
+      created_at,
+      profile:profiles!message_reactions_profile_id_fkey (
+        id,
+        full_name,
+        avatar_url,
+        role,
+        building_id,
+        unit_id
+      )
+    ),
+    moderation:message_moderation (
+      id,
+      action,
+      reason,
+      performed_by,
+      created_at,
+      metadata,
+      performed_by_profile:profiles!message_moderation_performed_by_fkey (
+        id,
+        full_name,
+        avatar_url,
+        role,
+        building_id,
+        unit_id
+      )
+    )
+  )
+`
+
+export const MESSAGE_WITH_RELATIONS_SELECT = `
+  id,
+  thread_id,
+  parent_message_id,
+  author_id,
+  content,
+  message_type,
+  metadata,
+  status,
+  client_id,
+  created_at,
+  updated_at,
+  deleted_at,
+  building_id,
+  unit_id,
+  author:profiles!messages_author_id_fkey (
+    id,
+    full_name,
+    avatar_url,
+    role,
+    building_id,
+    unit_id
+  ),
+  reactions:message_reactions (
+    id,
+    message_id,
+    profile_id,
+    reaction,
+    created_at,
+    profile:profiles!message_reactions_profile_id_fkey (
+      id,
+      full_name,
+      avatar_url,
+      role,
+      building_id,
+      unit_id
+    )
+  ),
+  moderation:message_moderation (
+    id,
+    action,
+    reason,
+    performed_by,
+    created_at,
+    metadata,
+    performed_by_profile:profiles!message_moderation_performed_by_fkey (
+      id,
+      full_name,
+      avatar_url,
+      role,
+      building_id,
+      unit_id
+    )
+  )
+`

--- a/lib/messages/realtime.ts
+++ b/lib/messages/realtime.ts
@@ -1,0 +1,119 @@
+import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js"
+
+import type {
+  MessageWithRelations,
+  ReactionWithProfile,
+  MessageRow,
+} from "@/types/messages"
+
+export function mergeMessageChange(
+  current: MessageWithRelations[],
+  payload: RealtimePostgresChangesPayload<MessageRow>,
+  mapRow: (row: MessageRow) => MessageWithRelations
+): MessageWithRelations[] {
+  const next = [...current]
+  const incoming = payload.new ?? payload.old
+  if (!incoming) {
+    return next
+  }
+
+  const resolveIndex = (row: MessageRow) =>
+    next.findIndex(
+      (message) =>
+        message.id === row.id || (row.client_id && message.client_id === row.client_id)
+    )
+
+  if (payload.eventType === "DELETE") {
+    const index = resolveIndex(incoming)
+    if (index >= 0) {
+      next.splice(index, 1)
+    }
+    return next
+  }
+
+  const mapped = mapRow((payload.new ?? incoming) as MessageRow)
+  const index = resolveIndex(mapped)
+
+  if (index >= 0) {
+    const existing = next[index]
+    const merged: MessageWithRelations = {
+      ...existing,
+      ...mapped,
+      reactions:
+        mapped.reactions && mapped.reactions.length > 0
+          ? mapped.reactions
+          : existing.reactions,
+      moderation:
+        mapped.moderation && mapped.moderation.length > 0
+          ? mapped.moderation
+          : existing.moderation,
+      author: mapped.author ?? existing.author,
+      metadata: mapped.metadata ?? existing.metadata,
+    }
+    next[index] = merged
+  } else {
+    next.push(mapped)
+  }
+
+  return next.sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  )
+}
+
+export function mergeReactionChange(
+  current: MessageWithRelations[],
+  payload: RealtimePostgresChangesPayload<ReactionWithProfile>
+): MessageWithRelations[] {
+  const next = current.map((message) => ({ ...message, reactions: [...message.reactions] }))
+  const incoming = payload.new ?? payload.old
+  if (!incoming) {
+    return next
+  }
+
+  return next.map((message) => {
+    if (
+      message.id !== incoming.message_id &&
+      message.id !== (payload.new?.message_id ?? payload.old?.message_id)
+    ) {
+      return message
+    }
+
+    const reactions = [...message.reactions]
+
+    const findIndex = () =>
+      reactions.findIndex((reaction) =>
+        incoming.id
+          ? reaction.id === incoming.id
+          : reaction.profile_id === incoming.profile_id &&
+            reaction.reaction === incoming.reaction
+      )
+
+    switch (payload.eventType) {
+      case "INSERT": {
+        const index = findIndex()
+        if (index === -1) {
+          reactions.push({ ...incoming })
+        }
+        break
+      }
+      case "UPDATE": {
+        const index = findIndex()
+        if (index >= 0) {
+          reactions[index] = { ...reactions[index], ...incoming }
+        }
+        break
+      }
+      case "DELETE": {
+        const index = findIndex()
+        if (index >= 0) {
+          reactions.splice(index, 1)
+        }
+        break
+      }
+      default:
+        break
+    }
+
+    return { ...message, reactions }
+  })
+}

--- a/lib/notifications/store.ts
+++ b/lib/notifications/store.ts
@@ -1,0 +1,86 @@
+"use client"
+
+import EventEmitter from "eventemitter3"
+
+export type NotificationType = "message:new" | "message:moderated" | "maintenance:update"
+
+export type NotificationItem = {
+  id: string
+  type: NotificationType
+  title: string
+  description?: string
+  createdAt: string
+  link?: string
+  status?: string
+  threadId?: string
+  messageId?: string
+  metadata?: Record<string, unknown>
+}
+
+const STORAGE_KEY = "share-house-notifications"
+const emitter = new EventEmitter<{ update: NotificationItem[] }>()
+let items: NotificationItem[] = []
+
+const loadFromStorage = () => {
+  if (typeof window === "undefined") {
+    return
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as NotificationItem[]
+      if (Array.isArray(parsed)) {
+        items = parsed
+      }
+    }
+  } catch (error) {
+    console.error("Failed to load notifications", error)
+  }
+}
+
+const persist = () => {
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items.slice(0, 100)))
+    } catch (error) {
+      console.error("Failed to persist notifications", error)
+    }
+  }
+  emitter.emit("update", [...items])
+}
+
+if (typeof window !== "undefined") {
+  loadFromStorage()
+}
+
+export const getNotifications = (): NotificationItem[] => [...items]
+
+export const pushNotification = (notification: NotificationItem) => {
+  const existingIndex = items.findIndex((item) => item.id === notification.id)
+  if (existingIndex >= 0) {
+    items[existingIndex] = { ...items[existingIndex], ...notification }
+  } else {
+    items = [notification, ...items]
+  }
+  persist()
+}
+
+export const acknowledgeNotification = (id: string) => {
+  const next = items.filter((notification) => notification.id !== id)
+  if (next.length !== items.length) {
+    items = next
+    persist()
+  }
+}
+
+export const subscribeNotifications = (
+  listener: (notifications: NotificationItem[]) => void
+) => {
+  emitter.on("update", listener)
+  return () => emitter.off("update", listener)
+}
+
+export const hydrateNotifications = (notifications: NotificationItem[]) => {
+  items = notifications
+  persist()
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -450,38 +450,58 @@ export type Database = {
         }
         Relationships: []
       }
-      chat: {
+      buildings: {
         Row: {
           created_at: string
-          id: number
-          messages: string[] | null
-          path: string | null
-          profile_id: string
-          sharepath: string | null
-          title: string | null
-          user_id: string | null
+          id: string
+          name: string
+          updated_at: string
         }
         Insert: {
-          created_at: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
-          profile_id: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
+          created_at?: string
+          id?: string
+          name: string
+          updated_at?: string
         }
         Update: {
           created_at?: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
-          profile_id?: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
+          id?: string
+          name?: string
+          updated_at?: string
         }
         Relationships: []
+      }
+      units: {
+        Row: {
+          building_id: string
+          created_at: string
+          id: string
+          name: string
+          updated_at: string
+        }
+        Insert: {
+          building_id: string
+          created_at?: string
+          id?: string
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          building_id?: string
+          created_at?: string
+          id?: string
+          name?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "units_building_id_fkey",
+            columns: ["building_id"],
+            isOneToOne: false,
+            referencedRelation: "buildings",
+            referencedColumns: ["id"],
+          },
+        ]
       }
       countries: {
         Row: {
@@ -509,6 +529,298 @@ export type Database = {
           name?: string | null
         }
         Relationships: []
+      }
+      message_moderation: {
+        Row: {
+          action: "pin" | "unpin" | "flag" | "unflag" | "delete" | "restore"
+          building_id: string
+          created_at: string
+          id: string
+          message_id: string
+          metadata: Json
+          performed_by: string | null
+          reason: string | null
+          thread_id: string
+        }
+        Insert: {
+          action: "pin" | "unpin" | "flag" | "unflag" | "delete" | "restore"
+          building_id: string
+          created_at?: string
+          id?: string
+          message_id: string
+          metadata?: Json
+          performed_by?: string | null
+          reason?: string | null
+          thread_id?: string
+        }
+        Update: {
+          action?: "pin" | "unpin" | "flag" | "unflag" | "delete" | "restore"
+          building_id?: string
+          created_at?: string
+          id?: string
+          message_id?: string
+          metadata?: Json
+          performed_by?: string | null
+          reason?: string | null
+          thread_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "message_moderation_building_id_fkey",
+            columns: ["building_id"],
+            isOneToOne: false,
+            referencedRelation: "buildings",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "message_moderation_message_id_fkey",
+            columns: ["message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "message_moderation_performed_by_fkey",
+            columns: ["performed_by"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "message_moderation_thread_id_fkey",
+            columns: ["thread_id"],
+            isOneToOne: false,
+            referencedRelation: "threads",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      message_reactions: {
+        Row: {
+          building_id: string
+          created_at: string
+          id: string
+          message_id: string
+          profile_id: string
+          reaction: string
+          unit_id: string | null
+        }
+        Insert: {
+          building_id: string
+          created_at?: string
+          id?: string
+          message_id: string
+          profile_id: string
+          reaction: string
+          unit_id?: string | null
+        }
+        Update: {
+          building_id?: string
+          created_at?: string
+          id?: string
+          message_id?: string
+          profile_id?: string
+          reaction?: string
+          unit_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "message_reactions_building_id_fkey",
+            columns: ["building_id"],
+            isOneToOne: false,
+            referencedRelation: "buildings",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "message_reactions_message_id_fkey",
+            columns: ["message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "message_reactions_profile_id_fkey",
+            columns: ["profile_id"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "message_reactions_unit_id_fkey",
+            columns: ["unit_id"],
+            isOneToOne: false,
+            referencedRelation: "units",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      messages: {
+        Row: {
+          author_id: string
+          building_id: string
+          client_id: string | null
+          content: string
+          created_at: string
+          deleted_at: string | null
+          id: string
+          message_type: "text" | "poll" | "system"
+          metadata: Json
+          parent_message_id: string | null
+          status: "active" | "flagged" | "deleted"
+          thread_id: string
+          unit_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          author_id: string
+          building_id: string
+          client_id?: string | null
+          content: string
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          message_type?: "text" | "poll" | "system"
+          metadata?: Json
+          parent_message_id?: string | null
+          status?: "active" | "flagged" | "deleted"
+          thread_id: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          author_id?: string
+          building_id?: string
+          client_id?: string | null
+          content?: string
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          message_type?: "text" | "poll" | "system"
+          metadata?: Json
+          parent_message_id?: string | null
+          status?: "active" | "flagged" | "deleted"
+          thread_id?: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "messages_author_id_fkey",
+            columns: ["author_id"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_building_id_fkey",
+            columns: ["building_id"],
+            isOneToOne: false,
+            referencedRelation: "buildings",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_parent_message_id_fkey",
+            columns: ["parent_message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_thread_id_fkey",
+            columns: ["thread_id"],
+            isOneToOne: false,
+            referencedRelation: "threads",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_unit_id_fkey",
+            columns: ["unit_id"],
+            isOneToOne: false,
+            referencedRelation: "units",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      threads: {
+        Row: {
+          building_id: string
+          created_at: string
+          created_by: string
+          id: string
+          last_message_at: string
+          metadata: Json
+          pinned_at: string | null
+          pinned_by: string | null
+          pinned_message_id: string | null
+          title: string
+          unit_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          building_id: string
+          created_at?: string
+          created_by: string
+          id?: string
+          last_message_at?: string
+          metadata?: Json
+          pinned_at?: string | null
+          pinned_by?: string | null
+          pinned_message_id?: string | null
+          title: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          building_id?: string
+          created_at?: string
+          created_by?: string
+          id?: string
+          last_message_at?: string
+          metadata?: Json
+          pinned_at?: string | null
+          pinned_by?: string | null
+          pinned_message_id?: string | null
+          title?: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "threads_building_id_fkey",
+            columns: ["building_id"],
+            isOneToOne: false,
+            referencedRelation: "buildings",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_created_by_fkey",
+            columns: ["created_by"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_pinned_by_fkey",
+            columns: ["pinned_by"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_pinned_message_fkey",
+            columns: ["pinned_message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_unit_id_fkey",
+            columns: ["unit_id"],
+            isOneToOne: false,
+            referencedRelation: "units",
+            referencedColumns: ["id"],
+          },
+        ]
       }
       crm_activities: {
         Row: {
@@ -1229,6 +1541,7 @@ export type Database = {
       profiles: {
         Row: {
           avatar_url: string | null
+          building_id: string | null
           card_style: Json | null
           card_styles: string | null
           company: string | null
@@ -1240,15 +1553,17 @@ export type Database = {
           job_title: string | null
           linkedin_url: string | null
           public_id: string | null
-          role: string | null
+          role: Database["public"]["Enums"]["tenant_role"] | null
           updated_at: string | null
           username: string | null
+          unit_id: string | null
           waddress: string | null
           website: string | null
           xhandle: string | null
         }
         Insert: {
           avatar_url?: string | null
+          building_id?: string | null
           card_style?: Json | null
           card_styles?: string | null
           company?: string | null
@@ -1260,15 +1575,17 @@ export type Database = {
           job_title?: string | null
           linkedin_url?: string | null
           public_id?: string | null
-          role?: string | null
+          role?: Database["public"]["Enums"]["tenant_role"] | null
           updated_at?: string | null
           username?: string | null
+          unit_id?: string | null
           waddress?: string | null
           website?: string | null
           xhandle?: string | null
         }
         Update: {
           avatar_url?: string | null
+          building_id?: string | null
           card_style?: Json | null
           card_styles?: string | null
           company?: string | null
@@ -1280,9 +1597,10 @@ export type Database = {
           job_title?: string | null
           linkedin_url?: string | null
           public_id?: string | null
-          role?: string | null
+          role?: Database["public"]["Enums"]["tenant_role"] | null
           updated_at?: string | null
           username?: string | null
+          unit_id?: string | null
           waddress?: string | null
           website?: string | null
           xhandle?: string | null
@@ -1775,6 +2093,7 @@ export type Database = {
         | "North America"
         | "South America"
       user_role: "user" | "admin"
+      tenant_role: "tenant" | "roommate" | "property_manager" | "admin"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -97,10 +98,11 @@
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
     "@types/eslint": "^8.56.2",
     "@types/lodash": "^4.14.202",
-    "@types/node": "^20.14.15",
+    "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.0.4",
@@ -109,6 +111,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -268,8 +268,8 @@ importers:
         specifier: ^4.14.202
         version: 4.14.202
       '@types/node':
-        specifier: ^20.14.15
-        version: 20.14.15
+        specifier: ^20.19.0
+        version: 20.19.17
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
@@ -279,6 +279,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.62.0
         version: 5.62.0(eslint@8.56.0)(typescript@5.5.4)
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0))
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.32)
@@ -306,6 +309,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
 
 packages:
 
@@ -1019,6 +1025,10 @@ packages:
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@csstools/cascade-layer-name-parser@2.0.0':
     resolution: {integrity: sha512-9GEQIvTMrjXfYaVnw1+FteDX5yF65CZq4ttYP75O3CANQevaCJ9jVVTiZt9YTpjYIk8C1mmf52y2S4Hr/CaE/g==}
     engines: {node: '>=18'}
@@ -1328,6 +1338,162 @@ packages:
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1402,6 +1568,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jdion/tilt-react@1.0.0':
     resolution: {integrity: sha512-Qvr0iwxoYc4BAxZzCkrCEF7Vk0DauFIY7eehKU6dCwdil6gj2tlYOOXkMDHMIrdcO6yYDL/yqLI4bNZr4F2swA==}
     peerDependencies:
@@ -1452,6 +1622,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@mdx-js/loader@3.0.1':
     resolution: {integrity: sha512-YbYUt7YyEOdFxhyuCWmLKf5vKhID/hJAojEUnheJk4D8iYVLFQw+BAoBWru/dHGch1omtmZOPstsmKPyBF68Tw==}
@@ -2323,6 +2496,116 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rushstack/eslint-patch@1.6.1':
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
 
@@ -2436,6 +2719,9 @@ packages:
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -2466,6 +2752,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
@@ -2487,8 +2776,8 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/google-one-tap@1.2.6':
     resolution: {integrity: sha512-REmJsXVHvKb/sgI8DF+7IesMbDbcsEokHBqxU01ENZ8d98UPWdRLhUCtxEm9bhNFFg6PJGy7PNFdvovp0hK3jA==}
@@ -2517,11 +2806,8 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@20.14.15':
-    resolution: {integrity: sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==}
-
-  '@types/node@20.17.30':
-    resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
+  '@types/node@20.19.17':
+    resolution: {integrity: sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==}
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
@@ -2648,6 +2934,44 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
@@ -2863,8 +3187,15 @@ packages:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-v8-to-istanbul@0.3.5:
+    resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
 
   astring@1.8.6:
     resolution: {integrity: sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==}
@@ -3020,6 +3351,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3056,6 +3391,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3084,6 +3423,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -3305,6 +3648,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
@@ -3314,6 +3666,10 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3456,8 +3812,8 @@ packages:
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
 
-  es-module-lexer@1.6.0:
-    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3473,6 +3829,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -3648,6 +4009,10 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -3682,6 +4047,15 @@ packages:
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
@@ -3949,6 +4323,9 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -4172,6 +4549,22 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.2:
     resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
 
@@ -4217,6 +4610,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -4357,6 +4753,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
@@ -4386,6 +4785,13 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -4781,6 +5187,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -4799,6 +5212,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -5015,8 +5432,8 @@ packages:
     resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   potpack@1.0.2:
@@ -5317,6 +5734,11 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5404,6 +5826,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5435,10 +5860,6 @@ packages:
 
   source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
-    engines: {node: '>=0.10.0'}
-
-  source-map-js@1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
 
   source-map-js@1.2.1:
@@ -5474,6 +5895,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
     peerDependencies:
@@ -5482,6 +5906,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -5544,6 +5971,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -5661,6 +6091,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
+
   text-decoder@1.1.1:
     resolution: {integrity: sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==}
 
@@ -5689,6 +6123,28 @@ packages:
 
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -5779,11 +6235,8 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -5934,6 +6387,79 @@ packages:
   victory-vendor@36.8.6:
     resolution: {integrity: sha512-PH8Wj9b0xIZ4AVfyn0c1SJrOhtxDJ5PNxj1ZDABPg1Gw1vJr1mJVqESPhvsFj7mXLQohVdiKqp4kWZkXlPcRcA==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.6:
+    resolution: {integrity: sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.4.35:
     resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
     peerDependencies:
@@ -5998,6 +6524,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workbox-background-sync@7.1.0:
@@ -6134,7 +6665,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
-    optional: true
 
   '@apideck/better-ajv-errors@0.3.6(ajv@8.17.1)':
     dependencies:
@@ -6179,7 +6709,7 @@ snapshots:
 
   '@babel/core@7.24.9':
     dependencies:
-      '@ampproject/remapping': 2.2.1
+      '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.10
       '@babel/helper-compilation-targets': 7.24.8
@@ -6206,8 +6736,8 @@ snapshots:
 
   '@babel/generator@7.24.10':
     dependencies:
-      '@babel/types': 7.24.9
-      '@jridgewell/gen-mapping': 0.3.5
+      '@babel/types': 7.27.0
+      '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
@@ -6387,15 +6917,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.24.8': {}
 
-  '@babel/helper-string-parser@7.25.9':
-    optional: true
+  '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.22.20': {}
 
   '@babel/helper-validator-identifier@7.24.7': {}
 
-  '@babel/helper-validator-identifier@7.25.9':
-    optional: true
+  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-option@7.23.5': {}
 
@@ -6421,7 +6949,7 @@ snapshots:
   '@babel/helpers@7.24.8':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.24.9
+      '@babel/types': 7.27.0
 
   '@babel/highlight@7.23.4':
     dependencies:
@@ -6442,12 +6970,11 @@ snapshots:
 
   '@babel/parser@7.24.8':
     dependencies:
-      '@babel/types': 7.24.9
+      '@babel/types': 7.27.0
 
   '@babel/parser@7.27.0':
     dependencies:
       '@babel/types': 7.27.0
-    optional: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7(@babel/core@7.24.9)':
     dependencies:
@@ -7011,8 +7538,8 @@ snapshots:
   '@babel/template@7.24.7':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
 
   '@babel/traverse@7.23.9':
     dependencies:
@@ -7037,8 +7564,8 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.9
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -7060,7 +7587,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-    optional: true
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@csstools/cascade-layer-name-parser@2.0.0(@csstools/css-parser-algorithms@3.0.0(@csstools/css-tokenizer@3.0.0))(@csstools/css-tokenizer@3.0.0)':
     dependencies:
@@ -7302,10 +7830,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7401,6 +7929,84 @@ snapshots:
 
   '@emotion/weak-memoize@0.3.1': {}
 
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
+    optional: true
+
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
       eslint: 8.56.0
@@ -7494,6 +8100,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@istanbuljs/schema@0.1.3': {}
+
   '@jdion/tilt-react@1.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@types/react': 18.3.3
@@ -7518,7 +8126,6 @@ snapshots:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
-    optional: true
 
   '@jridgewell/resolve-uri@3.1.1': {}
 
@@ -7543,6 +8150,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.4.15
 
   '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -8524,6 +9136,72 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
   '@rushstack/eslint-patch@1.6.1': {}
 
   '@scure/base@1.1.5': {}
@@ -8668,6 +9346,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.5
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -8696,16 +9378,18 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/draco3d@1.4.10': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.12
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   '@types/eslint@8.56.12':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/eslint@8.56.2':
@@ -8721,7 +9405,7 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
-  '@types/estree@1.0.7': {}
+  '@types/estree@1.0.8': {}
 
   '@types/google-one-tap@1.2.6': {}
 
@@ -8747,13 +9431,9 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@20.14.15':
+  '@types/node@20.19.17':
     dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@20.17.30':
-    dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.21.0
 
   '@types/offscreencanvas@2019.7.3': {}
 
@@ -8804,7 +9484,7 @@ snapshots:
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 20.14.15
+      '@types/node': 20.19.17
 
   '@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4)':
     dependencies:
@@ -8853,19 +9533,80 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.5
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.4.35':
     dependencies:
@@ -8891,7 +9632,7 @@ snapshots:
       '@vue/shared': 3.4.35
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
     optional: true
 
@@ -9148,7 +9889,15 @@ snapshots:
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
+
+  ast-v8-to-istanbul@0.3.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   astring@1.8.6: {}
 
@@ -9327,6 +10076,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -9359,6 +10110,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9383,6 +10142,8 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -9423,7 +10184,7 @@ snapshots:
   code-red@1.0.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -9582,6 +10343,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.0.2:
@@ -9591,6 +10356,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -9780,7 +10547,7 @@ snapshots:
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
 
-  es-module-lexer@1.6.0: {}
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -9802,6 +10569,35 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
@@ -9815,8 +10611,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +10634,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +10651,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +10672,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10065,6 +10861,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  expect-type@1.2.2: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@2.0.1: {}
@@ -10096,6 +10894,10 @@ snapshots:
   fault@1.0.4:
     dependencies:
       format: 0.2.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fflate@0.6.10: {}
 
@@ -10447,6 +11249,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-escaper@2.0.2: {}
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -10610,7 +11414,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
     optional: true
 
   is-regex@1.1.4:
@@ -10657,6 +11461,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.2:
     dependencies:
       define-properties: 1.2.1
@@ -10695,7 +11520,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -10714,6 +11539,8 @@ snapshots:
   js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -10829,6 +11656,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -10858,7 +11687,16 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.6.2
 
   markdown-extensions@2.0.0: {}
 
@@ -11239,8 +12077,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -11252,13 +12089,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +12105,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11437,6 +12274,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   peberminta@0.9.0: {}
 
   periscopic@3.1.0:
@@ -11449,10 +12290,11 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -11712,7 +12554,7 @@ snapshots:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.1
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   postcss@8.4.32:
     dependencies:
@@ -11720,12 +12562,11 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  postcss@8.5.3:
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   potpack@1.0.2: {}
 
@@ -12063,6 +12904,34 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12183,6 +13052,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -12210,10 +13081,7 @@ snapshots:
 
   source-map-js@1.0.2: {}
 
-  source-map-js@1.2.0: {}
-
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -12236,12 +13104,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
     dependencies:
       '@types/three': 0.176.0
       three: 0.160.0
 
   stats.js@0.17.0: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -12326,6 +13198,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -12334,12 +13210,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 
@@ -12375,8 +13251,8 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
-      '@types/estree': 1.0.7
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -12466,7 +13342,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.14(webpack@5.93.0):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
@@ -12486,6 +13362,12 @@ snapshots:
       acorn: 8.14.1
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
 
   text-decoder@1.1.1:
     dependencies:
@@ -12518,6 +13400,21 @@ snapshots:
   three@0.160.0: {}
 
   tiny-invariant@1.3.1: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-fast-properties@2.0.0: {}
 
@@ -12615,9 +13512,7 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  undici-types@5.26.5: {}
-
-  undici-types@6.19.8: {}
+  undici-types@6.21.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -12784,6 +13679,83 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.17
+      fsevents: 2.3.3
+      jiti: 1.21.0
+      terser: 5.39.0
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+      vite-node: 3.2.4(@types/node@20.19.17)(jiti@1.21.0)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
@@ -12818,7 +13790,7 @@ snapshots:
   webpack@5.93.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
@@ -12827,7 +13799,7 @@ snapshots:
       browserslist: 4.23.3
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
+      es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -12898,6 +13870,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workbox-background-sync@7.1.0:
     dependencies:

--- a/supabase/migrations/20250719_messages_overhaul.sql
+++ b/supabase/migrations/20250719_messages_overhaul.sql
@@ -1,0 +1,448 @@
+create extension if not exists "pgcrypto";
+
+drop table if exists public.chat cascade;
+
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'tenant_role') then
+    create type public.tenant_role as enum ('tenant', 'roommate', 'property_manager', 'admin');
+  end if;
+end $$;
+
+create table if not exists public.buildings (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.units (
+  id uuid primary key default gen_random_uuid(),
+  building_id uuid not null references public.buildings(id) on delete cascade,
+  name text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint units_unique_name_per_building unique (building_id, lower(name))
+);
+
+alter table public.profiles
+  add column if not exists building_id uuid references public.buildings(id) on delete set null,
+  add column if not exists unit_id uuid references public.units(id) on delete set null;
+
+alter table public.profiles
+  alter column role drop default;
+
+update public.profiles set role = 'tenant' where role is null or role = 'user';
+
+alter table public.profiles
+  alter column role type public.tenant_role using (role::text::public.tenant_role),
+  alter column role set default 'tenant';
+
+create table public.threads (
+  id uuid primary key default gen_random_uuid(),
+  building_id uuid not null references public.buildings(id) on delete cascade,
+  unit_id uuid references public.units(id) on delete set null,
+  title text not null,
+  created_by uuid not null references public.profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_message_at timestamptz not null default now(),
+  pinned_message_id uuid,
+  pinned_by uuid references public.profiles(id) on delete set null,
+  pinned_at timestamptz,
+  metadata jsonb default '{}'::jsonb
+);
+
+create table public.messages (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null references public.threads(id) on delete cascade,
+  parent_message_id uuid references public.messages(id) on delete cascade,
+  building_id uuid not null references public.buildings(id) on delete cascade,
+  unit_id uuid references public.units(id) on delete set null,
+  author_id uuid not null references public.profiles(id) on delete cascade,
+  content text not null,
+  message_type text not null default 'text',
+  metadata jsonb default '{}'::jsonb,
+  status text not null default 'active',
+  client_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+alter table public.messages add constraint messages_message_type_check check (message_type in ('text', 'poll', 'system'));
+alter table public.messages add constraint messages_status_check check (status in ('active', 'flagged', 'deleted'));
+
+alter table public.threads
+  add constraint threads_pinned_message_fkey foreign key (pinned_message_id) references public.messages(id) on delete set null;
+
+create table public.message_reactions (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.messages(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  building_id uuid not null references public.buildings(id) on delete cascade,
+  unit_id uuid references public.units(id) on delete set null,
+  reaction text not null,
+  created_at timestamptz not null default now(),
+  constraint message_reactions_unique unique (message_id, profile_id, reaction)
+);
+
+create table public.message_moderation (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.messages(id) on delete cascade,
+  thread_id uuid not null references public.threads(id) on delete cascade,
+  building_id uuid not null references public.buildings(id) on delete cascade,
+  action text not null,
+  reason text,
+  performed_by uuid references public.profiles(id) on delete set null,
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint message_moderation_action_check check (action in ('pin', 'unpin', 'flag', 'unflag', 'delete', 'restore'))
+);
+
+create or replace function public.set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create or replace function public.messages_set_scope()
+returns trigger as $$
+declare
+  thread_record record;
+begin
+  select building_id, unit_id into thread_record from public.threads where id = new.thread_id;
+  if not found then
+    raise exception 'Thread % does not exist', new.thread_id;
+  end if;
+  new.building_id := thread_record.building_id;
+  if thread_record.unit_id is not null then
+    if new.unit_id is not null and new.unit_id <> thread_record.unit_id then
+      raise exception 'Message unit mismatch for thread %', new.thread_id;
+    end if;
+    new.unit_id := thread_record.unit_id;
+  else
+    new.unit_id := null;
+  end if;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create or replace function public.message_reactions_set_scope()
+returns trigger as $$
+declare
+  message_record record;
+begin
+  select building_id, unit_id into message_record from public.messages where id = new.message_id;
+  if not found then
+    raise exception 'Message % does not exist', new.message_id;
+  end if;
+  new.building_id := message_record.building_id;
+  new.unit_id := message_record.unit_id;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create or replace function public.message_moderation_set_scope()
+returns trigger as $$
+declare
+  message_record record;
+begin
+  select thread_id, building_id, unit_id into message_record from public.messages where id = new.message_id;
+  if not found then
+    raise exception 'Message % does not exist', new.message_id;
+  end if;
+  new.thread_id := coalesce(new.thread_id, message_record.thread_id);
+  new.building_id := message_record.building_id;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create or replace function public.touch_thread_after_message()
+returns trigger as $$
+declare
+  target uuid;
+  reference_time timestamptz;
+begin
+  target := coalesce(new.thread_id, old.thread_id);
+  reference_time := coalesce(new.created_at, old.created_at, now());
+  update public.threads
+     set last_message_at = greatest(reference_time, last_message_at),
+         updated_at = now()
+   where id = target;
+  return coalesce(new, old);
+end;
+$$ language plpgsql security definer;
+
+create or replace function public.unpin_on_message_removal()
+returns trigger as $$
+declare
+  message_id uuid;
+begin
+  message_id := coalesce(new.id, old.id);
+  update public.threads
+     set pinned_message_id = null,
+         pinned_by = null,
+         pinned_at = null
+   where pinned_message_id = message_id
+     and (tg_op = 'DELETE' or new.status = 'deleted');
+  return coalesce(new, old);
+end;
+$$ language plpgsql security definer;
+
+create trigger set_timestamp_threads before update on public.threads
+for each row execute function public.set_updated_at();
+
+create trigger set_timestamp_messages before update on public.messages
+for each row execute function public.set_updated_at();
+
+create trigger messages_scope before insert on public.messages
+for each row execute function public.messages_set_scope();
+
+create trigger message_reactions_scope before insert on public.message_reactions
+for each row execute function public.message_reactions_set_scope();
+
+create trigger message_moderation_scope before insert on public.message_moderation
+for each row execute function public.message_moderation_set_scope();
+
+create trigger touch_thread_after_message_insert after insert on public.messages
+for each row execute function public.touch_thread_after_message();
+
+create trigger touch_thread_after_message_update after update on public.messages
+for each row execute function public.touch_thread_after_message();
+
+create trigger touch_thread_after_message_delete after delete on public.messages
+for each row execute function public.touch_thread_after_message();
+
+create trigger unpin_on_message_update after update on public.messages
+for each row execute function public.unpin_on_message_removal();
+
+create trigger unpin_on_message_delete after delete on public.messages
+for each row execute function public.unpin_on_message_removal();
+
+alter table public.buildings enable row level security;
+alter table public.units enable row level security;
+alter table public.threads enable row level security;
+alter table public.messages enable row level security;
+alter table public.message_reactions enable row level security;
+alter table public.message_moderation enable row level security;
+
+create policy "Tenants can read their building" on public.buildings
+for select using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = buildings.id
+  )
+);
+
+create policy "Staff manage buildings" on public.buildings
+for insert with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('property_manager', 'admin')
+  )
+);
+
+create policy "Tenants can read their units" on public.units
+for select using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = units.building_id
+      and (p.role in ('property_manager', 'admin') or p.unit_id = units.id)
+  )
+);
+
+create policy "Staff manage units" on public.units
+for insert with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.role in ('property_manager', 'admin')
+  )
+);
+
+create policy "View threads in building" on public.threads
+for select using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = threads.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or threads.unit_id is null
+        or p.unit_id = threads.unit_id
+      )
+  )
+);
+
+create policy "Create threads" on public.threads
+for insert with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = threads.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or p.unit_id = threads.unit_id
+        or threads.unit_id is null
+      )
+  )
+);
+
+create policy "Update threads" on public.threads
+for update using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = threads.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or threads.created_by = p.id
+      )
+  )
+) with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = threads.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or threads.created_by = p.id
+      )
+  )
+);
+
+create policy "Delete threads" on public.threads
+for delete using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = threads.building_id
+      and p.role in ('property_manager', 'admin')
+  )
+);
+
+create policy "View messages" on public.messages
+for select using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = messages.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or messages.unit_id is null
+        or p.unit_id = messages.unit_id
+      )
+  )
+);
+
+create policy "Create messages" on public.messages
+for insert with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = messages.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or p.unit_id = messages.unit_id
+        or messages.unit_id is null
+      )
+  )
+);
+
+create policy "Update messages" on public.messages
+for update using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = messages.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or messages.author_id = p.id
+      )
+  )
+) with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = messages.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or messages.author_id = p.id
+      )
+  )
+);
+
+create policy "Delete messages" on public.messages
+for delete using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = messages.building_id
+      and p.role in ('property_manager', 'admin')
+  )
+);
+
+create policy "View reactions" on public.message_reactions
+for select using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = message_reactions.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or message_reactions.unit_id is null
+        or p.unit_id = message_reactions.unit_id
+      )
+  )
+);
+
+create policy "React to messages" on public.message_reactions
+for insert with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = message_reactions.building_id
+      and (
+        p.role in ('property_manager', 'admin')
+        or message_reactions.unit_id is null
+        or p.unit_id = message_reactions.unit_id
+      )
+  )
+);
+
+create policy "Remove reactions" on public.message_reactions
+for delete using (
+  message_reactions.profile_id = auth.uid()
+);
+
+create policy "View moderation" on public.message_moderation
+for select using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = message_moderation.building_id
+  )
+);
+
+create policy "Moderate messages" on public.message_moderation
+for insert with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and p.building_id = message_moderation.building_id
+      and p.role in ('property_manager', 'admin')
+  )
+);
+
+create index if not exists threads_building_idx on public.threads (building_id, unit_id, last_message_at desc);
+create index if not exists threads_created_by_idx on public.threads (created_by);
+create index if not exists messages_thread_idx on public.messages (thread_id, created_at);
+create index if not exists messages_author_idx on public.messages (author_id);
+create index if not exists message_reactions_message_idx on public.message_reactions (message_id);
+create index if not exists message_moderation_message_idx on public.message_moderation (message_id);

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -1,0 +1,41 @@
+import type { Database } from "@/lib/supabase"
+
+export type TenantRole = Database["public"]["Enums"]["tenant_role"]
+export type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"]
+export type ThreadRow = Database["public"]["Tables"]["threads"]["Row"]
+export type MessageRow = Database["public"]["Tables"]["messages"]["Row"]
+export type MessageReactionRow = Database["public"]["Tables"]["message_reactions"]["Row"]
+export type MessageModerationRow = Database["public"]["Tables"]["message_moderation"]["Row"]
+
+export type ProfileSummary = Pick<
+  ProfileRow,
+  "id" | "full_name" | "avatar_url" | "role" | "building_id" | "unit_id"
+>
+
+export type ReactionWithProfile = MessageReactionRow & {
+  profile?: ProfileSummary | null
+}
+
+export type ModerationWithProfile = MessageModerationRow & {
+  performed_by_profile?: ProfileSummary | null
+}
+
+export type MessageWithRelations = MessageRow & {
+  author?: ProfileSummary | null
+  reactions: ReactionWithProfile[]
+  moderation: ModerationWithProfile[]
+}
+
+export type ThreadWithRelations = ThreadRow & {
+  created_by_profile?: ProfileSummary | null
+  pinned_by_profile?: ProfileSummary | null
+  unit?: { id: string; name: string } | null
+  building?: { id: string; name: string } | null
+  messages: MessageWithRelations[]
+}
+
+export type PollMetadata = {
+  poll_options?: { id: string; label: string }[]
+  poll_votes?: Record<string, string[]>
+  [key: string]: unknown
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config"
+import { fileURLToPath } from "node:url"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./", import.meta.url)),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- replace the legacy `chat` table with normalized `threads`, `messages`, `message_reactions`, and `message_moderation` tables, triggers, and RLS policies scoped by building and unit
- add typed message/thread models plus server actions that handle posting, polls, reactions, and moderation backed by Supabase permissions
- build the dashboard message board with realtime subscriptions, optimistic/offline handling, threaded replies, polls, reactions, and moderation controls while wiring notifications into the global feed
- configure Vitest and add unit tests covering realtime merge helpers and moderation permissions

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d04ceeb6388328a87583dcf9528d9b