### PR TITLE
feat: add household to-buy list automation

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { MixerHorizontalIcon, PersonIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -14,11 +14,11 @@ export default function NavLinks() {
 			text: "Members",
 			Icon: PersonIcon,
 		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
+                {
+                        href: "/dashboard/todo",
+                        text: "Shopping list",
+                        Icon: MixerHorizontalIcon,
+                },
 	];
 
 	return (

--- a/app/dashboard/components/SideNav.tsx
+++ b/app/dashboard/components/SideNav.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import NavLinks from "./NavLinks";
 
 import { cn } from "@/lib/utils";
-import ModeToggle from '../todo/components/ToggleDarkMode'
 import { Button } from "@/components/ui/button";
 import SignOut from "./SignOut";
 import { ThemeToggle } from "@/components/theme-toggle"

--- a/app/dashboard/todo/actions/index.ts
+++ b/app/dashboard/todo/actions/index.ts
@@ -1,9 +1,189 @@
-// "use server";
-export async function createTodo() {
-	console.log("create todo");
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { createActionClient } from "@/utils/supabase/actions";
+import { PRIORITY_LEVELS, type PriorityLevel } from "../constants";
+
+const DASHBOARD_TODO_PATH = "/dashboard/todo";
+
+async function getAuthenticatedContext() {
+  const supabase = await createActionClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    throw new Error("You must be signed in to manage household supplies.");
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("household_id")
+    .eq("id", user.id)
+    .single();
+
+  if (profileError || !profile) {
+    throw new Error("We couldn't find your household profile.");
+  }
+
+  return { supabase, userId: user.id, householdId: profile.household_id };
 }
-export async function updateTodoById(id: string) {
-	console.log("update todo");
+
+function validatePriority(priority: string): PriorityLevel {
+  if ((PRIORITY_LEVELS as readonly string[]).includes(priority)) {
+    return priority as PriorityLevel;
+  }
+
+  throw new Error("Invalid priority supplied.");
 }
-export async function deleteTodoById(id: string) {}
-export async function readTodos() {}
+
+export async function addToBuyItem(input: {
+  itemName?: string;
+  supplyItemId?: string;
+  priority: string;
+}) {
+  const priority = validatePriority(input.priority);
+  const trimmedName = input.itemName?.trim();
+
+  if (!input.supplyItemId && !trimmedName) {
+    throw new Error("Select an existing item or provide a name for a new one.");
+  }
+
+  const { supabase, userId, householdId } = await getAuthenticatedContext();
+
+  let supplyItemId = input.supplyItemId ?? null;
+
+  if (supplyItemId) {
+    const { data: existingItem, error: existingError } = await supabase
+      .from("supply_items")
+      .select("id")
+      .eq("id", supplyItemId)
+      .eq("household_id", householdId)
+      .single();
+
+    if (existingError || !existingItem) {
+      throw new Error("The selected supply item is no longer available.");
+    }
+  } else if (trimmedName) {
+    const { data: existingItems, error: fetchError } = await supabase
+      .from("supply_items")
+      .select("id")
+      .eq("household_id", householdId)
+      .ilike("name", trimmedName)
+      .limit(1);
+
+    if (fetchError) {
+      throw new Error("Unable to verify existing supply items.");
+    }
+
+    const existingMatch = existingItems?.[0];
+
+    if (existingMatch) {
+      supplyItemId = existingMatch.id;
+    } else {
+      const { data: createdItem, error: createError } = await supabase
+        .from("supply_items")
+        .insert({
+          name: trimmedName,
+          household_id: householdId,
+          created_by: userId,
+        })
+        .select("id")
+        .single();
+
+      if (createError || !createdItem) {
+        throw new Error("Unable to create the new supply item.");
+      }
+
+      supplyItemId = createdItem.id;
+    }
+  }
+
+  if (!supplyItemId) {
+    throw new Error("Unable to resolve a supply item for this request.");
+  }
+
+  const { data: existingToBuy, error: existingToBuyError } = await supabase
+    .from("to_buy_items")
+    .select("id, priority")
+    .eq("household_id", householdId)
+    .eq("supply_item_id", supplyItemId)
+    .is("fulfilled_at", null)
+    .maybeSingle();
+
+  if (existingToBuyError) {
+    throw new Error("Unable to check your open to-buy items.");
+  }
+
+  if (existingToBuy) {
+    if (existingToBuy.priority !== priority) {
+      const { error: updateError } = await supabase
+        .from("to_buy_items")
+        .update({ priority })
+        .eq("id", existingToBuy.id);
+
+      if (updateError) {
+        throw new Error("Unable to update the existing item priority.");
+      }
+    }
+  } else {
+    const { error: insertError } = await supabase.from("to_buy_items").insert({
+      supply_item_id: supplyItemId,
+      priority,
+      household_id: householdId,
+      added_by: userId,
+    });
+
+    if (insertError) {
+      throw new Error("Unable to add the item to your shopping list.");
+    }
+  }
+
+  revalidatePath(DASHBOARD_TODO_PATH);
+}
+
+export async function removeToBuyItem(id: string) {
+  const { supabase, householdId } = await getAuthenticatedContext();
+
+  const { error } = await supabase
+    .from("to_buy_items")
+    .delete()
+    .eq("id", id)
+    .eq("household_id", householdId);
+
+  if (error) {
+    throw new Error("Unable to remove the selected item.");
+  }
+
+  revalidatePath(DASHBOARD_TODO_PATH);
+}
+
+export async function logPurchase(toBuyItemId: string, notes?: string) {
+  const { supabase, userId, householdId } = await getAuthenticatedContext();
+
+  const { data: targetItem, error: fetchError } = await supabase
+    .from("to_buy_items")
+    .select("id, supply_item_id, household_id, fulfilled_at")
+    .eq("id", toBuyItemId)
+    .eq("household_id", householdId)
+    .single();
+
+  if (fetchError || !targetItem) {
+    throw new Error("Unable to locate the selected to-buy item.");
+  }
+
+  const { error: insertError } = await supabase.from("household_purchases").insert({
+    household_id: householdId,
+    supply_item_id: targetItem.supply_item_id,
+    purchased_by: userId,
+    notes: notes?.trim() || null,
+  });
+
+  if (insertError) {
+    throw new Error("Unable to log the purchase for this item.");
+  }
+
+  revalidatePath(DASHBOARD_TODO_PATH);
+}

--- a/app/dashboard/todo/components/CreateForm.tsx
+++ b/app/dashboard/todo/components/CreateForm.tsx
@@ -4,83 +4,188 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
+import { useTransition } from "react";
 
 import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/use-toast";
 import { Button } from "@/components/ui/button";
-import { useTransition } from "react";
-import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
-const FormSchema = z.object({
-	title: z.string().min(1, {
-		message: "Title is required.",
-	}),
-});
+import { addToBuyItem } from "../actions";
+import { PRIORITY_LEVELS, PRIORITY_LABELS } from "../constants";
 
-export default function CreateForm() {
-	const [isPending, startTransition] = useTransition();
+const prioritySchema = z.enum(PRIORITY_LEVELS);
 
-	const form = useForm<z.infer<typeof FormSchema>>({
-		resolver: zodResolver(FormSchema),
-		defaultValues: {
-			title: "",
-		},
-	});
+const formSchema = z
+  .object({
+    itemName: z.string().trim().optional(),
+    supplyItemId: z.string().uuid().optional().or(z.literal("")),
+    priority: prioritySchema,
+  })
+  .transform((value) => ({
+    ...value,
+    supplyItemId: value.supplyItemId ? value.supplyItemId : undefined,
+  }))
+  .refine(
+    (value) => Boolean(value.itemName?.length) || Boolean(value.supplyItemId),
+    {
+      message: "Select an item or provide a name to add a new one.",
+      path: ["itemName"],
+    },
+  );
 
-	function onSubmit(data: z.infer<typeof FormSchema>) {
-		toast({
-			title: "You have successfully create todo.",
-			description: (
-				<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-					<code className="text-white">{data.title} is created</code>
-				</pre>
-			),
-		});
-		form.reset();
-	}
+type FormValues = z.infer<typeof formSchema>;
 
-	return (
-		<Form {...form}>
-			<form
-				onSubmit={form.handleSubmit(onSubmit)}
-				className="w-full space-y-6"
-			>
-				<FormField
-					control={form.control}
-					name="title"
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Title</FormLabel>
-							<FormControl>
-								<Input
-									placeholder="todo title"
-									{...field}
-									onChange={field.onChange}
-								/>
-							</FormControl>
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
-<Button
-				className="flex w-full items-center gap-2"
-				variant="outline"
-			>
-				Create{" "}
-				<AiOutlineLoading3Quarters
-					className={cn(" animate-spin", { hidden: !isPending })}
-				/>
-			</Button>
+type CreateFormProps = {
+  existingItems: Array<{ id: string; name: string }>;
+};
 
-			</form>
-		</Form>
-	);
+export default function CreateForm({ existingItems }: CreateFormProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      itemName: "",
+      supplyItemId: undefined,
+      priority: "medium",
+    },
+  });
+
+  const selectedSupplyId = form.watch("supplyItemId");
+
+  async function onSubmit(values: FormValues) {
+    startTransition(async () => {
+      try {
+        await addToBuyItem({
+          itemName: values.itemName,
+          supplyItemId: values.supplyItemId,
+          priority: values.priority,
+        });
+
+        const resolvedName =
+          values.itemName && values.itemName.length > 0
+            ? values.itemName
+            : existingItems.find((item) => item.id === values.supplyItemId)?.name ?? "Existing item";
+
+        toast({
+          title: "Added to your list",
+          description: `${resolvedName} scheduled with ${PRIORITY_LABELS[values.priority]} priority.`,
+        });
+
+        form.reset({ itemName: "", supplyItemId: undefined, priority: "medium" });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unable to add this supply item right now.";
+        toast({
+          variant: "destructive",
+          title: "Something went wrong",
+          description: message,
+        });
+      }
+    });
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="supplyItemId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Use an existing supply</FormLabel>
+              <Select
+                onValueChange={(value) => field.onChange(value === "" ? undefined : value)}
+                value={field.value ?? ""}
+                disabled={isPending}
+              >
+                <FormControl>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select from your catalog" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="">Create a new supply</SelectItem>
+                  {existingItems.map((item) => (
+                    <SelectItem key={item.id} value={item.id}>
+                      {item.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="itemName"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>New supply name</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. Paper towels"
+                  {...field}
+                  value={field.value ?? ""}
+                  disabled={Boolean(selectedSupplyId) || isPending}
+                  onChange={(event) => field.onChange(event.target.value)}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="priority"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Priority</FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select priority" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {PRIORITY_LEVELS.map((priority) => (
+                    <SelectItem key={priority} value={priority}>
+                      {PRIORITY_LABELS[priority]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="flex w-full items-center justify-center gap-2" disabled={isPending}>
+          Add to list
+          <AiOutlineLoading3Quarters
+            className={`size-4 ${isPending ? "animate-spin" : "hidden"}`}
+            aria-hidden="true"
+          />
+        </Button>
+      </form>
+    </Form>
+  );
 }

--- a/app/dashboard/todo/components/ToBuyList.tsx
+++ b/app/dashboard/todo/components/ToBuyList.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { CheckCircle2, ShoppingCart, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { toast } from "@/components/ui/use-toast";
+
+import CreateForm from "./CreateForm";
+import { logPurchase, removeToBuyItem } from "../actions";
+import {
+  PRIORITY_LABELS,
+  PRIORITY_LEVELS,
+  PRIORITY_RANK,
+  type PriorityLevel,
+} from "../constants";
+
+type SupplyItem = {
+  id: string;
+  name: string;
+};
+
+type ToBuyItem = {
+  id: string;
+  priority: PriorityLevel;
+  fulfilled_at: string | null;
+  created_at: string;
+  supply_item: SupplyItem | null;
+};
+
+type FilterValue = "all" | PriorityLevel;
+
+type ToBuyListProps = {
+  items: ToBuyItem[];
+  supplyItems: SupplyItem[];
+};
+
+const FILTER_OPTIONS: FilterValue[] = ["all", ...PRIORITY_LEVELS];
+
+export default function ToBuyList({ items, supplyItems }: ToBuyListProps) {
+  const [filter, setFilter] = useState<FilterValue>("all");
+  const [isPending, startTransition] = useTransition();
+
+  const sortedItems = useMemo(() => {
+    return [...items].sort((a, b) => {
+      const rankDifference = PRIORITY_RANK[b.priority] - PRIORITY_RANK[a.priority];
+      if (rankDifference !== 0) {
+        return rankDifference;
+      }
+
+      const aFulfilled = Boolean(a.fulfilled_at);
+      const bFulfilled = Boolean(b.fulfilled_at);
+      if (aFulfilled !== bFulfilled) {
+        return Number(aFulfilled) - Number(bFulfilled);
+      }
+
+      return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    });
+  }, [items]);
+
+  const filteredItems = useMemo(() => {
+    if (filter === "all") {
+      return sortedItems;
+    }
+
+    return sortedItems.filter((item) => item.priority === filter);
+  }, [sortedItems, filter]);
+
+  const outstandingItems = filteredItems.filter((item) => !item.fulfilled_at);
+  const fulfilledItems = filteredItems.filter((item) => item.fulfilled_at);
+
+  const handleRemove = (id: string) => {
+    startTransition(async () => {
+      try {
+        await removeToBuyItem(id);
+        toast({ title: "Item removed" });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "We couldn't remove that item right now.";
+        toast({
+          variant: "destructive",
+          title: "Removal failed",
+          description: message,
+        });
+      }
+    });
+  };
+
+  const handleLogPurchase = (id: string) => {
+    startTransition(async () => {
+      try {
+        await logPurchase(id);
+        toast({ title: "Purchase logged" });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "We couldn't log that purchase right now.";
+        toast({
+          variant: "destructive",
+          title: "Action failed",
+          description: message,
+        });
+      }
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-3">
+      <Card className="lg:col-span-1">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+            <ShoppingCart className="size-5" />
+            Add to shopping list
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CreateForm existingItems={supplyItems} />
+        </CardContent>
+      </Card>
+
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Household shopping list</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex flex-wrap gap-2">
+            {FILTER_OPTIONS.map((option) => (
+              <Button
+                key={option}
+                variant={filter === option ? "default" : "outline"}
+                size="sm"
+                onClick={() => setFilter(option)}
+                disabled={isPending}
+              >
+                {option === "all" ? "All" : PRIORITY_LABELS[option]}
+              </Button>
+            ))}
+          </div>
+
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+              Needs purchasing
+            </h3>
+            {outstandingItems.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                You&rsquo;re all stocked up! Add an item on the left when something runs low.
+              </p>
+            ) : (
+              <ul className="space-y-3">
+                {outstandingItems.map((item) => (
+                  <li
+                    key={item.id}
+                    className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-base font-medium">
+                          {item.supply_item?.name ?? "Unnamed item"}
+                        </span>
+                        <Badge>{PRIORITY_LABELS[item.priority]}</Badge>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Added {formatDistanceToNow(new Date(item.created_at), { addSuffix: true })}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleLogPurchase(item.id)}
+                        disabled={isPending}
+                      >
+                        Log purchase
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Remove item"
+                        onClick={() => handleRemove(item.id)}
+                        disabled={isPending}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <Separator />
+
+          <section className="space-y-4">
+            <h3 className="flex items-center gap-2 text-sm font-semibold uppercase text-muted-foreground">
+              <CheckCircle2 className="size-4" /> Fulfilled
+            </h3>
+            {fulfilledItems.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No recent purchases logged yet.</p>
+            ) : (
+              <ul className="space-y-3">
+                {fulfilledItems.map((item) => (
+                  <li key={item.id} className="rounded-md border bg-muted/40 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex flex-col">
+                        <span className="text-sm font-medium">
+                          {item.supply_item?.name ?? "Unnamed item"}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          Purchased {formatDistanceToNow(new Date(item.fulfilled_at ?? item.created_at), {
+                            addSuffix: true,
+                          })}
+                        </span>
+                      </div>
+                      <Badge variant="secondary">{PRIORITY_LABELS[item.priority]}</Badge>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/dashboard/todo/constants.ts
+++ b/app/dashboard/todo/constants.ts
@@ -1,0 +1,17 @@
+export const PRIORITY_LEVELS = ["urgent", "high", "medium", "low"] as const;
+
+export type PriorityLevel = (typeof PRIORITY_LEVELS)[number];
+
+export const PRIORITY_LABELS: Record<PriorityLevel, string> = {
+  urgent: "Urgent",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+export const PRIORITY_RANK: Record<PriorityLevel, number> = {
+  urgent: 3,
+  high: 2,
+  medium: 1,
+  low: 0,
+};

--- a/app/dashboard/todo/page.tsx
+++ b/app/dashboard/todo/page.tsx
@@ -1,42 +1,62 @@
+import { redirect } from "next/navigation";
 
-import React from "react";
-import CreateForm from "./components/CreateForm";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import ToBuyList from "./components/ToBuyList";
+import { createClient } from "@/utils/supabase/server";
+import { PRIORITY_LEVELS, type PriorityLevel } from "./constants";
 
-export default function Todo() {
-	const todos = [
-		{
-			title: "Subscribe",
-			created_by: "091832901830",
-			id: "101981908",
-			completed: false,
-		},
-	];
+function isPriorityLevel(value: string): value is PriorityLevel {
+  return (PRIORITY_LEVELS as readonly string[]).includes(value);
+}
 
-	return (
-		<div className="flex h-screen items-center justify-center">
-			<div className="w-96 space-y-5">
+export default async function Todo() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-				<CreateForm />
+  if (!user) {
+    redirect("/auth/signin?redirect=/dashboard/todo");
+  }
 
-				{todos?.map((todo, index) => {
-					return (
-						<div key={index} className="flex items-center gap-6">
-							<h1
-								className={cn({
-									"line-through": todo.completed,
-								})}
-							>
-								{todo.title}
-							</h1>
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("household_id")
+    .eq("id", user.id)
+    .single();
 
-							<Button>delete</Button>
-							<Button>Update</Button>
-						</div>
-					);
-				})}
-			</div>
-		</div>
-	);
+  const householdId = profile?.household_id ?? user.id;
+
+  const { data: toBuyItems } = await supabase
+    .from("to_buy_items")
+    .select(
+      `id, priority, fulfilled_at, created_at, supply_item:supply_items ( id, name )`
+    )
+    .eq("household_id", householdId)
+    .order("fulfilled_at", { ascending: true, nullsFirst: true })
+    .order("created_at", { ascending: true });
+
+  const { data: supplyItems } = await supabase
+    .from("supply_items")
+    .select("id, name")
+    .eq("household_id", householdId)
+    .order("name", { ascending: true });
+
+  const items = (toBuyItems ?? []).map((item) => ({
+    id: item.id,
+    priority: isPriorityLevel(item.priority) ? item.priority : "medium",
+    fulfilled_at: item.fulfilled_at,
+    created_at: item.created_at,
+    supply_item: item.supply_item,
+  }));
+
+  return (
+    <div className="w-full space-y-6 p-4 md:p-8">
+      <h1 className="text-3xl font-bold">Household shopping list</h1>
+      <p className="max-w-2xl text-sm text-muted-foreground">
+        Track communal supplies, assign priorities, and automatically mark items fulfilled when
+        someone logs a purchase.
+      </p>
+      <ToBuyList items={items} supplyItems={supplyItems ?? []} />
+    </div>
+  );
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1226,6 +1226,128 @@ export type Database = {
         }
         Relationships: []
       }
+      household_purchases: {
+        Row: {
+          household_id: string
+          id: string
+          notes: string | null
+          purchased_at: string
+          purchased_by: string
+          supply_item_id: string
+        }
+        Insert: {
+          household_id: string
+          id?: string
+          notes?: string | null
+          purchased_at?: string
+          purchased_by: string
+          supply_item_id: string
+        }
+        Update: {
+          household_id?: string
+          id?: string
+          notes?: string | null
+          purchased_at?: string
+          purchased_by?: string
+          supply_item_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "household_purchases_purchased_by_fkey"
+            columns: ["purchased_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "household_purchases_supply_item_id_fkey"
+            columns: ["supply_item_id"]
+            isOneToOne: false
+            referencedRelation: "supply_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      supply_items: {
+        Row: {
+          created_at: string
+          created_by: string
+          household_id: string
+          id: string
+          name: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          household_id: string
+          id?: string
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          household_id?: string
+          id?: string
+          name?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_items_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      to_buy_items: {
+        Row: {
+          added_by: string
+          created_at: string
+          fulfilled_at: string | null
+          household_id: string
+          id: string
+          priority: string
+          supply_item_id: string
+        }
+        Insert: {
+          added_by: string
+          created_at?: string
+          fulfilled_at?: string | null
+          household_id: string
+          id?: string
+          priority: string
+          supply_item_id: string
+        }
+        Update: {
+          added_by?: string
+          created_at?: string
+          fulfilled_at?: string | null
+          household_id?: string
+          id?: string
+          priority?: string
+          supply_item_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "to_buy_items_added_by_fkey"
+            columns: ["added_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "to_buy_items_supply_item_id_fkey"
+            columns: ["supply_item_id"]
+            isOneToOne: false
+            referencedRelation: "supply_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           avatar_url: string | null
@@ -1236,6 +1358,7 @@ export type Database = {
           created_at: string | null
           email: string | null
           full_name: string | null
+          household_id: string
           id: string
           job_title: string | null
           linkedin_url: string | null
@@ -1256,6 +1379,7 @@ export type Database = {
           created_at?: string | null
           email?: string | null
           full_name?: string | null
+          household_id?: string
           id?: string
           job_title?: string | null
           linkedin_url?: string | null
@@ -1276,6 +1400,7 @@ export type Database = {
           created_at?: string | null
           email?: string | null
           full_name?: string | null
+          household_id?: string
           id?: string
           job_title?: string | null
           linkedin_url?: string | null

--- a/supabase/migrations/20240720_to_buy_items.sql
+++ b/supabase/migrations/20240720_to_buy_items.sql
@@ -1,0 +1,178 @@
+create extension if not exists "pgcrypto";
+
+alter table public.profiles
+  add column if not exists household_id uuid;
+
+update public.profiles
+set household_id = coalesce(household_id, gen_random_uuid());
+
+alter table public.profiles
+  alter column household_id set not null;
+
+create index if not exists profiles_household_id_idx
+  on public.profiles (household_id);
+
+create table public.supply_items (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null,
+  name text not null,
+  created_by uuid not null references public.profiles(id) on delete cascade,
+  created_at timestamptz not null default timezone('utc'::text, now()),
+  updated_at timestamptz not null default timezone('utc'::text, now())
+);
+
+create unique index supply_items_household_name_key
+  on public.supply_items (household_id, lower(name));
+
+alter table public.supply_items enable row level security;
+
+create policy "Household members can view supply items" on public.supply_items
+  for select using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create policy "Household members can insert supply items" on public.supply_items
+  for insert with check (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+    and created_by = auth.uid()
+  );
+
+create policy "Household members can update supply items" on public.supply_items
+  for update using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  ) with check (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create policy "Household members can delete supply items" on public.supply_items
+  for delete using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create table public.to_buy_items (
+  id uuid primary key default gen_random_uuid(),
+  supply_item_id uuid not null references public.supply_items(id) on delete cascade,
+  priority text not null check (priority in ('low', 'medium', 'high', 'urgent')),
+  household_id uuid not null,
+  added_by uuid not null references public.profiles(id) on delete cascade,
+  fulfilled_at timestamptz null,
+  created_at timestamptz not null default timezone('utc'::text, now())
+);
+
+create index to_buy_items_household_priority_idx on public.to_buy_items (household_id, priority);
+create index to_buy_items_supply_idx on public.to_buy_items (supply_item_id);
+
+alter table public.to_buy_items enable row level security;
+
+create policy "Household members can view to-buy items" on public.to_buy_items
+  for select using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create policy "Household members can insert to-buy items" on public.to_buy_items
+  for insert with check (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+    and added_by = auth.uid()
+  );
+
+create policy "Household members can update to-buy items" on public.to_buy_items
+  for update using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  ) with check (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create policy "Household members can delete to-buy items" on public.to_buy_items
+  for delete using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create table public.household_purchases (
+  id uuid primary key default gen_random_uuid(),
+  supply_item_id uuid not null references public.supply_items(id) on delete cascade,
+  household_id uuid not null,
+  purchased_by uuid not null references public.profiles(id) on delete cascade,
+  purchased_at timestamptz not null default timezone('utc'::text, now()),
+  notes text null
+);
+
+create index household_purchases_household_idx on public.household_purchases (household_id, purchased_at desc);
+create index household_purchases_supply_idx on public.household_purchases (supply_item_id);
+
+alter table public.household_purchases enable row level security;
+
+create policy "Household members can view purchases" on public.household_purchases
+  for select using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create policy "Household members can insert purchases" on public.household_purchases
+  for insert with check (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+    and purchased_by = auth.uid()
+  );
+
+create policy "Household members can update purchases" on public.household_purchases
+  for update using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  ) with check (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create policy "Household members can delete purchases" on public.household_purchases
+  for delete using (
+    household_id = (
+      select household_id from public.profiles where id = auth.uid()
+    )
+  );
+
+create or replace function public.mark_to_buy_items_fulfilled()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.to_buy_items
+  set fulfilled_at = coalesce(fulfilled_at, timezone('utc', now()))
+  where household_id = new.household_id
+    and supply_item_id = new.supply_item_id
+    and fulfilled_at is null;
+
+  return new;
+end;
+$$;
+
+create trigger to_buy_items_auto_fulfill
+  after insert on public.household_purchases
+  for each row
+  execute function public.mark_to_buy_items_fulfilled();
+


### PR DESCRIPTION
## Summary
- add migrations for supply items, to-buy items, and purchase logging with automatic fulfillment trigger
- extend Supabase types plus server actions for managing household shopping list entries
- build tenant shopping list UI with priority filters, add/remove controls, and navigation updates

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0eef8dc8328b9528d719f156e8f