### PR TITLE
feat: integrate Cal.com event types for amenities

### DIFF
--- a/app/dashboard/amenities/actions.ts
+++ b/app/dashboard/amenities/actions.ts
@@ -1,0 +1,60 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { createServiceRoleSupabaseClient } from "@/utils/supabase-service-role"
+
+export type AmenityEventTypeState = {
+  status: "idle" | "success" | "error"
+  message?: string
+}
+
+export async function updateAmenityEventType(
+  _prevState: AmenityEventTypeState,
+  formData: FormData,
+): Promise<AmenityEventTypeState> {
+  const idRaw = formData.get("id")
+  const calcomEventTypeIdRaw = formData.get("calcom_event_type_id")
+  const calcomEventTypeSlugRaw = formData.get("calcom_event_type_slug")
+
+  if (typeof idRaw !== "string" || idRaw.length === 0) {
+    return { status: "error", message: "Missing amenity identifier." }
+  }
+
+  const amenityId = Number(idRaw)
+  if (!Number.isInteger(amenityId) || amenityId <= 0) {
+    return { status: "error", message: "Amenity identifier is invalid." }
+  }
+
+  let calcomEventTypeId: number | null = null
+  if (typeof calcomEventTypeIdRaw === "string" && calcomEventTypeIdRaw.trim().length > 0) {
+    const parsed = Number(calcomEventTypeIdRaw)
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return { status: "error", message: "Cal.com event type ID must be a positive integer." }
+    }
+    calcomEventTypeId = parsed
+  }
+
+  const calcomEventTypeSlug =
+    typeof calcomEventTypeSlugRaw === "string" && calcomEventTypeSlugRaw.trim().length > 0
+      ? calcomEventTypeSlugRaw.trim()
+      : null
+
+  const supabase = createServiceRoleSupabaseClient()
+
+  const { error } = await supabase
+    .from("amenities")
+    .update({
+      calcom_event_type_id: calcomEventTypeId,
+      calcom_event_type_slug: calcomEventTypeSlug,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", amenityId)
+
+  if (error) {
+    return { status: "error", message: error.message }
+  }
+
+  revalidatePath("/dashboard/amenities")
+  return { status: "success", message: "Amenity event type saved." }
+}

--- a/app/dashboard/amenities/amenity-event-type-form.tsx
+++ b/app/dashboard/amenities/amenity-event-type-form.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useFormState, useFormStatus } from "react-dom"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+import type { AmenityEventTypeState } from "./actions"
+import { updateAmenityEventType } from "./actions"
+
+type AmenityEventTypeFormProps = {
+  amenityId: number
+  defaultEventTypeId: number | null
+  defaultEventTypeSlug: string | null
+}
+
+const initialState: AmenityEventTypeState = { status: "idle" }
+
+export function AmenityEventTypeForm({
+  amenityId,
+  defaultEventTypeId,
+  defaultEventTypeSlug,
+}: AmenityEventTypeFormProps) {
+  const [state, formAction] = useFormState(updateAmenityEventType, initialState)
+
+  return (
+    <form action={formAction} className="space-y-2">
+      <input name="id" type="hidden" value={amenityId} />
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Input
+          name="calcom_event_type_id"
+          defaultValue={defaultEventTypeId ? String(defaultEventTypeId) : ""}
+          placeholder="Cal.com event type ID"
+          inputMode="numeric"
+          className="sm:max-w-[160px]"
+        />
+        <Input
+          name="calcom_event_type_slug"
+          defaultValue={defaultEventTypeSlug ?? ""}
+          placeholder="Cal.com event type slug"
+          className="sm:max-w-[220px]"
+        />
+        <SubmitButton />
+      </div>
+      {state.status === "error" ? (
+        <p className="text-sm text-destructive">{state.message}</p>
+      ) : null}
+      {state.status === "success" ? (
+        <p className="text-sm text-muted-foreground">{state.message}</p>
+      ) : null}
+    </form>
+  )
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" disabled={pending} isLoading={pending}>
+      Save
+    </Button>
+  )
+}

