### PR TITLE
feat: implement household messaging threads with attachments

### DIFF
--- a/app/messaging/actions.ts
+++ b/app/messaging/actions.ts
@@ -1,0 +1,203 @@
+"use server"
+
+import { randomUUID } from "node:crypto"
+
+import { revalidatePath } from "next/cache"
+
+import { createActionClient } from "@/utils/supabase/actions"
+
+const MESSAGING_PATH = "/messaging"
+
+function sanitizeFileName(name: string) {
+  const normalized = name.normalize("NFKD").replace(/[^a-zA-Z0-9._-]+/g, "-")
+  return normalized.length > 0 ? normalized.toLowerCase() : `attachment-${Date.now()}`
+}
+
+type ActionResult =
+  | { status: "success" }
+  | { status: "error"; message: string }
+  | { status: "partial"; message: string }
+
+export async function createThreadAction(formData: FormData): Promise<ActionResult> {
+  const supabase = await createActionClient()
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return { status: "error", message: "You must be signed in to start a thread." }
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, household_id")
+    .eq("id", user.id)
+    .single()
+
+  if (profileError || !profile) {
+    return { status: "error", message: "We couldn't find your profile record." }
+  }
+
+  if (!profile.household_id) {
+    return { status: "error", message: "Join or create a household before posting." }
+  }
+
+  const title = formData.get("title")?.toString().trim() ?? ""
+  const topic = formData.get("topic")?.toString().trim() ?? ""
+  const summaryValue = formData.get("summary")?.toString().trim() ?? ""
+  const parentThreadIdValue = formData.get("parentThreadId")?.toString().trim() ?? ""
+  const tagsValue = formData.get("tags")?.toString().trim() ?? ""
+  const priorityValue = formData.get("priority")?.toString().trim() ?? ""
+
+  if (!title) {
+    return { status: "error", message: "A thread title is required." }
+  }
+
+  if (!topic) {
+    return { status: "error", message: "Choose a topic to help roommates understand the thread context." }
+  }
+
+  const metadata: Record<string, unknown> = {}
+
+  if (tagsValue) {
+    const tags = tagsValue
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean)
+    if (tags.length > 0) {
+      metadata.tags = tags
+    }
+  }
+
+  if (priorityValue) {
+    metadata.priority = priorityValue
+  }
+
+  const summary = summaryValue.length > 0 ? summaryValue : null
+  const parentThreadId = parentThreadIdValue.length > 0 ? parentThreadIdValue : null
+  const metadataPayload = Object.keys(metadata).length > 0 ? metadata : null
+
+  const { error: insertError } = await supabase.from("threads").insert({
+    created_by: profile.id,
+    household_id: profile.household_id,
+    parent_thread_id: parentThreadId,
+    title,
+    topic,
+    summary,
+    metadata: metadataPayload,
+  })
+
+  if (insertError) {
+    return { status: "error", message: "Something went wrong while creating the thread." }
+  }
+
+  revalidatePath(MESSAGING_PATH)
+  return { status: "success" }
+}
+
+export async function postMessageAction(formData: FormData): Promise<ActionResult> {
+  const supabase = await createActionClient()
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return { status: "error", message: "You must be signed in to send a message." }
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, household_id")
+    .eq("id", user.id)
+    .single()
+
+  if (profileError || !profile) {
+    return { status: "error", message: "We couldn't find your profile record." }
+  }
+
+  if (!profile.household_id) {
+    return { status: "error", message: "Join or create a household before messaging." }
+  }
+
+  const threadId = formData.get("threadId")?.toString().trim() ?? ""
+  const content = formData.get("content")?.toString().trim() ?? ""
+  const replyToValue = formData.get("replyTo")?.toString().trim() ?? ""
+
+  if (!threadId) {
+    return { status: "error", message: "Choose a thread before posting." }
+  }
+
+  if (!content) {
+    return { status: "error", message: "Add a message before sending." }
+  }
+
+  const parentMessageId = replyToValue.length > 0 ? replyToValue : null
+
+  const { data: message, error: messageError } = await supabase
+    .from("messages")
+    .insert({
+      content,
+      parent_message_id: parentMessageId,
+      sender_id: profile.id,
+      thread_id: threadId,
+    })
+    .select("id")
+    .single()
+
+  if (messageError || !message) {
+    return { status: "error", message: "Unable to post your message right now." }
+  }
+
+  const files = formData
+    .getAll("attachments")
+    .filter((file): file is File => file instanceof File && file.size > 0)
+
+  let hadAttachmentError = false
+
+  for (const file of files) {
+    const sanitizedName = sanitizeFileName(file.name)
+    const storagePath = `${profile.household_id}/threads/${threadId}/${message.id}/${randomUUID()}-${sanitizedName}`
+
+    const { error: uploadError } = await supabase.storage
+      .from("docs")
+      .upload(storagePath, file, {
+        cacheControl: "3600",
+        upsert: false,
+        contentType: file.type || "application/octet-stream",
+      })
+
+    if (uploadError) {
+      hadAttachmentError = true
+      continue
+    }
+
+    const { error: attachmentError } = await supabase.from("message_attachments").insert({
+      bucket_id: "docs",
+      content_type: file.type || null,
+      file_name: file.name,
+      file_size: file.size,
+      message_id: message.id,
+      storage_path: storagePath,
+    })
+
+    if (attachmentError) {
+      hadAttachmentError = true
+      await supabase.storage.from("docs").remove([storagePath])
+    }
+  }
+
+  revalidatePath(MESSAGING_PATH)
+
+  if (hadAttachmentError) {
+    return {
+      status: "partial",
+      message: "Message sent, but one or more attachments could not be uploaded.",
+    }
+  }
+
+  return { status: "success" }
+}

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,51 +1,231 @@
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
 
