### PR TITLE
Add bookings request API route handling Postgres conflicts

### DIFF
--- a/app/api/bookings/request/route.ts
+++ b/app/api/bookings/request/route.ts
@@ -1,0 +1,82 @@
+import { mapPostgresError } from "@/lib/postgres-error-map"
+import { createClient } from "@/utils/supabase/server"
+import { z } from "zod"
+
+const bookingRequestSchema = z
+  .object({
+    amenityId: z.string().min(1, "Amenity is required."),
+    unitId: z.string().min(1, "Unit is required."),
+    startsAt: z.coerce.date(),
+    endsAt: z.coerce.date(),
+    notes: z.string().max(500).optional(),
+  })
+  .refine((data) => data.endsAt > data.startsAt, {
+    message: "End time must be after start time.",
+    path: ["endsAt"],
+  })
+
+type BookingRequest = z.infer<typeof bookingRequestSchema>
+
+function formatBookingPayload(input: BookingRequest, tenantId: string) {
+  return {
+    amenity_id: input.amenityId,
+    unit_id: input.unitId,
+    start_time: input.startsAt.toISOString(),
+    end_time: input.endsAt.toISOString(),
+    notes: input.notes ?? null,
+    tenant_id: tenantId,
+  }
+}
+
+export async function POST(request: Request) {
+  const supabase = createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  let body: unknown
+
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ error: "Invalid JSON payload." }, { status: 400 })
+  }
+
+  const parsed = bookingRequestSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return Response.json(
+      {
+        error: "Invalid booking request.",
+        details: parsed.error.flatten(),
+      },
+      { status: 400 },
+    )
+  }
+
+  const bookingRow = formatBookingPayload(parsed.data, user.id)
+
+  try {
+    const { data, error } = await supabase
+      .from("bookings")
+      .insert(bookingRow)
+      .select()
+      .single()
+
+    if (error) {
+      const { message, status } = mapPostgresError(error)
+      return Response.json({ error: message }, { status })
+    }
+
+    return Response.json({ booking: data }, { status: 201 })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unexpected error."
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/lib/postgres-error-map.ts
+++ b/lib/postgres-error-map.ts
@@ -1,0 +1,42 @@
+import type { PostgrestError } from "@supabase/supabase-js"
+
+type PostgresErrorLike = Pick<PostgrestError, "code" | "message" | "details" | "hint">
+
+type UserFacingError = {
+  message: string
+  status: number
+}
+
+const POSTGRES_ERROR_MAP: Record<string, UserFacingError> = {
+  "23P01": {
+    message: "This amenity is already booked for the selected time.",
+    status: 409,
+  },
+  "23505": {
+    message: "This amenity is already booked for the selected time.",
+    status: 409,
+  },
+}
+
+const DEFAULT_POSTGRES_ERROR: UserFacingError = {
+  message: "Unable to process booking request.",
+  status: 500,
+}
+
+export function mapPostgresError(
+  error: PostgresErrorLike | null | undefined,
+): UserFacingError {
+  if (error?.code) {
+    const mapped = POSTGRES_ERROR_MAP[error.code]
+
+    if (mapped) {
+      return mapped
+    }
+  }
+
+  if (error?.message) {
+    return { ...DEFAULT_POSTGRES_ERROR, message: error.message }
+  }
+
+  return DEFAULT_POSTGRES_ERROR
+}

--- a/tests/api/bookings-request.spec.ts
+++ b/tests/api/bookings-request.spec.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { POST } from "@/app/api/bookings/request/route"
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+}))
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: createClientMock,
+}))
+
+describe("POST /api/bookings/request", () => {
+  let getUserMock: ReturnType<typeof vi.fn>
+  let singleMock: ReturnType<typeof vi.fn>
+  let insertMock: ReturnType<typeof vi.fn>
+  let selectMock: ReturnType<typeof vi.fn>
+  let fromMock: ReturnType<typeof vi.fn>
+
+  const buildRequest = (body: Record<string, unknown> = {}) =>
+    new Request("http://localhost/api/bookings/request", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        amenityId: "kitchen",
+        unitId: "unit-101",
+        startsAt: "2024-01-01T10:00:00.000Z",
+        endsAt: "2024-01-01T11:00:00.000Z",
+        ...body,
+      }),
+    })
+
+  beforeEach(() => {
+    getUserMock = vi.fn()
+    singleMock = vi.fn()
+    selectMock = vi.fn(() => ({ single: singleMock }))
+    insertMock = vi.fn(() => ({ select: selectMock }))
+    fromMock = vi.fn(() => ({ insert: insertMock }))
+
+    createClientMock.mockReturnValue({
+      auth: { getUser: getUserMock },
+      from: fromMock,
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("creates a booking for authenticated callers", async () => {
+    const bookingRecord = { id: 42 }
+
+    getUserMock.mockResolvedValue({ data: { user: { id: "user-1" } } })
+    singleMock.mockResolvedValue({ data: bookingRecord, error: null })
+
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(201)
+    const payload = await response.json()
+    expect(payload).toEqual({ booking: bookingRecord })
+
+    expect(fromMock).toHaveBeenCalledWith("bookings")
+    expect(insertMock).toHaveBeenCalledTimes(1)
+
+    const insertedRow = insertMock.mock.calls[0]?.[0]
+    expect(insertedRow).toMatchObject({
+      amenity_id: "kitchen",
+      unit_id: "unit-101",
+      tenant_id: "user-1",
+      start_time: "2024-01-01T10:00:00.000Z",
+      end_time: "2024-01-01T11:00:00.000Z",
+    })
+  })
+
+  it("returns a friendly error when an overlapping booking exists", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "user-1" } } })
+    singleMock.mockResolvedValue({
+      data: null,
+      error: {
+        code: "23P01",
+        message: "conflict",
+        details: "",
+        hint: "",
+      },
+    })
+
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(409)
+    const payload = await response.json()
+    expect(payload.error).toMatch(/already booked/i)
+  })
+
+  it("rejects unauthenticated requests", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } })
+
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+    expect(payload).toEqual({ error: "Unauthorized" })
+    expect(fromMock).not.toHaveBeenCalled()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.spec.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a bookings request API route that validates callers before inserting into Supabase
- centralize Postgres error mapping so exclusion violations return friendly messages
- extend vitest config and add coverage for success, conflict, and unauthorized booking flows

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0d63d748328b821f7da6401c62f