--- a/app/dashboard/amenities/page.tsx
+++ b/app/dashboard/amenities/page.tsx
@@ -1,0 +1,92 @@
+import { Metadata } from "next"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { createSupbaseServerClient } from "@/utils/supaone"
+import type { Database } from "@/lib/supabase"
+
+import { AmenityEventTypeForm } from "./amenity-event-type-form"
+
+export const metadata: Metadata = {
+  title: "Amenity event types",
+  description: "Manage Cal.com event types that power shared amenity scheduling.",
+}
+
+type Amenity = Database["public"]["Tables"]["amenities"]["Row"]
+
+export default async function AmenitiesPage() {
+  const supabase = await createSupbaseServerClient()
+  const { data: amenities, error } = await supabase
+    .from("amenities")
+    .select("*")
+    .order("name", { ascending: true })
+
+  if (error) {
+    console.error("Failed to load amenities", error)
+    throw new Error("Unable to load amenities")
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight">Amenity scheduling</h1>
+        <p className="text-muted-foreground">
+          Create and maintain the Cal.com event types that residents book for each shared amenity.
+        </p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Cal.com event type mapping</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {amenities && amenities.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px] table-auto border-collapse text-left text-sm">
+                <thead>
+                  <tr className="border-b border-border text-xs uppercase tracking-wider text-muted-foreground">
+                    <th className="py-3 pr-4">Amenity</th>
+                    <th className="py-3 pr-4">Slug</th>
+                    <th className="py-3 pr-4">Current event type ID</th>
+                    <th className="py-3 pr-4">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {amenities.map((amenity) => (
+                    <AmenityRow key={amenity.id} amenity={amenity} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No amenities have been configured yet.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function AmenityRow({ amenity }: { amenity: Amenity }) {
+  return (
+    <tr className="border-b border-border last:border-0">
+      <td className="py-4 pr-4 align-top">
+        <div className="font-medium">{amenity.name}</div>
+        {amenity.description ? (
+          <p className="text-sm text-muted-foreground">{amenity.description}</p>
+        ) : null}
+      </td>
+      <td className="py-4 pr-4 align-top text-muted-foreground">{amenity.slug}</td>
+      <td className="py-4 pr-4 align-top text-muted-foreground">
+        {amenity.calcom_event_type_id ? `#${amenity.calcom_event_type_id}` : "Not linked"}
+      </td>
+      <td className="py-4 pr-4 align-top">
+        <AmenityEventTypeForm
+          amenityId={amenity.id}
+          defaultEventTypeId={amenity.calcom_event_type_id}
+          defaultEventTypeSlug={amenity.calcom_event_type_slug}
+        />
+      </td>
+    </tr>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { CalendarIcon, PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,16 +8,21 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/amenities",
+                        text: "Amenities",
+                        Icon: CalendarIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
 		},
 	];
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -411,6 +411,45 @@ export type Database = {
         }
         Relationships: []
       }
+      amenities: {
+        Row: {
+          active: boolean
+          calcom_event_type_id: number | null
+          calcom_event_type_slug: string | null
+          created_at: string
+          description: string | null
+          id: number
+          metadata: Json | null
+          name: string
+          slug: string
+          updated_at: string
+        }
+        Insert: {
+          active?: boolean
+          calcom_event_type_id?: number | null
+          calcom_event_type_slug?: string | null
+          created_at?: string
+          description?: string | null
+          id?: number
+          metadata?: Json | null
+          name: string
+          slug: string
+          updated_at?: string
+        }
+        Update: {
+          active?: boolean
+          calcom_event_type_id?: number | null
+          calcom_event_type_slug?: string | null
+          created_at?: string
+          description?: string | null
+          id?: number
+          metadata?: Json | null
+          name?: string
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       business_cards: {
         Row: {
           businesscard_name: string | null

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "sync:calcom": "tsx scripts/calcom/sync-event-types.ts"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -110,6 +111,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
+    "tsx": "^4.15.1",
     "typescript": "^5.5.4",
     "vitest": "^3.2.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,12 +303,15 @@ importers:
       tailwindcss:
         specifier: ^3.4.0
         version: 3.4.0
+      tsx:
+        specifier: ^4.15.1
+        version: 4.20.5
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
 
 packages:
 
@@ -2762,9 +2765,6 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -3792,9 +3792,6 @@ packages:
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
 
-  es-module-lexer@1.6.0:
-    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
-
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -4158,6 +4155,9 @@ packages:
   get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   get-tsconfig@4.7.2:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
@@ -5389,10 +5389,6 @@ packages:
     resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6157,6 +6153,11 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -9346,11 +9347,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.12
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   '@types/eslint@8.56.12':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/eslint@8.56.2':
@@ -9365,8 +9366,6 @@ snapshots:
   '@types/estree@0.0.39': {}
 
   '@types/estree@1.0.5': {}
-
-  '@types/estree@1.0.7': {}
 
   '@types/estree@1.0.8': {}
 
@@ -9522,13 +9521,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))':
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9580,7 +9579,7 @@ snapshots:
       '@vue/shared': 3.4.35
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
     optional: true
 
@@ -10126,7 +10125,7 @@ snapshots:
   code-red@1.0.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -10488,8 +10487,6 @@ snapshots:
       internal-slot: 1.0.6
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
-
-  es-module-lexer@1.6.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -10978,6 +10975,10 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
 
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   get-tsconfig@4.7.2:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -11356,7 +11357,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
     optional: true
 
   is-regex@1.1.4:
@@ -12473,13 +12474,6 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  postcss@8.5.3:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    optional: true
-
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -13172,7 +13166,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -13377,6 +13371,13 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.5.4
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -13595,13 +13596,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+  vite-node@3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13616,7 +13617,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+  vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13629,12 +13630,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.0
       terser: 5.39.0
+      tsx: 4.20.5
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13652,8 +13654,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
-      vite-node: 3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
+      vite-node: 3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -13706,7 +13708,7 @@ snapshots:
   webpack@5.93.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
@@ -13715,7 +13717,7 @@ snapshots:
       browserslist: 4.23.3
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
+      es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/scripts/calcom/sync-event-types.ts
+++ b/scripts/calcom/sync-event-types.ts
@@ -1,0 +1,228 @@
+import { createClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/supabase'
+
+type Amenity = Database['public']['Tables']['amenities']['Row']
+
+type CalComEventType = {
+  id: number
+  slug: string
+  title: string
+  description?: string | null
+  length?: number | null
+  metadata?: Record<string, unknown> | null
+}
+
+const DEFAULT_EVENT_LENGTH = Number(process.env.CALCOM_DEFAULT_EVENT_LENGTH ?? 60)
+const CALCOM_API_KEY = process.env.CALCOM_API_KEY
+const CALCOM_BASE_URL = process.env.CALCOM_BASE_URL ?? 'https://api.cal.com/v1/'
+
+if (!CALCOM_API_KEY) {
+  throw new Error('CALCOM_API_KEY environment variable is required')
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('Supabase service role credentials are required to run the sync script')
+}
+
+const supabase = createClient<Database>(supabaseUrl, serviceRoleKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false,
+  },
+})
+
+async function calComRequest<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = new URL(path, CALCOM_BASE_URL.endsWith('/') ? CALCOM_BASE_URL : `${CALCOM_BASE_URL}/`)
+  url.searchParams.set('apiKey', CALCOM_API_KEY)
+
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  })
+
+  if (!response.ok) {
+    const errorBody = await response.text()
+    throw new Error(`Cal.com request to ${url.pathname} failed with ${response.status}: ${errorBody}`)
+  }
+
+  if (response.status === 204) {
+    return undefined as T
+  }
+
+  const text = await response.text()
+  if (!text) {
+    return undefined as T
+  }
+
+  try {
+    return JSON.parse(text) as T
+  } catch (error) {
+    throw new Error(`Unable to parse Cal.com response for ${url.pathname}: ${String(error)}`)
+  }
+}
+
+async function listEventTypes(): Promise<CalComEventType[]> {
+  const payload = await calComRequest<CalComEventType[] | { data: CalComEventType[] }>('/event-types')
+
+  if (Array.isArray(payload)) {
+    return payload
+  }
+
+  if ('data' in payload && Array.isArray(payload.data)) {
+    return payload.data
+  }
+
+  return []
+}
+
+async function createEventType(amenity: Amenity): Promise<CalComEventType> {
+  const body = {
+    title: amenity.name,
+    slug: amenity.slug,
+    description: amenity.description ?? undefined,
+    length: DEFAULT_EVENT_LENGTH,
+    hidden: false,
+    disableGuests: true,
+  }
+
+  const payload = await calComRequest<CalComEventType | { data: CalComEventType }>(
+    '/event-types',
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    },
+  )
+
+  if ('data' in (payload as { data?: CalComEventType })) {
+    return (payload as { data: CalComEventType }).data
+  }
+
+  return payload as CalComEventType
+}
+
+async function updateEventType(
+  currentEventType: CalComEventType,
+  amenity: Amenity,
+): Promise<CalComEventType> {
+  const body = {
+    title: amenity.name,
+    description: amenity.description ?? undefined,
+    length: DEFAULT_EVENT_LENGTH,
+    hidden: false,
+    disableGuests: true,
+  }
+
+  const payload = await calComRequest<CalComEventType | { data: CalComEventType }>(
+    `/event-types/${currentEventType.id}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    },
+  )
+
+  if (payload && typeof payload === 'object' && 'data' in payload) {
+    return (payload as { data: CalComEventType }).data
+  }
+
+  if (payload && typeof payload === 'object' && 'id' in payload) {
+    return payload as CalComEventType
+  }
+
+  return {
+    ...currentEventType,
+    title: amenity.name,
+    description: amenity.description ?? currentEventType.description,
+    length: DEFAULT_EVENT_LENGTH,
+  }
+}
+
+async function syncAmenity(amenity: Amenity, eventTypesBySlug: Map<string, CalComEventType>): Promise<void> {
+  let eventType: CalComEventType | null = null
+
+  if (amenity.calcom_event_type_id) {
+    eventType = eventTypesBySlug.get(String(amenity.calcom_event_type_id)) ?? null
+  }
+
+  if (!eventType) {
+    eventType = eventTypesBySlug.get(amenity.slug) ?? null
+  }
+
+  if (!eventType) {
+    eventType = await createEventType(amenity)
+    console.log(`Created Cal.com event type ${eventType.id} for amenity ${amenity.name}`)
+  } else {
+    const previousSlug = eventType.slug
+    eventType = await updateEventType(eventType, amenity)
+    console.log(`Updated Cal.com event type ${eventType.id} for amenity ${amenity.name}`)
+    if (previousSlug && previousSlug !== eventType.slug) {
+      eventTypesBySlug.delete(previousSlug)
+    }
+  }
+
+  const slugKeys = new Set<string>([amenity.slug])
+  if (eventType.slug) {
+    slugKeys.add(eventType.slug)
+  }
+  for (const slug of slugKeys) {
+    eventTypesBySlug.set(slug, eventType)
+  }
+  eventTypesBySlug.set(String(eventType.id), eventType)
+
+  const { error } = await supabase
+    .from('amenities')
+    .update({
+      calcom_event_type_id: eventType.id,
+      calcom_event_type_slug: eventType.slug,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', amenity.id)
+
+  if (error) {
+    throw new Error(`Failed to persist Cal.com event type for amenity ${amenity.name}: ${error.message}`)
+  }
+}
+
+async function main() {
+  const { data: amenities, error } = await supabase
+    .from('amenities')
+    .select('*')
+    .eq('active', true)
+    .order('name', { ascending: true })
+
+  if (error) {
+    throw new Error(`Unable to read amenities from Supabase: ${error.message}`)
+  }
+
+  if (!amenities || amenities.length === 0) {
+    console.log('No amenities found to sync.')
+    return
+  }
+
+  const eventTypes = await listEventTypes()
+  const eventTypesBySlug = new Map<string, CalComEventType>()
+
+  for (const eventType of eventTypes) {
+    if (eventType.slug) {
+      eventTypesBySlug.set(eventType.slug, eventType)
+    }
+    eventTypesBySlug.set(String(eventType.id), eventType)
+  }
+
+  for (const amenity of amenities) {
+    await syncAmenity(amenity, eventTypesBySlug)
+  }
+
+  console.log('Cal.com event type sync complete.')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/supabase/migrations/20240707_add_amenities_table.sql
+++ b/supabase/migrations/20240707_add_amenities_table.sql
@@ -1,0 +1,28 @@
+create table if not exists public.amenities (
+  id bigint generated always as identity primary key,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  name text not null,
+  slug text not null unique,
+  description text,
+  calcom_event_type_id integer,
+  calcom_event_type_slug text,
+  metadata jsonb null,
+  active boolean not null default true
+);
+
+alter table public.amenities enable row level security;
+
+create policy "Authenticated users can view amenities" on public.amenities
+  for select
+  to authenticated
+  using (true);
+
+insert into public.amenities (name, slug, description)
+values
+  ('Kitchen', 'kitchen', 'Shared kitchen for meal prep and cooking rotations.'),
+  ('TV Room', 'tv-room', 'Common television area for shared entertainment.'),
+  ('PlayStation Nook', 'playstation-nook', 'Dedicated gaming setup for roommates.'),
+  ('Parking Spot', 'parking-spot', 'Shared driveway or garage parking spot.'),
+  ('Shared Computer', 'shared-computer', 'Community workstation with desktop access.')
+on conflict (slug) do nothing;

--- a/utils/supabase-service-role.ts
+++ b/utils/supabase-service-role.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/supabase'
+
+export function createServiceRoleSupabaseClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Supabase service role credentials are not configured')
+  }
+
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add a dedicated `amenities` table with Cal.com event type columns and seed shared resources
- expose amenities management in the dashboard so admins can review and edit event type mappings
- implement a Cal.com sync script plus service-role helper to keep Supabase metadata aligned

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0d6dc988328ad9c1a5b43fe00a1