-const messagingHighlights = [
-  {
-    title: "Threaded conversations",
-    description:
-      "Organize roommate discussions by topic with reactions, polls, and attachments to keep everyone aligned.",
-  },
-  {
-    title: "Property manager updates",
-    description:
-      "Pinned announcements and maintenance notifications ensure tenants never miss critical information.",
-  },
-  {
-    title: "Realtime presence",
-    description:
-      "Supabase Realtime keeps typing indicators and read receipts in sync across roommates and devices.",
-  },
-  {
-    title: "Moderation controls",
-    description:
-      "Flag, archive, or escalate threads so property managers can maintain a respectful household community.",
-  },
-]
+import { createServerClient } from "@supabase/ssr"
 
-export default function MessagingPage() {
-  return (
-    <div className="container max-w-5xl space-y-10 py-12">
-      <header className="space-y-4">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Messaging</h1>
-          <p className="text-base text-muted-foreground sm:text-lg">
-            Stay connected with roommates and property managers using a realtime feed purpose-built for shared living.
-          </p>
-        </div>
-        <Separator />
-      </header>
-      <div className="grid gap-6 md:grid-cols-2">
-        {messagingHighlights.map((item) => (
-          <Card key={item.title}>
-            <CardHeader>
-              <CardTitle>{item.title}</CardTitle>
-              <CardDescription>{item.description}</CardDescription>
-            </CardHeader>
-          </Card>
-        ))}
+import type { Database, Tables } from "@/lib/supabase"
+import ThreadClient, { type ThreadAuthor, type ThreadMessage, type ThreadNode } from "./thread-client"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+function sortThreadTree(nodes: ThreadNode[]) {
+  nodes.sort((a, b) => {
+    if (a.is_pinned && !b.is_pinned) {
+      return -1
+    }
+    if (!a.is_pinned && b.is_pinned) {
+      return 1
+    }
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  })
+
+  nodes.forEach((node) => sortThreadTree(node.children))
+}
+
+export default async function MessagingPage() {
+  const cookieStore = cookies()
+  const supabase = createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+      },
+    },
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, full_name, avatar_url, household_id")
+    .eq("id", user.id)
+    .single()
+
+  if (profileError) {
+    throw profileError
+  }
+
+  if (!profile) {
+    throw new Error("Profile not found")
+  }
+
+  if (!profile.household_id) {
+    return (
+      <div className="container max-w-3xl space-y-6 py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>Join a household to start messaging</CardTitle>
+            <CardDescription>
+              Household threads keep roommates aligned on chores, maintenance, and community updates. Finish onboarding to join
+              the conversation.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Once you&apos;re part of a household, you&apos;ll unlock topic-driven threads, message attachments, and Supabase-backed
+              RLS protections that ensure conversations stay private to your address.
+            </p>
+          </CardContent>
+        </Card>
       </div>
+    )
+  }
+
+  type ThreadRow = Tables<"threads"> & {
+    created_by_profile: Pick<Tables<"profiles">, "id" | "full_name" | "avatar_url"> | null
+  }
+
+  const { data: threadRows, error: threadsError } = await supabase
+    .from("threads")
+    .select(
+      `id, title, topic, summary, metadata, is_pinned, created_at, parent_thread_id, created_by,
+       created_by_profile:profiles!threads_created_by_fkey(id, full_name, avatar_url)`
+    )
+    .eq("household_id", profile.household_id)
+    .order("is_pinned", { ascending: false })
+    .order("created_at", { ascending: false })
+
+  if (threadsError) {
+    throw threadsError
+  }
+
+  const threadNodes: ThreadNode[] = (threadRows ?? []).map((row: ThreadRow) => ({
+    id: row.id,
+    title: row.title,
+    topic: row.topic,
+    summary: row.summary,
+    metadata: (row.metadata as Record<string, unknown> | null) ?? null,
+    is_pinned: row.is_pinned,
+    created_at: row.created_at,
+    parent_thread_id: row.parent_thread_id,
+    created_by: row.created_by_profile
+      ? {
+          id: row.created_by_profile.id,
+          full_name: row.created_by_profile.full_name,
+          avatar_url: row.created_by_profile.avatar_url,
+        }
+      : null,
+    children: [],
+  }))
+
+  const threadMap = new Map<string, ThreadNode>()
+  threadNodes.forEach((node) => threadMap.set(node.id, node))
+
+  const rootThreads: ThreadNode[] = []
+
+  threadNodes.forEach((node) => {
+    if (node.parent_thread_id) {
+      const parent = threadMap.get(node.parent_thread_id)
+      if (parent) {
+        parent.children.push(node)
+        return
+      }
+    }
+    rootThreads.push(node)
+  })
+
+  sortThreadTree(rootThreads)
+
+  const threadIds = threadNodes.map((thread) => thread.id)
+
+  type MessageRow = Tables<"messages"> & {
+    sender_profile: Pick<Tables<"profiles">, "id" | "full_name" | "avatar_url"> | null
+    message_attachments: Tables<"message_attachments">[]
+  }
+
+  const messagesByThread = new Map<string, ThreadMessage[]>()
+
+  if (threadIds.length > 0) {
+    const { data: messageRows, error: messagesError } = await supabase
+      .from("messages")
+      .select(
+        `id, thread_id, content, created_at, sender_id,
+         sender_profile:profiles!messages_sender_id_fkey(id, full_name, avatar_url),
+         message_attachments(id, storage_path, file_name, file_size, content_type)`
+      )
+      .in("thread_id", threadIds)
+      .order("created_at", { ascending: true })
+
+    if (messagesError) {
+      throw messagesError
+    }
+
+    const attachments = (messageRows ?? []).flatMap((message) => message.message_attachments ?? [])
+    const uniquePaths = Array.from(new Set(attachments.map((attachment) => attachment.storage_path)))
+    const signedUrlMap = new Map<string, string | null>()
+
+    await Promise.all(
+      uniquePaths.map(async (path) => {
+        const { data: signed, error: signedError } = await supabase.storage.from("docs").createSignedUrl(path, 60 * 60)
+        if (signedError || !signed) {
+          signedUrlMap.set(path, null)
+        } else {
+          signedUrlMap.set(path, signed.signedUrl)
+        }
+      }),
+    )
+
+    messageRows?.forEach((row: MessageRow) => {
+      const sender: ThreadAuthor = {
+        id: row.sender_profile?.id ?? row.sender_id,
+        full_name: row.sender_profile?.full_name ?? null,
+        avatar_url: row.sender_profile?.avatar_url ?? null,
+      }
+
+      const attachmentsWithUrls = (row.message_attachments ?? []).map((attachment) => ({
+        id: attachment.id,
+        file_name: attachment.file_name,
+        file_size: attachment.file_size,
+        content_type: attachment.content_type,
+        signed_url: signedUrlMap.get(attachment.storage_path) ?? null,
+      }))
+
+      const message: ThreadMessage = {
+        id: row.id,
+        content: row.content,
+        created_at: row.created_at,
+        attachments: attachmentsWithUrls,
+        sender,
+      }
+
+      const existing = messagesByThread.get(row.thread_id)
+      if (existing) {
+        existing.push(message)
+      } else {
+        messagesByThread.set(row.thread_id, [message])
+      }
+    })
+  }
+
+  const serializedMessages: Record<string, ThreadMessage[]> = {}
+  messagesByThread.forEach((value, key) => {
+    serializedMessages[key] = value
+  })
+
+  const profileAuthor: ThreadAuthor = {
+    id: profile.id,
+    full_name: profile.full_name,
+    avatar_url: profile.avatar_url,
+  }
+
+  return (
+    <div className="container max-w-6xl space-y-8 py-12">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Household threads</h1>
+        <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+          Coordinate chores, maintenance, and announcements with secure Supabase-backed messaging that keeps every roommate in the
+          loop.
+        </p>
+      </header>
+      <ThreadClient profile={profileAuthor} threads={rootThreads} messagesByThread={serializedMessages} />
     </div>
   )
 }

