### PR TITLE
feat: rebuild supabase tenancy schema

### DIFF
--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -1,14 +1,46 @@
-import { EmailTemplate } from "@/components/email-template";
-import { Resend } from 'resend';
+import { headers } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { EmailTemplate } from '@/components/email-template'
+import type { Database } from '@/lib/supabase'
+import { assertTenantAccess, createSupbaseServerClient } from '@/utils/supaone'
+import { Resend } from 'resend'
+
+const ALLOWED_ROLES: Database['public']['Enums']['user_role_type'][] = [
+  'platform_admin',
+  'property_manager',
+  'building_staff',
+]
 
 export async function POST() {
-  const resendApiKey = process.env.RESEND_API_KEY;
+  const resendApiKey = process.env.RESEND_API_KEY
 
   if (!resendApiKey) {
-    return Response.json({ error: "Resend API key is not configured." }, { status: 500 });
+    return NextResponse.json(
+      { error: 'Resend API key is not configured.' },
+      { status: 500 }
+    )
   }
 
-  const resend = new Resend(resendApiKey);
+  const headerStore = headers()
+  const buildingId = headerStore.get('x-building-id') ?? headerStore.get('X-Building-Id')
+
+  if (!buildingId) {
+    return NextResponse.json(
+      { error: 'X-Building-Id header is required for messaging actions.' },
+      { status: 400 }
+    )
+  }
+
+  const supabase = await createSupbaseServerClient()
+
+  try {
+    await assertTenantAccess(supabase, buildingId, ALLOWED_ROLES)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unauthorized'
+    return NextResponse.json({ error: message }, { status: 403 })
+  }
+
+  const resend = new Resend(resendApiKey)
 
   try {
     const { data, error } = await resend.emails.send({
@@ -16,25 +48,22 @@ export async function POST() {
       to: ['delivered@resend.dev'],
       subject: 'Hello world',
       react: EmailTemplate({ firstName: 'John' }),
-    });
+    })
 
     if (error) {
-      // Type guard to ensure 'error' is an Error object
       if (error instanceof Error) {
-        return Response.json({ error: error.message }, { status: 500 });
-      } else {
-        // Handle cases where 'error' is not an Error object (e.g., a string or object)
-        return Response.json({ error: String(error) }, { status: 500 });
+        return NextResponse.json({ error: error.message }, { status: 500 })
       }
+
+      return NextResponse.json({ error: String(error) }, { status: 500 })
     }
 
-    return Response.json(data);
+    return NextResponse.json(data)
   } catch (error) {
-    // Type guard for the catch block 'error' as well.
     if (error instanceof Error) {
-      return Response.json({ error: error.message }, { status: 500 });
-    } else {
-      return Response.json({ error: String(error) }, { status: 500 });
+      return NextResponse.json({ error: error.message }, { status: 500 })
     }
+
+    return NextResponse.json({ error: String(error) }, { status: 500 })
   }
 }

--- a/app/countries/[id]/page.tsx
+++ b/app/countries/[id]/page.tsx
@@ -4,10 +4,10 @@ import useSupabaseBrowser from '@/utils/supabase-browser'
 import { getCountryById } from '@/queries/country-by-id'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 
