### PR TITLE
Add Documenso document workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL="https://your-supabase-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="supabase-anon-key"
+SUPABASE_SERVICE_ROLE_KEY="supabase-service-role-key"
+SUPABASE_JWT_SECRET="supabase-jwt-secret"
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
+# Documenso self-hosted configuration
+DOCUMENSO_BASE_URL="https://documenso.your-domain.com"
+DOCUMENSO_API_KEY="documenso-api-key"
+DOCUMENSO_WEBHOOK_SECRET="webhook-secret" # optional: used to verify webhook signatures
+DOCUMENSO_POLL_INTERVAL_SECONDS="60" # optional: used for background polling if you schedule it

--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ complete Supabase SSR Auth and DB integration, Zod validation, Tanstack React Qu
     - Configure the SUPABASE_WORKOS_CONNECTION_ID environment variable with the copied value
 
   - Ensure your Supabase tables match the tables and types found in '@/lib/supabase'.
-  - Add authorized development and production URL's to Supabase URL config. 
+  - Add authorized development and production URL's to Supabase URL config.
+  - Configure Documenso if you plan to manage lease agreements through the portal:
+    - DOCUMENSO_BASE_URL="https://documenso.your-domain.com"
+    - DOCUMENSO_API_KEY="a Documenso personal access token with template + envelope scopes"
+    - DOCUMENSO_WEBHOOK_SECRET="shared secret used to verify webhook payloads"
+    - (optional) Schedule a polling job using DOCUMENSO_POLL_INTERVAL_SECONDS if webhooks are unavailable.
 ### Run  
 - Development server:
 

--- a/app/api/documenso/webhook/route.ts
+++ b/app/api/documenso/webhook/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+
+import { createClient } from "@supabase/supabase-js";
+
+import {
+  coerceMetadata,
+  documentStatusFromEnvelope,
+  leaseVersionToUpdatePayload,
+} from "@/lib/documents-service";
+import { getDocumensoEnvelope } from "@/lib/documenso-client";
+import type { Database, Json } from "@/lib/supabase";
+
+function getServiceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceKey) {
+    throw new Error("Supabase service credentials are not configured");
+  }
+
+  return createClient<Database>(url, serviceKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const secret = process.env.DOCUMENSO_WEBHOOK_SECRET;
+    if (secret) {
+      const signature = request.headers.get("x-documenso-signature");
+      if (signature !== secret) {
+        return new Response("Invalid signature", { status: 401 });
+      }
+    }
+
+    const payload = await request.json();
+    const envelopeId: string | undefined =
+      payload?.envelope_id ??
+      payload?.data?.envelope_id ??
+      payload?.data?.id ??
+      payload?.envelope?.id ??
+      payload?.id;
+
+    if (!envelopeId) {
+      return new Response("Missing envelope identifier", { status: 400 });
+    }
+
+    const supabase = getServiceClient();
+    const { data: leaseVersion } = await supabase
+      .from("lease_versions")
+      .select("*")
+      .eq("documenso_envelope_id", envelopeId)
+      .maybeSingle();
+
+    if (!leaseVersion) {
+      return Response.json({ ok: true });
+    }
+
+    const { data: document } = await supabase
+      .from("documents")
+      .select("*")
+      .eq("id", leaseVersion.document_id)
+      .single();
+
+    if (!document) {
+      return Response.json({ ok: true });
+    }
+
+    const envelope = await getDocumensoEnvelope(envelopeId);
+    const leaseUpdate = leaseVersionToUpdatePayload(envelope, leaseVersion);
+    const typedDocument = { ...document, lease_versions: [leaseVersion] };
+    const docUpdate = documentStatusFromEnvelope(envelope, typedDocument);
+
+    const metadata = {
+      ...coerceMetadata(document.metadata),
+      lastWebhookAt: new Date().toISOString(),
+      lastWebhookEvent: payload?.type ?? envelope.status,
+    } as Record<string, unknown>;
+
+    await supabase
+      .from("lease_versions")
+      .update(leaseUpdate)
+      .eq("id", leaseVersion.id);
+
+    await supabase
+      .from("documents")
+      .update({
+        ...docUpdate,
+        metadata: metadata as Json,
+      })
+      .eq("id", document.id);
+
+    revalidatePath("/dashboard/documents");
+    revalidatePath("/dashboard/leases");
+
+    return Response.json({ ok: true });
+  } catch (error) {
+    console.error("Documenso webhook error", error);
+    return new Response("Webhook processing failed", { status: 500 });
+  }
+}

