### PR TITLE
Add visitor quota enforcement trigger and tests

### DIFF
--- a/docs/visitors.md
+++ b/docs/visitors.md
@@ -1,0 +1,43 @@
+# Overnight Visitor Policy
+
+The Share House Portal tracks overnight guest stays in the `visitor_requests`
+table. Each request records the host roommate, the room that will be used, the
+requested arrival and departure dates, and whether the stay has been approved by
+building staff.
+
+## Monthly Quotas
+
+To keep visitor load balanced across the building we enforce two rolling monthly
+limits:
+
+- **Per host** – A roommate can sponsor up to **10 approved guest nights** in a
+given calendar month. The allowance refreshes on the first day of each month and
+counts any approved stay that overlaps the month, even if it begins earlier.
+- **Per room** – A bedroom or shared room can be booked for at most **20 approved
+guest nights** in a calendar month. Nights from different hosts are pooled so the
+room never exceeds its shared capacity.
+
+These limits apply to the subset of visits with a status of `approved`. Pending,
+denied, or cancelled requests do not consume quota.
+
+## Enforcement
+
+A Supabase trigger named `visitor_requests_quota_enforcement` calls the
+`enforce_visitor_request_quota` function before insert or update. The function
+aggregates the approved nights for the host and room across every month touched
+by the stay. If a save would exceed either policy, the database raises a
+user-friendly error:
+
+- `Visitor quota exceeded for host …` when a roommate crosses their personal cap.
+- `Visitor quota exceeded for room …` when a room would exceed its shared quota.
+
+Because the checks happen in the database the limits are enforced consistently
+across the API, dashboards, and background jobs.
+
+## Exceptions and Overrides
+
+Property managers can override the limit by temporarily switching a request back
+to `pending`, adjusting the dates, and re-approving after discussing the change
+with roommates. Long-term policy adjustments should be implemented by changing
+the constants in the enforcement function and communicating the new limits to
+residents.

