### PR TITLE
Add amenity booking buffers and guardrails

### DIFF
--- a/app/schedule/actions/index.tsx
+++ b/app/schedule/actions/index.tsx
@@ -2,11 +2,15 @@
 
 import { createClient } from '@/utils/supa-server-actions';
 import { createGoogleCalendarEvent } from '@/lib/calendar-service';
-import { revalidatePath } from 'next/cache';
-import { Database } from '@/lib/supabase';
 import { z } from 'zod';
 import { cookies } from 'next/headers';
 import { formatISO, isPast } from 'date-fns'; // Import formatISO here
+import {
+  expandWithBuffer,
+  hasBufferedConflictWithWindows,
+  collectBufferedWindows,
+  type BookingRequest,
+} from '@/lib/bookings';
 
 // --- Updated Zod Schema for Server Action ---
 const scheduleSchema = z.object({
@@ -23,9 +27,13 @@ const scheduleSchema = z.object({
   endTime: z.coerce.date({
       errorMap: (issue, ctx) => ({ message: 'Invalid format for end date/time.' })
   }),
+  amenitySlug: z.string().min(1, { message: 'Please choose an amenity to book.' }),
+  bufferMinutes: z.coerce.number({
+    errorMap: () => ({ message: 'Buffer minutes must be a whole number.' }),
+  }).int().min(0, { message: 'Buffer minutes cannot be negative.' }).max(240, { message: 'Buffer minutes cannot exceed 240.' }),
   userEmail: z.string().email({ message: 'Invalid user email.' }),
   userName: z.string().min(1, { message: 'User name cannot be empty.' }),
-  summary: z.string().min(1, { message: 'Meeting summary cannot be empty.' }),
+  summary: z.string().min(1, { message: 'Booking summary cannot be empty.' }),
   description: z.string().optional(),
 })
 // Refine the relationship between the coerced Date objects
@@ -63,6 +71,8 @@ export async function scheduleMeetingAction(
        // Extract raw strings from FormData for Zod to coerce
        startTime: formData.get('startTime'),
        endTime: formData.get('endTime'),
+       amenitySlug: formData.get('amenitySlug'),
+       bufferMinutes: formData.get('bufferMinutes'),
        userEmail: formData.get('userEmail'),
        userName: formData.get('userName'),
        summary: formData.get('summary'),
@@ -91,6 +101,50 @@ export async function scheduleMeetingAction(
        return { success: false, message: null, error: 'User email mismatch.', googleEventLink: null };
    }
 
+
+  // --- Compute buffer window & verify availability before touching external services ---
+  const bookingRequest: BookingRequest = {
+    start: validatedData.startTime,
+    end: validatedData.endTime,
+    bufferMinutes: validatedData.bufferMinutes,
+  };
+
+  let bufferedSlot;
+  try {
+    bufferedSlot = expandWithBuffer(bookingRequest);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to apply buffer to booking request.';
+    return { success: false, message: null, error: message, googleEventLink: null };
+  }
+
+  const { data: existingBookings, error: existingBookingsError } = await supabase
+    .from('amenity_bookings')
+    .select('starts_at, ends_at, buffer_minutes')
+    .eq('amenity_slug', validatedData.amenitySlug);
+
+  if (existingBookingsError) {
+    console.error('Error loading existing bookings for buffer validation:', existingBookingsError);
+    return { success: false, message: null, error: 'Unable to confirm amenity availability. Please try again.', googleEventLink: null };
+  }
+
+  const existingWindows = existingBookings
+    ? collectBufferedWindows(
+        existingBookings.map((booking) => ({
+          start: new Date(booking.starts_at),
+          end: new Date(booking.ends_at),
+          bufferMinutes: booking.buffer_minutes ?? 0,
+        }))
+      )
+    : [];
+
+  if (hasBufferedConflictWithWindows(existingWindows, bufferedSlot.window)) {
+    return {
+      success: false,
+      message: null,
+      error: 'That time overlaps with another booking buffer. Please pick a different slot.',
+      googleEventLink: null,
+    };
+  }
 
   try {
     // 4. Create Google Calendar Event
@@ -135,13 +189,32 @@ export async function scheduleMeetingAction(
        console.log("Meeting details saved to database.");
     }
 
-    // 6. Revalidate the path if needed
-    // revalidatePath('/schedule');
+    const { error: bookingInsertError } = await supabase
+      .from('amenity_bookings')
+      .insert({
+        amenity_slug: validatedData.amenitySlug,
+        tenant_id: user.id,
+        starts_at: validatedData.startTime.toISOString(),
+        ends_at: validatedData.endTime.toISOString(),
+        slot: bufferedSlot.range,
+        buffer_minutes: validatedData.bufferMinutes,
+        note: validatedData.description ?? null,
+      });
 
-    // 7. Return success state
+    if (bookingInsertError) {
+      console.error('Error saving amenity booking:', bookingInsertError);
+      return {
+        success: false,
+        message: null,
+        error: 'Created calendar event but failed to save the booking. Please contact support.',
+        googleEventLink: calendarResult.link,
+      };
+    }
+
+    // 6. Return success state
     return {
         success: true,
-        message: 'Meeting scheduled successfully! Check your email for the invite.',
+        message: `Amenity reserved successfully. A ${validatedData.bufferMinutes}-minute buffer was applied before and after your booking.`,
         error: null,
         googleEventLink: calendarResult.link,
     };

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -37,9 +37,9 @@ export default async function SchedulePage() {
         <div className="container mx-auto flex justify-center p-4 pt-10">
             <Card className="w-full max-w-2xl">
                 <CardHeader>
-                    <CardTitle>Schedule a New Meeting</CardTitle>
+                    <CardTitle>Reserve a Shared Amenity</CardTitle>
                     <CardDescription>
-                        Fill in the details below to create a Google Calendar event with a Meet link.
+                        Choose the space, time, and spacing buffer to keep rotations calm for everyone. We&apos;ll apply the buffer window to the booking and send a calendar invite.
                     </CardDescription>
                 </CardHeader>
                 <CardContent>

--- a/components/schedule-form.tsx
+++ b/components/schedule-form.tsx
@@ -1,57 +1,62 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-import { Button } from '@/components/ui/button'
+import { useMemo, useState } from 'react';
 import { scheduleMeetingAction } from '@/app/schedule/actions';
 import { useFormState, useFormStatus } from 'react-dom';
 import { DayPicker } from 'react-day-picker';
-import { z } from 'zod'; // Import Zod
+import { z } from 'zod';
 import {
-    format,
-    formatISO,
-    addMinutes,
-    setHours,
-    setMinutes,
-    setSeconds,
-    setMilliseconds,
-    isPast,
-    isSameDay,
-    startOfDay,
-    isValid // Import isValid for robustness
+  format,
+  formatISO,
+  addMinutes,
+  subMinutes,
+  setHours,
+  setMinutes,
+  setSeconds,
+  setMilliseconds,
+  isPast,
+  isSameDay,
+  startOfDay,
+  isValid,
 } from 'date-fns';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 // --- Zod Schema for Client-Side Validation ---
-// This schema validates the data *after* the user has made selections
-// and we've constructed the initial Date objects.
 const clientScheduleSchema = z.object({
-    startDateTime: z.date({
-        // Error if we somehow fail to create a valid Date object
-        invalid_type_error: "Invalid date or time selected.",
-        // Error if the user hasn't selected both date and time slot
-        required_error: "Please select both a date and a time slot."
-       })
-       .refine(date => isValid(date), { // Ensure the created date is valid
-            message: "Invalid date/time combination."
-       })
-       .refine(date => !isPast(date), { // Ensure the date/time is not in the past
-            message: "The selected time slot has already passed. Please select a future time.",
-       }),
-    // We don't strictly need to validate endDateTime client-side if start is valid
-    // and duration is fixed, but it could be added for completeness.
-    // userEmail: z.string().email(), // Usually passed as prop, less critical here
-    // userName: z.string().min(1), // Usually passed as prop
+  startDateTime: z
+    .date({
+      invalid_type_error: 'Invalid date or time selected.',
+      required_error: 'Please select both a date and a time slot.',
+    })
+    .refine((date) => isValid(date), {
+      message: 'Invalid date/time combination.',
+    })
+    .refine((date) => !isPast(date), {
+      message: 'The selected time slot has already passed. Please select a future time.',
+    }),
 });
 
 // Type for flattened Zod errors specifically for our schema structure
 type ClientValidationErrors = z.inferFlattenedErrors<typeof clientScheduleSchema>['fieldErrors'];
-
 
 interface ScheduleFormProps {
   userEmail: string;
   userName: string;
 }
 
-const initialState: { message: string | null; error: string | null; success: boolean; googleEventLink?: string | null } = {
+const initialState: {
+  message: string | null;
+  error: string | null;
+  success: boolean;
+  googleEventLink?: string | null;
+} = {
   message: null,
   error: null,
   success: false,
@@ -61,39 +66,41 @@ const initialState: { message: string | null; error: string | null; success: boo
 const MEETING_DURATION_MINUTES = 60;
 const AVAILABLE_HOURS_START = 9;
 const AVAILABLE_HOURS_END = 17;
+const DEFAULT_BUFFER_MINUTES = 15;
+const BUFFER_OPTIONS = [0, 10, 15, 20, 30, 45];
+const AMENITIES = [
+  { value: 'kitchen', label: 'Kitchen' },
+  { value: 'tv-lounge', label: 'TV Lounge' },
+  { value: 'parking', label: 'Parking Spot' },
+  { value: 'gaming', label: 'Gaming Nook' },
+  { value: 'shared-office', label: 'Shared Office' },
+];
 
 function SubmitButton({ disabled }: { disabled: boolean }) {
   const { pending } = useFormStatus();
   const isDisabled = pending || disabled;
 
   return (
-    <button
-      type="submit"
-      aria-disabled={isDisabled}
-      disabled={isDisabled}
-      className={`rounded px-6 py-2 font-semibold text-white ${
-        isDisabled
-          ? 'cursor-not-allowed bg-gray-400'
-          : 'bg-green-500 hover:bg-green-600'
-      }`}
-    >
-      {pending ? 'Scheduling...' : 'Schedule Meeting'}
-    </button>
+    <Button type="submit" aria-disabled={isDisabled} disabled={isDisabled}>
+      {pending ? 'Reserving…' : 'Reserve Slot'}
+    </Button>
   );
 }
 
 export function ScheduleForm({ userEmail, userName }: ScheduleFormProps) {
-  // Server action state
   const [serverState, formAction] = useFormState(scheduleMeetingAction, initialState);
-  // Component state
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
   const [selectedTimeSlot, setSelectedTimeSlot] = useState<string | undefined>(undefined);
-  // Client-side validation state
+  const [selectedAmenity, setSelectedAmenity] = useState<string>(AMENITIES[0]?.value ?? '');
+  const [bufferMinutes, setBufferMinutes] = useState<number>(DEFAULT_BUFFER_MINUTES);
   const [clientErrors, setClientErrors] = useState<ClientValidationErrors | null>(null);
 
+  const selectedAmenityLabel = useMemo(
+    () => AMENITIES.find((amenity) => amenity.value === selectedAmenity)?.label ?? 'Amenity',
+    [selectedAmenity],
+  );
 
   const availableTimeSlots = useMemo(() => {
-    // ... (time slot generation logic remains the same) ...
     if (!selectedDate) return [];
     const slots: string[] = [];
     const today = startOfDay(new Date());
@@ -101,178 +108,244 @@ export function ScheduleForm({ userEmail, userName }: ScheduleFormProps) {
     for (let hour = AVAILABLE_HOURS_START; hour < AVAILABLE_HOURS_END; hour++) {
       const slotStartTime = setMilliseconds(setSeconds(setMinutes(setHours(selectedDate, hour), 0), 0), 0);
       if (isSameDay(selectedDayStart, today) && isPast(slotStartTime)) {
-          continue;
+        continue;
       }
       slots.push(format(slotStartTime, 'HH:mm'));
     }
     return slots;
   }, [selectedDate]);
 
-  // Clear client errors when selection changes
   const handleDateSelect = (date: Date | undefined) => {
     setSelectedDate(date);
     setSelectedTimeSlot(undefined);
-    setClientErrors(null); // Clear errors
+    setClientErrors(null);
   };
 
   const handleTimeSelect = (slot: string) => {
     setSelectedTimeSlot(slot);
-    setClientErrors(null); // Clear errors
+    setClientErrors(null);
   };
 
-  // Handle form submission
+  const previewTimes = useMemo(() => {
+    if (!selectedDate || !selectedTimeSlot) return null;
+    const [hour, minute] = selectedTimeSlot.split(':').map(Number);
+    if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+
+    const startDate = setMilliseconds(setSeconds(setMinutes(setHours(selectedDate, hour), minute), 0), 0);
+    const endDate = addMinutes(startDate, MEETING_DURATION_MINUTES);
+
+    return {
+      start: startDate,
+      end: endDate,
+      bufferStart: subMinutes(startDate, bufferMinutes),
+      bufferEnd: addMinutes(endDate, bufferMinutes),
+    };
+  }, [selectedDate, selectedTimeSlot, bufferMinutes]);
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setClientErrors(null); // Clear previous client errors on new submission attempt
+    setClientErrors(null);
 
-    // 1. Construct Date objects (attempt)
     let startDateTime: Date | null = null;
     let endDateTime: Date | null = null;
 
     if (selectedDate && selectedTimeSlot) {
-        try {
-            const [hour, minute] = selectedTimeSlot.split(':').map(Number);
-            // Ensure hour and minute are valid numbers before setting
-            if (!isNaN(hour) && !isNaN(minute)) {
-                startDateTime = setMilliseconds(setSeconds(setMinutes(setHours(selectedDate, hour), minute), 0), 0);
-                endDateTime = addMinutes(startDateTime, MEETING_DURATION_MINUTES);
-            } else {
-                 console.error("Invalid time slot format parsed:", selectedTimeSlot);
-                 // Set startDateTime to an invalid date to trigger Zod error below
-                 startDateTime = new Date('invalid date');
-            }
-        } catch (error) {
-            console.error("Error constructing date:", error);
-             // Set startDateTime to an invalid date to trigger Zod error below
-            startDateTime = new Date('invalid date');
+      try {
+        const [hour, minute] = selectedTimeSlot.split(':').map(Number);
+        if (!Number.isNaN(hour) && !Number.isNaN(minute)) {
+          startDateTime = setMilliseconds(setSeconds(setMinutes(setHours(selectedDate, hour), minute), 0), 0);
+          endDateTime = addMinutes(startDateTime, MEETING_DURATION_MINUTES);
+        } else {
+          startDateTime = new Date('invalid date');
         }
+      } catch (error) {
+        console.error('Error constructing date:', error);
+        startDateTime = new Date('invalid date');
+      }
     }
 
-    // 2. Client-side validation using Zod
-    // We primarily validate startDateTime as it implies date/time selection and past check
     const validationResult = clientScheduleSchema.safeParse({ startDateTime });
 
     if (!validationResult.success) {
-      // Validation failed: Update client error state and stop
       setClientErrors(validationResult.error.flatten().fieldErrors);
-      console.log("Client validation failed:", validationResult.error.flatten().fieldErrors);
       return;
     }
 
-    // 3. Validation successful: Proceed with formatting and FormData
-    // Use the validated data from result.data for type safety
     const startTimeISO = formatISO(validationResult.data.startDateTime);
-    // endDateTime was constructed earlier, assuming fixed duration based on validated start
-    const endTimeISO = formatISO(endDateTime!); // Use non-null assertion as startDateTime is valid
+    const endTimeISO = formatISO(endDateTime!);
 
-    // 4. Prepare FormData
     const formData = new FormData();
     formData.append('startTime', startTimeISO);
     formData.append('endTime', endTimeISO);
+    formData.append('amenitySlug', selectedAmenity);
+    formData.append('bufferMinutes', bufferMinutes.toString());
     formData.append('userEmail', userEmail);
     formData.append('userName', userName);
-    formData.append('summary', `Meeting with ${userName}`);
-    formData.append('description', `Scheduled via App by ${userEmail} for ${format(validationResult.data.startDateTime, 'PPP p')}`);
+    formData.append('summary', `Amenity booking – ${selectedAmenityLabel}`);
+    formData.append(
+      'description',
+      `Scheduled via App by ${userEmail} for ${format(validationResult.data.startDateTime, 'PPP p')} with a ${bufferMinutes}-minute buffer.`,
+    );
 
-    // 5. Trigger Server Action
-    console.log("Client validation passed. Submitting to server action...");
     formAction(formData);
   };
 
-  // Determine if the submit button should be disabled
-  const isSubmitDisabled = !selectedDate || !selectedTimeSlot;
-
-  // Get specific client-side error message for date/time selection
+  const isSubmitDisabled = !selectedDate || !selectedTimeSlot || !selectedAmenity;
   const dateTimeClientError = clientErrors?.startDateTime?.[0];
 
-  // CSS for DayPicker (remains the same)
   const css = `
     .rdp { /* ... same styles ... */ }
     /* ... other rdp styles ... */
   `;
 
-
   return (
     <form onSubmit={handleSubmit} className="max-w-md space-y-6">
-      {/* Display messages from server action state */}
       {serverState?.message && (
-        <p className={`rounded p-3 text-sm ${serverState.success ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
+        <p
+          className={`rounded p-3 text-sm ${
+            serverState.success ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+          }`}
+        >
           {serverState.message}
           {serverState.success && serverState.googleEventLink && (
-             <a href={serverState.googleEventLink} target="_blank" rel="noopener noreferrer" className="ml-2 font-semibold underline">View Event</a>
+            <a
+              href={serverState.googleEventLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-2 font-semibold underline"
+            >
+              View Event
+            </a>
           )}
         </p>
       )}
-       {serverState?.error && (
-        <p className="rounded bg-red-100 p-3 text-sm text-red-800">
-          Server Error: {serverState.error}
-        </p>
+      {serverState?.error && (
+        <p className="rounded bg-red-100 p-3 text-sm text-red-800">Server Error: {serverState.error}</p>
       )}
 
-      {/* Display General Client Validation Errors (if not specific to date/time) */}
-       {clientErrors && !dateTimeClientError && (
-             <div className="rounded border border-yellow-300 bg-yellow-100 p-3 text-sm text-yellow-800">
-                Please correct the errors indicated below.
-             </div>
-          )}
+      {clientErrors && !dateTimeClientError && (
+        <div className="rounded border border-yellow-300 bg-yellow-100 p-3 text-sm text-yellow-800">
+          Please correct the errors indicated below.
+        </div>
+      )}
 
-      {/* Date Selection */}
-      <div>
-         <h3 className="mb-2 text-lg font-semibold text-gray-800">1. Select a Date</h3>
-         <style>{css}</style>
-         <DayPicker
-            mode="single"
-            required // Keep required for accessibility, Zod handles actual logic
-            selected={selectedDate}
-            onSelect={handleDateSelect}
-            fromDate={new Date()}
-            // disabled={[ (day) => day.getDay() === 0 || day.getDay() === 6 ]}
-            footer={selectedDate ? `Selected date: ${format(selectedDate, 'PPP')}` : 'Please pick a day.'}
-            className="rounded-md bg-white shadow"
-            // Associate potential errors with the picker region for accessibility
-            aria-describedby={dateTimeClientError ? "datetime-client-error" : undefined}
-         />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-gray-800">Choose an amenity</h3>
+          <Select value={selectedAmenity} onValueChange={setSelectedAmenity}>
+            <SelectTrigger aria-label="Amenity">
+              <SelectValue placeholder="Select an amenity" />
+            </SelectTrigger>
+            <SelectContent>
+              {AMENITIES.map((amenity) => (
+                <SelectItem key={amenity.value} value={amenity.value}>
+                  {amenity.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-gray-800">Spacing buffer</h3>
+          <Select value={String(bufferMinutes)} onValueChange={(value) => setBufferMinutes(Number(value))}>
+            <SelectTrigger aria-label="Buffer minutes">
+              <SelectValue placeholder="Select buffer" />
+            </SelectTrigger>
+            <SelectContent>
+              {BUFFER_OPTIONS.map((option) => (
+                <SelectItem key={option} value={String(option)}>
+                  {option} minutes
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-muted-foreground">
+            We automatically hold {bufferMinutes} minutes before and after this booking to avoid overlaps.
+          </p>
+        </div>
       </div>
 
-      {/* Time Slot Selection */}
+      <div>
+        <h3 className="mb-2 text-lg font-semibold text-gray-800">1. Select a Date</h3>
+        <style>{css}</style>
+        <DayPicker
+          mode="single"
+          required
+          selected={selectedDate}
+          onSelect={handleDateSelect}
+          fromDate={new Date()}
+          footer={selectedDate ? `Selected date: ${format(selectedDate, 'PPP')}` : 'Please pick a day.'}
+          className="rounded-md bg-white shadow"
+          aria-describedby={dateTimeClientError ? 'datetime-client-error' : undefined}
+        />
+      </div>
+
       {selectedDate && (
         <div>
           <h3 className="mb-2 text-lg font-semibold text-gray-800">2. Select a Time Slot</h3>
           {availableTimeSlots.length > 0 ? (
-             <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-               {availableTimeSlots.map((slot) => (
-                 <button
-                   key={slot}
-                   type="button"
-                   onClick={() => handleTimeSelect(slot)} // Use specific handler
-                   className={`rounded border p-2 text-center text-sm font-medium transition-colors duration-150 ease-in-out ${
-                     selectedTimeSlot === slot
-                       ? 'border-green-700 bg-green-600 text-white ring-2 ring-green-300'
-                       : 'border-gray-300 bg-white text-gray-700 hover:border-gray-400 hover:bg-gray-100'
-                   }`}
-                    // Associate potential errors with the time slot region
-                    aria-describedby={dateTimeClientError ? "datetime-client-error" : undefined}
-                 >
-                   {slot}
-                 </button>
-               ))}
-             </div>
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+              {availableTimeSlots.map((slot) => (
+                <button
+                  key={slot}
+                  type="button"
+                  onClick={() => handleTimeSelect(slot)}
+                  className={`rounded border p-2 text-center text-sm font-medium transition-colors duration-150 ease-in-out ${
+                    selectedTimeSlot === slot
+                      ? 'border-green-700 bg-green-600 text-white ring-2 ring-green-300'
+                      : 'border-gray-300 bg-white text-gray-700 hover:border-gray-400 hover:bg-gray-100'
+                  }`}
+                  aria-describedby={dateTimeClientError ? 'datetime-client-error' : undefined}
+                >
+                  {slot}
+                </button>
+              ))}
+            </div>
           ) : (
-              <p className="italic text-gray-500">No available time slots for the selected date based on predefined hours.</p>
+            <p className="italic text-gray-500">
+              No available time slots for the selected date based on predefined hours.
+            </p>
           )}
-            {/* Display Client-Side Date/Time Validation Error */}
-            {dateTimeClientError && (
-              <p id="datetime-client-error" className="mt-2 text-sm text-red-600">
-                  {dateTimeClientError}
+          {dateTimeClientError && (
+            <p id="datetime-client-error" className="mt-2 text-sm text-red-600">
+              {dateTimeClientError}
+            </p>
+          )}
+          {previewTimes && (
+            <div className="mt-4 space-y-2 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+              <div className="flex items-center justify-between font-medium">
+                <span>{format(previewTimes.bufferStart, 'p')}</span>
+                <span>{format(previewTimes.bufferEnd, 'p')}</span>
+              </div>
+              <div className="flex h-2 w-full overflow-hidden rounded-full">
+                <div
+                  className="bg-amber-200"
+                  style={{ flex: Math.max(bufferMinutes, 0) }}
+                  aria-label={`Buffer before booking: ${bufferMinutes} minutes`}
+                />
+                <div
+                  className="bg-emerald-500"
+                  style={{ flex: MEETING_DURATION_MINUTES }}
+                  aria-label="Requested booking duration"
+                />
+                <div
+                  className="bg-amber-200"
+                  style={{ flex: Math.max(bufferMinutes, 0) }}
+                  aria-label={`Buffer after booking: ${bufferMinutes} minutes`}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Actual booking: {format(previewTimes.start, 'p')} – {format(previewTimes.end, 'p')}. Buffer holds the amenity from
+                {` ${format(previewTimes.bufferStart, 'p')} to ${format(previewTimes.start, 'p')}`} and again from
+                {` ${format(previewTimes.end, 'p')} to ${format(previewTimes.bufferEnd, 'p')}`}.
               </p>
-            )}
+            </div>
+          )}
         </div>
       )}
 
-      {/* Submit Button */}
       <div className="pt-4">
-         {/* Disable button based on selection, not clientErrors (Zod prevents submission) */}
-         <SubmitButton disabled={isSubmitDisabled} />
+        <SubmitButton disabled={isSubmitDisabled} />
       </div>
     </form>
   );

--- a/docs/engineering/booking-buffer.md
+++ b/docs/engineering/booking-buffer.md
@@ -1,0 +1,29 @@
+# Amenity Booking Buffer Windows
+
+The amenity scheduler enforces a configurable buffer window around every reservation to ensure hand-offs are calm and to prevent back-to-back usage from colliding.
+
+## How the buffer works
+
+- Tenants pick a buffer duration when submitting a booking. The default is 15 minutes, but they can choose from a curated set of options in the UI.
+- Before a booking is persisted the requested `start` and `end` timestamps are expanded by the selected buffer on both sides. The resulting window is stored in the `slot` `tsrange` column so that Postgres can enforce overlap rules.
+- Any existing reservations are expanded the same way during conflict checks. If the candidate’s buffered window overlaps one of those windows (using half-open `[start, end)` semantics) the request is rejected.
+- The UI previews the buffered window so roommates can see exactly when the amenity will be held, including the blocked buffer periods before and after their requested time.
+
+## Database details
+
+The Supabase migration `20250601_booking_buffer.sql` creates the `amenity_bookings` table with:
+
+- `slot tsrange` – stores the buffered window `[start-buffer, end+buffer)`.
+- `starts_at` and `ends_at` – keep the tenant’s requested times for display purposes.
+- `buffer_minutes` – the number of minutes added to both ends of the reservation.
+
+Row Level Security policies allow tenants to manage their own bookings, and a GiST index on `(amenity_slug, slot)` enables efficient overlap checks.
+
+## Testing expectations
+
+Unit tests in `tests/booking-buffer.test.ts` cover two critical cases:
+
+1. A candidate booking whose actual times would be back-to-back but fall inside another booking’s buffer is rejected.
+2. A booking that begins exactly when the previous buffer ends is accepted, ensuring the half-open interval logic is correct.
+
+Keep these scenarios in mind when adjusting buffer lengths or adding new scheduling surfaces.

--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -1,0 +1,79 @@
+import { addMinutes, subMinutes, formatISO } from 'date-fns'
+
+export interface BookingRequest {
+  start: Date
+  end: Date
+  bufferMinutes: number
+}
+
+export interface BufferedWindow {
+  start: Date
+  end: Date
+}
+
+export interface BufferedSlot {
+  range: string
+  window: BufferedWindow
+}
+
+function assertValidDate(date: Date, label: string) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new Error(`${label} must be a valid date`)
+  }
+}
+
+export function expandWithBuffer(request: BookingRequest): BufferedSlot {
+  assertValidDate(request.start, 'start')
+  assertValidDate(request.end, 'end')
+
+  if (request.start >= request.end) {
+    throw new Error('start must be before end')
+  }
+
+  if (!Number.isFinite(request.bufferMinutes) || request.bufferMinutes < 0) {
+    throw new Error('bufferMinutes must be a non-negative number')
+  }
+
+  if (!Number.isInteger(request.bufferMinutes)) {
+    throw new Error('bufferMinutes must be an integer value')
+  }
+
+  const bufferedStart = subMinutes(request.start, request.bufferMinutes)
+  const bufferedEnd = addMinutes(request.end, request.bufferMinutes)
+
+  return {
+    range: `[${formatISO(bufferedStart)},${formatISO(bufferedEnd)})`,
+    window: {
+      start: bufferedStart,
+      end: bufferedEnd,
+    },
+  }
+}
+
+export function windowsOverlap(a: BufferedWindow, b: BufferedWindow): boolean {
+  return a.start < b.end && b.start < a.end
+}
+
+export function toBufferedWindow(request: BookingRequest): BufferedWindow {
+  return expandWithBuffer(request).window
+}
+
+export function collectBufferedWindows(existing: BookingRequest[]): BufferedWindow[] {
+  return existing.map((booking) => toBufferedWindow(booking))
+}
+
+export function hasBufferedConflictWithWindows(
+  existing: BufferedWindow[],
+  candidate: BufferedWindow
+): boolean {
+  return existing.some((window) => windowsOverlap(window, candidate))
+}
+
+export function hasBufferedConflict(
+  existing: BookingRequest[],
+  candidate: BookingRequest
+): boolean {
+  const candidateWindow = toBufferedWindow(candidate)
+  const existingWindows = collectBufferedWindows(existing)
+  return hasBufferedConflictWithWindows(existingWindows, candidateWindow)
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -239,6 +239,50 @@ export type Database = {
           },
         ]
       }
+      amenity_bookings: {
+        Row: {
+          amenity_slug: string
+          buffer_minutes: number
+          created_at: string
+          ends_at: string
+          id: string
+          note: string | null
+          slot: string
+          starts_at: string
+          tenant_id: string
+        }
+        Insert: {
+          amenity_slug: string
+          buffer_minutes?: number
+          created_at?: string
+          ends_at: string
+          id?: string
+          note?: string | null
+          slot: string
+          starts_at: string
+          tenant_id?: string
+        }
+        Update: {
+          amenity_slug?: string
+          buffer_minutes?: number
+          created_at?: string
+          ends_at?: string
+          id?: string
+          note?: string | null
+          slot?: string
+          starts_at?: string
+          tenant_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "amenity_bookings_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       ai_analysis_results: {
         Row: {
           agent_id: string | null

--- a/supabase/migrations/20250601_booking_buffer.sql
+++ b/supabase/migrations/20250601_booking_buffer.sql
@@ -1,0 +1,41 @@
+create extension if not exists "pgcrypto";
+create extension if not exists btree_gist;
+
+create table if not exists public.amenity_bookings (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  amenity_slug text not null,
+  tenant_id uuid not null default auth.uid(),
+  starts_at timestamptz not null,
+  ends_at timestamptz not null,
+  slot tsrange not null,
+  buffer_minutes integer not null default 0,
+  note text null,
+  constraint amenity_bookings_start_before_end check (starts_at < ends_at),
+  constraint amenity_bookings_buffer_positive check (buffer_minutes >= 0)
+);
+
+alter table public.amenity_bookings
+  add constraint amenity_bookings_tenant_id_fkey foreign key (tenant_id) references auth.users (id) on delete cascade;
+
+create index if not exists amenity_bookings_amenity_idx on public.amenity_bookings (amenity_slug);
+create index if not exists amenity_bookings_slot_idx on public.amenity_bookings using gist (amenity_slug, slot);
+
+alter table public.amenity_bookings enable row level security;
+
+create policy "Users can view their amenity bookings" on public.amenity_bookings
+  for select
+  using (auth.uid() = tenant_id);
+
+create policy "Users can insert their amenity bookings" on public.amenity_bookings
+  for insert
+  with check (auth.uid() = tenant_id);
+
+create policy "Users can update their amenity bookings" on public.amenity_bookings
+  for update
+  using (auth.uid() = tenant_id)
+  with check (auth.uid() = tenant_id);
+
+create policy "Users can delete their amenity bookings" on public.amenity_bookings
+  for delete
+  using (auth.uid() = tenant_id);

--- a/tests/booking-buffer.test.ts
+++ b/tests/booking-buffer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { addMinutes, subMinutes, formatISO } from 'date-fns'
+
+import {
+  expandWithBuffer,
+  hasBufferedConflict,
+  type BookingRequest,
+} from '@/lib/bookings'
+
+describe('expandWithBuffer', () => {
+  const start = new Date('2024-05-01T10:00:00Z')
+  const end = new Date('2024-05-01T11:00:00Z')
+
+  it('expands the stored range by the configured buffer', () => {
+    const bufferMinutes = 15
+    const result = expandWithBuffer({ start, end, bufferMinutes })
+
+    const expectedStart = subMinutes(start, bufferMinutes)
+    const expectedEnd = addMinutes(end, bufferMinutes)
+
+    expect(result.range).toBe(`[${formatISO(expectedStart)},${formatISO(expectedEnd)})`)
+    expect(result.window.start.getTime()).toBe(expectedStart.getTime())
+    expect(result.window.end.getTime()).toBe(expectedEnd.getTime())
+  })
+
+  it('rejects negative buffer inputs', () => {
+    expect(() =>
+      expandWithBuffer({ start, end, bufferMinutes: -5 })
+    ).toThrow(/non-negative/)
+  })
+})
+
+describe('hasBufferedConflict', () => {
+  const existing: BookingRequest[] = [
+    {
+      start: new Date('2024-06-01T10:00:00Z'),
+      end: new Date('2024-06-01T11:00:00Z'),
+      bufferMinutes: 15,
+    },
+  ]
+
+  it('detects conflicts when the candidate sits inside an existing buffer window', () => {
+    const candidate: BookingRequest = {
+      start: new Date('2024-06-01T11:05:00Z'),
+      end: new Date('2024-06-01T12:00:00Z'),
+      bufferMinutes: 15,
+    }
+
+    expect(hasBufferedConflict(existing, candidate)).toBe(true)
+  })
+
+  it('allows a booking that starts exactly after the buffer window ends', () => {
+    const candidate: BookingRequest = {
+      start: new Date('2024-06-01T11:30:00Z'),
+      end: new Date('2024-06-01T12:30:00Z'),
+      bufferMinutes: 15,
+    }
+
+    expect(hasBufferedConflict(existing, candidate)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- enforce buffer windows when creating amenity bookings and persist the expanded tsrange alongside calendar events
- allow residents to pick buffer durations, preview the resulting hold window, and choose an amenity before submitting
- document the buffer rules, add Supabase schema support, and cover the buffer overlap logic with unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0d8e8a4832898ebd828969eca90