### PR TITLE
Add house rules management with realtime notifications

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, FileTextIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -9,16 +9,21 @@ export default function NavLinks() {
 	const pathname = usePathname();
 
 	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/house-rules",
+                        text: "House Rules",
+                        Icon: FileTextIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
 	];
 
 	return (

--- a/app/dashboard/house-rules/actions.ts
+++ b/app/dashboard/house-rules/actions.ts
@@ -1,0 +1,105 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { z } from "zod"
+
+import { getLatestHouseRuleRecord } from "@/queries/house-rules"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export type PublishHouseRuleState = {
+  success: boolean
+  message: string | null
+}
+
+const publishHouseRuleSchema = z.object({
+  content: z
+    .string()
+    .transform((value) => value.trim())
+    .refine((value) => value.length > 0, "House rules content is required.")
+    .refine((value) => value.length >= 20, "Provide at least 20 characters so roommates get clear guidance."),
+})
+
+export async function publishHouseRuleAction(
+  _prevState: PublishHouseRuleState,
+  formData: FormData,
+): Promise<PublishHouseRuleState> {
+  const parsed = publishHouseRuleSchema.safeParse({
+    content: formData.get("content"),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: parsed.error.flatten().fieldErrors.content?.[0] ?? "Please review the updated house rules and try again.",
+    }
+  }
+
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return { success: false, message: "You must be signed in to publish house rules." }
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    console.error("Failed to load profile for house rule publish", profileError)
+    return { success: false, message: "Unable to verify your permissions right now." }
+  }
+
+  if (!profile || !profile.role || !["admin", "property_manager"].includes(profile.role)) {
+    return { success: false, message: "Only admins or property managers can publish new house rules." }
+  }
+
+  const { data: latestRule, error: latestError } = await getLatestHouseRuleRecord(supabase)
+
+  if (latestError) {
+    console.error("Failed to fetch latest house rule", latestError)
+    return { success: false, message: "We couldn't determine the next version. Please try again." }
+  }
+
+  const nextVersion = (latestRule?.version ?? 0) + 1
+
+  const { data: insertedRule, error: insertError } = await supabase
+    .from("house_rules")
+    .insert({
+      version: nextVersion,
+      content: parsed.data.content,
+    })
+    .select("*")
+    .single()
+
+  if (insertError || !insertedRule) {
+    console.error("Failed to insert new house rule", insertError)
+    return { success: false, message: "Publishing the house rules failed. Please try again." }
+  }
+
+  const channel = supabase.channel("house-rules")
+  const broadcastResult = await channel.send({
+    type: "broadcast",
+    event: "house_rules:published",
+    payload: insertedRule,
+  })
+
+  if (broadcastResult !== "ok") {
+    console.error("Failed to broadcast house rule publish", broadcastResult)
+  }
+
+  await supabase.removeChannel(channel)
+
+  revalidatePath("/dashboard/house-rules")
+  revalidatePath("/house-rules")
+
+  return {
+    success: true,
+    message: `Published house rules v${insertedRule.version}.`,
+  }
+}

