### PR TITLE
Add realtime tenant messaging feed

### DIFF
--- a/app/(tenant)/messages/message-reducer.ts
+++ b/app/(tenant)/messages/message-reducer.ts
@@ -1,0 +1,252 @@
+import type { Database, Json } from "@/lib/supabase"
+
+export type MessageRow = Database["public"]["Tables"]["messages"]["Row"]
+
+export type MessageStatus = "pending" | "confirmed" | "failed"
+
+export type AttachmentMetadata = {
+  id: string
+  name: string
+  url?: string
+  bucket?: string
+  path?: string
+  size?: number
+  contentType?: string
+}
+
+export type MessageWithStatus = Omit<MessageRow, "attachments"> & {
+  attachments: AttachmentMetadata[]
+  status: MessageStatus
+  clientId: string
+}
+
+export interface MessagesState {
+  messages: MessageWithStatus[]
+}
+
+export const initialMessagesState: MessagesState = { messages: [] }
+
+const FALLBACK_ID = "attachment"
+
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+
+  return undefined
+}
+
+const isJsonObject = (value: Json | Json[]): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+export function normalizeAttachments(value: MessageRow["attachments"]): AttachmentMetadata[] {
+  if (!value) {
+    return []
+  }
+
+  const candidates = Array.isArray(value) ? value : [value]
+  const attachments: AttachmentMetadata[] = []
+
+  for (const candidate of candidates) {
+    if (!isJsonObject(candidate)) {
+      continue
+    }
+
+    const idCandidate = candidate.id
+    const nameCandidate = candidate.name ?? candidate.filename
+
+    const resolvedId = typeof idCandidate === "string" ? idCandidate : undefined
+    const resolvedName = typeof nameCandidate === "string" ? nameCandidate : undefined
+
+    if (!resolvedId && !resolvedName) {
+      continue
+    }
+
+    const attachment: AttachmentMetadata = {
+      id: resolvedId ?? resolvedName ?? FALLBACK_ID,
+      name: resolvedName ?? resolvedId ?? FALLBACK_ID,
+    }
+
+    const urlCandidate = candidate.url ?? candidate.signedUrl
+    if (typeof urlCandidate === "string") {
+      attachment.url = urlCandidate
+    }
+
+    if (typeof candidate.bucket === "string") {
+      attachment.bucket = candidate.bucket
+    }
+
+    const pathCandidate = candidate.path ?? candidate.filepath
+    if (typeof pathCandidate === "string") {
+      attachment.path = pathCandidate
+    }
+
+    const sizeCandidate = candidate.size ?? candidate.fileSize
+    const parsedSize = toNumber(sizeCandidate)
+    if (typeof parsedSize === "number") {
+      attachment.size = parsedSize
+    }
+
+    const contentTypeCandidate =
+      candidate.contentType ?? candidate.mimeType ?? candidate["content_type"]
+    if (typeof contentTypeCandidate === "string") {
+      attachment.contentType = contentTypeCandidate
+    }
+
+    attachments.push(attachment)
+  }
+
+  return attachments
+}
+
+export function mapRowToMessage(
+  row: MessageRow,
+  overrides: Partial<Pick<MessageWithStatus, "status" | "clientId">> = {}
+): MessageWithStatus {
+  return {
+    ...row,
+    attachments: normalizeAttachments(row.attachments),
+    status: overrides.status ?? "confirmed",
+    clientId: overrides.clientId ?? row.id,
+  }
+}
+
+export function createInitialState(rows: MessageRow[]): MessagesState {
+  return {
+    messages: sortMessages(rows.map((row) => mapRowToMessage(row))),
+  }
+}
+
+export function createOptimisticMessage(params: {
+  clientId: string
+  body: string
+  threadId: string
+  householdId: string
+  authorId: string
+  attachments?: AttachmentMetadata[]
+  createdAt?: string
+}): MessageWithStatus {
+  const timestamp = params.createdAt ?? new Date().toISOString()
+  const attachments = params.attachments?.map((item) => ({ ...item })) ?? []
+
+  return {
+    id: params.clientId,
+    clientId: params.clientId,
+    thread_id: params.threadId,
+    household_id: params.householdId,
+    author_id: params.authorId,
+    body: params.body,
+    attachments,
+    created_at: timestamp,
+    updated_at: timestamp,
+    status: "pending",
+  }
+}
+
+export type MessageAction =
+  | { type: "set"; messages: MessageRow[] }
+  | { type: "optimistic-add"; message: MessageWithStatus }
+  | { type: "confirm"; clientId: string; message: MessageRow }
+  | { type: "receive"; message: MessageRow }
+  | { type: "update"; message: MessageRow }
+  | { type: "fail"; clientId: string }
+
+const toTimestamp = (value: string): number => {
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+function sortMessages(messages: MessageWithStatus[]): MessageWithStatus[] {
+  return [...messages].sort((a, b) => {
+    const diff = toTimestamp(a.created_at) - toTimestamp(b.created_at)
+    if (diff !== 0) {
+      return diff
+    }
+
+    return a.clientId.localeCompare(b.clientId)
+  })
+}
+
+function replaceMessage(
+  messages: MessageWithStatus[],
+  incoming: MessageWithStatus,
+  predicate: (message: MessageWithStatus) => boolean
+): MessageWithStatus[] {
+  const next = [...messages]
+  const index = next.findIndex(predicate)
+
+  if (index === -1) {
+    next.push(incoming)
+    return next
+  }
+
+  next[index] = incoming
+  return next
+}
+
+export function messageReducer(
+  state: MessagesState,
+  action: MessageAction
+): MessagesState {
+  switch (action.type) {
+    case "set":
+      return createInitialState(action.messages)
+    case "optimistic-add": {
+      const next = state.messages.filter((message) => message.clientId !== action.message.clientId)
+      next.push(action.message)
+      return { messages: sortMessages(next) }
+    }
+    case "confirm": {
+      const confirmed = mapRowToMessage(action.message)
+      const withoutPending = state.messages.filter(
+        (message) => message.clientId !== action.clientId && message.id !== confirmed.id
+      )
+      withoutPending.push(confirmed)
+      return { messages: sortMessages(withoutPending) }
+    }
+    case "receive": {
+      const incoming = mapRowToMessage(action.message)
+      const withoutDuplicateId = state.messages.filter((message) => message.id !== incoming.id)
+
+      const pendingIndex = withoutDuplicateId.findIndex(
+        (message) =>
+          message.status === "pending" &&
+          message.author_id === incoming.author_id &&
+          message.body === incoming.body
+      )
+
+      if (pendingIndex !== -1) {
+        withoutDuplicateId.splice(pendingIndex, 1)
+      }
+
+      withoutDuplicateId.push(incoming)
+      return { messages: sortMessages(withoutDuplicateId) }
+    }
+    case "update": {
+      const incoming = mapRowToMessage(action.message)
+      const next = replaceMessage(
+        state.messages,
+        incoming,
+        (message) => message.id === incoming.id
+      )
+      return { messages: sortMessages(next) }
+    }
+    case "fail": {
+      const next = state.messages.map((message) =>
+        message.clientId === action.clientId
+          ? { ...message, status: "failed" as MessageStatus }
+          : message
+      )
+      return { messages: next }
+    }
+    default:
+      return state
+  }
+}

--- a/app/(tenant)/messages/messages-feed.tsx
+++ b/app/(tenant)/messages/messages-feed.tsx
@@ -1,0 +1,289 @@
+"use client"
+
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+import {
+  createInitialState,
+  createOptimisticMessage,
+  messageReducer,
+  type MessageRow,
+  type MessageStatus,
+} from "./message-reducer"
+
+import type { Database } from "@/lib/supabase"
+
+type MessageInsert = Database["public"]["Tables"]["messages"]["Insert"]
+
+type MessagesFeedProps = {
+  initialMessages: MessageRow[]
+  householdId: string
+  threadId: string
+  currentUserId: string | null
+  initialError?: string
+}
+
+const statusCopy: Record<MessageStatus, string> = {
+  confirmed: "Sent",
+  failed: "Failed to send",
+  pending: "Sending…",
+}
+
+const statusVariant: Record<MessageStatus, "secondary" | "outline" | "destructive"> = {
+  confirmed: "secondary",
+  failed: "destructive",
+  pending: "outline",
+}
+
+const formatTimestamp = (value: string) => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return ""
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}
+
+const formatFileSize = (value?: number) => {
+  if (!value || value <= 0) {
+    return null
+  }
+
+  if (value < 1024) {
+    return `${value} B`
+  }
+
+  const kb = value / 1024
+  if (kb < 1024) {
+    return `${kb.toFixed(1)} KB`
+  }
+
+  const mb = kb / 1024
+  if (mb < 1024) {
+    return `${mb.toFixed(1)} MB`
+  }
+
+  const gb = mb / 1024
+  return `${gb.toFixed(1)} GB`
+}
+
+const getClientId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID()
+  }
+
+  return Math.random().toString(36).slice(2)
+}
+
+const buildChannelName = (householdId: string, threadId: string) =>
+  `messages-${householdId}-${threadId}`
+
+export default function MessagesFeed({
+  initialMessages,
+  householdId,
+  threadId,
+  currentUserId,
+  initialError,
+}: MessagesFeedProps) {
+  const supabase = useSupabaseBrowser()
+  const [state, dispatch] = useReducer(messageReducer, initialMessages, createInitialState)
+  const [body, setBody] = useState("")
+  const [isSending, setIsSending] = useState(false)
+  const [composerError, setComposerError] = useState<string | null>(initialError ?? null)
+
+  const messages = useMemo(() => state.messages, [state.messages])
+
+  useEffect(() => {
+    dispatch({ type: "set", messages: initialMessages })
+  }, [initialMessages])
+
+  useEffect(() => {
+    setComposerError(initialError ?? null)
+  }, [initialError])
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(buildChannelName(householdId, threadId))
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+          filter: `thread_id=eq.${threadId}`,
+        },
+        (payload) => {
+          const data = payload.new as MessageRow | null
+          if (!data || data.household_id !== householdId) {
+            return
+          }
+
+          dispatch({ type: "receive", message: data })
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "messages",
+          filter: `thread_id=eq.${threadId}`,
+        },
+        (payload) => {
+          const data = payload.new as MessageRow | null
+          if (!data || data.household_id !== householdId) {
+            return
+          }
+
+          dispatch({ type: "update", message: data })
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [supabase, householdId, threadId])
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const trimmedBody = body.trim()
+
+      if (!trimmedBody) {
+        return
+      }
+
+      if (!currentUserId) {
+        setComposerError("You need to be signed in to send messages.")
+        return
+      }
+
+      setComposerError(null)
+
+      const clientId = getClientId()
+      const optimistic = createOptimisticMessage({
+        clientId,
+        body: trimmedBody,
+        threadId,
+        householdId,
+        authorId: currentUserId,
+      })
+
+      dispatch({ type: "optimistic-add", message: optimistic })
+      setIsSending(true)
+      setBody("")
+
+      try {
+        const payload: MessageInsert = {
+          body: trimmedBody,
+          thread_id: threadId,
+          household_id: householdId,
+          author_id: currentUserId,
+          attachments: optimistic.attachments as unknown as MessageInsert["attachments"],
+        }
+
+        const { data, error } = await supabase
+          .from("messages")
+          .insert(payload)
+          .select()
+          .single()
+
+        if (error || !data) {
+          throw error ?? new Error("Message was not returned")
+        }
+
+        dispatch({ type: "confirm", clientId, message: data })
+      } catch (error) {
+        dispatch({ type: "fail", clientId })
+        setComposerError(
+          error instanceof Error ? error.message : "Unable to send your message."
+        )
+        setBody(trimmedBody)
+      } finally {
+        setIsSending(false)
+      }
+    },
+    [body, currentUserId, householdId, supabase, threadId]
+  )
+
+  const canSend = Boolean(currentUserId) && body.trim().length > 0 && !isSending
+
+  return (
+    <div className="space-y-6">
+      <div className="overflow-hidden rounded-lg border bg-card text-card-foreground shadow-sm">
+        {messages.length === 0 ? (
+          <p className="p-6 text-sm text-muted-foreground">No messages yet. Start the conversation!</p>
+        ) : (
+          <ul className="divide-y">
+            {messages.map((message) => (
+              <li key={message.clientId} className="p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-xs text-muted-foreground">
+                    {formatTimestamp(message.created_at)}
+                  </div>
+                  <Badge variant={statusVariant[message.status]}>{statusCopy[message.status]}</Badge>
+                </div>
+                <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-foreground">
+                  {message.body}
+                </p>
+                {message.attachments.length > 0 && (
+                  <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
+                    {message.attachments.map((attachment) => (
+                      <li key={attachment.id} className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium text-foreground">{attachment.name}</span>
+                        {formatFileSize(attachment.size) ? (
+                          <span>• {formatFileSize(attachment.size)}</span>
+                        ) : null}
+                        {attachment.contentType ? <span>• {attachment.contentType}</span> : null}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-3 rounded-lg border bg-card p-4 shadow-sm">
+        <Textarea
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          placeholder="Share an update with your household"
+          disabled={isSending || !currentUserId}
+          className={cn(
+            composerError ? "border-destructive focus-visible:ring-destructive" : undefined
+          )}
+        />
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <div
+            className={cn(
+              "min-h-[1rem]",
+              composerError ? "text-destructive" : "text-muted-foreground"
+            )}
+          >
+            {composerError ?? (!currentUserId ? "Sign in to send a message." : null)}
+          </div>
+          <Button type="submit" disabled={!canSend}>
+            {isSending ? "Sending…" : "Send message"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/(tenant)/messages/page.tsx
+++ b/app/(tenant)/messages/page.tsx
@@ -1,0 +1,87 @@
+import { Separator } from "@/components/ui/separator"
+import { createClient } from "@/utils/supabase/server"
+
+import MessagesFeed from "./messages-feed"
+import type { MessageRow } from "./message-reducer"
+
+type MessagesPageSearchParams = Record<string, string | string[] | undefined>
+
+const takeFirst = (value?: string | string[]) =>
+  Array.isArray(value) ? value[0] : value
+
+const truncateIdentifier = (value: string) =>
+  value.length > 10 ? `${value.slice(0, 8)}…` : value
+
+export default async function MessagesPage({
+  searchParams,
+}: {
+  searchParams?: MessagesPageSearchParams
+}) {
+  const householdId = takeFirst(searchParams?.householdId)
+  const threadId = takeFirst(searchParams?.threadId)
+
+  if (!householdId || !threadId) {
+    return (
+      <div className="container max-w-4xl space-y-6 py-8">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">Messages</h1>
+          <p className="text-muted-foreground">
+            Select a household and thread to browse the realtime conversation feed.
+          </p>
+          <Separator />
+        </header>
+        <p className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/30 p-4 text-sm text-muted-foreground">
+          Provide <code>householdId</code> and <code>threadId</code> search parameters to load a specific
+          conversation.
+        </p>
+      </div>
+    )
+  }
+
+  const supabase = createClient()
+
+  const [userResult, messageResult] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase
+      .from("messages")
+      .select("*")
+      .eq("household_id", householdId)
+      .eq("thread_id", threadId)
+      .order("created_at", { ascending: true }),
+  ])
+
+  const {
+    data: { user },
+  } = userResult
+
+  const { data: rows, error } = messageResult
+
+  const messages = (rows ?? []) as MessageRow[]
+
+  return (
+    <div className="container max-w-4xl space-y-6 py-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Messages</h1>
+        <p className="text-sm text-muted-foreground">
+          Household <span className="font-medium text-foreground">{truncateIdentifier(householdId)}</span>
+          , thread <span className="font-medium text-foreground">{truncateIdentifier(threadId)}</span>
+          . Stay in sync with your roommates in realtime.
+        </p>
+        <Separator />
+        {error ? (
+          <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            Unable to load messages: {error.message}
+          </p>
+        ) : null}
+      </header>
+      <MessagesFeed
+        key={`${householdId}-${threadId}`}
+        initialMessages={messages}
+        householdId={householdId}
+        threadId={threadId}
+        currentUserId={user?.id ?? null}
+        initialError={error?.message}
+      />
+    </div>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1004,6 +1004,39 @@ export type Database = {
         }
         Relationships: []
       }
+      messages: {
+        Row: {
+          attachments: Json
+          author_id: string
+          body: string
+          created_at: string
+          household_id: string
+          id: string
+          thread_id: string
+          updated_at: string
+        }
+        Insert: {
+          attachments?: Json
+          author_id: string
+          body: string
+          created_at?: string
+          household_id: string
+          id?: string
+          thread_id: string
+          updated_at?: string
+        }
+        Update: {
+          attachments?: Json
+          author_id?: string
+          body?: string
+          created_at?: string
+          household_id?: string
+          id?: string
+          thread_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       members_table: {
         Row: {
           created_at: string

--- a/supabase/migrations/20240706_add_messages_table.sql
+++ b/supabase/migrations/20240706_add_messages_table.sql
@@ -1,0 +1,60 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.messages (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  household_id uuid not null,
+  thread_id uuid not null,
+  author_id uuid not null,
+  body text not null,
+  attachments jsonb not null default '[]'::jsonb
+);
+
+alter table public.messages enable row level security;
+
+create or replace function public.set_updated_at_timestamp()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger set_messages_updated_at
+before update on public.messages
+for each row
+execute function public.set_updated_at_timestamp();
+
+create index if not exists idx_messages_thread_created
+  on public.messages (thread_id, created_at);
+
+create index if not exists idx_messages_household_created
+  on public.messages (household_id, created_at);
+
+create policy "Authenticated users can read messages"
+  on public.messages
+  for select
+  to authenticated
+  using (true);
+
+create policy "Users can insert their own messages"
+  on public.messages
+  for insert
+  to authenticated
+  with check (auth.uid() = author_id);
+
+create policy "Users can update their own messages"
+  on public.messages
+  for update
+  to authenticated
+  using (auth.uid() = author_id);
+
+create policy "Users can delete their own messages"
+  on public.messages
+  for delete
+  to authenticated
+  using (auth.uid() = author_id);

--- a/tests/messages-reducer.test.ts
+++ b/tests/messages-reducer.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createInitialState,
+  createOptimisticMessage,
+  messageReducer,
+  normalizeAttachments,
+  type MessageRow,
+} from "@/app/(tenant)/messages/message-reducer"
+
+const baseTimestamp = "2024-01-01T00:00:00.000Z"
+
+const createRow = (overrides: Partial<MessageRow> = {}): MessageRow => ({
+  attachments: (
+    overrides.attachments ?? ([] as unknown as MessageRow["attachments"])
+  ) as MessageRow["attachments"],
+  author_id: overrides.author_id ?? "user-1",
+  body: overrides.body ?? "Hello from server",
+  created_at: overrides.created_at ?? baseTimestamp,
+  household_id: overrides.household_id ?? "house-1",
+  id: overrides.id ?? "message-1",
+  thread_id: overrides.thread_id ?? "thread-1",
+  updated_at: overrides.updated_at ?? overrides.created_at ?? baseTimestamp,
+})
+
+describe("message reducer", () => {
+  it("sorts incoming rows chronologically", () => {
+    const newest = createRow({ id: "message-new", created_at: "2024-01-05T08:00:00.000Z" })
+    const oldest = createRow({ id: "message-old", created_at: "2023-12-28T20:00:00.000Z" })
+
+    const state = createInitialState([newest, oldest])
+
+    expect(state.messages).toHaveLength(2)
+    expect(state.messages[0].id).toBe("message-old")
+    expect(state.messages[1].id).toBe("message-new")
+  })
+
+  it("tracks optimistic messages and replaces them on confirmation", () => {
+    const initialState = createInitialState([])
+    const optimistic = createOptimisticMessage({
+      clientId: "client-1",
+      body: "Taking the trash out tonight",
+      threadId: "thread-1",
+      householdId: "house-1",
+      authorId: "user-1",
+      createdAt: "2024-01-02T10:00:00.000Z",
+    })
+
+    const pendingState = messageReducer(initialState, {
+      type: "optimistic-add",
+      message: optimistic,
+    })
+
+    expect(pendingState.messages).toHaveLength(1)
+    expect(pendingState.messages[0].status).toBe("pending")
+
+    const confirmedRow = createRow({
+      id: "server-1",
+      body: optimistic.body,
+      author_id: optimistic.author_id,
+      created_at: optimistic.created_at,
+    })
+
+    const confirmedState = messageReducer(pendingState, {
+      type: "confirm",
+      clientId: optimistic.clientId,
+      message: confirmedRow,
+    })
+
+    expect(confirmedState.messages).toHaveLength(1)
+    expect(confirmedState.messages[0].id).toBe("server-1")
+    expect(confirmedState.messages[0].status).toBe("confirmed")
+  })
+
+  it("marks pending messages as failed when an error occurs", () => {
+    const optimistic = createOptimisticMessage({
+      clientId: "client-2",
+      body: "Washer is free now",
+      threadId: "thread-1",
+      householdId: "house-1",
+      authorId: "user-2",
+    })
+
+    const stateWithPending = messageReducer(createInitialState([]), {
+      type: "optimistic-add",
+      message: optimistic,
+    })
+
+    const failedState = messageReducer(stateWithPending, {
+      type: "fail",
+      clientId: optimistic.clientId,
+    })
+
+    expect(failedState.messages[0].status).toBe("failed")
+  })
+
+  it("deduplicates realtime inserts that correspond to optimistic entries", () => {
+    const optimistic = createOptimisticMessage({
+      clientId: "client-3",
+      body: "Can someone grab groceries?",
+      threadId: "thread-1",
+      householdId: "house-1",
+      authorId: "user-3",
+      createdAt: "2024-01-03T09:30:00.000Z",
+    })
+
+    const pendingState = messageReducer(createInitialState([]), {
+      type: "optimistic-add",
+      message: optimistic,
+    })
+
+    const realtimeRow = createRow({
+      id: "server-3",
+      body: optimistic.body,
+      author_id: optimistic.author_id,
+      created_at: optimistic.created_at,
+    })
+
+    const afterRealtime = messageReducer(pendingState, {
+      type: "receive",
+      message: realtimeRow,
+    })
+
+    expect(afterRealtime.messages).toHaveLength(1)
+    expect(afterRealtime.messages[0].id).toBe("server-3")
+    expect(afterRealtime.messages[0].status).toBe("confirmed")
+  })
+
+  it("applies updates to an existing message including attachment metadata", () => {
+    const existingRow = createRow({ id: "server-4" })
+    const state = createInitialState([existingRow])
+
+    const updatedRow = createRow({
+      id: "server-4",
+      body: "Lease signed and uploaded",
+      attachments: [
+        {
+          id: "file-1",
+          name: "lease.pdf",
+          size: 2048,
+          content_type: "application/pdf",
+        },
+      ] as unknown as MessageRow["attachments"],
+    })
+
+    const updatedState = messageReducer(state, {
+      type: "update",
+      message: updatedRow,
+    })
+
+    expect(updatedState.messages[0].body).toBe("Lease signed and uploaded")
+    expect(updatedState.messages[0].attachments).toHaveLength(1)
+    expect(updatedState.messages[0].attachments[0]).toMatchObject({
+      id: "file-1",
+      name: "lease.pdf",
+      size: 2048,
+      contentType: "application/pdf",
+    })
+  })
+
+  it("normalizes a variety of attachment metadata formats", () => {
+    const normalized = normalizeAttachments(
+      [
+        {
+          id: "file-1",
+          name: "trash-schedule.pdf",
+          size: "4096",
+          content_type: "application/pdf",
+        },
+        {
+          filename: "kitchen.png",
+          fileSize: 5120,
+          mimeType: "image/png",
+        },
+        "ignore-me",
+      ] as unknown as MessageRow["attachments"]
+    )
+
+    expect(normalized).toHaveLength(2)
+    expect(normalized[0]).toMatchObject({
+      id: "file-1",
+      name: "trash-schedule.pdf",
+      size: 4096,
+      contentType: "application/pdf",
+    })
+    expect(normalized[1]).toMatchObject({
+      id: "kitchen.png",
+      name: "kitchen.png",
+      size: 5120,
+      contentType: "image/png",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a Supabase migration for the messages table with indexes, trigger, and row-level security policies
- expose typed message models plus a realtime tenant feed with optimistic updates at app/(tenant)/messages
- cover reducer behaviors including optimistic confirmation, deduplication, and attachment normalization with vitest

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0eb065c8328b8c15302f003ca0f