### PR TITLE
Add chore credit ledger and cover completion flow

### DIFF
--- a/lib/chores.ts
+++ b/lib/chores.ts
@@ -1,0 +1,295 @@
+export type CompletionAction = 'self' | 'cover'
+
+export interface LedgerEntry {
+  id: string
+  createdAt: Date
+  memberId: string
+  assignmentId: string
+  creditsDelta: number
+  reason: string
+}
+
+export interface LedgerEntryInput {
+  memberId: string
+  assignmentId: string
+  creditsDelta: number
+  reason: string
+  id?: string
+  createdAt?: Date
+}
+
+export interface MemberProfile {
+  id: string
+  name?: string
+  creditBalance?: number
+  [key: string]: unknown
+}
+
+export interface ChoreAssignment {
+  id: string
+  assigneeId: string
+  status: 'pending' | 'completed'
+  title?: string
+  completedById?: string | null
+  completionAction?: CompletionAction | null
+  coveredById?: string | null
+  completedAt?: Date | null
+}
+
+export interface AuditEvent {
+  id: string
+  timestamp: Date
+  type: 'chore_completion'
+  assignmentId: string
+  actorId: string
+  metadata: Record<string, unknown>
+}
+
+export interface CompletionContext {
+  assignment: ChoreAssignment
+  actorId: string
+  ledger: ChoreCreditsLedger
+  auditTrail: AuditTrail
+  members: MemberDirectory
+  action?: CompletionAction
+  credits?: number
+  reason?: string
+  coverMemberId?: string
+}
+
+export interface CompletionResult {
+  assignment: ChoreAssignment
+  ledgerEntries: LedgerEntry[]
+  auditEvent: AuditEvent
+  balances: Record<string, number>
+}
+
+export type MemberDirectory = Map<string, MemberProfile> | MemberProfile[]
+
+function assertNonZeroCredits(delta: number) {
+  if (!Number.isFinite(delta)) {
+    throw new Error('credits must be a finite number')
+  }
+  if (delta <= 0) {
+    throw new Error('credits must be a positive value')
+  }
+}
+
+function nextIdentifier(prefix: string, counter: number) {
+  return `${prefix}-${counter}`
+}
+
+export class ChoreCreditsLedger {
+  private entries: LedgerEntry[]
+  private counter: number
+
+  constructor(entries: LedgerEntry[] = []) {
+    this.entries = entries.map((entry) => ({ ...entry }))
+    this.counter = entries.length
+  }
+
+  record(input: LedgerEntryInput): LedgerEntry {
+    if (!input.memberId) {
+      throw new Error('memberId is required for ledger entry')
+    }
+    if (!input.assignmentId) {
+      throw new Error('assignmentId is required for ledger entry')
+    }
+    if (input.creditsDelta === 0) {
+      throw new Error('creditsDelta must not be zero')
+    }
+
+    const id = input.id ?? nextIdentifier('ledger', ++this.counter)
+    const createdAt = input.createdAt ? new Date(input.createdAt) : new Date()
+    const entry: LedgerEntry = {
+      id,
+      createdAt,
+      memberId: input.memberId,
+      assignmentId: input.assignmentId,
+      creditsDelta: input.creditsDelta,
+      reason: input.reason,
+    }
+
+    this.entries.push(entry)
+    return entry
+  }
+
+  all(): readonly LedgerEntry[] {
+    return [...this.entries]
+  }
+
+  getBalance(memberId: string): number {
+    return this.entries
+      .filter((entry) => entry.memberId === memberId)
+      .reduce((total, entry) => total + entry.creditsDelta, 0)
+  }
+
+  getMemberBalances(): Map<string, number> {
+    const balances = new Map<string, number>()
+    for (const entry of this.entries) {
+      balances.set(entry.memberId, (balances.get(entry.memberId) ?? 0) + entry.creditsDelta)
+    }
+    return balances
+  }
+}
+
+export class AuditTrail {
+  private events: AuditEvent[]
+  private counter: number
+
+  constructor(events: AuditEvent[] = []) {
+    this.events = events.map((event) => ({
+      ...event,
+      timestamp: new Date(event.timestamp),
+      metadata: { ...event.metadata },
+    }))
+    this.counter = events.length
+  }
+
+  record(event: Omit<AuditEvent, 'id' | 'timestamp'> & { id?: string; timestamp?: Date }): AuditEvent {
+    const id = event.id ?? nextIdentifier('audit', ++this.counter)
+    const timestamp = event.timestamp ? new Date(event.timestamp) : new Date()
+    const metadata = { ...event.metadata }
+    const stored: AuditEvent = { id, timestamp, ...event, metadata }
+    this.events.push(stored)
+    return stored
+  }
+
+  all(): readonly AuditEvent[] {
+    return [...this.events]
+  }
+
+  findByAssignment(assignmentId: string): AuditEvent[] {
+    return this.events.filter((event) => event.assignmentId === assignmentId)
+  }
+}
+
+export function updateMemberBalances(directory: MemberDirectory, ledger: ChoreCreditsLedger): Record<string, number> {
+  const balancesFromLedger = ledger.getMemberBalances()
+  const knownIds = new Set<string>()
+  const results: Record<string, number> = {}
+
+  if (Array.isArray(directory)) {
+    for (const profile of directory) {
+      knownIds.add(profile.id)
+      const balance = balancesFromLedger.get(profile.id) ?? 0
+      profile.creditBalance = balance
+      results[profile.id] = balance
+    }
+  } else {
+    for (const [id, profile] of directory.entries()) {
+      knownIds.add(id)
+      const balance = balancesFromLedger.get(id) ?? 0
+      profile.creditBalance = balance
+      results[id] = balance
+    }
+    for (const [memberId, balance] of balancesFromLedger.entries()) {
+      if (!knownIds.has(memberId)) {
+        directory.set(memberId, { id: memberId, creditBalance: balance })
+        results[memberId] = balance
+      }
+    }
+  }
+
+  for (const [memberId, balance] of balancesFromLedger.entries()) {
+    if (!(memberId in results)) {
+      results[memberId] = balance
+    }
+  }
+
+  return results
+}
+
+export function completeChoreAssignment(context: CompletionContext): CompletionResult {
+  const {
+    assignment,
+    actorId,
+    ledger,
+    auditTrail,
+    members,
+    action = 'self',
+    credits = 1,
+    reason = 'Chore completed',
+    coverMemberId,
+  } = context
+
+  assertNonZeroCredits(credits)
+
+  const ledgerEntries: LedgerEntry[] = []
+  const baseReason = reason.trim()
+  const creditReason = action === 'cover' ? `${baseReason} (cover credit)` : baseReason
+  const debitReason = action === 'cover' ? `${baseReason} (cover debit)` : baseReason
+  const completedAt = new Date()
+
+  if (action === 'self') {
+    ledgerEntries.push(
+      ledger.record({
+        memberId: assignment.assigneeId,
+        assignmentId: assignment.id,
+        creditsDelta: credits,
+        reason: creditReason,
+      })
+    )
+  } else if (action === 'cover') {
+    const coveringMemberId = coverMemberId ?? actorId
+    ledgerEntries.push(
+      ledger.record({
+        memberId: coveringMemberId,
+        assignmentId: assignment.id,
+        creditsDelta: credits,
+        reason: creditReason,
+      })
+    )
+
+    if (coveringMemberId !== assignment.assigneeId) {
+      ledgerEntries.push(
+        ledger.record({
+          memberId: assignment.assigneeId,
+          assignmentId: assignment.id,
+          creditsDelta: -credits,
+          reason: debitReason,
+        })
+      )
+    }
+  } else {
+    throw new Error(`Unsupported completion action: ${action}`)
+  }
+
+  const balances = updateMemberBalances(members, ledger)
+
+  const coveringMemberId = action === 'cover' ? coverMemberId ?? actorId : undefined
+  const updatedAssignment: ChoreAssignment = {
+    ...assignment,
+    status: 'completed',
+    completedAt,
+    completionAction: action,
+    completedById: coveringMemberId ?? actorId,
+    coveredById: action === 'cover' ? coveringMemberId ?? actorId : assignment.coveredById ?? null,
+  }
+
+  const auditEvent = auditTrail.record({
+    type: 'chore_completion',
+    assignmentId: assignment.id,
+    actorId,
+    metadata: {
+      action,
+      reason: baseReason,
+      credits,
+      ledgerEntries: ledgerEntries.map((entry) => ({
+        id: entry.id,
+        memberId: entry.memberId,
+        assignmentId: entry.assignmentId,
+        creditsDelta: entry.creditsDelta,
+        reason: entry.reason,
+      })),
+      resultingBalances: balances,
+    },
+  })
+
+  return {
+    assignment: updatedAssignment,
+    ledgerEntries,
+    auditEvent,
+    balances,
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -483,6 +483,33 @@ export type Database = {
         }
         Relationships: []
       }
+      chore_credits: {
+        Row: {
+          assignment_id: string
+          credits_delta: number
+          created_at: string
+          id: number
+          member_id: string
+          reason: string
+        }
+        Insert: {
+          assignment_id: string
+          credits_delta: number
+          created_at?: string
+          id?: number
+          member_id: string
+          reason: string
+        }
+        Update: {
+          assignment_id?: string
+          credits_delta?: number
+          created_at?: string
+          id?: number
+          member_id?: string
+          reason?: string
+        }
+        Relationships: []
+      }
       countries: {
         Row: {
           continent: Database["public"]["Enums"]["continents"] | null

--- a/supabase/migrations/20250713_add_chore_credits.sql
+++ b/supabase/migrations/20250713_add_chore_credits.sql
@@ -1,0 +1,17 @@
+create table if not exists public.chore_credits (
+  id bigint generated always as identity primary key,
+  created_at timestamptz not null default now(),
+  member_id uuid not null,
+  assignment_id uuid not null,
+  credits_delta integer not null,
+  reason text not null
+);
+
+comment on table public.chore_credits is 'Ledger of credit movements for household chore assignments.';
+comment on column public.chore_credits.member_id is 'Profile identifier receiving or surrendering credits.';
+comment on column public.chore_credits.assignment_id is 'Chore assignment linked to the credit adjustment.';
+comment on column public.chore_credits.credits_delta is 'Positive values add credits, negative values remove credits.';
+comment on column public.chore_credits.reason is 'Human readable explanation for the credit change.';
+
+create index if not exists chore_credits_member_idx on public.chore_credits (member_id);
+create index if not exists chore_credits_assignment_idx on public.chore_credits (assignment_id);

--- a/tests/chore-credits.test.ts
+++ b/tests/chore-credits.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AuditTrail,
+  ChoreCreditsLedger,
+  completeChoreAssignment,
+  type ChoreAssignment,
+  type MemberProfile,
+} from '@/lib/chores'
+
+describe('Chore credit ledger', () => {
+  it('records ledger entries for standard completions and updates balances', () => {
+    const ledger = new ChoreCreditsLedger()
+    const auditTrail = new AuditTrail()
+    const members = new Map<string, MemberProfile>([
+      ['member-1', { id: 'member-1', name: 'Alex' }],
+    ])
+
+    const assignment: ChoreAssignment = {
+      id: 'assignment-1',
+      assigneeId: 'member-1',
+      status: 'pending',
+    }
+
+    const result = completeChoreAssignment({
+      assignment,
+      actorId: 'member-1',
+      ledger,
+      auditTrail,
+      members,
+      credits: 2,
+      reason: 'Took out the trash',
+    })
+
+    expect(result.assignment).toMatchObject({
+      status: 'completed',
+      completedById: 'member-1',
+      completionAction: 'self',
+    })
+    expect(result.ledgerEntries).toHaveLength(1)
+    expect(result.ledgerEntries[0]).toMatchObject({
+      memberId: 'member-1',
+      creditsDelta: 2,
+      reason: 'Took out the trash',
+    })
+    expect(members.get('member-1')?.creditBalance).toBe(2)
+
+    const [event] = auditTrail.all()
+    expect(event.metadata).toMatchObject({
+      action: 'self',
+      reason: 'Took out the trash',
+      credits: 2,
+    })
+    expect(event.metadata).toHaveProperty('ledgerEntries')
+    expect(event.metadata).toHaveProperty('resultingBalances')
+    expect((event.metadata as Record<string, any>).resultingBalances).toMatchObject({
+      'member-1': 2,
+    })
+  })
+
+  it('transfers credits when another roommate covers the chore', () => {
+    const ledger = new ChoreCreditsLedger()
+    const auditTrail = new AuditTrail()
+    const members = new Map<string, MemberProfile>([
+      ['member-original', { id: 'member-original', name: 'Casey' }],
+      ['member-cover', { id: 'member-cover', name: 'Riley' }],
+    ])
+
+    const assignment: ChoreAssignment = {
+      id: 'assignment-55',
+      assigneeId: 'member-original',
+      status: 'pending',
+    }
+
+    const result = completeChoreAssignment({
+      assignment,
+      actorId: 'member-cover',
+      ledger,
+      auditTrail,
+      members,
+      action: 'cover',
+      coverMemberId: 'member-cover',
+      credits: 3,
+      reason: 'Covered cleaning rotation',
+    })
+
+    expect(result.assignment).toMatchObject({
+      status: 'completed',
+      completedById: 'member-cover',
+      coveredById: 'member-cover',
+      completionAction: 'cover',
+    })
+
+    expect(result.ledgerEntries).toHaveLength(2)
+    expect(result.ledgerEntries).toEqual([
+      expect.objectContaining({
+        memberId: 'member-cover',
+        creditsDelta: 3,
+        reason: 'Covered cleaning rotation (cover credit)',
+      }),
+      expect.objectContaining({
+        memberId: 'member-original',
+        creditsDelta: -3,
+        reason: 'Covered cleaning rotation (cover debit)',
+      }),
+    ])
+
+    expect(members.get('member-cover')?.creditBalance).toBe(3)
+    expect(members.get('member-original')?.creditBalance).toBe(-3)
+
+    const [event] = auditTrail.findByAssignment('assignment-55')
+    expect(event.metadata).toMatchObject({
+      action: 'cover',
+      reason: 'Covered cleaning rotation',
+      credits: 3,
+    })
+    const metadata = event.metadata as Record<string, any>
+    expect(metadata.ledgerEntries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ memberId: 'member-cover', creditsDelta: 3 }),
+        expect.objectContaining({ memberId: 'member-original', creditsDelta: -3 }),
+      ])
+    )
+    expect(metadata.resultingBalances).toMatchObject({
+      'member-cover': 3,
+      'member-original': -3,
+    })
+  })
+
+  it('does not mutate the original assignment reference', () => {
+    const ledger = new ChoreCreditsLedger()
+    const auditTrail = new AuditTrail()
+    const members: MemberProfile[] = [
+      { id: 'resident-1', name: 'Avery' },
+    ]
+
+    const assignment: ChoreAssignment = {
+      id: 'assignment-9',
+      assigneeId: 'resident-1',
+      status: 'pending',
+    }
+
+    const originalSnapshot = { ...assignment }
+
+    const result = completeChoreAssignment({
+      assignment,
+      actorId: 'resident-1',
+      ledger,
+      auditTrail,
+      members,
+    })
+
+    expect(assignment).toEqual(originalSnapshot)
+    expect(result.assignment).not.toBe(assignment)
+    expect(members[0].creditBalance).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add a Supabase migration for the `chore_credits` ledger and expose the table in the generated types
- implement chore completion logic that records ledger movements, updates member balances, and logs audit entries including cover scenarios
- add unit tests covering the new ledger behaviour and cover-credit transfer rules

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0f3b8d883289cceb902d46284da