### PR TITLE
Add amenity blackout management and enforcement

### DIFF
--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import {
+  buildBlackoutConflictMessage,
+  ensureAmenityIsBookable,
+  type AmenityBlackout,
+} from '@/lib/amenities/blackouts'
+import { BookingBlackoutError } from '@/lib/errors'
+import { createClient } from '@/utils/supabase/server'
+
+const bookingSchema = z
+  .object({
+    amenityId: z.string().min(1, 'Amenity is required.'),
+    startsAt: z.coerce.date({
+      errorMap: () => ({ message: 'Provide a valid start date and time.' }),
+    }),
+    endsAt: z.coerce.date({
+      errorMap: () => ({ message: 'Provide a valid end date and time.' }),
+    }),
+    note: z
+      .string()
+      .max(280, 'Notes should be 280 characters or fewer.')
+      .optional(),
+  })
+  .refine((data) => data.endsAt > data.startsAt, {
+    message: 'The booking end time must be after the start time.',
+    path: ['endsAt'],
+  })
+
+export async function POST(request: Request) {
+  const supabase = createClient()
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Invalid JSON body.', details: 'Expected a JSON payload for the booking request.' },
+      { status: 400 }
+    )
+  }
+
+  const parsed = bookingSchema.safeParse(payload)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: 'Invalid booking request.',
+        issues: parsed.error.flatten().fieldErrors,
+      },
+      { status: 422 }
+    )
+  }
+
+  const { amenityId, startsAt, endsAt, note } = parsed.data
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return NextResponse.json(
+      { error: 'Authentication required.' },
+      { status: 401 }
+    )
+  }
+
+  try {
+    await ensureAmenityIsBookable(supabase, {
+      amenityId,
+      startsAt,
+      endsAt,
+    })
+  } catch (error) {
+    if (error instanceof BookingBlackoutError) {
+      const blackoutDetails = error.blackout as AmenityBlackout | undefined
+      return NextResponse.json(
+        {
+          error: 'Amenity blackout conflict.',
+          message: blackoutDetails
+            ? buildBlackoutConflictMessage(blackoutDetails)
+            : error.message,
+          blackout: blackoutDetails ?? null,
+        },
+        { status: 409 }
+      )
+    }
+
+    console.error('Unexpected booking validation error', error)
+    return NextResponse.json(
+      { error: 'Unable to validate amenity availability at this time.' },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json(
+    {
+      status: 'ok',
+      message: 'Booking permitted. Continue with the reservation workflow.',
+      note,
+    },
+    { status: 200 }
+  )
+}

--- a/app/dashboard/amenities/blackouts/actions.ts
+++ b/app/dashboard/amenities/blackouts/actions.ts
@@ -1,0 +1,150 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import { createActionClient } from '@/utils/supabase/actions'
+import {
+  buildBlackoutConflictMessage,
+  ensureAmenityIsBookable,
+  type AmenityBlackout,
+} from '@/lib/amenities/blackouts'
+import { BookingBlackoutError } from '@/lib/errors'
+
+export type BlackoutFormState = {
+  status: 'idle' | 'success' | 'error'
+  message?: string
+  issues?: Record<string, string[]>
+}
+
+export const initialBlackoutFormState: BlackoutFormState = {
+  status: 'idle',
+  message: undefined,
+  issues: undefined,
+}
+
+const blackoutSchema = z
+  .object({
+    amenityId: z.string().min(1, 'Select an amenity.'),
+    startsAt: z.coerce.date({
+      errorMap: () => ({ message: 'Provide a valid start date and time.' }),
+    }),
+    endsAt: z.coerce.date({
+      errorMap: () => ({ message: 'Provide a valid end date and time.' }),
+    }),
+    reason: z
+      .string()
+      .min(3, 'Share a short reason for the blackout.')
+      .max(280, 'Keep the blackout reason under 280 characters.'),
+  })
+  .refine((data) => data.endsAt > data.startsAt, {
+    message: 'The blackout end time must be after the start time.',
+    path: ['endsAt'],
+  })
+
+export async function createBlackoutAction(
+  prevState: BlackoutFormState,
+  formData: FormData
+): Promise<BlackoutFormState> {
+  const parsed = blackoutSchema.safeParse({
+    amenityId: formData.get('amenityId'),
+    startsAt: formData.get('startsAt'),
+    endsAt: formData.get('endsAt'),
+    reason: formData.get('reason'),
+  })
+
+  if (!parsed.success) {
+    return {
+      status: 'error',
+      message: 'Please correct the highlighted fields and try again.',
+      issues: parsed.error.flatten().fieldErrors,
+    }
+  }
+
+  const { amenityId, startsAt, endsAt, reason } = parsed.data
+  const supabase = await createActionClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      status: 'error',
+      message: 'You must be signed in to manage amenity blackouts.',
+    }
+  }
+
+  const startsAtIso = startsAt.toISOString()
+  const endsAtIso = endsAt.toISOString()
+
+  const { error } = await supabase.from('amenity_blackouts').insert({
+    amenity_id: amenityId,
+    starts_at: startsAtIso,
+    ends_at: endsAtIso,
+    reason,
+    created_by: user.id,
+  })
+
+  if (error) {
+    return {
+      status: 'error',
+      message: 'Unable to save the blackout. Please try again.',
+    }
+  }
+
+  revalidatePath('/dashboard/amenities/blackouts')
+
+  return {
+    status: 'success',
+    message: 'Blackout scheduled successfully.',
+  }
+}
+
+export async function deleteBlackoutAction(blackoutId: string) {
+  const supabase = await createActionClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { error: 'You must be signed in to manage amenity blackouts.' }
+  }
+
+  const { error } = await supabase
+    .from('amenity_blackouts')
+    .delete()
+    .eq('id', blackoutId)
+
+  if (error) {
+    return { error: 'Failed to remove the blackout. Please try again.' }
+  }
+
+  revalidatePath('/dashboard/amenities/blackouts')
+
+  return { success: true as const }
+}
+
+export async function checkBookingAgainstBlackouts(payload: {
+  amenityId: string
+  startsAt: Date
+  endsAt: Date
+}) {
+  const supabase = await createActionClient()
+
+  try {
+    await ensureAmenityIsBookable(supabase, payload)
+    return { ok: true as const }
+  } catch (error) {
+    if (error instanceof BookingBlackoutError) {
+      const blackout = error.blackout as AmenityBlackout | undefined
+      return {
+        ok: false as const,
+        message: blackout
+          ? buildBlackoutConflictMessage(blackout)
+          : error.message,
+      }
+    }
+
+    throw error
+  }
+}

