### PR TITLE
Add Supabase-backed tenant receipt uploads

### DIFF
--- a/app/(tenant)/billing/payments/[id]/page.tsx
+++ b/app/(tenant)/billing/payments/[id]/page.tsx
@@ -1,0 +1,131 @@
+import { notFound } from "next/navigation"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { canManageReceipt } from "@/lib/authorization/receipts"
+import type { Tables } from "@/lib/supabase"
+import { getPaymentById } from "@/queries/payments"
+import { createClient } from "@/utils/supabase/server"
+
+import { ReceiptUploader } from "./receipt-uploader"
+
+type PaymentPageProps = {
+  params: { id: string }
+}
+
+function formatCurrency(amountCents: number, currency: string) {
+  const normalizedCurrency = currency?.toUpperCase() || "USD"
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: normalizedCurrency,
+    currencyDisplay: "symbol",
+  }).format(amountCents / 100)
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "Not specified"
+
+  const parsed = new Date(value)
+
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed)
+}
+
+export default async function PaymentReceiptPage({ params }: PaymentPageProps) {
+  const supabase = createClient()
+  const { data: payment, error } = await getPaymentById(supabase, params.id)
+
+  if (error || !payment) {
+    notFound()
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  let viewerProfile: Pick<Tables<"profiles">, "id" | "role" | "full_name"> | null = null
+
+  if (user) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role, full_name")
+      .eq("id", user.id)
+      .maybeSingle()
+
+    viewerProfile = profile ?? null
+  }
+
+  const allowedToManageReceipt = canManageReceipt(payment.payer_id, viewerProfile)
+  const amountLabel = formatCurrency(payment.amount_cents, payment.currency)
+  const dueDateLabel = formatDate(payment.due_date)
+  const createdAtLabel = formatDate(payment.created_at)
+
+  const statusVariant = payment.status === "paid" ? "secondary" : "outline"
+
+  return (
+    <div className="container max-w-3xl space-y-8 py-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Payment receipt</h1>
+        <p className="text-base text-muted-foreground">
+          Upload bank transfer confirmations or cash payment receipts to reconcile balances quickly.
+        </p>
+      </div>
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>{amountLabel}</CardTitle>
+            <CardDescription>
+              {payment.description ?? "Rent or shared expense payment"}
+            </CardDescription>
+          </div>
+          <Badge variant={statusVariant} className="uppercase">
+            {payment.status}
+          </Badge>
+        </CardHeader>
+        <Separator />
+        <CardContent className="grid gap-6 sm:grid-cols-2">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-muted-foreground">Due date</p>
+            <p className="text-base font-semibold">{dueDateLabel}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-muted-foreground">Recorded</p>
+            <p className="text-base font-semibold">{createdAtLabel}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-muted-foreground">Payer</p>
+            <p className="text-base font-semibold">
+              {payment.payer?.full_name ?? "Resident"}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-muted-foreground">Receipt</p>
+            <p className="text-base font-semibold">
+              {payment.receipt_path ? "On file" : "Not uploaded"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+      <ReceiptUploader
+        paymentId={payment.id}
+        initialReceiptPath={payment.receipt_path}
+        canManageReceipt={allowedToManageReceipt}
+      />
+    </div>
+  )
+}

--- a/app/(tenant)/billing/payments/[id]/receipt-uploader.tsx
+++ b/app/(tenant)/billing/payments/[id]/receipt-uploader.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import Link from "next/link"
+import {
+  type ChangeEventHandler,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+interface ReceiptUploaderProps {
+  paymentId: string
+  initialReceiptPath: string | null
+  canManageReceipt: boolean
+}
+
+export function ReceiptUploader({
+  paymentId,
+  initialReceiptPath,
+  canManageReceipt,
+}: ReceiptUploaderProps) {
+  const supabase = useSupabaseBrowser()
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [receiptPath, setReceiptPath] = useState<string | null>(initialReceiptPath)
+  const [signedUrl, setSignedUrl] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  useEffect(() => {
+    setReceiptPath(initialReceiptPath)
+  }, [initialReceiptPath])
+
+  const loadSignedUrl = useCallback(
+    async (path: string | null) => {
+      if (!path || !canManageReceipt) {
+        setSignedUrl(null)
+        return
+      }
+
+      const { data, error: signedError } = await supabase
+        .storage
+        .from("receipts")
+        .createSignedUrl(path, 60 * 60)
+
+      if (signedError) {
+        setError(signedError.message)
+        setSignedUrl(null)
+        return
+      }
+
+      setSignedUrl(data?.signedUrl ?? null)
+    },
+    [canManageReceipt, supabase],
+  )
+
+  useEffect(() => {
+    setError(null)
+    void loadSignedUrl(receiptPath)
+  }, [loadSignedUrl, receiptPath])
+
+  const resetFileInput = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""
+    }
+  }
+
+  const handleFileChange: ChangeEventHandler<HTMLInputElement> = async (event) => {
+    if (!canManageReceipt) {
+      resetFileInput()
+      return
+    }
+
+    const file = event.target.files?.[0]
+
+    if (!file) {
+      return
+    }
+
+    setError(null)
+    setSuccess(null)
+    setUploading(true)
+
+    try {
+      const extension = file.name.split(".").pop()
+      const sanitizedExtension = extension ? `.${extension}` : ""
+      const newPath = `${paymentId}/${Date.now()}-${Math.random().toString(36).slice(2)}${sanitizedExtension}`
+
+      const { error: uploadError } = await supabase.storage
+        .from("receipts")
+        .upload(newPath, file, {
+          cacheControl: "3600",
+          metadata: { payment_id: paymentId },
+        })
+
+      if (uploadError) {
+        throw uploadError
+      }
+
+      const { error: updateError } = await supabase
+        .from("payments")
+        .update({
+          receipt_path: newPath,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", paymentId)
+        .select("receipt_path")
+        .single()
+
+      if (updateError) {
+        throw updateError
+      }
+
+      setReceiptPath(newPath)
+      setSuccess("Receipt uploaded successfully.")
+      await loadSignedUrl(newPath)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to upload receipt."
+      setError(message)
+    } finally {
+      resetFileInput()
+      setUploading(false)
+    }
+  }
+
+  const handleSelectClick = () => {
+    if (!canManageReceipt) return
+
+    fileInputRef.current?.click()
+  }
+
+  const showUploadCta = canManageReceipt
+  const hasReceipt = Boolean(receiptPath)
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <CardTitle>Receipt archive</CardTitle>
+          <CardDescription>
+            Upload confirmations for off-platform payments so everyone has a consistent record.
+          </CardDescription>
+        </div>
+        <Badge variant={hasReceipt ? "secondary" : "outline"}>
+          {hasReceipt ? "Receipt on file" : "No receipt uploaded"}
+        </Badge>
+      </CardHeader>
+      <Separator />
+      <CardContent className="space-y-4">
+        <input
+          ref={fileInputRef}
+          id="payment-receipt"
+          type="file"
+          accept="image/*,application/pdf"
+          className="hidden"
+          onChange={handleFileChange}
+          disabled={!canManageReceipt}
+        />
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex-1 space-y-2">
+            <Label htmlFor="payment-receipt">Receipt file</Label>
+            <Input
+              type="text"
+              readOnly
+              value={receiptPath ?? "No receipt uploaded yet"}
+              className="font-mono"
+              aria-readonly
+            />
+          </div>
+          {showUploadCta && (
+            <Button onClick={handleSelectClick} isLoading={uploading} disabled={uploading}>
+              {hasReceipt ? "Replace receipt" : "Upload receipt"}
+            </Button>
+          )}
+        </div>
+        {!canManageReceipt && (
+          <p className="text-sm text-muted-foreground">
+            Only the payer and administrators can manage receipt uploads for this payment.
+          </p>
+        )}
+        {signedUrl && (
+          <div className="flex flex-wrap items-center gap-3">
+            <Button variant="outline" asChild>
+              <Link href={signedUrl} target="_blank" rel="noopener noreferrer">
+                View uploaded receipt
+              </Link>
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              Signed link expires in one hour. Generate a new upload to refresh access.
+            </p>
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {success && <p className="text-sm text-emerald-600">{success}</p>}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/authorization/receipts.ts
+++ b/lib/authorization/receipts.ts
@@ -1,0 +1,27 @@
+import type { Tables } from "@/lib/supabase"
+
+type Profile = Pick<Tables<"profiles">, "id" | "role"> | null | undefined
+
+export function isAdmin(profile: Profile) {
+  const role = profile?.role
+
+  if (!role) return false
+
+  return role.toLowerCase() === "admin"
+}
+
+export function canAccessReceipt(payerId: string, profile: Profile) {
+  if (!profile?.id) {
+    return false
+  }
+
+  if (isAdmin(profile)) {
+    return true
+  }
+
+  return profile.id === payerId
+}
+
+export function canManageReceipt(payerId: string, profile: Profile) {
+  return canAccessReceipt(payerId, profile)
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1202,6 +1202,53 @@ export type Database = {
         }
         Relationships: []
       }
+      payments: {
+        Row: {
+          amount_cents: number
+          created_at: string
+          currency: string
+          description: string | null
+          due_date: string | null
+          id: string
+          payer_id: string
+          receipt_path: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          amount_cents: number
+          created_at?: string
+          currency?: string
+          description?: string | null
+          due_date?: string | null
+          id?: string
+          payer_id: string
+          receipt_path?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          amount_cents?: number
+          created_at?: string
+          currency?: string
+          description?: string | null
+          due_date?: string | null
+          id?: string
+          payer_id?: string
+          receipt_path?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "payments_payer_id_fkey"
+            columns: ["payer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       permission_table: {
         Row: {
           created_at: string

--- a/queries/payments.ts
+++ b/queries/payments.ts
@@ -1,0 +1,34 @@
+import type { PostgrestSingleResponse } from "@supabase/supabase-js"
+
+import type { Tables } from "@/lib/supabase"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+export type PaymentRecord = Tables<"payments">
+export type PaymentWithRelations = PaymentRecord & {
+  payer?: Pick<Tables<"profiles">, "full_name" | "email" | "role">
+}
+
+const PAYMENT_COLUMNS = `
+  id,
+  payer_id,
+  amount_cents,
+  currency,
+  status,
+  due_date,
+  description,
+  receipt_path,
+  created_at,
+  payer:profiles(full_name, email, role)
+`
+
+export function getPaymentById(
+  client: TypedSupabaseClient,
+  paymentId: string,
+): Promise<PostgrestSingleResponse<PaymentWithRelations>> {
+  return client
+    .from("payments")
+    .select(PAYMENT_COLUMNS)
+    .eq("id", paymentId)
+    .limit(1)
+    .single()
+}

--- a/supabase/migrations/20250717_add_payments_receipts.sql
+++ b/supabase/migrations/20250717_add_payments_receipts.sql
@@ -1,0 +1,109 @@
+create table if not exists public.payments (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  payer_id uuid not null references public.profiles(id) on delete cascade,
+  amount_cents integer not null,
+  currency text not null default 'USD',
+  status text not null default 'pending',
+  due_date date,
+  description text,
+  receipt_path text
+);
+
+alter table public.payments enable row level security;
+
+create index if not exists payments_payer_id_idx on public.payments (payer_id);
+
+create policy "Payers can view their payments" on public.payments
+  for select
+  using (
+    payer_id = auth.uid()
+  );
+
+create policy "Payers can update their payments" on public.payments
+  for update
+  using (
+    payer_id = auth.uid()
+  )
+  with check (
+    payer_id = auth.uid()
+  );
+
+create policy "Admins can manage payments" on public.payments
+  for all
+  using (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and lower(coalesce(p.role, '')) = 'admin'
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and lower(coalesce(p.role, '')) = 'admin'
+    )
+  );
+
+insert into storage.buckets (id, name, public)
+values ('receipts', 'receipts', false)
+on conflict (id) do nothing;
+
+create policy "Restrict receipt uploads to payer or admin" on storage.objects
+  for insert to authenticated
+  with check (
+    bucket_id = 'receipts'
+    and metadata ? 'payment_id'
+    and (
+      exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid()
+          and lower(coalesce(p.role, '')) = 'admin'
+      )
+      or exists (
+        select 1 from public.payments pay
+        where pay.id::text = metadata ->> 'payment_id'
+          and pay.payer_id = auth.uid()
+      )
+    )
+  );
+
+create policy "Restrict receipt access to payer or admin" on storage.objects
+  for select to authenticated
+  using (
+    bucket_id = 'receipts'
+    and metadata ? 'payment_id'
+    and (
+      exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid()
+          and lower(coalesce(p.role, '')) = 'admin'
+      )
+      or exists (
+        select 1 from public.payments pay
+        where pay.id::text = metadata ->> 'payment_id'
+          and pay.payer_id = auth.uid()
+      )
+    )
+  );
+
+create policy "Restrict receipt deletion to payer or admin" on storage.objects
+  for delete to authenticated
+  using (
+    bucket_id = 'receipts'
+    and metadata ? 'payment_id'
+    and (
+      exists (
+        select 1 from public.profiles p
+        where p.id = auth.uid()
+          and lower(coalesce(p.role, '')) = 'admin'
+      )
+      or exists (
+        select 1 from public.payments pay
+        where pay.id::text = metadata ->> 'payment_id'
+          and pay.payer_id = auth.uid()
+      )
+    )
+  );

--- a/tests/receipts-access.test.ts
+++ b/tests/receipts-access.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { canAccessReceipt, canManageReceipt, isAdmin } from "@/lib/authorization/receipts"
+
+const payerId = "00000000-0000-0000-0000-000000000111"
+const otherId = "00000000-0000-0000-0000-000000000222"
+
+describe("receipt access control", () => {
+  it("treats administrators as privileged viewers", () => {
+    const adminProfile = { id: otherId, role: "admin" }
+
+    expect(isAdmin(adminProfile)).toBe(true)
+    expect(canAccessReceipt(payerId, adminProfile)).toBe(true)
+    expect(canManageReceipt(payerId, adminProfile)).toBe(true)
+  })
+
+  it("allows the payer to upload or view receipts", () => {
+    const payerProfile = { id: payerId, role: "resident" }
+
+    expect(canAccessReceipt(payerId, payerProfile)).toBe(true)
+    expect(canManageReceipt(payerId, payerProfile)).toBe(true)
+  })
+
+  it("blocks roommates who are not administrators", () => {
+    const roommateProfile = { id: otherId, role: "resident" }
+
+    expect(canAccessReceipt(payerId, roommateProfile)).toBe(false)
+    expect(canManageReceipt(payerId, roommateProfile)).toBe(false)
+  })
+
+  it("handles missing profile contexts", () => {
+    expect(canAccessReceipt(payerId, null)).toBe(false)
+    expect(canManageReceipt(payerId, undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add a tenant payment receipt detail route that loads Supabase payment data and surfaces status details
- build a receipt uploader that pushes files to the `receipts` bucket with payment metadata and updates the payment record
- add the payments query, authorization helper, migration for the payments table and storage policies, and tests covering receipt access rules

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0c96e9c8328a15802ba94fdfe56