--- a/app/dashboard/house-rules/house-rules-admin-panel.tsx
+++ b/app/dashboard/house-rules/house-rules-admin-panel.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useFormState, useFormStatus } from "react-dom"
+import { format } from "date-fns"
+
+import { HouseRulesHistory } from "@/components/house-rules/history-list"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { getLatestHouseRule, sortHouseRulesByVersion, type HouseRule } from "@/lib/house-rules"
+
+import { publishHouseRuleAction, type PublishHouseRuleState } from "./actions"
+
+const initialState: PublishHouseRuleState = {
+  success: false,
+  message: null,
+}
+
+function PublishButton({ disabled }: { disabled: boolean }) {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" disabled={pending || disabled} aria-disabled={pending || disabled}>
+      {pending ? "Publishing…" : "Publish house rules"}
+    </Button>
+  )
+}
+
+export function HouseRulesAdminPanel({
+  initialRules,
+  canPublish,
+}: {
+  initialRules: HouseRule[]
+  canPublish: boolean
+}) {
+  const sortedRules = useMemo(() => sortHouseRulesByVersion(initialRules), [initialRules])
+  const latestRule = getLatestHouseRule(sortedRules)
+  const [content, setContent] = useState("")
+  const [state, formAction] = useFormState(publishHouseRuleAction, initialState)
+
+  useEffect(() => {
+    if (state.success) {
+      setContent("")
+    }
+  }, [state.success])
+
+  const nextVersion = (latestRule?.version ?? 0) + 1
+  const publishedLabel = (() => {
+    if (!latestRule) {
+      return "No house rules published yet."
+    }
+
+    const publishedDate = new Date(latestRule.published_at)
+
+    if (Number.isNaN(publishedDate.getTime())) {
+      return `Latest version v${latestRule.version}`
+    }
+
+    return `Latest version v${latestRule.version} went live on ${format(publishedDate, "PPP p")}`
+  })()
+
+  const isSubmitDisabled = content.trim().length < 20
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">House rules</h1>
+        <p className="text-muted-foreground">
+          Publish updates so every roommate understands expectations. Everyone connected to the portal receives the newest
+          version instantly.
+        </p>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Publish version v{nextVersion}</CardTitle>
+            <CardDescription>{publishedLabel}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {state.message ? (
+              <p className={`text-sm ${state.success ? "text-green-600" : "text-red-600"}`}>{state.message}</p>
+            ) : null}
+            {canPublish ? (
+              <form action={formAction} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="content">House rules content</Label>
+                  <Textarea
+                    id="content"
+                    name="content"
+                    value={content}
+                    onChange={(event) => setContent(event.target.value)}
+                    minLength={20}
+                    rows={10}
+                    placeholder="List quiet hours, shared responsibilities, guest policies, and escalation steps for your roommates."
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Minimum 20 characters. Be specific so roommates understand expectations and consequences.
+                  </p>
+                </div>
+                <PublishButton disabled={isSubmitDisabled} />
+              </form>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                You have read-only access. Contact an administrator if the house rules need to change.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+        <section className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="text-xl font-semibold">Version history</h2>
+            <p className="text-sm text-muted-foreground">
+              Roommates can review past versions and receive realtime notifications whenever you publish an update.
+            </p>
+          </div>
+          <HouseRulesHistory initialRules={sortedRules} />
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/house-rules/page.tsx
+++ b/app/dashboard/house-rules/page.tsx
@@ -1,0 +1,34 @@
+import { HouseRulesAdminPanel } from "./house-rules-admin-panel"
+
+import { getHouseRulesHistory } from "@/queries/house-rules"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export const dynamic = "force-dynamic"
+
+export default async function DashboardHouseRulesPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const profilePromise = user
+    ? supabase.from("profiles").select("role").eq("id", user.id).maybeSingle()
+    : Promise.resolve({ data: null, error: null })
+
+  const [{ data: history, error: historyError }, { data: profile, error: profileError }] = await Promise.all([
+    getHouseRulesHistory(supabase),
+    profilePromise,
+  ])
+
+  if (historyError) {
+    console.error("Failed to load house rules history", historyError)
+  }
+
+  if (profileError) {
+    console.error("Failed to resolve profile while loading house rules", profileError)
+  }
+
+  const canPublish = Boolean(profile?.role && ["admin", "property_manager"].includes(profile.role))
+
+  return <HouseRulesAdminPanel initialRules={history ?? []} canPublish={canPublish} />
+}

--- a/app/house-rules/page.tsx
+++ b/app/house-rules/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next"
+
+import { HouseRulesHistory } from "@/components/house-rules/history-list"
+import { getHouseRulesHistory } from "@/queries/house-rules"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export const metadata: Metadata = {
+  title: "House rules",
+  description: "Review the latest community guidelines and revisit previous versions for your shared home.",
+}
+
+export default async function HouseRulesPage() {
+  const supabase = await createSupbaseServerClient()
+  const { data: history, error } = await getHouseRulesHistory(supabase)
+
+  if (error) {
+    console.error("Failed to load house rules history", error)
+  }
+
+  return (
+    <div className="container max-w-4xl space-y-8 py-12">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">House rules</h1>
+        <p className="text-muted-foreground">
+          Stay aligned on quiet hours, guest policies, and shared responsibilities. New versions appear instantly for every
+          roommate.
+        </p>
+      </div>
+      <HouseRulesHistory initialRules={history ?? []} />
+    </div>
+  )
+}

--- a/components/house-rules/history-list.tsx
+++ b/components/house-rules/history-list.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { format } from "date-fns"
+import { z } from "zod"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { useToast } from "@/components/ui/use-toast"
+import { getLatestHouseRule, sortHouseRulesByVersion, type HouseRule } from "@/lib/house-rules"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+const broadcastPayloadSchema = z.object({
+  version: z.number(),
+  content: z.string(),
+  created_by: z.string(),
+  published_at: z.string(),
+})
+
+export function HouseRulesHistory({
+  initialRules,
+  subscribe = true,
+}: {
+  initialRules: HouseRule[]
+  subscribe?: boolean
+}) {
+  const supabase = useSupabaseBrowser()
+  const { toast } = useToast()
+  const sortedInitialRules = useMemo(() => sortHouseRulesByVersion(initialRules), [initialRules])
+  const [rules, setRules] = useState<HouseRule[]>(sortedInitialRules)
+
+  useEffect(() => {
+    setRules(sortedInitialRules)
+  }, [sortedInitialRules])
+
+  useEffect(() => {
+    if (!subscribe) {
+      return
+    }
+
+    const channel = supabase.channel("house-rules")
+
+    channel.on("broadcast", { event: "house_rules:published" }, ({ payload }) => {
+      const result = broadcastPayloadSchema.safeParse(payload)
+
+      if (!result.success) {
+        console.error("Received invalid house rules broadcast", result.error)
+        return
+      }
+
+      let shouldNotify = false
+
+      setRules((previous) => {
+        const existing = previous.find((rule) => rule.version === result.data.version)
+        const hasChanges =
+          !existing ||
+          existing.content !== result.data.content ||
+          existing.published_at !== result.data.published_at
+
+        if (!hasChanges) {
+          return previous
+        }
+
+        shouldNotify = true
+
+        const nextRules = existing
+          ? previous.map((rule) => (rule.version === result.data.version ? result.data : rule))
+          : [result.data, ...previous]
+
+        return sortHouseRulesByVersion(nextRules)
+      })
+
+      if (shouldNotify) {
+        toast({
+          title: "House rules updated",
+          description: `Version ${result.data.version} is now live.`,
+        })
+      }
+    })
+
+    channel.subscribe().catch((error) => {
+      console.error("Failed to subscribe to house rules broadcasts", error)
+    })
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [subscribe, supabase, toast])
+
+  const latestRule = getLatestHouseRule(rules)
+
+  return (
+    <div className="space-y-4">
+      {rules.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No house rules yet</CardTitle>
+            <CardDescription>
+              Published rules will appear here so everyone can review expectations for shared living.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        rules.map((rule) => {
+          const isLatest = latestRule?.version === rule.version
+          const publishedDate = new Date(rule.published_at)
+          const publishedLabel = Number.isNaN(publishedDate.getTime())
+            ? "Publication date unavailable"
+            : format(publishedDate, "PPP p")
+
+          return (
+            <Card key={rule.version}>
+              <CardHeader className="space-y-1">
+                <div className="flex items-center justify-between gap-2">
+                  <CardTitle className="text-lg">House rules v{rule.version}</CardTitle>
+                  {isLatest ? <Badge variant="secondary">Latest</Badge> : null}
+                </div>
+                <CardDescription>Published {publishedLabel}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="whitespace-pre-wrap text-sm text-muted-foreground">{rule.content}</div>
+              </CardContent>
+            </Card>
+          )
+        })
+      )}
+    </div>
+  )
+}

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -28,6 +28,10 @@ export const docsConfig: DocsConfig = {
       href: "/documents",
     },
     {
+      title: "House Rules",
+      href: "/house-rules",
+    },
+    {
       title: "Messaging",
       href: "/messaging",
     },

--- a/config/site.ts
+++ b/config/site.ts
@@ -26,6 +26,10 @@ export const siteConfig = {
       href: "/documents",
     },
     {
+      title: "House Rules",
+      href: "/house-rules",
+    },
+    {
       title: "Messaging",
       href: "/messaging",
     },

--- a/lib/house-rules.ts
+++ b/lib/house-rules.ts
@@ -1,0 +1,28 @@
+import type { Database } from './supabase'
+
+export type HouseRule = Database['public']['Tables']['house_rules']['Row']
+
+export function sortHouseRulesByVersion(rules: HouseRule[]): HouseRule[] {
+  return [...rules].sort((a, b) => {
+    if (a.version !== b.version) {
+      return b.version - a.version
+    }
+
+    const timeA = Date.parse(a.published_at)
+    const timeB = Date.parse(b.published_at)
+
+    if (Number.isNaN(timeA) || Number.isNaN(timeB)) {
+      return 0
+    }
+
+    return timeB - timeA
+  })
+}
+
+export function getLatestHouseRule(rules: HouseRule[]): HouseRule | null {
+  if (rules.length === 0) {
+    return null
+  }
+
+  return sortHouseRulesByVersion(rules)[0] ?? null
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -968,6 +968,35 @@ export type Database = {
         }
         Relationships: []
       }
+      house_rules: {
+        Row: {
+          content: string
+          created_by: string
+          published_at: string
+          version: number
+        }
+        Insert: {
+          content: string
+          created_by?: string
+          published_at?: string
+          version: number
+        }
+        Update: {
+          content?: string
+          created_by?: string
+          published_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "house_rules_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       meetings: {
         Row: {
           created_at: string | null

--- a/queries/house-rules.ts
+++ b/queries/house-rules.ts
@@ -1,0 +1,27 @@
+import type { PostgrestError } from '@supabase/supabase-js'
+
+import type { HouseRule } from '@/lib/house-rules'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+
+export async function getHouseRulesHistory(
+  client: TypedSupabaseClient,
+): Promise<{ data: HouseRule[]; error: PostgrestError | null }> {
+  return client
+    .from('house_rules')
+    .select('*')
+    .order('version', { ascending: false })
+    .order('published_at', { ascending: false })
+}
+
+export async function getLatestHouseRuleRecord(
+  client: TypedSupabaseClient,
+): Promise<{ data: HouseRule | null; error: PostgrestError | null }> {
+  const { data, error } = await client
+    .from('house_rules')
+    .select('*')
+    .order('version', { ascending: false })
+    .order('published_at', { ascending: false })
+    .limit(1)
+
+  return { data: data?.[0] ?? null, error }
+}

--- a/supabase/migrations/20250421_house_rules.sql
+++ b/supabase/migrations/20250421_house_rules.sql
@@ -1,0 +1,59 @@
+create table public.house_rules (
+  version integer primary key,
+  content text not null,
+  created_by uuid not null default auth.uid(),
+  published_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+alter table public.house_rules enable row level security;
+
+create policy "All authenticated users can read house rules" on public.house_rules
+  for select
+  to authenticated
+  using (true);
+
+create policy "Admins can publish house rules" on public.house_rules
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('admin', 'property_manager')
+    )
+  );
+
+create policy "Admins can update house rules" on public.house_rules
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('admin', 'property_manager')
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('admin', 'property_manager')
+    )
+  );
+
+create policy "Admins can delete house rules" on public.house_rules
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('admin', 'property_manager')
+    )
+  );
+
+create index house_rules_published_at_idx on public.house_rules (published_at desc);

