### PR TITLE
Implement visitor access code lifecycle

### DIFF
--- a/app/api/cron/revoke-visitor-access/route.ts
+++ b/app/api/cron/revoke-visitor-access/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server"
+
+import {
+  VisitorAccessControlService,
+  isRevocationEligible,
+  listRequestsPendingRevocation,
+} from "@/lib/access-control"
+import { createServiceSupabaseClient } from "@/lib/supabase-admin"
+
+export async function GET() {
+  let supabase
+
+  try {
+    supabase = createServiceSupabaseClient()
+  } catch (error) {
+    console.error("Missing Supabase configuration", error)
+    return NextResponse.json(
+      { message: "Service unavailable. Supabase credentials are not configured." },
+      { status: 500 }
+    )
+  }
+  const service = new VisitorAccessControlService(supabase)
+  const now = new Date().toISOString()
+
+  const expiringRequests = await listRequestsPendingRevocation(supabase, now)
+
+  let revokedCount = 0
+  const failures: Array<{ requestId: string; message: string }> = []
+
+  for (const request of expiringRequests) {
+    if (!isRevocationEligible(request, now)) {
+      continue
+    }
+
+    try {
+      await service.revokeRequest(request, {
+        reason: "Visit window expired",
+      })
+      revokedCount += 1
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error"
+      failures.push({ requestId: request.id, message })
+    }
+  }
+
+  return NextResponse.json({
+    checked: expiringRequests.length,
+    revoked: revokedCount,
+    failures,
+    timestamp: now,
+  })
+}

