### PR TITLE
Add amenity scheduling metadata and admin form

### DIFF
--- a/app/(admin)/amenities/_components/amenity-form.tsx
+++ b/app/(admin)/amenities/_components/amenity-form.tsx
@@ -1,0 +1,336 @@
+"use client"
+
+import { useState } from "react"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+
+const DAYS = [
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+] as const
+
+const DAY_LABELS: Record<(typeof DAYS)[number], string> = {
+  monday: "Monday",
+  tuesday: "Tuesday",
+  wednesday: "Wednesday",
+  thursday: "Thursday",
+  friday: "Friday",
+  saturday: "Saturday",
+  sunday: "Sunday",
+}
+
+const dayRangeSchema = z
+  .object({
+    start: z.string().optional(),
+    end: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if ((value.start && !value.end) || (!value.start && value.end)) {
+      if (!value.start) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Start time is required when an end time is provided.",
+          path: ["start"],
+        })
+      }
+      if (!value.end) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "End time is required when a start time is provided.",
+          path: ["end"],
+        })
+      }
+    }
+
+    if (value.start && value.end && value.start >= value.end) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "End time must be later than the start time.",
+        path: ["end"],
+      })
+    }
+  })
+
+const openHoursShape = DAYS.reduce(
+  (acc, day) => ({
+    ...acc,
+    [day]: dayRangeSchema,
+  }),
+  {} as Record<(typeof DAYS)[number], typeof dayRangeSchema>
+)
+
+const openHoursSchema = z.object(openHoursShape)
+
+const formSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters."),
+  description: z.string().max(500, "Description should be concise.").optional(),
+  location: z.string().max(120, "Location is too long.").optional(),
+  buffer_minutes: z
+    .coerce
+    .number({ invalid_type_error: "Buffer must be a whole number." })
+    .int("Buffer must be a whole number.")
+    .min(0, "Buffer cannot be negative."),
+  capacity: z
+    .coerce
+    .number({ invalid_type_error: "Capacity must be a whole number." })
+    .int("Capacity must be a whole number.")
+    .min(1, "Capacity must be at least 1."),
+  open_hours: openHoursSchema,
+})
+
+type FormValues = z.infer<typeof formSchema>
+
+type AmenityPreview = {
+  name: string
+  description: string | null
+  location: string | null
+  buffer_minutes: number
+  capacity: number
+  open_hours: Record<string, { end: string; start: string }[]>
+}
+
+const defaultOpenHours = DAYS.reduce(
+  (acc, day) => ({
+    ...acc,
+    [day]: { start: "", end: "" },
+  }),
+  {} as FormValues["open_hours"]
+)
+
+export function AmenityForm() {
+  const [preview, setPreview] = useState<AmenityPreview | null>(null)
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      location: "",
+      buffer_minutes: 0,
+      capacity: 1,
+      open_hours: defaultOpenHours,
+    },
+  })
+
+  function onSubmit(values: FormValues) {
+    const openHoursPayload = Object.entries(values.open_hours).reduce(
+      (acc, [day, range]) => {
+        if (range.start && range.end) {
+          acc[day] = [
+            {
+              start: range.start,
+              end: range.end,
+            },
+          ]
+        } else {
+          acc[day] = []
+        }
+        return acc
+      },
+      {} as AmenityPreview["open_hours"]
+    )
+
+    const payload: AmenityPreview = {
+      name: values.name.trim(),
+      description: values.description?.trim() ? values.description.trim() : null,
+      location: values.location?.trim() ? values.location.trim() : null,
+      buffer_minutes: values.buffer_minutes,
+      capacity: values.capacity,
+      open_hours: openHoursPayload,
+    }
+
+    setPreview(payload)
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <CardHeader>
+              <CardTitle>New amenity</CardTitle>
+              <CardDescription>
+                Capture the baseline configuration for a shared resource. These settings feed Supabase and Cal.com
+                automation so bookings respect business rules.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Name</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Roof deck" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="location"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Location</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Penthouse, building A" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Outline the equipment, etiquette, and any supervision requirements residents should know."
+                        className="min-h-[120px]"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      This copy appears in tenant portals alongside the booking calendar.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="buffer_minutes"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Buffer minutes</FormLabel>
+                      <FormControl>
+                        <Input type="number" min={0} step={5} placeholder="15" {...field} />
+                      </FormControl>
+                      <FormDescription>Hold this many minutes before and after every reservation.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="capacity"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Capacity</FormLabel>
+                      <FormControl>
+                        <Input type="number" min={1} step={1} placeholder="1" {...field} />
+                      </FormControl>
+                      <FormDescription>Maximum simultaneous participants allowed per booking slot.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="space-y-3">
+                <div>
+                  <h3 className="text-lg font-semibold">Open hours</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Provide daily availability windows using 24-hour time. Leave a day blank when the amenity is closed.
+                  </p>
+                </div>
+                <Separator />
+                <div className="space-y-4">
+                  {DAYS.map((day) => (
+                    <div
+                      key={day}
+                      className="grid gap-3 rounded-lg border p-4 sm:grid-cols-[140px_1fr_1fr] sm:items-center"
+                    >
+                      <span className="font-medium capitalize">{DAY_LABELS[day]}</span>
+                      <FormField
+                        control={form.control}
+                        name={`open_hours.${day}.start`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel className="sr-only">{DAY_LABELS[day]} start time</FormLabel>
+                            <FormControl>
+                              <Input type="time" step={300} {...field} />
+                            </FormControl>
+                            <FormDescription>Start</FormDescription>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name={`open_hours.${day}.end`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel className="sr-only">{DAY_LABELS[day]} end time</FormLabel>
+                            <FormControl>
+                              <Input type="time" step={300} {...field} />
+                            </FormControl>
+                            <FormDescription>End</FormDescription>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </CardContent>
+            <CardFooter className="justify-end">
+              <Button type="submit">Save configuration</Button>
+            </CardFooter>
+          </form>
+        </Form>
+      </Card>
+
+      {preview ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Payload preview</CardTitle>
+            <CardDescription>
+              This is the object that will be persisted to Supabase once a server action is wired up.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <pre className="whitespace-pre-wrap break-words rounded-md bg-muted p-4 text-sm">
+              {JSON.stringify(preview, null, 2)}
+            </pre>
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  )
+}

--- a/app/(admin)/amenities/page.tsx
+++ b/app/(admin)/amenities/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+
+import { AmenityForm } from "./_components/amenity-form"
+
+export const metadata: Metadata = {
+  title: "Amenity configuration",
+  description:
+    "Define availability, buffers, and capacity rules for shared amenities before exposing them to residents.",
+}
+
+export default function AmenitiesPage() {
+  return (
+    <section className="container mx-auto max-w-5xl space-y-6 py-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Amenity configuration</h1>
+        <p className="text-muted-foreground">
+          Manage booking windows and throughput for each shared space so reservations stay fair and predictable.
+        </p>
+      </div>
+      <AmenityForm />
+    </section>
+  )
+}

--- a/docs/amenities.md
+++ b/docs/amenities.md
@@ -1,0 +1,44 @@
+# Amenity configuration rules
+
+Shared amenity bookings depend on consistent metadata so Supabase, Cal.com, and the front-end stay in sync. The schema and UI now expose three core fields that govern how each resource can be reserved.
+
+## Schema columns
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `open_hours` | `jsonb` | Weekly availability windows keyed by weekday. Each day maps to an array of `{ "start": "HH:MM", "end": "HH:MM" }` objects using 24-hour time. Empty arrays mark closed days. |
+| `buffer_minutes` | `integer` | Minutes blocked before and after every booking to support cleaning, resets, or elevator travel. Set to `0` when no padding is required. |
+| `capacity` | `integer` (default `1`) | Maximum simultaneous participants allowed for a single slot. Drives both booking limits in Cal.com and conflict detection in Supabase. |
+
+## JSON structure for `open_hours`
+
+```json
+{
+  "monday": [{ "start": "08:00", "end": "22:00" }],
+  "tuesday": [{ "start": "08:00", "end": "22:00" }],
+  "wednesday": [],
+  "thursday": [{ "start": "10:00", "end": "18:00" }],
+  "friday": [{ "start": "10:00", "end": "18:00" }],
+  "saturday": [{ "start": "09:00", "end": "12:00" }],
+  "sunday": []
+}
+```
+
+**Validation rules:**
+
+- Use 24-hour `HH:MM` strings; seconds are omitted.
+- Provide both a `start` and `end` time for every window. Partial entries are rejected.
+- Ensure `end` is later than `start` for each range.
+- Leave the array empty for days the amenity stays closed.
+
+## Operational guidance
+
+- **Buffer minutes:** Align with the physical reset period (e.g., towel service, cleaning, elevator travel). When multiple services need time, choose the longest requirement so residents never overlap with staff.
+- **Capacity:** Represent the true simultaneous headcount limit, not per-day availability. If multiple families can use the space concurrently, raise the value accordingly.
+- **Versioning:** Update `updated_at` (if present) whenever these fields change so booking clients can invalidate caches.
+
+## UI workflow
+
+The admin form at `/app/(admin)/amenities` captures each of these fields. Open hours are entered with time pickers per weekday and converted into the JSON payload shown above. Buffer and capacity use numeric inputs with validation to prevent negative values.
+
+After saving, surface the `open_hours`, `buffer_minutes`, and `capacity` data when publishing amenity details to ensure tenants understand the booking policy.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -411,6 +411,42 @@ export type Database = {
         }
         Relationships: []
       }
+      amenities: {
+        Row: {
+          buffer_minutes: number | null
+          capacity: number
+          created_at: string | null
+          description: string | null
+          id: string
+          location: string | null
+          name: string
+          open_hours: Json | null
+          updated_at: string | null
+        }
+        Insert: {
+          buffer_minutes?: number | null
+          capacity?: number
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          location?: string | null
+          name: string
+          open_hours?: Json | null
+          updated_at?: string | null
+        }
+        Update: {
+          buffer_minutes?: number | null
+          capacity?: number
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          location?: string | null
+          name?: string
+          open_hours?: Json | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       business_cards: {
         Row: {
           businesscard_name: string | null

--- a/supabase/migrations/20250411_add_amenity_booking_fields.sql
+++ b/supabase/migrations/20250411_add_amenity_booking_fields.sql
@@ -1,0 +1,12 @@
+ALTER TABLE IF EXISTS public.amenities
+ADD COLUMN IF NOT EXISTS open_hours jsonb;
+
+ALTER TABLE IF EXISTS public.amenities
+ADD COLUMN IF NOT EXISTS buffer_minutes integer;
+
+ALTER TABLE IF EXISTS public.amenities
+ADD COLUMN IF NOT EXISTS capacity integer NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN public.amenities.open_hours IS 'Structured booking availability windows keyed by weekday.';
+COMMENT ON COLUMN public.amenities.buffer_minutes IS 'Minutes enforced between consecutive bookings.';
+COMMENT ON COLUMN public.amenities.capacity IS 'Maximum simultaneous participants per booking slot.';


### PR DESCRIPTION
## Summary
- add migration columns for amenity booking buffers, capacity, and structured hours
- extend Supabase types to expose the new amenity fields to the app layer
- introduce an admin amenity configuration form and documentation for open hours rules

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0d49b048328af8420ed31b11bd2