### PR TITLE
Add incident triage workflows and notifications

### DIFF
--- a/app/dashboard/incidents/actions.ts
+++ b/app/dashboard/incidents/actions.ts
@@ -1,0 +1,122 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { z } from "zod"
+
+import { createResendLandlordNotifier } from "@/lib/incidents/notifications"
+import { SupabaseIncidentRepository } from "@/lib/incidents/repository"
+import { createIncident, updateIncident } from "@/lib/incidents/service"
+import { INCIDENT_SEVERITIES, INCIDENT_STATUSES } from "@/lib/incidents/types"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+const createIncidentSchema = z.object({
+  householdId: z.string().min(1, "Household is required"),
+  title: z.string().min(1, "Title is required"),
+  description: z.string().min(1, "Description is required"),
+  severity: z.enum(INCIDENT_SEVERITIES),
+  assignedMemberId: z
+    .string()
+    .optional()
+    .transform((value) => (value ? value : null)),
+})
+
+const updateIncidentSchema = z.object({
+  incidentId: z.string().min(1, "Incident is required"),
+  status: z.enum(INCIDENT_STATUSES).optional(),
+  severity: z.enum(INCIDENT_SEVERITIES).optional(),
+  assignedMemberId: z
+    .string()
+    .optional()
+    .transform((value) => (value ? value : null)),
+  message: z.string().optional(),
+})
+
+export async function createIncidentAction(formData: FormData) {
+  const parseResult = createIncidentSchema.safeParse({
+    householdId: formData.get("householdId")?.toString() ?? "",
+    title: formData.get("title")?.toString() ?? "",
+    description: formData.get("description")?.toString() ?? "",
+    severity: formData.get("severity")?.toString() ?? "",
+    assignedMemberId: formData.get("assignedMemberId")?.toString() ?? undefined,
+  })
+
+  if (!parseResult.success) {
+    return { error: parseResult.error.flatten().fieldErrors }
+  }
+
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const repository = new SupabaseIncidentRepository(supabase)
+  const landlordNotifier = createResendLandlordNotifier()
+
+  try {
+    const result = await createIncident(
+      { repository, landlordNotifier },
+      {
+        householdId: parseResult.data.householdId,
+        title: parseResult.data.title,
+        description: parseResult.data.description,
+        severity: parseResult.data.severity,
+        assignedMemberId: parseResult.data.assignedMemberId,
+        reporterId: user?.id ?? null,
+        actorId: user?.id ?? null,
+        message: parseResult.data.description,
+      },
+    )
+
+    revalidatePath("/dashboard/incidents")
+    revalidatePath("/messaging")
+
+    return { success: true, incidentId: result.incident.id }
+  } catch (error) {
+    console.error("Failed to create incident", error)
+    return { error: "Failed to create incident" }
+  }
+}
+
+export async function updateIncidentAction(formData: FormData) {
+  const parseResult = updateIncidentSchema.safeParse({
+    incidentId: formData.get("incidentId")?.toString() ?? "",
+    status: formData.get("status")?.toString() ?? undefined,
+    severity: formData.get("severity")?.toString() ?? undefined,
+    assignedMemberId: formData.get("assignedMemberId")?.toString() ?? undefined,
+    message: formData.get("message")?.toString() ?? undefined,
+  })
+
+  if (!parseResult.success) {
+    return { error: parseResult.error.flatten().fieldErrors }
+  }
+
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const repository = new SupabaseIncidentRepository(supabase)
+  const landlordNotifier = createResendLandlordNotifier()
+
+  try {
+    const result = await updateIncident(
+      { repository, landlordNotifier },
+      {
+        id: parseResult.data.incidentId,
+        status: parseResult.data.status,
+        severity: parseResult.data.severity,
+        assignedMemberId: parseResult.data.assignedMemberId,
+        message: parseResult.data.message,
+        actorId: user?.id ?? null,
+      },
+    )
+
+    revalidatePath("/dashboard/incidents")
+    revalidatePath("/messaging")
+
+    return { success: true, incidentId: result.incident.id }
+  } catch (error) {
+    console.error("Failed to update incident", error)
+    return { error: "Failed to update incident" }
+  }
+}

