### PR TITLE
Add booking reminder and no-show automation

### DIFF
--- a/app/api/bookings/[bookingId]/check-in/route.ts
+++ b/app/api/bookings/[bookingId]/check-in/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { z } from 'zod'
+
+import { SupabaseBookingRepository } from '@/lib/bookings/repository'
+import type { CheckInMethod } from '@/lib/bookings/types'
+import { createServiceRoleSupabaseClient } from '@/lib/supabase-admin'
+import useSupabaseServer from '@/utils/supabase-server'
+
+const paramsSchema = z.object({
+  bookingId: z.string().uuid(),
+})
+
+const bodySchema = z
+  .object({
+    method: z.enum(['button', 'presence']).optional(),
+  })
+  .default({})
+
+export async function POST(request: Request, context: { params: { bookingId: string } }) {
+  const { params } = context
+
+  const parsedParams = paramsSchema.safeParse(params)
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'Invalid booking id.' }, { status: 400 })
+  }
+
+  const bookingId = parsedParams.data.bookingId
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    payload = {}
+  }
+
+  const parsedBody = bodySchema.safeParse(payload ?? {})
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      {
+        error: 'Invalid request body.',
+        details: parsedBody.error.flatten(),
+      },
+      { status: 400 },
+    )
+  }
+
+  const method: CheckInMethod = parsedBody.data.method ?? 'button'
+
+  const cookieStore = cookies()
+  const supabase = useSupabaseServer(cookieStore)
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const serviceClient = createServiceRoleSupabaseClient()
+  const repository = new SupabaseBookingRepository(serviceClient)
+
+  try {
+    const booking = await repository.getBookingById(bookingId)
+    if (!booking) {
+      return NextResponse.json({ error: 'Booking not found.' }, { status: 404 })
+    }
+
+    if (booking.member_id !== user.id) {
+      return NextResponse.json({ error: 'You are not allowed to check in to this booking.' }, { status: 403 })
+    }
+
+    if (booking.status === 'no_show_cancelled' || booking.status === 'cancelled') {
+      return NextResponse.json(
+        { error: `Cannot check in to a booking with status "${booking.status}".` },
+        { status: 409 },
+      )
+    }
+
+    if (booking.status === 'checked_in' && booking.check_in_at) {
+      return NextResponse.json({ status: 'checked_in', checkInAt: booking.check_in_at })
+    }
+
+    const now = new Date()
+    await repository.markCheckedIn(booking.id, now)
+    await repository.logEvent({
+      bookingId: booking.id,
+      memberId: booking.member_id,
+      eventType: 'booking.checked_in',
+      metadata: {
+        check_in_at: now.toISOString(),
+        method,
+      },
+    })
+
+    return NextResponse.json({ status: 'checked_in', checkInAt: now.toISOString() })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/cron/bookings/route.ts
+++ b/app/api/cron/bookings/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+
+import { processBookingNoShows, processBookingReminders, SupabaseBookingRepository } from '@/lib/bookings'
+import { createBookingNotificationService } from '@/lib/notifications/service'
+import { createServiceRoleSupabaseClient } from '@/lib/supabase-admin'
+
+export async function POST() {
+  return runCron()
+}
+
+export async function GET() {
+  return runCron()
+}
+
+async function runCron() {
+  try {
+    const supabase = createServiceRoleSupabaseClient()
+    const repository = new SupabaseBookingRepository(supabase)
+    const notifications = createBookingNotificationService()
+    const now = new Date()
+
+    const reminderResult = await processBookingReminders(repository, notifications, { now })
+    const noShowResult = await processBookingNoShows(repository, notifications, { now })
+
+    return NextResponse.json({
+      reminderResult,
+      noShowResult,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/lib/bookings/index.ts
+++ b/lib/bookings/index.ts
@@ -1,0 +1,3 @@
+export * from './jobs'
+export * from './repository'
+export * from './types'

--- a/lib/bookings/jobs.ts
+++ b/lib/bookings/jobs.ts
@@ -1,0 +1,255 @@
+import type { BookingNotificationService } from '@/lib/notifications/service'
+
+import type { BookingRepository } from './repository'
+import type { BookingRecord, BookingWaitlistEntry, JsonMap } from './types'
+
+const MINUTE_IN_MS = 60_000
+const DEFAULT_REMINDER_LEAD_MINUTES = 60
+const DEFAULT_REMINDER_WINDOW_MINUTES = 15
+const DEFAULT_NO_SHOW_GRACE_MINUTES = 15
+
+export interface JobError {
+  bookingId: string | null
+  stage: string
+  message: string
+  targetId?: string | null
+}
+
+export interface ReminderJobOptions {
+  now?: Date
+  leadTimeMinutes?: number
+  windowMinutes?: number
+}
+
+export interface ReminderJobResult {
+  considered: number
+  remindersSent: number
+  errors: JobError[]
+}
+
+export interface NoShowJobOptions {
+  now?: Date
+  gracePeriodMinutes?: number
+}
+
+export interface NoShowJobResult {
+  considered: number
+  cancellations: number
+  waitlistNotifications: number
+  errors: JobError[]
+}
+
+export async function processBookingReminders(
+  repository: BookingRepository,
+  notifications: BookingNotificationService,
+  options: ReminderJobOptions = {},
+): Promise<ReminderJobResult> {
+  const now = options.now ?? new Date()
+  const leadMinutes = options.leadTimeMinutes ?? DEFAULT_REMINDER_LEAD_MINUTES
+  const windowMinutes = options.windowMinutes ?? DEFAULT_REMINDER_WINDOW_MINUTES
+
+  const reminderWindowStart = new Date(now.getTime() + leadMinutes * MINUTE_IN_MS)
+  const reminderWindowEnd = new Date(reminderWindowStart.getTime() + windowMinutes * MINUTE_IN_MS)
+
+  const errors: JobError[] = []
+  let remindersSent = 0
+
+  let bookings: BookingRecord[] = []
+  try {
+    bookings = await repository.findBookingsNeedingReminder(reminderWindowStart, reminderWindowEnd)
+  } catch (error) {
+    addError(errors, null, 'load_reminders', error)
+    return {
+      considered: 0,
+      remindersSent: 0,
+      errors,
+    }
+  }
+
+  for (const booking of bookings) {
+    const startTime = new Date(booking.start_time)
+
+    try {
+      await notifications.sendReminder({
+        booking,
+        startTime,
+        reminderTime: now,
+        leadTimeMinutes: leadMinutes,
+      })
+      remindersSent += 1
+    } catch (error) {
+      addError(errors, booking.id, 'send_reminder', error)
+      continue
+    }
+
+    try {
+      await repository.markReminderSent(booking.id, now)
+    } catch (error) {
+      addError(errors, booking.id, 'update_reminder', error)
+    }
+
+    try {
+      await repository.logEvent({
+        bookingId: booking.id,
+        memberId: booking.member_id,
+        eventType: 'booking.reminder_sent',
+        metadata: reminderMetadata(booking, now, leadMinutes),
+      })
+    } catch (error) {
+      addError(errors, booking.id, 'log_reminder_event', error)
+    }
+  }
+
+  return {
+    considered: bookings.length,
+    remindersSent,
+    errors,
+  }
+}
+
+export async function processBookingNoShows(
+  repository: BookingRepository,
+  notifications: BookingNotificationService,
+  options: NoShowJobOptions = {},
+): Promise<NoShowJobResult> {
+  const now = options.now ?? new Date()
+  const graceMinutes = options.gracePeriodMinutes ?? DEFAULT_NO_SHOW_GRACE_MINUTES
+  const cutoff = new Date(now.getTime() - graceMinutes * MINUTE_IN_MS)
+
+  const errors: JobError[] = []
+  let cancellations = 0
+  let waitlistNotifications = 0
+
+  let bookings: BookingRecord[] = []
+  try {
+    bookings = await repository.findBookingsNeedingNoShowProcessing(cutoff)
+  } catch (error) {
+    addError(errors, null, 'load_no_shows', error)
+    return {
+      considered: 0,
+      cancellations: 0,
+      waitlistNotifications: 0,
+      errors,
+    }
+  }
+
+  for (const booking of bookings) {
+    const startTime = new Date(booking.start_time)
+
+    try {
+      await repository.cancelBookingForNoShow(booking.id, now)
+      cancellations += 1
+    } catch (error) {
+      addError(errors, booking.id, 'cancel_no_show', error)
+      continue
+    }
+
+    try {
+      await notifications.sendNoShowCancellation({
+        booking,
+        startTime,
+        cancellationTime: now,
+        gracePeriodMinutes: graceMinutes,
+      })
+    } catch (error) {
+      addError(errors, booking.id, 'send_no_show_cancellation', error)
+    }
+
+    try {
+      await repository.logEvent({
+        bookingId: booking.id,
+        memberId: booking.member_id,
+        eventType: 'booking.no_show_cancelled',
+        metadata: noShowMetadata(booking, now, graceMinutes),
+      })
+    } catch (error) {
+      addError(errors, booking.id, 'log_no_show_event', error)
+    }
+
+    let waitlist: BookingWaitlistEntry[] = []
+    try {
+      waitlist = await repository.listWaitlistForBooking(booking.id)
+    } catch (error) {
+      addError(errors, booking.id, 'load_waitlist', error)
+      continue
+    }
+
+    for (const entry of waitlist) {
+      try {
+        await notifications.sendWaitlistPromotion({
+          booking,
+          startTime,
+          waitlistEntry: entry,
+          notificationTime: now,
+        })
+        waitlistNotifications += 1
+      } catch (error) {
+        addError(errors, booking.id, 'send_waitlist_notification', error, entry.id)
+        continue
+      }
+
+      try {
+        await repository.markWaitlistEntryNotified(entry.id, now)
+      } catch (error) {
+        addError(errors, booking.id, 'update_waitlist_entry', error, entry.id)
+      }
+
+      try {
+        await repository.logEvent({
+          bookingId: booking.id,
+          memberId: entry.member_id,
+          eventType: 'booking.waitlist_notified',
+          metadata: waitlistMetadata(entry, now),
+        })
+      } catch (error) {
+        addError(errors, booking.id, 'log_waitlist_event', error, entry.id)
+      }
+    }
+  }
+
+  return {
+    considered: bookings.length,
+    cancellations,
+    waitlistNotifications,
+    errors,
+  }
+}
+
+function reminderMetadata(booking: BookingRecord, reminderTime: Date, leadMinutes: number): JsonMap {
+  return {
+    reminder_sent_at: reminderTime.toISOString(),
+    start_time: booking.start_time,
+    lead_minutes: leadMinutes,
+    member_email: booking.member_email,
+  }
+}
+
+function noShowMetadata(booking: BookingRecord, timestamp: Date, graceMinutes: number): JsonMap {
+  return {
+    cancelled_at: timestamp.toISOString(),
+    reason: 'no_show',
+    start_time: booking.start_time,
+    member_email: booking.member_email,
+    grace_minutes: graceMinutes,
+  }
+}
+
+function waitlistMetadata(entry: BookingWaitlistEntry, timestamp: Date): JsonMap {
+  return {
+    notified_at: timestamp.toISOString(),
+    waitlist_entry_id: entry.id,
+    waitlist_member_id: entry.member_id,
+    waitlist_member_email: entry.member_email,
+    position: entry.position,
+  }
+}
+
+function addError(errors: JobError[], bookingId: string | null, stage: string, cause: unknown, targetId?: string | null) {
+  const message = cause instanceof Error ? cause.message : String(cause)
+  errors.push({
+    bookingId,
+    stage,
+    message,
+    targetId: targetId ?? null,
+  })
+}

--- a/lib/bookings/repository.ts
+++ b/lib/bookings/repository.ts
@@ -1,0 +1,155 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/supabase'
+
+import type { BookingEventInput, BookingRecord, BookingWaitlistEntry } from './types'
+
+export interface BookingRepository {
+  findBookingsNeedingReminder(startWindow: Date, endWindow: Date): Promise<BookingRecord[]>
+  markReminderSent(bookingId: string, timestamp: Date): Promise<void>
+  logEvent(event: BookingEventInput): Promise<void>
+  findBookingsNeedingNoShowProcessing(cutoff: Date): Promise<BookingRecord[]>
+  cancelBookingForNoShow(bookingId: string, timestamp: Date): Promise<void>
+  listWaitlistForBooking(bookingId: string): Promise<BookingWaitlistEntry[]>
+  markWaitlistEntryNotified(entryId: string, timestamp: Date): Promise<void>
+  getBookingById(bookingId: string): Promise<BookingRecord | null>
+  markCheckedIn(bookingId: string, timestamp: Date): Promise<void>
+}
+
+export class SupabaseBookingRepository implements BookingRepository {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async findBookingsNeedingReminder(startWindow: Date, endWindow: Date) {
+    const { data, error } = await this.client
+      .from('bookings')
+      .select('*')
+      .eq('status', 'confirmed')
+      .is('reminder_sent_at', null)
+      .gte('start_time', startWindow.toISOString())
+      .lt('start_time', endWindow.toISOString())
+      .order('start_time', { ascending: true })
+
+    if (error) {
+      throw new Error(`Failed to load bookings for reminders: ${error.message}`)
+    }
+
+    return data ?? []
+  }
+
+  async markReminderSent(bookingId: string, timestamp: Date) {
+    const { error } = await this.client
+      .from('bookings')
+      .update({
+        reminder_sent_at: timestamp.toISOString(),
+        updated_at: timestamp.toISOString(),
+      })
+      .eq('id', bookingId)
+
+    if (error) {
+      throw new Error(`Failed to mark reminder as sent: ${error.message}`)
+    }
+  }
+
+  async logEvent(event: BookingEventInput) {
+    const { error } = await this.client.from('events').insert({
+      booking_id: event.bookingId,
+      member_id: event.memberId,
+      event_type: event.eventType,
+      metadata: event.metadata ?? null,
+    })
+
+    if (error) {
+      throw new Error(`Failed to log booking event: ${error.message}`)
+    }
+  }
+
+  async findBookingsNeedingNoShowProcessing(cutoff: Date) {
+    const { data, error } = await this.client
+      .from('bookings')
+      .select('*')
+      .eq('status', 'confirmed')
+      .is('check_in_at', null)
+      .is('no_show_processed_at', null)
+      .lte('start_time', cutoff.toISOString())
+      .order('start_time', { ascending: true })
+
+    if (error) {
+      throw new Error(`Failed to load bookings for no-show processing: ${error.message}`)
+    }
+
+    return data ?? []
+  }
+
+  async cancelBookingForNoShow(bookingId: string, timestamp: Date) {
+    const iso = timestamp.toISOString()
+    const { error } = await this.client
+      .from('bookings')
+      .update({
+        status: 'no_show_cancelled',
+        cancelled_at: iso,
+        no_show_processed_at: iso,
+        updated_at: iso,
+      })
+      .eq('id', bookingId)
+
+    if (error) {
+      throw new Error(`Failed to cancel booking: ${error.message}`)
+    }
+  }
+
+  async listWaitlistForBooking(bookingId: string) {
+    const { data, error } = await this.client
+      .from('booking_waitlist_entries')
+      .select('*')
+      .eq('booking_id', bookingId)
+      .order('position', { ascending: true })
+      .order('created_at', { ascending: true })
+
+    if (error) {
+      throw new Error(`Failed to load waitlist entries: ${error.message}`)
+    }
+
+    return data ?? []
+  }
+
+  async markWaitlistEntryNotified(entryId: string, timestamp: Date) {
+    const { error } = await this.client
+      .from('booking_waitlist_entries')
+      .update({ notified_at: timestamp.toISOString() })
+      .eq('id', entryId)
+
+    if (error) {
+      throw new Error(`Failed to mark waitlist entry as notified: ${error.message}`)
+    }
+  }
+
+  async getBookingById(bookingId: string) {
+    const { data, error } = await this.client
+      .from('bookings')
+      .select('*')
+      .eq('id', bookingId)
+      .maybeSingle()
+
+    if (error) {
+      throw new Error(`Failed to load booking: ${error.message}`)
+    }
+
+    return data ?? null
+  }
+
+  async markCheckedIn(bookingId: string, timestamp: Date) {
+    const iso = timestamp.toISOString()
+    const { error } = await this.client
+      .from('bookings')
+      .update({
+        status: 'checked_in',
+        check_in_at: iso,
+        updated_at: iso,
+      })
+      .eq('id', bookingId)
+
+    if (error) {
+      throw new Error(`Failed to record check-in: ${error.message}`)
+    }
+  }
+}

--- a/lib/bookings/types.ts
+++ b/lib/bookings/types.ts
@@ -1,0 +1,16 @@
+import type { Database, Json } from '@/lib/supabase'
+
+export type BookingRecord = Database['public']['Tables']['bookings']['Row']
+export type BookingWaitlistEntry = Database['public']['Tables']['booking_waitlist_entries']['Row']
+export type BookingStatus = BookingRecord['status']
+
+export type JsonMap = { [key: string]: Json }
+
+export interface BookingEventInput {
+  bookingId: string | null
+  memberId: string | null
+  eventType: string
+  metadata?: JsonMap
+}
+
+export type CheckInMethod = 'button' | 'presence'

--- a/lib/notifications/service.ts
+++ b/lib/notifications/service.ts
@@ -1,0 +1,125 @@
+import { Resend } from 'resend'
+
+import type { BookingRecord, BookingWaitlistEntry } from '@/lib/bookings/types'
+
+export interface BookingReminderPayload {
+  booking: BookingRecord
+  startTime: Date
+  reminderTime: Date
+  leadTimeMinutes: number
+}
+
+export interface BookingCancellationPayload {
+  booking: BookingRecord
+  startTime: Date
+  cancellationTime: Date
+  gracePeriodMinutes: number
+}
+
+export interface WaitlistPromotionPayload {
+  booking: BookingRecord
+  startTime: Date
+  waitlistEntry: BookingWaitlistEntry
+  notificationTime: Date
+}
+
+export interface BookingNotificationService {
+  sendReminder(payload: BookingReminderPayload): Promise<void>
+  sendNoShowCancellation(payload: BookingCancellationPayload): Promise<void>
+  sendWaitlistPromotion(payload: WaitlistPromotionPayload): Promise<void>
+}
+
+class ResendBookingNotificationService implements BookingNotificationService {
+  constructor(private readonly resend: Resend, private readonly fromAddress: string) {}
+
+  async sendReminder(payload: BookingReminderPayload) {
+    const { booking, startTime, leadTimeMinutes } = payload
+    const subject = `Reminder: ${describeAmenity(booking)} at ${formatDateTime(startTime)}`
+    const salutation = booking.member_name ? `Hi ${booking.member_name},` : 'Hi there,'
+    const bodyLines = [
+      salutation,
+      '',
+      `This is a friendly reminder that your booking for ${describeAmenity(booking)} starts in about ${leadTimeMinutes} minutes at ${formatDateTime(startTime)}.`,
+      'Please make sure you arrive on time and check in so roommates know the space is in use.',
+      '',
+      'Thanks for keeping the schedule coordinated!'
+    ]
+
+    await this.sendEmail({ to: booking.member_email, subject, bodyLines })
+  }
+
+  async sendNoShowCancellation(payload: BookingCancellationPayload) {
+    const { booking, startTime, cancellationTime, gracePeriodMinutes } = payload
+    const subject = `Booking cancelled due to missed check-in: ${describeAmenity(booking)}`
+    const salutation = booking.member_name ? `Hi ${booking.member_name},` : 'Hi there,'
+    const bodyLines = [
+      salutation,
+      '',
+      `We didn't receive a check-in for your ${describeAmenity(booking)} reservation that started at ${formatDateTime(startTime)}.`,
+      `After waiting ${gracePeriodMinutes} minutes, the booking was cancelled at ${formatDateTime(cancellationTime)} so others can claim the slot.`,
+      '',
+      'If you still need time in the space, please create a new booking.',
+    ]
+
+    await this.sendEmail({ to: booking.member_email, subject, bodyLines })
+  }
+
+  async sendWaitlistPromotion(payload: WaitlistPromotionPayload) {
+    const { booking, waitlistEntry, startTime, notificationTime } = payload
+    const subject = `Spot available: ${describeAmenity(booking)} at ${formatDateTime(startTime)}`
+    const salutation = waitlistEntry.member_name ? `Hi ${waitlistEntry.member_name},` : 'Hi there,'
+    const bodyLines = [
+      salutation,
+      '',
+      `Good news! A spot just opened for ${describeAmenity(booking)} starting at ${formatDateTime(startTime)}.`,
+      `You're next on the waitlist, so feel free to confirm the booking or claim the time in the portal.`,
+      '',
+      `Notification sent at ${formatDateTime(notificationTime)}.`,
+    ]
+
+    await this.sendEmail({ to: waitlistEntry.member_email, subject, bodyLines })
+  }
+
+  private async sendEmail({
+    to,
+    subject,
+    bodyLines,
+  }: {
+    to: string
+    subject: string
+    bodyLines: string[]
+  }) {
+    const { error } = await this.resend.emails.send({
+      from: this.fromAddress,
+      to: [to],
+      subject,
+      text: bodyLines.join('\n'),
+    })
+
+    if (error) {
+      throw error instanceof Error ? error : new Error(String(error))
+    }
+  }
+}
+
+export function createBookingNotificationService(): BookingNotificationService {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    throw new Error('RESEND_API_KEY is not configured')
+  }
+
+  const from = process.env.BOOKING_NOTIFICATIONS_FROM ?? 'Share House Portal <bookings@resend.dev>'
+  const resend = new Resend(apiKey)
+  return new ResendBookingNotificationService(resend, from)
+}
+
+function describeAmenity(booking: BookingRecord) {
+  return booking.amenity_name ?? 'shared amenity'
+}
+
+function formatDateTime(value: Date) {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(value)
+}

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/supabase'
+
+export function createServiceRoleSupabaseClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceKey) {
+    throw new Error('Supabase service role environment variables are not configured')
+  }
+
+  return createClient<Database>(url, serviceKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -411,6 +411,139 @@ export type Database = {
         }
         Relationships: []
       }
+      booking_waitlist_entries: {
+        Row: {
+          booking_id: string
+          created_at: string
+          id: string
+          member_email: string
+          member_id: string
+          member_name: string | null
+          notified_at: string | null
+          position: number
+        }
+        Insert: {
+          booking_id: string
+          created_at?: string
+          id?: string
+          member_email: string
+          member_id: string
+          member_name?: string | null
+          notified_at?: string | null
+          position: number
+        }
+        Update: {
+          booking_id?: string
+          created_at?: string
+          id?: string
+          member_email?: string
+          member_id?: string
+          member_name?: string | null
+          notified_at?: string | null
+          position?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "booking_waitlist_entries_booking_id_fkey"
+            columns: ["booking_id"]
+            isOneToOne: false
+            referencedRelation: "bookings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bookings: {
+        Row: {
+          amenity_id: string | null
+          amenity_name: string | null
+          cancelled_at: string | null
+          check_in_at: string | null
+          created_at: string
+          end_time: string
+          id: string
+          member_email: string
+          member_id: string
+          member_name: string | null
+          no_show_processed_at: string | null
+          reminder_sent_at: string | null
+          start_time: string
+          status: 'cancelled' | 'checked_in' | 'confirmed' | 'no_show_cancelled'
+          updated_at: string
+          waitlist_notified_at: string | null
+        }
+        Insert: {
+          amenity_id?: string | null
+          amenity_name?: string | null
+          cancelled_at?: string | null
+          check_in_at?: string | null
+          created_at?: string
+          end_time: string
+          id?: string
+          member_email: string
+          member_id: string
+          member_name?: string | null
+          no_show_processed_at?: string | null
+          reminder_sent_at?: string | null
+          start_time: string
+          status?: 'cancelled' | 'checked_in' | 'confirmed' | 'no_show_cancelled'
+          updated_at?: string
+          waitlist_notified_at?: string | null
+        }
+        Update: {
+          amenity_id?: string | null
+          amenity_name?: string | null
+          cancelled_at?: string | null
+          check_in_at?: string | null
+          created_at?: string
+          end_time?: string
+          id?: string
+          member_email?: string
+          member_id?: string
+          member_name?: string | null
+          no_show_processed_at?: string | null
+          reminder_sent_at?: string | null
+          start_time?: string
+          status?: 'cancelled' | 'checked_in' | 'confirmed' | 'no_show_cancelled'
+          updated_at?: string
+          waitlist_notified_at?: string | null
+        }
+        Relationships: []
+      }
+      events: {
+        Row: {
+          booking_id: string | null
+          created_at: string
+          event_type: string
+          id: string
+          member_id: string | null
+          metadata: Json | null
+        }
+        Insert: {
+          booking_id?: string | null
+          created_at?: string
+          event_type: string
+          id?: string
+          member_id?: string | null
+          metadata?: Json | null
+        }
+        Update: {
+          booking_id?: string | null
+          created_at?: string
+          event_type?: string
+          id?: string
+          member_id?: string | null
+          metadata?: Json | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "events_booking_id_fkey"
+            columns: ["booking_id"]
+            isOneToOne: false
+            referencedRelation: "bookings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       business_cards: {
         Row: {
           businesscard_name: string | null

--- a/supabase/migrations/20240710_booking_automation.sql
+++ b/supabase/migrations/20240710_booking_automation.sql
@@ -1,0 +1,56 @@
+create table if not exists public.bookings (
+  id uuid primary key default gen_random_uuid(),
+  amenity_id uuid,
+  amenity_name text,
+  start_time timestamptz not null,
+  end_time timestamptz not null,
+  member_id uuid not null references auth.users(id) on delete cascade,
+  member_email text not null,
+  member_name text,
+  status text not null default 'confirmed',
+  reminder_sent_at timestamptz,
+  check_in_at timestamptz,
+  cancelled_at timestamptz,
+  no_show_processed_at timestamptz,
+  waitlist_notified_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint bookings_end_after_start check (end_time > start_time),
+  constraint bookings_status_check check (status in ('confirmed', 'checked_in', 'cancelled', 'no_show_cancelled'))
+);
+
+create index if not exists bookings_start_time_idx on public.bookings (start_time);
+create index if not exists bookings_status_idx on public.bookings (status);
+
+alter table public.bookings enable row level security;
+
+create table if not exists public.booking_waitlist_entries (
+  id uuid primary key default gen_random_uuid(),
+  booking_id uuid not null references public.bookings(id) on delete cascade,
+  member_id uuid not null references auth.users(id) on delete cascade,
+  member_email text not null,
+  member_name text,
+  position integer not null,
+  notified_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now()),
+  constraint booking_waitlist_entries_position_check check (position > 0)
+);
+
+create unique index if not exists booking_waitlist_entries_unique on public.booking_waitlist_entries (booking_id, member_id);
+create index if not exists booking_waitlist_entries_position_idx on public.booking_waitlist_entries (booking_id, position);
+
+alter table public.booking_waitlist_entries enable row level security;
+
+create table if not exists public.events (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default timezone('utc', now()),
+  event_type text not null,
+  booking_id uuid references public.bookings(id) on delete set null,
+  member_id uuid references auth.users(id) on delete set null,
+  metadata jsonb
+);
+
+create index if not exists events_event_type_idx on public.events (event_type);
+create index if not exists events_booking_id_idx on public.events (booking_id);
+
+alter table public.events enable row level security;

--- a/tests/booking-jobs.test.ts
+++ b/tests/booking-jobs.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  processBookingNoShows,
+  processBookingReminders,
+  type BookingRepository,
+} from '@/lib/bookings'
+import type {
+  BookingCancellationPayload,
+  BookingNotificationService,
+  BookingReminderPayload,
+  WaitlistPromotionPayload,
+} from '@/lib/notifications/service'
+import type { BookingEventInput, BookingRecord, BookingWaitlistEntry } from '@/lib/bookings/types'
+
+const BASE_DATE = new Date('2024-07-10T10:00:00Z')
+
+describe('booking automation jobs', () => {
+  it('sends reminders for bookings within the reminder window and logs events', async () => {
+    const repository = new InMemoryBookingRepository({
+      bookings: [
+        createBooking({
+          id: 'booking-1',
+          startOffsetMinutes: 65,
+          memberEmail: 'alice@example.com',
+        }),
+        createBooking({
+          id: 'booking-2',
+          startOffsetMinutes: 120,
+          memberEmail: 'bob@example.com',
+        }),
+        createBooking({
+          id: 'booking-3',
+          startOffsetMinutes: 70,
+          reminder_sent_at: BASE_DATE.toISOString(),
+          memberEmail: 'carol@example.com',
+        }),
+      ],
+    })
+    const notifications = new TestNotificationService()
+
+    const result = await processBookingReminders(repository, notifications, {
+      now: BASE_DATE,
+      leadTimeMinutes: 60,
+      windowMinutes: 15,
+    })
+
+    expect(result.considered).toBe(1)
+    expect(result.remindersSent).toBe(1)
+    expect(result.errors).toHaveLength(0)
+
+    const updated = repository.findBooking('booking-1')
+    expect(updated?.reminder_sent_at).toBe(BASE_DATE.toISOString())
+    expect(notifications.reminders).toHaveLength(1)
+    expect(repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'booking.reminder_sent',
+        bookingId: 'booking-1',
+      }),
+    )
+  })
+
+  it('cancels no-show bookings, notifies waitlist, and records events', async () => {
+    const repository = new InMemoryBookingRepository({
+      bookings: [
+        createBooking({
+          id: 'booking-10',
+          startOffsetMinutes: -30,
+          memberEmail: 'dana@example.com',
+        }),
+      ],
+      waitlist: [
+        createWaitlistEntry({ id: 'wait-1', bookingId: 'booking-10', memberEmail: 'erin@example.com', position: 1 }),
+        createWaitlistEntry({ id: 'wait-2', bookingId: 'booking-10', memberEmail: 'frank@example.com', position: 2 }),
+      ],
+    })
+    const notifications = new TestNotificationService()
+
+    const result = await processBookingNoShows(repository, notifications, {
+      now: BASE_DATE,
+      gracePeriodMinutes: 15,
+    })
+
+    expect(result.considered).toBe(1)
+    expect(result.cancellations).toBe(1)
+    expect(result.waitlistNotifications).toBe(2)
+    expect(result.errors).toHaveLength(0)
+
+    const booking = repository.findBooking('booking-10')
+    expect(booking?.status).toBe('no_show_cancelled')
+    expect(booking?.cancelled_at).toBe(BASE_DATE.toISOString())
+    expect(booking?.no_show_processed_at).toBe(BASE_DATE.toISOString())
+
+    expect(repository.waitlistEntries.map((entry) => entry.notified_at)).toEqual([
+      BASE_DATE.toISOString(),
+      BASE_DATE.toISOString(),
+    ])
+
+    expect(repository.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: 'booking.no_show_cancelled', bookingId: 'booking-10' }),
+        expect.objectContaining({ eventType: 'booking.waitlist_notified', bookingId: 'booking-10' }),
+      ]),
+    )
+
+    expect(notifications.waitlistPromotions).toHaveLength(2)
+  })
+})
+
+class InMemoryBookingRepository implements BookingRepository {
+  bookings: BookingRecord[]
+  waitlistEntries: BookingWaitlistEntry[]
+  events: BookingEventInput[]
+
+  constructor(params: { bookings?: BookingRecord[]; waitlist?: BookingWaitlistEntry[] } = {}) {
+    this.bookings = params.bookings ?? []
+    this.waitlistEntries = params.waitlist ?? []
+    this.events = []
+  }
+
+  findBooking(id: string) {
+    return this.bookings.find((booking) => booking.id === id)
+  }
+
+  async findBookingsNeedingReminder(startWindow: Date, endWindow: Date) {
+    return this.bookings.filter((booking) => {
+      if (booking.status !== 'confirmed' || booking.reminder_sent_at) {
+        return false
+      }
+
+      const startTime = new Date(booking.start_time).getTime()
+      return startTime >= startWindow.getTime() && startTime < endWindow.getTime()
+    })
+  }
+
+  async markReminderSent(bookingId: string, timestamp: Date) {
+    const booking = this.findBooking(bookingId)
+    if (booking) {
+      booking.reminder_sent_at = timestamp.toISOString()
+      booking.updated_at = timestamp.toISOString()
+    }
+  }
+
+  async logEvent(event: BookingEventInput) {
+    this.events.push(event)
+  }
+
+  async findBookingsNeedingNoShowProcessing(cutoff: Date) {
+    return this.bookings.filter((booking) => {
+      if (booking.status !== 'confirmed' || booking.check_in_at || booking.no_show_processed_at) {
+        return false
+      }
+
+      const startTime = new Date(booking.start_time).getTime()
+      return startTime <= cutoff.getTime()
+    })
+  }
+
+  async cancelBookingForNoShow(bookingId: string, timestamp: Date) {
+    const booking = this.findBooking(bookingId)
+    if (booking) {
+      const iso = timestamp.toISOString()
+      booking.status = 'no_show_cancelled'
+      booking.cancelled_at = iso
+      booking.no_show_processed_at = iso
+      booking.updated_at = iso
+    }
+  }
+
+  async listWaitlistForBooking(bookingId: string) {
+    return this.waitlistEntries
+      .filter((entry) => entry.booking_id === bookingId)
+      .sort((a, b) => a.position - b.position || a.created_at.localeCompare(b.created_at))
+  }
+
+  async markWaitlistEntryNotified(entryId: string, timestamp: Date) {
+    const entry = this.waitlistEntries.find((item) => item.id === entryId)
+    if (entry) {
+      entry.notified_at = timestamp.toISOString()
+    }
+  }
+
+  async getBookingById(bookingId: string) {
+    return this.findBooking(bookingId) ?? null
+  }
+
+  async markCheckedIn(bookingId: string, timestamp: Date) {
+    const booking = this.findBooking(bookingId)
+    if (booking) {
+      const iso = timestamp.toISOString()
+      booking.status = 'checked_in'
+      booking.check_in_at = iso
+      booking.updated_at = iso
+    }
+  }
+}
+
+class TestNotificationService implements BookingNotificationService {
+  reminders: BookingReminderPayload[] = []
+  cancellations: BookingCancellationPayload[] = []
+  waitlistPromotions: WaitlistPromotionPayload[] = []
+
+  async sendReminder(payload: BookingReminderPayload) {
+    this.reminders.push(payload)
+  }
+
+  async sendNoShowCancellation(payload: BookingCancellationPayload) {
+    this.cancellations.push(payload)
+  }
+
+  async sendWaitlistPromotion(payload: WaitlistPromotionPayload) {
+    this.waitlistPromotions.push(payload)
+  }
+}
+
+function createBooking(options: {
+  id: string
+  startOffsetMinutes: number
+  memberEmail: string
+  reminder_sent_at?: string | null
+}): BookingRecord {
+  const start = new Date(BASE_DATE.getTime() + options.startOffsetMinutes * 60_000)
+  return {
+    id: options.id,
+    amenity_id: null,
+    amenity_name: 'Test amenity',
+    cancelled_at: null,
+    check_in_at: null,
+    created_at: BASE_DATE.toISOString(),
+    end_time: new Date(start.getTime() + 60 * 60_000).toISOString(),
+    member_email: options.memberEmail,
+    member_id: `${options.id}-member`,
+    member_name: 'Test Member',
+    no_show_processed_at: null,
+    reminder_sent_at: options.reminder_sent_at ?? null,
+    start_time: start.toISOString(),
+    status: 'confirmed',
+    updated_at: BASE_DATE.toISOString(),
+    waitlist_notified_at: null,
+  }
+}
+
+function createWaitlistEntry(options: {
+  id: string
+  bookingId: string
+  memberEmail: string
+  position: number
+}): BookingWaitlistEntry {
+  return {
+    id: options.id,
+    booking_id: options.bookingId,
+    member_id: `${options.id}-member`,
+    member_email: options.memberEmail,
+    member_name: 'Waitlist Member',
+    position: options.position,
+    notified_at: null,
+    created_at: BASE_DATE.toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary
- add database tables and type definitions for bookings, waitlists, and event logging to support automation
- implement booking automation jobs, cron entry point, and notification service to email reminders and process no-shows
- expose an authenticated check-in API that records attendance events and prevent double notifications

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0db97a4832890424c5a7547b1c9