### PR TITLE
Integrate Cal.com bookings into visitor request workflow

### DIFF
--- a/app/api/visitor-requests/[id]/approve/route.ts
+++ b/app/api/visitor-requests/[id]/approve/route.ts
@@ -1,0 +1,22 @@
+import { approveVisitorRequest } from '@/lib/visitor-requests'
+import { createClient } from '@/utils/supabase/server'
+
+interface RouteParams {
+  params: { id: string }
+}
+
+export async function POST(_request: Request, { params }: RouteParams) {
+  if (!params?.id) {
+    return Response.json({ error: 'Visitor request id is required.' }, { status: 400 })
+  }
+
+  const supabase = createClient()
+
+  try {
+    const { bookingId } = await approveVisitorRequest(supabase, params.id)
+    return Response.json({ bookingId })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error approving visitor request.'
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/visitor-requests/[id]/revoke/route.ts
+++ b/app/api/visitor-requests/[id]/revoke/route.ts
@@ -1,0 +1,22 @@
+import { revokeVisitorRequest } from '@/lib/visitor-requests'
+import { createClient } from '@/utils/supabase/server'
+
+interface RouteParams {
+  params: { id: string }
+}
+
+export async function POST(_request: Request, { params }: RouteParams) {
+  if (!params?.id) {
+    return Response.json({ error: 'Visitor request id is required.' }, { status: 400 })
+  }
+
+  const supabase = createClient()
+
+  try {
+    const { cancelledBookingId } = await revokeVisitorRequest(supabase, params.id)
+    return Response.json({ cancelledBookingId: cancelledBookingId ?? null })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error revoking visitor request.'
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/lib/calcom.ts
+++ b/lib/calcom.ts
@@ -1,0 +1,119 @@
+const DEFAULT_CALCOM_BASE_URL = "https://api.cal.com/v1"
+
+const trimTrailingSlash = (input: string) => input.replace(/\/+$/, "")
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+export interface CalcomAttendee {
+  email: string
+  name?: string
+  timeZone?: string
+}
+
+export interface CreateCalcomBookingPayload {
+  eventTypeId: number
+  start: string
+  end: string
+  title?: string
+  attendees?: CalcomAttendee[]
+  notes?: string | null
+  metadata?: Record<string, unknown>
+}
+
+export interface CalcomBookingResponse {
+  id: string
+  [key: string]: unknown
+}
+
+const ensureCalcomConfig = () => {
+  const apiKey = process.env.CALCOM_API_KEY
+
+  if (!apiKey) {
+    throw new Error("Cal.com API key (CALCOM_API_KEY) is not configured")
+  }
+
+  const baseUrl = trimTrailingSlash(process.env.CALCOM_BASE_URL ?? DEFAULT_CALCOM_BASE_URL)
+
+  return { apiKey, baseUrl }
+}
+
+const resolveFetch = (fetchImpl?: FetchLike) => fetchImpl ?? fetch
+
+export async function createCalcomBooking(
+  payload: CreateCalcomBookingPayload,
+  fetchImpl?: FetchLike,
+): Promise<CalcomBookingResponse> {
+  const { apiKey, baseUrl } = ensureCalcomConfig()
+  const fetchFn = resolveFetch(fetchImpl)
+
+  const response = await fetchFn(`${baseUrl}/bookings`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      eventTypeId: payload.eventTypeId,
+      start: payload.start,
+      end: payload.end,
+      title: payload.title,
+      attendees: payload.attendees?.length ? payload.attendees : undefined,
+      notes: payload.notes ?? undefined,
+      metadata: payload.metadata,
+    }),
+  })
+
+  if (!response.ok) {
+    const errorBody = await safeReadText(response)
+    throw new Error(`Failed to create Cal.com booking: ${response.status} ${errorBody}`)
+  }
+
+  const json = await safeReadJson(response)
+  const booking = (json?.booking as CalcomBookingResponse | undefined) ?? (json as CalcomBookingResponse | undefined)
+
+  if (!booking?.id) {
+    throw new Error("Cal.com booking response did not include an id")
+  }
+
+  return booking
+}
+
+export async function cancelCalcomBooking(
+  bookingId: string,
+  fetchImpl?: FetchLike,
+): Promise<void> {
+  const { apiKey, baseUrl } = ensureCalcomConfig()
+  const fetchFn = resolveFetch(fetchImpl)
+
+  const response = await fetchFn(`${baseUrl}/bookings/${bookingId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorBody = await safeReadText(response)
+    throw new Error(`Failed to cancel Cal.com booking: ${response.status} ${errorBody}`)
+  }
+}
+
+async function safeReadJson(response: Response) {
+  try {
+    return await response.clone().json()
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to parse Cal.com response JSON: ${error.message}`)
+    }
+
+    throw new Error("Failed to parse Cal.com response JSON")
+  }
+}
+
+async function safeReadText(response: Response) {
+  try {
+    return await response.clone().text()
+  } catch (error) {
+    return ""
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1596,6 +1596,51 @@ export type Database = {
           },
         ]
       }