--- a/package.json
+++ b/package.json
@@ -108,6 +108,8 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "pg": "^8.16.3",
+    "pg-embedded": "^0.2.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,12 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
+      pg-embedded:
+        specifier: ^0.2.2
+        version: 0.2.2
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -1726,6 +1732,66 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@pg-ts/pg-embedded-android-arm-eabi@0.2.2':
+    resolution: {integrity: sha512-LQzmRtPo+991VZ/gWOLo2TKGexBggzy6AQpmM51tjT1OmxQKAQQPwUkv4JwjAnMIHdmP/skKjtVHqGiNJNQ+HQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@pg-ts/pg-embedded-android-arm64@0.2.2':
+    resolution: {integrity: sha512-/zkSAMCLQF1C13CTFoujB1YtsE+vLA8ejdu9a7sHn3Tzq4o950VZN3MGZk71OrZ4eRuYiIvUs1YdejXX591qBA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@pg-ts/pg-embedded-darwin-arm64@0.2.2':
+    resolution: {integrity: sha512-BNsVafZMSQgNpmzJNyzhQiY7CD/EVmB6otYRmqC1QhWA6zhY2FOoA9l2nHGmMqY+gpMY8Fxocyv2ekYKGajBhg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pg-ts/pg-embedded-darwin-x64@0.2.2':
+    resolution: {integrity: sha512-0zesPujM/yiR58yDYVzIXTomM/hA4QWWpD1z3Syn6LPpIRbKQ1AqLU5HmtM6rtdu/eq7y32MhuylDJ83c7lOWg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pg-ts/pg-embedded-linux-arm-gnueabihf@0.2.2':
+    resolution: {integrity: sha512-SU12yjHZI70eH125gI+8iS1fUnZ9RuB/H7wtmf0V+eXIrA+tPeNrm86BKRzogboi8nAFExfYpirJw9Aj/Dh6Wg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@pg-ts/pg-embedded-linux-arm64-gnu@0.2.2':
+    resolution: {integrity: sha512-N44ThE7LXIlacDHb+rj3fTnxgiOlwrrbkdXcKe8X950cwVmc8ZXVhTxlx54/O5p2/L+321DeJxR5Px+/SFwPPQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pg-ts/pg-embedded-linux-arm64-musl@0.2.2':
+    resolution: {integrity: sha512-wOAUyGpFtZH7ozHOHQxvayeHY79TRvrAHanQ5ZdHhL6x/xANvAPRopTjygDjZcbiIcItl/HlBmadc351a3GNlQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pg-ts/pg-embedded-linux-x64-gnu@0.2.2':
+    resolution: {integrity: sha512-jtdu2AFN+K0WHzuk8cnjphVln1Ug1rIWDYEDaPeTK1yPBRzs5H0Q8a8JlQPYi+Hh4LghwFIqyrlYxkZrVT8HMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@pg-ts/pg-embedded-linux-x64-musl@0.2.2':
+    resolution: {integrity: sha512-7r0JrRPF+NGtVGe9CCruoD6MJGoZlg76aaFhYr9lnKGwtYQMcwAd2ZplnJ/7jqJx5psBkqCbkPDyeIFb0wWAxA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@pg-ts/pg-embedded-win32-x64-msvc@0.2.2':
+    resolution: {integrity: sha512-1KdUWb755AXkdwkgPd2ljlBKkVs9LSmDOUj7U8AzoaPFH4ayzkZsWsBp3O9b5TPOIm5IKWcd+QbnD4mxcBnVoA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2762,9 +2828,6 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -3791,9 +3854,6 @@ packages:
 
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
-
-  es-module-lexer@1.6.0:
-    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -5157,6 +5217,44 @@ packages:
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
+  pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-embedded@0.2.2:
+    resolution: {integrity: sha512-WbpeITJQoSrTwmhhwBR0cF+Gb37IN1DhygU1lrmwXxseCfdHFTIz6qolsSV90GTjA55qquCcw21ICXpIj+YB9g==}
+    engines: {node: '>= 10'}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
@@ -5389,13 +5487,25 @@ packages:
     resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
@@ -5859,6 +5969,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -8227,6 +8341,36 @@ snapshots:
   '@opentelemetry/api@1.9.0':
     optional: true
 
+  '@pg-ts/pg-embedded-android-arm-eabi@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-android-arm64@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-darwin-arm64@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-darwin-x64@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-linux-arm-gnueabihf@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-linux-arm64-gnu@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-linux-arm64-musl@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-linux-x64-gnu@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-linux-x64-musl@0.2.2':
+    optional: true
+
+  '@pg-ts/pg-embedded-win32-x64-msvc@0.2.2':
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -9346,11 +9490,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.12
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   '@types/eslint@8.56.12':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/eslint@8.56.2':
@@ -9365,8 +9509,6 @@ snapshots:
   '@types/estree@0.0.39': {}
 
   '@types/estree@1.0.5': {}
-
-  '@types/estree@1.0.7': {}
 
   '@types/estree@1.0.8': {}
 
@@ -9580,7 +9722,7 @@ snapshots:
       '@vue/shared': 3.4.35
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
     optional: true
 
@@ -10126,7 +10268,7 @@ snapshots:
   code-red@1.0.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -10488,8 +10630,6 @@ snapshots:
       internal-slot: 1.0.6
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
-
-  es-module-lexer@1.6.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -11356,7 +11496,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
     optional: true
 
   is-regex@1.1.4:
@@ -12197,6 +12337,54 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
+  pg-cloudflare@1.2.7:
+    optional: true
+
+  pg-connection-string@2.9.1: {}
+
+  pg-embedded@0.2.2:
+    optionalDependencies:
+      '@pg-ts/pg-embedded-android-arm-eabi': 0.2.2
+      '@pg-ts/pg-embedded-android-arm64': 0.2.2
+      '@pg-ts/pg-embedded-darwin-arm64': 0.2.2
+      '@pg-ts/pg-embedded-darwin-x64': 0.2.2
+      '@pg-ts/pg-embedded-linux-arm-gnueabihf': 0.2.2
+      '@pg-ts/pg-embedded-linux-arm64-gnu': 0.2.2
+      '@pg-ts/pg-embedded-linux-arm64-musl': 0.2.2
+      '@pg-ts/pg-embedded-linux-x64-gnu': 0.2.2
+      '@pg-ts/pg-embedded-linux-x64-musl': 0.2.2
+      '@pg-ts/pg-embedded-win32-x64-msvc': 0.2.2
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.10.1(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
+  pg-protocol@1.10.3: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.0.0: {}
 
   picocolors@1.0.1: {}
@@ -12473,18 +12661,21 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  postcss@8.5.3:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    optional: true
-
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   potpack@1.0.2: {}
 
@@ -13024,6 +13215,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  split2@4.2.0: {}
+
   stackback@0.0.2: {}
 
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
@@ -13172,7 +13365,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -13706,7 +13899,7 @@ snapshots:
   webpack@5.93.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
@@ -13715,7 +13908,7 @@ snapshots:
       browserslist: 4.23.3
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
+      es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/supabase/migrations/20250712_visitor_request_quotas.sql
+++ b/supabase/migrations/20250712_visitor_request_quotas.sql
@@ -1,0 +1,151 @@
+-- Visitor request quota enforcement
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    WHERE t.typname = 'visitor_request_status'
+      AND t.typnamespace = 'public'::regnamespace
+  ) THEN
+    CREATE TYPE public.visitor_request_status AS ENUM (
+      'pending',
+      'approved',
+      'denied',
+      'cancelled'
+    );
+  END IF;
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS public.visitor_requests (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  building_id uuid NOT NULL,
+  host_profile_id uuid NOT NULL,
+  room_id uuid NOT NULL,
+  arrival_date date NOT NULL,
+  departure_date date NOT NULL,
+  status public.visitor_request_status NOT NULL DEFAULT 'pending',
+  guest_name text,
+  purpose text,
+  CONSTRAINT visitor_requests_departure_after_arrival CHECK (departure_date > arrival_date)
+);
+
+CREATE OR REPLACE FUNCTION public.visitor_nights_in_month(
+  arrival date,
+  departure date,
+  month_start date
+) RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT GREATEST(
+    0,
+    LEAST(departure, (month_start + interval '1 month')::date)
+      - GREATEST(arrival, month_start)
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_visitor_request_quota()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  month_start date;
+  month_end date;
+  last_month date;
+  month_label text;
+  request_nights integer;
+  member_nights integer;
+  room_nights integer;
+  member_limit CONSTANT integer := 10;
+  room_limit CONSTANT integer := 20;
+BEGIN
+  -- Only enforce limits for approved stays.
+  IF NEW.status <> 'approved' THEN
+    NEW.updated_at := now();
+    RETURN NEW;
+  END IF;
+
+  IF NEW.departure_date <= NEW.arrival_date THEN
+    RAISE EXCEPTION USING MESSAGE =
+      format('Visitor request %s has invalid stay length: departure date must be after arrival date.',
+             COALESCE(NEW.id::text, 'pending'));
+  END IF;
+
+  month_start := date_trunc('month', NEW.arrival_date)::date;
+  last_month := date_trunc('month', (NEW.departure_date - interval '1 day'))::date;
+
+  LOOP
+    month_end := (month_start + interval '1 month')::date;
+    request_nights := public.visitor_nights_in_month(NEW.arrival_date, NEW.departure_date, month_start);
+
+    IF request_nights > 0 THEN
+      SELECT COALESCE(SUM(public.visitor_nights_in_month(v.arrival_date, v.departure_date, month_start)), 0)
+        INTO member_nights
+      FROM public.visitor_requests v
+      WHERE v.status = 'approved'
+        AND v.host_profile_id = NEW.host_profile_id
+        AND v.building_id = NEW.building_id
+        AND v.departure_date > month_start
+        AND v.arrival_date < month_end
+        AND (TG_OP = 'INSERT' OR v.id <> NEW.id);
+
+      member_nights := member_nights + request_nights;
+
+      IF member_nights > member_limit THEN
+        month_label := to_char(month_start, 'YYYY-MM');
+        RAISE EXCEPTION USING MESSAGE =
+          format('Visitor quota exceeded for host %s in %s: %s nights would exceed the %s-night monthly limit.',
+                 NEW.host_profile_id::text,
+                 month_label,
+                 member_nights,
+                 member_limit);
+      END IF;
+
+      SELECT COALESCE(SUM(public.visitor_nights_in_month(v.arrival_date, v.departure_date, month_start)), 0)
+        INTO room_nights
+      FROM public.visitor_requests v
+      WHERE v.status = 'approved'
+        AND v.room_id = NEW.room_id
+        AND v.building_id = NEW.building_id
+        AND v.departure_date > month_start
+        AND v.arrival_date < month_end
+        AND (TG_OP = 'INSERT' OR v.id <> NEW.id);
+
+      room_nights := room_nights + request_nights;
+
+      IF room_nights > room_limit THEN
+        month_label := to_char(month_start, 'YYYY-MM');
+        RAISE EXCEPTION USING MESSAGE =
+          format('Visitor quota exceeded for room %s in %s: %s nights would exceed the %s-night monthly limit.',
+                 NEW.room_id::text,
+                 month_label,
+                 room_nights,
+                 room_limit);
+      END IF;
+    END IF;
+
+    EXIT WHEN month_start >= last_month;
+    month_start := month_end;
+  END LOOP;
+
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS visitor_requests_quota_enforcement ON public.visitor_requests;
+CREATE TRIGGER visitor_requests_quota_enforcement
+  BEFORE INSERT OR UPDATE ON public.visitor_requests
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_visitor_request_quota();
+
+CREATE INDEX IF NOT EXISTS visitor_requests_host_month_idx
+  ON public.visitor_requests (host_profile_id, building_id, arrival_date, departure_date)
+  WHERE status = 'approved';
+
+CREATE INDEX IF NOT EXISTS visitor_requests_room_month_idx
+  ON public.visitor_requests (room_id, building_id, arrival_date, departure_date)
+  WHERE status = 'approved';

--- a/tests/visitor-quotas.test.ts
+++ b/tests/visitor-quotas.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
+import { Client } from "pg"
+import { PostgresInstance } from "pg-embedded"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const migrationFile = join(
+  process.cwd(),
+  "supabase/migrations/20250712_visitor_request_quotas.sql",
+)
+
+const primaryHost = "00000000-0000-0000-0000-000000000001"
+const secondaryHost = "00000000-0000-0000-0000-000000000002"
+const tertiaryHost = "00000000-0000-0000-0000-000000000003"
+const building = "11111111-1111-1111-1111-111111111111"
+const room = "22222222-2222-2222-2222-222222222222"
+const otherRoom = "33333333-3333-3333-3333-333333333333"
+
+let postgres: PostgresInstance
+let client: Client
+let tempRoot: string
+let dataDir: string
+let installDir: string
+
+type VisitorStatus = "approved" | "pending" | "denied" | "cancelled"
+
+function dropPrivilegesIfRunningAsRoot() {
+  if (typeof process.getuid === "function" && typeof process.setuid === "function" && process.getuid() === 0) {
+    if (typeof process.setgid === "function") {
+      try {
+        process.setgid("nogroup")
+      } catch {
+        process.setgid(65534)
+      }
+    }
+
+    try {
+      process.setuid("nobody")
+    } catch (error) {
+      throw new Error(
+        `Unable to drop root privileges for embedded Postgres tests: ${error instanceof Error ? error.message : error}`,
+      )
+    }
+  }
+}
+
+async function approveStay({
+  host = primaryHost,
+  roomId = room,
+  arrival,
+  departure,
+  status = "approved",
+  buildingId = building,
+}: {
+  host?: string
+  roomId?: string
+  arrival: string
+  departure: string
+  status?: VisitorStatus
+  buildingId?: string
+}) {
+  const result = await client.query(
+    `
+      INSERT INTO public.visitor_requests (
+        building_id, host_profile_id, room_id, arrival_date, departure_date, status
+      )
+      VALUES ($1, $2, $3, $4, $5, $6)
+      RETURNING id
+    `,
+    [buildingId, host, roomId, arrival, departure, status],
+  )
+
+  return Number(result.rows[0].id)
+}
+
+async function truncateRequests() {
+  await client.query("TRUNCATE TABLE public.visitor_requests RESTART IDENTITY;")
+}
+
+describe("visitor request quotas", () => {
+  beforeAll(async () => {
+    dropPrivilegesIfRunningAsRoot()
+
+    tempRoot = mkdtempSync(join(tmpdir(), "pg-embedded-"))
+    dataDir = join(tempRoot, "data")
+    installDir = join(tempRoot, "install")
+    mkdirSync(dataDir, { recursive: true })
+    mkdirSync(installDir, { recursive: true })
+
+    postgres = new PostgresInstance({
+      username: "postgres",
+      password: "postgres",
+      persistent: false,
+      dataDir,
+      installationDir: installDir,
+    })
+
+    await postgres.start()
+
+    const info = postgres.connectionInfo
+    client = new Client({
+      host: info.host,
+      port: info.port,
+      user: info.username,
+      password: info.password,
+      database: info.databaseName,
+    })
+
+    await client.connect()
+    const sql = readFileSync(migrationFile, "utf8")
+    await client.query(sql)
+  })
+
+  afterAll(async () => {
+    if (client) {
+      await client.end()
+    }
+
+    if (postgres) {
+      await postgres.stop().catch(() => undefined)
+      await postgres.cleanup().catch(() => undefined)
+    }
+
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  afterEach(async () => {
+    await truncateRequests()
+  })
+
+  it("allows approvals that stay within member and room limits", async () => {
+    await expect(
+      approveStay({ arrival: "2024-06-01", departure: "2024-06-04" }),
+    ).resolves.toBeTypeOf("number")
+
+    await expect(
+      approveStay({ arrival: "2024-06-10", departure: "2024-06-14" }),
+    ).resolves.toBeTypeOf("number")
+  })
+
+  it("blocks approvals that exceed the monthly host limit", async () => {
+    await approveStay({ arrival: "2024-06-01", departure: "2024-06-06" })
+
+    await expect(
+      approveStay({ arrival: "2024-06-06", departure: "2024-06-13" }),
+    ).rejects.toThrow(/Visitor quota exceeded for host/)
+  })
+
+  it("blocks approvals when a room crosses its shared monthly cap", async () => {
+    await approveStay({ arrival: "2024-06-01", departure: "2024-06-11" })
+    await approveStay({ host: secondaryHost, arrival: "2024-06-11", departure: "2024-06-21" })
+
+    await expect(
+      approveStay({ host: tertiaryHost, arrival: "2024-06-21", departure: "2024-06-24" }),
+    ).rejects.toThrow(/Visitor quota exceeded for room/)
+  })
+
+  it("re-evaluates limits when an approved stay is edited", async () => {
+    const requestId = await approveStay({ arrival: "2024-06-01", departure: "2024-06-05" })
+
+    await expect(approveStay({ arrival: "2024-06-15", departure: "2024-06-17", roomId: otherRoom })).resolves.toBeTypeOf(
+      "number",
+    )
+
+    await expect(
+      client.query(
+        `
+          UPDATE public.visitor_requests
+          SET departure_date = $1
+          WHERE id = $2
+        `,
+        ["2024-06-15", requestId],
+      ),
+    ).rejects.toThrow(/Visitor quota exceeded for host/)
+  })
+
+  it("counts overlapping stays in each affected month", async () => {
+    await approveStay({ arrival: "2024-06-27", departure: "2024-07-05" })
+
+    await expect(
+      approveStay({ arrival: "2024-07-01", departure: "2024-07-08" }),
+    ).rejects.toThrow(/Visitor quota exceeded for host/)
+  })
+})


### PR DESCRIPTION
## Summary
- add a visitor_requests schema helper that enforces per-host and per-room monthly guest night limits in the database
- cover approval, room, update, and cross-month limit scenarios with vitest using an embedded Postgres harness
- document the visitor quota policy and surface the resulting error messaging for operators

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0dd12cc832896a4040e699d82bf