--- a/tests/house-rules.test.ts
+++ b/tests/house-rules.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+
+import { getLatestHouseRule, sortHouseRulesByVersion, type HouseRule } from "@/lib/house-rules"
+
+function createRule(overrides: Partial<HouseRule> = {}): HouseRule {
+  return {
+    version: 1,
+    content: "Default content",
+    created_by: "00000000-0000-0000-0000-000000000000",
+    published_at: "2024-01-01T12:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("house rule helpers", () => {
+  it("sorts rules by version in descending order", () => {
+    const rules = [
+      createRule({ version: 2, published_at: "2024-01-01T12:00:00.000Z" }),
+      createRule({ version: 4, published_at: "2024-01-02T12:00:00.000Z" }),
+      createRule({ version: 3, published_at: "2024-01-03T12:00:00.000Z" }),
+    ]
+
+    const sorted = sortHouseRulesByVersion(rules)
+
+    expect(sorted.map((rule) => rule.version)).toEqual([4, 3, 2])
+  })
+
+  it("uses the most recent timestamp when versions match", () => {
+    const rules = [
+      createRule({ version: 2, published_at: "2024-01-01T09:00:00.000Z", content: "Older" }),
+      createRule({ version: 2, published_at: "2024-01-01T12:00:00.000Z", content: "Newer" }),
+      createRule({ version: 1, published_at: "2024-01-01T06:00:00.000Z", content: "Oldest" }),
+    ]
+
+    const sorted = sortHouseRulesByVersion(rules)
+
+    expect(sorted[0]?.content).toBe("Newer")
+  })
+
+  it("returns null when no rules exist", () => {
+    expect(getLatestHouseRule([])).toBeNull()
+  })
+
+  it("returns the highest numbered version", () => {
+    const rules = [
+      createRule({ version: 5, published_at: "2024-02-01T12:00:00.000Z" }),
+      createRule({ version: 3, published_at: "2024-01-01T12:00:00.000Z" }),
+    ]
+
+    expect(getLatestHouseRule(rules)?.version).toBe(5)
+  })
+})

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -7,6 +7,7 @@ const expectedEntries = [
   { title: "Payments", href: "/payments" },
   { title: "Bookings", href: "/bookings" },
   { title: "Documents", href: "/documents" },
+  { title: "House Rules", href: "/house-rules" },
   { title: "Messaging", href: "/messaging" },
 ]
 


### PR DESCRIPTION
## Summary
- add a `house_rules` table, migration, and Supabase typings for versioned policy content
- build an admin publishing flow with realtime broadcasts and navigation entry points
- expose a roommate-facing history view with realtime updates plus helper tests for version retrieval

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0e836ac83288d50e4f0e51468b6