### PR TITLE
Add polls for messaging threads with voting controls

### DIFF
--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,5 +1,7 @@
+import PollCenter from "@/components/messaging/poll-center"
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import type { MessageSummary, RoommateProfile, ThreadSummary } from "@/lib/poll-manager"
 
 const messagingHighlights = [
   {
@@ -24,9 +26,65 @@ const messagingHighlights = [
   },
 ]
 
+const roommateProfiles: RoommateProfile[] = [
+  { id: "alex-rivera", name: "Alex Rivera" },
+  { id: "jamie-chen", name: "Jamie Chen" },
+  { id: "morgan-patel", name: "Morgan Patel" },
+  { id: "sasha-ibarra", name: "Sasha Ibarra" },
+]
+
+const threadSummaries: ThreadSummary[] = [
+  {
+    id: "thread-chores",
+    title: "Weekly chore rotation",
+    summary: "Align on the cleaning cadence for shared spaces.",
+  },
+  {
+    id: "thread-groceries",
+    title: "Bulk grocery order",
+    summary: "Coordinate staples before the monthly Costco run.",
+  },
+  {
+    id: "thread-events",
+    title: "Summer roommate events",
+    summary: "Plan July game nights and patio dinners.",
+  },
+]
+
+const threadMessages: MessageSummary[] = [
+  {
+    id: "message-chores-1",
+    threadId: "thread-chores",
+    authorId: "alex-rivera",
+    body: "I drafted a kitchen/living room/bathroom rotation. Open to adjustments if a weekday works better.",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 18).toISOString(),
+  },
+  {
+    id: "message-chores-2",
+    threadId: "thread-chores",
+    authorId: "jamie-chen",
+    body: "Could we swap the deep clean to midweek so weekends stay open?",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 16).toISOString(),
+  },
+  {
+    id: "message-groceries-1",
+    threadId: "thread-groceries",
+    authorId: "morgan-patel",
+    body: "I'm putting together the Costco list. Drop any specialty items before Friday night.",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+  },
+  {
+    id: "message-events-1",
+    threadId: "thread-events",
+    authorId: "sasha-ibarra",
+    body: "Let's pick a weekend for a patio dinner. I can handle grilling if someone covers sides!",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+  },
+]
+
 export default function MessagingPage() {
   return (
-    <div className="container max-w-5xl space-y-10 py-12">
+    <div className="container max-w-5xl space-y-12 py-12">
       <header className="space-y-4">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Messaging</h1>
@@ -46,6 +104,7 @@ export default function MessagingPage() {
           </Card>
         ))}
       </div>
+      <PollCenter messages={threadMessages} roommates={roommateProfiles} threads={threadSummaries} />
     </div>
   )
 }

