### PR TITLE
Add chore streak analytics job and dashboard reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ complete Supabase SSR Auth and DB integration, Zod validation, Tanstack React Qu
     - SUPABASE_SERVIC_ROLE_KEY="Your supabase service role key"
     - NEXT_PUBLIC_SITE_URL="http://localhost:3000" # Used for auth redirects in development
     - SUPABASE_WORKOS_CONNECTION_ID="Your WorkOS connection ID" # Optional, required to enable SSO via WorkOS
+    - CRON_SECRET="your-cron-shared-secret" # Protects the scheduled chore analytics job
 
   - Enable WorkOS SSO (optional)
     - Create a WorkOS connection in the Supabase dashboard and copy the connection ID from the Connections table
@@ -64,7 +65,12 @@ complete Supabase SSR Auth and DB integration, Zod validation, Tanstack React Qu
     - Configure the SUPABASE_WORKOS_CONNECTION_ID environment variable with the copied value
 
   - Ensure your Supabase tables match the tables and types found in '@/lib/supabase'.
-  - Add authorized development and production URL's to Supabase URL config. 
+  - Add authorized development and production URL's to Supabase URL config.
+
+### Scheduled chore analytics
+- Supabase's `refresh_chore_member_streaks` function aggregates streaks, records history in `chore_streak_snapshots`, and enqueues deadline reminders in `tenant_notifications`.
+- Configure a Vercel Cron job (or equivalent scheduler) to `POST` to `/api/cron/chore-analytics` with the `CRON_SECRET` bearer token two or more times per day so reminders go out two days before each due date.
+- The dashboard reads from `chore_member_streaks` and `chore_streak_snapshots`, ensuring analytics persist for upcoming gamification features.
 ### Run  
 - Development server:
 

--- a/app/api/cron/chore-analytics/route.ts
+++ b/app/api/cron/chore-analytics/route.ts
@@ -1,0 +1,34 @@
+import { createClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+export async function POST(request: Request) {
+  const authorization = request.headers.get("authorization")
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret || authorization !== `Bearer ${cronSecret}`) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return Response.json(
+      { error: "Supabase environment variables are not configured." },
+      { status: 500 }
+    )
+  }
+
+  const supabase = createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  })
+
+  const { error } = await supabase.rpc("refresh_chore_member_streaks")
+
+  if (error) {
+    console.error("Failed to refresh chore streaks", error)
+    return Response.json({ error: error.message }, { status: 500 })
+  }
+
+  return Response.json({ ok: true })
+}

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -1,5 +1,8 @@
 import { Metadata } from "next"
