### PR TITLE
Implement weighted supply ledger calculations

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, RowsIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -14,12 +14,17 @@ export default function NavLinks() {
 			text: "Members",
 			Icon: PersonIcon,
 		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+                {
+                        href: "/dashboard/supplies",
+                        text: "Supply ledger",
+                        Icon: RowsIcon,
+                },
+        ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/supplies/page.tsx
+++ b/app/dashboard/supplies/page.tsx
@@ -1,0 +1,182 @@
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  calculatePurchaseShares,
+  type HouseholdMembershipRow,
+  type HouseholdRow,
+  type SupplyPurchaseRow,
+} from "@/lib/supply-ledger"
+
+const sampleTimestamp = "2024-06-01T00:00:00.000Z"
+
+const household: HouseholdRow = {
+  id: "household-1",
+  name: "Maple Street Flat",
+  default_split: "weighted",
+  created_at: sampleTimestamp,
+  updated_at: sampleTimestamp,
+}
+
+const householdMembers: HouseholdMembershipRow[] = [
+  {
+    id: "membership-1",
+    household_id: household.id,
+    profile_id: "profile-1",
+    weighting_factor: 1.4,
+    role: "primary tenant",
+    created_at: sampleTimestamp,
+    updated_at: sampleTimestamp,
+  },
+  {
+    id: "membership-2",
+    household_id: household.id,
+    profile_id: "profile-2",
+    weighting_factor: 1,
+    role: "roommate",
+    created_at: sampleTimestamp,
+    updated_at: sampleTimestamp,
+  },
+  {
+    id: "membership-3",
+    household_id: household.id,
+    profile_id: "profile-3",
+    weighting_factor: 0.8,
+    role: "roommate",
+    created_at: sampleTimestamp,
+    updated_at: sampleTimestamp,
+  },
+]
+
+const memberDirectory: Record<string, { name: string; note?: string }> = {
+  "profile-1": { name: "Amelia Chen", note: "Largest bedroom" },
+  "profile-2": { name: "Jasper Patel", note: "Medium bedroom" },
+  "profile-3": { name: "Noah Rivera", note: "Cozy bedroom" },
+}
+
+const purchases: SupplyPurchaseRow[] = [
+  {
+    id: "purchase-1",
+    household_id: household.id,
+    purchaser_id: "profile-1",
+    description: "Household cleaning supplies",
+    total_cost: 48.75,
+    purchased_at: "2024-06-15T15:30:00.000Z",
+    default_split: "weighted",
+    created_at: "2024-06-15T15:30:00.000Z",
+    updated_at: "2024-06-15T15:30:00.000Z",
+  },
+  {
+    id: "purchase-2",
+    household_id: household.id,
+    purchaser_id: "profile-2",
+    description: "Bulk paper goods",
+    total_cost: 36,
+    purchased_at: "2024-06-28T10:00:00.000Z",
+    default_split: "even",
+    created_at: "2024-06-28T10:00:00.000Z",
+    updated_at: "2024-06-28T10:00:00.000Z",
+  },
+]
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+})
+
+export default function SupplyLedgerPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Supply ledger</h1>
+          <p className="text-muted-foreground">
+            Track how shared supply purchases are split across the household. Weighted splits honour each
+            roommate&apos;s room size when applicable.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span>
+            Household default split: <strong>{formatMode(household.default_split)}</strong>
+          </span>
+          <Badge variant="secondary">Weights derived from room sizes</Badge>
+        </div>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        {purchases.map((purchase) => {
+          const calculation = calculatePurchaseShares(purchase, householdMembers)
+          const purchaser = memberDirectory[purchase.purchaser_id]
+          const purchaseDate = dateFormatter.format(new Date(purchase.purchased_at))
+
+          return (
+            <Card key={purchase.id} className="flex flex-col">
+              <CardHeader className="gap-2">
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <div className="space-y-1">
+                    <CardTitle>{purchase.description}</CardTitle>
+                    <CardDescription>
+                      Bought by {purchaser?.name ?? "Unknown member"} on {purchaseDate}
+                    </CardDescription>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">{currencyFormatter.format(calculation.total)}</Badge>
+                    <Badge variant={calculation.mode === "weighted" ? "default" : "secondary"}>
+                      {formatMode(calculation.mode)} split
+                    </Badge>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-3">
+                  {calculation.shares.map((share) => {
+                    const member = memberDirectory[share.profileId]
+                    const percentLabel = `${Math.round(share.percentage * 100)}%`
+
+                    return (
+                      <div
+                        key={share.membershipId}
+                        className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <div className="space-y-1">
+                          <p className="font-medium leading-none">
+                            {member?.name ?? "Unknown member"}
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            {member?.note ?? "Shared amenities"}
+                          </p>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-3">
+                          {calculation.mode === "weighted" ? (
+                            <Badge variant="secondary">
+                              Weight {share.weightingFactor.toFixed(1)}
+                            </Badge>
+                          ) : null}
+                          <span className="text-sm text-muted-foreground">{percentLabel}</span>
+                          <span className="text-base font-semibold">
+                            {currencyFormatter.format(share.amount)}
+                          </span>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </section>
+    </div>
+  )
+}
+
+function formatMode(mode: SupplyPurchaseRow["default_split"]) {
+  return mode === "weighted" ? "Weighted" : "Even"
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -941,6 +941,75 @@ export type Database = {
         }
         Relationships: []
       }
+      household_memberships: {
+        Row: {
+          created_at: string
+          household_id: string
+          id: string
+          profile_id: string
+          role: string | null
+          updated_at: string
+          weighting_factor: number
+        }
+        Insert: {
+          created_at?: string
+          household_id: string
+          id?: string
+          profile_id: string
+          role?: string | null
+          updated_at?: string
+          weighting_factor?: number
+        }
+        Update: {
+          created_at?: string
+          household_id?: string
+          id?: string
+          profile_id?: string
+          role?: string | null
+          updated_at?: string
+          weighting_factor?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "household_memberships_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "household_memberships_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      households: {
+        Row: {
+          created_at: string
+          default_split: Database["public"]["Enums"]["supply_split_mode"]
+          id: string
+          name: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          default_split?: Database["public"]["Enums"]["supply_split_mode"]
+          id?: string
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          default_split?: Database["public"]["Enums"]["supply_split_mode"]
+          id?: string
+          name?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       inqueries: {
         Row: {
           created_at: string
@@ -1522,6 +1591,57 @@ export type Database = {
           },
         ]
       }
+      supply_purchases: {
+        Row: {
+          created_at: string
+          default_split: Database["public"]["Enums"]["supply_split_mode"]
+          description: string
+          household_id: string
+          id: string
+          purchased_at: string
+          purchaser_id: string
+          total_cost: number
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          default_split?: Database["public"]["Enums"]["supply_split_mode"]
+          description: string
+          household_id: string
+          id?: string
+          purchased_at?: string
+          purchaser_id: string
+          total_cost: number
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          default_split?: Database["public"]["Enums"]["supply_split_mode"]
+          description?: string
+          household_id?: string
+          id?: string
+          purchased_at?: string
+          purchaser_id?: string
+          total_cost?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_purchases_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supply_purchases_purchaser_id_fkey"
+            columns: ["purchaser_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       supply_chain_data: {
         Row: {
           created_at: string | null
@@ -1774,6 +1894,7 @@ export type Database = {
         | "Oceania"
         | "North America"
         | "South America"
+      supply_split_mode: "even" | "weighted"
       user_role: "user" | "admin"
     }
     CompositeTypes: {
@@ -2233,6 +2354,7 @@ export const Constants = {
         "North America",
         "South America",
       ],
+      supply_split_mode: ["even", "weighted"],
       user_role: ["user", "admin"],
     },
   },

--- a/lib/supply-ledger.ts
+++ b/lib/supply-ledger.ts
@@ -1,0 +1,136 @@
+import type { Database } from "@/lib/supabase"
+
+export type SupplySplitMode = Database["public"]["Enums"]["supply_split_mode"]
+export type HouseholdRow = Database["public"]["Tables"]["households"]["Row"]
+export type HouseholdMembershipRow = Database["public"]["Tables"]["household_memberships"]["Row"]
+export type SupplyPurchaseRow = Database["public"]["Tables"]["supply_purchases"]["Row"]
+
+export interface PurchaseShare {
+  membershipId: string
+  profileId: string
+  amount: number
+  weightingFactor: number
+  percentage: number
+}
+
+export interface PurchaseShareCalculation {
+  mode: SupplySplitMode
+  total: number
+  shares: PurchaseShare[]
+}
+
+interface CalculationOptions {
+  overrideMode?: SupplySplitMode
+}
+
+export function calculatePurchaseShares(
+  purchase: SupplyPurchaseRow,
+  memberships: HouseholdMembershipRow[],
+  options: CalculationOptions = {}
+): PurchaseShareCalculation {
+  const applicableMemberships = memberships.filter(
+    (membership) => membership.household_id === purchase.household_id
+  )
+
+  if (applicableMemberships.length === 0 || !isFiniteNumber(purchase.total_cost)) {
+    return { mode: purchase.default_split, total: roundCurrency(purchase.total_cost), shares: [] }
+  }
+
+  const requestedMode = options.overrideMode ?? purchase.default_split
+  const sanitizedWeights = applicableMemberships.map((membership) =>
+    Math.max(0, coerceNumber(membership.weighting_factor, 1))
+  )
+
+  const baseTotal = roundCurrency(purchase.total_cost)
+
+  if (requestedMode === "weighted") {
+    const weightSum = sanitizedWeights.reduce((accumulator, weight) => accumulator + weight, 0)
+
+    if (weightSum <= 0) {
+      return distributeEvenly(applicableMemberships, baseTotal)
+    }
+
+    const rawShares = sanitizedWeights.map((weight) => (baseTotal * weight) / weightSum)
+    return finalizeCalculation(applicableMemberships, rawShares, baseTotal, "weighted")
+  }
+
+  const rawShares = new Array(applicableMemberships.length).fill(baseTotal / applicableMemberships.length)
+  return finalizeCalculation(applicableMemberships, rawShares, baseTotal, "even")
+}
+
+function finalizeCalculation(
+  memberships: HouseholdMembershipRow[],
+  rawShares: number[],
+  total: number,
+  intendedMode: SupplySplitMode
+): PurchaseShareCalculation {
+  const roundedShares = rawShares.map((share) => roundCurrency(share))
+  const roundedSum = roundedShares.reduce((accumulator, share) => accumulator + share, 0)
+  const roundingDelta = roundCurrency(total - roundedSum)
+
+  if (roundingDelta !== 0) {
+    const shareIndex = indexOfLargest(rawShares)
+    roundedShares[shareIndex] = roundCurrency(roundedShares[shareIndex] + roundingDelta)
+  }
+
+  const resultShares: PurchaseShare[] = memberships.map((membership, index) => {
+    const rawShare = rawShares[index]
+    const roundedShare = roundedShares[index]
+    const percentage = total > 0 ? rawShare / total : 0
+
+    return {
+      membershipId: membership.id,
+      profileId: membership.profile_id,
+      amount: roundedShare,
+      weightingFactor: coerceNumber(membership.weighting_factor, 1),
+      percentage,
+    }
+  })
+
+  return {
+    mode: intendedMode,
+    total,
+    shares: resultShares,
+  }
+}
+
+function distributeEvenly(
+  memberships: HouseholdMembershipRow[],
+  total: number
+): PurchaseShareCalculation {
+  if (memberships.length === 0) {
+    return { mode: "even", total, shares: [] }
+  }
+
+  const evenShare = total / memberships.length
+  const rawShares = memberships.map(() => evenShare)
+  return finalizeCalculation(memberships, rawShares, total, "even")
+}
+
+function roundCurrency(value: number): number {
+  const amount = coerceNumber(value, 0)
+  return Math.round((amount + Number.EPSILON) * 100) / 100
+}
+
+function indexOfLargest(values: number[]): number {
+  let index = 0
+  let largest = Number.NEGATIVE_INFINITY
+
+  values.forEach((value, currentIndex) => {
+    if (value > largest) {
+      largest = value
+      index = currentIndex
+    }
+  })
+
+  return index
+}
+
+function coerceNumber(value: unknown, fallback: number): number {
+  const parsed = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}

--- a/supabase/migrations/20250410_supply_ledger.sql
+++ b/supabase/migrations/20250410_supply_ledger.sql
@@ -1,0 +1,41 @@
+create type if not exists public.supply_split_mode as enum ('even', 'weighted');
+
+create table if not exists public.households (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  default_split public.supply_split_mode not null default 'even',
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.household_memberships (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  weighting_factor numeric(10, 2) not null default 1,
+  role text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  unique (household_id, profile_id)
+);
+
+create index if not exists household_memberships_household_id_idx
+  on public.household_memberships (household_id);
+
+create index if not exists household_memberships_profile_id_idx
+  on public.household_memberships (profile_id);
+
+create table if not exists public.supply_purchases (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  purchaser_id uuid not null references public.profiles(id) on delete restrict,
+  description text not null,
+  total_cost numeric(12, 2) not null,
+  purchased_at timestamptz not null default timezone('utc', now()),
+  default_split public.supply_split_mode not null default 'even',
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists supply_purchases_household_id_idx
+  on public.supply_purchases (household_id);

--- a/tests/supply-ledger.test.ts
+++ b/tests/supply-ledger.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  calculatePurchaseShares,
+  type HouseholdMembershipRow,
+  type SupplyPurchaseRow,
+} from "@/lib/supply-ledger"
+
+const householdId = "household-test"
+
+const createdAt = "2024-07-01T00:00:00.000Z"
+
+const memberships: HouseholdMembershipRow[] = [
+  {
+    id: "membership-a",
+    household_id: householdId,
+    profile_id: "profile-a",
+    weighting_factor: 2,
+    role: "primary tenant",
+    created_at: createdAt,
+    updated_at: createdAt,
+  },
+  {
+    id: "membership-b",
+    household_id: householdId,
+    profile_id: "profile-b",
+    weighting_factor: 1,
+    role: "roommate",
+    created_at: createdAt,
+    updated_at: createdAt,
+  },
+  {
+    id: "membership-c",
+    household_id: householdId,
+    profile_id: "profile-c",
+    weighting_factor: 1,
+    role: "roommate",
+    created_at: createdAt,
+    updated_at: createdAt,
+  },
+]
+
+describe("supply ledger share calculations", () => {
+  it("splits totals evenly when default split is even", () => {
+    const purchase: SupplyPurchaseRow = {
+      id: "purchase-even",
+      household_id: householdId,
+      purchaser_id: "profile-a",
+      description: "Shared spices",
+      total_cost: 60,
+      purchased_at: "2024-07-01T12:00:00.000Z",
+      default_split: "even",
+      created_at: createdAt,
+      updated_at: createdAt,
+    }
+
+    const result = calculatePurchaseShares(purchase, memberships)
+    const amounts = result.shares.map((share) => share.amount)
+
+    expect(result.mode).toBe("even")
+    expect(amounts).toEqual([20, 20, 20])
+    expect(result.total).toBe(60)
+    expect(result.shares.reduce((sum, share) => sum + share.amount, 0)).toBeCloseTo(60, 2)
+  })
+
+  it("weights amounts by membership factor when default split is weighted", () => {
+    const purchase: SupplyPurchaseRow = {
+      id: "purchase-weighted",
+      household_id: householdId,
+      purchaser_id: "profile-b",
+      description: "Bulk cleaning supplies",
+      total_cost: 120,
+      purchased_at: "2024-07-05T12:00:00.000Z",
+      default_split: "weighted",
+      created_at: createdAt,
+      updated_at: createdAt,
+    }
+
+    const result = calculatePurchaseShares(purchase, memberships)
+
+    expect(result.mode).toBe("weighted")
+    expect(result.total).toBe(120)
+
+    const sharesByProfile = Object.fromEntries(
+      result.shares.map((share) => [share.profileId, share.amount])
+    )
+
+    expect(sharesByProfile["profile-a"]).toBeCloseTo(60, 2)
+    expect(sharesByProfile["profile-b"]).toBeCloseTo(30, 2)
+    expect(sharesByProfile["profile-c"]).toBeCloseTo(30, 2)
+    expect(result.shares.reduce((sum, share) => sum + share.amount, 0)).toBeCloseTo(120, 2)
+  })
+})


### PR DESCRIPTION
## Summary
- add schema support for weighted household memberships and supply purchases, including split mode enum
- expose supply ledger calculation helpers and surface a supply ledger dashboard view with per-roommate breakdowns
- verify even and weighted splits with dedicated unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0ed5a5c8328b9cf74b4b000ca56