### PR TITLE
Add interactive floorplan overlay navigation

### DIFF
--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -22,6 +22,7 @@ import { RecentSales } from "@/app/dashboard/components/recent-sales"
 import { Search } from "@/app/dashboard/components/search"
 import TeamSwitcher from "@/app/dashboard/components/team-switcher"
 import { UserNav } from "@/app/dashboard/components/user-nav"
+import FloorPlanOverlayMap from "@/components/floorplan-overlay-map"
 
 export const metadata: Metadata = {
   title: "Onyx Dashboard",
@@ -188,6 +189,17 @@ export default function DashboardPage() {
                   </CardContent>
                 </Card>
               </div>
+              <Card>
+                <CardHeader>
+                  <CardTitle>House floorplan overlays</CardTitle>
+                  <CardDescription>
+                    Select a zone to jump directly into amenity bookings, roommate profiles, or parking reservations.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <FloorPlanOverlayMap />
+                </CardContent>
+              </Card>
             </TabsContent>
           </Tabs>
         </div>

--- a/components/floorplan-overlay-map.tsx
+++ b/components/floorplan-overlay-map.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useCallback, useEffect } from "react"
+import { useRouter } from "next/navigation"
+
+import { cn } from "@/lib/utils"
+import {
+  floorplanOverlays,
+  navigateToOverlay,
+  type FloorplanOverlayTarget,
+} from "@/lib/floorplan-overlays"
+
+const FloorPlanOverlayMap = () => {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (typeof router.prefetch !== "function") {
+      return
+    }
+
+    for (const overlay of floorplanOverlays) {
+      if (overlay.isExternal || !overlay.route.startsWith("/")) {
+        continue
+      }
+
+      router
+        .prefetch(overlay.route)
+        .catch(() => {
+          // Prefetch failures should not block rendering; ignore silently
+        })
+    }
+  }, [router])
+
+  const handleActivate = useCallback(
+    (overlay: FloorplanOverlayTarget) => {
+      navigateToOverlay(overlay, router, (href) => {
+        window.open(href, "_blank", "noopener,noreferrer")
+      })
+    },
+    [router],
+  )
+
+  return (
+    <div className="relative w-full space-y-4">
+      <div className="grid h-[360px] w-full grid-cols-6 grid-rows-4 gap-3 rounded-xl border border-border bg-muted/40 p-4">
+        {floorplanOverlays.map((overlay) => {
+          const tooltipId = `${overlay.id}-tooltip`
+
+          return (
+            <button
+              key={overlay.id}
+              type="button"
+              data-overlay-id={overlay.id}
+              aria-label={overlay.ariaLabel}
+              aria-describedby={tooltipId}
+              className={cn(
+                "group relative flex h-full w-full items-center justify-center rounded-lg border border-primary/50 bg-primary/10 px-3 py-2 text-sm font-semibold text-primary shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:bg-primary/20",
+                overlay.className,
+              )}
+              onClick={() => handleActivate(overlay)}
+            >
+              <span>{overlay.shortLabel}</span>
+              <span
+                id={tooltipId}
+                role="tooltip"
+                className="pointer-events-none absolute -top-2 left-1/2 z-20 w-48 -translate-x-1/2 -translate-y-full rounded-md border border-border bg-background/95 p-2 text-left text-xs text-foreground opacity-0 shadow-lg transition duration-150 group-focus-visible:opacity-100 group-hover:opacity-100"
+              >
+                <span className="block text-sm font-semibold">{overlay.label}</span>
+                <span className="mt-1 block text-[11px] text-muted-foreground">{overlay.tooltip}</span>
+              </span>
+            </button>
+          )
+        })}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Use Tab to move between overlays, then press Enter to open the linked workflow.
+      </p>
+    </div>
+  )
+}
+
+export default FloorPlanOverlayMap

