### PR TITLE
Add visitor request workflow for tenants and admins

### DIFF
--- a/app/(tenant)/visitors/[id]/page.tsx
+++ b/app/(tenant)/visitors/[id]/page.tsx
@@ -1,0 +1,127 @@
+import Link from 'next/link'
+import { cookies } from 'next/headers'
+import { notFound, redirect } from 'next/navigation'
+import { ChevronLeft } from 'lucide-react'
+
+import { VisitorRequestStatusBadge } from '@/components/visitor-request-status-badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { formatPgDateRange } from '@/lib/date-range'
+import { formatDate } from '@/lib/utils'
+import { createClient } from '@/utils/supa-server-actions'
+
+export default async function VisitorRequestDetailPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const requestId = Number(params.id)
+
+  if (Number.isNaN(requestId)) {
+    notFound()
+  }
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    redirect('/auth')
+  }
+
+  const { data: request, error: requestError } = await supabase
+    .from('visitor_requests')
+    .select('id, guest_name, date_range, reason, status, created_at, updated_at, approved_by, member_id')
+    .eq('id', requestId)
+    .maybeSingle()
+
+  if (requestError) {
+    console.error('Failed to load visitor request', requestError)
+  }
+
+  if (!request) {
+    notFound()
+  }
+
+  if (request.member_id !== user.id) {
+    // RLS should prevent this, but guard on the server just in case.
+    notFound()
+  }
+
+  let approvedByName: string | null = null
+
+  const statusLabel =
+    request.status.charAt(0).toUpperCase() + request.status.slice(1)
+
+  if (request.approved_by) {
+    const { data: approverProfile } = await supabase
+      .from('profiles')
+      .select('full_name, email')
+      .eq('id', request.approved_by)
+      .maybeSingle()
+
+    approvedByName = approverProfile?.full_name ?? approverProfile?.email ?? null
+  }
+
+  return (
+    <section className="container mx-auto flex max-w-3xl flex-col gap-6 py-10">
+      <Link
+        href="/visitors"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" aria-hidden />
+        Back to visitor requests
+      </Link>
+
+      <Card>
+        <CardHeader className="space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="text-2xl font-semibold">{request.guest_name}</CardTitle>
+              <CardDescription>{formatPgDateRange(request.date_range)}</CardDescription>
+            </div>
+            <VisitorRequestStatusBadge status={request.status} />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Submitted {formatDate(request.created_at)} · Last updated {formatDate(request.updated_at ?? request.created_at)}
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Reason for visit
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-foreground">{request.reason}</p>
+          </div>
+          <div className="grid gap-3 rounded-md border border-dashed border-muted-foreground/30 px-4 py-3 text-sm text-muted-foreground">
+            <div className="flex items-center justify-between gap-4">
+              <span>Stay window</span>
+              <span className="font-medium text-foreground">{formatPgDateRange(request.date_range)}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span>Status</span>
+              <span className="font-medium text-foreground">{statusLabel}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span>Approval</span>
+              <span className="font-medium text-foreground">
+                {request.status === 'pending'
+                  ? 'Awaiting review'
+                  : approvedByName ?? 'Approved internally'}
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/app/(tenant)/visitors/new/actions.ts
+++ b/app/(tenant)/visitors/new/actions.ts
@@ -1,0 +1,112 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+import { z } from 'zod'
+
+import { buildPgDateRange } from '@/lib/date-range'
+import type { Database } from '@/lib/supabase'
+import { createClient } from '@/utils/supa-server-actions'
+
+export type VisitorRequestActionState = {
+  success: boolean
+  message: string | null
+  errors: Record<string, string[]>
+}
+
+const formSchema = z.object({
+  guestName: z.string().trim().min(2, { message: 'Guest name is required.' }),
+  startDate: z.coerce.date({ invalid_type_error: 'Select a valid start date.' }),
+  endDate: z.coerce.date({ invalid_type_error: 'Select a valid end date.' }),
+  reason: z.string().trim().min(5, {
+    message: 'Share a short note explaining the visit (at least 5 characters).',
+  }),
+})
+
+function normalizeFieldErrors(errors: z.typeToFlattenedError<z.infer<typeof formSchema>>['fieldErrors']) {
+  const result: Record<string, string[]> = {}
+  for (const [key, value] of Object.entries(errors)) {
+    if (value && value.length > 0) {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+export async function submitVisitorRequest(
+  _prevState: VisitorRequestActionState,
+  formData: FormData
+): Promise<VisitorRequestActionState> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return {
+      success: false,
+      message: 'You must be signed in to submit a visitor request.',
+      errors: { general: ['Please log in to continue.'] },
+    }
+  }
+
+  const parsed = formSchema.safeParse({
+    guestName: formData.get('guestName'),
+    startDate: formData.get('startDate'),
+    endDate: formData.get('endDate'),
+    reason: formData.get('reason'),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Please double-check the highlighted fields.',
+      errors: normalizeFieldErrors(parsed.error.flatten().fieldErrors),
+    }
+  }
+
+  const { guestName, startDate, endDate, reason } = parsed.data
+
+  if (endDate < startDate) {
+    return {
+      success: false,
+      message: 'End date must be after the start date.',
+      errors: {
+        endDate: ['End date must come after the start date.'],
+      },
+    }
+  }
+
+  const dateRange = buildPgDateRange(startDate, endDate)
+
+  const { error } = await supabase
+    .from('visitor_requests' satisfies keyof Database['public']['Tables'])
+    .insert({
+      member_id: user.id,
+      guest_name: guestName,
+      date_range: dateRange,
+      reason,
+      status: 'pending',
+    })
+
+  if (error) {
+    console.error('Failed to submit visitor request', error)
+    return {
+      success: false,
+      message: 'Something went wrong while saving your request.',
+      errors: { general: ['Please try again or contact support.'] },
+    }
+  }
+
+  revalidatePath('/visitors')
+  revalidatePath('/dashboard/visitors')
+
+  return {
+    success: true,
+    message: 'Visitor request submitted for review.',
+    errors: {},
+  }
+}

--- a/app/(tenant)/visitors/new/page.tsx
+++ b/app/(tenant)/visitors/new/page.tsx
@@ -1,0 +1,61 @@
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { VisitorRequestForm } from '@/components/visitor-request-form'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { createClient } from '@/utils/supa-server-actions'
+
+export default async function NewVisitorRequestPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    redirect('/auth')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('full_name')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  const displayName = profile?.full_name ?? user.email ?? 'Roommate'
+
+  return (
+    <section className="container mx-auto flex max-w-3xl flex-col gap-6 py-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Register an overnight visitor</h1>
+        <p className="text-muted-foreground">
+          Log your guest&apos;s stay so your roommates and property manager stay in the loop.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Visitor details</CardTitle>
+          <CardDescription>
+            Submissions notify your roommates and property manager for review and approval.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="rounded-md bg-muted/50 px-4 py-3 text-sm text-muted-foreground">
+            Submitting as{' '}
+            <span className="font-medium text-foreground">{displayName}</span>
+          </div>
+          <VisitorRequestForm />
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/app/(tenant)/visitors/page.tsx
+++ b/app/(tenant)/visitors/page.tsx
@@ -1,0 +1,103 @@
+import Link from 'next/link'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { ChevronRight } from 'lucide-react'
+
+import { VisitorRequestStatusBadge } from '@/components/visitor-request-status-badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { formatPgDateRange } from '@/lib/date-range'
+import { formatDate } from '@/lib/utils'
+import { createClient } from '@/utils/supa-server-actions'
+
+export default async function VisitorRequestsPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    redirect('/auth')
+  }
+
+  const { data: requests, error: requestsError } = await supabase
+    .from('visitor_requests')
+    .select('id, guest_name, date_range, status, reason, updated_at, created_at, approved_by')
+    .eq('member_id', user.id)
+    .order('created_at', { ascending: false })
+
+  return (
+    <section className="container mx-auto flex max-w-4xl flex-col gap-6 py-10">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">Visitor requests</h1>
+          <p className="text-muted-foreground">
+            Track upcoming stays and keep everyone aligned on overnight guests.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/visitors/new">New request</Link>
+        </Button>
+      </div>
+
+      {requestsError ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Unable to load requests</CardTitle>
+            <CardDescription>
+              Something went wrong while fetching your visitor log. Please refresh the page and try again.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+
+      {!requestsError && (!requests || requests.length === 0) ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No visitor requests yet</CardTitle>
+            <CardDescription>
+              Submit a visitor to share arrival and departure dates with your roommates.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+
+      {!requestsError && requests && requests.length > 0 ? (
+        <div className="space-y-4">
+          {requests.map((request) => (
+            <Link key={request.id} href={`/visitors/${request.id}`} className="block">
+              <Card className="transition hover:border-primary/20 hover:shadow-md">
+                <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <CardTitle className="text-xl font-semibold">{request.guest_name}</CardTitle>
+                    <CardDescription>{formatPgDateRange(request.date_range)}</CardDescription>
+                  </div>
+                  <VisitorRequestStatusBadge status={request.status} />
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <p className="line-clamp-2 text-sm text-muted-foreground">{request.reason}</p>
+                  <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span>Updated {formatDate(request.updated_at ?? request.created_at)}</span>
+                    <span className="inline-flex items-center font-medium text-primary">
+                      View details
+                      <ChevronRight className="ml-1 size-4" aria-hidden />
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/app/dashboard/(dashboard)/visitors/[id]/page.tsx
+++ b/app/dashboard/(dashboard)/visitors/[id]/page.tsx
@@ -1,0 +1,145 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ChevronLeft } from 'lucide-react'
+
+import { VisitorRequestStatusBadge } from '@/components/visitor-request-status-badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { formatPgDateRange } from '@/lib/date-range'
+import { formatDate } from '@/lib/utils'
+import { createSupbaseServerClient } from '@/utils/supaone'
+
+type ProfileSummary = {
+  id: string
+  full_name: string | null
+  email: string | null
+}
+
+export default async function AdminVisitorRequestDetailPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const requestId = Number(params.id)
+
+  if (Number.isNaN(requestId)) {
+    notFound()
+  }
+
+  const supabase = await createSupbaseServerClient()
+
+  const { data: request, error } = await supabase
+    .from('visitor_requests')
+    .select('id, guest_name, member_id, approved_by, date_range, status, reason, created_at, updated_at')
+    .eq('id', requestId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('Failed to load visitor request', error)
+  }
+
+  if (!request) {
+    notFound()
+  }
+
+  const profileIds = [request.member_id, request.approved_by].filter(Boolean) as string[]
+  let profileMap = new Map<string, ProfileSummary>()
+
+  if (profileIds.length > 0) {
+    const { data: profiles, error: profileError } = await supabase
+      .from('profiles')
+      .select('id, full_name, email')
+      .in('id', profileIds)
+
+    if (profileError) {
+      console.error('Failed to load visitor request profiles', profileError)
+    }
+
+    if (profiles) {
+      profileMap = new Map(profiles.map((profile) => [profile.id, profile]))
+    }
+  }
+
+  const hostProfile = profileMap.get(request.member_id)
+  const approverProfile = request.approved_by
+    ? profileMap.get(request.approved_by)
+    : undefined
+
+  const hostLabel =
+    hostProfile?.full_name ?? hostProfile?.email ?? request.member_id
+
+  const approverLabel = approverProfile?.full_name ?? approverProfile?.email ?? null
+
+  const statusLabel =
+    request.status.charAt(0).toUpperCase() + request.status.slice(1)
+
+  return (
+    <section className="space-y-6">
+      <Link
+        href="/dashboard/visitors"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" aria-hidden />
+        Back to visitor requests
+      </Link>
+
+      <Card>
+        <CardHeader className="space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="text-2xl font-semibold">{request.guest_name}</CardTitle>
+              <CardDescription>{formatPgDateRange(request.date_range)}</CardDescription>
+            </div>
+            <VisitorRequestStatusBadge status={request.status} />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Submitted {formatDate(request.created_at)} · Last updated {formatDate(request.updated_at ?? request.created_at)}
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-3 rounded-md border border-dashed border-muted-foreground/30 px-4 py-3 text-sm text-muted-foreground">
+            <div className="flex items-center justify-between gap-4">
+              <span>Host roommate</span>
+              <span className="font-medium text-foreground">{hostLabel}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span>Status</span>
+              <span className="font-medium text-foreground">{statusLabel}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span>Decision owner</span>
+              <span className="font-medium text-foreground">{approverLabel ?? '—'}</span>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Reason for visit
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-foreground">{request.reason}</p>
+          </div>
+
+          <div className="grid gap-3 rounded-md border border-muted-foreground/30 px-4 py-3 text-sm text-muted-foreground sm:grid-cols-2">
+            <div className="flex items-center justify-between gap-4">
+              <span>Arrival - Departure</span>
+              <span className="font-medium text-foreground">{formatPgDateRange(request.date_range)}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span>Submitted</span>
+              <span className="font-medium text-foreground">{formatDate(request.created_at)}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span>Last touch</span>
+              <span className="font-medium text-foreground">{formatDate(request.updated_at ?? request.created_at)}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/app/dashboard/(dashboard)/visitors/page.tsx
+++ b/app/dashboard/(dashboard)/visitors/page.tsx
@@ -1,0 +1,142 @@
+import Link from 'next/link'
+import { ChevronRight } from 'lucide-react'
+
+import { VisitorRequestStatusBadge } from '@/components/visitor-request-status-badge'
+import Table from '@/components/ui/Table'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { formatPgDateRange } from '@/lib/date-range'
+import { formatDate } from '@/lib/utils'
+import { createSupbaseServerClient } from '@/utils/supaone'
+
+type ProfileSummary = {
+  id: string
+  full_name: string | null
+  email: string | null
+}
+
+export default async function AdminVisitorRequestsPage() {
+  const supabase = await createSupbaseServerClient()
+
+  const { data: requests, error } = await supabase
+    .from('visitor_requests')
+    .select('id, guest_name, member_id, approved_by, date_range, status, updated_at, created_at, reason')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Failed to load visitor requests', error)
+  }
+
+  const relevantIds = new Set<string>()
+  requests?.forEach((request) => {
+    relevantIds.add(request.member_id)
+    if (request.approved_by) {
+      relevantIds.add(request.approved_by)
+    }
+  })
+
+  let profileMap = new Map<string, ProfileSummary>()
+
+  if (relevantIds.size > 0) {
+    const { data: profiles, error: profilesError } = await supabase
+      .from('profiles')
+      .select('id, full_name, email')
+      .in('id', Array.from(relevantIds))
+
+    if (profilesError) {
+      console.error('Failed to load profiles for visitor requests', profilesError)
+    }
+
+    if (profiles) {
+      profileMap = new Map(profiles.map((profile) => [profile.id, profile]))
+    }
+  }
+
+  const tableHeaders = ['Guest', 'Host', 'Stay', 'Status', 'Last update']
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">Visitor requests</h1>
+          <p className="text-muted-foreground">
+            Monitor overnight guest submissions across the property and follow up on pending approvals.
+          </p>
+        </div>
+        <Badge variant="outline" className="w-fit">
+          {requests?.length ?? 0} total
+        </Badge>
+      </div>
+
+      {error ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Unable to load visitor requests</CardTitle>
+            <CardDescription>
+              There was a problem retrieving the latest submissions. Refresh the page or try again later.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+
+      {!error && (!requests || requests.length === 0) ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No visitor activity yet</CardTitle>
+            <CardDescription>
+              New roommate submissions will appear here as they register overnight guests.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+
+      {!error && requests && requests.length > 0 ? (
+        <Table headers={tableHeaders}>
+          <div className="mx-2 divide-y rounded-sm bg-white dark:bg-inherit">
+            {requests.map((request) => {
+              const hostProfile = profileMap.get(request.member_id)
+              const approverProfile = request.approved_by
+                ? profileMap.get(request.approved_by)
+                : undefined
+
+              const hostLabel =
+                hostProfile?.full_name ?? hostProfile?.email ?? request.member_id
+
+              const approverLabel = approverProfile?.full_name ?? approverProfile?.email
+
+              return (
+                <Link
+                  key={request.id}
+                  href={`/dashboard/visitors/${request.id}`}
+                  className="grid grid-cols-5 items-center gap-3 p-3 transition hover:bg-muted/60"
+                >
+                  <div className="truncate text-sm font-medium text-foreground">
+                    {request.guest_name}
+                  </div>
+                  <div className="truncate text-sm text-muted-foreground">
+                    {hostLabel}
+                  </div>
+                  <div className="truncate text-sm text-muted-foreground">
+                    {formatPgDateRange(request.date_range)}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <VisitorRequestStatusBadge status={request.status} />
+                    {approverLabel ? (
+                      <span className="hidden text-xs text-muted-foreground xl:inline">
+                        by {approverLabel}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span>{formatDate(request.updated_at ?? request.created_at)}</span>
+                    <ChevronRight className="size-4" aria-hidden />
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        </Table>
+      ) : null}
+    </section>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, CalendarIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -9,16 +9,21 @@ export default function NavLinks() {
 	const pathname = usePathname();
 
 	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/visitors",
+                        text: "Visitors",
+                        Icon: CalendarIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
 	];
 
 	return (

--- a/components/visitor-request-form.tsx
+++ b/components/visitor-request-form.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useFormState, useFormStatus } from 'react-dom'
+
+import { submitVisitorRequest, type VisitorRequestActionState } from '@/app/(tenant)/visitors/new/actions'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+
+const initialState: VisitorRequestActionState = {
+  success: false,
+  message: null,
+  errors: {},
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" disabled={pending} className="w-full sm:w-auto">
+      {pending ? 'Submitting…' : 'Submit request'}
+    </Button>
+  )
+}
+
+export function VisitorRequestForm() {
+  const [state, formAction] = useFormState(submitVisitorRequest, initialState)
+  const [startDate, setStartDate] = useState('')
+  const formRef = useRef<HTMLFormElement>(null)
+
+  useEffect(() => {
+    if (state.success) {
+      setStartDate('')
+      formRef.current?.reset()
+    }
+  }, [state.success])
+
+  const generalErrors = state.errors?.general ?? []
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-6">
+      {state.message ? (
+        <div
+          role="status"
+          className={cn(
+            'rounded-md border px-3 py-2 text-sm',
+            state.success
+              ? 'border-emerald-500/60 bg-emerald-50 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100'
+              : 'border-destructive/60 bg-destructive/10 text-destructive'
+          )}
+        >
+          {state.message}
+        </div>
+      ) : null}
+
+      {generalErrors.length > 0 ? (
+        <ul className="list-inside list-disc space-y-1 text-sm text-destructive">
+          {generalErrors.map((error, index) => (
+            <li key={index}>{error}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="space-y-2">
+        <Label htmlFor="guestName">Guest name</Label>
+        <Input
+          id="guestName"
+          name="guestName"
+          placeholder="Who is staying over?"
+          required
+          aria-invalid={state.errors?.guestName ? 'true' : 'false'}
+        />
+        {state.errors?.guestName?.map((error, index) => (
+          <p key={index} className="text-sm text-destructive">
+            {error}
+          </p>
+        ))}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="startDate">Arrival date</Label>
+          <Input
+            id="startDate"
+            name="startDate"
+            type="date"
+            required
+            onChange={(event) => setStartDate(event.target.value)}
+            aria-invalid={state.errors?.startDate ? 'true' : 'false'}
+          />
+          {state.errors?.startDate?.map((error, index) => (
+            <p key={index} className="text-sm text-destructive">
+              {error}
+            </p>
+          ))}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="endDate">Departure date</Label>
+          <Input
+            id="endDate"
+            name="endDate"
+            type="date"
+            required
+            min={startDate || undefined}
+            aria-invalid={state.errors?.endDate ? 'true' : 'false'}
+          />
+          {state.errors?.endDate?.map((error, index) => (
+            <p key={index} className="text-sm text-destructive">
+              {error}
+            </p>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="reason">Reason for visit</Label>
+        <Textarea
+          id="reason"
+          name="reason"
+          placeholder="Let your roommates know the context and any house needs."
+          required
+          rows={4}
+          aria-invalid={state.errors?.reason ? 'true' : 'false'}
+        />
+        {state.errors?.reason?.map((error, index) => (
+          <p key={index} className="text-sm text-destructive">
+            {error}
+          </p>
+        ))}
+      </div>
+
+      <SubmitButton />
+    </form>
+  )
+}

--- a/components/visitor-request-status-badge.tsx
+++ b/components/visitor-request-status-badge.tsx
@@ -1,0 +1,33 @@
+import { Badge, type BadgeProps } from '@/components/ui/badge'
+
+const STATUS_VARIANTS: Record<string, BadgeProps['variant']> = {
+  pending: 'outline',
+  approved: 'complete',
+  denied: 'destructive',
+}
+
+function toTitleCase(value: string): string {
+  if (!value) return ''
+  return value
+    .split(/[_\s]+/)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+}
+
+export function VisitorRequestStatusBadge({
+  status,
+  className,
+}: {
+  status: string
+  className?: string
+}) {
+  const normalized = status?.toLowerCase() ?? ''
+  const variant = STATUS_VARIANTS[normalized] ?? 'secondary'
+  const label = normalized ? toTitleCase(normalized) : 'Unknown'
+
+  return (
+    <Badge variant={variant} className={className}>
+      {label}
+    </Badge>
+  )
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -22,6 +22,10 @@ export const siteConfig = {
       href: "/bookings",
     },
     {
+      title: "Visitors",
+      href: "/visitors",
+    },
+    {
       title: "Documents",
       href: "/documents",
     },

--- a/lib/date-range.ts
+++ b/lib/date-range.ts
@@ -1,0 +1,51 @@
+import { format } from 'date-fns'
+
+export type ParsedDateRange = {
+  start: Date | null
+  end: Date | null
+}
+
+export function parsePgDateRange(range: string | null): ParsedDateRange {
+  if (!range) {
+    return { start: null, end: null }
+  }
+
+  const trimmed = range.trim()
+  if (trimmed.toLowerCase() === 'empty') {
+    return { start: null, end: null }
+  }
+
+  const normalized = trimmed.replace(/[\[\]\(\)]/g, '')
+  const [startValue, endValue] = normalized.split(',')
+
+  const start = startValue ? new Date(startValue.trim()) : null
+  const end = endValue ? new Date(endValue.trim()) : null
+
+  return { start, end }
+}
+
+export function formatPgDateRange(
+  range: string | null,
+  fallback = '—',
+  dateFormat = 'MMM d, yyyy'
+): string {
+  const { start, end } = parsePgDateRange(range)
+
+  if (!start && !end) {
+    return fallback
+  }
+
+  if (start && end) {
+    return `${format(start, dateFormat)} – ${format(end, dateFormat)}`
+  }
+
+  const singleDate = start ?? end
+  return singleDate ? format(singleDate, dateFormat) : fallback
+}
+
+export function buildPgDateRange(start: Date, end: Date): string {
+  const startString = format(start, 'yyyy-MM-dd')
+  const endString = format(end, 'yyyy-MM-dd')
+
+  return `[${startString},${endString}]`
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1226,6 +1226,42 @@ export type Database = {
         }
         Relationships: []
       }
+      visitor_requests: {
+        Row: {
+          approved_by: string | null
+          created_at: string
+          date_range: string
+          guest_name: string
+          id: number
+          member_id: string
+          reason: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          approved_by?: string | null
+          created_at?: string
+          date_range: string
+          guest_name: string
+          id?: number
+          member_id: string
+          reason: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          approved_by?: string | null
+          created_at?: string
+          date_range?: string
+          guest_name?: string
+          id?: number
+          member_id?: string
+          reason?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           avatar_url: string | null

--- a/supabase/migrations/20250505_add_visitor_requests.sql
+++ b/supabase/migrations/20250505_add_visitor_requests.sql
@@ -1,0 +1,87 @@
+CREATE TABLE public.visitor_requests (
+  id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  member_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  guest_name text NOT NULL,
+  date_range daterange NOT NULL,
+  reason text NOT NULL,
+  approved_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  status text NOT NULL DEFAULT 'pending',
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT visitor_requests_status_check CHECK (status = ANY (ARRAY['pending'::text, 'approved'::text, 'denied'::text]))
+);
+
+CREATE INDEX visitor_requests_member_id_idx ON public.visitor_requests (member_id);
+CREATE INDEX visitor_requests_status_idx ON public.visitor_requests (status);
+
+ALTER TABLE public.visitor_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Roommates and admins can view visitor requests"
+  ON public.visitor_requests
+  FOR SELECT
+  TO authenticated
+  USING (
+    member_id = auth.uid()
+    OR approved_by = auth.uid()
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('admin', 'property_manager')
+    )
+  );
+
+CREATE POLICY "Roommates can register visitor requests"
+  ON public.visitor_requests
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (member_id = auth.uid());
+
+CREATE POLICY "Roommates and admins can update visitor requests"
+  ON public.visitor_requests
+  FOR UPDATE
+  TO authenticated
+  USING (
+    member_id = auth.uid()
+    OR approved_by = auth.uid()
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('admin', 'property_manager')
+    )
+  )
+  WITH CHECK (
+    member_id = auth.uid()
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('admin', 'property_manager')
+    )
+  );
+
+CREATE POLICY "Roommates can remove their visitor requests"
+  ON public.visitor_requests
+  FOR DELETE
+  TO authenticated
+  USING (
+    member_id = auth.uid()
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('admin', 'property_manager')
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.set_visitor_requests_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER visitor_requests_set_updated_at
+BEFORE UPDATE ON public.visitor_requests
+FOR EACH ROW
+EXECUTE FUNCTION public.set_visitor_requests_updated_at();


### PR DESCRIPTION
## Summary
- add a Supabase migration for the new `visitor_requests` table with indexes, RLS policies, and timestamp trigger
- build tenant-facing visitor submission flow with server actions, reusable status badge, and list/detail pages
- introduce admin visitor monitoring views, shared date-range helpers, and navigation links to the new workflow

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0dc69488328a6820ceb00356ea8