### PR TITLE
Add catch-up payment workflow for one-off roommate balances

### DIFF
--- a/app/payments/_components/catch-up-payment-card.tsx
+++ b/app/payments/_components/catch-up-payment-card.tsx
@@ -1,0 +1,538 @@
+"use client"
+
+import { useEffect, useMemo, useState, useTransition } from "react"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { format, parseISO } from "date-fns"
+import { useForm } from "react-hook-form"
+
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { Separator } from "@/components/ui/separator"
+import { toast } from "@/components/ui/use-toast"
+import {
+  allocatePaymentToCharges,
+  applyAllocationsToCharges,
+  calculateOutstanding,
+  formatAutopayDay,
+  getNextOutstandingCharge,
+} from "@/lib/payments/catch-up"
+import { formatCurrency, parseCurrencyInput, roundToCurrency } from "@/lib/payments/currency"
+import { createCatchUpFormSchema } from "@/lib/payments/schemas"
+import type {
+  AutopayStatus,
+  CatchUpBalance,
+  CatchUpPaymentFormValues,
+  CatchUpPaymentSubmissionResult,
+} from "@/types/payments"
+
+import { submitCatchUpPayment } from "../actions"
+
+interface CatchUpPaymentCardProps {
+  balances: CatchUpBalance[]
+}
+
+const autopayBadgeCopy: Record<
+  AutopayStatus,
+  { label: string; variant: "complete" | "secondary" | "outline" }
+> = {
+  active: { label: "Autopay active", variant: "complete" },
+  paused: { label: "Autopay paused", variant: "secondary" },
+  disabled: { label: "Autopay off", variant: "outline" },
+}
+
+type QuickAmountKey = "next" | "half" | "full"
+
+type QuickAmount = {
+  key: QuickAmountKey
+  label: string
+  value: number
+}
+
+export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
+  const schema = useMemo(() => createCatchUpFormSchema(balances), [balances])
+  const form = useForm<CatchUpPaymentFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      roommateId: balances[0]?.roommateId ?? "",
+      amount: balances[0]
+        ? calculateOutstanding(balances[0].charges).toFixed(2)
+        : "",
+      includePropertyManager: false,
+      note: "",
+    },
+  })
+  const [isPending, startTransition] = useTransition()
+  const [lastResult, setLastResult] = useState<CatchUpPaymentSubmissionResult | null>(null)
+
+  const selectedRoommateId = form.watch("roommateId")
+  const amountInputValue = form.watch("amount")
+
+  const selectedBalance = useMemo(
+    () => balances.find((balance) => balance.roommateId === selectedRoommateId),
+    [balances, selectedRoommateId],
+  )
+
+  useEffect(() => {
+    if (!selectedBalance) {
+      return
+    }
+
+    const outstandingValue = calculateOutstanding(selectedBalance.charges)
+    form.setValue(
+      "amount",
+      outstandingValue > 0 ? outstandingValue.toFixed(2) : "0.00",
+      { shouldDirty: false, shouldValidate: true },
+    )
+    form.setValue("includePropertyManager", false, {
+      shouldDirty: false,
+      shouldValidate: false,
+    })
+    form.setValue("note", "", { shouldDirty: false, shouldValidate: false })
+  }, [selectedBalance, form])
+
+  const outstandingBalance = selectedBalance
+    ? calculateOutstanding(selectedBalance.charges)
+    : 0
+
+  const parsedAmount = parseCurrencyInput(amountInputValue)
+  const normalizedAmount =
+    Number.isFinite(parsedAmount)
+      ? Math.min(roundToCurrency(parsedAmount), outstandingBalance)
+      : 0
+
+  const allocationPreview = useMemo(() => {
+    if (!selectedBalance || normalizedAmount <= 0) {
+      return []
+    }
+
+    try {
+      return allocatePaymentToCharges(selectedBalance.charges, normalizedAmount)
+    } catch (error) {
+      return []
+    }
+  }, [normalizedAmount, selectedBalance])
+
+  const updatedChargesPreview = useMemo(() => {
+    if (!selectedBalance) {
+      return []
+    }
+
+    return applyAllocationsToCharges(selectedBalance.charges, allocationPreview)
+  }, [allocationPreview, selectedBalance])
+
+  const projectedBalance = selectedBalance
+    ? roundToCurrency(calculateOutstanding(updatedChargesPreview))
+    : 0
+
+  const coveragePercentage = selectedBalance && outstandingBalance > 0
+    ? Math.min(100, Math.round((normalizedAmount / outstandingBalance) * 1000) / 10)
+    : 0
+
+  const nextCharge = selectedBalance
+    ? getNextOutstandingCharge(selectedBalance.charges)
+    : undefined
+
+  const quickAmounts: QuickAmount[] = useMemo(() => {
+    if (!selectedBalance || outstandingBalance <= 0) {
+      return []
+    }
+
+    const amounts: QuickAmount[] = []
+
+    if (nextCharge) {
+      amounts.push({
+        key: "next",
+        label: `Next charge (${formatCurrency(nextCharge.outstandingAmount, selectedBalance.currency)})`,
+        value: roundToCurrency(nextCharge.outstandingAmount),
+      })
+    }
+
+    const half = roundToCurrency(outstandingBalance / 2)
+    if (half > 0) {
+      amounts.push({
+        key: "half",
+        label: `Half balance (${formatCurrency(half, selectedBalance.currency)})`,
+        value: half,
+      })
+    }
+
+    amounts.push({
+      key: "full",
+      label: `Pay in full (${formatCurrency(outstandingBalance, selectedBalance.currency)})`,
+      value: roundToCurrency(outstandingBalance),
+    })
+
+    return amounts.filter((amount, index, array) =>
+      array.findIndex((item) => item.value === amount.value) === index,
+    )
+  }, [nextCharge, outstandingBalance, selectedBalance])
+
+  const handleQuickAmount = (value: number) => {
+    form.setValue("amount", value.toFixed(2), {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }
+
+  const onSubmit = async (values: CatchUpPaymentFormValues) => {
+    const parsed = parseCurrencyInput(values.amount)
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      toast({
+        variant: "destructive",
+        title: "Invalid amount",
+        description: "Enter a valid catch-up amount before submitting.",
+      })
+      return
+    }
+
+    const sanitizedNote = values.note && values.note.trim().length > 0 ? values.note.trim() : undefined
+
+    startTransition(async () => {
+      try {
+        const result = await submitCatchUpPayment({
+          roommateId: values.roommateId,
+          amount: roundToCurrency(parsed),
+          includePropertyManager: values.includePropertyManager,
+          note: sanitizedNote,
+        })
+
+        setLastResult(result)
+        toast({
+          title: `Catch-up scheduled for ${result.roommateName}`,
+          description: `${formatCurrency(result.amount, result.currency)} applied • New balance ${formatCurrency(result.projectedBalance, result.currency)}`,
+        })
+
+        form.setValue(
+          "amount",
+          result.projectedBalance > 0
+            ? result.projectedBalance.toFixed(2)
+            : "0.00",
+          { shouldDirty: false, shouldValidate: true },
+        )
+      } catch (error) {
+        const description =
+          error instanceof Error
+            ? error.message
+            : "Something went wrong while scheduling the catch-up payment."
+        toast({
+          variant: "destructive",
+          title: "Unable to schedule catch-up payment",
+          description,
+        })
+      }
+    })
+  }
+
+  const disableSubmit =
+    !selectedBalance || outstandingBalance <= 0 || normalizedAmount <= 0 || isPending
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <CardTitle>One-time catch up</CardTitle>
+            <CardDescription>
+              Collect partial or one-off payments and apply them to outstanding roommate balances without waiting for the next cycle.
+            </CardDescription>
+          </div>
+          {selectedBalance ? (
+            <Badge variant={autopayBadgeCopy[selectedBalance.autopayStatus].variant}>
+              {autopayBadgeCopy[selectedBalance.autopayStatus].label}
+            </Badge>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Form {...form}>
+          <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="roommateId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Roommate</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select roommate" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {balances.map((balance) => (
+                          <SelectItem key={balance.roommateId} value={balance.roommateId}>
+                            {balance.roommateName} · {balance.unitLabel}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">Outstanding</span>
+                  <span>
+                    {selectedBalance
+                      ? formatCurrency(outstandingBalance, selectedBalance.currency)
+                      : "—"}
+                  </span>
+                </div>
+                {selectedBalance ? (
+                  <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                    <div>
+                      <p className="font-medium text-foreground">Autopay</p>
+                      <p>
+                        {formatAutopayDay(selectedBalance.autopayDay)} of each month
+                      </p>
+                    </div>
+                    <div>
+                      <p className="font-medium text-foreground">Last payment</p>
+                      <p>{format(parseISO(selectedBalance.lastPaymentDate), "MMM d, yyyy")}</p>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-[1.2fr_1fr]">
+              <FormField
+                control={form.control}
+                name="amount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Catch-up amount</FormLabel>
+                    <FormControl>
+                      <Input
+                        inputMode="decimal"
+                        placeholder="0.00"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {selectedBalance
+                        ? `${formatCurrency(outstandingBalance, selectedBalance.currency)} outstanding`
+                        : "Enter an amount to distribute across open charges."}
+                    </FormDescription>
+                    <FormMessage />
+                    {quickAmounts.length > 0 ? (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {quickAmounts.map((item) => (
+                          <Button
+                            key={item.key}
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleQuickAmount(item.value)}
+                          >
+                            {item.label}
+                          </Button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </FormItem>
+                )}
+              />
+              <div className="space-y-2 rounded-lg border bg-muted/20 p-4 text-sm">
+                <div className="flex items-center justify-between font-medium">
+                  <span>Projected remaining</span>
+                  <span>
+                    {selectedBalance
+                      ? formatCurrency(projectedBalance, selectedBalance.currency)
+                      : "—"}
+                  </span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Covers {coveragePercentage.toFixed(1)}% of the open balance.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div>
+                <h3 className="text-sm font-medium">Allocation preview</h3>
+                <p className="text-xs text-muted-foreground">
+                  We prioritize the earliest due charges when applying one-time payments.
+                </p>
+              </div>
+              <div className="overflow-hidden rounded-lg border">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/40 text-left text-xs uppercase text-muted-foreground">
+                    <tr>
+                      <th className="py-2 pl-4 pr-2 font-medium">Charge</th>
+                      <th className="py-2 pr-2 font-medium">Due</th>
+                      <th className="py-2 pr-2 text-right font-medium">Outstanding</th>
+                      <th className="py-2 pr-2 text-right font-medium">Applying</th>
+                      <th className="py-2 pr-4 text-right font-medium">Remaining</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {selectedBalance ? (
+                      selectedBalance.charges.map((charge) => {
+                        const allocation = allocationPreview.find(
+                          (item) => item.chargeId === charge.id,
+                        )
+                        const updatedCharge = updatedChargesPreview.find(
+                          (item) => item.id === charge.id,
+                        )
+                        const applyingAmount = allocation?.amount ?? 0
+                        const remainingAmount = updatedCharge?.outstandingAmount ?? charge.outstandingAmount
+
+                        return (
+                          <tr key={charge.id} className="border-t">
+                            <td className="py-2 pl-4 pr-2">
+                              <div className="font-medium">{charge.description}</div>
+                              <div className="text-xs text-muted-foreground capitalize">
+                                {charge.category}
+                              </div>
+                            </td>
+                            <td className="py-2 pr-2 text-sm text-muted-foreground">
+                              {format(parseISO(charge.dueDate), "MMM d")}
+                            </td>
+                            <td className="py-2 pr-2 text-right">
+                              {formatCurrency(charge.outstandingAmount, selectedBalance.currency)}
+                            </td>
+                            <td className="py-2 pr-2 text-right text-emerald-600">
+                              {applyingAmount > 0
+                                ? `-${formatCurrency(applyingAmount, selectedBalance.currency)}`
+                                : "—"}
+                            </td>
+                            <td className="py-2 pr-4 text-right">
+                              {formatCurrency(remainingAmount, selectedBalance.currency)}
+                            </td>
+                          </tr>
+                        )
+                      })
+                    ) : (
+                      <tr>
+                        <td className="py-4 pl-4 text-sm text-muted-foreground" colSpan={5}>
+                          Select a roommate to preview catch-up distribution.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <FormField
+              control={form.control}
+              name="includePropertyManager"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                  <div className="space-y-0.5">
+                    <FormLabel>Send property manager a receipt</FormLabel>
+                    <FormDescription>
+                      {selectedBalance?.contacts.propertyManager
+                        ? `We will copy ${selectedBalance.contacts.propertyManager.email} when we send the confirmation.`
+                        : "No property manager email on file for this roommate."}
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled={!selectedBalance?.contacts.propertyManager}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="note"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Optional note</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Share context for this catch-up payment (visible on the receipt)."
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Add up to 280 characters. Leave blank to skip including a note.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              <p className="text-xs text-muted-foreground">
+                Catch-up payments post to the shared ledger immediately.
+              </p>
+              <Button disabled={disableSubmit} type="submit">
+                {isPending ? "Scheduling..." : "Schedule catch-up"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+      {lastResult ? (
+        <>
+          <Separator />
+          <CardFooter className="flex flex-col items-start gap-3 bg-muted/30">
+            <div className="flex w-full flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium">
+                  Payment {lastResult.paymentIntentId}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Sent to {lastResult.recipients.map((recipient) => recipient.email).join(", ")}
+                </p>
+              </div>
+              <div className="text-sm font-semibold">
+                {formatCurrency(lastResult.amount, lastResult.currency)}
+              </div>
+            </div>
+            <div className="flex w-full flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>Remaining balance {formatCurrency(lastResult.projectedBalance, lastResult.currency)}</span>
+              <span aria-hidden="true">•</span>
+              <span>
+                Allocated to {lastResult.allocations.length} charge{lastResult.allocations.length === 1 ? "" : "s"}
+              </span>
+            </div>
+            <div className="flex w-full flex-wrap gap-2">
+              {lastResult.allocations.map((allocation) => (
+                <Badge key={allocation.chargeId} variant="outline">
+                  {allocation.description}: {formatCurrency(allocation.amount, lastResult.currency)}
+                </Badge>
+              ))}
+            </div>
+            {lastResult.note ? (
+              <p className="w-full rounded-md bg-background/60 p-3 text-xs text-muted-foreground">
+                Note: {lastResult.note}
+              </p>
+            ) : null}
+          </CardFooter>
+        </>
+      ) : null}
+    </Card>
+  )
+}

--- a/app/payments/actions.ts
+++ b/app/payments/actions.ts
@@ -1,0 +1,101 @@
+"use server"
+
+import { z } from "zod"
+
+import {
+  allocatePaymentToCharges,
+  applyAllocationsToCharges,
+  calculateOutstanding,
+  findCatchUpBalance,
+  generateMockPaymentIntentId,
+} from "@/lib/payments/catch-up"
+import { formatCurrency, roundToCurrency } from "@/lib/payments/currency"
+import { catchUpBalances } from "@/lib/payments/mock-data"
+import type { CatchUpPaymentSubmissionResult } from "@/types/payments"
+
+const catchUpPaymentActionSchema = z.object({
+  roommateId: z.string().min(1),
+  amount: z.number().positive(),
+  includePropertyManager: z.boolean().optional(),
+  note: z.string().trim().max(280).optional(),
+})
+
+export async function submitCatchUpPayment(
+  input: z.infer<typeof catchUpPaymentActionSchema>,
+): Promise<CatchUpPaymentSubmissionResult> {
+  const parsed = catchUpPaymentActionSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid catch-up payment request."
+    throw new Error(message)
+  }
+
+  const {
+    roommateId,
+    amount,
+    includePropertyManager = false,
+    note,
+  } = parsed.data
+
+  const balance = findCatchUpBalance(catchUpBalances, roommateId)
+  if (!balance) {
+    throw new Error("Selected roommate is not available for catch-up payments.")
+  }
+
+  const outstanding = calculateOutstanding(balance.charges)
+  if (amount > outstanding) {
+    throw new Error(
+      `Catch-up amount exceeds outstanding balance of ${formatCurrency(outstanding, balance.currency)}.`,
+    )
+  }
+
+  const allocations = allocatePaymentToCharges(balance.charges, amount)
+  if (allocations.length === 0) {
+    throw new Error("There are no outstanding charges to apply this payment to.")
+  }
+  const updatedCharges = applyAllocationsToCharges(balance.charges, allocations)
+  const projectedBalance = roundToCurrency(
+    calculateOutstanding(updatedCharges),
+  )
+
+  const allocationDetails = allocations.map((allocation) => {
+    const originalCharge = balance.charges.find(
+      (charge) => charge.id === allocation.chargeId,
+    )
+    const updatedCharge = updatedCharges.find(
+      (charge) => charge.id === allocation.chargeId,
+    )
+
+    return {
+      chargeId: allocation.chargeId,
+      amount: roundToCurrency(allocation.amount),
+      description: originalCharge?.description ?? "Charge",
+      category: originalCharge?.category ?? "other",
+      dueDate:
+        originalCharge?.dueDate ?? new Date().toISOString().slice(0, 10),
+      remainingBalance: roundToCurrency(
+        updatedCharge?.outstandingAmount ?? 0,
+      ),
+    }
+  })
+
+  const recipients = [balance.contacts.primary]
+  if (includePropertyManager && balance.contacts.propertyManager) {
+    recipients.push(balance.contacts.propertyManager)
+  }
+
+  const sanitizedNote = note && note.trim().length > 0 ? note.trim() : undefined
+
+  return {
+    paymentIntentId: generateMockPaymentIntentId(),
+    roommateId: balance.roommateId,
+    roommateName: balance.roommateName,
+    amount: roundToCurrency(amount),
+    currency: balance.currency,
+    projectedBalance,
+    allocations: allocationDetails,
+    recipients,
+    autopayStatus: balance.autopayStatus,
+    autopayDay: balance.autopayDay,
+    note: sanitizedNote,
+  }
+}

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -1,5 +1,22 @@
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { format, parseISO } from "date-fns"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { CatchUpPaymentCard } from "./_components/catch-up-payment-card"
+import {
+  calculateOutstanding,
+  formatAutopayDay,
+  getNextOutstandingCharge,
+} from "@/lib/payments/catch-up"
+import { formatCurrency } from "@/lib/payments/currency"
+import { catchUpBalances } from "@/lib/payments/mock-data"
+import type { CatchUpBalance } from "@/types/payments"
 
 const paymentHighlights = [
   {
@@ -24,6 +41,57 @@ const paymentHighlights = [
   },
 ]
 
+const outstandingSummaries = catchUpBalances.map((balance) => {
+  const outstanding = calculateOutstanding(balance.charges)
+  const nextCharge = getNextOutstandingCharge(balance.charges)
+  return { balance, outstanding, nextCharge }
+})
+
+const totalOutstanding = outstandingSummaries.reduce(
+  (sum, item) => sum + item.outstanding,
+  0,
+)
+
+const activeAutopays = catchUpBalances.filter(
+  (balance) => balance.autopayStatus === "active",
+).length
+const pausedAutopays = catchUpBalances.filter(
+  (balance) => balance.autopayStatus === "paused",
+).length
+const disabledAutopays = catchUpBalances.filter(
+  (balance) => balance.autopayStatus === "disabled",
+).length
+
+const autopCoveragePercentage =
+  catchUpBalances.length > 0
+    ? Math.round((activeAutopays / catchUpBalances.length) * 100)
+    : 0
+
+const defaultCurrency = catchUpBalances[0]?.currency ?? "USD"
+
+const roommateSummaries = [...outstandingSummaries].sort(
+  (a, b) => b.outstanding - a.outstanding,
+)
+
+function describeAutopayStatus(balance: CatchUpBalance) {
+  const autopayDay = formatAutopayDay(balance.autopayDay)
+
+  switch (balance.autopayStatus) {
+    case "active":
+      return `Autopay active · ${autopayDay} each month`
+    case "paused":
+      return `Autopay paused · resumes ${autopayDay}`
+    case "disabled":
+      return "Autopay off"
+  }
+
+  return ""
+}
+
+function formatFullDate(date: string) {
+  return format(parseISO(date), "MMM d, yyyy")
+}
+
 export default function PaymentsPage() {
   return (
     <div className="container max-w-5xl space-y-10 py-12">
@@ -46,6 +114,97 @@ export default function PaymentsPage() {
           </Card>
         ))}
       </div>
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Catch-up snapshot</CardTitle>
+              <CardDescription>
+                Monitor outstanding balances and autopay coverage across the unit.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid gap-4 sm:grid-cols-3">
+                <div className="space-y-1 rounded-lg border bg-muted/40 p-4">
+                  <dt className="text-xs uppercase text-muted-foreground">
+                    Outstanding total
+                  </dt>
+                  <dd className="text-lg font-semibold">
+                    {formatCurrency(totalOutstanding, defaultCurrency)}
+                  </dd>
+                  <p className="text-xs text-muted-foreground">
+                    {catchUpBalances.length} roommates tracked
+                  </p>
+                </div>
+                <div className="space-y-1 rounded-lg border bg-muted/40 p-4">
+                  <dt className="text-xs uppercase text-muted-foreground">
+                    Autopay coverage
+                  </dt>
+                  <dd className="text-lg font-semibold">
+                    {activeAutopays}/{catchUpBalances.length}
+                  </dd>
+                  <p className="text-xs text-muted-foreground">
+                    {autopCoveragePercentage}% of roommates on autopay
+                  </p>
+                </div>
+                <div className="space-y-1 rounded-lg border bg-muted/40 p-4">
+                  <dt className="text-xs uppercase text-muted-foreground">
+                    Catch-up required
+                  </dt>
+                  <dd className="text-lg font-semibold">
+                    {pausedAutopays + disabledAutopays}
+                  </dd>
+                  <p className="text-xs text-muted-foreground">
+                    {pausedAutopays} paused · {disabledAutopays} off
+                  </p>
+                </div>
+              </dl>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Roommate balances</CardTitle>
+              <CardDescription>
+                Review who still owes what before creating a catch-up payment.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {roommateSummaries.map(({ balance, outstanding, nextCharge }) => (
+                <div
+                  key={balance.roommateId}
+                  className="flex flex-wrap items-start justify-between gap-4 rounded-lg border bg-muted/30 p-4"
+                >
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">{balance.roommateName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {balance.unitLabel} · {describeAutopayStatus(balance)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Last payment {formatFullDate(balance.lastPaymentDate)} · {formatCurrency(
+                        balance.lastPaymentAmount,
+                        balance.currency,
+                      )}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-semibold">
+                      {formatCurrency(outstanding, balance.currency)}
+                    </p>
+                    {nextCharge ? (
+                      <p className="text-xs text-muted-foreground">
+                        Next: {nextCharge.description} due {format(parseISO(nextCharge.dueDate), "MMM d")}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">No outstanding charges</p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+        <CatchUpPaymentCard balances={catchUpBalances} />
+      </section>
     </div>
   )
 }

--- a/lib/payments/catch-up.ts
+++ b/lib/payments/catch-up.ts
@@ -1,0 +1,127 @@
+import type {
+  CatchUpBalance,
+  CatchUpCharge,
+  CatchUpPaymentAllocation,
+} from "@/types/payments"
+
+import { roundToCurrency } from "./currency"
+
+export function calculateOutstanding(charges: CatchUpCharge[]): number {
+  const totalCents = charges.reduce((sum, charge) => {
+    return sum + Math.round(charge.outstandingAmount * 100)
+  }, 0)
+
+  return totalCents / 100
+}
+
+export function getOutstandingCharges(
+  charges: CatchUpCharge[],
+): CatchUpCharge[] {
+  return charges
+    .filter((charge) => roundToCurrency(charge.outstandingAmount) > 0)
+    .sort(
+      (a, b) =>
+        new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
+    )
+}
+
+export function getNextOutstandingCharge(
+  charges: CatchUpCharge[],
+): CatchUpCharge | undefined {
+  return getOutstandingCharges(charges)[0]
+}
+
+export function allocatePaymentToCharges(
+  charges: CatchUpCharge[],
+  amount: number,
+): CatchUpPaymentAllocation[] {
+  const outstandingCharges = getOutstandingCharges(charges)
+  let remainingCents = Math.round(amount * 100)
+  const allocations: CatchUpPaymentAllocation[] = []
+
+  for (const charge of outstandingCharges) {
+    if (remainingCents <= 0) {
+      break
+    }
+
+    const chargeCents = Math.round(charge.outstandingAmount * 100)
+    if (chargeCents <= 0) {
+      continue
+    }
+
+    const appliedCents = Math.min(chargeCents, remainingCents)
+    if (appliedCents > 0) {
+      allocations.push({ chargeId: charge.id, amount: appliedCents / 100 })
+      remainingCents -= appliedCents
+    }
+  }
+
+  if (remainingCents > 0 && allocations.length > 0) {
+    const adjustment = remainingCents / 100
+    const lastAllocation = allocations[allocations.length - 1]
+    lastAllocation.amount = roundToCurrency(lastAllocation.amount + adjustment)
+    remainingCents = 0
+  }
+
+  if (remainingCents > 0) {
+    throw new Error("Catch-up amount exceeds outstanding charges.")
+  }
+
+  return allocations
+}
+
+export function applyAllocationsToCharges(
+  charges: CatchUpCharge[],
+  allocations: CatchUpPaymentAllocation[],
+): CatchUpCharge[] {
+  return charges.map((charge) => {
+    const allocationTotal = allocations
+      .filter((allocation) => allocation.chargeId === charge.id)
+      .reduce((sum, allocation) => sum + allocation.amount, 0)
+
+    const remaining = Math.max(
+      0,
+      roundToCurrency(charge.outstandingAmount - allocationTotal),
+    )
+
+    return {
+      ...charge,
+      outstandingAmount: remaining,
+    }
+  })
+}
+
+export function findCatchUpBalance(
+  balances: CatchUpBalance[],
+  roommateId: string,
+): CatchUpBalance | undefined {
+  return balances.find((balance) => balance.roommateId === roommateId)
+}
+
+export function generateMockPaymentIntentId(): string {
+  const globalCrypto = globalThis.crypto
+  if (globalCrypto && typeof globalCrypto.randomUUID === "function") {
+    return `pi_${globalCrypto.randomUUID().replace(/-/g, "").slice(0, 24)}`
+  }
+
+  return `pi_${Math.random().toString(36).slice(2, 26)}`
+}
+
+export function formatAutopayDay(day: number): string {
+  const remainder = day % 10
+  const remainderHundreds = day % 100
+
+  if (remainder === 1 && remainderHundreds !== 11) {
+    return `${day}st`
+  }
+
+  if (remainder === 2 && remainderHundreds !== 12) {
+    return `${day}nd`
+  }
+
+  if (remainder === 3 && remainderHundreds !== 13) {
+    return `${day}rd`
+  }
+
+  return `${day}th`
+}

--- a/lib/payments/currency.ts
+++ b/lib/payments/currency.ts
@@ -1,0 +1,32 @@
+export function roundToCurrency(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+export function parseCurrencyInput(rawValue: string): number {
+  if (!rawValue) {
+    return Number.NaN
+  }
+
+  const normalized = rawValue.replace(/[^0-9.-]/g, "").trim()
+  if (!normalized) {
+    return Number.NaN
+  }
+
+  const parsed = Number.parseFloat(normalized)
+  if (!Number.isFinite(parsed)) {
+    return Number.NaN
+  }
+
+  return roundToCurrency(parsed)
+}
+
+export function formatCurrency(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).format(amount)
+  } catch (error) {
+    return `${roundToCurrency(amount).toFixed(2)} ${currency.toUpperCase()}`
+  }
+}

--- a/lib/payments/mock-data.ts
+++ b/lib/payments/mock-data.ts
@@ -1,0 +1,149 @@
+import type { CatchUpBalance } from "@/types/payments"
+
+export const catchUpBalances: CatchUpBalance[] = [
+  {
+    roommateId: "rm_avery",
+    roommateName: "Avery Chen",
+    unitLabel: "Unit 3B",
+    currency: "USD",
+    monthlyShare: 1260,
+    autopayDay: 1,
+    autopayStatus: "active",
+    lastPaymentDate: "2024-05-28",
+    lastPaymentAmount: 1260,
+    charges: [
+      {
+        id: "rm_avery_rent_june",
+        description: "June rent share",
+        category: "rent",
+        dueDate: "2024-06-01",
+        originalAmount: 1260,
+        outstandingAmount: 260,
+      },
+      {
+        id: "rm_avery_wifi_june",
+        description: "Wi-Fi reimbursement",
+        category: "utilities",
+        dueDate: "2024-06-12",
+        originalAmount: 45,
+        outstandingAmount: 45,
+      },
+      {
+        id: "rm_avery_maintenance_june",
+        description: "Community maintenance fee",
+        category: "maintenance",
+        dueDate: "2024-06-18",
+        originalAmount: 30,
+        outstandingAmount: 30,
+      },
+    ],
+    contacts: {
+      primary: {
+        name: "Avery Chen",
+        email: "avery.chen@example.com",
+      },
+      roommates: [
+        { name: "Jordan Blake", email: "jordan.blake@example.com" },
+        { name: "Priya Desai", email: "priya.desai@example.com" },
+      ],
+      propertyManager: {
+        name: "Morgan Ellis",
+        email: "morgan.ellis@sharehouse.example",
+      },
+    },
+  },
+  {
+    roommateId: "rm_jordan",
+    roommateName: "Jordan Blake",
+    unitLabel: "Unit 3B",
+    currency: "USD",
+    monthlyShare: 1260,
+    autopayDay: 1,
+    autopayStatus: "paused",
+    lastPaymentDate: "2024-05-12",
+    lastPaymentAmount: 800,
+    charges: [
+      {
+        id: "rm_jordan_rent_june",
+        description: "June rent share",
+        category: "rent",
+        dueDate: "2024-06-01",
+        originalAmount: 1260,
+        outstandingAmount: 480,
+      },
+      {
+        id: "rm_jordan_utilities_may",
+        description: "Shared utilities true-up",
+        category: "utilities",
+        dueDate: "2024-06-10",
+        originalAmount: 62,
+        outstandingAmount: 62,
+      },
+      {
+        id: "rm_jordan_parking_may",
+        description: "Parking spot 17",
+        category: "parking",
+        dueDate: "2024-05-29",
+        originalAmount: 80,
+        outstandingAmount: 40,
+      },
+    ],
+    contacts: {
+      primary: {
+        name: "Jordan Blake",
+        email: "jordan.blake@example.com",
+      },
+      roommates: [
+        { name: "Avery Chen", email: "avery.chen@example.com" },
+        { name: "Priya Desai", email: "priya.desai@example.com" },
+      ],
+      propertyManager: {
+        name: "Morgan Ellis",
+        email: "morgan.ellis@sharehouse.example",
+      },
+    },
+  },
+  {
+    roommateId: "rm_priya",
+    roommateName: "Priya Desai",
+    unitLabel: "Unit 3B",
+    currency: "USD",
+    monthlyShare: 1260,
+    autopayDay: 1,
+    autopayStatus: "disabled",
+    lastPaymentDate: "2024-04-30",
+    lastPaymentAmount: 1260,
+    charges: [
+      {
+        id: "rm_priya_rent_june",
+        description: "June rent share",
+        category: "rent",
+        dueDate: "2024-06-01",
+        originalAmount: 1260,
+        outstandingAmount: 1260,
+      },
+      {
+        id: "rm_priya_supplies_may",
+        description: "Household supplies reimbursement",
+        category: "fees",
+        dueDate: "2024-06-08",
+        originalAmount: 38,
+        outstandingAmount: 38,
+      },
+    ],
+    contacts: {
+      primary: {
+        name: "Priya Desai",
+        email: "priya.desai@example.com",
+      },
+      roommates: [
+        { name: "Avery Chen", email: "avery.chen@example.com" },
+        { name: "Jordan Blake", email: "jordan.blake@example.com" },
+      ],
+      propertyManager: {
+        name: "Morgan Ellis",
+        email: "morgan.ellis@sharehouse.example",
+      },
+    },
+  },
+]

--- a/lib/payments/schemas.ts
+++ b/lib/payments/schemas.ts
@@ -1,0 +1,68 @@
+import { z } from "zod"
+
+import type { CatchUpBalance } from "@/types/payments"
+
+import { calculateOutstanding } from "./catch-up"
+import { formatCurrency, parseCurrencyInput } from "./currency"
+
+export const createCatchUpFormSchema = (balances: CatchUpBalance[]) =>
+  z
+    .object({
+      roommateId: z.string().min(1, "Select a roommate"),
+      amount: z
+        .string()
+        .trim()
+        .min(1, "Enter a payment amount")
+        .refine((value) => !Number.isNaN(parseCurrencyInput(value)), {
+          message: "Enter a valid amount",
+        }),
+      includePropertyManager: z.boolean().default(false),
+      note: z
+        .string()
+        .trim()
+        .max(280, "Note must be 280 characters or fewer")
+        .optional(),
+    })
+    .superRefine((data, ctx) => {
+      const amount = parseCurrencyInput(data.amount)
+
+      if (!Number.isFinite(amount)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["amount"],
+          message: "Enter a valid amount",
+        })
+        return
+      }
+
+      if (amount <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["amount"],
+          message: "Amount must be greater than zero",
+        })
+        return
+      }
+
+      const balance = balances.find((item) => item.roommateId === data.roommateId)
+      if (!balance) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["roommateId"],
+          message: "Selected roommate is no longer available",
+        })
+        return
+      }
+
+      const outstanding = calculateOutstanding(balance.charges)
+      if (amount > outstanding) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["amount"],
+          message: `Amount exceeds outstanding balance of ${formatCurrency(outstanding, balance.currency)}`,
+        })
+      }
+    })
+
+export type CatchUpFormSchema = ReturnType<typeof createCatchUpFormSchema>
+

--- a/tests/catch-up.test.ts
+++ b/tests/catch-up.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  allocatePaymentToCharges,
+  applyAllocationsToCharges,
+  calculateOutstanding,
+  formatAutopayDay,
+  generateMockPaymentIntentId,
+} from "@/lib/payments/catch-up"
+import type { CatchUpCharge } from "@/types/payments"
+
+const sampleCharges: CatchUpCharge[] = [
+  {
+    id: "charge_rent",
+    description: "June rent share",
+    category: "rent",
+    dueDate: "2024-06-01",
+    originalAmount: 1200,
+    outstandingAmount: 450.25,
+  },
+  {
+    id: "charge_wifi",
+    description: "Wi-Fi",
+    category: "utilities",
+    dueDate: "2024-06-10",
+    originalAmount: 45,
+    outstandingAmount: 45,
+  },
+  {
+    id: "charge_supplies",
+    description: "Household supplies",
+    category: "fees",
+    dueDate: "2024-06-15",
+    originalAmount: 32,
+    outstandingAmount: 12.5,
+  },
+]
+
+describe("catch-up helpers", () => {
+  it("calculates outstanding totals with cent precision", () => {
+    const total = calculateOutstanding(sampleCharges)
+    expect(total).toBeCloseTo(507.75)
+  })
+
+  it("allocates partial payments to the earliest due charges first", () => {
+    const allocations = allocatePaymentToCharges(sampleCharges, 200)
+    expect(allocations).toHaveLength(1)
+    expect(allocations[0]).toEqual({ chargeId: "charge_rent", amount: 200 })
+  })
+
+  it("spreads payments across multiple charges when needed", () => {
+    const allocations = allocatePaymentToCharges(sampleCharges, 480)
+    expect(allocations).toEqual([
+      { chargeId: "charge_rent", amount: 450.25 },
+      { chargeId: "charge_wifi", amount: 29.75 },
+    ])
+  })
+
+  it("reduces outstanding amounts after applying allocations", () => {
+    const allocations = [
+      { chargeId: "charge_rent", amount: 450.25 },
+      { chargeId: "charge_wifi", amount: 29.75 },
+    ]
+
+    const updated = applyAllocationsToCharges(sampleCharges, allocations)
+    expect(updated.find((charge) => charge.id === "charge_rent")?.outstandingAmount).toBe(0)
+    expect(updated.find((charge) => charge.id === "charge_wifi")?.outstandingAmount).toBeCloseTo(15.25)
+    expect(updated.find((charge) => charge.id === "charge_supplies")?.outstandingAmount).toBe(12.5)
+  })
+
+  it("formats autopay day with ordinal suffix", () => {
+    expect(formatAutopayDay(1)).toBe("1st")
+    expect(formatAutopayDay(2)).toBe("2nd")
+    expect(formatAutopayDay(3)).toBe("3rd")
+    expect(formatAutopayDay(11)).toBe("11th")
+    expect(formatAutopayDay(22)).toBe("22nd")
+  })
+
+  it("generates mock payment intent identifiers", () => {
+    const id = generateMockPaymentIntentId()
+    expect(id.startsWith("pi_")).toBe(true)
+    expect(id.length).toBeGreaterThan(5)
+  })
+})

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -1,0 +1,77 @@
+export type AutopayStatus = "active" | "paused" | "disabled"
+
+export type CatchUpChargeCategory =
+  | "rent"
+  | "utilities"
+  | "fees"
+  | "deposit"
+  | "maintenance"
+  | "parking"
+  | "other"
+
+export interface CatchUpCharge {
+  id: string
+  description: string
+  category: CatchUpChargeCategory
+  dueDate: string
+  originalAmount: number
+  outstandingAmount: number
+}
+
+export interface CatchUpContact {
+  name: string
+  email: string
+}
+
+export interface CatchUpContacts {
+  primary: CatchUpContact
+  roommates?: CatchUpContact[]
+  propertyManager?: CatchUpContact
+}
+
+export interface CatchUpBalance {
+  roommateId: string
+  roommateName: string
+  unitLabel: string
+  currency: string
+  monthlyShare: number
+  autopayDay: number
+  autopayStatus: AutopayStatus
+  lastPaymentDate: string
+  lastPaymentAmount: number
+  charges: CatchUpCharge[]
+  contacts: CatchUpContacts
+}
+
+export interface CatchUpPaymentAllocation {
+  chargeId: string
+  amount: number
+}
+
+export interface CatchUpPaymentAllocationDetail extends CatchUpPaymentAllocation {
+  description: string
+  category: CatchUpChargeCategory
+  dueDate: string
+  remainingBalance: number
+}
+
+export interface CatchUpPaymentSubmissionResult {
+  paymentIntentId: string
+  roommateId: string
+  roommateName: string
+  amount: number
+  currency: string
+  projectedBalance: number
+  allocations: CatchUpPaymentAllocationDetail[]
+  recipients: CatchUpContact[]
+  autopayStatus: AutopayStatus
+  autopayDay: number
+  note?: string
+}
+
+export interface CatchUpPaymentFormValues {
+  roommateId: string
+  amount: string
+  includePropertyManager: boolean
+  note?: string
+}


### PR DESCRIPTION
## Summary
- add reusable payment helpers, sample balances, and validation schemas for partial catch-up flows
- build a one-time catch up form with allocation previews, autopay insights, and receipt options
- enrich the payments page with roommate balance snapshots and wire up the new workflow plus helper tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d05e9dedf08328969901af55c3878f