--- a/components/messaging/poll-builder.tsx
+++ b/components/messaging/poll-builder.tsx
@@ -1,0 +1,285 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+
+import type { MessageSummary, RoommateProfile, ThreadSummary } from "@/lib/poll-manager"
+
+export type PollFormState = {
+  threadId: string
+  messageId?: string
+  question: string
+  options: string[]
+  allowAnonymous: boolean
+  closesAt: string
+}
+
+export type PollCreationResponse =
+  | { success: true }
+  | {
+      success: false
+      error: string
+    }
+
+const DEFAULT_OPTIONS = ["Yes", "No"] as const
+
+const toDateTimeLocalValue = (date: Date) => {
+  const isoValue = date.toISOString()
+  return isoValue.slice(0, 16)
+}
+
+type PollBuilderProps = {
+  threads: ThreadSummary[]
+  messages: MessageSummary[]
+  roommates: RoommateProfile[]
+  currentUserId: string | null
+  onCreate: (data: PollFormState) => PollCreationResponse
+}
+
+const PollBuilder = ({ threads, messages, roommates, currentUserId, onCreate }: PollBuilderProps) => {
+  const defaultThreadId = threads[0]?.id ?? ""
+  const [threadId, setThreadId] = useState<string>(defaultThreadId)
+  const [messageId, setMessageId] = useState<string | undefined>(undefined)
+  const [question, setQuestion] = useState<string>("")
+  const [options, setOptions] = useState<string[]>(() => [...DEFAULT_OPTIONS])
+  const [allowAnonymous, setAllowAnonymous] = useState<boolean>(true)
+  const [closesAt, setClosesAt] = useState<string>(() =>
+    toDateTimeLocalValue(new Date(Date.now() + 1000 * 60 * 60 * 24)),
+  )
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [statusVariant, setStatusVariant] = useState<"success" | "error" | null>(null)
+
+  const threadMessages = useMemo(
+    () => messages.filter((message) => message.threadId === threadId),
+    [messages, threadId],
+  )
+
+  useEffect(() => {
+    if (!threadId) {
+      setMessageId(undefined)
+      return
+    }
+
+    if (threadMessages.length === 0) {
+      setMessageId(undefined)
+      return
+    }
+
+    setMessageId((previous) => previous ?? threadMessages[0]?.id)
+  }, [threadId, threadMessages])
+
+  const roommateDirectory = useMemo(
+    () =>
+      roommates.reduce<Record<string, string>>((directory, roommate) => {
+        directory[roommate.id] = roommate.name
+        return directory
+      }, {}),
+    [roommates],
+  )
+
+  const resetForm = () => {
+    setQuestion("")
+    setOptions([...DEFAULT_OPTIONS])
+    setAllowAnonymous(true)
+    setClosesAt(toDateTimeLocalValue(new Date(Date.now() + 1000 * 60 * 60 * 24)))
+    setStatusVariant(null)
+    setStatusMessage(null)
+  }
+
+  const handleOptionChange = (value: string, index: number) => {
+    setOptions((currentOptions) => currentOptions.map((option, optionIndex) => (optionIndex === index ? value : option)))
+  }
+
+  const handleAddOption = () => {
+    setOptions((currentOptions) => [...currentOptions, ""])
+  }
+
+  const handleRemoveOption = (index: number) => {
+    setOptions((currentOptions) => currentOptions.filter((_, optionIndex) => optionIndex !== index))
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!currentUserId) {
+      setStatusVariant("error")
+      setStatusMessage("Select who you are before creating a poll.")
+      return
+    }
+
+    if (!closesAt) {
+      setStatusVariant("error")
+      setStatusMessage("Choose when the poll should close.")
+      return
+    }
+
+    const payload: PollFormState = {
+      threadId,
+      messageId,
+      question,
+      options,
+      allowAnonymous,
+      closesAt,
+    }
+
+    const response = onCreate(payload)
+
+    if (response.success) {
+      setStatusVariant("success")
+      setStatusMessage("Poll created and shared to the thread.")
+      resetForm()
+      return
+    }
+
+    setStatusVariant("error")
+    setStatusMessage(response.error)
+  }
+
+  const hasMessagesForThread = threadMessages.length > 0
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create a poll</CardTitle>
+        <CardDescription>
+          Collect decisions from roommates by attaching polls directly to an existing thread message.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="poll-thread">Thread</Label>
+              <Select onValueChange={setThreadId} value={threadId}>
+                <SelectTrigger id="poll-thread">
+                  <SelectValue placeholder="Select a thread" />
+                </SelectTrigger>
+                <SelectContent>
+                  {threads.map((thread) => (
+                    <SelectItem key={thread.id} value={thread.id}>
+                      {thread.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="poll-message">Message</Label>
+              <Select
+                disabled={!hasMessagesForThread}
+                onValueChange={setMessageId}
+                value={messageId ?? (hasMessagesForThread ? threadMessages[0]?.id : "")}
+              >
+                <SelectTrigger id="poll-message">
+                  <SelectValue placeholder="Select a message" />
+                </SelectTrigger>
+                <SelectContent>
+                  {threadMessages.map((message) => (
+                    <SelectItem key={message.id} value={message.id}>
+                      <div className="flex flex-col">
+                        <span className="text-sm font-medium">{roommateDirectory[message.authorId] ?? "Roommate"}</span>
+                        <span className="text-xs text-muted-foreground">{message.body.slice(0, 60)}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {!hasMessagesForThread ? (
+                <p className="text-xs text-muted-foreground">There are no messages in this thread yet.</p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="poll-question">Question</Label>
+            <Textarea
+              id="poll-question"
+              placeholder="Where should we host the next roommate dinner?"
+              value={question}
+              onChange={(event) => setQuestion(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-3">
+            <Label>Options</Label>
+            <div className="space-y-2">
+              {options.map((option, index) => (
+                <div className="flex items-center gap-2" key={`poll-option-${index}`}>
+                  <Input
+                    placeholder={`Option ${index + 1}`}
+                    value={option}
+                    onChange={(event) => handleOptionChange(event.target.value, index)}
+                  />
+                  {options.length > 2 ? (
+                    <Button
+                      aria-label={`Remove option ${index + 1}`}
+                      onClick={() => handleRemoveOption(index)}
+                      type="button"
+                      variant="ghost"
+                    >
+                      Remove
+                    </Button>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+            <Button onClick={handleAddOption} type="button" variant="outline">
+              Add another option
+            </Button>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex items-center justify-between rounded-md border px-3 py-2">
+              <div>
+                <Label htmlFor="poll-anonymous">Anonymous voting</Label>
+                <p className="text-xs text-muted-foreground">Hide who voted while still counting their responses.</p>
+              </div>
+              <Switch
+                checked={allowAnonymous}
+                id="poll-anonymous"
+                onCheckedChange={setAllowAnonymous}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="poll-closes-at">Poll closes</Label>
+              <Input
+                id="poll-closes-at"
+                min={toDateTimeLocalValue(new Date())}
+                onChange={(event) => setClosesAt(event.target.value)}
+                type="datetime-local"
+                value={closesAt}
+              />
+              <p className="text-xs text-muted-foreground">Voting automatically closes at the selected time.</p>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Button disabled={!threads.length || !currentUserId} type="submit">
+              Publish poll to thread
+            </Button>
+            {!currentUserId ? (
+              <p className="text-xs text-muted-foreground">Select yourself above to create a poll.</p>
+            ) : null}
+            {statusMessage ? (
+              <p
+                className={`text-sm ${statusVariant === "success" ? "text-green-600" : "text-destructive"}`}
+                role={statusVariant === "error" ? "alert" : undefined}
+              >
+                {statusMessage}
+              </p>
+            ) : null}
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default PollBuilder

--- a/components/messaging/poll-card.tsx
+++ b/components/messaging/poll-card.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+
+import { getPollResults, getVotesByOption, isPollClosed, type MessageSummary, type Poll, type RoommateProfile, type ThreadSummary } from "@/lib/poll-manager"
+
+import { formatDistanceToNow } from "date-fns"
+
+export type VoteResponse =
+  | { success: true }
+  | {
+      success: false
+      error: string
+    }
+
+type PollCardProps = {
+  poll: Poll
+  thread?: ThreadSummary
+  message?: MessageSummary
+  roommates: RoommateProfile[]
+  currentUserId: string | null
+  onVote: (pollId: string, optionIndex: number) => VoteResponse | Promise<VoteResponse>
+}
+
+const PollCard = ({ poll, thread, message, roommates, currentUserId, onVote }: PollCardProps) => {
+  const [now, setNow] = useState<Date>(() => new Date())
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [feedbackVariant, setFeedbackVariant] = useState<"success" | "error" | null>(null)
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setNow(new Date())
+    }, 30000)
+
+    return () => window.clearInterval(interval)
+  }, [])
+
+  const roommateDirectory = useMemo(
+    () =>
+      roommates.reduce<Record<string, string>>((directory, roommate) => {
+        directory[roommate.id] = roommate.name
+        return directory
+      }, {}),
+    [roommates],
+  )
+
+  const closed = isPollClosed(poll, now)
+  const results = getPollResults(poll)
+  const votesByOption = getVotesByOption(poll)
+  const totalVotes = poll.votes.length
+  const currentVote = poll.votes.find((vote) => vote.voterId === currentUserId)
+
+  const voteDisabledReason = useMemo(() => {
+    if (!currentUserId) {
+      return "Select a roommate profile to vote."
+    }
+
+    if (closed) {
+      return "Voting has closed for this poll."
+    }
+
+    if (currentVote) {
+      return "You already voted."
+    }
+
+    return null
+  }, [closed, currentUserId, currentVote])
+
+  const handleVote = async (optionIndex: number) => {
+    if (voteDisabledReason) {
+      setFeedbackVariant("error")
+      setFeedback(voteDisabledReason)
+      return
+    }
+
+    const response = await onVote(poll.id, optionIndex)
+
+    if (response.success) {
+      setFeedbackVariant("success")
+      setFeedback("Vote recorded.")
+      return
+    }
+
+    setFeedbackVariant("error")
+    setFeedback(response.error)
+  }
+
+  const closingDescriptor = formatDistanceToNow(new Date(poll.closesAt), {
+    addSuffix: true,
+  })
+  const closingLabel = closed ? `Closed ${closingDescriptor}` : `Closes ${closingDescriptor}`
+
+  return (
+    <Card>
+      <CardHeader className="space-y-2">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          {thread ? <span>{thread.title}</span> : null}
+          {thread && message ? <span aria-hidden>•</span> : null}
+          {message ? <span>{message.body.slice(0, 50)}{message.body.length > 50 ? "…" : ""}</span> : null}
+        </div>
+        <CardTitle className="text-xl">{poll.question}</CardTitle>
+        <CardDescription>
+          <span className="font-medium">{totalVotes}</span> vote{totalVotes === 1 ? "" : "s"} · {poll.allowAnonymous ? "Anonymous" : "Names visible"}
+        </CardDescription>
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <Badge variant={closed ? "secondary" : "outline"}>{closed ? "Voting closed" : "Open for votes"}</Badge>
+          <span>{closingLabel}</span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {results.map((result) => {
+          const optionVotes = votesByOption[result.optionIndex] ?? []
+          const voters = optionVotes.map((vote) => roommateDirectory[vote.voterId] ?? "Roommate")
+          const isUsersSelection = currentVote?.optionIndex === result.optionIndex
+
+          return (
+            <div className="space-y-2" key={`poll-${poll.id}-option-${result.optionIndex}`}>
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{result.text}</span>
+                <span className="text-sm text-muted-foreground">
+                  {result.voteCount} vote{result.voteCount === 1 ? "" : "s"} · {result.percentage}%
+                </span>
+              </div>
+              <Progress className="h-2" value={result.percentage} />
+              {!poll.allowAnonymous && voters.length > 0 ? (
+                <p className="text-xs text-muted-foreground">{voters.join(", ")}</p>
+              ) : null}
+              <div className="flex items-center gap-2">
+                <Button
+                  disabled={Boolean(voteDisabledReason)}
+                  onClick={() => handleVote(result.optionIndex)}
+                  type="button"
+                  variant={isUsersSelection ? "default" : "outline"}
+                >
+                  {isUsersSelection ? "Your vote" : "Vote"}
+                </Button>
+              </div>
+            </div>
+          )
+        })}
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-2">
+        {feedback ? (
+          <p className={`text-sm ${feedbackVariant === "success" ? "text-green-600" : "text-destructive"}`}>{feedback}</p>
+        ) : null}
+        {message ? (
+          <p className="text-xs text-muted-foreground">Posted by {roommateDirectory[message.authorId] ?? "Roommate"}</p>
+        ) : null}
+        <p className="text-xs text-muted-foreground">Created {formatDistanceToNow(new Date(poll.createdAt), { addSuffix: true })}</p>
+      </CardFooter>
+    </Card>
+  )
+}
+
+export default PollCard

--- a/components/messaging/poll-center.tsx
+++ b/components/messaging/poll-center.tsx
@@ -1,0 +1,209 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+import PollBuilder, { type PollCreationResponse, type PollFormState } from "@/components/messaging/poll-builder"
+import PollCard, { type VoteResponse } from "@/components/messaging/poll-card"
+import { castVote, createPoll, type MessageSummary, type Poll, type RoommateProfile, type ThreadSummary } from "@/lib/poll-manager"
+
+type PollCenterProps = {
+  threads: ThreadSummary[]
+  messages: MessageSummary[]
+  roommates: RoommateProfile[]
+}
+
+const PollCenter = ({ threads, messages, roommates }: PollCenterProps) => {
+  const [currentUserId, setCurrentUserId] = useState<string | null>(roommates[0]?.id ?? null)
+
+  const initialPolls = useMemo(() => {
+    if (!threads.length) {
+      return [] as Poll[]
+    }
+
+    const defaultThread = threads[0]
+    const threadMessages = messages.filter((message) => message.threadId === defaultThread.id)
+    const primaryMessage = threadMessages[0]
+
+    const creatorId = roommates[0]?.id ?? "system"
+
+    try {
+      const basePoll = createPoll(
+        {
+          threadId: defaultThread.id,
+          messageId: primaryMessage?.id,
+          question: "When should we schedule the next deep clean?",
+          options: ["Sunday afternoon", "Wednesday evening", "Hire cleaners monthly"],
+          allowAnonymous: false,
+          closesAt: new Date(Date.now() + 1000 * 60 * 60 * 12),
+          createdBy: creatorId,
+        },
+        new Date(Date.now() - 1000 * 60 * 15),
+      )
+
+      const seededPoll = roommates.slice(1, Math.min(roommates.length, 4)).reduce((poll, roommate, index) => {
+        const voteTime = new Date(Date.now() - (index + 1) * 1000 * 60 * 5)
+        const optionIndex = index % poll.options.length
+        return castVote(poll, optionIndex, roommate.id, voteTime)
+      }, basePoll)
+
+      return [seededPoll]
+    } catch {
+      return [] as Poll[]
+    }
+  }, [messages, roommates, threads])
+
+  const [polls, setPolls] = useState<Poll[]>(initialPolls)
+
+  const threadDirectory = useMemo(
+    () =>
+      threads.reduce<Record<string, ThreadSummary>>((directory, thread) => {
+        directory[thread.id] = thread
+        return directory
+      }, {}),
+    [threads],
+  )
+
+  const messageDirectory = useMemo(
+    () =>
+      messages.reduce<Record<string, MessageSummary>>((directory, message) => {
+        directory[message.id] = message
+        return directory
+      }, {}),
+    [messages],
+  )
+
+  const handleCreatePoll = (formState: PollFormState): PollCreationResponse => {
+    if (!currentUserId) {
+      return { success: false, error: "Select a roommate profile before creating a poll." }
+    }
+
+    if (!formState.closesAt) {
+      return { success: false, error: "Choose a closing time for the poll." }
+    }
+
+    try {
+      const poll = createPoll(
+        {
+          threadId: formState.threadId,
+          messageId: formState.messageId,
+          question: formState.question,
+          options: formState.options,
+          allowAnonymous: formState.allowAnonymous,
+          closesAt: new Date(formState.closesAt),
+          createdBy: currentUserId,
+        },
+        new Date(),
+      )
+
+      setPolls((currentPolls) => [poll, ...currentPolls])
+      return { success: true }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unable to create poll.",
+      }
+    }
+  }
+
+  const handleVote = (pollId: string, optionIndex: number): VoteResponse => {
+    if (!currentUserId) {
+      return { success: false, error: "Select a roommate profile to vote." }
+    }
+
+    try {
+      setPolls((currentPolls) =>
+        currentPolls.map((poll) => {
+          if (poll.id !== pollId) {
+            return poll
+          }
+
+          return castVote(poll, optionIndex, currentUserId, new Date())
+        }),
+      )
+
+      return { success: true }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unable to record vote.",
+      }
+    }
+  }
+
+  const handleUserChange = (value: string) => {
+    setCurrentUserId(value || null)
+  }
+
+  return (
+    <div className="space-y-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Poll coordination</CardTitle>
+          <CardDescription>
+            Choose who you are acting as and draft a poll to include in a thread message.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-6 md:grid-cols-[280px_1fr]">
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <span className="text-sm font-medium text-muted-foreground">Responding as</span>
+                <Select onValueChange={handleUserChange} value={currentUserId ?? ""}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a roommate" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">Spectator (no votes)</SelectItem>
+                    {roommates.map((roommate) => (
+                      <SelectItem key={roommate.id} value={roommate.id}>
+                        {roommate.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Selecting a roommate lets you preview how the experience changes once someone has voted. You can still create and
+                manage polls without posting real messages.
+              </p>
+            </div>
+            <PollBuilder
+              currentUserId={currentUserId}
+              messages={messages}
+              onCreate={handleCreatePoll}
+              roommates={roommates}
+              threads={threads}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-4">
+        {polls.length === 0 ? (
+          <Card>
+            <CardContent className="py-10 text-center text-muted-foreground">
+              Create a poll to start collecting votes in your roommate threads.
+            </CardContent>
+          </Card>
+        ) : (
+          polls.map((poll) => (
+            <PollCard
+              key={poll.id}
+              currentUserId={currentUserId}
+              message={poll.messageId ? messageDirectory[poll.messageId] : undefined}
+              onVote={handleVote}
+              poll={poll}
+              roommates={roommates}
+              thread={threadDirectory[poll.threadId]}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default PollCenter

--- a/lib/poll-manager.ts
+++ b/lib/poll-manager.ts
@@ -1,0 +1,170 @@
+export type ThreadSummary = {
+  id: string
+  title: string
+  summary?: string
+}
+
+export type MessageSummary = {
+  id: string
+  threadId: string
+  authorId: string
+  body: string
+  createdAt: string
+}
+
+export type RoommateProfile = {
+  id: string
+  name: string
+}
+
+export type PollOption = {
+  index: number
+  text: string
+}
+
+export type PollVote = {
+  optionIndex: number
+  voterId: string
+  votedAt: string
+}
+
+export type Poll = {
+  id: string
+  threadId: string
+  messageId?: string
+  question: string
+  options: PollOption[]
+  allowAnonymous: boolean
+  closesAt: string
+  createdBy: string
+  createdAt: string
+  votes: PollVote[]
+}
+
+export type PollCreationInput = {
+  threadId: string
+  messageId?: string
+  question: string
+  options: string[]
+  allowAnonymous: boolean
+  closesAt: Date
+  createdBy: string
+}
+
+export type PollResult = {
+  optionIndex: number
+  text: string
+  voteCount: number
+  percentage: number
+}
+
+export const POLL_ERRORS = {
+  emptyQuestion: "Poll question is required.",
+  insufficientOptions: "Provide at least two poll options.",
+  duplicateOptions: "Poll options must be unique.",
+  pastDeadline: "Poll closing time must be in the future.",
+  invalidOption: "Selected option does not belong to this poll.",
+  pollClosed: "Voting has closed for this poll.",
+  alreadyVoted: "You have already voted on this poll.",
+} as const
+
+const generateId = () => {
+  if (typeof globalThis.crypto !== "undefined" && typeof globalThis.crypto.randomUUID === "function") {
+    return globalThis.crypto.randomUUID()
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+const normalizeOptions = (options: string[]): string[] =>
+  options.map((option) => option.trim()).filter((option) => option.length > 0)
+
+export const createPoll = (input: PollCreationInput, now = new Date()): Poll => {
+  const sanitizedQuestion = input.question.trim()
+  if (!sanitizedQuestion) {
+    throw new Error(POLL_ERRORS.emptyQuestion)
+  }
+
+  const normalizedOptions = normalizeOptions(input.options)
+  if (normalizedOptions.length < 2) {
+    throw new Error(POLL_ERRORS.insufficientOptions)
+  }
+
+  const uniqueOptions = Array.from(new Set(normalizedOptions))
+  if (uniqueOptions.length !== normalizedOptions.length) {
+    throw new Error(POLL_ERRORS.duplicateOptions)
+  }
+
+  if (input.closesAt.getTime() <= now.getTime()) {
+    throw new Error(POLL_ERRORS.pastDeadline)
+  }
+
+  return {
+    id: generateId(),
+    threadId: input.threadId,
+    messageId: input.messageId,
+    question: sanitizedQuestion,
+    allowAnonymous: input.allowAnonymous,
+    closesAt: input.closesAt.toISOString(),
+    createdBy: input.createdBy,
+    createdAt: now.toISOString(),
+    options: normalizedOptions.map((option, index) => ({
+      index,
+      text: option,
+    })),
+    votes: [],
+  }
+}
+
+export const isPollClosed = (poll: Poll, now = new Date()): boolean =>
+  new Date(poll.closesAt).getTime() <= now.getTime()
+
+export const castVote = (poll: Poll, optionIndex: number, voterId: string, now = new Date()): Poll => {
+  if (isPollClosed(poll, now)) {
+    throw new Error(POLL_ERRORS.pollClosed)
+  }
+
+  const optionExists = poll.options.some((option) => option.index === optionIndex)
+  if (!optionExists) {
+    throw new Error(POLL_ERRORS.invalidOption)
+  }
+
+  const hasExistingVote = poll.votes.some((vote) => vote.voterId === voterId)
+  if (hasExistingVote) {
+    throw new Error(POLL_ERRORS.alreadyVoted)
+  }
+
+  return {
+    ...poll,
+    votes: [
+      ...poll.votes,
+      {
+        optionIndex,
+        voterId,
+        votedAt: now.toISOString(),
+      },
+    ],
+  }
+}
+
+export const getPollResults = (poll: Poll): PollResult[] => {
+  const totalVotes = poll.votes.length
+  return poll.options.map((option) => {
+    const voteCount = poll.votes.filter((vote) => vote.optionIndex === option.index).length
+    const percentage = totalVotes === 0 ? 0 : Math.round((voteCount / totalVotes) * 1000) / 10
+
+    return {
+      optionIndex: option.index,
+      text: option.text,
+      voteCount,
+      percentage,
+    }
+  })
+}
+
+export const getVotesByOption = (poll: Poll): Record<number, PollVote[]> => {
+  return poll.votes.reduce<Record<number, PollVote[]>>((accumulator, vote) => {
+    accumulator[vote.optionIndex] = [...(accumulator[vote.optionIndex] ?? []), vote]
+    return accumulator
+  }, {})
+}

--- a/supabase/migrations/20250702_roommate_polls.sql
+++ b/supabase/migrations/20250702_roommate_polls.sql
@@ -1,0 +1,55 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+DO $$
+BEGIN
+  CREATE TABLE IF NOT EXISTS public.threads (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    title text NOT NULL,
+    created_by uuid REFERENCES public.profiles (id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+    updated_at timestamptz NULL
+  );
+END;
+$$;
+
+DO $$
+BEGIN
+  CREATE TABLE IF NOT EXISTS public.messages (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    thread_id uuid NOT NULL REFERENCES public.threads (id) ON DELETE CASCADE,
+    author_id uuid REFERENCES public.profiles (id) ON DELETE SET NULL,
+    body text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+    updated_at timestamptz NULL
+  );
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS public.polls (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id uuid NOT NULL REFERENCES public.threads (id) ON DELETE CASCADE,
+  message_id uuid REFERENCES public.messages (id) ON DELETE SET NULL,
+  question text NOT NULL,
+  options text[] NOT NULL CHECK (array_length(options, 1) >= 2),
+  allow_anonymous boolean NOT NULL DEFAULT false,
+  closes_at timestamptz NOT NULL,
+  created_by uuid REFERENCES public.profiles (id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  closed_at timestamptz NULL,
+  CONSTRAINT polls_closes_after_creation CHECK (closes_at > created_at)
+);
+
+CREATE INDEX IF NOT EXISTS polls_thread_id_idx ON public.polls (thread_id);
+CREATE INDEX IF NOT EXISTS polls_closes_at_idx ON public.polls (closes_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.poll_votes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  poll_id uuid NOT NULL REFERENCES public.polls (id) ON DELETE CASCADE,
+  voter_id uuid NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  option_index integer NOT NULL CHECK (option_index >= 0),
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT poll_votes_unique_vote UNIQUE (poll_id, voter_id)
+);
+
+CREATE INDEX IF NOT EXISTS poll_votes_poll_id_idx ON public.poll_votes (poll_id);
+CREATE INDEX IF NOT EXISTS poll_votes_voter_idx ON public.poll_votes (voter_id);

--- a/tests/poll-manager.test.ts
+++ b/tests/poll-manager.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  POLL_ERRORS,
+  castVote,
+  createPoll,
+  getPollResults,
+  isPollClosed,
+  type Poll,
+} from "@/lib/poll-manager"
+
+describe("poll manager", () => {
+  const baseNow = new Date("2024-07-01T12:00:00.000Z")
+
+  const buildPoll = (overrides?: Partial<Poll>) =>
+    createPoll(
+      {
+        threadId: overrides?.threadId ?? "thread-1",
+        messageId: overrides?.messageId ?? "message-1",
+        question: overrides?.question ?? "Where should we host the next roommate dinner?",
+        options: overrides?.options?.map((option) => option.text) ?? ["Roof deck", "Living room", "Try a restaurant"],
+        allowAnonymous: overrides?.allowAnonymous ?? true,
+        closesAt: overrides?.closesAt ? new Date(overrides.closesAt) : new Date(baseNow.getTime() + 1000 * 60 * 60 * 4),
+        createdBy: overrides?.createdBy ?? "alex",
+      },
+      overrides?.createdAt ? new Date(overrides.createdAt) : baseNow,
+    )
+
+  test("createPoll trims input and enforces option uniqueness", () => {
+    const poll = createPoll(
+      {
+        threadId: "thread-1",
+        messageId: "message-1",
+        question: "  Favorite meal prep night?  ",
+        options: ["Monday", "Wednesday", "Friday"],
+        allowAnonymous: true,
+        closesAt: new Date(baseNow.getTime() + 1000 * 60 * 60 * 2),
+        createdBy: "jamie",
+      },
+      baseNow,
+    )
+
+    expect(poll.question).toBe("Favorite meal prep night?")
+    expect(poll.options.map((option) => option.text)).toEqual(["Monday", "Wednesday", "Friday"])
+  })
+
+  test("createPoll throws for duplicate or past-due options", () => {
+    expect(() =>
+      createPoll(
+        {
+          threadId: "thread-1",
+          messageId: "message-1",
+          question: "Duplicate options",
+          options: ["Same", "Same"],
+          allowAnonymous: true,
+          closesAt: new Date(baseNow.getTime() + 1000 * 60 * 30),
+          createdBy: "alex",
+        },
+        baseNow,
+      ),
+    ).toThrowError(POLL_ERRORS.duplicateOptions)
+
+    expect(() =>
+      createPoll(
+        {
+          threadId: "thread-1",
+          messageId: "message-1",
+          question: "Past due",
+          options: ["Option A", "Option B"],
+          allowAnonymous: false,
+          closesAt: new Date(baseNow.getTime() - 1000 * 60 * 5),
+          createdBy: "alex",
+        },
+        baseNow,
+      ),
+    ).toThrowError(POLL_ERRORS.pastDeadline)
+  })
+
+  test("castVote records a new vote and prevents duplicates", () => {
+    let poll = buildPoll()
+
+    poll = castVote(poll, 0, "alex", new Date(baseNow.getTime() + 1000 * 60 * 10))
+    expect(poll.votes).toHaveLength(1)
+    expect(poll.votes[0]).toMatchObject({ optionIndex: 0, voterId: "alex" })
+
+    expect(() => castVote(poll, 1, "alex", new Date(baseNow.getTime() + 1000 * 60 * 12))).toThrowError(
+      POLL_ERRORS.alreadyVoted,
+    )
+  })
+
+  test("castVote rejects votes after the poll closes", () => {
+    const poll = buildPoll({ closesAt: new Date(baseNow.getTime() + 1000 * 60 * 30).toISOString() })
+
+    const closedMoment = new Date(baseNow.getTime() + 1000 * 60 * 60 * 6)
+    expect(isPollClosed(poll, closedMoment)).toBe(true)
+    expect(() => castVote(poll, 0, "jamie", closedMoment)).toThrowError(POLL_ERRORS.pollClosed)
+  })
+
+  test("getPollResults summarizes vote counts and percentages", () => {
+    let poll = buildPoll({ allowAnonymous: false })
+
+    poll = castVote(poll, 0, "alex", new Date(baseNow.getTime() + 1000 * 60 * 5))
+    poll = castVote(poll, 1, "jamie", new Date(baseNow.getTime() + 1000 * 60 * 6))
+    poll = castVote(poll, 0, "morgan", new Date(baseNow.getTime() + 1000 * 60 * 7))
+
+    const results = getPollResults(poll)
+    const optionOne = results.find((result) => result.optionIndex === 0)
+    const optionTwo = results.find((result) => result.optionIndex === 1)
+
+    expect(optionOne).toMatchObject({ voteCount: 2, percentage: 66.7 })
+    expect(optionTwo).toMatchObject({ voteCount: 1, percentage: 33.3 })
+    expect(results.reduce((total, result) => total + result.voteCount, 0)).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary
- add a Supabase migration that introduces polls and poll_votes tables scoped to messaging threads and messages
- implement client-side poll management utilities and UI components so roommates can create polls, toggle anonymity, and vote before deadlines
- update the messaging page to surface the new polling experience and cover vote counting with Vitest

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0e9a58c83288c56a56e280d1f39