-import Image from "next/image"
+import { redirect } from "next/navigation"
+import { cookies } from "next/headers"
+import { differenceInCalendarDays, format } from "date-fns"
+import { AlarmClock, Award, CheckCircle2, Flame } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -9,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
 import {
   Tabs,
   TabsContent,
@@ -17,18 +21,200 @@ import {
 } from "@/components/ui/tabs"
 import { CalendarDateRangePicker } from "@/app/dashboard/components/date-range-picker"
 import { MainNav } from "@/app/dashboard/components/main-nav"
-import { Overview } from "@/app/dashboard/components/overview"
-import { RecentSales } from "@/app/dashboard/components/recent-sales"
+import { Overview, type OverviewDatum } from "@/app/dashboard/components/overview"
+import { RecentSales, type Reminder } from "@/app/dashboard/components/recent-sales"
 import { Search } from "@/app/dashboard/components/search"
 import TeamSwitcher from "@/app/dashboard/components/team-switcher"
 import { UserNav } from "@/app/dashboard/components/user-nav"
+import type { Database } from "@/lib/supabase"
+import { createClient } from "@/utils/supa-server-actions"
 
 export const metadata: Metadata = {
   title: "Onyx Dashboard",
   description: "Manage your Onyx account and users.",
 }
 
-export default function DashboardPage() {
+type ChoreAssignment = Database["public"]["Tables"]["chore_assignments"]["Row"]
+type StreakRow = Database["public"]["Tables"]["chore_member_streaks"]["Row"]
+type SnapshotRow = Database["public"]["Tables"]["chore_streak_snapshots"]["Row"]
+type TenantNotification = Database["public"]["Tables"]["tenant_notifications"]["Row"]
+
+function formatDueCopy(diff: number, dueDate: Date) {
+  const dateLabel = format(dueDate, "EEE, MMM d")
+  if (diff < 0) {
+    return `Overdue by ${Math.abs(diff)} days • ${dateLabel}`
+  }
+  if (diff === 0) {
+    return `Due today • ${dateLabel}`
+  }
+  if (diff === 1) {
+    return `Due tomorrow • ${dateLabel}`
+  }
+  return `Due in ${diff} days • ${dateLabel}`
+}
+
+export default async function DashboardPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const [
+    { data: streakData, error: streakError },
+    { data: assignmentsData, error: assignmentsError },
+    { data: notificationsData, error: notificationsError },
+    { data: snapshotsData, error: snapshotsError },
+  ] = await Promise.all([
+    supabase
+      .from("chore_member_streaks")
+      .select("*")
+      .eq("member_id", user.id)
+      .maybeSingle(),
+    supabase
+      .from("chore_assignments")
+      .select("id, chore_title, due_date, completed_at, notes")
+      .eq("member_id", user.id)
+      .order("due_date", { ascending: true }),
+    supabase
+      .from("tenant_notifications")
+      .select(
+        "id, member_id, assignment_id, notification_type, title, body, metadata, scheduled_for, delivered_at, created_at"
+      )
+      .eq("member_id", user.id)
+      .order("scheduled_for", { ascending: true })
+      .limit(10),
+    supabase
+      .from("chore_streak_snapshots")
+      .select("snapshot_date, current_streak, longest_streak, total_completed, total_assignments")
+      .eq("member_id", user.id)
+      .order("snapshot_date", { ascending: true })
+      .limit(14),
+  ])
+
+  if (streakError) {
+    console.error("Failed to load streak data", streakError)
+  }
+  if (assignmentsError) {
+    console.error("Failed to load chore assignments", assignmentsError)
+  }
+  if (notificationsError) {
+    console.error("Failed to load notifications", notificationsError)
+  }
+  if (snapshotsError) {
+    console.error("Failed to load streak history", snapshotsError)
+  }
+
+  const assignments = (assignmentsData ?? []) as ChoreAssignment[]
+  const notifications = (notificationsData ?? []) as TenantNotification[]
+  const snapshots = (snapshotsData ?? []) as SnapshotRow[]
+
+  const fallbackStreak: StreakRow = {
+    member_id: user.id,
+    current_streak: 0,
+    longest_streak: 0,
+    last_completed_date: null,
+    total_completed: assignments.filter((assignment) => assignment.completed_at).length,
+    total_assignments: assignments.length,
+    updated_at: new Date().toISOString(),
+  }
+
+  const streak = (streakData as StreakRow | null) ?? fallbackStreak
+
+  const today = new Date()
+  const upcomingAssignments = assignments.filter((assignment) => {
+    const dueDate = new Date(assignment.due_date)
+    const diff = differenceInCalendarDays(dueDate, today)
+    return !assignment.completed_at && diff >= 0
+  })
+  const dueSoonAssignments = upcomingAssignments.filter((assignment) => {
+    const diff = differenceInCalendarDays(new Date(assignment.due_date), today)
+    return diff <= 7
+  })
+  const dueSoonCount = dueSoonAssignments.length
+  const dueInTwoDaysAssignments = upcomingAssignments.filter(
+    (assignment) => differenceInCalendarDays(new Date(assignment.due_date), today) === 2
+  )
+  const overdueAssignments = assignments.filter((assignment) => {
+    const diff = differenceInCalendarDays(new Date(assignment.due_date), today)
+    return !assignment.completed_at && diff < 0
+  })
+  const overdueCount = overdueAssignments.length
+
+  const upcomingAssignmentItems = dueSoonAssignments.slice(0, 5).map((assignment) => {
+    const dueDate = new Date(assignment.due_date)
+    const diff = differenceInCalendarDays(dueDate, today)
+    return {
+      id: assignment.id,
+      choreTitle: assignment.chore_title,
+      dueCopy: formatDueCopy(diff, dueDate),
+      dueIn: diff,
+    }
+  })
+
+  const chartSource =
+    snapshots.length > 0
+      ? snapshots.map((snapshot) => ({
+          snapshot_date: snapshot.snapshot_date,
+          current_streak: snapshot.current_streak,
+        }))
+      : [
+          {
+            snapshot_date: today.toISOString(),
+            current_streak: streak.current_streak,
+          },
+        ]
+
+  const streakChartData: OverviewDatum[] = chartSource.map((entry) => ({
+    label: format(new Date(entry.snapshot_date), "MMM d"),
+    value: entry.current_streak,
+  }))
+
+  const completionRate =
+    streak.total_assignments === 0
+      ? 0
+      : Math.round((streak.total_completed / streak.total_assignments) * 100)
+
+  const reminders: Reminder[] = notifications.map((notification) => {
+    const metadata = (notification.metadata ?? {}) as Record<string, unknown>
+    const dueDateValue = typeof metadata.due_date === "string" ? metadata.due_date : null
+    const choreTitleValue =
+      typeof metadata.chore_title === "string"
+        ? metadata.chore_title
+        : assignments.find((assignment) => assignment.id === notification.assignment_id)?.chore_title ?? null
+
+    return {
+      id: notification.id,
+      title: notification.title,
+      body: notification.body,
+      scheduledFor: notification.scheduled_for ?? notification.created_at,
+      deliveredAt: notification.delivered_at ?? undefined,
+      dueDate: dueDateValue,
+      choreTitle: choreTitleValue,
+    }
+  })
+
+  const lastCompletedLabel = streak.last_completed_date
+    ? format(new Date(streak.last_completed_date), "MMM d, yyyy")
+    : "No completions yet"
+  const analyticsUpdatedLabel = format(new Date(streak.updated_at), "MMM d, yyyy")
+  const dueSoonMessage = dueSoonCount
+    ? dueInTwoDaysAssignments.length
+      ? `${dueInTwoDaysAssignments.length} due in two days`
+      : `${dueSoonCount} due within seven days`
+    : "No chores due in the next seven days"
+  const upcomingCardDescription = dueSoonCount
+    ? "Stay ahead of this week's assignments."
+    : "You're all caught up for the coming week."
+  const completionInsightDescription = overdueCount
+    ? `${overdueCount} chore${overdueCount === 1 ? "" : "s"} are overdue.`
+    : "All chores are on schedule."
+
   return (
     <>
       <div className="xs:flex max-w-dvw w-full flex-col">
@@ -68,123 +254,128 @@ export default function DashboardPage() {
                 <Card>
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                     <CardTitle className="text-sm font-medium">
-                      Total Revenue
+                      Current streak
                     </CardTitle>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      className="size-4 text-muted-foreground"
-                    >
-                      <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-                    </svg>
+                    <Flame className="size-4 text-muted-foreground" />
                   </CardHeader>
                   <CardContent>
-                    <div className="text-2xl font-bold">$45,231.89</div>
+                    <div className="text-2xl font-bold">{streak.current_streak} days</div>
+                    <p className="text-xs text-muted-foreground">Last completion: {lastCompletedLabel}</p>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <CardTitle className="text-sm font-medium">Longest streak</CardTitle>
+                    <Award className="size-4 text-muted-foreground" />
+                  </CardHeader>
+                  <CardContent>
+                    <div className="text-2xl font-bold">{streak.longest_streak} days</div>
                     <p className="text-xs text-muted-foreground">
-                      +20.1% from last month
+                      Updated {analyticsUpdatedLabel}
                     </p>
                   </CardContent>
                 </Card>
                 <Card>
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">
-                      Subscriptions
-                    </CardTitle>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      className="size-4 text-muted-foreground"
-                    >
-                      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                      <circle cx="9" cy="7" r="4" />
-                      <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
-                    </svg>
+                    <CardTitle className="text-sm font-medium">Completion rate</CardTitle>
+                    <CheckCircle2 className="size-4 text-muted-foreground" />
                   </CardHeader>
                   <CardContent>
-                    <div className="text-2xl font-bold">+2350</div>
-                    <p className="text-xs text-muted-foreground">
-                      +180.1% from last month
+                    <div className="text-2xl font-bold">{completionRate}%</div>
+                    <Progress value={completionRate} className="mt-3 h-2" />
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {streak.total_completed} of {streak.total_assignments} assignments completed.
                     </p>
                   </CardContent>
                 </Card>
                 <Card>
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">Sales</CardTitle>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      className="size-4 text-muted-foreground"
-                    >
-                      <rect width="20" height="14" x="2" y="5" rx="2" />
-                      <path d="M2 10h20" />
-                    </svg>
+                    <CardTitle className="text-sm font-medium">Upcoming chores</CardTitle>
+                    <AlarmClock className="size-4 text-muted-foreground" />
                   </CardHeader>
                   <CardContent>
-                    <div className="text-2xl font-bold">+12,234</div>
-                    <p className="text-xs text-muted-foreground">
-                      +19% from last month
-                    </p>
-                  </CardContent>
-                </Card>
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">
-                      Active Now
-                    </CardTitle>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      className="size-4 text-muted-foreground"
-                    >
-                      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-                    </svg>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">+573</div>
-                    <p className="text-xs text-muted-foreground">
-                      +201 since last hour
-                    </p>
+                    <div className="text-2xl font-bold">{dueSoonCount}</div>
+                    <p className="text-xs text-muted-foreground">{dueSoonMessage}</p>
                   </CardContent>
                 </Card>
               </div>
               <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
-                <Card className="col-span-4">
+                <Card className="lg:col-span-4">
                   <CardHeader>
-                    <CardTitle>Overview</CardTitle>
+                    <CardTitle>Streak trend</CardTitle>
+                    <CardDescription>
+                      Analytics refresh nightly to power gamification features.
+                    </CardDescription>
                   </CardHeader>
-                  <CardContent className="pl-2">
-                    <Overview />
+                  <CardContent className="pl-2 pt-4">
+                    <Overview data={streakChartData} />
                   </CardContent>
                 </Card>
-                <Card className="col-span-3">
+                <Card className="lg:col-span-3">
                   <CardHeader>
-                    <CardTitle>Recent Sales</CardTitle>
+                    <CardTitle>Chore reminders</CardTitle>
                     <CardDescription>
-                      You made 265 sales this month.
+                      Automatic notifications send two days before each deadline.
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <RecentSales />
+                    <RecentSales reminders={reminders} />
+                  </CardContent>
+                </Card>
+              </div>
+              <div className="grid gap-4 lg:grid-cols-7">
+                <Card className="lg:col-span-4">
+                  <CardHeader>
+                    <CardTitle>Upcoming chore deadlines</CardTitle>
+                    <CardDescription>{upcomingCardDescription}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {upcomingAssignmentItems.length ? (
+                      <ul className="space-y-3">
+                        {upcomingAssignmentItems.map((item) => (
+                          <li
+                            key={item.id}
+                            className="flex items-center justify-between rounded-md border border-border p-3"
+                          >
+                            <div>
+                              <p className="text-sm font-medium leading-none">{item.choreTitle}</p>
+                              <p className="text-xs text-muted-foreground">{item.dueCopy}</p>
+                            </div>
+                            {item.dueIn <= 2 ? (
+                              <span className="text-xs font-semibold text-primary">
+                                Reminder scheduled
+                              </span>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No upcoming chores within the next week.
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+                <Card className="lg:col-span-3">
+                  <CardHeader>
+                    <CardTitle>Completion insights</CardTitle>
+                    <CardDescription>{completionInsightDescription}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4 text-sm">
+                      <div>
+                        <p className="text-muted-foreground">Assignments completed</p>
+                        <p className="text-2xl font-semibold">{streak.total_completed}</p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Total assignments</p>
+                        <p className="text-2xl font-semibold">{streak.total_assignments}</p>
+                      </div>
+                    </div>
+                    <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+                      Analytics last updated {analyticsUpdatedLabel}. Historical streak snapshots
+                      are preserved for upcoming gamification features.
+                    </div>
                   </CardContent>
                 </Card>
               </div>

--- a/app/dashboard/components/overview.tsx
+++ b/app/dashboard/components/overview.tsx
@@ -2,63 +2,29 @@
 
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts"
 
-const data = [
-  {
-    name: "Jan",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Feb",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Mar",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Apr",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "May",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Jun",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Jul",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Aug",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Sep",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Oct",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Nov",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Dec",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-]
+export type OverviewDatum = {
+  label: string
+  value: number
+}
 
-export function Overview() {
+interface OverviewProps {
+  data: OverviewDatum[]
+}
+
+export function Overview({ data }: OverviewProps) {
+  if (!data.length) {
+    return (
+      <div className="flex h-[350px] w-full items-center justify-center text-sm text-muted-foreground">
+        No streak history yet. Complete your chores to build momentum.
+      </div>
+    )
+  }
+
   return (
     <ResponsiveContainer width="100%" height={350}>
       <BarChart data={data}>
         <XAxis
-          dataKey="name"
+          dataKey="label"
           stroke="#888888"
           fontSize={12}
           tickLine={false}
@@ -69,10 +35,11 @@ export function Overview() {
           fontSize={12}
           tickLine={false}
           axisLine={false}
-          tickFormatter={(value) => `$${value}`}
+          allowDecimals={false}
+          tickFormatter={(value) => `${value}d`}
         />
         <Bar
-          dataKey="total"
+          dataKey="value"
           fill="currentColor"
           radius={[4, 4, 0, 0]}
           className="fill-primary"

--- a/app/dashboard/components/recent-sales.tsx
+++ b/app/dashboard/components/recent-sales.tsx
@@ -1,71 +1,59 @@
-import {
-    Avatar,
-    AvatarFallback,
-    AvatarImage,
-  } from "@/components/ui/avatar"
-  
-  export function RecentSales() {
+import { format, formatDistanceToNow } from "date-fns"
+
+export type Reminder = {
+  id: number
+  title: string
+  body: string
+  scheduledFor: string
+  dueDate?: string | null
+  deliveredAt?: string | null
+  choreTitle?: string | null
+}
+
+export function RecentSales({ reminders }: { reminders: Reminder[] }) {
+  if (!reminders.length) {
     return (
-      <div className="space-y-8">
-        <div className="flex items-center">
-          <Avatar className="size-9">
-            <AvatarImage src="/avatars/01.png" alt="Avatar" />
-            <AvatarFallback>OM</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">Olivia Martin</p>
-            <p className="text-sm text-muted-foreground">
-              olivia.martin@email.com
-            </p>
-          </div>
-          <div className="ml-auto font-medium">+$1,999.00</div>
-        </div>
-        <div className="flex items-center">
-          <Avatar className="flex size-9 items-center justify-center space-y-0 border">
-            <AvatarImage src="/avatars/02.png" alt="Avatar" />
-            <AvatarFallback>JL</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">Jackson Lee</p>
-            <p className="text-sm text-muted-foreground">jackson.lee@email.com</p>
-          </div>
-          <div className="ml-auto font-medium">+$39.00</div>
-        </div>
-        <div className="flex items-center">
-          <Avatar className="size-9">
-            <AvatarImage src="/avatars/03.png" alt="Avatar" />
-            <AvatarFallback>IN</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">Isabella Nguyen</p>
-            <p className="text-sm text-muted-foreground">
-              isabella.nguyen@email.com
-            </p>
-          </div>
-          <div className="ml-auto font-medium">+$299.00</div>
-        </div>
-        <div className="flex items-center">
-          <Avatar className="size-9">
-            <AvatarImage src="/avatars/04.png" alt="Avatar" />
-            <AvatarFallback>WK</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">William Kim</p>
-            <p className="text-sm text-muted-foreground">will@email.com</p>
-          </div>
-          <div className="ml-auto font-medium">+$99.00</div>
-        </div>
-        <div className="flex items-center">
-          <Avatar className="size-9">
-            <AvatarImage src="/avatars/05.png" alt="Avatar" />
-            <AvatarFallback>SD</AvatarFallback>
-          </Avatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">Sofia Davis</p>
-            <p className="text-sm text-muted-foreground">sofia.davis@email.com</p>
-          </div>
-          <div className="ml-auto font-medium">+$39.00</div>
-        </div>
-      </div>
+      <p className="text-sm text-muted-foreground">
+        No chore reminders have been scheduled yet.
+      </p>
     )
   }
+
+  return (
+    <div className="space-y-4">
+      {reminders.map((reminder) => {
+        const scheduledText = formatDistanceToNow(new Date(reminder.scheduledFor), {
+          addSuffix: true,
+        })
+        const deliveredText =
+          reminder.deliveredAt && !Number.isNaN(new Date(reminder.deliveredAt).getTime())
+            ? formatDistanceToNow(new Date(reminder.deliveredAt), { addSuffix: true })
+            : null
+        const dueText =
+          reminder.dueDate && !Number.isNaN(new Date(reminder.dueDate).getTime())
+            ? format(new Date(reminder.dueDate), "MMM d, yyyy")
+            : null
+
+        return (
+          <div
+            key={reminder.id}
+            className="space-y-2 rounded-lg border border-border p-3"
+          >
+            <div>
+              <p className="text-sm font-medium leading-none">{reminder.title}</p>
+              <p className="text-sm text-muted-foreground">{reminder.body}</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              {reminder.choreTitle ? (
+                <span className="font-medium text-foreground">{reminder.choreTitle}</span>
+              ) : null}
+              {dueText ? <span>Due {dueText}</span> : null}
+              <span>Scheduled {scheduledText}</span>
+              {deliveredText ? <span>Sent {deliveredText}</span> : null}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -483,6 +483,136 @@ export type Database = {
         }
         Relationships: []
       }
+      chore_assignments: {
+        Row: {
+          chore_title: string
+          completed_at: string | null
+          created_at: string
+          due_date: string
+          id: number
+          inserted_by: string
+          member_id: string
+          notes: string | null
+          updated_at: string
+        }
+        Insert: {
+          chore_title: string
+          completed_at?: string | null
+          created_at?: string
+          due_date: string
+          id?: number
+          inserted_by?: string
+          member_id: string
+          notes?: string | null
+          updated_at?: string
+        }
+        Update: {
+          chore_title?: string
+          completed_at?: string | null
+          created_at?: string
+          due_date?: string
+          id?: number
+          inserted_by?: string
+          member_id?: string
+          notes?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chore_assignments_inserted_by_fkey"
+            columns: ["inserted_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chore_assignments_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      chore_member_streaks: {
+        Row: {
+          current_streak: number
+          last_completed_date: string | null
+          longest_streak: number
+          member_id: string
+          total_assignments: number
+          total_completed: number
+          updated_at: string
+        }
+        Insert: {
+          current_streak?: number
+          last_completed_date?: string | null
+          longest_streak?: number
+          member_id: string
+          total_assignments?: number
+          total_completed?: number
+          updated_at?: string
+        }
+        Update: {
+          current_streak?: number
+          last_completed_date?: string | null
+          longest_streak?: number
+          member_id?: string
+          total_assignments?: number
+          total_completed?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chore_member_streaks_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      chore_streak_snapshots: {
+        Row: {
+          created_at: string
+          current_streak: number
+          id: number
+          longest_streak: number
+          member_id: string
+          snapshot_date: string
+          total_assignments: number
+          total_completed: number
+        }
+        Insert: {
+          created_at?: string
+          current_streak: number
+          id?: number
+          longest_streak: number
+          member_id: string
+          snapshot_date: string
+          total_assignments: number
+          total_completed: number
+        }
+        Update: {
+          created_at?: string
+          current_streak?: number
+          id?: number
+          longest_streak?: number
+          member_id?: string
+          snapshot_date?: string
+          total_assignments?: number
+          total_completed?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chore_streak_snapshots_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       countries: {
         Row: {
           continent: Database["public"]["Enums"]["continents"] | null
@@ -1558,6 +1688,60 @@ export type Database = {
         }
         Relationships: []
       }
+      tenant_notifications: {
+        Row: {
+          assignment_id: number | null
+          body: string
+          created_at: string
+          delivered_at: string | null
+          id: number
+          member_id: string
+          metadata: Json | null
+          notification_type: string
+          scheduled_for: string
+          title: string
+        }
+        Insert: {
+          assignment_id?: number | null
+          body: string
+          created_at?: string
+          delivered_at?: string | null
+          id?: number
+          member_id: string
+          metadata?: Json | null
+          notification_type: string
+          scheduled_for?: string
+          title: string
+        }
+        Update: {
+          assignment_id?: number | null
+          body?: string
+          created_at?: string
+          delivered_at?: string | null
+          id?: number
+          member_id?: string
+          metadata?: Json | null
+          notification_type?: string
+          scheduled_for?: string
+          title?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_notifications_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "chore_assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tenant_notifications_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       todos: {
         Row: {
           created_at: string
@@ -1598,6 +1782,19 @@ export type Database = {
       }
     }
     Views: {
+      chore_member_streak_overview: {
+        Row: {
+          completion_percent: number | null
+          current_streak: number | null
+          last_completed_date: string | null
+          longest_streak: number | null
+          member_id: string | null
+          total_assignments: number | null
+          total_completed: number | null
+          updated_at: string | null
+        }
+        Relationships: []
+      }
       package_utilization: {
         Row: {
           created_at: string | null
@@ -1637,6 +1834,10 @@ export type Database = {
       }
       decrement_package_usage: {
         Args: { package_id: string }
+        Returns: undefined
+      }
+      refresh_chore_member_streaks: {
+        Args: Record<PropertyKey, never>
         Returns: undefined
       }
       get_page_parents: {

--- a/supabase/migrations/20250718_chore_analytics.sql
+++ b/supabase/migrations/20250718_chore_analytics.sql
@@ -1,0 +1,286 @@
+create table public.chore_assignments (
+  id bigint generated always as identity primary key,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  member_id uuid not null references public.profiles(id) on delete cascade,
+  chore_title text not null,
+  due_date date not null,
+  completed_at timestamptz null,
+  notes text,
+  inserted_by uuid not null default auth.uid(),
+  constraint chore_assignments_due_date_check check (due_date >= date '2000-01-01')
+);
+
+alter table public.chore_assignments
+  add constraint chore_assignments_inserted_by_fkey foreign key (inserted_by) references public.profiles(id) on delete cascade;
+
+create index idx_chore_assignments_member on public.chore_assignments(member_id);
+create index idx_chore_assignments_due_date on public.chore_assignments(due_date);
+create index idx_chore_assignments_completed on public.chore_assignments(completed_at);
+
+create or replace function public.set_chore_assignment_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger set_chore_assignment_updated_at
+before update on public.chore_assignments
+for each row
+execute function public.set_chore_assignment_updated_at();
+
+alter table public.chore_assignments enable row level security;
+
+create policy "Members can manage their chore assignments"
+  on public.chore_assignments
+  for all
+  using (member_id = auth.uid())
+  with check (member_id = auth.uid());
+
+create table public.chore_member_streaks (
+  member_id uuid primary key references public.profiles(id) on delete cascade,
+  current_streak integer not null default 0,
+  longest_streak integer not null default 0,
+  last_completed_date date,
+  total_completed integer not null default 0,
+  total_assignments integer not null default 0,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.chore_member_streaks enable row level security;
+
+create policy "Members can view their streaks"
+  on public.chore_member_streaks
+  for select
+  using (member_id = auth.uid());
+
+create table public.chore_streak_snapshots (
+  id bigint generated always as identity primary key,
+  member_id uuid not null references public.profiles(id) on delete cascade,
+  snapshot_date date not null,
+  current_streak integer not null,
+  longest_streak integer not null,
+  total_completed integer not null,
+  total_assignments integer not null,
+  created_at timestamptz not null default now(),
+  constraint chore_streak_snapshots_snapshot_unique unique (member_id, snapshot_date)
+);
+
+create index idx_chore_streak_snapshots_member_date on public.chore_streak_snapshots(member_id, snapshot_date);
+
+alter table public.chore_streak_snapshots enable row level security;
+
+create policy "Members can view their streak history"
+  on public.chore_streak_snapshots
+  for select
+  using (member_id = auth.uid());
+
+create table public.tenant_notifications (
+  id bigint generated always as identity primary key,
+  member_id uuid not null references public.profiles(id) on delete cascade,
+  assignment_id bigint references public.chore_assignments(id) on delete cascade,
+  notification_type text not null,
+  title text not null,
+  body text not null,
+  metadata jsonb,
+  scheduled_for timestamptz not null default now(),
+  delivered_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create unique index tenant_notifications_assignment_type_idx on public.tenant_notifications (assignment_id, notification_type);
+
+alter table public.tenant_notifications enable row level security;
+
+create policy "Members can view their notifications"
+  on public.tenant_notifications
+  for select
+  using (member_id = auth.uid());
+
+create policy "Members can acknowledge their notifications"
+  on public.tenant_notifications
+  for update
+  using (member_id = auth.uid())
+  with check (member_id = auth.uid());
+
+create or replace function public.refresh_chore_member_streaks()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  run_at timestamptz := now();
+begin
+  with assignment_members as (
+    select distinct member_id from public.chore_assignments
+  ),
+  completions as (
+    select
+      member_id,
+      (completed_at at time zone 'utc')::date as completed_date
+    from public.chore_assignments
+    where completed_at is not null
+    group by member_id, (completed_at at time zone 'utc')::date
+  ),
+  ordered as (
+    select
+      member_id,
+      completed_date,
+      row_number() over (partition by member_id order by completed_date) as rn
+    from completions
+  ),
+  grouped as (
+    select
+      member_id,
+      completed_date,
+      completed_date - (rn::int * interval '1 day') as grp
+    from ordered
+  ),
+  streaks as (
+    select
+      member_id,
+      max(completed_date) as last_completed_date,
+      count(*)::int as streak_length
+    from grouped
+    group by member_id, grp
+  ),
+  latest as (
+    select
+      member_id,
+      last_completed_date,
+      streak_length,
+      row_number() over (partition by member_id order by last_completed_date desc) as rn
+    from streaks
+  ),
+  aggregates as (
+    select
+      am.member_id,
+      coalesce(
+        max(
+          case
+            when l.rn = 1 and l.last_completed_date >= (run_at::date - 1)
+            then l.streak_length
+            else 0
+          end
+        ),
+        0
+      ) as current_streak,
+      coalesce(max(s.streak_length), 0) as longest_streak,
+      max(case when l.rn = 1 then l.last_completed_date end) as last_completed_date,
+      count(ca.*) filter (where ca.completed_at is not null) as total_completed,
+      count(ca.*) as total_assignments
+    from assignment_members am
+    left join latest l on am.member_id = l.member_id
+    left join streaks s on am.member_id = s.member_id
+    left join public.chore_assignments ca on ca.member_id = am.member_id
+    group by am.member_id
+  )
+  insert into public.chore_member_streaks as cms (
+    member_id,
+    current_streak,
+    longest_streak,
+    last_completed_date,
+    total_completed,
+    total_assignments,
+    updated_at
+  )
+  select
+    ag.member_id,
+    ag.current_streak,
+    ag.longest_streak,
+    ag.last_completed_date,
+    ag.total_completed,
+    ag.total_assignments,
+    run_at
+  from aggregates ag
+  on conflict (member_id) do update
+  set
+    current_streak = excluded.current_streak,
+    longest_streak = excluded.longest_streak,
+    last_completed_date = excluded.last_completed_date,
+    total_completed = excluded.total_completed,
+    total_assignments = excluded.total_assignments,
+    updated_at = excluded.updated_at;
+
+  insert into public.chore_streak_snapshots as snap (
+    member_id,
+    snapshot_date,
+    current_streak,
+    longest_streak,
+    total_completed,
+    total_assignments,
+    created_at
+  )
+  select
+    ag.member_id,
+    run_at::date,
+    ag.current_streak,
+    ag.longest_streak,
+    ag.total_completed,
+    ag.total_assignments,
+    run_at
+  from aggregates ag
+  on conflict (member_id, snapshot_date) do update
+  set
+    current_streak = excluded.current_streak,
+    longest_streak = excluded.longest_streak,
+    total_completed = excluded.total_completed,
+    total_assignments = excluded.total_assignments,
+    created_at = excluded.created_at;
+
+  insert into public.tenant_notifications (
+    member_id,
+    assignment_id,
+    notification_type,
+    title,
+    body,
+    metadata,
+    scheduled_for,
+    created_at
+  )
+  select
+    ca.member_id,
+    ca.id,
+    'chore_deadline',
+    'Upcoming chore deadline',
+    format('"%s" is due on %s. Keep your streak alive!', ca.chore_title, to_char(ca.due_date, 'FMMon DD, YYYY')),
+    jsonb_build_object(
+      'assignment_id', ca.id,
+      'chore_title', ca.chore_title,
+      'due_date', ca.due_date
+    ),
+    run_at,
+    run_at
+  from public.chore_assignments ca
+  where ca.completed_at is null
+    and ca.due_date = run_at::date + 2
+    and not exists (
+      select 1
+      from public.tenant_notifications tn
+      where tn.assignment_id = ca.id
+        and tn.notification_type = 'chore_deadline'
+    );
+end;
+$$;
+
+grant execute on function public.refresh_chore_member_streaks() to anon;
+grant execute on function public.refresh_chore_member_streaks() to authenticated;
+grant execute on function public.refresh_chore_member_streaks() to service_role;
+
+create or replace view public.chore_member_streak_overview as
+select
+  cms.member_id,
+  cms.current_streak,
+  cms.longest_streak,
+  cms.last_completed_date,
+  cms.total_completed,
+  cms.total_assignments,
+  case
+    when cms.total_assignments = 0 then 0::numeric
+    else round((cms.total_completed::numeric / cms.total_assignments::numeric) * 100, 2)
+  end as completion_percent,
+  cms.updated_at
+from public.chore_member_streaks cms;


### PR DESCRIPTION
## Summary
- add Supabase schema for chore assignments, streak metrics, snapshots, and tenant notifications
- implement the refresh_chore_member_streaks RPC plus a cron endpoint to run analytics and schedule reminders
- surface chore streak metrics, history, and reminders on the tenant dashboard with persistent analytics storage

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0f10f1083288f69cfcb46621a52