### PR TITLE
Add supply purchase workflow with automated share splitting

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { BoxIcon, CrumpledPaperIcon, PersonIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,18 +8,23 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+                {
+                        href: "/dashboard/supplies/purchases",
+                        text: "Supply Purchases",
+                        Icon: BoxIcon,
+                },
+        ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/supplies/purchases/actions.ts
+++ b/app/dashboard/supplies/purchases/actions.ts
@@ -1,0 +1,79 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { z } from "zod"
+
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+const createPurchaseSchema = z.object({
+  householdId: z.string().uuid({ message: "A household is required." }),
+  itemName: z.string().min(1, { message: "Enter what was purchased." }),
+  priceCad: z.number().nonnegative({ message: "Price must be zero or greater." }),
+  amount: z.number().positive({ message: "Amount must be greater than zero." }),
+  purchasedAt: z.string().min(1, { message: "Purchase date is required." }),
+  receiptPath: z.string().nullable().optional(),
+})
+
+export type CreateSupplyPurchaseInput = z.infer<typeof createPurchaseSchema>
+
+export async function createSupplyPurchase(input: CreateSupplyPurchaseInput) {
+  const parsed = createPurchaseSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: "Invalid purchase details provided." }
+  }
+
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return { error: "You must be signed in to record a purchase." }
+  }
+
+  const { householdId, itemName, priceCad, amount, purchasedAt, receiptPath } = parsed.data
+
+  const { data: membership } = await supabase
+    .from("household_members")
+    .select("id")
+    .eq("household_id", householdId)
+    .eq("profile_id", user.id)
+    .limit(1)
+    .maybeSingle()
+
+  if (!membership) {
+    return { error: "You are not a member of this household." }
+  }
+
+  const purchaseDate = new Date(purchasedAt)
+  if (Number.isNaN(purchaseDate.getTime())) {
+    return { error: "Purchase date is invalid." }
+  }
+
+  const normalizedPrice = Number(priceCad.toFixed(2))
+  const normalizedAmount = Number(amount.toFixed(2))
+
+  const { data, error } = await supabase
+    .from("supply_purchases")
+    .insert({
+      household_id: householdId,
+      item_name: itemName,
+      price_cad: normalizedPrice,
+      amount: normalizedAmount,
+      purchased_at: purchaseDate.toISOString(),
+      receipt_url: receiptPath && receiptPath.length > 0 ? receiptPath : null,
+      buyer_id: user.id,
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    console.error("createSupplyPurchase", error)
+    return { error: "Unable to save the purchase. Please try again." }
+  }
+
+  revalidatePath("/dashboard/supplies/purchases")
+
+  return { data }
+}