--- a/app/dashboard/incidents/page.tsx
+++ b/app/dashboard/incidents/page.tsx
@@ -1,0 +1,254 @@
+import { formatDistanceToNow } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { createIncidentAction, updateIncidentAction } from "@/app/dashboard/incidents/actions"
+import type { Incident, IncidentSeverity, IncidentUpdate } from "@/lib/incidents/types"
+import { INCIDENT_SEVERITIES, INCIDENT_STATUSES } from "@/lib/incidents/types"
+import { createSupbaseServerClient } from "@/utils/supaone"
+import { cn } from "@/lib/utils"
+import { humanizeLabel, severityBadgeStyles } from "@/lib/incidents/presentation"
+
+type IncidentWithUpdates = Incident & {
+  incident_updates?: IncidentUpdate[] | null
+}
+
+type ProfileSummary = {
+  id: string
+  full_name: string | null
+}
+
+export default async function IncidentsPage() {
+  const supabase = await createSupbaseServerClient()
+
+  const [incidentsResponse, profilesResponse] = await Promise.all([
+    supabase
+      .from("incidents")
+      .select("*, incident_updates(*)")
+      .order("created_at", { ascending: false })
+      .order("created_at", { referencedTable: "incident_updates", ascending: false }),
+    supabase.from("profiles").select("id, full_name").order("full_name", { ascending: true }),
+  ])
+
+  if (incidentsResponse.error) {
+    console.error("Failed to load incidents", incidentsResponse.error)
+  }
+
+  if (profilesResponse.error) {
+    console.error("Failed to load profiles", profilesResponse.error)
+  }
+
+  const incidents = (incidentsResponse.data ?? []) as IncidentWithUpdates[]
+  const profiles = (profilesResponse.data ?? []) as ProfileSummary[]
+
+  return (
+    <div className="space-y-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Report a new incident</CardTitle>
+          <CardDescription>
+            Capture maintenance or safety issues and broadcast them to the household message board.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form action={createIncidentAction} className="grid gap-4">
+            <div className="grid gap-2">
+              <label htmlFor="householdId" className="text-sm font-medium">
+                Household ID
+              </label>
+              <Input id="householdId" name="householdId" placeholder="e.g. 2b81d1d0-..." required />
+            </div>
+            <div className="grid gap-2">
+              <label htmlFor="title" className="text-sm font-medium">
+                Title
+              </label>
+              <Input id="title" name="title" placeholder="Short summary" required />
+            </div>
+            <div className="grid gap-2">
+              <label htmlFor="description" className="text-sm font-medium">
+                Description
+              </label>
+              <Textarea
+                id="description"
+                name="description"
+                placeholder="Provide context that will be shared on the message board"
+                required
+              />
+            </div>
+            <div className="grid gap-2 md:grid-cols-2">
+              <div className="grid gap-2">
+                <label htmlFor="severity" className="text-sm font-medium">
+                  Severity
+                </label>
+                <select
+                  id="severity"
+                  name="severity"
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  defaultValue="medium"
+                >
+                  {INCIDENT_SEVERITIES.map((option) => (
+                    <option key={option} value={option}>
+                      {option.replace(/_/g, " ")}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="grid gap-2">
+                <label htmlFor="assignedMemberId" className="text-sm font-medium">
+                  Assigned team member
+                </label>
+                <select
+                  id="assignedMemberId"
+                  name="assignedMemberId"
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  defaultValue=""
+                >
+                  <option value="">Unassigned</option>
+                  {profiles.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.full_name ?? profile.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="flex justify-end">
+              <Button type="submit">Create incident</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">Active incidents</h2>
+          <p className="text-sm text-muted-foreground">
+            Use the forms below to update status, severity, assignments, and broadcast message board updates.
+          </p>
+        </div>
+        <div className="grid gap-4">
+          {incidents.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-sm text-muted-foreground">
+                No incidents have been reported yet.
+              </CardContent>
+            </Card>
+          ) : (
+            incidents.map((incident) => {
+              const latestUpdate = incident.incident_updates?.[0]
+              return (
+                <Card key={incident.id}>
+                  <CardHeader>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <CardTitle className="text-lg">{incident.title}</CardTitle>
+                        <CardDescription>Household {incident.household_id}</CardDescription>
+                      </div>
+                      <div className="flex gap-2">
+                        <Badge className={cn("capitalize", severityBadgeStyles[incident.severity as IncidentSeverity])}>
+                          {humanizeLabel(incident.severity)}
+                        </Badge>
+                        <Badge variant="outline" className="capitalize">
+                          {humanizeLabel(incident.status)}
+                        </Badge>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-6">
+                    <p className="text-sm text-muted-foreground">{incident.description}</p>
+                    <div className="rounded-md border bg-muted/30 p-4">
+                      <p className="text-xs font-medium uppercase text-muted-foreground">Latest update</p>
+                      {latestUpdate ? (
+                        <div className="mt-1 space-y-1 text-sm">
+                          <p>{latestUpdate.message}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {formatDistanceToNow(new Date(latestUpdate.created_at), { addSuffix: true })}
+                          </p>
+                        </div>
+                      ) : (
+                        <p className="mt-1 text-sm text-muted-foreground">No updates have been posted yet.</p>
+                      )}
+                    </div>
+                    <form action={updateIncidentAction} className="grid gap-4">
+                      <input type="hidden" name="incidentId" value={incident.id} />
+                      <div className="grid gap-2 sm:grid-cols-2">
+                        <div className="grid gap-2">
+                          <label htmlFor={`status-${incident.id}`} className="text-sm font-medium">
+                            Status
+                          </label>
+                          <select
+                            id={`status-${incident.id}`}
+                            name="status"
+                            defaultValue={incident.status}
+                            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                          >
+                            {INCIDENT_STATUSES.map((option) => (
+                              <option key={option} value={option}>
+                                {humanizeLabel(option)}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="grid gap-2">
+                          <label htmlFor={`severity-${incident.id}`} className="text-sm font-medium">
+                            Severity
+                          </label>
+                          <select
+                            id={`severity-${incident.id}`}
+                            name="severity"
+                            defaultValue={incident.severity}
+                            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                          >
+                            {INCIDENT_SEVERITIES.map((option) => (
+                              <option key={option} value={option}>
+                                {humanizeLabel(option)}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+                      <div className="grid gap-2">
+                        <label htmlFor={`assigned-${incident.id}`} className="text-sm font-medium">
+                          Assigned team member
+                        </label>
+                        <select
+                          id={`assigned-${incident.id}`}
+                          name="assignedMemberId"
+                          defaultValue={incident.assigned_member_id ?? ""}
+                          className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        >
+                          <option value="">Unassigned</option>
+                          {profiles.map((profile) => (
+                            <option key={profile.id} value={profile.id}>
+                              {profile.full_name ?? profile.id}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="grid gap-2">
+                        <label htmlFor={`message-${incident.id}`} className="text-sm font-medium">
+                          Message board note
+                        </label>
+                        <Textarea
+                          id={`message-${incident.id}`}
+                          name="message"
+                          placeholder="Share context for roommates and property managers"
+                        />
+                      </div>
+                      <div className="flex justify-end">
+                        <Button type="submit">Post update</Button>
+                      </div>
+                    </form>
+                  </CardContent>
+                </Card>
+              )
+            })
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,5 +1,12 @@
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { formatDistanceToNow } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { createSupbaseServerClient } from "@/utils/supaone"
+import { cn } from "@/lib/utils"
+import type { IncidentSeverity, IncidentUpdate } from "@/lib/incidents/types"
+import { humanizeLabel, severityBadgeStyles } from "@/lib/incidents/presentation"
 
 const messagingHighlights = [
   {
@@ -24,7 +31,41 @@ const messagingHighlights = [
   },
 ]
 
-export default function MessagingPage() {
+type IncidentFeedEntry = IncidentUpdate & {
+  incidents: {
+    id: string
+    title: string | null
+    household_id: string | null
+  } | null
+  author: {
+    id: string
+    full_name: string | null
+  } | null
+}
+
+async function getIncidentFeed(): Promise<IncidentFeedEntry[]> {
+  const supabase = await createSupbaseServerClient()
+  const { data, error } = await supabase
+    .from("incident_updates")
+    .select(
+      `id, message, created_at, status, severity,
+       incidents:incident_id (id, title, household_id),
+       author:author_id (id, full_name)`,
+    )
+    .order("created_at", { ascending: false })
+    .limit(20)
+
+  if (error) {
+    console.error("Failed to load incident feed", error)
+    return []
+  }
+
+  return (data ?? []) as IncidentFeedEntry[]
+}
+
+export default async function MessagingPage() {
+  const incidentFeed = await getIncidentFeed()
+
   return (
     <div className="container max-w-5xl space-y-10 py-12">
       <header className="space-y-4">
@@ -46,6 +87,54 @@ export default function MessagingPage() {
           </Card>
         ))}
       </div>
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">Incident updates</h2>
+          <p className="text-sm text-muted-foreground">
+            Every status change from the incidents dashboard is posted here so the household stays informed in real time.
+          </p>
+        </div>
+        <div className="grid gap-4">
+          {incidentFeed.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-sm text-muted-foreground">
+                Incident activity will appear here after the first report is triaged.
+              </CardContent>
+            </Card>
+          ) : (
+            incidentFeed.map((entry) => (
+              <Card key={entry.id}>
+                <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <CardTitle className="text-base">
+                      {entry.incidents?.title ?? "Incident update"}
+                    </CardTitle>
+                    <CardDescription>
+                      Household {entry.incidents?.household_id ?? "unknown"}
+                    </CardDescription>
+                  </div>
+                  <div className="flex gap-2">
+                    <Badge className={cn("capitalize", severityBadgeStyles[entry.severity as IncidentSeverity])}>
+                      {humanizeLabel(entry.severity)}
+                    </Badge>
+                    <Badge variant="outline" className="capitalize">
+                      {humanizeLabel(entry.status)}
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <p className="text-sm leading-relaxed">{entry.message}</p>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>{entry.author?.full_name ?? "System"}</span>
+                    <span aria-hidden>•</span>
+                    <span>{formatDistanceToNow(new Date(entry.created_at), { addSuffix: true })}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
+      </section>
     </div>
   )
 }

--- a/lib/incidents/notifications.ts
+++ b/lib/incidents/notifications.ts
@@ -1,0 +1,78 @@
+import { Resend } from "resend"
+
+import type { LandlordNotifier } from "./service"
+import type { Incident, IncidentUpdate } from "./types"
+
+function buildTextBody(incident: Incident, update: IncidentUpdate) {
+  const lines = [
+    `Incident: ${incident.title}`,
+    `Household: ${incident.household_id}`,
+    `Severity: ${incident.severity}`,
+    `Status: ${incident.status}`,
+    `Latest update: ${update.message}`,
+    `Recorded at: ${new Date(update.created_at).toISOString()}`,
+    "",
+    `Description: ${incident.description}`,
+  ]
+
+  return lines.join("\n")
+}
+
+function buildHtmlBody(incident: Incident, update: IncidentUpdate) {
+  return `<!doctype html>
+<html>
+  <body>
+    <h1>Critical household incident</h1>
+    <p><strong>Incident:</strong> ${incident.title}</p>
+    <p><strong>Household:</strong> ${incident.household_id}</p>
+    <p><strong>Severity:</strong> ${incident.severity}</p>
+    <p><strong>Status:</strong> ${incident.status}</p>
+    <p><strong>Latest update:</strong> ${update.message}</p>
+    <p><strong>Recorded at:</strong> ${new Date(update.created_at).toLocaleString()}</p>
+    <hr />
+    <p>${incident.description}</p>
+  </body>
+</html>`
+}
+
+const DEFAULT_SENDER = "Share House Alerts <alerts@resend.dev>"
+
+export function createResendLandlordNotifier(): LandlordNotifier {
+  const apiKey = process.env.RESEND_API_KEY
+  const landlordEmail = process.env.LANDLORD_ALERT_EMAIL
+  const fromAddress = process.env.RESEND_ALERTS_FROM ?? DEFAULT_SENDER
+
+  if (!apiKey || !landlordEmail) {
+    return {
+      async notifyCriticalIncident() {
+        console.warn(
+          "Skipping landlord notification because RESEND_API_KEY or LANDLORD_ALERT_EMAIL is not configured.",
+        )
+      },
+    }
+  }
+
+  const resend = new Resend(apiKey)
+
+  return {
+    async notifyCriticalIncident({ incident, update }) {
+      try {
+        await resend.emails.send({
+          from: fromAddress,
+          to: [landlordEmail],
+          subject: `[Critical Incident] ${incident.title}`,
+          text: buildTextBody(incident, update),
+          html: buildHtmlBody(incident, update),
+        })
+      } catch (error) {
+        console.error("Failed to send landlord escalation", error)
+      }
+    },
+  }
+}
+
+export const noopLandlordNotifier: LandlordNotifier = {
+  async notifyCriticalIncident() {
+    // intentional noop for tests
+  },
+}

--- a/lib/incidents/presentation.ts
+++ b/lib/incidents/presentation.ts
@@ -1,0 +1,12 @@
+import type { IncidentSeverity } from "./types"
+
+export const severityBadgeStyles: Record<IncidentSeverity, string> = {
+  low: "bg-emerald-100 text-emerald-900 dark:bg-emerald-500/10 dark:text-emerald-300",
+  medium: "bg-amber-100 text-amber-900 dark:bg-amber-500/10 dark:text-amber-300",
+  high: "bg-orange-100 text-orange-900 dark:bg-orange-500/10 dark:text-orange-300",
+  critical: "bg-red-100 text-red-900 dark:bg-red-500/10 dark:text-red-300",
+}
+
+export function humanizeLabel(value: string) {
+  return value.replace(/_/g, " ")
+}

--- a/lib/incidents/repository.ts
+++ b/lib/incidents/repository.ts
@@ -1,0 +1,104 @@
+import type { Incident, IncidentUpdate, IncidentSeverity, IncidentStatus } from "./types"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+export interface CreateIncidentRecord {
+  household_id: string
+  title: string
+  description: string
+  severity: IncidentSeverity
+  status: IncidentStatus
+  assigned_member_id: string | null
+  reported_by: string | null
+  landlord_notified_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface UpdateIncidentChanges {
+  assigned_member_id?: string | null
+  description?: string
+  severity?: IncidentSeverity
+  status?: IncidentStatus
+  title?: string
+  landlord_notified_at?: string | null
+  updated_at: string
+}
+
+export interface CreateIncidentUpdateRecord {
+  incident_id: string
+  message: string
+  author_id: string | null
+  status: IncidentStatus
+  severity: IncidentSeverity
+  created_at: string
+}
+
+export interface IncidentRepository {
+  createIncident(record: CreateIncidentRecord): Promise<Incident>
+  getIncidentById(id: string): Promise<Incident | null>
+  updateIncident(id: string, changes: UpdateIncidentChanges): Promise<Incident>
+  createIncidentUpdate(record: CreateIncidentUpdateRecord): Promise<IncidentUpdate>
+}
+
+export class SupabaseIncidentRepository implements IncidentRepository {
+  constructor(private readonly client: TypedSupabaseClient) {}
+
+  async createIncident(record: CreateIncidentRecord): Promise<Incident> {
+    const payload = this.cleanUndefined(record)
+    const { data, error } = await this.client.from("incidents").insert(payload).select().single()
+
+    if (error) {
+      throw new Error(`Failed to create incident: ${error.message}`)
+    }
+
+    return data
+  }
+
+  async getIncidentById(id: string): Promise<Incident | null> {
+    const { data, error } = await this.client.from("incidents").select("*").eq("id", id).maybeSingle()
+
+    if (error) {
+      throw new Error(`Failed to load incident ${id}: ${error.message}`)
+    }
+
+    return data ?? null
+  }
+
+  async updateIncident(id: string, changes: UpdateIncidentChanges): Promise<Incident> {
+    const payload = this.cleanUndefined(changes)
+    const { data, error } = await this.client
+      .from("incidents")
+      .update(payload)
+      .eq("id", id)
+      .select()
+      .single()
+
+    if (error) {
+      throw new Error(`Failed to update incident ${id}: ${error.message}`)
+    }
+
+    return data
+  }
+
+  async createIncidentUpdate(record: CreateIncidentUpdateRecord): Promise<IncidentUpdate> {
+    const payload = {
+      ...record,
+      author_id: record.author_id ?? null,
+    }
+    const { data, error } = await this.client
+      .from("incident_updates")
+      .insert(payload)
+      .select()
+      .single()
+
+    if (error) {
+      throw new Error(`Failed to record incident update: ${error.message}`)
+    }
+
+    return data
+  }
+
+  private cleanUndefined<T extends Record<string, unknown>>(value: T): T {
+    return Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined)) as T
+  }
+}

--- a/lib/incidents/service.ts
+++ b/lib/incidents/service.ts
@@ -1,0 +1,147 @@
+import { type Incident, type IncidentSeverity, type IncidentStatus, type IncidentUpdate, isCritical } from "./types"
+import type { IncidentRepository } from "./repository"
+
+export interface LandlordNotifier {
+  notifyCriticalIncident(payload: { incident: Incident; update: IncidentUpdate }): Promise<void>
+}
+
+export interface IncidentServiceDependencies {
+  repository: IncidentRepository
+  landlordNotifier: LandlordNotifier
+  clock?: () => Date
+}
+
+const DEFAULT_STATUS: IncidentStatus = "open"
+
+const DEFAULT_MESSAGE_TRIM_THRESHOLD = 0
+
+function currentIso(clock?: () => Date) {
+  const now = clock ? clock() : new Date()
+  return now.toISOString()
+}
+
+function normaliseOptional(value: string | null | undefined) {
+  if (value === undefined) return undefined
+  return value === null || value === "" ? null : value
+}
+
+export interface CreateIncidentInput {
+  householdId: string
+  title: string
+  description: string
+  severity: IncidentSeverity
+  status?: IncidentStatus
+  assignedMemberId?: string | null
+  reporterId?: string | null
+  actorId?: string | null
+  message?: string | null
+}
+
+export async function createIncident(
+  deps: IncidentServiceDependencies,
+  input: CreateIncidentInput,
+) {
+  const { repository, landlordNotifier, clock } = deps
+  const nowIso = currentIso(clock)
+  const status = input.status ?? DEFAULT_STATUS
+  const severity = input.severity
+  const shouldNotifyLandlord = isCritical(severity)
+  const landlordNotifiedAt = shouldNotifyLandlord ? nowIso : null
+
+  const incident = await repository.createIncident({
+    household_id: input.householdId,
+    title: input.title,
+    description: input.description,
+    severity,
+    status,
+    assigned_member_id: normaliseOptional(input.assignedMemberId) ?? null,
+    reported_by: normaliseOptional(input.reporterId) ?? null,
+    landlord_notified_at: landlordNotifiedAt,
+    created_at: nowIso,
+    updated_at: nowIso,
+  })
+
+  const message = normaliseMessage(
+    input.message ?? input.description ?? `New ${severity} incident reported: ${input.title}`,
+  )
+
+  const update = await repository.createIncidentUpdate({
+    incident_id: incident.id,
+    author_id: normaliseOptional(input.actorId ?? input.reporterId) ?? null,
+    message,
+    status: incident.status,
+    severity: incident.severity,
+    created_at: nowIso,
+  })
+
+  if (shouldNotifyLandlord) {
+    await landlordNotifier.notifyCriticalIncident({ incident, update })
+  }
+
+  return { incident, update }
+}
+
+export interface UpdateIncidentInput {
+  id: string
+  status?: IncidentStatus
+  severity?: IncidentSeverity
+  assignedMemberId?: string | null
+  message?: string | null
+  actorId?: string | null
+}
+
+export async function updateIncident(
+  deps: IncidentServiceDependencies,
+  input: UpdateIncidentInput,
+) {
+  const { repository, landlordNotifier, clock } = deps
+  const existing = await repository.getIncidentById(input.id)
+
+  if (!existing) {
+    throw new Error(`Incident ${input.id} was not found`)
+  }
+
+  const nowIso = currentIso(clock)
+  const nextStatus: IncidentStatus = input.status ?? existing.status
+  const nextSeverity: IncidentSeverity = input.severity ?? existing.severity
+  const shouldNotifyLandlord = isCritical(nextSeverity) && !existing.landlord_notified_at
+
+  const changes = {
+    updated_at: nowIso,
+    ...(input.status !== undefined ? { status: nextStatus } : {}),
+    ...(input.severity !== undefined ? { severity: nextSeverity } : {}),
+    ...(input.assignedMemberId !== undefined
+      ? { assigned_member_id: normaliseOptional(input.assignedMemberId) ?? null }
+      : {}),
+    ...(shouldNotifyLandlord ? { landlord_notified_at: nowIso } : {}),
+  }
+
+  const incident = await repository.updateIncident(input.id, changes)
+
+  const message = normaliseMessage(
+    input.message ?? `Status updated to ${incident.status}`,
+  )
+
+  const update = await repository.createIncidentUpdate({
+    incident_id: incident.id,
+    author_id: normaliseOptional(input.actorId) ?? null,
+    message,
+    status: incident.status,
+    severity: incident.severity,
+    created_at: nowIso,
+  })
+
+  if (shouldNotifyLandlord) {
+    await landlordNotifier.notifyCriticalIncident({ incident, update })
+  }
+
+  return { incident, update }
+}
+
+function normaliseMessage(message: string) {
+  const trimmed = message.trim()
+  if (trimmed.length <= DEFAULT_MESSAGE_TRIM_THRESHOLD) {
+    return "Update posted"
+  }
+  return trimmed
+}

--- a/lib/incidents/types.ts
+++ b/lib/incidents/types.ts
@@ -1,0 +1,14 @@
+import type { Database } from "@/lib/supabase"
+
+export const INCIDENT_SEVERITIES = ["low", "medium", "high", "critical"] as const
+export type IncidentSeverity = (typeof INCIDENT_SEVERITIES)[number]
+
+export const INCIDENT_STATUSES = ["open", "in_progress", "resolved", "closed"] as const
+export type IncidentStatus = (typeof INCIDENT_STATUSES)[number]
+
+export type Incident = Database["public"]["Tables"]["incidents"]["Row"]
+export type IncidentUpdate = Database["public"]["Tables"]["incident_updates"]["Row"]
+
+export function isCritical(severity: IncidentSeverity) {
+  return severity === "critical"
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -941,6 +941,108 @@ export type Database = {
         }
         Relationships: []
       }
+      incident_updates: {
+        Row: {
+          author_id: string | null
+          created_at: string
+          id: string
+          incident_id: string
+          message: string
+          severity: string
+          status: string
+        }
+        Insert: {
+          author_id?: string | null
+          created_at?: string
+          id?: string
+          incident_id: string
+          message: string
+          severity: string
+          status: string
+        }
+        Update: {
+          author_id?: string | null
+          created_at?: string
+          id?: string
+          incident_id?: string
+          message?: string
+          severity?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "incident_updates_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "incident_updates_incident_id_fkey"
+            columns: ["incident_id"]
+            isOneToOne: false
+            referencedRelation: "incidents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      incidents: {
+        Row: {
+          assigned_member_id: string | null
+          created_at: string
+          description: string
+          household_id: string
+          id: string
+          landlord_notified_at: string | null
+          reported_by: string | null
+          severity: string
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          assigned_member_id?: string | null
+          created_at?: string
+          description: string
+          household_id: string
+          id?: string
+          landlord_notified_at?: string | null
+          reported_by?: string | null
+          severity: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          assigned_member_id?: string | null
+          created_at?: string
+          description?: string
+          household_id?: string
+          id?: string
+          landlord_notified_at?: string | null
+          reported_by?: string | null
+          severity?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "incidents_assigned_member_id_fkey"
+            columns: ["assigned_member_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "incidents_reported_by_fkey"
+            columns: ["reported_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       inqueries: {
         Row: {
           created_at: string

--- a/supabase/migrations/20250410_incidents.sql
+++ b/supabase/migrations/20250410_incidents.sql
@@ -1,0 +1,38 @@
+create table public.incidents (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  household_id uuid not null,
+  title text not null,
+  description text not null,
+  severity text not null check (severity in ('low','medium','high','critical')),
+  assigned_member_id uuid null references public.profiles (id) on delete set null,
+  status text not null default 'open' check (status in ('open','in_progress','resolved','closed')),
+  reported_by uuid null references public.profiles (id) on delete set null,
+  landlord_notified_at timestamp with time zone null
+);
+
+create index idx_incidents_household_id on public.incidents (household_id);
+create index idx_incidents_status on public.incidents (status);
+
+alter table public.incidents enable row level security;
+
+create table public.incident_updates (
+  id uuid primary key default gen_random_uuid(),
+  incident_id uuid not null references public.incidents (id) on delete cascade,
+  message text not null,
+  created_at timestamp with time zone not null default now(),
+  author_id uuid null references public.profiles (id) on delete set null,
+  status text not null check (status in ('open','in_progress','resolved','closed')),
+  severity text not null check (severity in ('low','medium','high','critical'))
+);
+
+create index idx_incident_updates_incident_id on public.incident_updates (incident_id);
+create index idx_incident_updates_created_at on public.incident_updates (created_at desc);
+
+alter table public.incident_updates enable row level security;
+
+comment on table public.incidents is 'Tracks household maintenance and safety incidents.';
+comment on table public.incident_updates is 'Stores message board updates associated with incidents.';
+
+-- Remember to configure appropriate RLS policies for production use.

--- a/tests/incidents.service.test.ts
+++ b/tests/incidents.service.test.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "crypto"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+import { createIncident, updateIncident } from "@/lib/incidents/service"
+import type {
+  CreateIncidentRecord,
+  CreateIncidentUpdateRecord,
+  IncidentRepository,
+  UpdateIncidentChanges,
+} from "@/lib/incidents/repository"
+import type { Incident, IncidentUpdate, IncidentSeverity, IncidentStatus } from "@/lib/incidents/types"
+
+class InMemoryIncidentRepository implements IncidentRepository {
+  incidents = new Map<string, Incident>()
+  updates: IncidentUpdate[] = []
+
+  async createIncident(record: CreateIncidentRecord): Promise<Incident> {
+    const id = randomUUID()
+    const incident: Incident = {
+      id,
+      created_at: record.created_at,
+      updated_at: record.updated_at,
+      household_id: record.household_id,
+      title: record.title,
+      description: record.description,
+      severity: record.severity,
+      assigned_member_id: record.assigned_member_id,
+      status: record.status,
+      reported_by: record.reported_by,
+      landlord_notified_at: record.landlord_notified_at,
+    }
+
+    this.incidents.set(id, incident)
+    return incident
+  }
+
+  async getIncidentById(id: string): Promise<Incident | null> {
+    return this.incidents.get(id) ?? null
+  }
+
+  async updateIncident(id: string, changes: UpdateIncidentChanges): Promise<Incident> {
+    const existing = this.incidents.get(id)
+    if (!existing) {
+      throw new Error("Incident not found")
+    }
+
+    const updated: Incident = {
+      ...existing,
+      ...changes,
+      severity: (changes.severity ?? existing.severity) as IncidentSeverity,
+      status: (changes.status ?? existing.status) as IncidentStatus,
+      assigned_member_id:
+        changes.assigned_member_id !== undefined
+          ? changes.assigned_member_id
+          : existing.assigned_member_id,
+      landlord_notified_at:
+        changes.landlord_notified_at !== undefined
+          ? changes.landlord_notified_at
+          : existing.landlord_notified_at,
+      updated_at: changes.updated_at,
+    }
+
+    this.incidents.set(id, updated)
+    return updated
+  }
+
+  async createIncidentUpdate(record: CreateIncidentUpdateRecord): Promise<IncidentUpdate> {
+    const update: IncidentUpdate = {
+      id: randomUUID(),
+      incident_id: record.incident_id,
+      message: record.message,
+      author_id: record.author_id,
+      status: record.status,
+      severity: record.severity,
+      created_at: record.created_at,
+    }
+
+    this.updates.push(update)
+    return update
+  }
+}
+
+describe("incident service", () => {
+  let repository: InMemoryIncidentRepository
+  let notifier: { notifyCriticalIncident: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    repository = new InMemoryIncidentRepository()
+    notifier = { notifyCriticalIncident: vi.fn().mockResolvedValue(undefined) }
+  })
+
+  it("escalates critical incidents on creation", async () => {
+    const { incident } = await createIncident(
+      { repository, landlordNotifier: notifier },
+      {
+        householdId: "household-1",
+        title: "Gas leak",
+        description: "Strong smell coming from the kitchen",
+        severity: "critical",
+        reporterId: "user-1",
+      },
+    )
+
+    expect(notifier.notifyCriticalIncident).toHaveBeenCalledTimes(1)
+    expect(repository.updates).toHaveLength(1)
+    expect(repository.updates[0]?.message).toBe("Strong smell coming from the kitchen")
+    expect(incident.landlord_notified_at).not.toBeNull()
+  })
+
+  it("does not escalate non-critical incidents", async () => {
+    await createIncident(
+      { repository, landlordNotifier: notifier },
+      {
+        householdId: "household-1",
+        title: "Light flickering",
+        description: "Living room light flickers occasionally",
+        severity: "low",
+      },
+    )
+
+    expect(notifier.notifyCriticalIncident).not.toHaveBeenCalled()
+    expect(repository.updates).toHaveLength(1)
+  })
+
+  it("escalates when a case is upgraded to critical", async () => {
+    const { incident } = await createIncident(
+      { repository, landlordNotifier: notifier },
+      {
+        householdId: "household-2",
+        title: "Water leak",
+        description: "Slow drip from ceiling",
+        severity: "medium",
+      },
+    )
+
+    notifier.notifyCriticalIncident.mockClear()
+
+    const result = await updateIncident(
+      { repository, landlordNotifier: notifier },
+      {
+        id: incident.id,
+        severity: "critical",
+        message: "Escalating leak after ceiling damage",
+      },
+    )
+
+    expect(notifier.notifyCriticalIncident).toHaveBeenCalledTimes(1)
+    expect(repository.updates.at(-1)?.message).toBe("Escalating leak after ceiling damage")
+    expect(result.incident.landlord_notified_at).not.toBeNull()
+  })
+
+  it("avoids duplicate landlord notifications once escalated", async () => {
+    const { incident } = await createIncident(
+      { repository, landlordNotifier: notifier },
+      {
+        householdId: "household-3",
+        title: "Carbon monoxide alarm",
+        description: "Detector briefly triggered",
+        severity: "critical",
+      },
+    )
+
+    notifier.notifyCriticalIncident.mockClear()
+
+    await updateIncident(
+      { repository, landlordNotifier: notifier },
+      {
+        id: incident.id,
+        status: "in_progress",
+        message: "Maintenance dispatched",
+      },
+    )
+
+    expect(notifier.notifyCriticalIncident).not.toHaveBeenCalled()
+    expect(repository.updates.at(-1)?.message).toBe("Maintenance dispatched")
+  })
+})


### PR DESCRIPTION
## Summary
- add Supabase schema for incidents and incident message updates, plus generated typings
- build incident service, server actions, and admin UI that post to the message board and escalate critical issues by email
- surface incident activity on the messaging page and cover critical escalation logic with unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0e7ca4c832884edc15689a8713d