### PR TITLE
feat: add accessible floorplan overlays

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { CrumpledPaperIcon, LayersIcon, PersonIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,17 +8,22 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/floorplans",
+                        text: "Floorplan",
+                        Icon: LayersIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
 	];
 
 	return (

--- a/app/dashboard/floorplans/page.tsx
+++ b/app/dashboard/floorplans/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next"
+
+import FloorplanOverlays from "@/components/floorplan/floorplan-overlays"
+
+export const metadata: Metadata = {
+  title: "Floorplan overlays",
+  description:
+    "Interactive roommate assignments mapped to the shared floorplan with accessible overlays and saved viewing preferences.",
+}
+
+export default function FloorplanDashboardPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Floorplan overlays</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          Review storage assignments, cleaning rotations, maintenance tasks, and guest policies directly on the digital floorplan.
+          Adjust the zoom and pan to your liking—your preferences are stored for the next visit.
+        </p>
+      </header>
+      <FloorplanOverlays />
+    </div>
+  )
+}

--- a/app/dashboard/members/styles/styles.css
+++ b/app/dashboard/members/styles/styles.css
@@ -1,6 +1,6 @@
 /* styles.css */
 .DialogOverlay {
-    background: rgba(0 0 0 / 0.5);
+    background: hsl(var(--overlay-scrim) / 0.75);
     position: fixed;
     top: 0;
     left: 0;
@@ -15,4 +15,7 @@
     min-width: 300px;
     padding: 30px;
     border-radius: 4px;
+    background: hsl(var(--overlay-surface));
+    color: hsl(var(--overlay-surface-foreground));
+    border: 1px solid hsl(var(--overlay-outline));
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -141,6 +141,18 @@ body {
     --input: 214 32% 91%;
     --ring: 196 100% 45%;
     --radius: 0.5rem;
+    --overlay-scrim: 222 47% 11%;
+    --overlay-surface: 210 40% 98%;
+    --overlay-surface-foreground: 222 47% 11%;
+    --overlay-outline: 215 25% 65%;
+    --overlay-storage: 188 72% 32%;
+    --overlay-storage-foreground: 210 40% 98%;
+    --overlay-chores: 276 65% 35%;
+    --overlay-chores-foreground: 210 40% 98%;
+    --overlay-maintenance: 26 90% 38%;
+    --overlay-maintenance-foreground: 210 40% 98%;
+    --overlay-visitors: 204 78% 34%;
+    --overlay-visitors-foreground: 210 40% 98%;
   }
 
   .dark {
@@ -163,6 +175,18 @@ body {
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 196 100% 50%;
+    --overlay-scrim: 222 67% 4%;
+    --overlay-surface: 222 47% 16%;
+    --overlay-surface-foreground: 210 40% 96%;
+    --overlay-outline: 215 15% 50%;
+    --overlay-storage: 188 75% 42%;
+    --overlay-storage-foreground: 222 47% 11%;
+    --overlay-chores: 276 65% 55%;
+    --overlay-chores-foreground: 210 40% 98%;
+    --overlay-maintenance: 26 90% 52%;
+    --overlay-maintenance-foreground: 222 47% 11%;
+    --overlay-visitors: 204 78% 52%;
+    --overlay-visitors-foreground: 222 47% 11%;
   }
 }
 

--- a/components/floorplan/floorplan-overlays.tsx
+++ b/components/floorplan/floorplan-overlays.tsx
@@ -1,0 +1,378 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+} from "@radix-ui/react-icons"
+
+import { Button } from "@/components/ui/button"
+import { Slider } from "@/components/ui/slider"
+import { cn } from "@/lib/utils"
+import {
+  PAN_RANGE,
+  ZOOM_RANGE,
+  useFloorplanPreferences,
+} from "@/hooks/use-floorplan-preferences"
+
+const overlayThemes = {
+  storage: {
+    active: "border-overlay-storage bg-overlay-storage/80 text-overlay-storage-foreground shadow-lg",
+    inactive: "border-overlay-outline/60 bg-transparent text-overlay-surface-foreground/70",
+    legend: "border-overlay-storage/60 bg-overlay-storage/15 text-overlay-storage-foreground",
+    dot: "bg-overlay-storage",
+  },
+  chores: {
+    active: "border-overlay-chores bg-overlay-chores/80 text-overlay-chores-foreground shadow-lg",
+    inactive: "border-overlay-outline/60 bg-transparent text-overlay-surface-foreground/70",
+    legend: "border-overlay-chores/60 bg-overlay-chores/15 text-overlay-chores-foreground",
+    dot: "bg-overlay-chores",
+  },
+  maintenance: {
+    active:
+      "border-overlay-maintenance bg-overlay-maintenance/80 text-overlay-maintenance-foreground shadow-lg",
+    inactive: "border-overlay-outline/60 bg-transparent text-overlay-surface-foreground/70",
+    legend: "border-overlay-maintenance/60 bg-overlay-maintenance/15 text-overlay-maintenance-foreground",
+    dot: "bg-overlay-maintenance",
+  },
+  visitors: {
+    active: "border-overlay-visitors bg-overlay-visitors/80 text-overlay-visitors-foreground shadow-lg",
+    inactive: "border-overlay-outline/60 bg-transparent text-overlay-surface-foreground/70",
+    legend: "border-overlay-visitors/60 bg-overlay-visitors/15 text-overlay-visitors-foreground",
+    dot: "bg-overlay-visitors",
+  },
+} as const
+
+type OverlayThemeName = keyof typeof overlayThemes
+
+interface OverlayDefinition {
+  id: string
+  name: string
+  description: string
+  theme: OverlayThemeName
+  area: {
+    top: string
+    left: string
+    width: string
+    height: string
+  }
+}
+
+const overlays: OverlayDefinition[] = [
+  {
+    id: "storage",
+    name: "Storage lockers",
+    description:
+      "Assigned shelving for each roommate. Keep bulky gear secured without overcrowding shared closets.",
+    theme: "storage",
+    area: {
+      top: "7%",
+      left: "6%",
+      width: "34%",
+      height: "38%",
+    },
+  },
+  {
+    id: "chores",
+    name: "Cleaning rotation",
+    description:
+      "Kitchen and living room duties rotate weekly. The active roommate receives reminders the night before.",
+    theme: "chores",
+    area: {
+      top: "7%",
+      left: "58%",
+      width: "34%",
+      height: "38%",
+    },
+  },
+  {
+    id: "maintenance",
+    name: "Maintenance tasks",
+    description:
+      "Track filter swaps, appliance servicing, and shared supply restocks. Completed items sync back to management.",
+    theme: "maintenance",
+    area: {
+      top: "54%",
+      left: "6%",
+      width: "34%",
+      height: "36%",
+    },
+  },
+  {
+    id: "visitors",
+    name: "Quiet hours & guests",
+    description:
+      "Overnight guest approvals and quiet hours live here. Everyone sees the schedule and policy reminders at a glance.",
+    theme: "visitors",
+    area: {
+      top: "54%",
+      left: "58%",
+      width: "34%",
+      height: "36%",
+    },
+  },
+]
+
+const PAN_STEP = 32
+
+const formatPanLabel = (value: number) => `${Math.round(value)}px`
+
+export default function FloorplanOverlays() {
+  const { preferences, setPreferences, reset, isHydrated } = useFloorplanPreferences()
+
+  const [activeOverlays, setActiveOverlays] = useState<Set<string>>(
+    () => new Set(overlays.map((overlay) => overlay.id))
+  )
+
+  const transformStyle = useMemo(() => {
+    return {
+      transform: `translate(${preferences.pan.x}px, ${preferences.pan.y}px) scale(${preferences.zoom})`,
+      transformOrigin: "center",
+    }
+  }, [preferences.pan.x, preferences.pan.y, preferences.zoom])
+
+  const toggleOverlay = (id: string) => {
+    setActiveOverlays((previous) => {
+      const next = new Set(previous)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const updateZoom = (value: number) => {
+    const safeValue = Math.min(ZOOM_RANGE.max, Math.max(ZOOM_RANGE.min, Number(value.toFixed(2))))
+    setPreferences((current) => ({
+      ...current,
+      zoom: safeValue,
+    }))
+  }
+
+  const handleSliderChange = (values: number[]) => {
+    if (!values?.length) return
+    updateZoom(values[0])
+  }
+
+  const clampPan = (axis: "x" | "y", value: number) => {
+    return Math.min(PAN_RANGE, Math.max(-PAN_RANGE, value))
+  }
+
+  const handleKeyboardPan = (axis: "x" | "y", delta: number) => {
+    setPreferences((current) => ({
+      ...current,
+      pan: {
+        ...current.pan,
+        [axis]: clampPan(axis, current.pan[axis] + delta),
+      },
+    }))
+  }
+
+  const activeOverlayList = useMemo(() => Array.from(activeOverlays), [activeOverlays])
+  const activeOverlayNames = useMemo(
+    () =>
+      activeOverlayList
+        .map((id) => overlays.find((overlay) => overlay.id === id)?.name)
+        .filter((name): name is string => Boolean(name)),
+    [activeOverlayList]
+  )
+
+  return (
+    <section aria-labelledby="floorplan-title" className="space-y-6">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex min-w-[240px] flex-1 flex-col gap-2">
+            <div className="flex items-center justify-between text-sm font-medium text-overlay-surface-foreground/80">
+              <span>Zoom</span>
+              <span aria-live="polite">{preferences.zoom.toFixed(2)}×</span>
+            </div>
+            <Slider
+              aria-label="Adjust floorplan zoom"
+              value={[preferences.zoom]}
+              min={ZOOM_RANGE.min}
+              max={ZOOM_RANGE.max}
+              step={0.05}
+              onValueChange={handleSliderChange}
+              className="w-full"
+              disabled={!isHydrated}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-overlay-surface-foreground/80">Pan</span>
+            <div className="flex items-center gap-1" role="group" aria-label="Pan controls">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => handleKeyboardPan("y", -PAN_STEP)}
+                aria-label="Pan up"
+                disabled={!isHydrated}
+              >
+                <ChevronUpIcon className="size-4" />
+              </Button>
+              <div className="flex flex-col gap-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => handleKeyboardPan("x", -PAN_STEP)}
+                  aria-label="Pan left"
+                  disabled={!isHydrated}
+                >
+                  <ChevronLeftIcon className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => handleKeyboardPan("x", PAN_STEP)}
+                  aria-label="Pan right"
+                  disabled={!isHydrated}
+                >
+                  <ChevronRightIcon className="size-4" />
+                </Button>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => handleKeyboardPan("y", PAN_STEP)}
+                aria-label="Pan down"
+                disabled={!isHydrated}
+              >
+                <ChevronDownIcon className="size-4" />
+              </Button>
+            </div>
+            <div className="flex flex-col text-xs text-overlay-surface-foreground/70">
+              <span>Horizontal: {formatPanLabel(preferences.pan.x)}</span>
+              <span>Vertical: {formatPanLabel(preferences.pan.y)}</span>
+            </div>
+          </div>
+          <Button type="button" variant="secondary" onClick={reset} disabled={!isHydrated}>
+            Reset view
+          </Button>
+        </div>
+        <p className="text-sm text-overlay-surface-foreground/70">
+          Your zoom and pan preferences are stored locally and applied automatically the next time you return.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-base font-semibold text-overlay-surface-foreground" id="floorplan-title">
+          Floorplan overlays
+        </h2>
+        <fieldset className="flex flex-wrap gap-3" aria-describedby="overlay-legend-help">
+          <legend className="sr-only">Choose which overlays are visible</legend>
+          {overlays.map((overlay) => {
+            const theme = overlayThemes[overlay.theme]
+            const isActive = activeOverlays.has(overlay.id)
+            return (
+              <label
+                key={overlay.id}
+                className={cn(
+                  "group flex cursor-pointer items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition-all",
+                  isActive ? theme.legend : "border-overlay-outline/60 text-overlay-surface-foreground/70"
+                )}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn("size-2.5 rounded-full transition-transform", theme.dot, {
+                    "scale-110": isActive,
+                  })}
+                />
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={isActive}
+                  onChange={() => toggleOverlay(overlay.id)}
+                />
+                <span>{overlay.name}</span>
+              </label>
+            )
+          })}
+        </fieldset>
+        <p className="text-xs text-overlay-surface-foreground/60" id="overlay-legend-help">
+          Toggle overlays to focus on specific assignments or policies. Tooltips offer additional context for each zone.
+        </p>
+      </div>
+
+      <div className="relative aspect-[4/3] overflow-hidden rounded-2xl border border-overlay-outline bg-overlay-surface text-overlay-surface-foreground shadow-xl">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.25)_0,rgba(255,255,255,0)_70%)] opacity-80"
+        />
+        <div className="absolute inset-4 grid grid-cols-2 gap-4 text-sm font-medium uppercase tracking-wide text-overlay-surface-foreground/70">
+          <div className="flex items-center justify-center rounded-xl border border-overlay-outline/60 bg-overlay-surface/80">
+            Kitchen
+          </div>
+          <div className="flex items-center justify-center rounded-xl border border-overlay-outline/60 bg-overlay-surface/80">
+            Living room
+          </div>
+          <div className="flex items-center justify-center rounded-xl border border-overlay-outline/60 bg-overlay-surface/80">
+            Utility closet
+          </div>
+          <div className="flex items-center justify-center rounded-xl border border-overlay-outline/60 bg-overlay-surface/80">
+            Bedrooms
+          </div>
+        </div>
+        <div className="absolute inset-0" style={transformStyle}>
+          {overlays.map((overlay) => {
+            const theme = overlayThemes[overlay.theme]
+            const isActive = activeOverlays.has(overlay.id)
+            const tooltipId = `${overlay.id}-description`
+
+            return (
+              <div
+                key={overlay.id}
+                className="group absolute"
+                style={{
+                  top: overlay.area.top,
+                  left: overlay.area.left,
+                  width: overlay.area.width,
+                  height: overlay.area.height,
+                }}
+              >
+                <button
+                  type="button"
+                  aria-pressed={isActive}
+                  aria-describedby={tooltipId}
+                  onClick={() => toggleOverlay(overlay.id)}
+                  className={cn(
+                    "flex h-full w-full flex-col justify-between rounded-xl border-2 p-3 text-left transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-overlay-outline",
+                    isActive ? theme.active : theme.inactive
+                  )}
+                >
+                  <span className="text-sm font-semibold">{overlay.name}</span>
+                  <span className="text-xs font-medium uppercase tracking-wide opacity-75">Tap to toggle</span>
+                  <span id={tooltipId} className="sr-only">
+                    {overlay.description}
+                  </span>
+                </button>
+                <div
+                  role="tooltip"
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 w-56 -translate-x-1/2 rounded-lg border border-overlay-outline bg-overlay-surface p-3 text-xs leading-relaxed text-overlay-surface-foreground opacity-0 shadow-lg transition-all duration-150 ease-out invisible group-hover:visible group-hover:translate-y-1 group-hover:opacity-100 group-focus-within:visible group-focus-within:translate-y-1 group-focus-within:opacity-100"
+                >
+                  {overlay.description}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-overlay-outline bg-overlay-surface p-4 text-sm text-overlay-surface-foreground shadow-inner">
+        <h3 className="text-base font-semibold">Currently visible overlays</h3>
+        <p className="mt-1 text-sm text-overlay-surface-foreground/70">
+          {activeOverlayNames.length > 0
+            ? activeOverlayNames.join(", ")
+            : "All overlays are hidden. Enable one to see assignments on the floorplan."}
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -18,7 +18,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-overlay-scrim/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -18,14 +18,14 @@ const DialogOverlay = React.forwardRef<
 	React.ElementRef<typeof DialogPrimitive.Overlay>,
 	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-	<DialogPrimitive.Overlay
-		ref={ref}
-		className={cn(
-			"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 dark:bg-[#09090B]",
-			className
-		)}
-		{...props}
-	/>
+        <DialogPrimitive.Overlay
+                ref={ref}
+                className={cn(
+                        "fixed inset-0 z-50 bg-overlay-scrim/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+                        className
+                )}
+                {...props}
+        />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -19,17 +19,17 @@ const SheetPortal = ({ ...props }: SheetPrimitive.DialogPortalProps) => (
 SheetPortal.displayName = SheetPrimitive.Portal.displayName;
 
 const SheetOverlay = React.forwardRef<
-	React.ElementRef<typeof SheetPrimitive.Overlay>,
-	React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+        React.ElementRef<typeof SheetPrimitive.Overlay>,
+        React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-	<SheetPrimitive.Overlay
-		className={cn(
-			"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-			className
-		)}
-		{...props}
-		ref={ref}
-	/>
+        <SheetPrimitive.Overlay
+                className={cn(
+                        "fixed inset-0 z-50 bg-overlay-scrim/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+                        className
+                )}
+                {...props}
+                ref={ref}
+        />
 ));
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 

--- a/config/tailwind/colors.ts
+++ b/config/tailwind/colors.ts
@@ -1,0 +1,66 @@
+export const overlayThemeTokens = {
+  light: {
+    scrim: "222 47% 11%",
+    surface: "210 40% 98%",
+    surfaceForeground: "222 47% 11%",
+    outline: "215 25% 65%",
+    storage: "188 72% 32%",
+    storageForeground: "210 40% 98%",
+    chores: "276 65% 35%",
+    choresForeground: "210 40% 98%",
+    maintenance: "26 90% 38%",
+    maintenanceForeground: "210 40% 98%",
+    visitors: "204 78% 34%",
+    visitorsForeground: "210 40% 98%",
+  },
+  dark: {
+    scrim: "222 67% 4%",
+    surface: "222 47% 16%",
+    surfaceForeground: "210 40% 96%",
+    outline: "215 15% 50%",
+    storage: "188 75% 42%",
+    storageForeground: "222 47% 11%",
+    chores: "276 65% 55%",
+    choresForeground: "210 40% 98%",
+    maintenance: "26 90% 52%",
+    maintenanceForeground: "222 47% 11%",
+    visitors: "204 78% 52%",
+    visitorsForeground: "222 47% 11%",
+  },
+} as const
+
+export const overlayColorPalette = {
+  overlay: {
+    scrim: "hsl(var(--overlay-scrim))",
+    outline: "hsl(var(--overlay-outline))",
+    surface: {
+      DEFAULT: "hsl(var(--overlay-surface))",
+      foreground: "hsl(var(--overlay-surface-foreground))",
+    },
+    storage: {
+      DEFAULT: "hsl(var(--overlay-storage))",
+      foreground: "hsl(var(--overlay-storage-foreground))",
+    },
+    chores: {
+      DEFAULT: "hsl(var(--overlay-chores))",
+      foreground: "hsl(var(--overlay-chores-foreground))",
+    },
+    maintenance: {
+      DEFAULT: "hsl(var(--overlay-maintenance))",
+      foreground: "hsl(var(--overlay-maintenance-foreground))",
+    },
+    visitors: {
+      DEFAULT: "hsl(var(--overlay-visitors))",
+      foreground: "hsl(var(--overlay-visitors-foreground))",
+    },
+  },
+} as const
+
+export const overlaySemanticTokens = [
+  "storage",
+  "chores",
+  "maintenance",
+  "visitors",
+] as const
+
+export type OverlaySemanticToken = (typeof overlaySemanticTokens)[number]

--- a/hooks/use-floorplan-preferences.ts
+++ b/hooks/use-floorplan-preferences.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+export interface FloorplanPreferences {
+  zoom: number
+  pan: {
+    x: number
+    y: number
+  }
+}
+
+export type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">
+
+export const FLOORPLAN_PREFERENCES_STORAGE_KEY = "share-house-portal:floorplan-preferences"
+
+export const ZOOM_RANGE = {
+  min: 0.75,
+  max: 2.5,
+}
+
+export const PAN_RANGE = 200
+
+const basePreferences: FloorplanPreferences = {
+  zoom: 1,
+  pan: { x: 0, y: 0 },
+}
+
+export const defaultFloorplanPreferences: FloorplanPreferences = {
+  zoom: basePreferences.zoom,
+  pan: { ...basePreferences.pan },
+}
+
+export const createDefaultFloorplanPreferences = (): FloorplanPreferences => ({
+  zoom: basePreferences.zoom,
+  pan: { ...basePreferences.pan },
+})
+
+const clampNumber = (value: unknown, min: number, max: number, fallback: number): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.min(max, Math.max(min, value))
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return Math.min(max, Math.max(min, parsed))
+    }
+  }
+
+  return fallback
+}
+
+export const sanitizeFloorplanPreferences = (
+  candidate: Partial<FloorplanPreferences> | null | undefined
+): FloorplanPreferences => {
+  const fallback = createDefaultFloorplanPreferences()
+  if (!candidate || typeof candidate !== "object") {
+    return fallback
+  }
+
+  const zoom = clampNumber(candidate.zoom, ZOOM_RANGE.min, ZOOM_RANGE.max, fallback.zoom)
+  const panX = clampNumber(candidate.pan?.x, -PAN_RANGE, PAN_RANGE, fallback.pan.x)
+  const panY = clampNumber(candidate.pan?.y, -PAN_RANGE, PAN_RANGE, fallback.pan.y)
+
+  return {
+    zoom,
+    pan: { x: panX, y: panY },
+  }
+}
+
+export const readFloorplanPreferences = (storage?: StorageLike | null): FloorplanPreferences => {
+  if (!storage) {
+    return createDefaultFloorplanPreferences()
+  }
+
+  try {
+    const rawValue = storage.getItem(FLOORPLAN_PREFERENCES_STORAGE_KEY)
+    if (!rawValue) {
+      return createDefaultFloorplanPreferences()
+    }
+
+    const parsed = JSON.parse(rawValue) as Partial<FloorplanPreferences> | null
+    return sanitizeFloorplanPreferences(parsed ?? undefined)
+  } catch (error) {
+    console.warn("Unable to read floorplan preferences", error)
+    return createDefaultFloorplanPreferences()
+  }
+}
+
+export const writeFloorplanPreferences = (
+  preferences: FloorplanPreferences,
+  storage?: StorageLike | null
+) => {
+  if (!storage) return
+
+  const safePreferences = sanitizeFloorplanPreferences(preferences)
+  storage.setItem(FLOORPLAN_PREFERENCES_STORAGE_KEY, JSON.stringify(safePreferences))
+}
+
+export const clearFloorplanPreferences = (storage?: StorageLike | null) => {
+  storage?.removeItem(FLOORPLAN_PREFERENCES_STORAGE_KEY)
+}
+
+export const useFloorplanPreferences = (storage?: StorageLike | null) => {
+  const storageRef = useRef<StorageLike | null | undefined>(storage)
+  const [preferences, setInternalPreferences] = useState<FloorplanPreferences>(createDefaultFloorplanPreferences)
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const resolvedStorage = storageRef.current ?? window.localStorage
+    storageRef.current = resolvedStorage
+
+    const initial = readFloorplanPreferences(resolvedStorage)
+    setInternalPreferences(initial)
+    setIsHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (!isHydrated) return
+
+    const resolvedStorage = storageRef.current
+    if (!resolvedStorage) return
+
+    writeFloorplanPreferences(preferences, resolvedStorage)
+  }, [preferences, isHydrated])
+
+  const setPreferences = useCallback<React.Dispatch<React.SetStateAction<FloorplanPreferences>>>(
+    (update) => {
+      setInternalPreferences((previous) => {
+        const nextValue = typeof update === "function" ? update(previous) : update
+        return sanitizeFloorplanPreferences(nextValue)
+      })
+    },
+    []
+  )
+
+  const reset = useCallback(() => {
+    setPreferences(() => createDefaultFloorplanPreferences())
+  }, [setPreferences])
+
+  return useMemo(
+    () => ({
+      preferences,
+      setPreferences,
+      reset,
+      isHydrated,
+    }),
+    [preferences, setPreferences, reset, isHydrated]
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,7 @@
 import type { Config } from "tailwindcss"
 
+import { overlayColorPalette } from "./config/tailwind/colors"
+
 const config = {
   darkMode: ["class"],
   content: [
@@ -53,6 +55,7 @@ const config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        ...overlayColorPalette,
       },
       borderRadius: {
         lg: "var(--radius)",

--- a/tests/floorplan-preferences.test.ts
+++ b/tests/floorplan-preferences.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  FLOORPLAN_PREFERENCES_STORAGE_KEY,
+  PAN_RANGE,
+  ZOOM_RANGE,
+  createDefaultFloorplanPreferences,
+  readFloorplanPreferences,
+  sanitizeFloorplanPreferences,
+  writeFloorplanPreferences,
+} from "@/hooks/use-floorplan-preferences"
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+}
+
+describe("floorplan preference persistence", () => {
+  it("returns defaults when no stored preferences exist", () => {
+    const storage = new MemoryStorage()
+    expect(readFloorplanPreferences(storage)).toEqual(createDefaultFloorplanPreferences())
+  })
+
+  it("persists zoom and pan values for subsequent sessions", () => {
+    const storage = new MemoryStorage()
+    const preferences = {
+      zoom: 1.75,
+      pan: { x: 48, y: -24 },
+    }
+
+    writeFloorplanPreferences(preferences, storage)
+    expect(readFloorplanPreferences(storage)).toEqual(preferences)
+  })
+
+  it("clamps zoom and pan within supported ranges", () => {
+    const storage = new MemoryStorage()
+    const outOfRange = {
+      zoom: ZOOM_RANGE.max + 5,
+      pan: { x: PAN_RANGE + 420, y: -PAN_RANGE - 500 },
+    }
+
+    writeFloorplanPreferences(outOfRange, storage)
+    const persisted = readFloorplanPreferences(storage)
+
+    expect(persisted.zoom).toBe(ZOOM_RANGE.max)
+    expect(persisted.pan.x).toBe(PAN_RANGE)
+    expect(persisted.pan.y).toBe(-PAN_RANGE)
+  })
+
+  it("recovers from corrupted storage entries", () => {
+    const storage = new MemoryStorage()
+    storage.setItem(FLOORPLAN_PREFERENCES_STORAGE_KEY, "{not-valid-json}")
+
+    expect(readFloorplanPreferences(storage)).toEqual(createDefaultFloorplanPreferences())
+  })
+
+  it("sanitises malformed inputs before persistence", () => {
+    const malformed = sanitizeFloorplanPreferences({
+      zoom: "abc" as unknown as number,
+      pan: {
+        x: "200px" as unknown as number,
+        y: null as unknown as number,
+      },
+    })
+
+    expect(malformed).toEqual(createDefaultFloorplanPreferences())
+  })
+})

--- a/tests/overlay-accessibility.test.ts
+++ b/tests/overlay-accessibility.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+
+import { overlayThemeTokens } from "@/config/tailwind/colors"
+
+type ThemeMode = keyof typeof overlayThemeTokens
+
+type OverlayToken = "storage" | "chores" | "maintenance" | "visitors"
+
+const OVERLAY_TOKENS: OverlayToken[] = ["storage", "chores", "maintenance", "visitors"]
+const CONTRAST_TARGET = 4.5
+
+interface RGB {
+  r: number
+  g: number
+  b: number
+}
+
+const parseHsl = (value: string) => {
+  const [hueRaw, saturationRaw, lightnessRaw] = value.trim().split(/\s+/)
+  const hue = Number.parseFloat(hueRaw)
+  const saturation = Number.parseFloat(saturationRaw.replace("%", "")) / 100
+  const lightness = Number.parseFloat(lightnessRaw.replace("%", "")) / 100
+
+  return { hue, saturation, lightness }
+}
+
+const hueToRgb = (p: number, q: number, t: number) => {
+  let temp = t
+  if (temp < 0) temp += 1
+  if (temp > 1) temp -= 1
+  if (temp < 1 / 6) return p + (q - p) * 6 * temp
+  if (temp < 1 / 2) return q
+  if (temp < 2 / 3) return p + (q - p) * (2 / 3 - temp) * 6
+  return p
+}
+
+const hslToRgb = (value: string): RGB => {
+  const { hue, saturation, lightness } = parseHsl(value)
+
+  if (saturation === 0) {
+    const channel = lightness * 255
+    return { r: channel, g: channel, b: channel }
+  }
+
+  const q =
+    lightness < 0.5
+      ? lightness * (1 + saturation)
+      : lightness + saturation - lightness * saturation
+  const p = 2 * lightness - q
+
+  const r = hueToRgb(p, q, hue / 360 + 1 / 3)
+  const g = hueToRgb(p, q, hue / 360)
+  const b = hueToRgb(p, q, hue / 360 - 1 / 3)
+
+  return { r: r * 255, g: g * 255, b: b * 255 }
+}
+
+const channelLuminance = (channel: number) => {
+  const normalized = channel / 255
+  return normalized <= 0.03928
+    ? normalized / 12.92
+    : Math.pow((normalized + 0.055) / 1.055, 2.4)
+}
+
+const relativeLuminance = ({ r, g, b }: RGB) =>
+  0.2126 * channelLuminance(r) +
+  0.7152 * channelLuminance(g) +
+  0.0722 * channelLuminance(b)
+
+const contrastRatio = (foreground: RGB, background: RGB) => {
+  const l1 = relativeLuminance(foreground)
+  const l2 = relativeLuminance(background)
+  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1]
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+describe("overlay color accessibility", () => {
+  const modes: ThemeMode[] = ["light", "dark"]
+
+  modes.forEach((mode) => {
+    it(`${mode} surface foreground maintains contrast`, () => {
+      const tokens = overlayThemeTokens[mode]
+      const contrast = contrastRatio(
+        hslToRgb(tokens.surfaceForeground),
+        hslToRgb(tokens.surface)
+      )
+
+      expect(contrast).toBeGreaterThanOrEqual(CONTRAST_TARGET)
+    })
+
+    OVERLAY_TOKENS.forEach((token) => {
+      it(`${mode} ${token} overlay meets WCAG contrast`, () => {
+        const tokens = overlayThemeTokens[mode]
+        const background = tokens[token]
+        const foregroundKey = `${token}Foreground` as keyof typeof tokens
+        const foreground = tokens[foregroundKey]
+
+        const contrast = contrastRatio(hslToRgb(foreground), hslToRgb(background))
+        expect(contrast).toBeGreaterThanOrEqual(CONTRAST_TARGET)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- define shared overlay color tokens and expose them as CSS variables for light and dark themes
- add a dashboard floorplan experience with tooltip descriptions and persistent zoom/pan preferences
- update existing overlay surfaces to use the new tokens and add regression tests for color contrast and preference storage

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0e4e88c832882a853d9e9b08009