--- a/app/dashboard/amenities/blackouts/blackout-form.tsx
+++ b/app/dashboard/amenities/blackouts/blackout-form.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useFormState } from 'react-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { AMENITY_OPTIONS } from '@/lib/amenities'
+import {
+  createBlackoutAction,
+  initialBlackoutFormState,
+  type BlackoutFormState,
+} from './actions'
+
+export function BlackoutForm() {
+  const [state, formAction] = useFormState<BlackoutFormState, FormData>(
+    createBlackoutAction,
+    initialBlackoutFormState
+  )
+  const formRef = useRef<HTMLFormElement | null>(null)
+
+  useEffect(() => {
+    if (state.status === 'success') {
+      formRef.current?.reset()
+    }
+  }, [state.status])
+
+  const amenityError = state.issues?.amenityId?.[0]
+  const startError = state.issues?.startsAt?.[0]
+  const endError = state.issues?.endsAt?.[0]
+  const reasonError = state.issues?.reason?.[0]
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-6">
+      {state.message && (
+        <div
+          role="status"
+          className={`rounded border p-3 text-sm ${
+            state.status === 'success'
+              ? 'border-green-200 bg-green-50 text-green-700'
+              : 'border-red-200 bg-red-50 text-red-700'
+          }`}
+        >
+          {state.message}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="amenityId">Amenity</Label>
+        <select
+          id="amenityId"
+          name="amenityId"
+          required
+          className={`w-full rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+            amenityError ? 'border-red-500 focus-visible:ring-red-400' : 'border-input'
+          }`}
+          defaultValue=""
+        >
+          <option value="" disabled>
+            Select an amenity
+          </option>
+          {AMENITY_OPTIONS.map((amenity) => (
+            <option key={amenity.id} value={amenity.id}>
+              {amenity.label}
+            </option>
+          ))}
+        </select>
+        {amenityError && (
+          <p className="text-sm text-red-600" role="alert">
+            {amenityError}
+          </p>
+        )}
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="startsAt">Starts</Label>
+          <Input
+            id="startsAt"
+            name="startsAt"
+            type="datetime-local"
+            required
+            className={startError ? 'border-red-500 focus-visible:ring-red-400' : undefined}
+          />
+          {startError && (
+            <p className="text-sm text-red-600" role="alert">
+              {startError}
+            </p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="endsAt">Ends</Label>
+          <Input
+            id="endsAt"
+            name="endsAt"
+            type="datetime-local"
+            required
+            className={endError ? 'border-red-500 focus-visible:ring-red-400' : undefined}
+          />
+          {endError && (
+            <p className="text-sm text-red-600" role="alert">
+              {endError}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="reason">Reason</Label>
+        <Textarea
+          id="reason"
+          name="reason"
+          required
+          rows={3}
+          maxLength={280}
+          placeholder="Maintenance, deep cleaning, policy change..."
+          className={reasonError ? 'border-red-500 focus-visible:ring-red-400' : undefined}
+        />
+        <p className="text-xs text-muted-foreground">
+          This message is shared with tenants when they try to book an amenity during the blackout.
+        </p>
+        {reasonError && (
+          <p className="text-sm text-red-600" role="alert">
+            {reasonError}
+          </p>
+        )}
+      </div>
+
+      <Button type="submit" className="w-full md:w-auto">
+        Save blackout
+      </Button>
+    </form>
+  )
+}

--- a/app/dashboard/amenities/blackouts/blackout-list.tsx
+++ b/app/dashboard/amenities/blackouts/blackout-list.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { format } from 'date-fns'
+
+import { Button } from '@/components/ui/button'
+import { getAmenityLabel } from '@/lib/amenities'
+import type { AmenityBlackout } from '@/lib/amenities/blackouts'
+import { deleteBlackoutAction } from './actions'
+
+export type AmenityBlackoutSummary = Pick<
+  AmenityBlackout,
+  'id' | 'amenity_id' | 'starts_at' | 'ends_at' | 'reason'
+>
+
+export function BlackoutList({ blackouts }: { blackouts: AmenityBlackoutSummary[] }) {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  if (!blackouts.length) {
+    return (
+      <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+        No blackout windows scheduled yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {errorMessage && (
+        <div
+          role="alert"
+          className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+        >
+          {errorMessage}
+        </div>
+      )}
+      <ul className="space-y-4">
+        {blackouts.map((blackout) => {
+          const startsAt = new Date(blackout.starts_at)
+          const endsAt = new Date(blackout.ends_at)
+
+          return (
+            <li
+              key={blackout.id}
+              className="rounded-lg border bg-card p-4 shadow-sm"
+            >
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                    {getAmenityLabel(blackout.amenity_id)}
+                  </p>
+                  <p className="text-base font-medium">
+                    {format(startsAt, 'MMM d, yyyy h:mm a')} → {format(endsAt, 'MMM d, yyyy h:mm a')}
+                  </p>
+                  <p className="text-sm text-muted-foreground">{blackout.reason}</p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isPending && pendingId === blackout.id}
+                  onClick={() => {
+                    setErrorMessage(null)
+                    setPendingId(blackout.id)
+                    startTransition(async () => {
+                      try {
+                        const result = await deleteBlackoutAction(blackout.id)
+                        if (result?.error) {
+                          setErrorMessage(result.error)
+                        }
+                      } catch (error) {
+                        setErrorMessage('Failed to remove the blackout. Please try again.')
+                      } finally {
+                        setPendingId(null)
+                      }
+                    })
+                  }}
+                >
+                  {isPending && pendingId === blackout.id ? 'Removing…' : 'Remove'}
+                </Button>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/app/dashboard/amenities/blackouts/page.tsx
+++ b/app/dashboard/amenities/blackouts/page.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { createClient } from '@/utils/supabase/server'
+import type { AmenityBlackoutSummary } from './blackout-list'
+import { BlackoutForm } from './blackout-form'
+import { BlackoutList } from './blackout-list'
+
+export const metadata = {
+  title: 'Amenity blackouts',
+  description: 'Block out maintenance windows so residents cannot book unavailable amenities.',
+}
+
+export default async function AmenityBlackoutsPage() {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('amenity_blackouts')
+    .select('id, amenity_id, starts_at, ends_at, reason')
+    .order('starts_at', { ascending: true })
+
+  if (error) {
+    console.error('Failed to load amenity blackouts', error)
+  }
+
+  const blackouts: AmenityBlackoutSummary[] = (data ?? []).map((blackout) => ({
+    id: blackout.id,
+    amenity_id: blackout.amenity_id,
+    starts_at: blackout.starts_at,
+    ends_at: blackout.ends_at,
+    reason: blackout.reason,
+  }))
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 p-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Amenity blackouts</h1>
+        <p className="text-muted-foreground">
+          Create downtime windows for maintenance, cleaning, or policy changes. Residents attempting to
+          book within a blackout will see the corresponding message.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Schedule a blackout</CardTitle>
+            <CardDescription>
+              Choose an amenity, specify the downtime window, and share a short note for residents.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <BlackoutForm />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Upcoming downtime</CardTitle>
+            <CardDescription>
+              Review and remove blackouts that are no longer needed.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <BlackoutList blackouts={blackouts} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/lib/amenities/blackouts.ts
+++ b/lib/amenities/blackouts.ts
@@ -1,0 +1,100 @@
+import { format } from 'date-fns'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/supabase'
+import { ApplicationError, BookingBlackoutError } from '@/lib/errors'
+
+export type AmenityBlackout = Database['public']['Tables']['amenity_blackouts']['Row']
+
+export type AmenityBlackoutInput = {
+  amenityId: string
+  startsAt: Date
+  endsAt: Date
+  excludeId?: string
+}
+
+export function doTimeslotsOverlap(
+  startA: Date,
+  endA: Date,
+  startB: Date,
+  endB: Date
+) {
+  return startA < endB && endA > startB
+}
+
+export function findLocalConflict(
+  blackouts: AmenityBlackout[],
+  startsAt: Date,
+  endsAt: Date
+): AmenityBlackout | null {
+  return (
+    blackouts.find((blackout) =>
+      doTimeslotsOverlap(
+        startsAt,
+        endsAt,
+        new Date(blackout.starts_at),
+        new Date(blackout.ends_at)
+      )
+    ) ?? null
+  )
+}
+
+export function describeBlackout(blackout: AmenityBlackout) {
+  const formattedStart = format(new Date(blackout.starts_at), 'MMM d, yyyy h:mm a')
+  const formattedEnd = format(new Date(blackout.ends_at), 'MMM d, yyyy h:mm a')
+
+  return `${formattedStart} – ${formattedEnd} · ${blackout.reason}`
+}
+
+export async function fetchConflictingBlackout(
+  client: SupabaseClient<Database>,
+  { amenityId, startsAt, endsAt, excludeId }: AmenityBlackoutInput
+): Promise<AmenityBlackout | null> {
+  const query = client
+    .from('amenity_blackouts')
+    .select('id, amenity_id, starts_at, ends_at, reason')
+    .eq('amenity_id', amenityId)
+    .lt('starts_at', endsAt.toISOString())
+    .gt('ends_at', startsAt.toISOString())
+
+  if (excludeId) {
+    query.neq('id', excludeId)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    throw new ApplicationError('Failed to load amenity blackout windows.', {
+      error,
+    })
+  }
+
+  if (!data) {
+    return null
+  }
+
+  return findLocalConflict(data, startsAt, endsAt)
+}
+
+export async function ensureAmenityIsBookable(
+  client: SupabaseClient<Database>,
+  input: AmenityBlackoutInput
+) {
+  const conflict = await fetchConflictingBlackout(client, input)
+
+  if (conflict) {
+    throw new BookingBlackoutError(
+      buildBlackoutConflictMessage(conflict),
+      conflict
+    )
+  }
+}
+
+export function buildBlackoutConflictMessage(blackout: AmenityBlackout) {
+  return `Amenity is unavailable from ${format(
+    new Date(blackout.starts_at),
+    'MMM d, yyyy h:mm a'
+  )} to ${format(new Date(blackout.ends_at), 'MMM d, yyyy h:mm a')} because: ${
+    blackout.reason
+  }`
+}

--- a/lib/amenities/index.ts
+++ b/lib/amenities/index.ts
@@ -1,0 +1,19 @@
+export type AmenityOption = {
+  id: string
+  label: string
+  description?: string
+}
+
+export const AMENITY_OPTIONS: AmenityOption[] = [
+  { id: 'kitchen', label: 'Kitchen', description: 'Shared cooking space' },
+  { id: 'tv_lounge', label: 'TV Lounge', description: 'Living room with shared TV setup' },
+  { id: 'gaming_nook', label: 'Gaming Nook', description: 'Console and gaming accessories' },
+  { id: 'parking_spot', label: 'Parking Spot', description: 'Reserved vehicle parking' },
+  { id: 'study_room', label: 'Study Room', description: 'Quiet workspace for residents' },
+]
+
+const AMENITY_LOOKUP = new Map(AMENITY_OPTIONS.map((amenity) => [amenity.id, amenity.label]))
+
+export function getAmenityLabel(id: string) {
+  return AMENITY_LOOKUP.get(id) ?? 'Unknown amenity'
+}

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -5,3 +5,13 @@ export class ApplicationError extends Error {
 }
 
 export class UserError extends ApplicationError {}
+
+export class BookingBlackoutError extends UserError {
+  blackout?: Record<string, any>
+
+  constructor(message: string, blackout?: Record<string, any>) {
+    super(message, blackout ? { blackout } : {})
+    this.name = 'BookingBlackoutError'
+    this.blackout = blackout
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -239,6 +239,39 @@ export type Database = {
           },
         ]
       }
+      amenity_blackouts: {
+        Row: {
+          amenity_id: string
+          created_at: string
+          created_by: string | null
+          ends_at: string
+          id: string
+          reason: string
+          starts_at: string
+          timeslot: unknown
+        }
+        Insert: {
+          amenity_id: string
+          created_at?: string
+          created_by?: string | null
+          ends_at: string
+          id?: string
+          reason: string
+          starts_at: string
+          timeslot?: unknown
+        }
+        Update: {
+          amenity_id?: string
+          created_at?: string
+          created_by?: string | null
+          ends_at?: string
+          id?: string
+          reason?: string
+          starts_at?: string
+          timeslot?: unknown
+        }
+        Relationships: []
+      }
       ai_analysis_results: {
         Row: {
           agent_id: string | null

--- a/supabase/migrations/20250616_amenity_blackouts.sql
+++ b/supabase/migrations/20250616_amenity_blackouts.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS public.amenity_blackouts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  amenity_id text NOT NULL,
+  starts_at timestamptz NOT NULL,
+  ends_at timestamptz NOT NULL,
+  timeslot tstzrange GENERATED ALWAYS AS (tstzrange(starts_at, ends_at, '[)')) STORED,
+  reason text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  CONSTRAINT amenity_blackouts_valid_range CHECK (starts_at < ends_at)
+);
+
+CREATE INDEX IF NOT EXISTS amenity_blackouts_amenity_timeslot_idx
+  ON public.amenity_blackouts USING gist (amenity_id, timeslot);
+
+CREATE INDEX IF NOT EXISTS amenity_blackouts_amenity_window_idx
+  ON public.amenity_blackouts (amenity_id, starts_at, ends_at);
+
+ALTER TABLE public.amenity_blackouts ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.amenity_blackouts IS 'Administrative amenity downtime windows to block scheduling.';
+COMMENT ON COLUMN public.amenity_blackouts.timeslot IS 'Derived range capturing the blackout window in [start, end) format.';
+-- Remember to create RLS policies tailored to your access patterns.

--- a/tests/amenity-blackouts.test.ts
+++ b/tests/amenity-blackouts.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildBlackoutConflictMessage,
+  doTimeslotsOverlap,
+  ensureAmenityIsBookable,
+  findLocalConflict,
+  type AmenityBlackout,
+} from '@/lib/amenities/blackouts'
+import { BookingBlackoutError } from '@/lib/errors'
+
+const baseBlackout: AmenityBlackout = {
+  id: 'blackout-1',
+  amenity_id: 'kitchen',
+  starts_at: '2024-06-01T10:00:00.000Z',
+  ends_at: '2024-06-01T12:00:00.000Z',
+  reason: 'Deep cleaning',
+  created_at: '2024-05-31T20:00:00.000Z',
+  created_by: 'admin-user',
+  timeslot: null,
+}
+
+describe('amenity blackout helpers', () => {
+  it('detects overlapping ranges', () => {
+    const overlap = doTimeslotsOverlap(
+      new Date('2024-06-01T10:30:00Z'),
+      new Date('2024-06-01T11:30:00Z'),
+      new Date(baseBlackout.starts_at),
+      new Date(baseBlackout.ends_at)
+    )
+
+    const noOverlap = doTimeslotsOverlap(
+      new Date('2024-06-01T12:00:00Z'),
+      new Date('2024-06-01T13:00:00Z'),
+      new Date(baseBlackout.starts_at),
+      new Date(baseBlackout.ends_at)
+    )
+
+    expect(overlap).toBe(true)
+    expect(noOverlap).toBe(false)
+  })
+
+  it('finds conflicting blackout from a list', () => {
+    const conflict = findLocalConflict(
+      [baseBlackout],
+      new Date('2024-06-01T11:00:00Z'),
+      new Date('2024-06-01T11:30:00Z')
+    )
+
+    expect(conflict).toMatchObject({ id: 'blackout-1' })
+  })
+
+  it('formats descriptive blackout conflict messages', () => {
+    const message = buildBlackoutConflictMessage(baseBlackout)
+
+    expect(message).toContain('Amenity is unavailable')
+    expect(message).toContain('Deep cleaning')
+  })
+
+  it('throws a BookingBlackoutError when a conflict exists', async () => {
+    const query: any = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      lt: vi.fn(),
+      gt: vi.fn(),
+      neq: vi.fn(),
+    }
+
+    query.select.mockReturnValue(query)
+    query.eq.mockReturnValue(query)
+    query.lt.mockReturnValue(query)
+    query.neq.mockReturnValue(query)
+    query.gt.mockReturnValue(
+      Promise.resolve({
+        data: [baseBlackout],
+        error: null,
+      })
+    )
+
+    const client: any = {
+      from: vi.fn(() => query),
+    }
+
+    await expect(
+      ensureAmenityIsBookable(client, {
+        amenityId: 'kitchen',
+        startsAt: new Date('2024-06-01T11:00:00Z'),
+        endsAt: new Date('2024-06-01T11:30:00Z'),
+      })
+    ).rejects.toBeInstanceOf(BookingBlackoutError)
+  })
+
+  it('passes when no conflicting blackout exists', async () => {
+    const query: any = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      lt: vi.fn(),
+      gt: vi.fn(),
+      neq: vi.fn(),
+    }
+
+    query.select.mockReturnValue(query)
+    query.eq.mockReturnValue(query)
+    query.lt.mockReturnValue(query)
+    query.neq.mockReturnValue(query)
+    query.gt.mockReturnValue(
+      Promise.resolve({
+        data: [],
+        error: null,
+      })
+    )
+
+    const client: any = {
+      from: vi.fn(() => query),
+    }
+
+    await expect(
+      ensureAmenityIsBookable(client, {
+        amenityId: 'kitchen',
+        startsAt: new Date('2024-06-02T11:00:00Z'),
+        endsAt: new Date('2024-06-02T11:30:00Z'),
+      })
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('booking route blackout enforcement', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  function createMockSupabase(data: AmenityBlackout[]) {
+    const query: any = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      lt: vi.fn(),
+      gt: vi.fn(),
+      neq: vi.fn(),
+    }
+
+    query.select.mockReturnValue(query)
+    query.eq.mockReturnValue(query)
+    query.lt.mockReturnValue(query)
+    query.neq.mockReturnValue(query)
+    query.gt.mockReturnValue(Promise.resolve({ data, error: null }))
+
+    return {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        }),
+      },
+      from: vi.fn(() => query),
+    }
+  }
+
+  it('returns a conflict response when a blackout overlaps', async () => {
+    vi.doMock('@/utils/supabase/server', () => ({
+      createClient: () => createMockSupabase([baseBlackout]),
+    }))
+
+    const { POST } = await import('@/app/api/bookings/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/bookings', {
+        method: 'POST',
+        body: JSON.stringify({
+          amenityId: 'kitchen',
+          startsAt: '2024-06-01T10:30:00Z',
+          endsAt: '2024-06-01T11:30:00Z',
+        }),
+      })
+    )
+
+    expect(response.status).toBe(409)
+    const payload = await response.json()
+    expect(payload.error).toBe('Amenity blackout conflict.')
+    expect(payload.message).toContain('Deep cleaning')
+  })
+
+  it('allows the booking when no blackouts overlap', async () => {
+    vi.doMock('@/utils/supabase/server', () => ({
+      createClient: () => createMockSupabase([]),
+    }))
+
+    const { POST } = await import('@/app/api/bookings/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/bookings', {
+        method: 'POST',
+        body: JSON.stringify({
+          amenityId: 'kitchen',
+          startsAt: '2024-06-02T10:30:00Z',
+          endsAt: '2024-06-02T11:30:00Z',
+        }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+    expect(payload.status).toBe('ok')
+  })
+})


### PR DESCRIPTION
## Summary
- add a Supabase migration and typed helpers for the new `amenity_blackouts` table
- build an admin dashboard surface with form and list controls for scheduling blackout windows
- block API bookings that overlap blackout ranges and cover the behaviour with Vitest suites

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d0a0d9f86c8328a6fdcfcf3e8ecaf5