### PR TITLE
Add floorplan overlay editor and viewer

### DIFF
--- a/app/dashboard/components/main-nav.tsx
+++ b/app/dashboard/components/main-nav.tsx
@@ -24,10 +24,10 @@ export function MainNav({
         Customers
       </Link>
       <Link
-       href="#"
+        href="/dashboard/floorplans"
         className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
       >
-        Products
+        Floorplans
       </Link>
       <Link
         href="#"

--- a/app/dashboard/floorplans/[id]/page.tsx
+++ b/app/dashboard/floorplans/[id]/page.tsx
@@ -1,0 +1,102 @@
+import { notFound } from "next/navigation"
+
+import { FloorplanOverlayEditor } from "@/components/floorplans/floorplan-overlay-editor"
+import { FloorplanOverlayViewer } from "@/components/floorplans/floorplan-overlay-viewer"
+import { parseNormalizedPolygon } from "@/lib/floorplan-geometry"
+import type { Floorplan, OverlayShape } from "@/types/floorplans"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+import {
+  deleteOverlayShapeAction,
+  saveOverlayShapeAction,
+} from "../actions"
+
+type FloorplanPageProps = {
+  params: {
+    id: string
+  }
+}
+
+export default async function FloorplanDetailPage({ params }: FloorplanPageProps) {
+  const floorplanId = params.id
+  const supabase = await createSupbaseServerClient()
+
+  const { data: floorplanRow, error: floorplanError } = await supabase
+    .from("floorplans")
+    .select("id, name, image_url, description, created_at")
+    .eq("id", floorplanId)
+    .maybeSingle()
+
+  if (floorplanError || !floorplanRow) {
+    return notFound()
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { data: profile } = user
+    ? await supabase
+        .from("profiles")
+        .select("id, role, full_name, email")
+        .eq("id", user.id)
+        .maybeSingle()
+    : { data: null }
+
+  const { data: overlayRows } = await supabase
+    .from("overlay_shapes")
+    .select("id, label, type, polygon, tenant_id, floorplan_id, created_at")
+    .eq("floorplan_id", floorplanId)
+    .order("created_at", { ascending: true })
+
+  const overlays: OverlayShape[] = (overlayRows ?? []).map((row) => ({
+    id: row.id,
+    floorplanId: row.floorplan_id,
+    label: row.label,
+    type: row.type,
+    polygon: parseNormalizedPolygon(row.polygon),
+    tenantId: row.tenant_id,
+    createdAt: row.created_at,
+  }))
+
+  const floorplan: Floorplan = {
+    id: floorplanRow.id,
+    name: floorplanRow.name,
+    imageUrl: floorplanRow.image_url,
+    description: floorplanRow.description,
+    createdAt: floorplanRow.created_at,
+  }
+
+  const isAdmin = profile?.role === "admin"
+
+  const tenantOptions = isAdmin
+    ? ((await supabase
+        .from("profiles")
+        .select("id, full_name, email")
+        .order("full_name", { ascending: true })).data ?? [])
+        .map((tenant) => ({
+          id: tenant.id,
+          label: tenant.full_name ?? tenant.email ?? "Unnamed tenant",
+        }))
+    : []
+
+  if (isAdmin) {
+    return (
+      <FloorplanOverlayEditor
+        floorplan={floorplan}
+        overlays={overlays}
+        tenants={tenantOptions}
+        onSave={saveOverlayShapeAction}
+        onDelete={deleteOverlayShapeAction}
+      />
+    )
+  }
+
+  return (
+    <FloorplanOverlayViewer
+      floorplan={floorplan}
+      overlays={overlays}
+      tenantId={profile?.id ?? null}
+    />
+  )
+}

--- a/app/dashboard/floorplans/actions.ts
+++ b/app/dashboard/floorplans/actions.ts
@@ -1,0 +1,96 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { serializeNormalizedPolygon } from "@/lib/floorplan-geometry"
+import { overlayShapeMutationSchema } from "@/lib/schemas/overlay-shape"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+async function assertAdminRole() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error("You need to sign in to manage overlays.")
+  }
+
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single()
+
+  if (error) {
+    throw new Error("Unable to verify permissions for the current user.")
+  }
+
+  if (profile?.role !== "admin") {
+    throw new Error("Only administrators can modify floorplan overlays.")
+  }
+
+  return supabase
+}
+
+export async function saveOverlayShapeAction(rawInput: unknown) {
+  const supabase = await assertAdminRole()
+
+  const parsed = overlayShapeMutationSchema.parse({
+    ...(rawInput as Record<string, unknown>),
+    tenantId:
+      (rawInput as { tenantId?: string | null | undefined })?.tenantId ?? null,
+  })
+
+  const normalizedPolygon = serializeNormalizedPolygon(parsed.polygon)
+
+  if (parsed.id) {
+    const { error } = await supabase
+      .from("overlay_shapes")
+      .update({
+        label: parsed.label,
+        type: parsed.type,
+        polygon: normalizedPolygon,
+        tenant_id: parsed.tenantId,
+      })
+      .eq("id", parsed.id)
+
+    if (error) {
+      throw new Error(error.message)
+    }
+  } else {
+    const { error } = await supabase.from("overlay_shapes").insert({
+      floorplan_id: parsed.floorplanId,
+      label: parsed.label,
+      type: parsed.type,
+      polygon: normalizedPolygon,
+      tenant_id: parsed.tenantId,
+    })
+
+    if (error) {
+      throw new Error(error.message)
+    }
+  }
+
+  revalidatePath(`/dashboard/floorplans/${parsed.floorplanId}`)
+  revalidatePath("/dashboard/floorplans")
+}
+
+export async function deleteOverlayShapeAction(payload: {
+  id: string
+  floorplanId: string
+}) {
+  const supabase = await assertAdminRole()
+
+  const { error } = await supabase
+    .from("overlay_shapes")
+    .delete()
+    .eq("id", payload.id)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  revalidatePath(`/dashboard/floorplans/${payload.floorplanId}`)
+  revalidatePath("/dashboard/floorplans")
+}

--- a/app/dashboard/floorplans/page.tsx
+++ b/app/dashboard/floorplans/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export default async function FloorplansPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { data: profile } = user
+    ? await supabase
+        .from("profiles")
+        .select("id, role, full_name")
+        .eq("id", user.id)
+        .maybeSingle()
+    : { data: null }
+
+  const { data: floorplans } = await supabase
+    .from("floorplans")
+    .select("id, name, image_url, description, created_at")
+    .order("created_at", { ascending: true })
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-bold">Floorplans</h1>
+        <p className="text-muted-foreground">
+          Manage overlays for each property floorplan and review the areas assigned to
+          individual tenants.
+        </p>
+        {profile?.role !== "admin" ? (
+          <Badge variant="secondary" className="w-fit">
+            You are viewing tenant mode. Editing tools are hidden.
+          </Badge>
+        ) : null}
+      </div>
+      {floorplans && floorplans.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {floorplans.map((floorplan) => (
+            <Card key={floorplan.id} className="flex flex-col">
+              <CardHeader>
+                <CardTitle>{floorplan.name}</CardTitle>
+                {floorplan.description ? (
+                  <CardDescription>{floorplan.description}</CardDescription>
+                ) : null}
+              </CardHeader>
+              <CardContent className="flex-1">
+                <div className="aspect-[4/3] overflow-hidden rounded-md border">
+                  <img
+                    src={floorplan.image_url}
+                    alt={floorplan.name}
+                    className="size-full object-cover"
+                  />
+                </div>
+              </CardContent>
+              <CardFooter>
+                <Link
+                  href={`/dashboard/floorplans/${floorplan.id}`}
+                  className="text-sm font-medium text-primary hover:underline"
+                >
+                  {profile?.role === "admin" ? "Open editor" : "View assignments"}
+                </Link>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>No floorplans yet</CardTitle>
+            <CardDescription>
+              Create a floorplan record in Supabase to begin annotating shared spaces.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/components/floorplans/floorplan-overlay-editor.tsx
+++ b/components/floorplans/floorplan-overlay-editor.tsx
@@ -1,0 +1,493 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState, useTransition } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
+import {
+  fromNormalizedPoint,
+  serializeNormalizedPolygon,
+  toNormalizedPoint,
+} from "@/lib/floorplan-geometry"
+import type { NormalizedPoint } from "@/lib/schemas/overlay-shape"
+import { cn } from "@/lib/utils"
+import type { Floorplan, OverlayShape } from "@/types/floorplans"
+
+const MIN_POINTS = 3
+
+type TenantOption = {
+  id: string
+  label: string
+}
+
+type SaveOverlayHandler = (payload: {
+  id?: string
+  floorplanId: string
+  label: string
+  type: string
+  polygon: NormalizedPoint[]
+  tenantId: string | null
+}) => Promise<void>
+
+type DeleteOverlayHandler = (payload: {
+  id: string
+  floorplanId: string
+}) => Promise<void>
+
+type FloorplanOverlayEditorProps = {
+  floorplan: Floorplan
+  overlays: OverlayShape[]
+  tenants: TenantOption[]
+  onSave: SaveOverlayHandler
+  onDelete: DeleteOverlayHandler
+}
+
+type Dimensions = {
+  width: number
+  height: number
+}
+
+export function FloorplanOverlayEditor({
+  floorplan,
+  overlays,
+  tenants,
+  onSave,
+  onDelete,
+}: FloorplanOverlayEditorProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [dimensions, setDimensions] = useState<Dimensions>({ width: 0, height: 0 })
+  const [draftPoints, setDraftPoints] = useState<NormalizedPoint[]>([])
+  const [editingShapeId, setEditingShapeId] = useState<string | null>(null)
+  const [label, setLabel] = useState("")
+  const [type, setType] = useState("custom")
+  const [tenantId, setTenantId] = useState<string | null>(null)
+  const [isDrawing, setIsDrawing] = useState(false)
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return
+    }
+
+    const updateDimensions = () => {
+      if (!containerRef.current) {
+        return
+      }
+
+      const rect = containerRef.current.getBoundingClientRect()
+      setDimensions({ width: rect.width, height: rect.height })
+    }
+
+    updateDimensions()
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(updateDimensions)
+      observer.observe(containerRef.current)
+
+      return () => observer.disconnect()
+    }
+
+    window.addEventListener("resize", updateDimensions)
+    return () => window.removeEventListener("resize", updateDimensions)
+  }, [])
+
+  useEffect(() => {
+    if (dragIndex === null) {
+      return
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!containerRef.current) {
+        return
+      }
+
+      const rect = containerRef.current.getBoundingClientRect()
+      const x = event.clientX - rect.left
+      const y = event.clientY - rect.top
+      const normalized = toNormalizedPoint(x, y, rect.width, rect.height)
+
+      setDraftPoints((current) => {
+        const next = [...current]
+        next[dragIndex] = normalized
+        return next
+      })
+    }
+
+    const handlePointerUp = () => setDragIndex(null)
+
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", handlePointerUp)
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", handlePointerUp)
+    }
+  }, [dragIndex])
+
+  const resetState = () => {
+    setIsDrawing(false)
+    setDraftPoints([])
+    setEditingShapeId(null)
+    setLabel("")
+    setType("custom")
+    setTenantId(null)
+  }
+
+  const handleStartDrawing = () => {
+    resetState()
+    setIsDrawing(true)
+  }
+
+  const handleCanvasClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!isDrawing || !containerRef.current) {
+      return
+    }
+
+    const rect = containerRef.current.getBoundingClientRect()
+    const x = event.clientX - rect.left
+    const y = event.clientY - rect.top
+    const normalized = toNormalizedPoint(x, y, rect.width, rect.height)
+
+    setDraftPoints((points) => [...points, normalized])
+  }
+
+  const handleEditShape = (shape: OverlayShape) => {
+    setIsDrawing(true)
+    setEditingShapeId(shape.id)
+    setDraftPoints(shape.polygon)
+    setLabel(shape.label)
+    setType(shape.type)
+    setTenantId(shape.tenantId)
+  }
+
+  const handleDelete = (id: string) => {
+    startTransition(async () => {
+      try {
+        await onDelete({ id, floorplanId: floorplan.id })
+        toast({
+          title: "Overlay removed",
+          description: "The selected overlay has been deleted.",
+        })
+        resetState()
+      } catch (error) {
+        toast({
+          title: "Unable to delete overlay",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Something went wrong while deleting the overlay.",
+          variant: "destructive",
+        })
+      }
+    })
+  }
+
+  const handleSave = () => {
+    if (draftPoints.length < MIN_POINTS) {
+      toast({
+        title: "Add more points",
+        description: "Draw at least three points to define an area.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    if (!label.trim()) {
+      toast({
+        title: "Label is required",
+        description: "Give the overlay a descriptive label before saving.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    const payload = {
+      id: editingShapeId ?? undefined,
+      floorplanId: floorplan.id,
+      label: label.trim(),
+      type: type.trim() || "custom",
+      polygon: serializeNormalizedPolygon(draftPoints),
+      tenantId,
+    }
+
+    startTransition(async () => {
+      try {
+        await onSave(payload)
+        toast({
+          title: editingShapeId ? "Overlay updated" : "Overlay saved",
+          description: "Changes to the floorplan overlay have been saved.",
+        })
+        resetState()
+      } catch (error) {
+        toast({
+          title: "Unable to save overlay",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Something went wrong while saving the overlay.",
+          variant: "destructive",
+        })
+      }
+    })
+  }
+
+  const overlayPolygons = useMemo(() => {
+    if (!dimensions.width || !dimensions.height) {
+      return []
+    }
+
+    return overlays.map((shape) => ({
+      shape,
+      points: shape.polygon
+        .map((point) => fromNormalizedPoint(point, dimensions.width, dimensions.height))
+        .map((point) => `${point.x},${point.y}`)
+        .join(" "),
+    }))
+  }, [dimensions.height, dimensions.width, overlays])
+
+  const draftPolyline = useMemo(() => {
+    if (!dimensions.width || !dimensions.height) {
+      return ""
+    }
+
+    return draftPoints
+      .map((point) => fromNormalizedPoint(point, dimensions.width, dimensions.height))
+      .map((point) => `${point.x},${point.y}`)
+      .join(" ")
+  }, [dimensions.height, dimensions.width, draftPoints])
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border bg-card p-4 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="md:w-2/3">
+            <div className="mb-3 space-y-2">
+              <h2 className="text-lg font-semibold">{floorplan.name}</h2>
+              <p className="text-sm text-muted-foreground">
+                Click to drop points and outline an area. Drag the handles to fine-tune
+                the shape. All coordinates are stored as values between 0 and 1 so
+                overlays stay aligned on responsive layouts.
+              </p>
+            </div>
+            <div
+              ref={containerRef}
+              className={cn(
+                "relative aspect-[4/3] w-full overflow-hidden rounded-md border",
+                isDrawing ? "cursor-crosshair" : "cursor-pointer",
+              )}
+              onClick={handleCanvasClick}
+              role="img"
+              aria-label={`Floorplan ${floorplan.name}`}
+            >
+              <img
+                src={floorplan.imageUrl}
+                alt={`Floorplan ${floorplan.name}`}
+                className="size-full object-contain"
+              />
+              <svg
+                className="absolute inset-0 size-full"
+                viewBox={`0 0 ${Math.max(dimensions.width, 1)} ${Math.max(dimensions.height, 1)}`}
+                preserveAspectRatio="none"
+              >
+                {overlayPolygons.map((shape) => (
+                  <polygon
+                    key={shape.shape.id}
+                    points={shape.points}
+                    className={cn(
+                      "pointer-events-auto fill-primary/10 stroke-primary",
+                      shape.shape.id === editingShapeId && "fill-primary/20 stroke-2",
+                    )}
+                    strokeWidth={shape.shape.id === editingShapeId ? 2.5 : 1.5}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      if (!isDrawing) {
+                        handleEditShape(shape.shape)
+                      }
+                    }}
+                    aria-label={`${shape.shape.label} (${shape.shape.type})`}
+                  />
+                ))}
+                {draftPoints.length > 0 ? (
+                  <>
+                    <polyline
+                      points={draftPolyline}
+                      className="fill-primary/20 stroke-primary"
+                      strokeDasharray={editingShapeId ? undefined : "6 4"}
+                      strokeWidth={2}
+                    />
+                    {draftPoints.map((point, index) => {
+                      const absolute = fromNormalizedPoint(
+                        point,
+                        dimensions.width,
+                        dimensions.height,
+                      )
+
+                      return (
+                        <circle
+                          key={`${point.x}-${point.y}-${index}`}
+                          cx={absolute.x}
+                          cy={absolute.y}
+                          r={6}
+                          className="pointer-events-auto fill-primary stroke-background"
+                          onPointerDown={(event) => {
+                            event.preventDefault()
+                            event.stopPropagation()
+                            setDragIndex(index)
+                          }}
+                          aria-label={`Point ${index + 1}`}
+                        />
+                      )
+                    })}
+                  </>
+                ) : null}
+              </svg>
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <Button type="button" onClick={handleStartDrawing} disabled={isPending}>
+                {editingShapeId ? "Draw new overlay" : "Start drawing"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={resetState}
+                disabled={!isDrawing && !editingShapeId}
+              >
+                Cancel editing
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={isPending || draftPoints.length < MIN_POINTS}
+              >
+                {editingShapeId ? "Update overlay" : "Save overlay"}
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {draftPoints.length >= MIN_POINTS
+                  ? `${draftPoints.length} points`
+                  : (() => {
+                      const remaining = MIN_POINTS - draftPoints.length
+                      return `Place ${remaining} more point${
+                        remaining === 1 ? "" : "s"
+                      } to complete the shape`
+                    })()}
+              </span>
+            </div>
+          </div>
+          <div className="md:w-1/3 md:pl-6">
+            <div className="space-y-4 rounded-md border bg-muted/20 p-4">
+              <div className="space-y-2">
+                <Label htmlFor="overlay-label">Overlay label</Label>
+                <Input
+                  id="overlay-label"
+                  value={label}
+                  onChange={(event) => setLabel(event.target.value)}
+                  placeholder="e.g. Bedroom A"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="overlay-type">Overlay type</Label>
+                <Input
+                  id="overlay-type"
+                  value={type}
+                  onChange={(event) => setType(event.target.value)}
+                  placeholder="e.g. bedroom"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="overlay-tenant">Assigned tenant (optional)</Label>
+                <Select
+                  value={tenantId ?? ""}
+                  onValueChange={(value) => {
+                    if (!value) {
+                      setTenantId(null)
+                      return
+                    }
+                    setTenantId(value)
+                  }}
+                >
+                  <SelectTrigger id="overlay-tenant">
+                    <SelectValue placeholder="Unassigned" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">Unassigned</SelectItem>
+                    {tenants.map((tenant) => (
+                      <SelectItem key={tenant.id} value={tenant.id}>
+                        {tenant.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="mt-6 space-y-3">
+              <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                Existing overlays
+              </h3>
+              {overlays.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No overlays have been created for this floorplan yet.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {overlays.map((shape) => (
+                    <li
+                      key={shape.id}
+                      className={cn(
+                        "rounded-md border bg-background p-3",
+                        editingShapeId === shape.id && "border-primary",
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="font-medium">{shape.label}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {shape.type} · {shape.polygon.length} points
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {shape.tenantId
+                              ? tenants.find((tenant) => tenant.id === shape.tenantId)?.label ??
+                                "Assigned tenant"
+                              : "Unassigned"}
+                          </p>
+                        </div>
+                        <div className="flex flex-col gap-2">
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => handleEditShape(shape)}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => handleDelete(shape.id)}
+                            disabled={isPending}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/floorplans/floorplan-overlay-viewer.tsx
+++ b/components/floorplans/floorplan-overlay-viewer.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import {
+  fromNormalizedPoint,
+  parseNormalizedPolygon,
+} from "@/lib/floorplan-geometry"
+import type { Floorplan, OverlayShape } from "@/types/floorplans"
+
+import { cn } from "@/lib/utils"
+
+type FloorplanOverlayViewerProps = {
+  floorplan: Floorplan
+  overlays: OverlayShape[]
+  tenantId: string | null
+}
+
+type Dimensions = {
+  width: number
+  height: number
+}
+
+export function FloorplanOverlayViewer({
+  floorplan,
+  overlays,
+  tenantId,
+}: FloorplanOverlayViewerProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [dimensions, setDimensions] = useState<Dimensions>({ width: 0, height: 0 })
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return
+    }
+
+    const update = () => {
+      if (!containerRef.current) {
+        return
+      }
+
+      const rect = containerRef.current.getBoundingClientRect()
+      setDimensions({ width: rect.width, height: rect.height })
+    }
+
+    update()
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(update)
+      observer.observe(containerRef.current)
+      return () => observer.disconnect()
+    }
+
+    window.addEventListener("resize", update)
+    return () => window.removeEventListener("resize", update)
+  }, [])
+
+  const polygons = useMemo(() => {
+    if (!dimensions.width || !dimensions.height) {
+      return []
+    }
+
+    return overlays.map((shape) => {
+      const normalized = parseNormalizedPolygon(shape.polygon)
+      const points = normalized
+        .map((point) => fromNormalizedPoint(point, dimensions.width, dimensions.height))
+        .map((point) => `${point.x},${point.y}`)
+        .join(" ")
+
+      return {
+        shape,
+        points,
+        isTenant: tenantId != null && shape.tenantId === tenantId,
+      }
+    })
+  }, [dimensions.height, dimensions.width, overlays, tenantId])
+
+  const tenantShape = polygons.find((polygon) => polygon.isTenant)
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold">{floorplan.name}</h2>
+          <p className="text-sm text-muted-foreground">
+            Areas assigned to you are outlined in bold blue with a contrasting pattern
+            for improved visibility.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <span className="flex h-4 w-4 items-center justify-center rounded-sm border-2 border-blue-600 bg-blue-500/30">
+            <span className="h-2 w-2 rounded-[2px] bg-blue-900" />
+          </span>
+          <span>Your space</span>
+        </div>
+      </div>
+      <div
+        ref={containerRef}
+        className="relative aspect-[4/3] w-full overflow-hidden rounded-lg border"
+        role="img"
+        aria-label={`Floorplan view for ${floorplan.name}`}
+      >
+        <img
+          src={floorplan.imageUrl}
+          alt={`Floorplan ${floorplan.name}`}
+          className="size-full object-contain"
+        />
+        <svg
+          className="absolute inset-0 size-full"
+          viewBox={`0 0 ${Math.max(dimensions.width, 1)} ${Math.max(dimensions.height, 1)}`}
+          preserveAspectRatio="none"
+        >
+          {polygons.map((polygon) => (
+            <polygon
+              key={polygon.shape.id}
+              points={polygon.points}
+              className={cn(
+                "fill-primary/5 stroke-muted-foreground",
+                polygon.isTenant &&
+                  "fill-blue-500/25 stroke-blue-600 stroke-[3] [stroke-dasharray:8_4]",
+              )}
+              aria-label={`${polygon.shape.label} (${polygon.shape.type})`}
+            />
+          ))}
+        </svg>
+      </div>
+      {tenantShape ? (
+        <div className="rounded-md border bg-blue-50 p-4 text-sm text-blue-900 dark:bg-blue-500/10 dark:text-blue-100">
+          <p className="font-medium">{tenantShape.shape.label}</p>
+          <p className="mt-1">
+            This area is assigned to you. The outline uses a thick dashed stroke with a
+            high-contrast blue fill to support low-vision viewing.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+          No area is currently assigned to your profile on this floorplan.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/floorplan-geometry.ts
+++ b/lib/floorplan-geometry.ts
@@ -1,0 +1,114 @@
+import type { NormalizedPoint } from "@/lib/schemas/overlay-shape"
+export type { NormalizedPoint }
+
+export type AbsolutePoint = {
+  x: number
+  y: number
+}
+
+const DEFAULT_PRECISION = 4
+
+export function clampNormalized(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  if (value < 0) {
+    return 0
+  }
+
+  if (value > 1) {
+    return 1
+  }
+
+  return value
+}
+
+export function toNormalizedPoint(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): NormalizedPoint {
+  if (width <= 0 || height <= 0) {
+    return { x: 0, y: 0 }
+  }
+
+  return {
+    x: clampNormalized(x / width),
+    y: clampNormalized(y / height),
+  }
+}
+
+export function fromNormalizedPoint(
+  point: NormalizedPoint,
+  width: number,
+  height: number,
+): AbsolutePoint {
+  return {
+    x: clampNormalized(point.x) * Math.max(width, 0),
+    y: clampNormalized(point.y) * Math.max(height, 0),
+  }
+}
+
+export function roundNormalizedPoint(
+  point: NormalizedPoint,
+  precision = DEFAULT_PRECISION,
+): NormalizedPoint {
+  const factor = 10 ** precision
+  return {
+    x: Math.round(clampNormalized(point.x) * factor) / factor,
+    y: Math.round(clampNormalized(point.y) * factor) / factor,
+  }
+}
+
+export function serializeNormalizedPolygon(
+  points: NormalizedPoint[],
+  precision = DEFAULT_PRECISION,
+): NormalizedPoint[] {
+  if (!Array.isArray(points) || points.length < 3) {
+    throw new Error("A polygon must contain at least three points")
+  }
+
+  return points.map((point) => roundNormalizedPoint(point, precision))
+}
+
+export function isNormalizedPoint(value: unknown): value is NormalizedPoint {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  const x = candidate.x
+  const y = candidate.y
+
+  return (
+    typeof x === "number" &&
+    typeof y === "number" &&
+    Number.isFinite(x) &&
+    Number.isFinite(y)
+  )
+}
+
+export function parseNormalizedPolygon(value: unknown): NormalizedPoint[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Polygon must be an array of points")
+  }
+
+  if (value.length < 3) {
+    throw new Error("Polygon must contain at least three points")
+  }
+
+  const parsed = value.map((point) => {
+    if (!isNormalizedPoint(point)) {
+      throw new Error("Polygon contains invalid points")
+    }
+
+    return {
+      x: clampNormalized((point as NormalizedPoint).x),
+      y: clampNormalized((point as NormalizedPoint).y),
+    }
+  })
+
+  return serializeNormalizedPolygon(parsed)
+}

--- a/lib/schemas/overlay-shape.ts
+++ b/lib/schemas/overlay-shape.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+export const normalizedPointSchema = z.object({
+  x: z.number().min(0).max(1),
+  y: z.number().min(0).max(1),
+})
+
+export const normalizedPolygonSchema = z
+  .array(normalizedPointSchema)
+  .min(3, { message: "Draw at least three points" })
+
+export const overlayShapeBaseSchema = z.object({
+  label: z
+    .string()
+    .min(1, { message: "Label is required" })
+    .max(80, { message: "Label must be 80 characters or fewer" }),
+  type: z
+    .string()
+    .min(1, { message: "Type is required" })
+    .max(40, { message: "Type must be 40 characters or fewer" }),
+  polygon: normalizedPolygonSchema,
+  tenantId: z
+    .union([z.string().uuid({ message: "Invalid tenant" }), z.null()])
+    .optional(),
+})
+
+export const overlayShapeMutationSchema = overlayShapeBaseSchema.extend({
+  id: z.string().uuid().optional(),
+  floorplanId: z.string().uuid(),
+})
+
+export type NormalizedPoint = z.infer<typeof normalizedPointSchema>
+export type OverlayShapeMutationInput = z.infer<typeof overlayShapeMutationSchema>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -914,6 +914,30 @@ export type Database = {
         }
         Relationships: []
       }
+      floorplans: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: string
+          image_url: string
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          image_url: string
+          name: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          image_url?: string
+          name?: string
+        }
+        Relationships: []
+      }
       gpt_one: {
         Row: {
           created_at: string
@@ -940,6 +964,51 @@ export type Database = {
           vector_one?: string | null
         }
         Relationships: []
+      }
+      overlay_shapes: {
+        Row: {
+          created_at: string
+          floorplan_id: string
+          id: string
+          label: string
+          polygon: Json
+          tenant_id: string | null
+          type: string
+        }
+        Insert: {
+          created_at?: string
+          floorplan_id: string
+          id?: string
+          label: string
+          polygon: Json
+          tenant_id?: string | null
+          type: string
+        }
+        Update: {
+          created_at?: string
+          floorplan_id?: string
+          id?: string
+          label?: string
+          polygon?: Json
+          tenant_id?: string | null
+          type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "overlay_shapes_floorplan_id_fkey"
+            columns: ["floorplan_id"]
+            isOneToOne: false
+            referencedRelation: "floorplans"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "overlay_shapes_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       inqueries: {
         Row: {

--- a/supabase/migrations/20250707_overlay_shapes.sql
+++ b/supabase/migrations/20250707_overlay_shapes.sql
@@ -1,0 +1,28 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.floorplans (
+    id uuid primary key default gen_random_uuid(),
+    created_at timestamp with time zone not null default now(),
+    name text not null,
+    image_url text not null,
+    description text null
+);
+
+alter table public.floorplans enable row level security;
+
+create table if not exists public.overlay_shapes (
+    id uuid primary key default gen_random_uuid(),
+    created_at timestamp with time zone not null default now(),
+    floorplan_id uuid not null references public.floorplans(id) on delete cascade,
+    type text not null,
+    polygon jsonb not null,
+    label text not null,
+    tenant_id uuid null references public.profiles(id) on delete set null,
+    constraint overlay_shapes_polygon_is_array check (jsonb_typeof(polygon) = 'array')
+);
+
+alter table public.overlay_shapes enable row level security;
+
+create index if not exists overlay_shapes_floorplan_idx on public.overlay_shapes (floorplan_id);
+create index if not exists overlay_shapes_tenant_idx on public.overlay_shapes (tenant_id);
+create index if not exists overlay_shapes_polygon_gin on public.overlay_shapes using gin (polygon);

--- a/tests/floorplan-geometry.test.ts
+++ b/tests/floorplan-geometry.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  clampNormalized,
+  fromNormalizedPoint,
+  parseNormalizedPolygon,
+  serializeNormalizedPolygon,
+  toNormalizedPoint,
+} from "@/lib/floorplan-geometry"
+
+import type { NormalizedPoint } from "@/lib/schemas/overlay-shape"
+
+describe("floorplan geometry helpers", () => {
+  it("converts absolute coordinates to normalized ratios", () => {
+    const point = toNormalizedPoint(50, 75, 200, 150)
+    expect(point).toEqual({ x: 0.25, y: 0.5 })
+  })
+
+  it("clamps normalized coordinates within bounds", () => {
+    expect(clampNormalized(-0.3)).toBe(0)
+    expect(clampNormalized(0.5)).toBe(0.5)
+    expect(clampNormalized(4)).toBe(1)
+  })
+
+  it("rounds and validates polygons before serialization", () => {
+    const polygon: NormalizedPoint[] = [
+      { x: 0, y: 0 },
+      { x: 0.3333333, y: 0.5 },
+      { x: 0.8, y: 1 },
+    ]
+
+    const serialized = serializeNormalizedPolygon(polygon, 3)
+    expect(serialized).toEqual([
+      { x: 0, y: 0 },
+      { x: 0.333, y: 0.5 },
+      { x: 0.8, y: 1 },
+    ])
+  })
+
+  it("throws when attempting to serialize invalid polygons", () => {
+    expect(() => serializeNormalizedPolygon([], 2)).toThrow()
+    expect(() => serializeNormalizedPolygon([{ x: 0, y: 0 }])).toThrow()
+    expect(() => serializeNormalizedPolygon([{ x: 0, y: 0 }, { x: 1, y: 1 }])).toThrow()
+  })
+
+  it("parses polygon payloads and clamps coordinates", () => {
+    const input = [
+      { x: 1.2, y: -0.2 },
+      { x: 0.5, y: 0.5 },
+      { x: 0.9, y: 0.9 },
+    ]
+
+    const parsed = parseNormalizedPolygon(input)
+    expect(parsed).toEqual([
+      { x: 1, y: 0 },
+      { x: 0.5, y: 0.5 },
+      { x: 0.9, y: 0.9 },
+    ])
+  })
+
+  it("translates normalized points back to absolute coordinates", () => {
+    const result = fromNormalizedPoint({ x: 0.5, y: 0.25 }, 400, 200)
+    expect(result).toEqual({ x: 200, y: 50 })
+  })
+})

--- a/types/floorplans.ts
+++ b/types/floorplans.ts
@@ -1,0 +1,19 @@
+import type { NormalizedPoint } from "@/lib/schemas/overlay-shape"
+
+export type OverlayShape = {
+  id: string
+  floorplanId: string
+  label: string
+  type: string
+  polygon: NormalizedPoint[]
+  tenantId: string | null
+  createdAt: string
+}
+
+export type Floorplan = {
+  id: string
+  name: string
+  imageUrl: string
+  description: string | null
+  createdAt: string
+}


### PR DESCRIPTION
## Summary
- add Supabase schema definitions and migration for floorplans and overlay shapes
- introduce geometry helpers, validation schemas, and tests for normalized polygon data
- build admin overlay editor, tenant viewer, and routing/actions for managing floorplan annotations

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0e6417c832886a63408c1e7ffdc