--- a/app/dashboard/supplies/purchases/page.tsx
+++ b/app/dashboard/supplies/purchases/page.tsx
@@ -1,0 +1,84 @@
+import { redirect } from "next/navigation"
+
+import type { Database } from "@/lib/supabase"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+import PurchaseEntryForm from "./purchase-entry-form"
+
+type HouseholdMemberRow =
+  Database["public"]["Tables"]["household_members"]["Row"] & {
+    profile: Pick<Database["public"]["Tables"]["profiles"]["Row"], "full_name" | "username"> | null
+  }
+
+type HouseholdRow = Database["public"]["Tables"]["households"]["Row"] & {
+  household_members: HouseholdMemberRow[] | null
+}
+
+export default async function SupplyPurchasesPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return redirect("/auth")
+  }
+
+  const { data: membershipRows, error: membershipError } = await supabase
+    .from("household_members")
+    .select("household_id")
+    .eq("profile_id", user.id)
+
+  if (membershipError) {
+    console.error("supply purchases memberships", membershipError)
+    throw new Error("Unable to load household memberships")
+  }
+
+  const householdIds = Array.from(
+    new Set(membershipRows?.map((row) => row.household_id) ?? []),
+  )
+
+  let households: HouseholdRow[] = []
+  if (householdIds.length) {
+    const { data: householdsData, error: householdsError } = await supabase
+      .from("households")
+      .select(
+        `
+          id,
+          name,
+          household_members (
+            profile_id,
+            default_supply_split,
+            profile:profiles (
+              full_name,
+              username
+            )
+          )
+        `,
+      )
+      .in("id", householdIds)
+
+    if (householdsError) {
+      console.error("supply purchases households", householdsError)
+      throw new Error("Unable to load household information")
+    }
+
+    households = (householdsData ?? []) as HouseholdRow[]
+  }
+
+  const formattedHouseholds = households
+    .map((household) => ({
+      id: household.id,
+      name: household.name,
+      members:
+        household.household_members?.map((member) => ({
+          profile_id: member.profile_id,
+          default_supply_split: member.default_supply_split,
+          profile: member.profile ?? null,
+        })) ?? [],
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  return <PurchaseEntryForm households={formattedHouseholds} userId={user.id} />
+}

--- a/app/dashboard/supplies/purchases/purchase-entry-form.tsx
+++ b/app/dashboard/supplies/purchases/purchase-entry-form.tsx
@@ -1,0 +1,507 @@
+"use client"
+
+import { useEffect, useMemo, useState, useTransition, type ChangeEvent } from "react"
+import { z } from "zod"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useToast } from "@/components/ui/use-toast"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+import { createSupplyPurchase } from "./actions"
+
+const formSchema = z.object({
+  householdId: z.string().min(1, { message: "Choose a household." }),
+  itemName: z
+    .string()
+    .min(1, { message: "Enter what was purchased." })
+    .refine((value) => value.trim().length > 0, {
+      message: "Enter what was purchased.",
+    }),
+  priceCad: z
+    .string()
+    .min(1, { message: "Enter the price." })
+    .refine((value) => !Number.isNaN(Number(value)) && Number(value) >= 0, {
+      message: "Price must be zero or greater.",
+    }),
+  amount: z
+    .string()
+    .min(1, { message: "Enter the quantity." })
+    .refine((value) => !Number.isNaN(Number(value)) && Number(value) > 0, {
+      message: "Amount must be greater than zero.",
+    }),
+  purchasedAt: z.string().min(1, { message: "Select the purchase date." }),
+  receiptPath: z.string().nullable().optional(),
+})
+
+const currencyFormatter = new Intl.NumberFormat("en-CA", {
+  style: "currency",
+  currency: "CAD",
+})
+
+const percentFormatter = new Intl.NumberFormat("en-CA", {
+  style: "percent",
+  maximumFractionDigits: 1,
+})
+
+type FormValues = z.infer<typeof formSchema>
+
+type HouseholdMember = {
+  profile_id: string
+  default_supply_split: number | null
+  profile?: {
+    full_name: string | null
+    username: string | null
+  } | null
+}
+
+type Household = {
+  id: string
+  name: string
+  members: HouseholdMember[]
+}
+
+type UploadState =
+  | { status: "idle" }
+  | { status: "uploading" }
+  | { status: "uploaded"; path: string }
+  | { status: "error"; message: string }
+
+const receiptBucket = "supply-receipts"
+
+function getMemberDisplayName(member: HouseholdMember) {
+  return (
+    member.profile?.full_name?.trim() ||
+    member.profile?.username?.trim() ||
+    member.profile_id.slice(0, 8)
+  )
+}
+
+function calculateShares(members: HouseholdMember[], totalCost: number) {
+  if (!members.length || !Number.isFinite(totalCost)) {
+    return [] as Array<{ profileId: string; ratio: number; amount: number; name: string }>
+  }
+
+  const weights = members.map((member) => Number(member.default_supply_split ?? 0))
+  const weightSum = weights.reduce((sum, weight) => sum + weight, 0)
+  const evenRatio = 1 / members.length
+
+  let runningTotal = 0
+  return members.map((member, index) => {
+    const ratio = weightSum <= 0 ? evenRatio : Number(member.default_supply_split ?? 0) / weightSum
+    let amount = Number((totalCost * ratio).toFixed(2))
+
+    if (index === members.length - 1) {
+      amount = Number((totalCost - runningTotal).toFixed(2))
+    } else {
+      runningTotal = Number((runningTotal + amount).toFixed(2))
+    }
+
+    const safeAmount = Number.isFinite(amount) ? amount : 0
+
+    return {
+      profileId: member.profile_id,
+      ratio,
+      amount: safeAmount,
+      name: getMemberDisplayName(member),
+    }
+  })
+}
+
+interface PurchaseEntryFormProps {
+  households: Household[]
+  userId: string
+}
+
+export default function PurchaseEntryForm({ households, userId }: PurchaseEntryFormProps) {
+  const { toast } = useToast()
+  const supabase = useSupabaseBrowser()
+  const [uploadState, setUploadState] = useState<UploadState>({ status: "idle" })
+  const [isPending, startTransition] = useTransition()
+
+  const defaultHouseholdId = households[0]?.id ?? ""
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      householdId: defaultHouseholdId,
+      itemName: "",
+      priceCad: "",
+      amount: "1",
+      purchasedAt: new Date().toISOString().slice(0, 10),
+      receiptPath: null,
+    },
+  })
+
+  const selectedHouseholdId = form.watch("householdId")
+  const selectedHousehold = useMemo(
+    () => households.find((household) => household.id === selectedHouseholdId),
+    [households, selectedHouseholdId],
+  )
+
+  const priceValue = form.watch("priceCad")
+  const amountValue = form.watch("amount")
+  const totalCost = useMemo(() => {
+    const price = Number(priceValue)
+    const amount = Number(amountValue)
+
+    if (Number.isNaN(price) || Number.isNaN(amount)) {
+      return 0
+    }
+
+    return Number((price * amount).toFixed(2))
+  }, [priceValue, amountValue])
+
+  const sharePreview = useMemo(
+    () => calculateShares(selectedHousehold?.members ?? [], totalCost),
+    [selectedHousehold?.members, totalCost],
+  )
+
+  useEffect(() => {
+    if (!selectedHouseholdId) {
+      form.setValue("receiptPath", null)
+      setUploadState({ status: "idle" })
+    }
+  }, [form, selectedHouseholdId])
+
+  const handleReceiptUpload = async (
+    event: ChangeEvent<HTMLInputElement>,
+    onChange: (value: string | null) => void,
+  ) => {
+    const file = event.target.files?.[0]
+    if (!file) {
+      return
+    }
+
+    if (!selectedHouseholdId) {
+      setUploadState({ status: "error", message: "Select a household before uploading." })
+      return
+    }
+
+    setUploadState({ status: "uploading" })
+    const extension = file.name.split(".").pop()?.toLowerCase()
+    const fileName = `${selectedHouseholdId}/${Date.now()}-${Math.random().toString(36).slice(2)}` +
+      (extension ? `.${extension}` : "")
+
+    const { error } = await supabase.storage.from(receiptBucket).upload(fileName, file, {
+      cacheControl: "3600",
+      upsert: false,
+    })
+
+    if (error) {
+      console.error("receipt upload", error)
+      setUploadState({ status: "error", message: "Failed to upload receipt. Try again." })
+      event.target.value = ""
+      return
+    }
+
+    onChange(fileName)
+    setUploadState({ status: "uploaded", path: fileName })
+    toast({
+      title: "Receipt uploaded",
+      description: "The receipt is stored securely with this purchase.",
+    })
+    event.target.value = ""
+  }
+
+  const handleSubmit = (values: FormValues) => {
+    startTransition(async () => {
+      const priceCad = Number(values.priceCad)
+      const amount = Number(values.amount)
+
+      const result = await createSupplyPurchase({
+        householdId: values.householdId,
+        itemName: values.itemName.trim(),
+        priceCad,
+        amount,
+        purchasedAt: values.purchasedAt,
+        receiptPath: values.receiptPath ?? null,
+      })
+
+      if (result?.error) {
+        toast({
+          title: "Could not save purchase",
+          description: result.error,
+          variant: "destructive",
+        })
+        return
+      }
+
+      toast({
+        title: "Purchase recorded",
+        description: "Shares have been allocated to household members.",
+      })
+
+      form.reset({
+        householdId: values.householdId,
+        itemName: "",
+        priceCad: "",
+        amount: "1",
+        purchasedAt: new Date().toISOString().slice(0, 10),
+        receiptPath: null,
+      })
+      setUploadState({ status: "idle" })
+    })
+  }
+
+  const formDisabled = households.length === 0
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Record a supply purchase</CardTitle>
+          <CardDescription>
+            Track shared supply costs and automatically split the total across your household.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {formDisabled ? (
+            <p className="mb-6 text-sm text-muted-foreground">
+              Join or create a household to start recording shared purchases.
+            </p>
+          ) : null}
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="space-y-6"
+            >
+              <fieldset className="grid gap-6" disabled={isPending || formDisabled}>
+                <FormField
+                  control={form.control}
+                  name="householdId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Household</FormLabel>
+                      <Select
+                        onValueChange={(value) => {
+                          field.onChange(value)
+                          form.setValue("receiptPath", null)
+                          setUploadState({ status: "idle" })
+                        }}
+                        value={field.value}
+                        disabled={formDisabled}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a household" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {households.map((household) => (
+                            <SelectItem key={household.id} value={household.id}>
+                              {household.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="itemName"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Item</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="Paper towels, cleaning spray, etc."
+                          autoComplete="off"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <div className="grid gap-6 md:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="priceCad"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Price (CAD)</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            inputMode="decimal"
+                            placeholder="0.00"
+                            value={field.value ?? ""}
+                            onChange={(event) => field.onChange(event.target.value)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="amount"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Quantity</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            inputMode="decimal"
+                            placeholder="1"
+                            value={field.value ?? ""}
+                            onChange={(event) => field.onChange(event.target.value)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name="purchasedAt"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Purchased on</FormLabel>
+                      <FormControl>
+                        <Input type="date" max={new Date().toISOString().slice(0, 10)} {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="receiptPath"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Receipt (optional)</FormLabel>
+                      <FormControl>
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                          <Input
+                            ref={field.ref}
+                            type="file"
+                            accept="image/*,application/pdf"
+                            onChange={(event) => handleReceiptUpload(event, (value) => field.onChange(value))}
+                            disabled={uploadState.status === "uploading" || formDisabled}
+                          />
+                          {field.value ? (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              onClick={() => {
+                                field.onChange(null)
+                                setUploadState({ status: "idle" })
+                              }}
+                            >
+                              Remove receipt
+                            </Button>
+                          ) : null}
+                        </div>
+                      </FormControl>
+                      {uploadState.status === "uploading" ? (
+                        <p className="text-sm text-muted-foreground">Uploading receipt…</p>
+                      ) : null}
+                      {uploadState.status === "error" ? (
+                        <p className="text-sm text-destructive">{uploadState.message}</p>
+                      ) : null}
+                      {uploadState.status === "uploaded" ? (
+                        <p className="text-sm text-muted-foreground">Stored as {uploadState.path}</p>
+                      ) : null}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </fieldset>
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium">Total cost</p>
+                  <p className="text-lg font-semibold">
+                    {currencyFormatter.format(totalCost || 0)}
+                  </p>
+                </div>
+                <Button type="submit" disabled={formDisabled || isPending}>
+                  {isPending ? "Saving…" : "Record purchase"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Default share breakdown</CardTitle>
+          <CardDescription>
+            Preview how the purchase will be allocated based on the household default split.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {selectedHousehold && sharePreview.length ? (
+            <div className="space-y-3">
+              {sharePreview.map((share) => (
+                <div
+                  key={share.profileId}
+                  className="flex items-center justify-between rounded-md border border-dashed border-muted-foreground/40 p-3"
+                >
+                  <div>
+                    <p className="font-medium">{share.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {percentFormatter.format(share.ratio)} of total
+                    </p>
+                  </div>
+                  <p className="text-sm font-semibold">
+                    {currencyFormatter.format(share.amount)}
+                  </p>
+                </div>
+              ))}
+              <div className="flex items-center justify-between border-t pt-3 text-sm text-muted-foreground">
+                <span>Buyer</span>
+                <span className="font-medium">
+                  {getMemberDisplayName({
+                    profile_id: userId,
+                    default_supply_split: null,
+                    profile: selectedHousehold.members.find((member) => member.profile_id === userId)?.profile ?? null,
+                  })}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {selectedHousehold
+                ? "Add household members with default splits to preview how costs will be shared."
+                : "Select a household to preview the share breakdown."}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1475,6 +1475,74 @@ export type Database = {
         }
         Relationships: []
       }
+      households: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          id: string
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "households_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      household_members: {
+        Row: {
+          created_at: string
+          default_supply_split: number
+          household_id: string
+          id: string
+          profile_id: string
+        }
+        Insert: {
+          created_at?: string
+          default_supply_split?: number
+          household_id: string
+          id?: string
+          profile_id?: string
+        }
+        Update: {
+          created_at?: string
+          default_supply_split?: number
+          household_id?: string
+          id?: string
+          profile_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "household_members_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "household_members_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       sui_nfts: {
         Row: {
           avatar_url: string
@@ -1518,6 +1586,99 @@ export type Database = {
             columns: ["profile_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      supply_purchases: {
+        Row: {
+          amount: number
+          buyer_id: string
+          created_at: string
+          household_id: string
+          id: string
+          item_name: string
+          price_cad: number
+          purchased_at: string
+          receipt_url: string | null
+        }
+        Insert: {
+          amount?: number
+          buyer_id: string
+          created_at?: string
+          household_id: string
+          id?: string
+          item_name: string
+          price_cad: number
+          purchased_at?: string
+          receipt_url?: string | null
+        }
+        Update: {
+          amount?: number
+          buyer_id?: string
+          created_at?: string
+          household_id?: string
+          id?: string
+          item_name?: string
+          price_cad?: number
+          purchased_at?: string
+          receipt_url?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_purchases_buyer_id_fkey"
+            columns: ["buyer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supply_purchases_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      supply_shares: {
+        Row: {
+          created_at: string
+          id: string
+          profile_id: string
+          purchase_id: string
+          share_amount: number
+          share_ratio: number
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          profile_id: string
+          purchase_id: string
+          share_amount: number
+          share_ratio: number
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          profile_id?: string
+          purchase_id?: string
+          share_amount?: number
+          share_ratio?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_shares_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supply_shares_purchase_id_fkey"
+            columns: ["purchase_id"]
+            isOneToOne: false
+            referencedRelation: "supply_purchases"
             referencedColumns: ["id"]
           },
         ]

--- a/supabase/migrations/20240518_supply_purchases.sql
+++ b/supabase/migrations/20240518_supply_purchases.sql
@@ -1,0 +1,348 @@
+-- Supply purchases schema and automation
+create extension if not exists "pgcrypto";
+
+-- Core household tables -----------------------------------------------------
+create table if not exists public.households (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  created_by uuid default auth.uid(),
+  constraint households_created_by_fkey foreign key (created_by) references public.profiles(id) on delete set null
+);
+
+alter table public.households enable row level security;
+
+create table if not exists public.household_members (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null,
+  profile_id uuid not null default auth.uid(),
+  default_supply_split numeric not null default 1,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  constraint household_members_household_id_fkey foreign key (household_id) references public.households(id) on delete cascade,
+  constraint household_members_profile_id_fkey foreign key (profile_id) references public.profiles(id) on delete cascade,
+  constraint household_members_default_supply_split_check check (default_supply_split >= 0),
+  constraint household_members_household_id_profile_id_key unique (household_id, profile_id)
+);
+
+alter table public.household_members enable row level security;
+
+-- Supply purchase tables ----------------------------------------------------
+create table if not exists public.supply_purchases (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null,
+  item_name text not null,
+  price_cad numeric(12, 2),
+  amount numeric(12, 2) not null default 1,
+  purchased_at timestamp with time zone not null default timezone('utc'::text, now()),
+  buyer_id uuid,
+  receipt_url text,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  constraint supply_purchases_household_id_fkey foreign key (household_id) references public.households(id) on delete cascade,
+  constraint supply_purchases_buyer_id_fkey foreign key (buyer_id) references public.profiles(id) on delete restrict
+);
+
+alter table public.supply_purchases enable row level security;
+
+alter table public.supply_purchases
+  add column if not exists price_cad numeric(12, 2);
+
+alter table public.supply_purchases
+  add column if not exists amount numeric(12, 2) not null default 1;
+
+alter table public.supply_purchases
+  add column if not exists buyer_id uuid;
+
+alter table public.supply_purchases
+  add column if not exists receipt_url text;
+
+alter table public.supply_purchases
+  add column if not exists created_at timestamp with time zone not null default timezone('utc'::text, now());
+
+alter table public.supply_purchases
+  alter column price_cad set not null,
+  alter column amount set default 1,
+  alter column buyer_id set not null,
+  add constraint supply_purchases_price_cad_check check (price_cad >= 0),
+  add constraint supply_purchases_amount_check check (amount > 0);
+
+create index if not exists supply_purchases_household_id_idx
+  on public.supply_purchases (household_id);
+
+create table if not exists public.supply_shares (
+  id uuid primary key default gen_random_uuid(),
+  purchase_id uuid not null,
+  profile_id uuid not null,
+  share_amount numeric(12, 2) not null,
+  share_ratio numeric not null,
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  constraint supply_shares_purchase_id_fkey foreign key (purchase_id) references public.supply_purchases(id) on delete cascade,
+  constraint supply_shares_profile_id_fkey foreign key (profile_id) references public.profiles(id) on delete cascade,
+  constraint supply_shares_purchase_id_profile_id_key unique (purchase_id, profile_id)
+);
+
+alter table public.supply_shares enable row level security;
+
+create index if not exists supply_shares_purchase_id_idx
+  on public.supply_shares (purchase_id);
+
+create index if not exists household_members_household_id_idx
+  on public.household_members (household_id);
+
+-- Storage bucket for receipts ------------------------------------------------
+insert into storage.buckets (id, name, public)
+values ('supply-receipts', 'supply-receipts', false)
+on conflict (id) do nothing;
+
+drop policy if exists "Authenticated manage supply receipts" on storage.objects;
+create policy "Authenticated manage supply receipts"
+  on storage.objects
+  for all
+  to authenticated
+  using (
+    bucket_id = 'supply-receipts'
+    and (owner = auth.uid())
+  )
+  with check (
+    bucket_id = 'supply-receipts'
+    and (owner = auth.uid())
+  );
+
+-- Policies ------------------------------------------------------------------
+drop policy if exists "Members can view their households" on public.households;
+create policy "Members can view their households"
+  on public.households
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Members manage their households" on public.households;
+create policy "Members manage their households"
+  on public.households
+  for all
+  to authenticated
+  using (
+    created_by = auth.uid()
+    or exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = id
+        and hm.profile_id = auth.uid()
+    )
+  )
+  with check (
+    created_by = auth.uid()
+    or exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Members view household peers" on public.household_members;
+create policy "Members view household peers"
+  on public.household_members
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = household_members.household_id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Members can join households" on public.household_members;
+create policy "Members can join households"
+  on public.household_members
+  for insert
+  to authenticated
+  with check (
+    profile_id = auth.uid()
+    and exists (
+      select 1
+      from public.households h
+      where h.id = household_id
+    )
+  );
+
+drop policy if exists "Members manage household memberships" on public.household_members;
+create policy "Members manage household memberships"
+  on public.household_members
+  for update
+  to authenticated
+  using (profile_id = auth.uid())
+  with check (profile_id = auth.uid());
+
+drop policy if exists "Members leave households" on public.household_members;
+create policy "Members leave households"
+  on public.household_members
+  for delete
+  to authenticated
+  using (profile_id = auth.uid());
+
+drop policy if exists "Members view supply purchases" on public.supply_purchases;
+create policy "Members view supply purchases"
+  on public.supply_purchases
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = supply_purchases.household_id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Members create supply purchases" on public.supply_purchases;
+create policy "Members create supply purchases"
+  on public.supply_purchases
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = supply_purchases.household_id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Members update supply purchases" on public.supply_purchases;
+create policy "Members update supply purchases"
+  on public.supply_purchases
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = supply_purchases.household_id
+        and hm.profile_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = supply_purchases.household_id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Members delete supply purchases" on public.supply_purchases;
+create policy "Members delete supply purchases"
+  on public.supply_purchases
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.household_members hm
+      where hm.household_id = supply_purchases.household_id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Members view supply shares" on public.supply_shares;
+create policy "Members view supply shares"
+  on public.supply_shares
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.supply_purchases sp
+      join public.household_members hm on hm.household_id = sp.household_id
+      where sp.id = supply_shares.purchase_id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Members manage supply shares" on public.supply_shares;
+create policy "Members manage supply shares"
+  on public.supply_shares
+  for all
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.supply_purchases sp
+      join public.household_members hm on hm.household_id = sp.household_id
+      where sp.id = supply_shares.purchase_id
+        and hm.profile_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.supply_purchases sp
+      join public.household_members hm on hm.household_id = sp.household_id
+      where sp.id = supply_shares.purchase_id
+        and hm.profile_id = auth.uid()
+    )
+  );
+
+-- Trigger to maintain supply shares ----------------------------------------
+create or replace function public.create_supply_shares_for_purchase()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  member record;
+  total_cost numeric := coalesce(new.price_cad, 0) * coalesce(new.amount, 1);
+  weight_sum numeric := 0;
+  member_count integer := 0;
+  share_ratio numeric;
+begin
+  select coalesce(sum(default_supply_split), 0), count(*)
+    into weight_sum, member_count
+  from public.household_members
+  where household_id = new.household_id;
+
+  if member_count = 0 then
+    return new;
+  end if;
+
+  delete from public.supply_shares where purchase_id = new.id;
+
+  for member in
+    select profile_id, default_supply_split
+    from public.household_members
+    where household_id = new.household_id
+  loop
+    if weight_sum <= 0 then
+      share_ratio := 1::numeric / member_count;
+    else
+      share_ratio := coalesce(member.default_supply_split, 0) / weight_sum;
+    end if;
+
+    insert into public.supply_shares (purchase_id, profile_id, share_amount, share_ratio)
+    values (
+      new.id,
+      member.profile_id,
+      round(total_cost * share_ratio, 2),
+      share_ratio
+    );
+  end loop;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists supply_purchases_create_shares on public.supply_purchases;
+create trigger supply_purchases_create_shares
+  after insert or update on public.supply_purchases
+  for each row
+  execute function public.create_supply_shares_for_purchase();


### PR DESCRIPTION
## Summary
- add household, supply purchase, and share schema with row-level security and triggers
deploying supply cost splits on insert
- extend Supabase client typings and navigation to surface the new supply purchase page
- implement supply purchase form with file upload and real-time share preview backed by a server action

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d0a0ee15a88328ac52816fa8e56d9b