--- a/app/messaging/thread-client.tsx
+++ b/app/messaging/thread-client.tsx
@@ -1,0 +1,564 @@
+"use client"
+
+import type { ChangeEvent, FormEvent } from "react"
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react"
+
+import { useRouter } from "next/navigation"
+
+import { formatDistanceToNow } from "date-fns"
+import { Loader2, Paperclip, Pin, PlusCircle } from "lucide-react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+import { createThreadAction, postMessageAction } from "./actions"
+
+export type ThreadAuthor = {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+}
+
+export type ThreadAttachment = {
+  id: string
+  file_name: string
+  file_size: number | null
+  content_type: string | null
+  signed_url: string | null
+}
+
+export type ThreadMessage = {
+  id: string
+  content: string
+  created_at: string
+  attachments: ThreadAttachment[]
+  sender: ThreadAuthor
+}
+
+export type ThreadNode = {
+  id: string
+  title: string
+  topic: string
+  summary: string | null
+  metadata: Record<string, unknown> | null
+  is_pinned: boolean
+  created_at: string
+  parent_thread_id: string | null
+  created_by: ThreadAuthor | null
+  children: ThreadNode[]
+}
+
+type ThreadClientProps = {
+  profile: ThreadAuthor
+  threads: ThreadNode[]
+  messagesByThread: Record<string, ThreadMessage[]>
+}
+
+type FeedbackState = { type: "error" | "success" | "info"; message: string }
+
+const topicBadgePalette = [
+  "bg-sky-100 text-sky-800",
+  "bg-emerald-100 text-emerald-800",
+  "bg-indigo-100 text-indigo-800",
+  "bg-amber-100 text-amber-900",
+  "bg-rose-100 text-rose-800",
+  "bg-purple-100 text-purple-800",
+]
+
+const formFieldClassName =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+
+function formatBytes(bytes: number | null) {
+  if (!bytes || bytes <= 0) {
+    return ""
+  }
+
+  const units = ["B", "KB", "MB", "GB", "TB"]
+  let size = bytes
+  let unitIndex = 0
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex += 1
+  }
+
+  return `${size.toFixed(size >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`
+}
+
+function getTopicBadgeClass(topic: string) {
+  if (!topic) {
+    return topicBadgePalette[0]
+  }
+
+  const normalized = topic.toLowerCase()
+  let hash = 0
+  for (let index = 0; index < normalized.length; index += 1) {
+    hash = (hash << 5) - hash + normalized.charCodeAt(index)
+    hash |= 0
+  }
+
+  const paletteIndex = Math.abs(hash) % topicBadgePalette.length
+  return topicBadgePalette[paletteIndex]
+}
+
+function flattenThreads(nodes: ThreadNode[]): ThreadNode[] {
+  return nodes.flatMap((node) => [node, ...flattenThreads(node.children)])
+}
+
+function ThreadTree({
+  threads,
+  selectedId,
+  onSelect,
+  depth = 0,
+}: {
+  threads: ThreadNode[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+  depth?: number
+}) {
+  return (
+    <ul className={cn("space-y-3", depth > 0 && "border-l border-border pl-4")}> 
+      {threads.map((thread) => (
+        <li key={thread.id} className="space-y-2">
+          <button
+            type="button"
+            onClick={() => onSelect(thread.id)}
+            className={cn(
+              "w-full rounded-md border p-3 text-left transition hover:border-primary/60 hover:bg-muted/50",
+              selectedId === thread.id && "border-primary bg-primary/5",
+            )}
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge className={cn("capitalize", getTopicBadgeClass(thread.topic))}>{thread.topic}</Badge>
+              {thread.is_pinned ? (
+                <Badge variant="secondary" className="flex items-center gap-1">
+                  <Pin className="size-3" />
+                  Pinned
+                </Badge>
+              ) : null}
+            </div>
+            <p className="mt-2 text-sm font-semibold leading-5">{thread.title}</p>
+            {thread.summary ? (
+              <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{thread.summary}</p>
+            ) : null}
+            {Array.isArray(thread.metadata?.tags) && thread.metadata?.tags.length ? (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {(thread.metadata?.tags as unknown[]).map((tag) => (
+                  <Badge key={String(tag)} variant="outline" className="text-xs">
+                    {String(tag)}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+          </button>
+          {thread.children.length > 0 ? (
+            <ThreadTree threads={thread.children} onSelect={onSelect} selectedId={selectedId} depth={depth + 1} />
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default function ThreadClient({ profile, threads, messagesByThread }: ThreadClientProps) {
+  const router = useRouter()
+  const flatThreads = useMemo(() => flattenThreads(threads), [threads])
+  const initialThreadId = threads[0]?.id ?? null
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(initialThreadId)
+  const [threadFeedback, setThreadFeedback] = useState<FeedbackState | null>(null)
+  const [messageFeedback, setMessageFeedback] = useState<FeedbackState | null>(null)
+  const [createThreadPending, startCreateThreadTransition] = useTransition()
+  const [sendMessagePending, startSendMessageTransition] = useTransition()
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
+
+  useEffect(() => {
+    if (!selectedThreadId && threads.length > 0) {
+      setSelectedThreadId(threads[0].id)
+    }
+  }, [threads, selectedThreadId])
+
+  useEffect(() => {
+    if (selectedThreadId && !flatThreads.some((thread) => thread.id === selectedThreadId)) {
+      setSelectedThreadId(threads[0]?.id ?? null)
+    }
+  }, [flatThreads, selectedThreadId, threads])
+
+  const selectedThread = useMemo(
+    () => flatThreads.find((thread) => thread.id === selectedThreadId) ?? null,
+    [flatThreads, selectedThreadId],
+  )
+
+  const messages = useMemo(() => {
+    if (!selectedThreadId) {
+      return []
+    }
+
+    return messagesByThread[selectedThreadId] ?? []
+  }, [messagesByThread, selectedThreadId])
+
+  const handleSelectThread = useCallback((threadId: string) => {
+    setSelectedThreadId(threadId)
+    setMessageFeedback(null)
+  }, [])
+
+  const handleCreateThread = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const form = event.currentTarget
+      const formData = new FormData(form)
+      setThreadFeedback(null)
+      startCreateThreadTransition(async () => {
+        const result = await createThreadAction(formData)
+        if (result.status === "success") {
+          form.reset()
+          setThreadFeedback({ type: "success", message: "Thread created successfully." })
+          router.refresh()
+        } else {
+          const message = result.message ?? "Unable to create thread."
+          const type = result.status === "partial" ? "info" : "error"
+          setThreadFeedback({ type, message })
+        }
+      })
+    },
+    [router],
+  )
+
+  const handleAttachmentChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files ? Array.from(event.target.files) : []
+    setSelectedFiles(files)
+  }, [])
+
+  const handleSendMessage = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (!selectedThreadId) {
+        setMessageFeedback({ type: "error", message: "Select a thread before posting." })
+        return
+      }
+
+      const form = event.currentTarget
+      const formData = new FormData(form)
+      setMessageFeedback(null)
+      startSendMessageTransition(async () => {
+        const result = await postMessageAction(formData)
+        if (result.status === "success") {
+          form.reset()
+          setSelectedFiles([])
+          setMessageFeedback({ type: "success", message: "Message posted." })
+          router.refresh()
+        } else if (result.status === "partial") {
+          form.reset()
+          setSelectedFiles([])
+          setMessageFeedback({ type: "info", message: result.message })
+          router.refresh()
+        } else {
+          setMessageFeedback({ type: "error", message: result.message ?? "Unable to send message." })
+        }
+      })
+    },
+    [router, selectedThreadId],
+  )
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+      <aside className="space-y-6">
+        <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <PlusCircle className="size-4" /> Start a new thread
+              </CardTitle>
+            <CardDescription>
+              Group updates by topic so every roommate can find the conversations that matter.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleCreateThread} className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="thread-title">
+                  Title
+                </label>
+                <Input id="thread-title" name="title" placeholder="e.g. Spring deep clean" required disabled={createThreadPending} />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="thread-topic">
+                  Topic
+                </label>
+                <Input id="thread-topic" name="topic" placeholder="Maintenance, bills, chores…" required disabled={createThreadPending} />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="thread-summary">
+                  Summary
+                </label>
+                <Textarea
+                  id="thread-summary"
+                  name="summary"
+                  rows={3}
+                  placeholder="Share context or desired outcome for this thread."
+                  disabled={createThreadPending}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="thread-tags">
+                  Tags
+                </label>
+                <Input
+                  id="thread-tags"
+                  name="tags"
+                  placeholder="Comma-separated keywords"
+                  disabled={createThreadPending}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="thread-priority">
+                  Priority
+                </label>
+                <select
+                  id="thread-priority"
+                  name="priority"
+                  className={formFieldClassName}
+                  defaultValue=""
+                  disabled={createThreadPending}
+                >
+                  <option value="">Normal</option>
+                  <option value="low">Low</option>
+                  <option value="normal">Normal</option>
+                  <option value="high">High</option>
+                  <option value="urgent">Urgent</option>
+                </select>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="thread-parent">
+                  Parent thread
+                </label>
+                <select
+                  id="thread-parent"
+                  name="parentThreadId"
+                  className={formFieldClassName}
+                  defaultValue=""
+                  disabled={createThreadPending || flatThreads.length === 0}
+                >
+                  <option value="">No parent</option>
+                  {flatThreads.map((thread) => (
+                    <option key={thread.id} value={thread.id}>
+                      {thread.title}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {threadFeedback ? (
+                <p
+                  className={cn(
+                    "text-sm",
+                    threadFeedback.type === "success" && "text-emerald-600",
+                    threadFeedback.type === "error" && "text-destructive",
+                    threadFeedback.type === "info" && "text-amber-600",
+                  )}
+                >
+                  {threadFeedback.message}
+                </p>
+              ) : null}
+              <Button type="submit" disabled={createThreadPending} className="w-full">
+                {createThreadPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                Create thread
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Active threads</CardTitle>
+            <CardDescription>Browse announcements, discussions, and nested follow-ups.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {threads.length ? (
+              <ThreadTree threads={threads} selectedId={selectedThreadId} onSelect={handleSelectThread} />
+            ) : (
+              <p className="text-sm text-muted-foreground">Start a conversation to bring your household together.</p>
+            )}
+          </CardContent>
+        </Card>
+      </aside>
+      <section className="space-y-6">
+        {selectedThread ? (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex flex-wrap items-center gap-2">
+                  <Badge className={cn("capitalize", getTopicBadgeClass(selectedThread.topic))}>{selectedThread.topic}</Badge>
+                  <span>{selectedThread.title}</span>
+                </CardTitle>
+                {selectedThread.summary ? (
+                  <CardDescription>{selectedThread.summary}</CardDescription>
+                ) : null}
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+                  <span>
+                    Created {formatDistanceToNow(new Date(selectedThread.created_at), { addSuffix: true })}
+                  </span>
+                  {selectedThread.created_by ? (
+                    <span>by {selectedThread.created_by.full_name ?? "Household member"}</span>
+                  ) : null}
+                  {typeof selectedThread.metadata?.priority === "string" ? (
+                    <Badge variant="secondary" className="capitalize">
+                      Priority: {String(selectedThread.metadata?.priority)}
+                    </Badge>
+                  ) : null}
+                </div>
+                {Array.isArray(selectedThread.metadata?.tags) && selectedThread.metadata?.tags.length ? (
+                  <div className="flex flex-wrap gap-2">
+                    {(selectedThread.metadata?.tags as unknown[]).map((tag) => (
+                      <Badge key={String(tag)} variant="outline">
+                        {String(tag)}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </CardContent>
+            </Card>
+            <Card className="overflow-hidden">
+              <CardHeader>
+                <CardTitle className="text-base">Conversation</CardTitle>
+              </CardHeader>
+              <Separator />
+              <ScrollArea className="h-[420px]">
+                <CardContent className="space-y-4">
+                  {messages.length ? (
+                    messages.map((message) => (
+                      <article key={message.id} className="rounded-lg border p-4">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="flex items-center gap-3">
+                            <Avatar className="size-9">
+                              <AvatarImage src={message.sender.avatar_url ?? undefined} alt={message.sender.full_name ?? "Roommate"} />
+                              <AvatarFallback>{(message.sender.full_name ?? profile.full_name ?? "?").slice(0, 2).toUpperCase()}</AvatarFallback>
+                            </Avatar>
+                            <div>
+                              <p className="text-sm font-medium">{message.sender.full_name ?? "Household member"}</p>
+                              <p className="text-xs text-muted-foreground">
+                                {formatDistanceToNow(new Date(message.created_at), { addSuffix: true })}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <p className="mt-3 whitespace-pre-line text-sm leading-6 text-muted-foreground">{message.content}</p>
+                        {message.attachments.length ? (
+                          <div className="mt-4 space-y-2">
+                            {message.attachments.map((attachment) => (
+                              <a
+                                key={attachment.id}
+                                href={attachment.signed_url ?? undefined}
+                                target="_blank"
+                                rel="noreferrer"
+                                className={cn(
+                                  "flex items-center gap-3 rounded-md border p-2 text-sm transition",
+                                  attachment.signed_url ? "hover:border-primary/60 hover:text-primary" : "cursor-not-allowed opacity-70",
+                                )}
+                              >
+                                <Paperclip className="size-4" />
+                                <div>
+                                  <p className="font-medium">{attachment.file_name}</p>
+                                  <p className="text-xs text-muted-foreground">
+                                    {formatBytes(attachment.file_size)}
+                                    {attachment.content_type ? ` • ${attachment.content_type}` : ""}
+                                  </p>
+                                </div>
+                              </a>
+                            ))}
+                          </div>
+                        ) : null}
+                      </article>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No messages yet. Be the first to share an update.</p>
+                  )}
+                </CardContent>
+              </ScrollArea>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Share an update</CardTitle>
+                <CardDescription>Attach receipts, maintenance photos, or documents for roommates to review.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <form onSubmit={handleSendMessage} className="space-y-4">
+                  <input type="hidden" name="threadId" value={selectedThread.id} />
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="message-content">
+                      Message
+                    </label>
+                    <Textarea
+                      id="message-content"
+                      name="content"
+                      rows={4}
+                      placeholder="Keep everyone aligned with context, next steps, and requests."
+                      disabled={sendMessagePending}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="message-attachments">
+                      Attachments
+                    </label>
+                    <Input
+                      id="message-attachments"
+                      name="attachments"
+                      type="file"
+                      multiple
+                      onChange={handleAttachmentChange}
+                      disabled={sendMessagePending}
+                    />
+                    {selectedFiles.length ? (
+                      <ul className="space-y-1 text-xs text-muted-foreground">
+                        {selectedFiles.map((file) => (
+                          <li key={`${file.name}-${file.lastModified}`} className="flex items-center gap-2">
+                            <Paperclip className="size-3" />
+                            <span>
+                              {file.name} {formatBytes(file.size) ? `(${formatBytes(file.size)})` : ""}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </div>
+                  {messageFeedback ? (
+                    <p
+                      className={cn(
+                        "text-sm",
+                        messageFeedback.type === "success" && "text-emerald-600",
+                        messageFeedback.type === "error" && "text-destructive",
+                        messageFeedback.type === "info" && "text-amber-600",
+                      )}
+                    >
+                      {messageFeedback.message}
+                    </p>
+                  ) : null}
+                  <Button type="submit" disabled={sendMessagePending}>
+                    {sendMessagePending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                    Send message
+                  </Button>
+                </form>
+              </CardContent>
+            </Card>
+          </>
+        ) : (
+          <Card className="flex h-full min-h-[420px] flex-col items-center justify-center space-y-3 text-center">
+            <div className="rounded-full bg-muted p-3">
+              <PlusCircle className="size-6" />
+            </div>
+            <CardTitle className="text-xl">Create your first thread</CardTitle>
+            <CardDescription className="max-w-sm">
+              Start a discussion to coordinate chores, schedule maintenance, or share household announcements.
+            </CardDescription>
+          </Card>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -144,7 +144,15 @@ export type Database = {
           image?: string | null
           name?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "profiles_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+        ]
       }
       verification_tokens: {
         Row: {
@@ -1226,6 +1234,193 @@ export type Database = {
         }
         Relationships: []
       }
+      households: {
+        Row: {
+          created_at: string
+          id: string
+          metadata: Json | null
+          name: string
+          slug: string
+          timezone: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          name: string
+          slug: string
+          timezone?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          name?: string
+          slug?: string
+          timezone?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      message_attachments: {
+        Row: {
+          bucket_id: string
+          content_type: string | null
+          created_at: string
+          file_name: string
+          file_size: number | null
+          id: string
+          message_id: string
+          storage_path: string
+        }
+        Insert: {
+          bucket_id?: string
+          content_type?: string | null
+          created_at?: string
+          file_name: string
+          file_size?: number | null
+          id?: string
+          message_id: string
+          storage_path: string
+        }
+        Update: {
+          bucket_id?: string
+          content_type?: string | null
+          created_at?: string
+          file_name?: string
+          file_size?: number | null
+          id?: string
+          message_id?: string
+          storage_path?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "message_attachments_message_id_fkey",
+            columns: ["message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      messages: {
+        Row: {
+          content: string
+          created_at: string
+          id: string
+          parent_message_id: string | null
+          sender_id: string
+          thread_id: string
+          updated_at: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          id?: string
+          parent_message_id?: string | null
+          sender_id: string
+          thread_id: string
+          updated_at?: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          id?: string
+          parent_message_id?: string | null
+          sender_id?: string
+          thread_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "messages_parent_message_id_fkey",
+            columns: ["parent_message_id"],
+            isOneToOne: false,
+            referencedRelation: "messages",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_sender_id_fkey",
+            columns: ["sender_id"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_thread_id_fkey",
+            columns: ["thread_id"],
+            isOneToOne: false,
+            referencedRelation: "threads",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      threads: {
+        Row: {
+          created_at: string
+          created_by: string
+          household_id: string
+          id: string
+          is_pinned: boolean
+          metadata: Json | null
+          parent_thread_id: string | null
+          summary: string | null
+          title: string
+          topic: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          household_id: string
+          id?: string
+          is_pinned?: boolean
+          metadata?: Json | null
+          parent_thread_id?: string | null
+          summary?: string | null
+          title: string
+          topic: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          household_id?: string
+          id?: string
+          is_pinned?: boolean
+          metadata?: Json | null
+          parent_thread_id?: string | null
+          summary?: string | null
+          title?: string
+          topic?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "threads_created_by_fkey",
+            columns: ["created_by"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_parent_thread_id_fkey",
+            columns: ["parent_thread_id"],
+            isOneToOne: false,
+            referencedRelation: "threads",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
       profiles: {
         Row: {
           avatar_url: string | null
@@ -1236,6 +1431,7 @@ export type Database = {
           created_at: string | null
           email: string | null
           full_name: string | null
+          household_id: string | null
           id: string
           job_title: string | null
           linkedin_url: string | null
@@ -1256,6 +1452,7 @@ export type Database = {
           created_at?: string | null
           email?: string | null
           full_name?: string | null
+          household_id?: string | null
           id?: string
           job_title?: string | null
           linkedin_url?: string | null
@@ -1276,6 +1473,7 @@ export type Database = {
           created_at?: string | null
           email?: string | null
           full_name?: string | null
+          household_id?: string | null
           id?: string
           job_title?: string | null
           linkedin_url?: string | null
@@ -1287,7 +1485,15 @@ export type Database = {
           website?: string | null
           xhandle?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "profiles_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+        ]
       }
       reusable_packages: {
         Row: {

--- a/supabase/migrations/20240511_messaging_threads.sql
+++ b/supabase/migrations/20240511_messaging_threads.sql
@@ -1,0 +1,255 @@
+create extension if not exists "pgcrypto" with schema public;
+
+create table if not exists public.households (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text not null unique,
+  timezone text not null default 'UTC',
+  metadata jsonb null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.households enable row level security;
+
+create table if not exists public.threads (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  created_by uuid not null references public.profiles(id) on delete restrict,
+  parent_thread_id uuid null references public.threads(id) on delete cascade,
+  title text not null,
+  topic text not null,
+  summary text null,
+  metadata jsonb null,
+  is_pinned boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists threads_household_id_created_at_idx on public.threads(household_id, created_at desc);
+create index if not exists threads_parent_thread_id_idx on public.threads(parent_thread_id);
+
+alter table public.threads enable row level security;
+
+create table if not exists public.messages (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null references public.threads(id) on delete cascade,
+  sender_id uuid not null references public.profiles(id) on delete restrict,
+  parent_message_id uuid null references public.messages(id) on delete cascade,
+  content text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists messages_thread_id_created_at_idx on public.messages(thread_id, created_at);
+create index if not exists messages_parent_message_id_idx on public.messages(parent_message_id);
+
+alter table public.messages enable row level security;
+
+create table if not exists public.message_attachments (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.messages(id) on delete cascade,
+  storage_path text not null,
+  bucket_id text not null default 'docs',
+  file_name text not null,
+  file_size bigint null,
+  content_type text null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists message_attachments_message_id_idx on public.message_attachments(message_id);
+create index if not exists message_attachments_storage_path_idx on public.message_attachments(storage_path);
+
+alter table public.message_attachments enable row level security;
+
+alter table public.profiles
+  add column if not exists household_id uuid references public.households(id) on delete set null;
+
+create index if not exists profiles_household_id_idx on public.profiles(household_id);
+
+create policy "Members can view their households" on public.households
+  for select
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = households.id
+    )
+  );
+
+create policy "Members can insert households" on public.households
+  for insert
+  with check (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+    )
+  );
+
+create policy "Members can update their households" on public.households
+  for update
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = households.id
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = households.id
+    )
+  );
+
+create policy "Members can read threads" on public.threads
+  for select
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = threads.household_id
+    )
+  );
+
+create policy "Members can insert threads" on public.threads
+  for insert
+  with check (
+    auth.uid() = created_by
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = threads.household_id
+    )
+  );
+
+create policy "Thread creators can update threads" on public.threads
+  for update
+  using (auth.uid() = created_by)
+  with check (auth.uid() = created_by);
+
+create policy "Thread creators can delete threads" on public.threads
+  for delete
+  using (auth.uid() = created_by);
+
+create policy "Members can read messages" on public.messages
+  for select
+  using (
+    exists (
+      select 1
+      from public.threads t
+      join public.profiles p on p.id = auth.uid()
+      where t.id = messages.thread_id
+        and p.household_id = t.household_id
+    )
+  );
+
+create policy "Members can insert messages" on public.messages
+  for insert
+  with check (
+    auth.uid() = sender_id
+    and exists (
+      select 1
+      from public.threads t
+      join public.profiles p on p.id = auth.uid()
+      where t.id = messages.thread_id
+        and p.household_id = t.household_id
+    )
+  );
+
+create policy "Senders can update their messages" on public.messages
+  for update
+  using (auth.uid() = sender_id)
+  with check (auth.uid() = sender_id);
+
+create policy "Senders can delete their messages" on public.messages
+  for delete
+  using (auth.uid() = sender_id);
+
+create policy "Members can read message attachments" on public.message_attachments
+  for select
+  using (
+    exists (
+      select 1
+      from public.messages m
+      join public.threads t on t.id = m.thread_id
+      join public.profiles p on p.id = auth.uid()
+      where m.id = message_attachments.message_id
+        and p.household_id = t.household_id
+    )
+  );
+
+create policy "Senders can insert message attachments" on public.message_attachments
+  for insert
+  with check (
+    exists (
+      select 1
+      from public.messages m
+      join public.threads t on t.id = m.thread_id
+      where m.id = message_attachments.message_id
+        and m.sender_id = auth.uid()
+        and exists (
+          select 1
+          from public.profiles p
+          where p.id = auth.uid()
+            and p.household_id = t.household_id
+        )
+    )
+  );
+
+create policy "Senders can delete message attachments" on public.message_attachments
+  for delete
+  using (
+    exists (
+      select 1
+      from public.messages m
+      where m.id = message_attachments.message_id
+        and m.sender_id = auth.uid()
+    )
+  );
+
+create policy "Household docs read" on storage.objects
+  for select
+  using (
+    bucket_id = 'docs'
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id is not null
+        and p.household_id::text = split_part(name, '/', 1)
+    )
+  );
+
+create policy "Household docs insert" on storage.objects
+  for insert
+  with check (
+    bucket_id = 'docs'
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id is not null
+        and p.household_id::text = split_part(name, '/', 1)
+    )
+  );
+
+create policy "Household docs delete" on storage.objects
+  for delete
+  using (
+    bucket_id = 'docs'
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id is not null
+        and p.household_id::text = split_part(name, '/', 1)
+    )
+  );


### PR DESCRIPTION
## Summary
- add Supabase schema for households, threads, messages, and attachments with appropriate RLS and storage policies
- update the generated Supabase types so clients can work with household-scoped threads and profile membership
- build the messaging experience with server actions for posting threads/messages, attachment uploads, and a threaded UI

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0ea368c8328bc80f5d9198786a8