--- a/app/api/documents/[documentId]/download/route.ts
+++ b/app/api/documents/[documentId]/download/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest } from "next/server";
+
+import { downloadEnvelopeDocument } from "@/lib/documenso-client";
+import {
+  DocumentWithRelations,
+  filterDocumentsForViewer,
+  getActiveLeaseVersion,
+  getLatestCompletedLeaseVersion,
+  getLeaseVersions,
+} from "@/lib/documents-service";
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { documentId: string } },
+) {
+  const documentId = params.documentId;
+  if (!documentId) {
+    return new Response("Missing document id", { status: 400 });
+  }
+
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user) {
+    return new Response("Authentication required", { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, role")
+    .eq("id", session.user.id)
+    .single();
+
+  const leaseVersionId = request.nextUrl.searchParams.get("leaseVersion");
+
+  const { data, error } = await supabase
+    .from("documents")
+    .select(
+      "*, tenant:profiles!documents_tenant_id_fkey(id, full_name, email), lease_versions(*)",
+    )
+    .eq("id", documentId)
+    .maybeSingle();
+
+  if (error || !data) {
+    return new Response("Document not found", { status: 404 });
+  }
+
+  const document = data as DocumentWithRelations;
+  const accessible = filterDocumentsForViewer([document], session.user.id, profile?.role);
+
+  if (accessible.length === 0) {
+    return new Response("Not authorised", { status: 403 });
+  }
+
+  const versions = getLeaseVersions(document);
+  const targetVersion = leaseVersionId
+    ? versions.find((version) => version.id === leaseVersionId)
+    : getLatestCompletedLeaseVersion(document) ?? getActiveLeaseVersion(document);
+
+  if (!targetVersion?.documenso_envelope_id) {
+    return new Response("Envelope not available", { status: 404 });
+  }
+
+  const download = await downloadEnvelopeDocument(targetVersion.documenso_envelope_id);
+
+  await supabase.from("document_download_audit").insert({
+    document_id: document.id,
+    lease_version_id: targetVersion.id,
+    downloaded_by: session.user.id,
+    documenso_envelope_id: targetVersion.documenso_envelope_id,
+    source: "portal",
+    remote_addr: request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null,
+    user_agent: request.headers.get("user-agent"),
+  });
+
+  const buffer = Buffer.from(new Uint8Array(download.data));
+  const disposition = `attachment; filename="${download.filename}"`;
+
+  return new Response(buffer, {
+    status: 200,
+    headers: {
+      "Content-Type": download.contentType,
+      "Content-Disposition": disposition,
+      "Cache-Control": "private, max-age=0, must-revalidate",
+    },
+  });
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,11 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import {
+  CrumpledPaperIcon,
+  FileTextIcon,
+  LayersIcon,
+  PersonIcon,
+} from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,18 +13,28 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+        const links = [
+                {
+                        href: "/dashboard/documents",
+                        text: "Documents",
+                        Icon: FileTextIcon,
+                },
+                {
+                        href: "/dashboard/leases",
+                        text: "Leases",
+                        Icon: LayersIcon,
+                },
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+        ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/documents/actions.ts
+++ b/app/dashboard/documents/actions.ts
@@ -1,0 +1,308 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import {
+  createEnvelopeFromTemplate,
+  getDocumensoEnvelope,
+} from "@/lib/documenso-client";
+import {
+  DocumentStatus,
+  DocumentWithRelations,
+  coerceMetadata,
+  documentStatusFromEnvelope,
+  extractSigningUrlForRecipient,
+  filterDocumentsForViewer,
+  getActiveLeaseVersion,
+  getNextLeaseVersionNumber,
+  isManagerRole,
+  leaseVersionToUpdatePayload,
+  mapDocumensoStatusToDocumentStatus,
+  mapRecipientsToSigners,
+  shouldAllowNewEnvelope,
+} from "@/lib/documents-service";
+import type { Json } from "@/lib/supabase";
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+export type SendDocumentResult = {
+  success?: boolean;
+  error?: string;
+  status?: DocumentStatus;
+  envelopeId?: string;
+  signingUrl?: string | null;
+};
+
+export type RefreshDocumentStatusInput = {
+  documentId: string;
+  openForSigner?: boolean;
+};
+
+export type RefreshDocumentStatusResult = {
+  success?: boolean;
+  error?: string;
+  status?: DocumentStatus;
+  envelopeId?: string;
+  signingUrl?: string | null;
+};
+
+async function getViewerContext() {
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError) {
+    throw sessionError;
+  }
+
+  if (!session?.user) {
+    return { supabase, session: null, profile: null } as const;
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, full_name, email, role")
+    .eq("id", session.user.id)
+    .single();
+
+  if (profileError) {
+    throw profileError;
+  }
+
+  return { supabase, session, profile } as const;
+}
+
+async function getDocumentById(supabase: ReturnType<typeof createSupbaseServerClient> extends Promise<infer T> ? T : never, documentId: string) {
+  const { data, error } = await supabase
+    .from("documents")
+    .select(
+      "*, tenant:profiles!documents_tenant_id_fkey(id, full_name, email), lease_versions(*)",
+    )
+    .eq("id", documentId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data as DocumentWithRelations | null;
+}
+
+export async function sendDocumentForSignatureAction(documentId: string): Promise<SendDocumentResult> {
+  try {
+    if (!documentId) {
+      return { error: "Document identifier is required." };
+    }
+
+    const { supabase, session, profile } = await getViewerContext();
+
+    if (!session?.user) {
+      return { error: "You must be signed in to send documents." };
+    }
+
+    if (!profile || !isManagerRole(profile.role)) {
+      return { error: "Only property managers can initiate Documenso envelopes." };
+    }
+
+    const document = await getDocumentById(supabase, documentId);
+
+    if (!document) {
+      return { error: "Document not found." };
+    }
+
+    if (!shouldAllowNewEnvelope(document)) {
+      return {
+        error: "A Documenso envelope is already in progress for this document.",
+        status: document.status,
+      };
+    }
+
+    if (!document.tenant_id || !document.tenant?.email) {
+      return {
+        error: "Tenant contact information is missing. Add a tenant email before sending.",
+      };
+    }
+
+    const recipients = [
+      {
+        name: document.tenant.full_name ?? document.tenant.email,
+        email: document.tenant.email,
+        role: "tenant",
+        signingOrder: 1,
+      },
+    ];
+
+    if (profile.email) {
+      recipients.push({
+        name: profile.full_name ?? profile.email,
+        email: profile.email,
+        role: "manager",
+        signingOrder: 2,
+      });
+    }
+
+    const metadata = coerceMetadata(document.metadata);
+    const timestamp = new Date().toISOString();
+
+    const envelope = await createEnvelopeFromTemplate({
+      templateId: document.documenso_template_id,
+      recipients,
+      metadata: {
+        ...metadata,
+        documentId: document.id,
+        tenantId: document.tenant_id,
+        createdBy: profile.id,
+        requestedAt: timestamp,
+      },
+      redirectUrl: process.env.NEXT_PUBLIC_APP_URL
+        ? `${process.env.NEXT_PUBLIC_APP_URL}/dashboard/documents`
+        : undefined,
+    });
+
+    const versionNumber = getNextLeaseVersionNumber(document);
+    const leaseInsert = {
+      document_id: document.id,
+      version: versionNumber,
+      documenso_envelope_id: envelope.id,
+      status: mapDocumensoStatusToDocumentStatus(envelope.status),
+      signers: mapRecipientsToSigners(envelope.recipients ?? []) as Json,
+      sent_at: timestamp,
+      expires_at: envelope.expiresAt ?? null,
+    } as const;
+
+    const { error: leaseError } = await supabase.from("lease_versions").insert(leaseInsert);
+    if (leaseError) {
+      return { error: leaseError.message };
+    }
+
+    const nextStatus = mapDocumensoStatusToDocumentStatus(envelope.status);
+    const updatedMetadata = {
+      ...metadata,
+      lastEnvelopeId: envelope.id,
+      lastSentAt: timestamp,
+    } satisfies Record<string, unknown>;
+
+    const { error: documentError } = await supabase
+      .from("documents")
+      .update({
+        status: nextStatus,
+        active_envelope_id: envelope.id,
+        metadata: updatedMetadata as Json,
+        created_by: profile.id,
+      })
+      .eq("id", document.id);
+
+    if (documentError) {
+      return { error: documentError.message };
+    }
+
+    revalidatePath("/dashboard/documents");
+    revalidatePath("/dashboard/leases");
+
+    return {
+      success: true,
+      status: nextStatus,
+      envelopeId: envelope.id,
+      signingUrl: envelope.recipients?.[0]?.signingUrl ?? null,
+    };
+  } catch (error) {
+    console.error("sendDocumentForSignatureAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Unable to send Documenso envelope.",
+    };
+  }
+}
+
+export async function refreshDocumentStatusAction(
+  input: RefreshDocumentStatusInput,
+): Promise<RefreshDocumentStatusResult> {
+  try {
+    const documentId = input?.documentId;
+    if (!documentId) {
+      return { error: "Document identifier is required." };
+    }
+
+    const { supabase, session, profile } = await getViewerContext();
+
+    if (!session?.user) {
+      return { error: "You must be signed in to refresh document status." };
+    }
+
+    const document = await getDocumentById(supabase, documentId);
+
+    if (!document) {
+      return { error: "Document not found." };
+    }
+
+    const accessible = filterDocumentsForViewer([document], session.user.id, profile?.role);
+    if (accessible.length === 0) {
+      return { error: "You do not have access to this document." };
+    }
+
+    const activeVersion = getActiveLeaseVersion(document);
+    if (!activeVersion) {
+      return {
+        error: "No envelope has been created for this document yet.",
+        status: document.status,
+      };
+    }
+
+    const envelope = await getDocumensoEnvelope(activeVersion.documenso_envelope_id);
+    const leaseUpdate = leaseVersionToUpdatePayload(envelope, activeVersion);
+    const documentUpdate = documentStatusFromEnvelope(envelope, document);
+    const nextStatus = documentUpdate.status ?? document.status;
+
+    const metadata = {
+      ...coerceMetadata(document.metadata),
+      lastSyncedAt: new Date().toISOString(),
+      lastKnownEnvelopeStatus: nextStatus,
+    } satisfies Record<string, unknown>;
+
+    const { error: leaseError } = await supabase
+      .from("lease_versions")
+      .update(leaseUpdate)
+      .eq("id", activeVersion.id);
+
+    if (leaseError) {
+      return { error: leaseError.message };
+    }
+
+    const { error: documentError } = await supabase
+      .from("documents")
+      .update({
+        ...documentUpdate,
+        metadata: metadata as Json,
+      })
+      .eq("id", document.id);
+
+    if (documentError) {
+      return { error: documentError.message };
+    }
+
+    revalidatePath("/dashboard/documents");
+    revalidatePath("/dashboard/leases");
+
+    let signingUrl: string | null = null;
+    if (input.openForSigner) {
+      const candidateEmail = profile?.email ?? session.user.email ?? null;
+      if (candidateEmail) {
+        signingUrl =
+          extractSigningUrlForRecipient(envelope, candidateEmail) ??
+          signingUrl;
+      }
+    }
+
+    return {
+      success: true,
+      status: nextStatus,
+      envelopeId: envelope.id,
+      signingUrl,
+    };
+  } catch (error) {
+    console.error("refreshDocumentStatusAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Unable to refresh document status.",
+    };
+  }
+}

--- a/app/dashboard/documents/components/document-actions.tsx
+++ b/app/dashboard/documents/components/document-actions.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  refreshDocumentStatusAction,
+  sendDocumentForSignatureAction,
+} from "../actions";
+
+type ActionFeedback = {
+  type: "success" | "error";
+  message: string;
+};
+
+type BaseProps = {
+  documentId: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+export function SendForSignatureButton({
+  documentId,
+  disabled,
+  className,
+}: BaseProps) {
+  const [pending, startTransition] = useTransition();
+  const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+
+  return (
+    <div className="space-y-1">
+      <Button
+        className={className}
+        disabled={disabled || pending}
+        onClick={() => {
+          startTransition(async () => {
+            setFeedback(null);
+            const result = await sendDocumentForSignatureAction(documentId);
+
+            if (result.error) {
+              setFeedback({ type: "error", message: result.error });
+              return;
+            }
+
+            setFeedback({
+              type: "success",
+              message: "Documenso envelope sent successfully.",
+            });
+
+            if (result.signingUrl) {
+              window.open(result.signingUrl, "_blank", "noopener,noreferrer");
+            }
+          });
+        }}
+        variant="default"
+      >
+        {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+        {pending ? "Sending..." : "Send for signature"}
+      </Button>
+      {feedback ? (
+        <p
+          className={`text-sm ${feedback.type === "error" ? "text-destructive" : "text-muted-foreground"}`}
+        >
+          {feedback.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+type RefreshProps = BaseProps & {
+  label?: string;
+  openForSigner?: boolean;
+};
+
+export function RefreshStatusButton({
+  documentId,
+  disabled,
+  className,
+  label = "Refresh status",
+  openForSigner,
+}: RefreshProps) {
+  const [pending, startTransition] = useTransition();
+  const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+
+  return (
+    <div className="space-y-1">
+      <Button
+        className={className}
+        variant="secondary"
+        disabled={disabled || pending}
+        onClick={() => {
+          startTransition(async () => {
+            setFeedback(null);
+            const result = await refreshDocumentStatusAction({
+              documentId,
+              openForSigner: Boolean(openForSigner),
+            });
+
+            if (result.error) {
+              setFeedback({ type: "error", message: result.error });
+              return;
+            }
+
+            setFeedback({
+              type: "success",
+              message: `Status updated${result.status ? ` (${result.status})` : ""}.`,
+            });
+
+            if (openForSigner && result.signingUrl) {
+              window.open(result.signingUrl, "_blank", "noopener,noreferrer");
+            }
+          });
+        }}
+      >
+        {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+        {pending ? "Refreshing..." : label}
+      </Button>
+      {feedback ? (
+        <p
+          className={`text-sm ${feedback.type === "error" ? "text-destructive" : "text-muted-foreground"}`}
+        >
+          {feedback.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function ContinueSigningButton({
+  documentId,
+  disabled,
+  className,
+}: BaseProps) {
+  return (
+    <RefreshStatusButton
+      className={className}
+      documentId={documentId}
+      disabled={disabled}
+      label="Open signing session"
+      openForSigner
+    />
+  );
+}

--- a/app/dashboard/documents/components/document-card.tsx
+++ b/app/dashboard/documents/components/document-card.tsx
@@ -1,0 +1,221 @@
+import Link from "next/link";
+import { format } from "date-fns";
+import { FileDown } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  ContinueSigningButton,
+  RefreshStatusButton,
+  SendForSignatureButton,
+} from "./document-actions";
+import { StatusBadge } from "./status-badge";
+import {
+  DocumentWithRelations,
+  SignerMetadata,
+  getActiveLeaseVersion,
+  getLatestCompletedLeaseVersion,
+  getLeaseVersions,
+  isManagerRole,
+  parseSigners,
+  resolveDocumentStatus,
+  shouldAllowNewEnvelope,
+  STATUS_LABELS,
+} from "@/lib/documents-service";
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+
+  try {
+    return format(new Date(value), "MMM d, yyyy");
+  } catch (error) {
+    return value;
+  }
+}
+
+function SignerList({ signers }: { signers: SignerMetadata[] }) {
+  if (!signers.length) {
+    return <p className="text-sm text-muted-foreground">No signer metadata available yet.</p>;
+  }
+
+  return (
+    <ul className="space-y-1 text-sm text-muted-foreground">
+      {signers.map((signer, index) => (
+        <li key={`${signer.email ?? signer.name ?? "signer"}-${index}`}>
+          <span className="font-medium text-foreground">{signer.name ?? signer.email}</span>
+          {signer.email ? <span className="ml-1">({signer.email})</span> : null}
+          {signer.status ? (
+            <Badge className="ml-2" variant="outline">
+              {signer.status}
+            </Badge>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function DocumentCard({
+  document,
+  viewerRole,
+}: {
+  document: DocumentWithRelations;
+  viewerRole?: string | null;
+}) {
+  const status = resolveDocumentStatus(document);
+  const versions = getLeaseVersions(document);
+  const activeVersion = getActiveLeaseVersion(document);
+  const completedVersion = getLatestCompletedLeaseVersion(document);
+  const isManager = isManagerRole(viewerRole);
+  const canSend = isManager && shouldAllowNewEnvelope(document);
+  const canRefresh = Boolean(activeVersion);
+  const canContinue = !isManager && Boolean(activeVersion);
+  const tenantName = document.tenant?.full_name ?? document.tenant?.email ?? "Unknown tenant";
+  const lastUpdated = document.updated_at ?? activeVersion?.updated_at ?? document.created_at ?? null;
+
+  return (
+    <Card>
+      <CardHeader className="gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <CardTitle className="flex items-center gap-3 text-xl font-semibold">
+            {document.title}
+            <StatusBadge status={status} />
+          </CardTitle>
+          <CardDescription className="mt-1 text-sm text-muted-foreground">
+            Template <span className="font-medium text-foreground">{document.documenso_template_id}</span>
+            {document.tenant ? (
+              <>
+                {" "}· Tenant <span className="font-medium text-foreground">{tenantName}</span>
+              </>
+            ) : null}
+          </CardDescription>
+        </div>
+        <div className="flex flex-col gap-3 sm:items-end">
+          <p className="text-sm text-muted-foreground">Last updated {formatDate(lastUpdated)}</p>
+          <div className="flex flex-wrap gap-2">
+            {isManager ? (
+              <SendForSignatureButton documentId={document.id} disabled={!canSend} />
+            ) : null}
+            {canRefresh ? (
+              <RefreshStatusButton documentId={document.id} disabled={false} />
+            ) : null}
+            {canContinue ? (
+              <ContinueSigningButton documentId={document.id} disabled={!canContinue} />
+            ) : null}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <section className="grid gap-4 rounded-md border bg-muted/50 p-4 text-sm text-muted-foreground sm:grid-cols-2">
+          <div>
+            <span className="font-medium text-foreground">Active envelope</span>
+            <p className="mt-1 break-all text-sm text-muted-foreground">
+              {document.active_envelope_id ?? "No active envelope"}
+            </p>
+          </div>
+          <div>
+            <span className="font-medium text-foreground">Latest status</span>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {STATUS_LABELS[status]} (synced {formatDate(document.updated_at)})
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h3 className="text-base font-semibold">Lease versions</h3>
+          {versions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No Documenso envelopes have been created for this document yet.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {versions.map((version) => {
+                const signers = parseSigners(version.signers);
+                const downloadUrl = `/api/documents/${document.id}/download?leaseVersion=${version.id}`;
+                const canDownload = version.status === "completed";
+
+                return (
+                  <div
+                    key={version.id}
+                    className="space-y-3 rounded-md border p-4"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex flex-col">
+                        <span className="text-sm font-semibold text-foreground">
+                          Version {version.version}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          Envelope {version.documenso_envelope_id}
+                        </span>
+                      </div>
+                      <StatusBadge status={version.status} />
+                    </div>
+                    <dl className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-3">
+                      <div>
+                        <dt className="font-medium text-foreground">Sent</dt>
+                        <dd>{formatDate(version.sent_at)}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-medium text-foreground">Completed</dt>
+                        <dd>{formatDate(version.completed_at)}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-medium text-foreground">Expires</dt>
+                        <dd>{formatDate(version.expires_at)}</dd>
+                      </div>
+                    </dl>
+                    <div>
+                      <h4 className="text-sm font-semibold text-foreground">Signers</h4>
+                      <SignerList signers={signers} />
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3">
+                      {isManager ? (
+                        <RefreshStatusButton
+                          documentId={document.id}
+                          disabled={false}
+                          label="Sync version"
+                        />
+                      ) : null}
+                      {canDownload ? (
+                        <Link
+                          className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+                          href={downloadUrl}
+                        >
+                          <FileDown className="size-4" /> Download signed PDF
+                        </Link>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          Signed copy will be available once the envelope is completed.
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        {completedVersion ? (
+          <section className="rounded-md border border-dashed p-4 text-sm">
+            <p className="flex items-center gap-2">
+              <FileDown className="size-4 text-muted-foreground" />
+              <Link
+                className="font-medium text-primary hover:underline"
+                href={`/api/documents/${document.id}/download?leaseVersion=${completedVersion.id}`}
+              >
+                Download latest signed copy
+              </Link>
+            </p>
+          </section>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/dashboard/documents/components/document-list.tsx
+++ b/app/dashboard/documents/components/document-list.tsx
@@ -1,0 +1,29 @@
+import { DocumentCard } from "./document-card";
+import type { DocumentWithRelations } from "@/lib/documents-service";
+
+export function DocumentList({
+  documents,
+  viewerRole,
+}: {
+  documents: DocumentWithRelations[];
+  viewerRole?: string | null;
+}) {
+  if (!documents.length) {
+    return (
+      <div className="rounded-md border border-dashed p-6 text-center">
+        <h3 className="text-lg font-semibold">No documents yet</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          When your property manager prepares your lease paperwork it will appear here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {documents.map((document) => (
+        <DocumentCard key={document.id} document={document} viewerRole={viewerRole} />
+      ))}
+    </div>
+  );
+}

--- a/app/dashboard/documents/components/status-badge.tsx
+++ b/app/dashboard/documents/components/status-badge.tsx
@@ -1,0 +1,14 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  DocumentStatus,
+  getStatusLabel,
+  getStatusVariant,
+} from "@/lib/documents-service";
+
+export function StatusBadge({ status, className }: { status: DocumentStatus; className?: string }) {
+  return (
+    <Badge className={className} variant={getStatusVariant(status)}>
+      {getStatusLabel(status)}
+    </Badge>
+  );
+}

--- a/app/dashboard/documents/page.tsx
+++ b/app/dashboard/documents/page.tsx
@@ -1,0 +1,57 @@
+import { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { DocumentList } from "./components/document-list";
+import {
+  DocumentWithRelations,
+  filterDocumentsForViewer,
+} from "@/lib/documents-service";
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+export const metadata: Metadata = {
+  title: "Lease documents",
+};
+
+export default async function DocumentsPage() {
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user) {
+    redirect("/auth");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, role, full_name")
+    .eq("id", session.user.id)
+    .single();
+
+  const { data, error } = await supabase
+    .from("documents")
+    .select(
+      "*, tenant:profiles!documents_tenant_id_fkey(id, full_name, email), lease_versions(*)",
+    )
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Failed to load documents", error);
+  }
+
+  const documents = (data ?? []) as DocumentWithRelations[];
+  const filtered = filterDocumentsForViewer(documents, session.user.id, profile?.role);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Documents</h1>
+        <p className="text-sm text-muted-foreground">
+          Review lease templates, track Documenso envelopes, and download signed copies.
+        </p>
+      </div>
+
+      <DocumentList documents={filtered} viewerRole={profile?.role} />
+    </div>
+  );
+}

--- a/app/dashboard/leases/page.tsx
+++ b/app/dashboard/leases/page.tsx
@@ -1,0 +1,155 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { RefreshStatusButton, SendForSignatureButton } from "../documents/components/document-actions";
+import { StatusBadge } from "../documents/components/status-badge";
+import {
+  DocumentWithRelations,
+  getActiveLeaseVersion,
+  getLatestCompletedLeaseVersion,
+  getLeaseVersions,
+  isManagerRole,
+  resolveDocumentStatus,
+  shouldAllowNewEnvelope,
+} from "@/lib/documents-service";
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+export const metadata: Metadata = {
+  title: "Lease management",
+};
+
+export default async function LeasesPage() {
+  const supabase = await createSupbaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user) {
+    redirect("/auth");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, role, full_name")
+    .eq("id", session.user.id)
+    .single();
+
+  const { data, error } = await supabase
+    .from("documents")
+    .select(
+      "*, tenant:profiles!documents_tenant_id_fkey(id, full_name, email), lease_versions(*)",
+    )
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Failed to load documents", error);
+  }
+
+  const documents = (data ?? []) as DocumentWithRelations[];
+  const isManager = isManagerRole(profile?.role);
+
+  if (!isManager) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold">Leases</h1>
+          <p className="text-sm text-muted-foreground">
+            This view is limited to property managers. You can review your own agreements on the Documents page.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const rows = documents.map((document) => {
+    const activeVersion = getActiveLeaseVersion(document);
+    const latestCompleted = getLatestCompletedLeaseVersion(document);
+    const status = resolveDocumentStatus(document);
+
+    return {
+      document,
+      activeVersion,
+      latestCompleted,
+      status,
+      canSend: shouldAllowNewEnvelope(document),
+    };
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Lease workflows</h1>
+        <p className="text-sm text-muted-foreground">
+          Track Documenso envelopes across all tenants, resend templates, and download completed agreements.
+        </p>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border">
+        <table className="min-w-full divide-y divide-border text-sm">
+          <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium">Document</th>
+              <th className="px-4 py-3 text-left font-medium">Tenant</th>
+              <th className="px-4 py-3 text-left font-medium">Status</th>
+              <th className="px-4 py-3 text-left font-medium">Active envelope</th>
+              <th className="px-4 py-3 text-left font-medium">Versions</th>
+              <th className="px-4 py-3 text-left font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border bg-background">
+            {rows.map(({ document, activeVersion, latestCompleted, status, canSend }) => (
+              <tr key={document.id} className="align-top">
+                <td className="px-4 py-3">
+                  <div className="font-medium text-foreground">{document.title}</div>
+                  <div className="text-xs text-muted-foreground">
+                    Template {document.documenso_template_id}
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="font-medium text-foreground">
+                    {document.tenant?.full_name ?? document.tenant?.email ?? "—"}
+                  </div>
+                  <div className="text-xs text-muted-foreground">{document.tenant?.email ?? ""}</div>
+                </td>
+                <td className="px-4 py-3">
+                  <StatusBadge status={status} />
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {document.active_envelope_id ?? "No active envelope"}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-xs text-muted-foreground">
+                  <div className="font-medium text-foreground">
+                    {activeVersion ? `Version ${activeVersion.version}` : "—"}
+                  </div>
+                  <div>
+                    {activeVersion?.documenso_envelope_id ?? "Awaiting envelope"}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-xs text-muted-foreground">
+                  <div>{getLeaseVersions(document).length} versions</div>
+                  {latestCompleted ? (
+                    <Link
+                      className="mt-1 inline-flex items-center gap-1 font-medium text-primary hover:underline"
+                      href={`/api/documents/${document.id}/download?leaseVersion=${latestCompleted.id}`}
+                    >
+                      Download signed copy
+                    </Link>
+                  ) : (
+                    <span className="mt-1 block">No signed version yet</span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-col gap-2">
+                    <SendForSignatureButton documentId={document.id} disabled={!canSend} />
+                    <RefreshStatusButton documentId={document.id} disabled={!activeVersion} />
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/lib/documenso-client.ts
+++ b/lib/documenso-client.ts
@@ -1,0 +1,276 @@
+"use server";
+
+import "server-only";
+
+export type DocumensoEnvelopeStatus =
+  | "draft"
+  | "ready"
+  | "sent"
+  | "viewed"
+  | "completed"
+  | "declined"
+  | "expired"
+  | "cancelled";
+
+export interface DocumensoTemplate {
+  id: string;
+  name: string;
+  description?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface DocumensoRecipient {
+  id: string | null;
+  name: string | null;
+  email: string | null;
+  role: string | null;
+  status?: string | null;
+  signingUrl?: string | null;
+}
+
+export interface DocumensoEnvelope {
+  id: string;
+  status: DocumensoEnvelopeStatus;
+  templateId?: string | null;
+  redirectUrl?: string | null;
+  metadata?: Record<string, unknown> | null;
+  completedAt?: string | null;
+  expiresAt?: string | null;
+  recipients?: DocumensoRecipient[];
+  raw?: unknown;
+}
+
+export interface CreateEnvelopeFromTemplateInput {
+  templateId: string;
+  recipients: Array<{
+    name: string;
+    email: string;
+    role?: string;
+    signingOrder?: number;
+  }>;
+  metadata?: Record<string, unknown>;
+  redirectUrl?: string;
+}
+
+export interface DocumensoDownload {
+  data: ArrayBuffer;
+  filename: string;
+  contentType: string;
+}
+
+export class DocumensoError extends Error {
+  readonly status: number;
+  readonly details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = "DocumensoError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+function getBaseUrl() {
+  const baseUrl = process.env.DOCUMENSO_BASE_URL;
+  if (!baseUrl) {
+    throw new DocumensoError(
+      "DOCUMENSO_BASE_URL is not configured. Add it to your environment variables to enable document workflows.",
+      500,
+    );
+  }
+
+  return baseUrl.replace(/\/$/, "");
+}
+
+function getApiKey() {
+  const apiKey = process.env.DOCUMENSO_API_KEY;
+  if (!apiKey) {
+    throw new DocumensoError(
+      "DOCUMENSO_API_KEY is not configured. Generate an API key in Documenso and expose it via the environment.",
+      500,
+    );
+  }
+
+  return apiKey;
+}
+
+async function documensoRequest(path: string, init: RequestInit = {}) {
+  const url = `${getBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+  const headers: HeadersInit = {
+    Accept: init.headers ? undefined : "application/json",
+    Authorization: `Bearer ${getApiKey()}`,
+    ...init.headers,
+  };
+
+  const response = await fetch(url, {
+    ...init,
+    headers,
+  });
+
+  if (!response.ok) {
+    const contentType = response.headers.get("content-type");
+    let details: unknown = undefined;
+
+    if (contentType?.includes("application/json")) {
+      try {
+        details = await response.json();
+      } catch (error) {
+        details = await response.text();
+      }
+    } else {
+      details = await response.text();
+    }
+
+    throw new DocumensoError(
+      `Documenso request failed with status ${response.status}`,
+      response.status,
+      details,
+    );
+  }
+
+  return response;
+}
+
+async function documensoJson<T>(path: string, init: RequestInit = {}) {
+  const response = await documensoRequest(path, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+
+  return (await response.json()) as T;
+}
+
+function normaliseRecipient(payload: any): DocumensoRecipient {
+  const candidate = payload?.member ?? payload;
+  const email =
+    typeof candidate?.email === "string"
+      ? candidate.email.toLowerCase()
+      : typeof payload?.email === "string"
+        ? payload.email.toLowerCase()
+        : null;
+
+  const signingUrl =
+    payload?.signing_url ??
+    payload?.signingUrl ??
+    payload?.links?.signing ??
+    payload?.links?.sign ??
+    payload?.member?.signing_url ??
+    payload?.member?.signingUrl ??
+    payload?.embedded_signing_url ??
+    payload?.embeddedSigningUrl ??
+    null;
+
+  return {
+    id: candidate?.id ?? payload?.id ?? null,
+    name: candidate?.name ?? payload?.name ?? null,
+    email,
+    role: candidate?.role ?? payload?.role ?? payload?.role_name ?? null,
+    status: (payload?.status ?? candidate?.status ?? payload?.state ?? null) ?? null,
+    signingUrl,
+  };
+}
+
+function normaliseEnvelope(payload: any): DocumensoEnvelope {
+  const recipientsSource =
+    payload?.recipients ?? payload?.members ?? payload?.roles ?? payload?.signers ?? [];
+  const recipients = Array.isArray(recipientsSource)
+    ? recipientsSource.map(normaliseRecipient)
+    : undefined;
+
+  const status = String(payload?.status ?? payload?.state ?? "draft").toLowerCase();
+
+  return {
+    id: String(payload?.id ?? payload?.envelope_id ?? payload?.uuid ?? ""),
+    status: status as DocumensoEnvelopeStatus,
+    templateId: payload?.template_id ?? payload?.templateId ?? null,
+    redirectUrl: payload?.redirect_url ?? payload?.redirectUrl ?? null,
+    metadata: (payload?.metadata ?? null) as Record<string, unknown> | null,
+    completedAt: payload?.completed_at ?? payload?.completedAt ?? null,
+    expiresAt: payload?.expires_at ?? payload?.expiresAt ?? null,
+    recipients,
+    raw: payload,
+  };
+}
+
+function normaliseTemplate(payload: any): DocumensoTemplate {
+  return {
+    id: String(payload?.id ?? payload?.uuid ?? ""),
+    name: payload?.name ?? payload?.title ?? "",
+    description: payload?.description ?? null,
+    updatedAt: payload?.updated_at ?? payload?.updatedAt ?? null,
+  };
+}
+
+export async function listDocumensoTemplates() {
+  const data = await documensoJson<any[]>("/api/v1/templates");
+  return data.map(normaliseTemplate);
+}
+
+export async function getDocumensoEnvelope(envelopeId: string) {
+  const data = await documensoJson<any>(`/api/v1/envelopes/${encodeURIComponent(envelopeId)}`);
+  return normaliseEnvelope(data);
+}
+
+export async function createEnvelopeFromTemplate(input: CreateEnvelopeFromTemplateInput) {
+  const payload = {
+    template_id: input.templateId,
+    recipients: input.recipients.map((recipient, index) => ({
+      name: recipient.name,
+      email: recipient.email,
+      role: recipient.role ?? "signer",
+      signing_order: recipient.signingOrder ?? index + 1,
+    })),
+    metadata: input.metadata ?? {},
+    redirect_url: input.redirectUrl,
+  };
+
+  const data = await documensoJson<any>("/api/v1/envelopes/from-template", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  return normaliseEnvelope(data);
+}
+
+export async function downloadEnvelopeDocument(envelopeId: string): Promise<DocumensoDownload> {
+  const response = await documensoRequest(
+    `/api/v1/envelopes/${encodeURIComponent(envelopeId)}/documents`,
+    {
+      headers: {
+        Accept: "application/pdf",
+      },
+    },
+  );
+
+  const contentType = response.headers.get("content-type") ?? "application/pdf";
+  const contentDisposition = response.headers.get("content-disposition");
+  const fallbackName = `envelope-${envelopeId}.pdf`;
+  const filename = extractFilename(contentDisposition) ?? fallbackName;
+  const data = await response.arrayBuffer();
+
+  return {
+    contentType,
+    filename,
+    data,
+  };
+}
+
+function extractFilename(header: string | null) {
+  if (!header) return null;
+
+  const filenameMatch = /filename\*=UTF-8''([^;]+)/i.exec(header);
+  if (filenameMatch?.[1]) {
+    return decodeURIComponent(filenameMatch[1]);
+  }
+
+  const quotedMatch = /filename="?([^";]+)"?/i.exec(header);
+  if (quotedMatch?.[1]) {
+    return quotedMatch[1];
+  }
+
+  return null;
+}

--- a/lib/documents-service.ts
+++ b/lib/documents-service.ts
@@ -1,0 +1,254 @@
+import { type Database, type Json } from "./supabase";
+import type {
+  DocumensoEnvelope,
+  DocumensoEnvelopeStatus,
+  DocumensoRecipient,
+} from "./documenso-client";
+
+export type DocumentStatus = Database["public"]["Enums"]["document_status"];
+
+export type DocumentRow = Database["public"]["Tables"]["documents"]["Row"];
+export type LeaseVersionRow = Database["public"]["Tables"]["lease_versions"]["Row"];
+export type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+
+export type DocumentWithRelations = DocumentRow & {
+  lease_versions?: LeaseVersionRow[] | null;
+  tenant?: Pick<ProfileRow, "id" | "email" | "full_name"> | null;
+};
+
+export type SignerMetadata = {
+  name?: string | null;
+  email?: string | null;
+  role?: string | null;
+  status?: string | null;
+  signingUrl?: string | null;
+};
+
+export const MANAGER_ROLES = new Set(["property_manager", "admin"]);
+
+export function isManagerRole(role?: string | null) {
+  return role ? MANAGER_ROLES.has(role) : false;
+}
+
+export function filterDocumentsForViewer<T extends DocumentWithRelations>(
+  documents: T[],
+  viewerId: string,
+  viewerRole?: string | null,
+) {
+  if (isManagerRole(viewerRole)) {
+    return documents;
+  }
+
+  return documents.filter((document) => document.tenant_id === viewerId);
+}
+
+export function getLeaseVersions(document: DocumentWithRelations) {
+  return [...(document.lease_versions ?? [])].sort((a, b) => {
+    if (a.version !== b.version) {
+      return b.version - a.version;
+    }
+
+    const aDate = a.updated_at ?? a.created_at ?? "";
+    const bDate = b.updated_at ?? b.created_at ?? "";
+
+    return bDate.localeCompare(aDate);
+  });
+}
+
+export function getLatestLeaseVersion(document: DocumentWithRelations) {
+  return getLeaseVersions(document)[0];
+}
+
+export function getActiveLeaseVersion(document: DocumentWithRelations) {
+  const versions = getLeaseVersions(document);
+
+  if (document.active_envelope_id) {
+    const match = versions.find(
+      (version) => version.documenso_envelope_id === document.active_envelope_id,
+    );
+
+    if (match) {
+      return match;
+    }
+  }
+
+  return versions[0];
+}
+
+export function getLatestCompletedLeaseVersion(document: DocumentWithRelations) {
+  return getLeaseVersions(document).find((version) => version.status === "completed");
+}
+
+export function resolveDocumentStatus(document: DocumentWithRelations): DocumentStatus {
+  const versions = getLeaseVersions(document);
+  if (versions.length === 0) {
+    return document.status;
+  }
+
+  const active = getActiveLeaseVersion(document);
+  if (active?.status) {
+    return active.status;
+  }
+
+  return document.status;
+}
+
+export function isTerminalStatus(status: DocumentStatus) {
+  return ["completed", "declined", "expired", "cancelled"].includes(status);
+}
+
+export function isActiveStatus(status: DocumentStatus) {
+  return status === "sent" || status === "viewed";
+}
+
+export const STATUS_LABELS: Record<DocumentStatus, string> = {
+  draft: "Draft",
+  sent: "Sent",
+  viewed: "Viewed",
+  completed: "Completed",
+  declined: "Declined",
+  expired: "Expired",
+  cancelled: "Cancelled",
+};
+
+export const STATUS_VARIANTS: Record<DocumentStatus, "default" | "secondary" | "destructive" | "complete" | "outline"> = {
+  draft: "secondary",
+  sent: "default",
+  viewed: "default",
+  completed: "complete",
+  declined: "destructive",
+  expired: "outline",
+  cancelled: "outline",
+};
+
+export function getStatusLabel(status: DocumentStatus) {
+  return STATUS_LABELS[status] ?? status;
+}
+
+export function getStatusVariant(status: DocumentStatus) {
+  return STATUS_VARIANTS[status] ?? "default";
+}
+
+export function parseSigners(signers: LeaseVersionRow["signers"]): SignerMetadata[] {
+  if (!signers) return [];
+
+  if (Array.isArray(signers)) {
+    return signers as SignerMetadata[];
+  }
+
+  if (typeof signers === "object") {
+    return Object.values(signers).filter((value) => typeof value === "object") as SignerMetadata[];
+  }
+
+  return [];
+}
+
+export function mapRecipientsToSigners(recipients: DocumensoRecipient[] = []) {
+  return recipients.map<SignerMetadata>((recipient) => ({
+    name: recipient.name,
+    email: recipient.email,
+    role: recipient.role,
+    status: recipient.status ?? undefined,
+    signingUrl: recipient.signingUrl ?? undefined,
+  }));
+}
+
+export function mapDocumensoStatusToDocumentStatus(status?: string | null): DocumentStatus {
+  const value = (status ?? "draft").toString().toLowerCase() as DocumensoEnvelopeStatus | string;
+
+  switch (value) {
+    case "completed":
+      return "completed";
+    case "declined":
+      return "declined";
+    case "expired":
+      return "expired";
+    case "cancelled":
+      return "cancelled";
+    case "viewed":
+      return "viewed";
+    case "sent":
+    case "ready":
+    case "in_progress":
+      return "sent";
+    default:
+      return "draft";
+  }
+}
+
+export function shouldAllowNewEnvelope(document: DocumentWithRelations) {
+  if (!document.active_envelope_id) {
+    return true;
+  }
+
+  return isTerminalStatus(document.status);
+}
+
+export function getNextLeaseVersionNumber(document: DocumentWithRelations) {
+  const versions = getLeaseVersions(document);
+  if (versions.length === 0) {
+    return 1;
+  }
+
+  const highest = versions[0]?.version ?? 0;
+  return highest + 1;
+}
+
+export function coerceMetadata(metadata: DocumentRow["metadata"]) {
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+    return { ...metadata } as Record<string, unknown>;
+  }
+
+  return {} as Record<string, unknown>;
+}
+
+export function extractSigningUrlForRecipient(
+  envelope: DocumensoEnvelope,
+  email: string,
+) {
+  const target = email.toLowerCase();
+  const recipients = envelope.recipients ?? [];
+
+  for (const recipient of recipients) {
+    if ((recipient.email ?? "").toLowerCase() === target && recipient.signingUrl) {
+      return recipient.signingUrl;
+    }
+  }
+
+  return null;
+}
+
+export function leaseVersionToUpdatePayload(
+  envelope: DocumensoEnvelope,
+  previous: LeaseVersionRow,
+) {
+  const status = mapDocumensoStatusToDocumentStatus(envelope.status);
+
+  return {
+    status,
+    signers: mapRecipientsToSigners(envelope.recipients ?? []) as Json,
+    completed_at:
+      status === "completed"
+        ? envelope.completedAt ?? previous.completed_at ?? new Date().toISOString()
+        : previous.completed_at,
+    expires_at: envelope.expiresAt ?? previous.expires_at,
+    sent_at:
+      status === "draft"
+        ? previous.sent_at
+        : previous.sent_at ?? new Date().toISOString(),
+  } satisfies Partial<LeaseVersionRow>;
+}
+
+export function documentStatusFromEnvelope(
+  envelope: DocumensoEnvelope,
+  previous: DocumentWithRelations,
+) {
+  const status = mapDocumensoStatusToDocumentStatus(envelope.status);
+
+  return {
+    status,
+    active_envelope_id: isTerminalStatus(status)
+      ? null
+      : previous.active_envelope_id ?? envelope.id,
+  } satisfies Partial<DocumentRow>;
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -914,6 +914,121 @@ export type Database = {
         }
         Relationships: []
       }
+      document_download_audit: {
+        Row: {
+          document_id: string
+          documenso_envelope_id: string | null
+          downloaded_at: string
+          downloaded_by: string | null
+          id: string
+          lease_version_id: string | null
+          notes: string | null
+          remote_addr: string | null
+          source: string | null
+          user_agent: string | null
+        }
+        Insert: {
+          document_id: string
+          documenso_envelope_id?: string | null
+          downloaded_at?: string
+          downloaded_by?: string | null
+          id?: string
+          lease_version_id?: string | null
+          notes?: string | null
+          remote_addr?: string | null
+          source?: string | null
+          user_agent?: string | null
+        }
+        Update: {
+          document_id?: string
+          documenso_envelope_id?: string | null
+          downloaded_at?: string
+          downloaded_by?: string | null
+          id?: string
+          lease_version_id?: string | null
+          notes?: string | null
+          remote_addr?: string | null
+          source?: string | null
+          user_agent?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "document_download_audit_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "document_download_audit_downloaded_by_fkey"
+            columns: ["downloaded_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "document_download_audit_lease_version_id_fkey"
+            columns: ["lease_version_id"]
+            isOneToOne: false
+            referencedRelation: "lease_versions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      documents: {
+        Row: {
+          active_envelope_id: string | null
+          created_at: string
+          created_by: string | null
+          documenso_template_id: string
+          id: string
+          metadata: Json
+          status: Database["public"]["Enums"]["document_status"]
+          tenant_id: string | null
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          active_envelope_id?: string | null
+          created_at?: string
+          created_by?: string | null
+          documenso_template_id: string
+          id?: string
+          metadata?: Json
+          status?: Database["public"]["Enums"]["document_status"]
+          tenant_id?: string | null
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          active_envelope_id?: string | null
+          created_at?: string
+          created_by?: string | null
+          documenso_template_id?: string
+          id?: string
+          metadata?: Json
+          status?: Database["public"]["Enums"]["document_status"]
+          tenant_id?: string | null
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "documents_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "documents_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       gpt_one: {
         Row: {
           created_at: string
@@ -967,6 +1082,56 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      }
+      lease_versions: {
+        Row: {
+          completed_at: string | null
+          created_at: string
+          documenso_envelope_id: string
+          document_id: string
+          expires_at: string | null
+          id: string
+          sent_at: string | null
+          signers: Json
+          status: Database["public"]["Enums"]["document_status"]
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          completed_at?: string | null
+          created_at?: string
+          documenso_envelope_id: string
+          document_id: string
+          expires_at?: string | null
+          id?: string
+          sent_at?: string | null
+          signers?: Json
+          status?: Database["public"]["Enums"]["document_status"]
+          updated_at?: string
+          version: number
+        }
+        Update: {
+          completed_at?: string | null
+          created_at?: string
+          documenso_envelope_id?: string
+          document_id?: string
+          expires_at?: string | null
+          id?: string
+          sent_at?: string | null
+          signers?: Json
+          status?: Database["public"]["Enums"]["document_status"]
+          updated_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lease_versions_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       meetings: {
         Row: {
@@ -1774,6 +1939,14 @@ export type Database = {
         | "Oceania"
         | "North America"
         | "South America"
+      document_status:
+        | "draft"
+        | "sent"
+        | "viewed"
+        | "completed"
+        | "declined"
+        | "expired"
+        | "cancelled"
       user_role: "user" | "admin"
     }
     CompositeTypes: {
@@ -2232,6 +2405,15 @@ export const Constants = {
         "Oceania",
         "North America",
         "South America",
+      ],
+      document_status: [
+        "draft",
+        "sent",
+        "viewed",
+        "completed",
+        "declined",
+        "expired",
+        "cancelled",
       ],
       user_role: ["user", "admin"],
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -109,6 +110,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ducanh2912/next-pwa':
         specifier: ^10.2.8
-        version: 10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
+        version: 10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.11.3(@types/react@18.3.3)(react@18.2.0)
@@ -133,10 +133,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -187,13 +187,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
         version: 5.0.2(postcss@8.4.32)
@@ -306,6 +306,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
 
 packages:
 
@@ -1328,6 +1331,162 @@ packages:
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2323,6 +2482,116 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rushstack/eslint-patch@1.6.1':
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
 
@@ -2436,6 +2705,9 @@ packages:
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -2466,6 +2738,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
@@ -2489,6 +2764,9 @@ packages:
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/google-one-tap@1.2.6':
     resolution: {integrity: sha512-REmJsXVHvKb/sgI8DF+7IesMbDbcsEokHBqxU01ENZ8d98UPWdRLhUCtxEm9bhNFFg6PJGy7PNFdvovp0hK3jA==}
@@ -2648,6 +2926,35 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
@@ -2863,6 +3170,10 @@ packages:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -3020,6 +3331,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3056,6 +3371,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3084,6 +3403,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -3305,6 +3628,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
@@ -3314,6 +3646,10 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3459,6 +3795,9 @@ packages:
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3473,6 +3812,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -3648,6 +3992,10 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -3682,6 +4030,15 @@ packages:
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
@@ -4218,6 +4575,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -4356,6 +4716,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -4781,6 +5144,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -4799,6 +5169,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -5017,6 +5391,10 @@ packages:
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   potpack@1.0.2:
@@ -5317,6 +5695,11 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5404,6 +5787,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5474,6 +5860,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
     peerDependencies:
@@ -5482,6 +5871,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -5544,6 +5936,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -5689,6 +6084,28 @@ packages:
 
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -5934,6 +6351,79 @@ packages:
   victory-vendor@36.8.6:
     resolution: {integrity: sha512-PH8Wj9b0xIZ4AVfyn0c1SJrOhtxDJ5PNxj1ZDABPg1Gw1vJr1mJVqESPhvsFj7mXLQohVdiKqp4kWZkXlPcRcA==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.6:
+    resolution: {integrity: sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.4.35:
     resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
     peerDependencies:
@@ -5998,6 +6488,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workbox-background-sync@7.1.0:
@@ -7302,10 +7797,10 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
-  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
+  '@ducanh2912/next-pwa@10.2.8(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(webpack@5.93.0)':
     dependencies:
       fast-glob: 3.3.2
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       semver: 7.6.2
       webpack: 5.93.0
       workbox-build: 7.1.1
@@ -7400,6 +7895,84 @@ snapshots:
   '@emotion/utils@1.2.1': {}
 
   '@emotion/weak-memoize@0.3.1': {}
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
+    optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
@@ -8524,6 +9097,72 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    optional: true
+
   '@rushstack/eslint-patch@1.6.1': {}
 
   '@scure/base@1.1.5': {}
@@ -8668,6 +9307,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.5
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -8696,6 +9339,8 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/draco3d@1.4.10': {}
 
   '@types/eslint-scope@3.7.7':
@@ -8722,6 +9367,8 @@ snapshots:
   '@types/estree@1.0.5': {}
 
   '@types/estree@1.0.7': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/google-one-tap@1.2.6': {}
 
@@ -8853,19 +9500,61 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.4.35':
     dependencies:
@@ -9148,6 +9837,8 @@ snapshots:
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astring@1.8.6: {}
@@ -9327,6 +10018,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -9359,6 +10052,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9383,6 +10084,8 @@ snapshots:
   character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -9582,6 +10285,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.0.2:
@@ -9591,6 +10298,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -9782,6 +10491,8 @@ snapshots:
 
   es-module-lexer@1.6.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -9802,6 +10513,35 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
   escalade@3.1.2: {}
 
   escape-string-regexp@1.0.5: {}
@@ -9815,8 +10555,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -9838,13 +10578,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9855,18 +10595,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -9876,7 +10616,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10065,6 +10805,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  expect-type@1.2.2: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@2.0.1: {}
@@ -10096,6 +10838,10 @@ snapshots:
   fault@1.0.4:
     dependencies:
       format: 0.2.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fflate@0.6.10: {}
 
@@ -10715,6 +11461,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -10829,6 +11577,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -10858,7 +11608,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   markdown-extensions@2.0.0: {}
 
@@ -11239,8 +11988,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -11252,13 +12000,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -11268,7 +12016,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.9)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.4
       '@next/swc-darwin-x64': 14.2.4
@@ -11437,6 +12185,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   peberminta@0.9.0: {}
 
   periscopic@3.1.0:
@@ -11449,10 +12201,11 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -11726,6 +12479,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
     optional: true
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   potpack@1.0.2: {}
 
@@ -12063,6 +12822,34 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  rollup@4.52.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12183,6 +12970,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -12212,8 +13001,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -12236,12 +13024,16 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
     dependencies:
       '@types/three': 0.176.0
       three: 0.160.0
 
   stats.js@0.17.0: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -12326,6 +13118,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -12334,12 +13130,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   stylis@4.2.0: {}
 
@@ -12518,6 +13314,21 @@ snapshots:
   three@0.160.0: {}
 
   tiny-invariant@1.3.1: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-fast-properties@2.0.0: {}
 
@@ -12784,6 +13595,83 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.14.15
+      fsevents: 2.3.3
+      jiti: 1.21.0
+      terser: 5.39.0
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite-node: 3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.14.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
@@ -12898,6 +13786,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workbox-background-sync@7.1.0:
     dependencies:

--- a/supabase/migrations/20240709_documenso_documents.sql
+++ b/supabase/migrations/20240709_documenso_documents.sql
@@ -1,0 +1,200 @@
+-- Documenso document management schema
+create type if not exists public.document_status as enum (
+  'draft',
+  'sent',
+  'viewed',
+  'completed',
+  'declined',
+  'expired',
+  'cancelled'
+);
+
+create table if not exists public.documents (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid references public.profiles(id) on delete cascade,
+  created_by uuid references public.profiles(id) on delete set null,
+  title text not null,
+  documenso_template_id text not null,
+  active_envelope_id text,
+  status public.document_status not null default 'draft',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.lease_versions (
+  id uuid primary key default gen_random_uuid(),
+  document_id uuid not null references public.documents(id) on delete cascade,
+  version integer not null,
+  documenso_envelope_id text not null,
+  status public.document_status not null default 'draft',
+  signers jsonb not null default '[]'::jsonb,
+  sent_at timestamptz,
+  completed_at timestamptz,
+  expires_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint lease_versions_document_version_unique unique (document_id, version)
+);
+
+create table if not exists public.document_download_audit (
+  id uuid primary key default gen_random_uuid(),
+  document_id uuid not null references public.documents(id) on delete cascade,
+  lease_version_id uuid references public.lease_versions(id) on delete set null,
+  downloaded_by uuid references public.profiles(id) on delete set null,
+  documenso_envelope_id text,
+  source text,
+  remote_addr inet,
+  user_agent text,
+  downloaded_at timestamptz not null default timezone('utc', now()),
+  notes text
+);
+
+create index if not exists documents_tenant_id_idx on public.documents(tenant_id);
+create index if not exists lease_versions_document_id_idx on public.lease_versions(document_id);
+create index if not exists lease_versions_envelope_id_idx on public.lease_versions(documenso_envelope_id);
+create index if not exists document_download_audit_document_id_idx on public.document_download_audit(document_id);
+create index if not exists document_download_audit_downloaded_by_idx on public.document_download_audit(downloaded_by);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists documents_updated_at on public.documents;
+create trigger documents_updated_at
+before update on public.documents
+for each row execute function public.set_updated_at();
+
+drop trigger if exists lease_versions_updated_at on public.lease_versions;
+create trigger lease_versions_updated_at
+before update on public.lease_versions
+for each row execute function public.set_updated_at();
+
+alter table public.documents enable row level security;
+alter table public.lease_versions enable row level security;
+alter table public.document_download_audit enable row level security;
+
+create policy if not exists "documents_viewer_access"
+  on public.documents
+  for select
+  using (
+    tenant_id = auth.uid()
+    or exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('property_manager', 'admin')
+    )
+  );
+
+create policy if not exists "documents_manager_insert"
+  on public.documents
+  for insert
+  with check (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('property_manager', 'admin')
+    )
+  );
+
+create policy if not exists "documents_manager_update"
+  on public.documents
+  for update
+  using (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('property_manager', 'admin')
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('property_manager', 'admin')
+    )
+  );
+
+create policy if not exists "documents_manager_delete"
+  on public.documents
+  for delete
+  using (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('property_manager', 'admin')
+    )
+  );
+
+create policy if not exists "lease_versions_viewer_access"
+  on public.lease_versions
+  for select
+  using (
+    exists (
+      select 1 from public.documents d
+      where d.id = lease_versions.document_id
+        and (
+          d.tenant_id = auth.uid()
+          or exists (
+            select 1 from public.profiles p
+            where p.id = auth.uid()
+              and p.role in ('property_manager', 'admin')
+          )
+        )
+    )
+  );
+
+create policy if not exists "lease_versions_manager_write"
+  on public.lease_versions
+  for all
+  using (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('property_manager', 'admin')
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('property_manager', 'admin')
+    )
+  );
+
+create policy if not exists "document_download_audit_read"
+  on public.document_download_audit
+  for select
+  using (
+    downloaded_by = auth.uid()
+    or exists (
+      select 1 from public.documents d
+      where d.id = document_download_audit.document_id
+        and (
+          d.tenant_id = auth.uid()
+          or exists (
+            select 1 from public.profiles p
+            where p.id = auth.uid()
+              and p.role in ('property_manager', 'admin')
+          )
+        )
+    )
+  );
+
+create policy if not exists "document_download_audit_insert"
+  on public.document_download_audit
+  for insert
+  with check (
+    downloaded_by = auth.uid()
+    or exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('property_manager', 'admin')
+    )
+  );

--- a/tests/documents.test.ts
+++ b/tests/documents.test.ts
@@ -1,0 +1,106 @@
+import {
+  DocumentWithRelations,
+  filterDocumentsForViewer,
+  getNextLeaseVersionNumber,
+  mapDocumensoStatusToDocumentStatus,
+  resolveDocumentStatus,
+} from "@/lib/documents-service";
+
+const baseDocument: DocumentWithRelations = {
+  id: "doc-1",
+  tenant_id: "tenant-1",
+  created_at: "2024-01-01T00:00:00.000Z",
+  updated_at: "2024-01-01T00:00:00.000Z",
+  created_by: null,
+  title: "Standard lease",
+  documenso_template_id: "template-1",
+  active_envelope_id: null,
+  metadata: {},
+  status: "draft",
+  tenant: null,
+  lease_versions: [],
+};
+
+function createLeaseVersion(version: number, status: DocumentWithRelations["status"], envelopeId: string) {
+  return {
+    id: `lease-${version}`,
+    document_id: baseDocument.id,
+    version,
+    status,
+    documenso_envelope_id: envelopeId,
+    signers: [],
+    sent_at: null,
+    completed_at: null,
+    expires_at: null,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+  };
+}
+
+describe("documents-service", () => {
+  it("restricts tenant visibility to their own documents", () => {
+    const documents = [
+      baseDocument,
+      { ...baseDocument, id: "doc-2", tenant_id: "tenant-2" },
+    ];
+
+    const result = filterDocumentsForViewer(documents, "tenant-1", "tenant");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("doc-1");
+  });
+
+  it("allows managers to view all documents", () => {
+    const documents = [
+      baseDocument,
+      { ...baseDocument, id: "doc-2", tenant_id: "tenant-2" },
+    ];
+
+    const result = filterDocumentsForViewer(documents, "manager-1", "property_manager");
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("maps Documenso statuses to local enum", () => {
+    expect(mapDocumensoStatusToDocumentStatus("completed")).toBe("completed");
+    expect(mapDocumensoStatusToDocumentStatus("READY")).toBe("sent");
+    expect(mapDocumensoStatusToDocumentStatus("expired")).toBe("expired");
+    expect(mapDocumensoStatusToDocumentStatus("unknown" as any)).toBe("draft");
+  });
+
+  it("calculates the next lease version number", () => {
+    const document: DocumentWithRelations = {
+      ...baseDocument,
+      lease_versions: [
+        createLeaseVersion(1, "completed", "env-1"),
+        createLeaseVersion(3, "sent", "env-3"),
+      ],
+    };
+
+    expect(getNextLeaseVersionNumber(document)).toBe(4);
+  });
+
+  it("prefers active envelope status when resolving document status", () => {
+    const document: DocumentWithRelations = {
+      ...baseDocument,
+      status: "draft",
+      active_envelope_id: "env-2",
+      lease_versions: [
+        createLeaseVersion(1, "completed", "env-1"),
+        createLeaseVersion(2, "sent", "env-2"),
+      ],
+    };
+
+    expect(resolveDocumentStatus(document)).toBe("sent");
+  });
+
+  it("falls back to document status when no versions are present", () => {
+    const document: DocumentWithRelations = {
+      ...baseDocument,
+      status: "completed",
+      lease_versions: [],
+    };
+
+    expect(resolveDocumentStatus(document)).toBe("completed");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
         "name": "next"
       }
     ],
+    "types": ["vitest/globals"],
     "paths": {
       "@/*": ["./*"]
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(rootDir, "."),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- add a Documenso API client, webhook handler, and download route to integrate with self-hosted Documenso envelopes
- extend the Supabase schema with documents, lease_versions, and audit tables plus TypeScript types and configuration docs
- build document and lease dashboard views with server actions to trigger signing flows, sync status, and surface downloads
- add Vitest coverage for document filtering and status transitions and configure local testing

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d04ce0cefc832883188fd4c27ddcca