-export default function CountryPage({ params }: { params: { id: number } }) {
+export default function CountryPage({ params }: { params: { id: string } }) {
   const supabase = useSupabaseBrowser()
   const {
-    data: country,
+    data: building,
     isLoading,
     isError,
   } = useQuery(getCountryById(supabase, params.id))
@@ -16,13 +16,27 @@ export default function CountryPage({ params }: { params: { id: number } }) {
     return <div>Loading...</div>
   }
 
-  if (isError || !country) {
+  if (isError || !building) {
     return <div>Error</div>
   }
 
   return (
     <div>
-      <h1>{country.name}</h1>
+      <h1>{building.name}</h1>
+      <dl>
+        <div>
+          <dt className="font-medium">Code</dt>
+          <dd>{building.code}</dd>
+        </div>
+        <div>
+          <dt className="font-medium">Timezone</dt>
+          <dd>{building.timezone}</dd>
+        </div>
+        <div>
+          <dt className="font-medium">Status</dt>
+          <dd>{building.is_active ? 'Active' : 'Inactive'}</dd>
+        </div>
+      </dl>
     </div>
   )
 }

--- a/app/ssrcountries/[id]/country.tsx
+++ b/app/ssrcountries/[id]/country.tsx
@@ -5,15 +5,15 @@ import useSupabaseBrowser from '@/utils/supabase-browser'
 import { getCountryById } from '@/queries/country-by-id'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 
-export default function Country({ id }: { id: number }) {
+export default function Country({ id }: { id: string }) {
   const supabase = useSupabaseBrowser()
   // This useQuery could just as well happen in some deeper
   // child to <Posts>, data will be available immediately either way
-  const { data: country } = useQuery(getCountryById(supabase, id))
+  const { data: building } = useQuery(getCountryById(supabase, id))
 
   return (
     <div>
-      <h1>SSR: {country?.name}</h1>
+      <h1>SSR: {building?.name}</h1>
     </div>
   )
 }

--- a/app/ssrcountries/[id]/page.tsx
+++ b/app/ssrcountries/[id]/page.tsx
@@ -5,7 +5,7 @@ import { cookies } from 'next/headers'
 import Country from './country'
 import { getCountryById } from '@/queries/country-by-id'
 
-export default async function CountryPage({ params }: { params: { id: number } }) {
+export default async function CountryPage({ params }: { params: { id: string } }) {
   const queryClient = new QueryClient()
   const cookieStore = cookies()
   const supabase = await useSupabaseServer(cookieStore)

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -183,1598 +183,992 @@ export type Database = {
   }
   public: {
     Tables: {
-      ai_agents: {
+      amenities: {
         Row: {
-          created_at: string | null
-          description: string | null
           id: string
-          is_active: boolean | null
-          max_tokens: number | null
-          model_id: string | null
+          building_id: string
+          slug: string
           name: string
-          parameters: Json | null
-          system_prompt: string | null
-          temperature: number | null
-          tools: Json | null
-          updated_at: string | null
-          user_id: string
-        }
-        Insert: {
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean | null
-          max_tokens?: number | null
-          model_id?: string | null
-          name: string
-          parameters?: Json | null
-          system_prompt?: string | null
-          temperature?: number | null
-          tools?: Json | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Update: {
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean | null
-          max_tokens?: number | null
-          model_id?: string | null
-          name?: string
-          parameters?: Json | null
-          system_prompt?: string | null
-          temperature?: number | null
-          tools?: Json | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "ai_agents_model_id_fkey"
-            columns: ["model_id"]
-            isOneToOne: false
-            referencedRelation: "ai_models"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      ai_analysis_results: {
-        Row: {
-          agent_id: string | null
-          analysis_type: string
+          description: string | null
+          location: string | null
+          is_bookable: boolean
+          calcom_event_type_id: string | null
+          open_time: string | null
+          close_time: string | null
           created_at: string
-          id: string
-          metadata: Json | null
-          results: Json
-          source_id: string
-          source_type: string
-          user_id: string | null
-        }
-        Insert: {
-          agent_id?: string | null
-          analysis_type: string
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          results: Json
-          source_id: string
-          source_type: string
-          user_id?: string | null
-        }
-        Update: {
-          agent_id?: string | null
-          analysis_type?: string
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          results?: Json
-          source_id?: string
-          source_type?: string
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "ai_analysis_results_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "ai_agents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      ai_models: {
-        Row: {
-          capabilities: Json | null
-          cost_per_1k_tokens: number | null
-          created_at: string | null
-          description: string | null
-          id: string
-          is_active: boolean | null
-          model_id: string
-          name: string
-          parameters: Json | null
-          provider: string
-          updated_at: string | null
-        }
-        Insert: {
-          capabilities?: Json | null
-          cost_per_1k_tokens?: number | null
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean | null
-          model_id: string
-          name: string
-          parameters?: Json | null
-          provider: string
-          updated_at?: string | null
-        }
-        Update: {
-          capabilities?: Json | null
-          cost_per_1k_tokens?: number | null
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean | null
-          model_id?: string
-          name?: string
-          parameters?: Json | null
-          provider?: string
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
-      ai_workflow_runs: {
-        Row: {
-          created_at: string | null
-          end_time: string | null
-          error: string | null
-          id: string
-          results: Json | null
-          start_time: string | null
-          status: string | null
-          updated_at: string | null
-          user_id: string
-          workflow_id: string | null
-        }
-        Insert: {
-          created_at?: string | null
-          end_time?: string | null
-          error?: string | null
-          id?: string
-          results?: Json | null
-          start_time?: string | null
-          status?: string | null
-          updated_at?: string | null
-          user_id?: string
-          workflow_id?: string | null
-        }
-        Update: {
-          created_at?: string | null
-          end_time?: string | null
-          error?: string | null
-          id?: string
-          results?: Json | null
-          start_time?: string | null
-          status?: string | null
-          updated_at?: string | null
-          user_id?: string
-          workflow_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "ai_workflow_runs_workflow_id_fkey"
-            columns: ["workflow_id"]
-            isOneToOne: false
-            referencedRelation: "ai_workflows"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      ai_workflows: {
-        Row: {
-          created_at: string | null
-          description: string | null
-          id: string
-          is_active: boolean | null
-          name: string
-          steps: Json
-          trigger_config: Json | null
-          trigger_type: string | null
-          updated_at: string | null
-          user_id: string
-        }
-        Insert: {
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean | null
-          name: string
-          steps: Json
-          trigger_config?: Json | null
-          trigger_type?: string | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Update: {
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean | null
-          name?: string
-          steps?: Json
-          trigger_config?: Json | null
-          trigger_type?: string | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Relationships: []
-      }
-      business_cards: {
-        Row: {
-          businesscard_name: string | null
-          company_name: string | null
-          created_at: string
-          id: string
-          public_access: boolean | null
-          public_id: string | null
-          style: Json | null
           updated_at: string
-          user_id: string
-          website: string | null
         }
         Insert: {
-          businesscard_name?: string | null
-          company_name?: string | null
-          created_at?: string
           id?: string
-          public_access?: boolean | null
-          public_id?: string | null
-          style?: Json | null
+          building_id: string
+          slug: string
+          name: string
+          description?: string | null
+          location?: string | null
+          is_bookable?: boolean
+          calcom_event_type_id?: string | null
+          open_time?: string | null
+          close_time?: string | null
+          created_at?: string
           updated_at?: string
-          user_id: string
-          website?: string | null
         }
         Update: {
-          businesscard_name?: string | null
-          company_name?: string | null
-          created_at?: string
           id?: string
-          public_access?: boolean | null
-          public_id?: string | null
-          style?: Json | null
+          building_id?: string
+          slug?: string
+          name?: string
+          description?: string | null
+          location?: string | null
+          is_bookable?: boolean
+          calcom_event_type_id?: string | null
+          open_time?: string | null
+          close_time?: string | null
+          created_at?: string
           updated_at?: string
-          user_id?: string
-          website?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'amenities_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      amenity_bookings: {
+        Row: {
+          id: string
+          building_id: string
+          amenity_id: string
+          lease_id: string | null
+          booked_by: string
+          status: Database['public']['Enums']['booking_status']
+          starts_at: string
+          ends_at: string
+          notes: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          building_id: string
+          amenity_id: string
+          lease_id?: string | null
+          booked_by: string
+          status?: Database['public']['Enums']['booking_status']
+          starts_at: string
+          ends_at: string
+          notes?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          building_id?: string
+          amenity_id?: string
+          lease_id?: string | null
+          booked_by?: string
+          status?: Database['public']['Enums']['booking_status']
+          starts_at?: string
+          ends_at?: string
+          notes?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'amenity_bookings_amenity_fk'
+            columns: ['building_id', 'amenity_id']
+            isOneToOne: false
+            referencedRelation: 'amenities'
+            referencedColumns: ['building_id', 'id']
+          },
+          {
+            foreignKeyName: 'amenity_bookings_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'amenity_bookings_lease_fk'
+            columns: ['building_id', 'lease_id']
+            isOneToOne: false
+            referencedRelation: 'leases'
+            referencedColumns: ['building_id', 'id']
+          },
+          {
+            foreignKeyName: 'amenity_bookings_booked_by_fkey'
+            columns: ['booked_by']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      buildings: {
+        Row: {
+          id: string
+          name: string
+          code: string
+          address_line1: string
+          address_line2: string | null
+          city: string | null
+          state: string | null
+          postal_code: string | null
+          country: string | null
+          timezone: string
+          is_active: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          name: string
+          code: string
+          address_line1: string
+          address_line2?: string | null
+          city?: string | null
+          state?: string | null
+          postal_code?: string | null
+          country?: string | null
+          timezone?: string
+          is_active?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          name?: string
+          code?: string
+          address_line1?: string
+          address_line2?: string | null
+          city?: string | null
+          state?: string | null
+          postal_code?: string | null
+          country?: string | null
+          timezone?: string
+          is_active?: boolean
+          created_at?: string
+          updated_at?: string
         }
         Relationships: []
       }
-      chat: {
+      documents: {
         Row: {
+          id: string
+          building_id: string
+          lease_id: string | null
+          uploaded_by: string
+          category: Database['public']['Enums']['document_category']
+          title: string
+          storage_path: string
+          version: number
+          metadata: Json
           created_at: string
+        }
+        Insert: {
+          id?: string
+          building_id: string
+          lease_id?: string | null
+          uploaded_by: string
+          category?: Database['public']['Enums']['document_category']
+          title: string
+          storage_path: string
+          version?: number
+          metadata?: Json
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          building_id?: string
+          lease_id?: string | null
+          uploaded_by?: string
+          category?: Database['public']['Enums']['document_category']
+          title?: string
+          storage_path?: string
+          version?: number
+          metadata?: Json
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'documents_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'documents_lease_fk'
+            columns: ['building_id', 'lease_id']
+            isOneToOne: false
+            referencedRelation: 'leases'
+            referencedColumns: ['building_id', 'id']
+          },
+          {
+            foreignKeyName: 'documents_uploaded_by_fkey'
+            columns: ['uploaded_by']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      floorplan_annotations: {
+        Row: {
+          id: string
+          building_id: string
+          floorplan_id: string
+          created_by: string
+          label: string
+          payload: Json
+          visibility: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          building_id: string
+          floorplan_id: string
+          created_by: string
+          label: string
+          payload: Json
+          visibility?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          building_id?: string
+          floorplan_id?: string
+          created_by?: string
+          label?: string
+          payload?: Json
+          visibility?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'floorplan_annotations_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'floorplan_annotations_floorplan_fk'
+            columns: ['building_id', 'floorplan_id']
+            isOneToOne: false
+            referencedRelation: 'floorplans'
+            referencedColumns: ['building_id', 'id']
+          },
+          {
+            foreignKeyName: 'floorplan_annotations_created_by_fkey'
+            columns: ['created_by']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      floorplans: {
+        Row: {
+          id: string
+          building_id: string
+          unit_id: string | null
+          name: string
+          storage_path: string
+          version: number
+          uploaded_by: string | null
+          uploaded_at: string
+          is_active: boolean
+        }
+        Insert: {
+          id?: string
+          building_id: string
+          unit_id?: string | null
+          name: string
+          storage_path: string
+          version?: number
+          uploaded_by?: string | null
+          uploaded_at?: string
+          is_active?: boolean
+        }
+        Update: {
+          id?: string
+          building_id?: string
+          unit_id?: string | null
+          name?: string
+          storage_path?: string
+          version?: number
+          uploaded_by?: string | null
+          uploaded_at?: string
+          is_active?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'floorplans_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'floorplans_unit_id_fkey'
+            columns: ['unit_id']
+            isOneToOne: false
+            referencedRelation: 'units'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'floorplans_uploaded_by_fkey'
+            columns: ['uploaded_by']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      lease_tenants: {
+        Row: {
           id: number
-          messages: string[] | null
-          path: string | null
-          profile_id: string
-          sharepath: string | null
-          title: string | null
-          user_id: string | null
+          building_id: string
+          lease_id: string
+          tenant_id: string
+          rent_share: number | null
+          joined_at: string
         }
         Insert: {
+          id?: number
+          building_id: string
+          lease_id: string
+          tenant_id: string
+          rent_share?: number | null
+          joined_at?: string
+        }
+        Update: {
+          id?: number
+          building_id?: string
+          lease_id?: string
+          tenant_id?: string
+          rent_share?: number | null
+          joined_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'lease_tenants_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'lease_tenants_lease_fk'
+            columns: ['building_id', 'lease_id']
+            isOneToOne: false
+            referencedRelation: 'leases'
+            referencedColumns: ['building_id', 'id']
+          },
+          {
+            foreignKeyName: 'lease_tenants_tenant_id_fkey'
+            columns: ['tenant_id']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      leases: {
+        Row: {
+          id: string
+          building_id: string
+          unit_id: string
+          primary_tenant_id: string
+          status: Database['public']['Enums']['lease_status']
+          start_date: string
+          end_date: string | null
+          rent_amount: number
+          security_deposit: number | null
+          billing_cycle_day: number
+          stripe_customer_id: string | null
+          notes: string | null
           created_at: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
-          profile_id: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
+          updated_at: string
         }
-        Update: {
+        Insert: {
+          id?: string
+          building_id: string
+          unit_id: string
+          primary_tenant_id: string
+          status?: Database['public']['Enums']['lease_status']
+          start_date: string
+          end_date?: string | null
+          rent_amount: number
+          security_deposit?: number | null
+          billing_cycle_day?: number
+          stripe_customer_id?: string | null
+          notes?: string | null
           created_at?: string
-          id?: number
-          messages?: string[] | null
-          path?: string | null
-          profile_id?: string
-          sharepath?: string | null
-          title?: string | null
-          user_id?: string | null
-        }
-        Relationships: []
-      }
-      countries: {
-        Row: {
-          continent: Database["public"]["Enums"]["continents"] | null
-          id: number
-          iso2: string
-          iso3: string | null
-          local_name: string | null
-          name: string | null
-        }
-        Insert: {
-          continent?: Database["public"]["Enums"]["continents"] | null
-          id?: number
-          iso2: string
-          iso3?: string | null
-          local_name?: string | null
-          name?: string | null
+          updated_at?: string
         }
         Update: {
-          continent?: Database["public"]["Enums"]["continents"] | null
-          id?: number
-          iso2?: string
-          iso3?: string | null
-          local_name?: string | null
-          name?: string | null
-        }
-        Relationships: []
-      }
-      crm_activities: {
-        Row: {
-          completed_date: string | null
-          connection_id: string | null
-          contact_id: string | null
-          created_at: string | null
-          custom_fields: Json | null
-          deal_id: string | null
-          description: string | null
-          due_date: string | null
-          external_id: string
-          id: string
-          priority: string | null
-          status: string | null
-          subject: string
-          type: string
-          updated_at: string | null
-          user_id: string
-        }
-        Insert: {
-          completed_date?: string | null
-          connection_id?: string | null
-          contact_id?: string | null
-          created_at?: string | null
-          custom_fields?: Json | null
-          deal_id?: string | null
-          description?: string | null
-          due_date?: string | null
-          external_id: string
           id?: string
-          priority?: string | null
-          status?: string | null
-          subject: string
-          type: string
-          updated_at?: string | null
-          user_id?: string
-        }
-        Update: {
-          completed_date?: string | null
-          connection_id?: string | null
-          contact_id?: string | null
-          created_at?: string | null
-          custom_fields?: Json | null
-          deal_id?: string | null
-          description?: string | null
-          due_date?: string | null
-          external_id?: string
-          id?: string
-          priority?: string | null
-          status?: string | null
-          subject?: string
-          type?: string
-          updated_at?: string | null
-          user_id?: string
+          building_id?: string
+          unit_id?: string
+          primary_tenant_id?: string
+          status?: Database['public']['Enums']['lease_status']
+          start_date?: string
+          end_date?: string | null
+          rent_amount?: number
+          security_deposit?: number | null
+          billing_cycle_day?: number
+          stripe_customer_id?: string | null
+          notes?: string | null
+          created_at?: string
+          updated_at?: string
         }
         Relationships: [
           {
-            foreignKeyName: "crm_activities_connection_id_fkey"
-            columns: ["connection_id"]
+            foreignKeyName: 'leases_building_id_fkey'
+            columns: ['building_id']
             isOneToOne: false
-            referencedRelation: "crm_connections"
-            referencedColumns: ["id"]
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "crm_activities_contact_id_fkey"
-            columns: ["contact_id"]
+            foreignKeyName: 'leases_primary_tenant_id_fkey'
+            columns: ['primary_tenant_id']
             isOneToOne: false
-            referencedRelation: "crm_contacts"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "crm_activities_deal_id_fkey"
-            columns: ["deal_id"]
+            foreignKeyName: 'leases_unit_id_fkey'
+            columns: ['unit_id']
             isOneToOne: false
-            referencedRelation: "crm_deals"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "fk_connection"
-            columns: ["connection_id"]
-            isOneToOne: false
-            referencedRelation: "crm_connections"
-            referencedColumns: ["id"]
+            referencedRelation: 'units'
+            referencedColumns: ['id']
           },
         ]
       }
-      crm_connections: {
+      maintenance_requests: {
         Row: {
-          access_token: string | null
-          api_key: string | null
-          created_at: string | null
-          expires_at: string | null
           id: string
-          instance_url: string | null
-          is_active: boolean | null
-          last_sync_at: string | null
-          name: string
-          provider: string
-          refresh_token: string | null
-          updated_at: string | null
-          user_id: string
-        }
-        Insert: {
-          access_token?: string | null
-          api_key?: string | null
-          created_at?: string | null
-          expires_at?: string | null
-          id?: string
-          instance_url?: string | null
-          is_active?: boolean | null
-          last_sync_at?: string | null
-          name: string
-          provider: string
-          refresh_token?: string | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Update: {
-          access_token?: string | null
-          api_key?: string | null
-          created_at?: string | null
-          expires_at?: string | null
-          id?: string
-          instance_url?: string | null
-          is_active?: boolean | null
-          last_sync_at?: string | null
-          name?: string
-          provider?: string
-          refresh_token?: string | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Relationships: []
-      }
-      crm_contacts: {
-        Row: {
-          address: string | null
-          company: string | null
-          connection_id: string | null
-          created_at: string | null
-          custom_fields: Json | null
-          email: string | null
-          external_id: string
-          first_name: string | null
-          id: string
-          job_title: string | null
-          last_contacted: string | null
-          last_name: string | null
-          phone: string | null
-          status: string | null
-          tags: string[] | null
-          updated_at: string | null
-          user_id: string
-        }
-        Insert: {
-          address?: string | null
-          company?: string | null
-          connection_id?: string | null
-          created_at?: string | null
-          custom_fields?: Json | null
-          email?: string | null
-          external_id: string
-          first_name?: string | null
-          id?: string
-          job_title?: string | null
-          last_contacted?: string | null
-          last_name?: string | null
-          phone?: string | null
-          status?: string | null
-          tags?: string[] | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Update: {
-          address?: string | null
-          company?: string | null
-          connection_id?: string | null
-          created_at?: string | null
-          custom_fields?: Json | null
-          email?: string | null
-          external_id?: string
-          first_name?: string | null
-          id?: string
-          job_title?: string | null
-          last_contacted?: string | null
-          last_name?: string | null
-          phone?: string | null
-          status?: string | null
-          tags?: string[] | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "crm_contacts_connection_id_fkey"
-            columns: ["connection_id"]
-            isOneToOne: false
-            referencedRelation: "crm_connections"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "fk_connection"
-            columns: ["connection_id"]
-            isOneToOne: false
-            referencedRelation: "crm_connections"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      crm_data: {
-        Row: {
-          connection_id: string | null
-          created_at: string | null
-          data: Json
-          external_id: string
-          id: string
-          last_updated: string | null
-          record_type: string
-          user_id: string | null
-        }
-        Insert: {
-          connection_id?: string | null
-          created_at?: string | null
-          data: Json
-          external_id: string
-          id?: string
-          last_updated?: string | null
-          record_type: string
-          user_id?: string | null
-        }
-        Update: {
-          connection_id?: string | null
-          created_at?: string | null
-          data?: Json
-          external_id?: string
-          id?: string
-          last_updated?: string | null
-          record_type?: string
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "crm_data_connection_id_fkey"
-            columns: ["connection_id"]
-            isOneToOne: false
-            referencedRelation: "crm_connections"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      crm_deals: {
-        Row: {
-          amount: number | null
-          close_date: string | null
-          connection_id: string | null
-          contact_id: string | null
-          created_at: string | null
-          currency: string | null
-          custom_fields: Json | null
-          description: string | null
-          external_id: string
-          id: string
-          name: string
-          probability: number | null
-          stage: string | null
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          amount?: number | null
-          close_date?: string | null
-          connection_id?: string | null
-          contact_id?: string | null
-          created_at?: string | null
-          currency?: string | null
-          custom_fields?: Json | null
-          description?: string | null
-          external_id: string
-          id?: string
-          name: string
-          probability?: number | null
-          stage?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          amount?: number | null
-          close_date?: string | null
-          connection_id?: string | null
-          contact_id?: string | null
-          created_at?: string | null
-          currency?: string | null
-          custom_fields?: Json | null
-          description?: string | null
-          external_id?: string
-          id?: string
-          name?: string
-          probability?: number | null
-          stage?: string | null
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "crm_deals_connection_id_fkey"
-            columns: ["connection_id"]
-            isOneToOne: false
-            referencedRelation: "crm_connections"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "crm_deals_contact_id_fkey"
-            columns: ["contact_id"]
-            isOneToOne: false
-            referencedRelation: "crm_contacts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "fk_connection"
-            columns: ["connection_id"]
-            isOneToOne: false
-            referencedRelation: "crm_connections"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      data_embeddings: {
-        Row: {
-          created_at: string | null
-          description: string | null
-          embedding_model: string
-          id: string
-          metadata: Json | null
-          name: string
-          source_id: string | null
-          source_type: string
-          updated_at: string | null
-          user_id: string
-          vector_data: string | null
-        }
-        Insert: {
-          created_at?: string | null
-          description?: string | null
-          embedding_model: string
-          id?: string
-          metadata?: Json | null
-          name: string
-          source_id?: string | null
-          source_type: string
-          updated_at?: string | null
-          user_id?: string
-          vector_data?: string | null
-        }
-        Update: {
-          created_at?: string | null
-          description?: string | null
-          embedding_model?: string
-          id?: string
-          metadata?: Json | null
-          name?: string
-          source_id?: string | null
-          source_type?: string
-          updated_at?: string | null
-          user_id?: string
-          vector_data?: string | null
-        }
-        Relationships: []
-      }
-      developer_tools: {
-        Row: {
-          configuration: Json
-          created_at: string | null
-          description: string | null
-          id: string
-          is_active: boolean | null
-          name: string
-          tool_type: string
-          updated_at: string | null
-          user_id: string
-        }
-        Insert: {
-          configuration: Json
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean | null
-          name: string
-          tool_type: string
-          updated_at?: string | null
-          user_id?: string
-        }
-        Update: {
-          configuration?: Json
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean | null
-          name?: string
-          tool_type?: string
-          updated_at?: string | null
-          user_id?: string
-        }
-        Relationships: []
-      }
-      gpt_one: {
-        Row: {
-          created_at: string
-          email: string
-          id: string
-          messages: string | null
-          user_input: string | null
-          vector_one: string | null
-        }
-        Insert: {
-          created_at?: string
-          email?: string
-          id?: string
-          messages?: string | null
-          user_input?: string | null
-          vector_one?: string | null
-        }
-        Update: {
-          created_at?: string
-          email?: string
-          id?: string
-          messages?: string | null
-          user_input?: string | null
-          vector_one?: string | null
-        }
-        Relationships: []
-      }
-      inqueries: {
-        Row: {
-          created_at: string
-          email: string
-          id: number
-          message: string
-          name: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          email?: string
-          id?: number
-          message: string
-          name?: string
-          user_id?: string
-        }
-        Update: {
-          created_at?: string
-          email?: string
-          id?: number
-          message?: string
-          name?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      meetings: {
-        Row: {
-          created_at: string | null
-          description: string | null
-          end_time: string
-          id: string
-          meet_link: string
-          start_time: string
+          building_id: string
+          unit_id: string
+          lease_id: string | null
+          reported_by: string
+          assigned_to: string | null
+          status: Database['public']['Enums']['maintenance_status']
+          priority: Database['public']['Enums']['maintenance_priority']
+          category: string | null
           summary: string
-          updated_at: string | null
-          user_id: string
+          description: string | null
+          metadata: Json
+          requested_at: string
+          resolved_at: string | null
+          closed_at: string | null
         }
         Insert: {
-          created_at?: string | null
-          description?: string | null
-          end_time: string
           id?: string
-          meet_link: string
-          start_time: string
+          building_id: string
+          unit_id: string
+          lease_id?: string | null
+          reported_by: string
+          assigned_to?: string | null
+          status?: Database['public']['Enums']['maintenance_status']
+          priority?: Database['public']['Enums']['maintenance_priority']
+          category?: string | null
           summary: string
-          updated_at?: string | null
-          user_id?: string
+          description?: string | null
+          metadata?: Json
+          requested_at?: string
+          resolved_at?: string | null
+          closed_at?: string | null
         }
         Update: {
-          created_at?: string | null
-          description?: string | null
-          end_time?: string
           id?: string
-          meet_link?: string
-          start_time?: string
+          building_id?: string
+          unit_id?: string
+          lease_id?: string | null
+          reported_by?: string
+          assigned_to?: string | null
+          status?: Database['public']['Enums']['maintenance_status']
+          priority?: Database['public']['Enums']['maintenance_priority']
+          category?: string | null
           summary?: string
-          updated_at?: string | null
-          user_id?: string
-        }
-        Relationships: []
-      }
-      members_table: {
-        Row: {
-          created_at: string
-          email: string | null
-          id: number
-          member_id: string
-          name: string | null
-          password: string
-        }
-        Insert: {
-          created_at?: string
-          email?: string | null
-          id: number
-          member_id: string
-          name?: string | null
-          password?: string
-        }
-        Update: {
-          created_at?: string
-          email?: string | null
-          id?: number
-          member_id?: string
-          name?: string | null
-          password?: string
-        }
-        Relationships: []
-      }
-      moralis_users: {
-        Row: {
-          created_at: string
-          id: string
-          metadata: Json | null
-          moralis_provider: string | null
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          moralis_provider?: string | null
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          moralis_provider?: string | null
-        }
-        Relationships: []
-      }
-      nfts: {
-        Row: {
-          created_at: string
-          id: string
-          name: string | null
-          profile_id: string | null
-          token_id: string | null
-          tx_hash: string | null
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          name?: string | null
-          profile_id?: string | null
-          token_id?: string | null
-          tx_hash?: string | null
-          user_id?: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          name?: string | null
-          profile_id?: string | null
-          token_id?: string | null
-          tx_hash?: string | null
-          user_id?: string
+          description?: string | null
+          metadata?: Json
+          requested_at?: string
+          resolved_at?: string | null
+          closed_at?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "nfts_profile_id_fkey"
-            columns: ["profile_id"]
+            foreignKeyName: 'maintenance_requests_assigned_to_fkey'
+            columns: ['assigned_to']
             isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
-        ]
-      }
-      nods_page: {
-        Row: {
-          checksum: string | null
-          id: number
-          meta: Json | null
-          parent_page_id: number | null
-          path: string
-          source: string | null
-          type: string | null
-        }
-        Insert: {
-          checksum?: string | null
-          id?: number
-          meta?: Json | null
-          parent_page_id?: number | null
-          path: string
-          source?: string | null
-          type?: string | null
-        }
-        Update: {
-          checksum?: string | null
-          id?: number
-          meta?: Json | null
-          parent_page_id?: number | null
-          path?: string
-          source?: string | null
-          type?: string | null
-        }
-        Relationships: [
           {
-            foreignKeyName: "nods_page_parent_page_id_fkey"
-            columns: ["parent_page_id"]
+            foreignKeyName: 'maintenance_requests_building_id_fkey'
+            columns: ['building_id']
             isOneToOne: false
-            referencedRelation: "nods_page"
-            referencedColumns: ["id"]
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
           },
-        ]
-      }
-      nods_page_section: {
-        Row: {
-          content: string | null
-          embedding: string | null
-          heading: string | null
-          id: number
-          page_id: number
-          slug: string | null
-          token_count: number | null
-        }
-        Insert: {
-          content?: string | null
-          embedding?: string | null
-          heading?: string | null
-          id?: number
-          page_id: number
-          slug?: string | null
-          token_count?: number | null
-        }
-        Update: {
-          content?: string | null
-          embedding?: string | null
-          heading?: string | null
-          id?: number
-          page_id?: number
-          slug?: string | null
-          token_count?: number | null
-        }
-        Relationships: [
           {
-            foreignKeyName: "nods_page_section_page_id_fkey"
-            columns: ["page_id"]
+            foreignKeyName: 'maintenance_requests_lease_fk'
+            columns: ['building_id', 'lease_id']
             isOneToOne: false
-            referencedRelation: "nods_page"
-            referencedColumns: ["id"]
+            referencedRelation: 'leases'
+            referencedColumns: ['building_id', 'id']
+          },
+          {
+            foreignKeyName: 'maintenance_requests_reported_by_fkey'
+            columns: ['reported_by']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'maintenance_requests_unit_id_fkey'
+            columns: ['unit_id']
+            isOneToOne: false
+            referencedRelation: 'units'
+            referencedColumns: ['id']
           },
         ]
       }
-      packages: {
+      messages: {
         Row: {
-          created_at: string
-          description: string | null
           id: string
-          name: string
-          qr_code_url: string | null
-          status: string
-          type: string | null
+          building_id: string
+          thread_id: string
+          sender_id: string
+          body: string
+          attachments: Json
+          is_system: boolean
+          reply_to: string | null
+          created_at: string
           updated_at: string
-          user_id: string
         }
         Insert: {
-          created_at?: string
-          description?: string | null
           id?: string
-          name: string
-          qr_code_url?: string | null
-          status?: string
-          type?: string | null
+          building_id: string
+          thread_id: string
+          sender_id: string
+          body: string
+          attachments?: Json
+          is_system?: boolean
+          reply_to?: string | null
+          created_at?: string
           updated_at?: string
-          user_id: string
         }
         Update: {
-          created_at?: string
-          description?: string | null
           id?: string
-          name?: string
-          qr_code_url?: string | null
-          status?: string
-          type?: string | null
+          building_id?: string
+          thread_id?: string
+          sender_id?: string
+          body?: string
+          attachments?: Json
+          is_system?: boolean
+          reply_to?: string | null
+          created_at?: string
           updated_at?: string
-          user_id?: string
         }
-        Relationships: []
-      }
-      permission_table: {
-        Row: {
-          created_at: string
-          id: number
-          member_id: string
-          role: string
-          status: string
-        }
-        Insert: {
-          created_at?: string
-          id?: number
-          member_id: string
-          role: string
-          status: string
-        }
-        Update: {
-          created_at?: string
-          id?: number
-          member_id?: string
-          role?: string
-          status?: string
-        }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: 'messages_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'messages_reply_to_fkey'
+            columns: ['reply_to']
+            isOneToOne: false
+            referencedRelation: 'messages'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'messages_sender_id_fkey'
+            columns: ['sender_id']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'messages_thread_fk'
+            columns: ['building_id', 'thread_id']
+            isOneToOne: false
+            referencedRelation: 'threads'
+            referencedColumns: ['building_id', 'id']
+          },
+        ]
       }
       profiles: {
         Row: {
-          avatar_url: string | null
-          card_style: Json | null
-          card_styles: string | null
-          company: string | null
-          company_logo_url: string | null
-          created_at: string | null
-          email: string | null
+          id: string
+          created_at: string
+          updated_at: string
           full_name: string | null
-          id: string
-          job_title: string | null
-          linkedin_url: string | null
-          public_id: string | null
-          role: string | null
-          updated_at: string | null
-          username: string | null
-          waddress: string | null
-          website: string | null
-          xhandle: string | null
+          phone_number: string | null
+          avatar_url: string | null
+          default_building_id: string | null
+          onboarding_completed_at: string | null
+          preferences: Json
         }
         Insert: {
-          avatar_url?: string | null
-          card_style?: Json | null
-          card_styles?: string | null
-          company?: string | null
-          company_logo_url?: string | null
-          created_at?: string | null
-          email?: string | null
-          full_name?: string | null
           id?: string
-          job_title?: string | null
-          linkedin_url?: string | null
-          public_id?: string | null
-          role?: string | null
-          updated_at?: string | null
-          username?: string | null
-          waddress?: string | null
-          website?: string | null
-          xhandle?: string | null
-        }
-        Update: {
-          avatar_url?: string | null
-          card_style?: Json | null
-          card_styles?: string | null
-          company?: string | null
-          company_logo_url?: string | null
-          created_at?: string | null
-          email?: string | null
-          full_name?: string | null
-          id?: string
-          job_title?: string | null
-          linkedin_url?: string | null
-          public_id?: string | null
-          role?: string | null
-          updated_at?: string | null
-          username?: string | null
-          waddress?: string | null
-          website?: string | null
-          xhandle?: string | null
-        }
-        Relationships: []
-      }
-      reusable_packages: {
-        Row: {
-          created_at: string | null
-          current_uses: number | null
-          description: string | null
-          dimensions: string | null
-          id: string
-          material: string | null
-          max_uses: number | null
-          name: string
-          notes: string | null
-          package_id: string | null
-          qr_code: string | null
-          reuse_count: number | null
-          status: string
-          updated_at: string | null
-          weight: number | null
-        }
-        Insert: {
-          created_at?: string | null
-          current_uses?: number | null
-          description?: string | null
-          dimensions?: string | null
-          id: string
-          material?: string | null
-          max_uses?: number | null
-          name: string
-          notes?: string | null
-          package_id?: string | null
-          qr_code?: string | null
-          reuse_count?: number | null
-          status?: string
-          updated_at?: string | null
-          weight?: number | null
-        }
-        Update: {
-          created_at?: string | null
-          current_uses?: number | null
-          description?: string | null
-          dimensions?: string | null
-          id?: string
-          material?: string | null
-          max_uses?: number | null
-          name?: string
-          notes?: string | null
-          package_id?: string | null
-          qr_code?: string | null
-          reuse_count?: number | null
-          status?: string
-          updated_at?: string | null
-          weight?: number | null
-        }
-        Relationships: []
-      }
-      shipments: {
-        Row: {
-          carrier: string | null
-          created_at: string | null
-          delivered_at: string | null
-          destination: string
-          estimated_delivery: string | null
-          id: string
-          notes: string | null
-          origin: string
-          package_id: string | null
-          qr_code: string | null
-          recipient_email: string | null
-          recipient_name: string | null
-          shipped_at: string | null
-          status: string
-          tracking_number: string
-          updated_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          carrier?: string | null
-          created_at?: string | null
-          delivered_at?: string | null
-          destination: string
-          estimated_delivery?: string | null
-          id: string
-          notes?: string | null
-          origin: string
-          package_id?: string | null
-          qr_code?: string | null
-          recipient_email?: string | null
-          recipient_name?: string | null
-          shipped_at?: string | null
-          status?: string
-          tracking_number: string
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          carrier?: string | null
-          created_at?: string | null
-          delivered_at?: string | null
-          destination?: string
-          estimated_delivery?: string | null
-          id?: string
-          notes?: string | null
-          origin?: string
-          package_id?: string | null
-          qr_code?: string | null
-          recipient_email?: string | null
-          recipient_name?: string | null
-          shipped_at?: string | null
-          status?: string
-          tracking_number?: string
-          updated_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "shipments_package_id_fkey"
-            columns: ["package_id"]
-            isOneToOne: false
-            referencedRelation: "package_utilization"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "shipments_package_id_fkey"
-            columns: ["package_id"]
-            isOneToOne: false
-            referencedRelation: "reusable_packages"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      shipping: {
-        Row: {
-          actual_delivery: string | null
-          carrier: string | null
-          cost: number | null
-          created_at: string | null
-          destination_address: Json
-          dimensions: Json | null
-          estimated_delivery: string | null
-          id: string
-          metadata: Json | null
-          origin_address: Json
-          package_ids: Json | null
-          shipping_date: string | null
-          status: string | null
-          tracking_number: string
-          updated_at: string | null
-          weight: number | null
-        }
-        Insert: {
-          actual_delivery?: string | null
-          carrier?: string | null
-          cost?: number | null
-          created_at?: string | null
-          destination_address: Json
-          dimensions?: Json | null
-          estimated_delivery?: string | null
-          id?: string
-          metadata?: Json | null
-          origin_address: Json
-          package_ids?: Json | null
-          shipping_date?: string | null
-          status?: string | null
-          tracking_number: string
-          updated_at?: string | null
-          weight?: number | null
-        }
-        Update: {
-          actual_delivery?: string | null
-          carrier?: string | null
-          cost?: number | null
-          created_at?: string | null
-          destination_address?: Json
-          dimensions?: Json | null
-          estimated_delivery?: string | null
-          id?: string
-          metadata?: Json | null
-          origin_address?: Json
-          package_ids?: Json | null
-          shipping_date?: string | null
-          status?: string | null
-          tracking_number?: string
-          updated_at?: string | null
-          weight?: number | null
-        }
-        Relationships: []
-      }
-      sui_nfts: {
-        Row: {
-          avatar_url: string
-          blockchain: string
-          content_url: string
-          created_at: string | null
-          domain_name: string
-          id: string
-          name: string
-          profile_id: string | null
-          tx_hash: string
-          user_id: string | null
-        }
-        Insert: {
-          avatar_url: string
-          blockchain?: string
-          content_url: string
-          created_at?: string | null
-          domain_name: string
-          id?: string
-          name: string
-          profile_id?: string | null
-          tx_hash: string
-          user_id?: string | null
-        }
-        Update: {
-          avatar_url?: string
-          blockchain?: string
-          content_url?: string
-          created_at?: string | null
-          domain_name?: string
-          id?: string
-          name?: string
-          profile_id?: string | null
-          tx_hash?: string
-          user_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "sui_nfts_profile_id_fkey"
-            columns: ["profile_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      supply_chain_data: {
-        Row: {
-          created_at: string | null
-          data: Json
-          data_type: string
-          description: string | null
-          id: string
-          metadata: Json | null
-          name: string
-          updated_at: string | null
-          user_id: string
-        }
-        Insert: {
-          created_at?: string | null
-          data: Json
-          data_type: string
-          description?: string | null
-          id?: string
-          metadata?: Json | null
-          name: string
-          updated_at?: string | null
-          user_id?: string
-        }
-        Update: {
-          created_at?: string | null
-          data?: Json
-          data_type?: string
-          description?: string | null
-          id?: string
-          metadata?: Json | null
-          name?: string
-          updated_at?: string | null
-          user_id?: string
-        }
-        Relationships: []
-      }
-      todos: {
-        Row: {
-          created_at: string
-          created_by: string
-          id: number
-          is_complete: boolean | null
-          task: string | null
-          title: string
-          user_id: string
-        }
-        Insert: {
-          created_at: string
-          created_by: string
-          id?: number
-          is_complete?: boolean | null
-          task?: string | null
-          title?: string
-          user_id: string
-        }
-        Update: {
           created_at?: string
-          created_by?: string
-          id?: number
-          is_complete?: boolean | null
-          task?: string | null
-          title?: string
-          user_id?: string
+          updated_at?: string
+          full_name?: string | null
+          phone_number?: string | null
+          avatar_url?: string | null
+          default_building_id?: string | null
+          onboarding_completed_at?: string | null
+          preferences?: Json
+        }
+        Update: {
+          id?: string
+          created_at?: string
+          updated_at?: string
+          full_name?: string | null
+          phone_number?: string | null
+          avatar_url?: string | null
+          default_building_id?: string | null
+          onboarding_completed_at?: string | null
+          preferences?: Json
         }
         Relationships: [
           {
-            foreignKeyName: "todos_created_by_fkey"
-            columns: ["created_by"]
+            foreignKeyName: 'profiles_default_building_id_fkey'
+            columns: ['default_building_id']
             isOneToOne: false
-            referencedRelation: "members_table"
-            referencedColumns: ["member_id"]
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'profiles_id_fkey'
+            columns: ['id']
+            isOneToOne: true
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      rent_payments: {
+        Row: {
+          id: string
+          building_id: string
+          lease_id: string
+          amount: number
+          due_date: string
+          paid_at: string | null
+          status: Database['public']['Enums']['payment_status']
+          stripe_payment_intent_id: string | null
+          memo: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          building_id: string
+          lease_id: string
+          amount: number
+          due_date: string
+          paid_at?: string | null
+          status?: Database['public']['Enums']['payment_status']
+          stripe_payment_intent_id?: string | null
+          memo?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          building_id?: string
+          lease_id?: string
+          amount?: number
+          due_date?: string
+          paid_at?: string | null
+          status?: Database['public']['Enums']['payment_status']
+          stripe_payment_intent_id?: string | null
+          memo?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'rent_payments_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'rent_payments_lease_fk'
+            columns: ['building_id', 'lease_id']
+            isOneToOne: false
+            referencedRelation: 'leases'
+            referencedColumns: ['building_id', 'id']
+          },
+        ]
+      }
+      threads: {
+        Row: {
+          id: string
+          building_id: string
+          subject: string
+          created_by: string
+          status: Database['public']['Enums']['thread_status']
+          is_private: boolean
+          is_pinned: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          building_id: string
+          subject: string
+          created_by: string
+          status?: Database['public']['Enums']['thread_status']
+          is_private?: boolean
+          is_pinned?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          building_id?: string
+          subject?: string
+          created_by?: string
+          status?: Database['public']['Enums']['thread_status']
+          is_private?: boolean
+          is_pinned?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'threads_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'threads_created_by_fkey'
+            columns: ['created_by']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      units: {
+        Row: {
+          id: string
+          building_id: string
+          unit_number: string
+          floor: number | null
+          bedrooms: number | null
+          bathrooms: number | null
+          square_feet: number | null
+          rent_amount: number | null
+          status: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          building_id: string
+          unit_number: string
+          floor?: number | null
+          bedrooms?: number | null
+          bathrooms?: number | null
+          square_feet?: number | null
+          rent_amount?: number | null
+          status?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          building_id?: string
+          unit_number?: string
+          floor?: number | null
+          bedrooms?: number | null
+          bathrooms?: number | null
+          square_feet?: number | null
+          rent_amount?: number | null
+          status?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'units_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      user_roles: {
+        Row: {
+          id: number
+          user_id: string
+          building_id: string
+          role: Database['public']['Enums']['user_role_type']
+          granted_by: string | null
+          granted_at: string
+        }
+        Insert: {
+          id?: number
+          user_id: string
+          building_id: string
+          role: Database['public']['Enums']['user_role_type']
+          granted_by?: string | null
+          granted_at?: string
+        }
+        Update: {
+          id?: number
+          user_id?: string
+          building_id?: string
+          role?: Database['public']['Enums']['user_role_type']
+          granted_by?: string | null
+          granted_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'user_roles_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'user_roles_granted_by_fkey'
+            columns: ['granted_by']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'user_roles_user_id_fkey'
+            columns: ['user_id']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      visitor_logs: {
+        Row: {
+          id: string
+          building_id: string
+          lease_id: string
+          host_user_id: string
+          visitor_name: string
+          status: Database['public']['Enums']['visitor_status']
+          arrival_at: string
+          departure_at: string | null
+          purpose: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          building_id: string
+          lease_id: string
+          host_user_id: string
+          visitor_name: string
+          status?: Database['public']['Enums']['visitor_status']
+          arrival_at: string
+          departure_at?: string | null
+          purpose?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          building_id?: string
+          lease_id?: string
+          host_user_id?: string
+          visitor_name?: string
+          status?: Database['public']['Enums']['visitor_status']
+          arrival_at?: string
+          departure_at?: string | null
+          purpose?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'visitor_logs_building_id_fkey'
+            columns: ['building_id']
+            isOneToOne: false
+            referencedRelation: 'buildings'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'visitor_logs_lease_fk'
+            columns: ['building_id', 'lease_id']
+            isOneToOne: false
+            referencedRelation: 'leases'
+            referencedColumns: ['building_id', 'id']
+          },
+          {
+            foreignKeyName: 'visitor_logs_host_user_id_fkey'
+            columns: ['host_user_id']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
     }
     Views: {
-      package_utilization: {
-        Row: {
-          created_at: string | null
-          days_since_creation: number | null
-          id: string | null
-          last_used_date: string | null
-          name: string | null
-          package_id: string | null
-          reuse_count: number | null
-          reuses_per_day: number | null
-          shipment_count: number | null
-          status: string | null
-        }
-        Relationships: []
-      }
-      shipping_analytics: {
-        Row: {
-          avg_actual_delivery_days: number | null
-          avg_cost: number | null
-          avg_estimated_delivery_days: number | null
-          avg_weight: number | null
-          delayed_count: number | null
-          delivered_count: number | null
-          in_transit_count: number | null
-          shipping_day: string | null
-          total_cost: number | null
-          total_shipments: number | null
-          total_weight: number | null
-        }
-        Relationships: []
-      }
+      [_ in never]: never
     }
     Functions: {
-      binary_quantize: {
-        Args: { "": string } | { "": unknown }
-        Returns: unknown
-      }
-      decrement_package_usage: {
-        Args: { package_id: string }
-        Returns: undefined
-      }
-      get_page_parents: {
-        Args: { page_id: number }
-        Returns: {
-          id: number
-          parent_page_id: number
-          path: string
-          meta: Json
-        }[]
-      }
-      halfvec_avg: {
-        Args: { "": number[] }
-        Returns: unknown
-      }
-      halfvec_out: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      halfvec_send: {
-        Args: { "": unknown }
-        Returns: string
-      }
-      halfvec_typmod_in: {
-        Args: { "": unknown[] }
-        Returns: number
-      }
-      hnsw_bit_support: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      hnsw_halfvec_support: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      hnsw_sparsevec_support: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      hnswhandler: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      increment_package_usage: {
-        Args: { package_id: string }
-        Returns: undefined
-      }
-      is_admin: {
-        Args: { user_id: string }
-        Returns: boolean
-      }
-      is_first_user: {
-        Args: { user_id: string }
-        Returns: boolean
-      }
-      ivfflat_bit_support: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      ivfflat_halfvec_support: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      ivfflathandler: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      l2_norm: {
-        Args: { "": unknown } | { "": unknown }
-        Returns: number
-      }
-      l2_normalize: {
-        Args: { "": string } | { "": unknown } | { "": unknown }
-        Returns: string
-      }
-      match_page_sections: {
+      has_building_role: {
         Args: {
-          embedding: string
-          match_threshold: number
-          match_count: number
-          min_content_length: number
+          target_building: string
+          allowed_roles?: Database['public']['Enums']['user_role_type'][] | null
         }
-        Returns: {
-          id: number
-          page_id: number
-          slug: string
-          heading: string
-          content: string
-          similarity: number
-        }[]
+        Returns: boolean
       }
-      sparsevec_out: {
-        Args: { "": unknown }
-        Returns: unknown
-      }
-      sparsevec_send: {
-        Args: { "": unknown }
-        Returns: string
-      }
-      sparsevec_typmod_in: {
-        Args: { "": unknown[] }
-        Returns: number
-      }
-      vector_avg: {
-        Args: { "": number[] }
-        Returns: string
-      }
-      vector_dims: {
-        Args: { "": string } | { "": unknown }
-        Returns: number
-      }
-      vector_norm: {
-        Args: { "": string }
-        Returns: number
-      }
-      vector_out: {
-        Args: { "": string }
-        Returns: unknown
-      }
-      vector_send: {
-        Args: { "": string }
-        Returns: string
-      }
-      vector_typmod_in: {
-        Args: { "": unknown[] }
-        Returns: number
+      has_shared_building: {
+        Args: {
+          target_user: string
+          allowed_roles?: Database['public']['Enums']['user_role_type'][] | null
+        }
+        Returns: boolean
       }
     }
     Enums: {
-      continents:
-        | "Africa"
-        | "Antarctica"
-        | "Asia"
-        | "Europe"
-        | "Oceania"
-        | "North America"
-        | "South America"
-      user_role: "user" | "admin"
+      booking_status: 'pending' | 'confirmed' | 'cancelled' | 'completed'
+      document_category: 'lease' | 'payment' | 'notice' | 'policy' | 'other'
+      lease_status: 'draft' | 'pending' | 'active' | 'terminated' | 'expired'
+      maintenance_priority: 'low' | 'medium' | 'high' | 'urgent'
+      maintenance_status: 'open' | 'in_progress' | 'on_hold' | 'resolved' | 'closed'
+      payment_status: 'scheduled' | 'processing' | 'paid' | 'failed' | 'refunded'
+      thread_status: 'open' | 'locked' | 'archived'
+      user_role_type:
+        | 'platform_admin'
+        | 'property_manager'
+        | 'building_staff'
+        | 'resident'
+        | 'support_agent'
+      visitor_status: 'registered' | 'checked_in' | 'checked_out' | 'denied'
     }
     CompositeTypes: {
       [_ in never]: never
@@ -2224,16 +1618,21 @@ export const Constants = {
   },
   public: {
     Enums: {
-      continents: [
-        "Africa",
-        "Antarctica",
-        "Asia",
-        "Europe",
-        "Oceania",
-        "North America",
-        "South America",
+      booking_status: ["pending", "confirmed", "cancelled", "completed"],
+      document_category: ["lease", "payment", "notice", "policy", "other"],
+      lease_status: ["draft", "pending", "active", "terminated", "expired"],
+      maintenance_priority: ["low", "medium", "high", "urgent"],
+      maintenance_status: ["open", "in_progress", "on_hold", "resolved", "closed"],
+      payment_status: ["scheduled", "processing", "paid", "failed", "refunded"],
+      thread_status: ["open", "locked", "archived"],
+      user_role_type: [
+        "platform_admin",
+        "property_manager",
+        "building_staff",
+        "resident",
+        "support_agent",
       ],
-      user_role: ["user", "admin"],
+      visitor_status: ["registered", "checked_in", "checked_out", "denied"],
     },
   },
   storage: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:schema": "vitest run supabase/tests/schema-validation.test.ts"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -109,6 +111,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -306,6 +306,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
 
 packages:
 
@@ -1328,6 +1331,162 @@ packages:
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2323,6 +2482,116 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rushstack/eslint-patch@1.6.1':
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
 
@@ -2436,6 +2705,9 @@ packages:
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -2466,6 +2738,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
@@ -2489,6 +2764,9 @@ packages:
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/google-one-tap@1.2.6':
     resolution: {integrity: sha512-REmJsXVHvKb/sgI8DF+7IesMbDbcsEokHBqxU01ENZ8d98UPWdRLhUCtxEm9bhNFFg6PJGy7PNFdvovp0hK3jA==}
@@ -2648,6 +2926,35 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
@@ -2863,6 +3170,10 @@ packages:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -3020,6 +3331,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3056,6 +3371,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3084,6 +3403,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -3305,6 +3628,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
@@ -3314,6 +3646,10 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3459,6 +3795,9 @@ packages:
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3473,6 +3812,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -3648,6 +3992,10 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -3682,6 +4030,15 @@ packages:
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
@@ -4218,6 +4575,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -4356,6 +4716,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -4781,6 +5144,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -4799,6 +5169,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -5017,6 +5391,10 @@ packages:
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   potpack@1.0.2:
@@ -5317,6 +5695,11 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5404,6 +5787,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5474,6 +5860,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
     peerDependencies:
@@ -5482,6 +5871,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -5544,6 +5936,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -5689,6 +6084,28 @@ packages:
 
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -5934,6 +6351,79 @@ packages:
   victory-vendor@36.8.6:
     resolution: {integrity: sha512-PH8Wj9b0xIZ4AVfyn0c1SJrOhtxDJ5PNxj1ZDABPg1Gw1vJr1mJVqESPhvsFj7mXLQohVdiKqp4kWZkXlPcRcA==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.6:
+    resolution: {integrity: sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.4.35:
     resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
     peerDependencies:
@@ -5998,6 +6488,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workbox-background-sync@7.1.0:
@@ -7302,10 +7797,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7400,6 +7895,84 @@ snapshots:
   '@emotion/utils@1.2.1': {}
 
   '@emotion/weak-memoize@0.3.1': {}
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
+    optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
@@ -8524,6 +9097,72 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
   '@rushstack/eslint-patch@1.6.1': {}
 
   '@scure/base@1.1.5': {}
@@ -8668,6 +9307,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.5
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -8696,6 +9339,8 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/draco3d@1.4.10': {}
 
   '@types/eslint-scope@3.7.7':
@@ -8722,6 +9367,8 @@ snapshots:
   '@types/estree@1.0.5': {}
 
   '@types/estree@1.0.7': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/google-one-tap@1.2.6': {}
 
@@ -8853,19 +9500,61 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.4.35':
     dependencies:
@@ -9148,6 +9837,8 @@ snapshots:
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astring@1.8.6: {}
@@ -9327,6 +10018,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -9359,6 +10052,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9383,6 +10084,8 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -9582,6 +10285,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.0.2:
@@ -9591,6 +10298,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -9782,6 +10491,8 @@ snapshots:
 
   es-module-lexer@1.6.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -9802,6 +10513,35 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
@@ -9815,8 +10555,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +10578,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +10595,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +10616,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10065,6 +10805,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  expect-type@1.2.2: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@2.0.1: {}
@@ -10096,6 +10838,10 @@ snapshots:
   fault@1.0.4:
     dependencies:
       format: 0.2.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fflate@0.6.10: {}
 
@@ -10715,6 +11461,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -10829,6 +11577,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -10858,7 +11608,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   markdown-extensions@2.0.0: {}
 
@@ -11239,8 +11988,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -11252,13 +12000,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +12016,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11437,6 +12185,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   peberminta@0.9.0: {}
 
   periscopic@3.1.0:
@@ -11449,10 +12201,11 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -11726,6 +12479,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
     optional: true
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   potpack@1.0.2: {}
 
@@ -12063,6 +12822,34 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12183,6 +12970,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -12212,8 +13001,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -12236,12 +13024,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
     dependencies:
       '@types/three': 0.176.0
       three: 0.160.0
 
   stats.js@0.17.0: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -12326,6 +13118,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -12334,12 +13130,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 
@@ -12518,6 +13314,21 @@ snapshots:
   three@0.160.0: {}
 
   tiny-invariant@1.3.1: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-fast-properties@2.0.0: {}
 
@@ -12784,6 +13595,83 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.14.15
+      fsevents: 2.3.3
+      jiti: 1.21.0
+      terser: 5.39.0
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite-node: 3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.14.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
@@ -12898,6 +13786,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workbox-background-sync@7.1.0:
     dependencies:

--- a/queries/country-by-id.tsx
+++ b/queries/country-by-id.tsx
@@ -1,15 +1,18 @@
-import { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
 
-export function getCountryById(client: TypedSupabaseClient, countryId: number) {
+export function getCountryById(client: TypedSupabaseClient, buildingId: string) {
   return client
-    .from('countries')
+    .from('buildings')
     .select(
       `
       id,
-      name
+      name,
+      code,
+      timezone,
+      is_active
     `
     )
-    .eq('id', countryId)
+    .eq('id', buildingId)
     .throwOnError()
     .single()
 }

--- a/supabase/migrations/20240612_building_portal_schema.sql
+++ b/supabase/migrations/20240612_building_portal_schema.sql
@@ -1,0 +1,838 @@
+-- Replaces legacy prototype tables with building-scoped schema per ADR-0001.
+set check_function_bodies = off;
+
+-- Drop unused legacy tables and supporting policies.
+drop table if exists public.chat cascade;
+drop table if exists public.countries cascade;
+drop table if exists public.inqueries cascade;
+drop table if exists public.meetings cascade;
+drop table if exists public.members_table cascade;
+drop table if exists public.permission_table cascade;
+drop table if exists public.todos cascade;
+
+drop table if exists public.profiles cascade;
+
+-- Ensure uuid generation helpers are available.
+create extension if not exists "pgcrypto" with schema public;
+
+-- Enum definitions used across the tenancy-aware schema.
+do $$
+begin
+    if not exists (select 1 from pg_type where typname = 'user_role_type') then
+        create type public.user_role_type as enum (
+            'platform_admin',
+            'property_manager',
+            'building_staff',
+            'resident',
+            'support_agent'
+        );
+    end if;
+
+    if not exists (select 1 from pg_type where typname = 'lease_status') then
+        create type public.lease_status as enum (
+            'draft',
+            'pending',
+            'active',
+            'terminated',
+            'expired'
+        );
+    end if;
+
+    if not exists (select 1 from pg_type where typname = 'payment_status') then
+        create type public.payment_status as enum (
+            'scheduled',
+            'processing',
+            'paid',
+            'failed',
+            'refunded'
+        );
+    end if;
+
+    if not exists (select 1 from pg_type where typname = 'booking_status') then
+        create type public.booking_status as enum (
+            'pending',
+            'confirmed',
+            'cancelled',
+            'completed'
+        );
+    end if;
+
+    if not exists (select 1 from pg_type where typname = 'maintenance_status') then
+        create type public.maintenance_status as enum (
+            'open',
+            'in_progress',
+            'on_hold',
+            'resolved',
+            'closed'
+        );
+    end if;
+
+    if not exists (select 1 from pg_type where typname = 'maintenance_priority') then
+        create type public.maintenance_priority as enum (
+            'low',
+            'medium',
+            'high',
+            'urgent'
+        );
+    end if;
+
+    if not exists (select 1 from pg_type where typname = 'thread_status') then
+        create type public.thread_status as enum (
+            'open',
+            'locked',
+            'archived'
+        );
+    end if;
+
+    if not exists (select 1 from pg_type where typname = 'document_category') then
+        create type public.document_category as enum (
+            'lease',
+            'payment',
+            'notice',
+            'policy',
+            'other'
+        );
+    end if;
+
+    if not exists (select 1 from pg_type where typname = 'visitor_status') then
+        create type public.visitor_status as enum (
+            'registered',
+            'checked_in',
+            'checked_out',
+            'denied'
+        );
+    end if;
+end $$;
+
+create table public.buildings (
+    id uuid primary key default gen_random_uuid(),
+    name text not null,
+    code text not null unique,
+    address_line1 text not null,
+    address_line2 text,
+    city text,
+    state text,
+    postal_code text,
+    country text,
+    timezone text not null default 'UTC',
+    is_active boolean not null default true,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+comment on table public.buildings is 'Authoritative list of managed properties. Every core entity references buildings.id for tenancy boundaries (ADR-0001).';
+
+create table public.profiles (
+    id uuid primary key default auth.uid() references auth.users(id) on delete cascade,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    full_name text,
+    phone_number text,
+    avatar_url text,
+    default_building_id uuid references public.buildings(id),
+    onboarding_completed_at timestamptz,
+    preferences jsonb not null default '{}'::jsonb
+);
+
+comment on table public.profiles is 'Extended auth profile metadata for portal users. Building membership is tracked via user_roles.';
+
+create table public.user_roles (
+    id bigserial primary key,
+    user_id uuid not null references auth.users(id) on delete cascade,
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    role public.user_role_type not null,
+    granted_by uuid references auth.users(id),
+    granted_at timestamptz not null default timezone('utc', now()),
+    constraint user_roles_unique_membership unique (user_id, building_id, role)
+);
+
+comment on table public.user_roles is 'Maps a user to a specific building and role for RBAC enforcement.';
+
+create index idx_user_roles_building_role on public.user_roles (building_id, role);
+create index idx_user_roles_user on public.user_roles (user_id);
+
+create table public.units (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    unit_number text not null,
+    floor integer,
+    bedrooms integer,
+    bathrooms numeric(4,2),
+    square_feet integer,
+    rent_amount numeric(10,2),
+    status text not null default 'available',
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint unique_unit_per_building unique (building_id, unit_number)
+);
+
+create index idx_units_building on public.units (building_id);
+
+create table public.leases (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    unit_id uuid not null references public.units(id) on delete restrict,
+    primary_tenant_id uuid not null references auth.users(id) on delete restrict,
+    status public.lease_status not null default 'pending',
+    start_date date not null,
+    end_date date,
+    rent_amount numeric(10,2) not null,
+    security_deposit numeric(10,2),
+    billing_cycle_day integer not null default 1,
+    stripe_customer_id text,
+    notes text,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint leases_unit_active_unique unique (unit_id, status) deferrable initially deferred
+);
+
+create unique index leases_building_id_id_idx on public.leases (building_id, id);
+create index leases_unit_idx on public.leases (unit_id);
+
+create table public.lease_tenants (
+    id bigserial primary key,
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    lease_id uuid not null,
+    tenant_id uuid not null references auth.users(id) on delete cascade,
+    rent_share numeric(5,2),
+    joined_at timestamptz not null default timezone('utc', now()),
+    constraint lease_tenants_unique unique (lease_id, tenant_id),
+    constraint lease_tenants_lease_fk foreign key (building_id, lease_id) references public.leases (building_id, id) on delete cascade
+);
+
+create index lease_tenants_building_idx on public.lease_tenants (building_id);
+create index lease_tenants_lease_idx on public.lease_tenants (lease_id);
+
+create table public.rent_payments (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    lease_id uuid not null,
+    amount numeric(10,2) not null,
+    due_date date not null,
+    paid_at timestamptz,
+    status public.payment_status not null default 'scheduled',
+    stripe_payment_intent_id text,
+    memo text,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint rent_payments_lease_fk foreign key (building_id, lease_id) references public.leases (building_id, id) on delete cascade
+);
+
+create index rent_payments_building_idx on public.rent_payments (building_id);
+create index rent_payments_lease_idx on public.rent_payments (lease_id);
+
+create table public.amenities (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    slug text not null,
+    name text not null,
+    description text,
+    location text,
+    is_bookable boolean not null default true,
+    calcom_event_type_id text,
+    open_time time,
+    close_time time,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint amenities_unique_slug unique (building_id, slug)
+);
+
+create index amenities_building_idx on public.amenities (building_id);
+create unique index amenities_building_id_id_idx on public.amenities (building_id, id);
+
+create table public.amenity_bookings (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    amenity_id uuid not null,
+    lease_id uuid,
+    booked_by uuid not null references auth.users(id) on delete cascade,
+    status public.booking_status not null default 'pending',
+    starts_at timestamptz not null,
+    ends_at timestamptz not null,
+    notes text,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint amenity_booking_time_check check (ends_at > starts_at),
+    constraint amenity_bookings_amenity_fk foreign key (building_id, amenity_id) references public.amenities (building_id, id) on delete cascade,
+    constraint amenity_bookings_lease_fk foreign key (building_id, lease_id) references public.leases (building_id, id) on delete cascade
+);
+
+create index amenity_bookings_building_idx on public.amenity_bookings (building_id);
+create index amenity_bookings_amenity_idx on public.amenity_bookings (amenity_id);
+create index amenity_bookings_lease_idx on public.amenity_bookings (lease_id);
+
+create table public.visitor_logs (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    lease_id uuid not null,
+    host_user_id uuid not null references auth.users(id) on delete cascade,
+    visitor_name text not null,
+    status public.visitor_status not null default 'registered',
+    arrival_at timestamptz not null,
+    departure_at timestamptz,
+    purpose text,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint visitor_logs_lease_fk foreign key (building_id, lease_id) references public.leases (building_id, id) on delete cascade
+);
+
+create index visitor_logs_building_idx on public.visitor_logs (building_id);
+create index visitor_logs_lease_idx on public.visitor_logs (lease_id);
+
+create table public.maintenance_requests (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    unit_id uuid not null references public.units(id) on delete restrict,
+    lease_id uuid,
+    reported_by uuid not null references auth.users(id) on delete cascade,
+    assigned_to uuid references auth.users(id) on delete set null,
+    status public.maintenance_status not null default 'open',
+    priority public.maintenance_priority not null default 'medium',
+    category text,
+    summary text not null,
+    description text,
+    metadata jsonb not null default '{}'::jsonb,
+    requested_at timestamptz not null default timezone('utc', now()),
+    resolved_at timestamptz,
+    closed_at timestamptz,
+    constraint maintenance_requests_lease_fk foreign key (building_id, lease_id) references public.leases (building_id, id) on delete set null
+);
+
+create index maintenance_requests_building_idx on public.maintenance_requests (building_id);
+create index maintenance_requests_unit_idx on public.maintenance_requests (unit_id);
+create index maintenance_requests_status_idx on public.maintenance_requests (status);
+
+create table public.floorplans (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    unit_id uuid references public.units(id) on delete set null,
+    name text not null,
+    storage_path text not null,
+    version integer not null default 1,
+    uploaded_by uuid references auth.users(id) on delete set null,
+    uploaded_at timestamptz not null default timezone('utc', now()),
+    is_active boolean not null default true
+);
+
+create index floorplans_building_idx on public.floorplans (building_id);
+create index floorplans_unit_idx on public.floorplans (unit_id);
+create unique index floorplans_building_id_id_idx on public.floorplans (building_id, id);
+
+create table public.floorplan_annotations (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    floorplan_id uuid not null,
+    created_by uuid not null references auth.users(id) on delete cascade,
+    label text not null,
+    payload jsonb not null,
+    visibility text not null default 'private',
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint floorplan_annotations_floorplan_fk foreign key (building_id, floorplan_id) references public.floorplans (building_id, id) on delete cascade
+);
+
+create index floorplan_annotations_building_idx on public.floorplan_annotations (building_id);
+create index floorplan_annotations_floorplan_idx on public.floorplan_annotations (floorplan_id);
+
+create table public.documents (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    lease_id uuid,
+    uploaded_by uuid not null references auth.users(id) on delete cascade,
+    category public.document_category not null default 'other',
+    title text not null,
+    storage_path text not null,
+    version integer not null default 1,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default timezone('utc', now()),
+    constraint documents_lease_fk foreign key (building_id, lease_id) references public.leases (building_id, id) on delete set null
+);
+
+create index documents_building_idx on public.documents (building_id);
+create index documents_lease_idx on public.documents (lease_id);
+
+create table public.threads (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    subject text not null,
+    created_by uuid not null references auth.users(id) on delete cascade,
+    status public.thread_status not null default 'open',
+    is_private boolean not null default false,
+    is_pinned boolean not null default false,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index threads_building_idx on public.threads (building_id);
+create index threads_status_idx on public.threads (status);
+create unique index threads_building_id_id_idx on public.threads (building_id, id);
+
+create table public.messages (
+    id uuid primary key default gen_random_uuid(),
+    building_id uuid not null references public.buildings(id) on delete cascade,
+    thread_id uuid not null,
+    sender_id uuid not null references auth.users(id) on delete cascade,
+    body text not null,
+    attachments jsonb not null default '[]'::jsonb,
+    is_system boolean not null default false,
+    reply_to uuid references public.messages(id) on delete set null,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint messages_thread_fk foreign key (building_id, thread_id) references public.threads (building_id, id) on delete cascade
+);
+
+create index messages_building_idx on public.messages (building_id);
+create index messages_thread_idx on public.messages (thread_id);
+
+-- Helper functions used by policies.
+create or replace function public.has_building_role(target_building uuid, allowed_roles public.user_role_type[] default null)
+returns boolean
+language sql
+stable
+as $$
+    select
+        coalesce(
+            exists (
+                select 1
+                from public.user_roles ur
+                where ur.user_id = auth.uid()
+                  and (
+                    ur.role = 'platform_admin'::public.user_role_type
+                    or (
+                        ur.building_id = target_building
+                        and (
+                            allowed_roles is null
+                            or array_length(allowed_roles, 1) is null
+                            or ur.role = any(allowed_roles)
+                        )
+                    )
+                )
+            ), false
+        )
+        or auth.role() = 'service_role';
+$$;
+
+comment on function public.has_building_role(uuid, public.user_role_type[]) is 'Returns true when the authenticated user has one of the required roles for the provided building or holds the service role.';
+
+create or replace function public.has_shared_building(target_user uuid, allowed_roles public.user_role_type[] default null)
+returns boolean
+language sql
+stable
+as $$
+    select
+        coalesce(
+            exists (
+                select 1
+                from public.user_roles target
+                join public.user_roles actor
+                  on actor.building_id = target.building_id
+                where target.user_id = target_user
+                  and actor.user_id = auth.uid()
+                  and (
+                    actor.role = 'platform_admin'::public.user_role_type
+                    or (
+                        allowed_roles is null
+                        or array_length(allowed_roles, 1) is null
+                        or actor.role = any(allowed_roles)
+                    )
+                )
+            ), false
+        )
+        or auth.role() = 'service_role';
+$$;
+
+comment on function public.has_shared_building(uuid, public.user_role_type[]) is 'Checks whether the authenticated user shares a building with the target user with one of the permitted roles.';
+
+-- Enable row level security and apply tenancy-aware policies.
+alter table public.buildings enable row level security;
+alter table public.profiles enable row level security;
+alter table public.user_roles enable row level security;
+alter table public.units enable row level security;
+alter table public.leases enable row level security;
+alter table public.lease_tenants enable row level security;
+alter table public.rent_payments enable row level security;
+alter table public.amenities enable row level security;
+alter table public.amenity_bookings enable row level security;
+alter table public.visitor_logs enable row level security;
+alter table public.maintenance_requests enable row level security;
+alter table public.floorplans enable row level security;
+alter table public.floorplan_annotations enable row level security;
+alter table public.documents enable row level security;
+alter table public.threads enable row level security;
+alter table public.messages enable row level security;
+
+-- Buildings policies
+create policy "Building members can read building metadata" on public.buildings
+    for select
+    using (public.has_building_role(buildings.id, array['platform_admin','property_manager','building_staff','resident','support_agent']::public.user_role_type[]));
+comment on policy "Building members can read building metadata" on public.buildings is 'Allows any role assigned to a building to view its configuration per authorization model.';
+
+create policy "Only platform admins manage buildings" on public.buildings
+    for all
+    using (public.has_building_role(buildings.id, array['platform_admin']::public.user_role_type[]))
+    with check (public.has_building_role(buildings.id, array['platform_admin']::public.user_role_type[]));
+comment on policy "Only platform admins manage buildings" on public.buildings is 'Restricts create/update/delete of building records to platform administrators or service role.';
+
+-- Profiles policies
+create policy "Profiles are visible to self and scoped staff" on public.profiles
+    for select
+    using (auth.uid() = id or public.has_shared_building(id, array['platform_admin','property_manager','building_staff','support_agent']::public.user_role_type[]));
+comment on policy "Profiles are visible to self and scoped staff" on public.profiles is 'Residents see their own profile; staff roles can view profiles for shared buildings.';
+
+create policy "Profiles are self managed" on public.profiles
+    for update
+    using (auth.uid() = id)
+    with check (auth.uid() = id);
+comment on policy "Profiles are self managed" on public.profiles is 'Users may update only their own profile fields.';
+
+create policy "Profiles inserted by service actors" on public.profiles
+    for insert
+    with check (auth.role() = 'service_role');
+comment on policy "Profiles inserted by service actors" on public.profiles is 'Profile creation occurs via backend provisioning using the service role.';
+
+-- User roles policies
+create policy "Users can view their own role assignments" on public.user_roles
+    for select
+    using (auth.uid() = user_id or public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]));
+comment on policy "Users can view their own role assignments" on public.user_roles is 'Surface memberships for the current user while allowing managers to audit roles per building.';
+
+create policy "Building managers maintain memberships" on public.user_roles
+    for insert
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]));
+comment on policy "Building managers maintain memberships" on public.user_roles is 'Platform admins and property managers can assign roles within their buildings.';
+
+create policy "Building managers update memberships" on public.user_roles
+    for update
+    using (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]));
+comment on policy "Building managers update memberships" on public.user_roles is 'Managers can adjust assigned roles within their authorized buildings.';
+
+create policy "Platform admins remove memberships" on public.user_roles
+    for delete
+    using (public.has_building_role(building_id, array['platform_admin']::public.user_role_type[]));
+comment on policy "Platform admins remove memberships" on public.user_roles is 'Only platform administrators or the service role may revoke role assignments.';
+
+-- Units policies
+create policy "Building members read units" on public.units
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident','support_agent']::public.user_role_type[]));
+comment on policy "Building members read units" on public.units is 'Expose unit metadata to all building roles for onboarding and support flows.';
+
+create policy "Managers manage units" on public.units
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]));
+comment on policy "Managers manage units" on public.units is 'Only platform admins and property managers can create or update units.';
+
+-- Leases policies
+create policy "Staff view leases" on public.leases
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','support_agent']::public.user_role_type[]));
+comment on policy "Staff view leases" on public.leases is 'Staff roles within a building may review lease records for operations.';
+
+create policy "Residents view their leases" on public.leases
+    for select
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and (
+            primary_tenant_id = auth.uid()
+            or exists (
+                select 1 from public.lease_tenants lt
+                where lt.lease_id = leases.id
+                  and lt.tenant_id = auth.uid()
+            )
+        )
+    );
+comment on policy "Residents view their leases" on public.leases is 'Residents can access lease records where they are listed as tenants.';
+
+create policy "Managers modify leases" on public.leases
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]));
+comment on policy "Managers modify leases" on public.leases is 'Lease creation and updates are restricted to property managers and platform admins.';
+
+-- Lease tenants policies
+create policy "Lease tenant visibility" on public.lease_tenants
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','support_agent','resident']::public.user_role_type[]));
+comment on policy "Lease tenant visibility" on public.lease_tenants is 'Members of a building can view assigned residents for collaboration.';
+
+create policy "Residents manage own membership" on public.lease_tenants
+    for delete
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and tenant_id = auth.uid()
+    );
+comment on policy "Residents manage own membership" on public.lease_tenants is 'Allows residents to leave roommate groups when they have building access.';
+
+create policy "Managers administer lease tenants" on public.lease_tenants
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]));
+comment on policy "Managers administer lease tenants" on public.lease_tenants is 'Managers can add or update resident allocations for leases.';
+
+-- Rent payments policies
+create policy "Staff view rent payments" on public.rent_payments
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','support_agent']::public.user_role_type[]));
+comment on policy "Staff view rent payments" on public.rent_payments is 'Finance and support roles review rent payment status within a building.';
+
+create policy "Residents view their rent payments" on public.rent_payments
+    for select
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and exists (
+            select 1 from public.leases l
+            left join public.lease_tenants lt on lt.lease_id = l.id and lt.tenant_id = auth.uid()
+            where l.id = rent_payments.lease_id
+              and (l.primary_tenant_id = auth.uid() or lt.tenant_id = auth.uid())
+        )
+    );
+comment on policy "Residents view their rent payments" on public.rent_payments is 'Residents can see payment history for leases where they are participants.';
+
+create policy "Managers manage rent payments" on public.rent_payments
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager']::public.user_role_type[]));
+comment on policy "Managers manage rent payments" on public.rent_payments is 'Only platform admins and property managers can create or adjust payment records.';
+
+-- Amenities policies
+create policy "Building members view amenities" on public.amenities
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident','support_agent']::public.user_role_type[]));
+comment on policy "Building members view amenities" on public.amenities is 'All building roles need read access to amenity configuration for scheduling.';
+
+create policy "Managers and staff manage amenities" on public.amenities
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Managers and staff manage amenities" on public.amenities is 'Property managers and staff can configure amenity availability.';
+
+-- Amenity bookings policies
+create policy "Building members view bookings" on public.amenity_bookings
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident','support_agent']::public.user_role_type[]));
+comment on policy "Building members view bookings" on public.amenity_bookings is 'All roles can review booking schedules for coordination.';
+
+create policy "Residents create amenity bookings" on public.amenity_bookings
+    for insert
+    with check (
+        public.has_building_role(building_id, array['resident','platform_admin','property_manager','building_staff']::public.user_role_type[])
+        and booked_by = auth.uid()
+    );
+comment on policy "Residents create amenity bookings" on public.amenity_bookings is 'Residents and staff can schedule amenities for their building; the actor must be the creator.';
+
+create policy "Residents manage their bookings" on public.amenity_bookings
+    for update
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and booked_by = auth.uid()
+    )
+    with check (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and booked_by = auth.uid()
+    );
+comment on policy "Residents manage their bookings" on public.amenity_bookings is 'Residents may adjust their own bookings while scoped to their building.';
+
+create policy "Managers override amenity bookings" on public.amenity_bookings
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Managers override amenity bookings" on public.amenity_bookings is 'Property teams can create, update, or cancel bookings for operational needs.';
+
+-- Visitor logs policies
+create policy "Staff view visitor logs" on public.visitor_logs
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','support_agent']::public.user_role_type[]));
+comment on policy "Staff view visitor logs" on public.visitor_logs is 'Visitor oversight is limited to authorized building staff and support roles.';
+
+create policy "Residents see their visitor logs" on public.visitor_logs
+    for select
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and host_user_id = auth.uid()
+    );
+comment on policy "Residents see their visitor logs" on public.visitor_logs is 'Residents can review visitor submissions that they created.';
+
+create policy "Residents manage their visitor logs" on public.visitor_logs
+    for update
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and host_user_id = auth.uid()
+    )
+    with check (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and host_user_id = auth.uid()
+    );
+comment on policy "Residents manage their visitor logs" on public.visitor_logs is 'Residents can edit upcoming visitor records that they submitted.';
+
+create policy "Managers manage visitor logs" on public.visitor_logs
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Managers manage visitor logs" on public.visitor_logs is 'Operational staff may create, update, or delete visitor records as needed.';
+
+-- Maintenance requests policies
+create policy "Building staff view maintenance" on public.maintenance_requests
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','support_agent']::public.user_role_type[]));
+comment on policy "Building staff view maintenance" on public.maintenance_requests is 'Maintenance tickets are visible to operational teams and support.';
+
+create policy "Residents view their maintenance" on public.maintenance_requests
+    for select
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and reported_by = auth.uid()
+    );
+comment on policy "Residents view their maintenance" on public.maintenance_requests is 'Residents may follow maintenance requests they submit.';
+
+create policy "Residents submit maintenance" on public.maintenance_requests
+    for insert
+    with check (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and reported_by = auth.uid()
+    );
+comment on policy "Residents submit maintenance" on public.maintenance_requests is 'Residents can open tickets scoped to their building.';
+
+create policy "Residents update their maintenance" on public.maintenance_requests
+    for update
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and reported_by = auth.uid()
+    )
+    with check (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and reported_by = auth.uid()
+    );
+comment on policy "Residents update their maintenance" on public.maintenance_requests is 'Residents can add context or close their own maintenance requests.';
+
+create policy "Staff manage maintenance" on public.maintenance_requests
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Staff manage maintenance" on public.maintenance_requests is 'Building staff and managers can triage and resolve tickets.';
+
+-- Floorplans policies
+create policy "Building members view floorplans" on public.floorplans
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident','support_agent']::public.user_role_type[]));
+comment on policy "Building members view floorplans" on public.floorplans is 'All roles need read access to floorplan assets for collaboration.';
+
+create policy "Staff manage floorplans" on public.floorplans
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Staff manage floorplans" on public.floorplans is 'Only staff can upload or version floorplans.';
+
+-- Floorplan annotations policies
+create policy "Building members view annotations" on public.floorplan_annotations
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident','support_agent']::public.user_role_type[]));
+comment on policy "Building members view annotations" on public.floorplan_annotations is 'Annotations are shared across building roles for coordination.';
+
+create policy "Creators manage annotations" on public.floorplan_annotations
+    for update
+    using (
+        public.has_building_role(building_id, array['resident','building_staff','property_manager','platform_admin']::public.user_role_type[])
+        and created_by = auth.uid()
+    )
+    with check (
+        public.has_building_role(building_id, array['resident','building_staff','property_manager','platform_admin']::public.user_role_type[])
+        and created_by = auth.uid()
+    );
+comment on policy "Creators manage annotations" on public.floorplan_annotations is 'Users can maintain annotations they created when still assigned to the building.';
+
+create policy "Staff curate annotations" on public.floorplan_annotations
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Staff curate annotations" on public.floorplan_annotations is 'Staff can moderate or remove annotations as needed.';
+
+-- Documents policies
+create policy "Staff read documents" on public.documents
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','support_agent']::public.user_role_type[]));
+comment on policy "Staff read documents" on public.documents is 'Documents like leases and notices are accessible to support and property teams.';
+
+create policy "Residents read their documents" on public.documents
+    for select
+    using (
+        public.has_building_role(building_id, array['resident']::public.user_role_type[])
+        and (
+            uploaded_by = auth.uid()
+            or exists (
+                select 1 from public.leases l
+                left join public.lease_tenants lt on lt.lease_id = l.id and lt.tenant_id = auth.uid()
+                where l.id = documents.lease_id
+                  and (l.primary_tenant_id = auth.uid() or lt.tenant_id = auth.uid())
+            )
+        )
+    );
+comment on policy "Residents read their documents" on public.documents is 'Residents can access documents they uploaded or that are tied to their lease.';
+
+create policy "Staff manage documents" on public.documents
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Staff manage documents" on public.documents is 'Document creation and updates are restricted to staff roles.';
+
+-- Threads policies
+create policy "Building members view threads" on public.threads
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident','support_agent']::public.user_role_type[]));
+comment on policy "Building members view threads" on public.threads is 'Community conversations are visible to all roles within the building scope.';
+
+create policy "Building members post threads" on public.threads
+    for insert
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident']::public.user_role_type[]));
+comment on policy "Building members post threads" on public.threads is 'Residents and staff can initiate new discussions when scoped to their building.';
+
+create policy "Thread owners manage threads" on public.threads
+    for update
+    using (
+        public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident']::public.user_role_type[])
+        and created_by = auth.uid()
+    )
+    with check (
+        public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident']::public.user_role_type[])
+        and created_by = auth.uid()
+    );
+comment on policy "Thread owners manage threads" on public.threads is 'Thread creators can edit their posts while they remain members of the building.';
+
+create policy "Staff moderate threads" on public.threads
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Staff moderate threads" on public.threads is 'Staff can update or delete threads to enforce community guidelines.';
+
+-- Messages policies
+create policy "Building members read messages" on public.messages
+    for select
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident','support_agent']::public.user_role_type[]));
+comment on policy "Building members read messages" on public.messages is 'Messages inside a thread follow the same building-scoped visibility rules.';
+
+create policy "Members send messages" on public.messages
+    for insert
+    with check (
+        public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident']::public.user_role_type[])
+        and sender_id = auth.uid()
+    );
+comment on policy "Members send messages" on public.messages is 'Residents and staff can send messages to conversations inside their building.';
+
+create policy "Message authors edit" on public.messages
+    for update
+    using (
+        public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident']::public.user_role_type[])
+        and sender_id = auth.uid()
+    )
+    with check (
+        public.has_building_role(building_id, array['platform_admin','property_manager','building_staff','resident']::public.user_role_type[])
+        and sender_id = auth.uid()
+    );
+comment on policy "Message authors edit" on public.messages is 'Authors can update their own messages while retaining building membership.';
+
+create policy "Staff moderate messages" on public.messages
+    for all
+    using (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]))
+    with check (public.has_building_role(building_id, array['platform_admin','property_manager','building_staff']::public.user_role_type[]));
+comment on policy "Staff moderate messages" on public.messages is 'Staff can moderate conversations within their buildings.';

--- a/supabase/seeds/20240612_core_reference_data.sql
+++ b/supabase/seeds/20240612_core_reference_data.sql
@@ -1,0 +1,113 @@
+-- Core reference data used for local development and automated schema tests.
+-- Inserts a canonical building along with amenity definitions and optional
+-- role assignments when matching auth.users accounts exist.
+
+insert into public.buildings (id, name, code, address_line1, city, state, postal_code, country, timezone)
+values (
+    '11111111-1111-1111-1111-111111111111',
+    'Test Share House',
+    'test-share-house',
+    '123 Example Street',
+    'Portland',
+    'OR',
+    '97205',
+    'US',
+    'America/Los_Angeles'
+)
+on conflict (id) do update
+set
+    name = excluded.name,
+    code = excluded.code,
+    address_line1 = excluded.address_line1,
+    city = excluded.city,
+    state = excluded.state,
+    postal_code = excluded.postal_code,
+    country = excluded.country,
+    timezone = excluded.timezone,
+    updated_at = timezone('utc', now());
+
+insert into public.amenities (id, building_id, slug, name, description, location, is_bookable)
+values
+    (
+        'aaaaaaaa-1111-1111-1111-111111111111',
+        '11111111-1111-1111-1111-111111111111',
+        'kitchen',
+        'Communal Kitchen',
+        'Shared kitchen stocked with cookware and smart appliances.',
+        'Level 1',
+        true
+    ),
+    (
+        'aaaaaaaa-2222-2222-2222-222222222222',
+        '11111111-1111-1111-1111-111111111111',
+        'tv-room',
+        'Theatre & TV Room',
+        'Ultra-short throw projector with Dolby Atmos sound.',
+        'Level 2',
+        true
+    ),
+    (
+        'aaaaaaaa-3333-3333-3333-333333333333',
+        '11111111-1111-1111-1111-111111111111',
+        'playstation-nook',
+        'PlayStation Gaming Nook',
+        'PS5 with VR accessories and weekly tournament board.',
+        'Level 2',
+        true
+    ),
+    (
+        'aaaaaaaa-4444-4444-4444-444444444444',
+        '11111111-1111-1111-1111-111111111111',
+        'parking',
+        'Parking Garage',
+        'Two tandem EV-ready parking spots.',
+        'Sublevel',
+        true
+    ),
+    (
+        'aaaaaaaa-5555-5555-5555-555555555555',
+        '11111111-1111-1111-1111-111111111111',
+        'shared-computer',
+        'Shared Computer Lab',
+        'Dual-monitor workstation for printing and research.',
+        'Level 3',
+        true
+    )
+on conflict (building_id, slug) do update
+set
+    name = excluded.name,
+    description = excluded.description,
+    location = excluded.location,
+    is_bookable = excluded.is_bookable,
+    updated_at = timezone('utc', now());
+
+-- Optional role fixtures; these execute only when corresponding auth.users
+-- accounts already exist (for example, in integration tests).
+do $$
+declare
+    manager_user_id uuid;
+    staff_user_id uuid;
+    admin_user_id uuid;
+begin
+    select id into manager_user_id from auth.users where email = 'manager@example.com';
+    select id into staff_user_id from auth.users where email = 'staff@example.com';
+    select id into admin_user_id from auth.users where email = 'admin@example.com';
+
+    if admin_user_id is not null then
+        insert into public.user_roles (user_id, building_id, role)
+        values (admin_user_id, '11111111-1111-1111-1111-111111111111', 'platform_admin')
+        on conflict (user_id, building_id, role) do nothing;
+    end if;
+
+    if manager_user_id is not null then
+        insert into public.user_roles (user_id, building_id, role)
+        values (manager_user_id, '11111111-1111-1111-1111-111111111111', 'property_manager')
+        on conflict (user_id, building_id, role) do nothing;
+    end if;
+
+    if staff_user_id is not null then
+        insert into public.user_roles (user_id, building_id, role)
+        values (staff_user_id, '11111111-1111-1111-1111-111111111111', 'building_staff')
+        on conflict (user_id, building_id, role) do nothing;
+    end if;
+end $$;

--- a/supabase/tests/schema-validation.test.ts
+++ b/supabase/tests/schema-validation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type { Database } from '../../lib/supabase'
+
+type Tables = Database['public']['Tables']
+
+type BuildingScopedTables = {
+  [Key in keyof Tables]: 'building_id' extends keyof Tables[Key]['Row'] ? Key : never
+}[keyof Tables]
+
+describe('supabase schema', () => {
+  it('exposes required building scoped tables', () => {
+    const scopedTables: BuildingScopedTables[] = [
+      'amenities',
+      'amenity_bookings',
+      'documents',
+      'leases',
+      'maintenance_requests',
+      'messages',
+      'rent_payments',
+      'threads',
+      'units',
+      'user_roles',
+      'visitor_logs',
+    ]
+
+    expectTypeOf<(typeof scopedTables)[number]>().toEqualTypeOf<BuildingScopedTables>()
+  })
+
+  it('enforces building_id as non-nullable string on core tables', () => {
+    expectTypeOf<Tables['amenities']['Row']['building_id']>().toEqualTypeOf<string>()
+    expectTypeOf<Tables['leases']['Row']['building_id']>().toEqualTypeOf<string>()
+    expectTypeOf<Tables['rent_payments']['Row']['building_id']>().toEqualTypeOf<string>()
+    expectTypeOf<Tables['maintenance_requests']['Row']['building_id']>().toEqualTypeOf<string>()
+  })
+
+  it('includes tenancy-aware helper functions', () => {
+    expectTypeOf<
+      Database['public']['Functions']['has_building_role']['Args']['target_building']
+    >().toEqualTypeOf<string>()
+
+    expectTypeOf<
+      Database['public']['Functions']['has_building_role']['Args']['allowed_roles']
+    >().toEqualTypeOf<Database['public']['Enums']['user_role_type'][] | null | undefined>()
+
+    expectTypeOf<
+      Database['public']['Functions']['has_shared_building']['Returns']
+    >().toEqualTypeOf<boolean>()
+  })
+
+  it('tracks all role enum values', () => {
+    expectTypeOf<Database['public']['Enums']['user_role_type']>().toEqualTypeOf<
+      | 'platform_admin'
+      | 'property_manager'
+      | 'building_staff'
+      | 'resident'
+      | 'support_agent'
+    >()
+  })
+})

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,8 +1,14 @@
 import { type CookieOptions, createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import type { Database } from '@/lib/supabase'
+import {
+  assertTenantAccess,
+  createBuildingScopedQuery,
+  type BuildingRole,
+} from '@/utils/supabase/tenancy'
 
 export function createClient(cookieStore: ReturnType<typeof cookies>) {
-  return createServerClient(
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
@@ -20,3 +26,19 @@ export function createClient(cookieStore: ReturnType<typeof cookies>) {
     }
   )
 }
+
+export async function createTenantScopedActionClient(
+  buildingId: string,
+  allowedRoles: BuildingRole[] = []
+) {
+  const client = createClient(cookies())
+  await assertTenantAccess(client, buildingId, allowedRoles)
+
+  return {
+    client,
+    buildingId,
+    scope: createBuildingScopedQuery(client, buildingId),
+  }
+}
+
+export { assertTenantAccess }

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,10 +1,16 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import type { Database } from '@/lib/supabase'
+import {
+  assertTenantAccess,
+  createBuildingScopedQuery,
+  type BuildingRole,
+} from '@/utils/supabase/tenancy'
 
 export function createClient() {
   const cookieStore = cookies()
 
-  return createServerClient(
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
@@ -34,3 +40,19 @@ export function createClient() {
     }
   )
 }
+
+export async function createTenantScopedServerClient(
+  buildingId: string,
+  allowedRoles: BuildingRole[] = []
+) {
+  const client = createClient()
+  await assertTenantAccess(client, buildingId, allowedRoles)
+
+  return {
+    client,
+    buildingId,
+    scope: createBuildingScopedQuery(client, buildingId),
+  }
+}
+
+export { assertTenantAccess }

--- a/utils/supabase/tenancy.ts
+++ b/utils/supabase/tenancy.ts
@@ -1,0 +1,66 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/supabase'
+
+export type TypedSupabaseClient = SupabaseClient<Database>
+export type BuildingRole = Database['public']['Enums']['user_role_type']
+
+type Tables = Database['public']['Tables']
+export type BuildingScopedTable = {
+  [Key in keyof Tables]: 'building_id' extends keyof Tables[Key]['Row'] ? Key : never
+}[keyof Tables]
+
+export function createBuildingScopedQuery(
+  client: TypedSupabaseClient,
+  buildingId: string
+) {
+  return <TableName extends BuildingScopedTable>(table: TableName) =>
+    client.from(table).eq('building_id', buildingId)
+}
+
+export async function assertTenantAccess(
+  client: TypedSupabaseClient,
+  buildingId: string,
+  allowedRoles: BuildingRole[] = []
+): Promise<BuildingRole[]> {
+  const {
+    data: { user },
+    error: userError,
+  } = await client.auth.getUser()
+
+  if (userError) {
+    throw new Error(`Unable to load authenticated user: ${userError.message}`)
+  }
+
+  if (!user) {
+    throw new Error('Authentication required to access building scoped data')
+  }
+
+  const { data, error } = await client
+    .from('user_roles')
+    .select('role')
+    .eq('building_id', buildingId)
+    .eq('user_id', user.id)
+
+  if (error) {
+    throw new Error(`Unable to verify tenancy membership: ${error.message}`)
+  }
+
+  const roles = (data ?? []).map((entry) => entry.role)
+
+  if (roles.includes('platform_admin')) {
+    return roles
+  }
+
+  if (allowedRoles.length === 0) {
+    if (roles.length === 0) {
+      throw new Error('User is not assigned to the requested building')
+    }
+    return roles
+  }
+
+  if (!roles.some((role) => allowedRoles.includes(role))) {
+    throw new Error('User does not hold one of the required roles for this building')
+  }
+
+  return roles
+}

--- a/utils/supaone.tsx
+++ b/utils/supaone.tsx
@@ -1,42 +1,70 @@
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
-import { cookies } from "next/headers";
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { cookies } from 'next/headers'
 import type { Database } from '@/lib/supabase'
-import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import {
+  assertTenantAccess,
+  createBuildingScopedQuery,
+  type BuildingRole,
+  type TypedSupabaseClient,
+} from '@/utils/supabase/tenancy'
+
+export type TenantScopedClient = {
+  client: TypedSupabaseClient
+  buildingId: string
+  scope: ReturnType<typeof createBuildingScopedQuery>
+}
 
 export async function createSupbaseServerClientReadOnly() {
-	const cookieStore = cookies();
+  const cookieStore = cookies()
 
-	return createServerClient(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				get(name: string) {
-					return cookieStore.get(name)?.value;
-				},
-			},
-		}
-	);
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+      },
+    }
+  )
 }
 
 export async function createSupbaseServerClient() {
-	const cookieStore = cookies();
+  const cookieStore = cookies()
 
-	return createServerClient<Database>(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				get(name: string) {
-					return cookieStore.get(name)?.value;
-				},
-				set(name: string, value: string, options: CookieOptions) {
-					cookieStore.set({ name, value, ...options });
-				},
-				remove(name: string, options: CookieOptions) {
-					cookieStore.set({ name, value: "", ...options });
-				},
-			},
-		}
-	);
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options: CookieOptions) {
+          cookieStore.set({ name, value: '', ...options })
+        },
+      },
+    }
+  )
 }
+
+export async function createTenantScopedClient(
+  buildingId: string,
+  allowedRoles: BuildingRole[] = []
+): Promise<TenantScopedClient> {
+  const client = await createSupbaseServerClient()
+
+  await assertTenantAccess(client, buildingId, allowedRoles)
+
+  return {
+    client,
+    buildingId,
+    scope: createBuildingScopedQuery(client, buildingId),
+  }
+}
+
+export { assertTenantAccess }

--- a/utils/typed-supabase-client.tsx
+++ b/utils/typed-supabase-client.tsx
@@ -1,4 +1,1 @@
-import { SupabaseClient } from '@supabase/supabase-js'
-import type { Database } from '@/lib/supabase'
-
-export type TypedSupabaseClient = SupabaseClient<Database>
+export type { TypedSupabaseClient } from '@/utils/supabase/tenancy'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['supabase/tests/**/*.test.ts'],
+    environment: 'node',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- define building-scoped Supabase tables, enums, and RLS policies per ADR-0001 while dropping unused prototypes
- regenerate the typed client and update Supabase helpers/API route with tenancy-aware helpers and role checks
- add seed fixtures plus Vitest schema validation to guard the new schema definitions

## Testing
- pnpm lint
- pnpm test:schema

------
https://chatgpt.com/codex/tasks/task_e_68d04cded31c8328b105fdebc4badd80