+      visitor_requests: {
+        Row: {
+          calcom_booking_id: string | null
+          calcom_event_type_id: number
+          created_at: string
+          ends_at: string
+          guest_email: string | null
+          guest_name: string
+          host_email: string
+          id: string
+          notes: string | null
+          starts_at: string
+          status: "pending" | "approved" | "revoked"
+          updated_at: string | null
+        }
+        Insert: {
+          calcom_booking_id?: string | null
+          calcom_event_type_id: number
+          created_at?: string
+          ends_at: string
+          guest_email?: string | null
+          guest_name: string
+          host_email: string
+          id?: string
+          notes?: string | null
+          starts_at: string
+          status?: "pending" | "approved" | "revoked"
+          updated_at?: string | null
+        }
+        Update: {
+          calcom_booking_id?: string | null
+          calcom_event_type_id?: number
+          created_at?: string
+          ends_at?: string
+          guest_email?: string | null
+          guest_name?: string
+          host_email?: string
+          id?: string
+          notes?: string | null
+          starts_at?: string
+          status?: "pending" | "approved" | "revoked"
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
     }
     Views: {
       package_utilization: {

--- a/lib/visitor-requests.ts
+++ b/lib/visitor-requests.ts
@@ -1,0 +1,154 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { cancelCalcomBooking, createCalcomBooking } from '@/lib/calcom'
+import type { Database } from '@/lib/supabase'
+
+type SupabaseDatabase = SupabaseClient<Database>
+
+type VisitorRequestsTable = Database['public']['Tables']['visitor_requests']
+
+type VisitorRequestRow = VisitorRequestsTable['Row']
+
+type VisitorRequestStatus = VisitorRequestRow['status']
+
+const APPROVED_STATUS: VisitorRequestStatus = 'approved'
+const REVOKED_STATUS: VisitorRequestStatus = 'revoked'
+
+interface BaseOptions {
+  fetchImpl?: typeof fetch
+  now?: () => Date
+}
+
+export interface ApproveVisitorRequestResult {
+  bookingId: string
+}
+
+export interface RevokeVisitorRequestResult {
+  cancelledBookingId?: string
+}
+
+const defaultNow = () => new Date()
+
+const fetchVisitorRequest = async (supabase: SupabaseDatabase, id: string) => {
+  const { data, error } = await supabase
+    .from('visitor_requests')
+    .select(
+      'id, status, guest_name, guest_email, host_email, starts_at, ends_at, calcom_event_type_id, calcom_booking_id, notes, updated_at',
+    )
+    .eq('id', id)
+    .single()
+
+  if (error) {
+    throw new Error(`Failed to load visitor request ${id}: ${error.message}`)
+  }
+
+  if (!data) {
+    throw new Error(`Visitor request ${id} was not found`)
+  }
+
+  return data
+}
+
+const ensureEventSchedulingFields = (request: VisitorRequestRow) => {
+  if (!request.calcom_event_type_id) {
+    throw new Error('Visitor request is missing a Cal.com event type id')
+  }
+
+  if (!request.starts_at || !request.ends_at) {
+    throw new Error('Visitor request is missing scheduling information')
+  }
+
+  return request
+}
+
+const buildAttendees = (request: VisitorRequestRow) => {
+  const attendees = [] as { email: string; name?: string }[]
+
+  if (request.host_email) {
+    attendees.push({ email: request.host_email, name: 'Host resident' })
+  }
+
+  if (request.guest_email) {
+    attendees.push({ email: request.guest_email, name: request.guest_name })
+  }
+
+  return attendees
+}
+
+const updateVisitorRequest = async (
+  supabase: SupabaseDatabase,
+  id: string,
+  patch: VisitorRequestsTable['Update'],
+) => {
+  const { error } = await supabase.from('visitor_requests').update(patch).eq('id', id)
+
+  if (error) {
+    throw new Error(`Failed to update visitor request ${id}: ${error.message}`)
+  }
+}
+
+export async function approveVisitorRequest(
+  supabase: SupabaseDatabase,
+  id: string,
+  options: BaseOptions = {},
+): Promise<ApproveVisitorRequestResult> {
+  const now = options.now ?? defaultNow
+  const request = await fetchVisitorRequest(supabase, id)
+
+  if (request.calcom_booking_id) {
+    if (request.status !== APPROVED_STATUS) {
+      await updateVisitorRequest(supabase, id, {
+        status: APPROVED_STATUS,
+        updated_at: now().toISOString(),
+      })
+    }
+
+    return { bookingId: request.calcom_booking_id }
+  }
+
+  ensureEventSchedulingFields(request)
+
+  const booking = await createCalcomBooking(
+    {
+      eventTypeId: request.calcom_event_type_id,
+      start: request.starts_at,
+      end: request.ends_at,
+      title: request.notes ? `Guest stay: ${request.notes}` : `Guest stay for ${request.guest_name}`,
+      attendees: buildAttendees(request),
+      notes: request.notes,
+      metadata: { visitorRequestId: request.id },
+    },
+    options.fetchImpl,
+  )
+
+  await updateVisitorRequest(supabase, id, {
+    status: APPROVED_STATUS,
+    calcom_booking_id: booking.id,
+    updated_at: now().toISOString(),
+  })
+
+  return { bookingId: booking.id }
+}
+
+export async function revokeVisitorRequest(
+  supabase: SupabaseDatabase,
+  id: string,
+  options: BaseOptions = {},
+): Promise<RevokeVisitorRequestResult> {
+  const now = options.now ?? defaultNow
+  const request = await fetchVisitorRequest(supabase, id)
+  let cancelledBookingId: string | undefined
+
+  if (request.calcom_booking_id) {
+    await cancelCalcomBooking(request.calcom_booking_id, options.fetchImpl)
+    cancelledBookingId = request.calcom_booking_id
+  }
+
+  await updateVisitorRequest(supabase, id, {
+    status: REVOKED_STATUS,
+    calcom_booking_id: null,
+    updated_at: now().toISOString(),
+  })
+
+  return { cancelledBookingId }
+}

--- a/tests/visitor-requests.test.ts
+++ b/tests/visitor-requests.test.ts
@@ -1,0 +1,157 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { approveVisitorRequest, revokeVisitorRequest } from '@/lib/visitor-requests'
+import type { Database } from '@/lib/supabase'
+
+type VisitorRequestRow = Database['public']['Tables']['visitor_requests']['Row']
+
+type SupabaseLike = SupabaseClient<Database>
+
+type SupabaseStub = {
+  supabase: SupabaseLike
+  spies: {
+    from: ReturnType<typeof vi.fn>
+    select: ReturnType<typeof vi.fn>
+    selectEq: ReturnType<typeof vi.fn>
+    single: ReturnType<typeof vi.fn>
+    update: ReturnType<typeof vi.fn>
+    updateEq: ReturnType<typeof vi.fn>
+  }
+}
+
+const baseVisitorRequest: VisitorRequestRow = {
+  calcom_booking_id: null,
+  calcom_event_type_id: 42,
+  created_at: '2025-04-10T00:00:00.000Z',
+  ends_at: '2025-04-11T10:00:00.000Z',
+  guest_email: 'guest@example.com',
+  guest_name: 'Jordan Guest',
+  host_email: 'host@example.com',
+  id: 'visitor-request-1',
+  notes: 'Guest room stay',
+  starts_at: '2025-04-11T08:00:00.000Z',
+  status: 'pending',
+  updated_at: null,
+}
+
+const createSupabaseStub = (request: VisitorRequestRow): SupabaseStub => {
+  const single = vi.fn().mockResolvedValue({ data: request, error: null })
+  const selectEq = vi.fn(() => ({ single }))
+  const select = vi.fn(() => ({ eq: selectEq }))
+  const updateEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const update = vi.fn(() => ({ eq: updateEq }))
+  const from = vi.fn(() => ({ select, update }))
+
+  return {
+    supabase: { from } as unknown as SupabaseLike,
+    spies: { from, select, selectEq, single, update, updateEq },
+  }
+}
+
+describe('visitor request scheduling', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+    vi.stubEnv('CALCOM_API_KEY', 'test-api-key')
+    vi.stubEnv('CALCOM_BASE_URL', 'https://cal.example.com')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('creates a Cal.com booking when approving a pending visitor request', async () => {
+    const { supabase, spies } = createSupabaseStub(structuredClone(baseVisitorRequest))
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ booking: { id: 'booking_123', link: 'https://cal.com/bookings/booking_123' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    const timestamp = new Date('2025-04-01T12:00:00.000Z')
+
+    const result = await approveVisitorRequest(supabase, baseVisitorRequest.id, {
+      fetchImpl: fetchMock,
+      now: () => timestamp,
+    })
+
+    expect(result.bookingId).toBe('booking_123')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://cal.example.com/bookings',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    )
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit
+    const body = JSON.parse(requestInit.body as string)
+    expect(body.eventTypeId).toBe(baseVisitorRequest.calcom_event_type_id)
+    expect(body.start).toBe(baseVisitorRequest.starts_at)
+    expect(body.end).toBe(baseVisitorRequest.ends_at)
+    expect(body.metadata).toEqual({ visitorRequestId: baseVisitorRequest.id })
+
+    expect(spies.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calcom_booking_id: 'booking_123',
+        status: 'approved',
+        updated_at: timestamp.toISOString(),
+      }),
+    )
+    expect(spies.updateEq).toHaveBeenCalledWith('id', baseVisitorRequest.id)
+  })
+
+  it('cancels the Cal.com booking and clears it from Supabase on revocation', async () => {
+    const request = { ...structuredClone(baseVisitorRequest), status: 'approved' as const, calcom_booking_id: 'booking_123' }
+    const { supabase, spies } = createSupabaseStub(request)
+    const fetchMock = vi.fn(async () => new Response('', { status: 200 }))
+    const timestamp = new Date('2025-04-02T09:30:00.000Z')
+
+    const result = await revokeVisitorRequest(supabase, request.id, {
+      fetchImpl: fetchMock,
+      now: () => timestamp,
+    })
+
+    expect(result.cancelledBookingId).toBe('booking_123')
+    expect(fetchMock).toHaveBeenCalledWith('https://cal.example.com/bookings/booking_123', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer test-api-key' },
+    })
+
+    expect(spies.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calcom_booking_id: null,
+        status: 'revoked',
+        updated_at: timestamp.toISOString(),
+      }),
+    )
+  })
+
+  it('skips cancelling bookings when none exist and still updates status', async () => {
+    const request = structuredClone(baseVisitorRequest)
+    const { supabase, spies } = createSupabaseStub(request)
+    const fetchMock = vi.fn()
+
+    const result = await revokeVisitorRequest(supabase, request.id, {
+      fetchImpl: fetchMock,
+      now: () => new Date('2025-04-03T10:00:00.000Z'),
+    })
+
+    expect(result.cancelledBookingId).toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(spies.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'revoked', calcom_booking_id: null }),
+    )
+  })
+
+  it('throws an error if the visitor request is missing an event type id', async () => {
+    const request = { ...structuredClone(baseVisitorRequest), calcom_event_type_id: 0 }
+    const { supabase } = createSupabaseStub(request)
+
+    await expect(
+      approveVisitorRequest(supabase, request.id, {
+        fetchImpl: vi.fn(),
+      }),
+    ).rejects.toThrow(/event type id/i)
+  })
+})


### PR DESCRIPTION
## Summary
- add a Cal.com booking helper that uses environment configuration and supports dependency injection for tests
- wire visitor-request approval and revocation server logic to create/cancel Cal.com bookings while persisting booking ids in Supabase
- expose API routes for the approval/revocation actions and cover the behaviour with Vitest mocks

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0de42ec8328b4f44502abbdc456