--- a/lib/floorplan-overlays.ts
+++ b/lib/floorplan-overlays.ts
@@ -1,0 +1,110 @@
+export type FloorplanOverlayCategory = "amenity" | "parking" | "roommate"
+
+export interface FloorplanOverlayTarget {
+  id: string
+  label: string
+  shortLabel: string
+  tooltip: string
+  ariaLabel: string
+  route: string
+  className: string
+  type: FloorplanOverlayCategory
+  isExternal?: boolean
+}
+
+const rawParkingBase = process.env.NEXT_PUBLIC_CALCOM_PARKING_URL?.trim()
+const parkingBase = rawParkingBase && rawParkingBase.length > 0 ? rawParkingBase.replace(/\/$/, "") : "https://cal.com/share-house/parking"
+
+const buildParkingUrl = (slot: string) => {
+  const separator = parkingBase.includes("?") ? "&" : "?"
+  return `${parkingBase}${separator}slot=${encodeURIComponent(slot)}`
+}
+
+export const floorplanOverlays: FloorplanOverlayTarget[] = [
+  {
+    id: "amenity-kitchen",
+    label: "Kitchen amenity",
+    shortLabel: "Kitchen",
+    tooltip: "Reserve stove time or review appliance guidance before meal prep.",
+    ariaLabel: "Open kitchen amenity booking details",
+    route: "/bookings?amenity=kitchen",
+    className: "col-span-2 col-start-1 row-span-2 row-start-1",
+    type: "amenity",
+  },
+  {
+    id: "amenity-lounge",
+    label: "TV lounge",
+    shortLabel: "Lounge",
+    tooltip: "See the shared TV lounge calendar and quiet-hour rules.",
+    ariaLabel: "Open TV lounge amenity booking details",
+    route: "/bookings?amenity=lounge",
+    className: "col-span-2 col-start-3 row-span-2 row-start-1",
+    type: "amenity",
+  },
+  {
+    id: "parking-a",
+    label: "Parking bay A",
+    shortLabel: "Parking A",
+    tooltip: "Launch Cal.com to reserve parking bay A before driving home.",
+    ariaLabel: "Open parking bay A booking scheduler on Cal.com",
+    route: buildParkingUrl("A"),
+    className: "col-span-2 col-start-5 row-span-1 row-start-1",
+    type: "parking",
+    isExternal: true,
+  },
+  {
+    id: "parking-b",
+    label: "Parking bay B",
+    shortLabel: "Parking B",
+    tooltip: "Launch Cal.com to reserve parking bay B before driving home.",
+    ariaLabel: "Open parking bay B booking scheduler on Cal.com",
+    route: buildParkingUrl("B"),
+    className: "col-span-2 col-start-5 row-span-1 row-start-2",
+    type: "parking",
+    isExternal: true,
+  },
+  {
+    id: "roommate-aria",
+    label: "Aria Chen — Bedroom 1",
+    shortLabel: "Aria",
+    tooltip: "View Aria's roommate profile, storage assignments, and contact info.",
+    ariaLabel: "Open roommate profile for Aria Chen",
+    route: "/dashboard/members?member=aria-chen",
+    className: "col-span-3 col-start-1 row-span-2 row-start-3",
+    type: "roommate",
+  },
+  {
+    id: "roommate-jamal",
+    label: "Jamal Rivera — Bedroom 2",
+    shortLabel: "Jamal",
+    tooltip: "Review Jamal's roommate profile, chores, and communication preferences.",
+    ariaLabel: "Open roommate profile for Jamal Rivera",
+    route: "/dashboard/members?member=jamal-rivera",
+    className: "col-span-3 col-start-4 row-span-2 row-start-3",
+    type: "roommate",
+  },
+]
+
+const overlayIndex = new Map(floorplanOverlays.map((overlay) => [overlay.id, overlay]))
+
+export const getOverlayById = (id: string) => overlayIndex.get(id)
+
+export interface OverlayNavigator {
+  push: (href: string) => void
+  prefetch?: (href: string) => Promise<void>
+}
+
+export type ExternalOpener = (href: string) => void
+
+export const navigateToOverlay = (
+  overlay: FloorplanOverlayTarget,
+  router: OverlayNavigator,
+  openExternal: ExternalOpener,
+) => {
+  if (overlay.isExternal) {
+    openExternal(overlay.route)
+    return
+  }
+
+  router.push(overlay.route)
+}

--- a/tests/floorplan-overlays.test.ts
+++ b/tests/floorplan-overlays.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  floorplanOverlays,
+  getOverlayById,
+  navigateToOverlay,
+  type OverlayNavigator,
+} from "@/lib/floorplan-overlays"
+
+describe("floorplan overlay configuration", () => {
+  it("exposes navigation routes for each overlay id", () => {
+    const kitchen = getOverlayById("amenity-kitchen")
+    const aria = getOverlayById("roommate-aria")
+
+    expect(kitchen?.route).toBe("/bookings?amenity=kitchen")
+    expect(aria?.route).toBe("/dashboard/members?member=aria-chen")
+  })
+
+  it("links parking overlays to the Cal.com scheduler", () => {
+    const parkingOverlays = floorplanOverlays.filter((overlay) => overlay.type === "parking")
+
+    expect(parkingOverlays.length).toBeGreaterThan(0)
+
+    for (const overlay of parkingOverlays) {
+      expect(overlay.isExternal).toBe(true)
+      expect(() => new URL(overlay.route)).not.toThrow()
+      expect(new URL(overlay.route).hostname).toContain("cal.com")
+    }
+  })
+
+  it("provides tooltip and aria labels for accessibility", () => {
+    for (const overlay of floorplanOverlays) {
+      expect(overlay.tooltip.trim().length).toBeGreaterThan(0)
+      expect(overlay.ariaLabel.trim().length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("floorplan overlay navigation", () => {
+  it("pushes internal routes through the Next.js router", () => {
+    const overlay = getOverlayById("amenity-lounge")
+    expect(overlay).toBeDefined()
+
+    const router: OverlayNavigator = {
+      push: vi.fn(),
+    }
+    const openExternal = vi.fn()
+
+    navigateToOverlay(overlay!, router, openExternal)
+
+    expect(router.push).toHaveBeenCalledWith(overlay!.route)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it("opens external Cal.com links in a new tab", () => {
+    const overlay = getOverlayById("parking-a")
+    expect(overlay).toBeDefined()
+
+    const router: OverlayNavigator = {
+      push: vi.fn(),
+    }
+    const openExternal = vi.fn()
+
+    navigateToOverlay(overlay!, router, openExternal)
+
+    expect(router.push).not.toHaveBeenCalled()
+    expect(openExternal).toHaveBeenCalledWith(overlay!.route)
+  })
+})


### PR DESCRIPTION
## Summary
- add an interactive floorplan overlay map to the dashboard with accessible tooltips
- route overlays to amenity, roommate, and Cal.com booking workflows via shared configuration
- cover overlay navigation helpers with vitest checks

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0e604988328839f31c0c3419c36