--- a/app/api/visitor-requests/[id]/approve/route.ts
+++ b/app/api/visitor-requests/[id]/approve/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import { VisitorAccessControlService, fetchVisitorRequest } from "@/lib/access-control"
+import { createServiceSupabaseClient } from "@/lib/supabase-admin"
+
+const approvalSchema = z
+  .object({
+    actorProfileId: z.string().uuid().optional(),
+    approvalNotes: z.string().min(1).max(500).optional(),
+    expiresAt: z.string().datetime().optional(),
+  })
+  .partial()
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+): Promise<NextResponse> {
+  let supabase
+
+  try {
+    supabase = createServiceSupabaseClient()
+  } catch (error) {
+    console.error("Missing Supabase configuration", error)
+    return NextResponse.json(
+      { message: "Service unavailable. Supabase credentials are not configured." },
+      { status: 500 }
+    )
+  }
+
+  let payload: z.infer<typeof approvalSchema>
+
+  try {
+    const json = await request.json().catch(() => ({}))
+    payload = approvalSchema.parse(json)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid approval payload", issues: error.issues },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({ message: "Unable to parse request body" }, { status: 400 })
+  }
+
+  const visitorRequest = await fetchVisitorRequest(supabase, params.id)
+
+  if (!visitorRequest) {
+    return NextResponse.json({ message: "Visitor request not found" }, { status: 404 })
+  }
+
+  try {
+    const service = new VisitorAccessControlService(supabase)
+
+    const visitEnd = new Date(visitorRequest.visit_end)
+    const visitStart = new Date(visitorRequest.visit_start)
+    const requestedExpiration = payload.expiresAt
+      ? new Date(payload.expiresAt)
+      : new Date(visitorRequest.access_code_expires_at ?? visitorRequest.visit_end)
+
+    if (Number.isNaN(requestedExpiration.getTime())) {
+      return NextResponse.json(
+        { message: "Invalid expiration timestamp provided" },
+        { status: 400 }
+      )
+    }
+
+    if (requestedExpiration.getTime() < visitStart.getTime()) {
+      return NextResponse.json(
+        { message: "Access expiration cannot precede the visit start time" },
+        { status: 400 }
+      )
+    }
+
+    const effectiveExpiration =
+      requestedExpiration.getTime() < visitEnd.getTime()
+        ? visitEnd.toISOString()
+        : requestedExpiration.toISOString()
+
+    const result = await service.mintAccessCode(visitorRequest, {
+      actorProfileId: payload.actorProfileId ?? null,
+      approvalNotes: payload.approvalNotes ?? null,
+      expiresAt: effectiveExpiration,
+    })
+
+    return NextResponse.json(
+      {
+        accessCode: result.accessCode,
+        issuedAt: result.issuedAt,
+        expiresAt: result.expiresAt,
+        visitorRequest: result.request,
+      },
+      { status: 200 }
+    )
+  } catch (error) {
+    console.error("Failed to approve visitor request", error)
+    return NextResponse.json(
+      { message: "Failed to approve visitor request" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,10 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import {
+        CrumpledPaperIcon,
+        LockClosedIcon,
+        PersonIcon,
+} from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,18 +12,23 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+                {
+                        href: "/dashboard/visitor-requests",
+                        text: "Visitor access",
+                        Icon: LockClosedIcon,
+                },
+        ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/components/main-nav.tsx
+++ b/app/dashboard/components/main-nav.tsx
@@ -12,28 +12,28 @@ export function MainNav({
       {...props}
     >
       <Link
-        href="#"
+        href="/dashboard"
         className="text-sm font-medium transition-colors hover:text-primary"
       >
         Overview
       </Link>
       <Link
-        href="#"
+        href="/dashboard/visitor-requests"
         className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
       >
-        Customers
+        Visitor access
       </Link>
       <Link
-       href="#"
+        href="/dashboard/members"
         className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
       >
-        Products
+        Members
       </Link>
       <Link
-        href="#"
+        href="/dashboard/todo"
         className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
       >
-        Settings
+        Tasks
       </Link>
     </nav>
   )

--- a/app/dashboard/visitor-requests/page.tsx
+++ b/app/dashboard/visitor-requests/page.tsx
@@ -1,0 +1,191 @@
+import { Metadata } from "next"
+import { redirect } from "next/navigation"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export const metadata: Metadata = {
+  title: "Visitor access",
+  description: "Review overnight guest requests and access codes.",
+}
+
+type VisitorRequest = {
+  id: string
+  guest_name: string
+  guest_email: string | null
+  visit_start: string
+  visit_end: string
+  status: "pending" | "approved" | "denied" | "revoked"
+  access_code: string | null
+  access_code_issued_at: string | null
+  access_code_expires_at: string | null
+  revoked_at: string | null
+}
+
+type AuditEntry = {
+  visitor_request_id: string
+  event: "code_issued" | "revocation_scheduled" | "revoked"
+  status: string
+  created_at: string
+}
+
+const formatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+})
+
+const statusLabels: Record<VisitorRequest["status"], string> = {
+  pending: "Pending approval",
+  approved: "Approved",
+  denied: "Denied",
+  revoked: "Revoked",
+}
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "—"
+  }
+
+  return formatter.format(new Date(value))
+}
+
+function resolveRevocationStatus(request: VisitorRequest, audits: AuditEntry[]) {
+  if (request.status === "revoked") {
+    const revokedEntry = audits.find((entry) => entry.event === "revoked" && entry.status === "completed")
+    if (revokedEntry) {
+      return `Revoked ${formatDate(revokedEntry.created_at)}`
+    }
+
+    return request.revoked_at ? `Revoked ${formatDate(request.revoked_at)}` : "Revoked"
+  }
+
+  const scheduledEntry = audits.find((entry) => entry.event === "revocation_scheduled")
+  if (scheduledEntry) {
+    return `Scheduled for ${formatDate(request.access_code_expires_at)}`
+  }
+
+  if (request.status === "approved") {
+    return request.access_code_expires_at
+      ? `Scheduled for ${formatDate(request.access_code_expires_at)}`
+      : "Revocation scheduled"
+  }
+
+  return "—"
+}
+
+export default async function VisitorRequestsPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return redirect("/auth")
+  }
+
+  const { data: requests } = await supabase
+    .from("visitor_requests")
+    .select(
+      "id, guest_name, guest_email, visit_start, visit_end, status, access_code, access_code_issued_at, access_code_expires_at, revoked_at"
+    )
+    .eq("host_profile_id", user.id)
+    .order("visit_start", { ascending: false })
+
+  const requestRows: VisitorRequest[] = requests ?? []
+  const requestIds = requestRows.map((request) => request.id)
+
+  let auditMap = new Map<string, AuditEntry[]>()
+
+  if (requestIds.length > 0) {
+    const { data: audits } = await supabase
+      .from("visitor_access_audit")
+      .select("visitor_request_id, event, status, created_at")
+      .in("visitor_request_id", requestIds)
+      .order("created_at", { ascending: false })
+
+    if (audits) {
+      auditMap = audits.reduce((acc, audit) => {
+        const existing = acc.get(audit.visitor_request_id) ?? []
+        existing.push(audit as AuditEntry)
+        acc.set(audit.visitor_request_id, existing)
+        return acc
+      }, new Map<string, AuditEntry[]>())
+    }
+  }
+
+  return (
+    <div className="max-w-dvw flex flex-col gap-6">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight">Visitor access</h1>
+        <p className="text-muted-foreground">
+          Approved guest stays receive a temporary access code. Codes expire automatically after the visit window.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {requestRows.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>No visitor requests yet</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Once you submit an overnight visitor request you&apos;ll see approval details and access codes here.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          requestRows.map((request) => {
+            const audits = auditMap.get(request.id) ?? []
+            const revocationStatus = resolveRevocationStatus(request, audits)
+            const codeActive = request.status === "approved" && !request.revoked_at
+
+            return (
+              <Card key={request.id}>
+                <CardHeader className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <CardTitle className="text-xl font-semibold">{request.guest_name}</CardTitle>
+                    <Badge
+                      variant={request.status === "approved" ? "default" : request.status === "pending" ? "secondary" : "destructive"}
+                    >
+                      {statusLabels[request.status]}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {formatDate(request.visit_start)} – {formatDate(request.visit_end)}
+                  </p>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  {request.guest_email ? (
+                    <div>
+                      <p className="font-medium">Guest email</p>
+                      <p className="text-muted-foreground">{request.guest_email}</p>
+                    </div>
+                  ) : null}
+                  <div>
+                    <p className="font-medium">Access code</p>
+                    <p className="text-muted-foreground">
+                      {codeActive && request.access_code ? request.access_code : "Code unavailable"}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Issued</p>
+                    <p className="text-muted-foreground">{formatDate(request.access_code_issued_at)}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Revocation</p>
+                    <p className="text-muted-foreground">{revocationStatus}</p>
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/access-control.ts
+++ b/lib/access-control.ts
@@ -1,0 +1,244 @@
+import crypto from "node:crypto"
+
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+const DEFAULT_CODE_LENGTH = 8
+const MAX_CODE_ATTEMPTS = 8
+
+export type VisitorRequestRow =
+  Database["public"]["Tables"]["visitor_requests"]["Row"]
+
+type VisitorAccessAuditInsert =
+  Database["public"]["Tables"]["visitor_access_audit"]["Insert"]
+
+type VisitorRequestStatus =
+  Database["public"]["Enums"]["visitor_request_status"]
+
+export class VisitorAccessControlService {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async mintAccessCode(
+    request: VisitorRequestRow,
+    options: {
+      actorProfileId?: string | null
+      approvalNotes?: string | null
+      expiresAt?: string | null
+    } = {}
+  ) {
+    if (request.status !== "pending") {
+      throw new Error("Visitor request must be pending before minting an access code")
+    }
+
+    const accessCode = await this.generateUniqueCode()
+    const issuedAt = new Date().toISOString()
+    const expiresAt = options.expiresAt ?? request.access_code_expires_at ?? request.visit_end
+
+    const updatePayload: Partial<VisitorRequestRow> = {
+      status: "approved" satisfies VisitorRequestStatus,
+      approval_notes: options.approvalNotes ?? request.approval_notes,
+      approved_at: issuedAt,
+      approved_by: options.actorProfileId ?? request.approved_by,
+      access_code: accessCode,
+      access_code_issued_at: issuedAt,
+      access_code_expires_at: expiresAt,
+      revoked_at: null,
+      revocation_reason: null,
+      updated_at: issuedAt,
+    }
+
+    const { data, error } = await this.client
+      .from("visitor_requests")
+      .update(updatePayload)
+      .eq("id", request.id)
+      .select()
+      .single()
+
+    if (error || !data) {
+      throw error ?? new Error("Unable to update visitor request with access code")
+    }
+
+    await this.logEvent({
+      building_id: request.building_id,
+      visitor_request_id: request.id,
+      event: "code_issued",
+      status: "granted",
+      metadata: {
+        accessCode,
+        expiresAt,
+      },
+      actor_profile_id: options.actorProfileId ?? null,
+    })
+
+    await this.scheduleRevocation(data, {
+      actorProfileId: options.actorProfileId ?? null,
+      revokeAt: expiresAt,
+    })
+
+    return {
+      accessCode,
+      issuedAt,
+      expiresAt,
+      request: data,
+    }
+  }
+
+  async scheduleRevocation(
+    request: VisitorRequestRow,
+    options: { actorProfileId?: string | null; revokeAt?: string | null } = {}
+  ) {
+    const revokeAt = options.revokeAt ?? request.access_code_expires_at ?? request.visit_end
+
+    await this.logEvent({
+      building_id: request.building_id,
+      visitor_request_id: request.id,
+      event: "revocation_scheduled",
+      status: "scheduled",
+      metadata: {
+        revokeAt,
+      },
+      actor_profile_id: options.actorProfileId ?? null,
+    })
+
+    return revokeAt
+  }
+
+  async revokeRequest(
+    request: VisitorRequestRow,
+    options: { actorProfileId?: string | null; reason?: string | null } = {}
+  ) {
+    const revokedAt = new Date().toISOString()
+    const updatePayload: Partial<VisitorRequestRow> = {
+      status: "revoked" satisfies VisitorRequestStatus,
+      revoked_at: revokedAt,
+      revocation_reason: options.reason ?? request.revocation_reason,
+      updated_at: revokedAt,
+    }
+
+    const { error } = await this.client
+      .from("visitor_requests")
+      .update(updatePayload)
+      .eq("id", request.id)
+
+    if (error) {
+      await this.logEvent({
+        building_id: request.building_id,
+        visitor_request_id: request.id,
+        event: "revoked",
+        status: "failed",
+        metadata: {
+          reason: options.reason ?? null,
+          error: error.message,
+        },
+        actor_profile_id: options.actorProfileId ?? null,
+      })
+
+      throw error
+    }
+
+    await this.logEvent({
+      building_id: request.building_id,
+      visitor_request_id: request.id,
+      event: "revoked",
+      status: "completed",
+      metadata: {
+        reason: options.reason ?? null,
+        revokedAt,
+      },
+      actor_profile_id: options.actorProfileId ?? null,
+    })
+
+    return revokedAt
+  }
+
+  private async logEvent(entry: VisitorAccessAuditInsert) {
+    const { error } = await this.client.from("visitor_access_audit").insert(entry)
+
+    if (error) {
+      throw new Error(`Failed to write visitor access audit event: ${error.message}`)
+    }
+  }
+
+  private async generateUniqueCode(length = DEFAULT_CODE_LENGTH): Promise<string> {
+    for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS; attempt += 1) {
+      const candidate = this.generateCode(length)
+      const { data, error } = await this.client
+        .from("visitor_requests")
+        .select("id")
+        .eq("access_code", candidate)
+        .maybeSingle()
+
+      if (error) {
+        throw error
+      }
+
+      if (!data) {
+        return candidate
+      }
+    }
+
+    throw new Error("Unable to generate a unique visitor access code")
+  }
+
+  private generateCode(length = DEFAULT_CODE_LENGTH) {
+    const bytes = crypto.randomBytes(length)
+    let result = ""
+
+    for (let i = 0; i < length; i += 1) {
+      result += CODE_ALPHABET[bytes[i] % CODE_ALPHABET.length]
+    }
+
+    return result
+  }
+}
+
+export async function fetchVisitorRequest(
+  client: SupabaseClient<Database>,
+  requestId: string
+): Promise<VisitorRequestRow | null> {
+  const { data, error } = await client
+    .from("visitor_requests")
+    .select("*")
+    .eq("id", requestId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return data ?? null
+}
+
+export async function listRequestsPendingRevocation(
+  client: SupabaseClient<Database>,
+  before: string
+) {
+  const { data, error } = await client
+    .from("visitor_requests")
+    .select("*")
+    .eq("status", "approved" satisfies VisitorRequestStatus)
+    .is("revoked_at", null)
+    .lte("access_code_expires_at", before)
+
+  if (error) {
+    throw error
+  }
+
+  return data ?? []
+}
+
+export function isRevocationEligible(request: VisitorRequestRow, nowIso = new Date().toISOString()) {
+  if (request.status !== "approved") {
+    return false
+  }
+
+  if (request.revoked_at) {
+    return false
+  }
+
+  const expiresAt = request.access_code_expires_at ?? request.visit_end
+
+  return expiresAt <= nowIso
+}

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,0 +1,21 @@
+import { createClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+export function createServiceSupabaseClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      "Missing Supabase configuration. Ensure NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are set."
+    )
+  }
+
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1596,6 +1596,135 @@ export type Database = {
           },
         ]
       }
+      visitor_access_audit: {
+        Row: {
+          actor_profile_id: string | null
+          building_id: string
+          created_at: string
+          event: Database["public"]["Enums"]["visitor_access_event"]
+          id: number
+          metadata: Json | null
+          status: string
+          visitor_request_id: string
+        }
+        Insert: {
+          actor_profile_id?: string | null
+          building_id: string
+          created_at?: string
+          event: Database["public"]["Enums"]["visitor_access_event"]
+          id?: number
+          metadata?: Json | null
+          status?: string
+          visitor_request_id: string
+        }
+        Update: {
+          actor_profile_id?: string | null
+          building_id?: string
+          created_at?: string
+          event?: Database["public"]["Enums"]["visitor_access_event"]
+          id?: number
+          metadata?: Json | null
+          status?: string
+          visitor_request_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "visitor_access_audit_actor_profile_id_fkey"
+            columns: ["actor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_access_audit_visitor_request_id_fkey"
+            columns: ["visitor_request_id"]
+            isOneToOne: false
+            referencedRelation: "visitor_requests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      visitor_requests: {
+        Row: {
+          access_code: string | null
+          access_code_expires_at: string | null
+          access_code_issued_at: string | null
+          approval_notes: string | null
+          approved_at: string | null
+          approved_by: string | null
+          building_id: string
+          created_at: string
+          guest_email: string | null
+          guest_name: string
+          host_profile_id: string
+          id: string
+          revoked_at: string | null
+          revocation_reason: string | null
+          status: Database["public"]["Enums"]["visitor_request_status"]
+          updated_at: string
+          visit_end: string
+          visit_reason: string | null
+          visit_start: string
+        }
+        Insert: {
+          access_code?: string | null
+          access_code_expires_at?: string | null
+          access_code_issued_at?: string | null
+          approval_notes?: string | null
+          approved_at?: string | null
+          approved_by?: string | null
+          building_id: string
+          created_at?: string
+          guest_email?: string | null
+          guest_name: string
+          host_profile_id: string
+          id?: string
+          revoked_at?: string | null
+          revocation_reason?: string | null
+          status?: Database["public"]["Enums"]["visitor_request_status"]
+          updated_at?: string
+          visit_end: string
+          visit_reason?: string | null
+          visit_start: string
+        }
+        Update: {
+          access_code?: string | null
+          access_code_expires_at?: string | null
+          access_code_issued_at?: string | null
+          approval_notes?: string | null
+          approved_at?: string | null
+          approved_by?: string | null
+          building_id?: string
+          created_at?: string
+          guest_email?: string | null
+          guest_name?: string
+          host_profile_id?: string
+          id?: string
+          revoked_at?: string | null
+          revocation_reason?: string | null
+          status?: Database["public"]["Enums"]["visitor_request_status"]
+          updated_at?: string
+          visit_end?: string
+          visit_reason?: string | null
+          visit_start?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "visitor_requests_approved_by_fkey"
+            columns: ["approved_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_requests_host_profile_id_fkey"
+            columns: ["host_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       package_utilization: {
@@ -2234,6 +2363,12 @@ export const Constants = {
         "South America",
       ],
       user_role: ["user", "admin"],
+      visitor_access_event: [
+        "code_issued",
+        "revocation_scheduled",
+        "revoked",
+      ],
+      visitor_request_status: ["pending", "approved", "denied", "revoked"],
     },
   },
   storage: {

--- a/supabase/migrations/20240706_add_visitor_access.sql
+++ b/supabase/migrations/20240706_add_visitor_access.sql
@@ -1,0 +1,69 @@
+-- Visitor access control support for overnight guests
+
+create type public.visitor_request_status as enum ('pending', 'approved', 'denied', 'revoked');
+
+create type public.visitor_access_event as enum ('code_issued', 'revocation_scheduled', 'revoked');
+
+create table public.visitor_requests (
+  id uuid primary key default gen_random_uuid(),
+  building_id uuid not null,
+  host_profile_id uuid not null references public.profiles(id) on delete cascade,
+  guest_name text not null,
+  guest_email text,
+  visit_reason text,
+  visit_start timestamp with time zone not null,
+  visit_end timestamp with time zone not null,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  updated_at timestamp with time zone not null default timezone('utc'::text, now()),
+  status public.visitor_request_status not null default 'pending',
+  approval_notes text,
+  approved_by uuid references public.profiles(id) on delete set null,
+  approved_at timestamp with time zone,
+  access_code text unique,
+  access_code_issued_at timestamp with time zone,
+  access_code_expires_at timestamp with time zone,
+  revoked_at timestamp with time zone,
+  revocation_reason text,
+  constraint visitor_requests_visit_window check (visit_end > visit_start)
+);
+
+create index visitor_requests_building_idx on public.visitor_requests (building_id, visit_start desc);
+create index visitor_requests_status_idx on public.visitor_requests (status, access_code_expires_at);
+
+alter table public.visitor_requests enable row level security;
+
+create policy "Hosts can view their visitor requests" on public.visitor_requests
+  for select using (auth.uid() = host_profile_id);
+
+create policy "Hosts can create visitor requests" on public.visitor_requests
+  for insert with check (auth.uid() = host_profile_id);
+
+create policy "Hosts can edit pending visitor requests" on public.visitor_requests
+  for update using (auth.uid() = host_profile_id and status = 'pending')
+  with check (auth.uid() = host_profile_id);
+
+create table public.visitor_access_audit (
+  id bigint generated always as identity primary key,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  building_id uuid not null,
+  visitor_request_id uuid not null references public.visitor_requests(id) on delete cascade,
+  event public.visitor_access_event not null,
+  status text not null default 'recorded',
+  metadata jsonb,
+  actor_profile_id uuid references public.profiles(id) on delete set null
+);
+
+create index visitor_access_audit_request_idx on public.visitor_access_audit (visitor_request_id, created_at desc);
+create index visitor_access_audit_building_idx on public.visitor_access_audit (building_id, created_at desc);
+
+alter table public.visitor_access_audit enable row level security;
+
+create policy "Hosts can view visitor access audits" on public.visitor_access_audit
+  for select using (
+    exists (
+      select 1
+      from public.visitor_requests vr
+      where vr.id = visitor_access_audit.visitor_request_id
+        and vr.host_profile_id = auth.uid()
+    )
+  );

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,11 @@
     "app/api/**/*.rs": {
       "runtime": "vercel-rust@4.0.8"
     }
-  }
+  },
+  "crons": [
+    {
+      "path": "/api/cron/revoke-visitor-access",
+      "schedule": "0 * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add Supabase tables and enums for visitor requests and access audits
- implement access control service, approval API, and scheduled revocation cron
- surface approved visitor access codes in the dashboard navigation and visitor view

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68d0a0dfc88c8328bc9bee7868435e0c