### PR TITLE
Add tenant chore assignments with realtime updates

### DIFF
--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -1,5 +1,6 @@
+import { cookies } from "next/headers"
 import { Metadata } from "next"
-import Image from "next/image"
+import { redirect } from "next/navigation"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -22,13 +23,30 @@ import { RecentSales } from "@/app/dashboard/components/recent-sales"
 import { Search } from "@/app/dashboard/components/search"
 import TeamSwitcher from "@/app/dashboard/components/team-switcher"
 import { UserNav } from "@/app/dashboard/components/user-nav"
+import { createClient } from "@/utils/supa-server-actions"
 
 export const metadata: Metadata = {
   title: "Onyx Dashboard",
   description: "Manage your Onyx account and users.",
 }
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error) {
+    console.error("Failed to fetch authenticated user for dashboard", error)
+  }
+
+  if (!user) {
+    redirect("/auth")
+  }
+
   return (
     <>
       <div className="xs:flex max-w-dvw w-full flex-col">
@@ -173,7 +191,7 @@ export default function DashboardPage() {
                     <CardTitle>Overview</CardTitle>
                   </CardHeader>
                   <CardContent className="pl-2">
-                    <Overview />
+                    <Overview tenantId={user?.id} />
                   </CardContent>
                 </Card>
                 <Card className="col-span-3">

--- a/app/dashboard/chores/components/chore-assignments-client.tsx
+++ b/app/dashboard/chores/components/chore-assignments-client.tsx
@@ -1,0 +1,418 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { format } from "date-fns"
+import { CheckCircle2, CircleDot, UploadCloud, XCircle } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { toast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+import type { Database } from "@/lib/supabase"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+type ChoreAssignment = Database["public"]["Tables"]["chore_assignments"]["Row"]
+type ChoreStatus = Database["public"]["Enums"]["chore_assignment_status"]
+
+type Props = {
+  initialAssignments: ChoreAssignment[]
+  tenantId: string
+}
+
+type RealtimePayload = {
+  eventType: "INSERT" | "UPDATE" | "DELETE"
+  new: ChoreAssignment
+  old: ChoreAssignment
+}
+
+const statusOrder: ChoreStatus[] = ["pending", "completed", "approved", "rejected"]
+
+const statusLabels: Record<ChoreStatus, string> = {
+  pending: "Pending",
+  completed: "Completed",
+  approved: "Approved",
+  rejected: "Rejected",
+}
+
+const statusStyles: Record<ChoreStatus, string> = {
+  pending:
+    "border-amber-200 bg-amber-100 text-amber-900 dark:border-amber-400/30 dark:bg-amber-900/30 dark:text-amber-200",
+  completed:
+    "border-blue-200 bg-blue-100 text-blue-900 dark:border-blue-400/30 dark:bg-blue-900/30 dark:text-blue-200",
+  approved:
+    "border-emerald-200 bg-emerald-100 text-emerald-900 dark:border-emerald-400/30 dark:bg-emerald-900/30 dark:text-emerald-200",
+  rejected:
+    "border-rose-200 bg-rose-100 text-rose-900 dark:border-rose-400/30 dark:bg-rose-900/30 dark:text-rose-200",
+}
+
+const proofBucket = "chore-proofs"
+
+function sortAssignments(assignments: ChoreAssignment[]): ChoreAssignment[] {
+  return [...assignments].sort((a, b) => {
+    const dueA = a.due_date ? new Date(a.due_date).getTime() : Number.POSITIVE_INFINITY
+    const dueB = b.due_date ? new Date(b.due_date).getTime() : Number.POSITIVE_INFINITY
+
+    if (Number.isNaN(dueA) && Number.isNaN(dueB)) {
+      return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    }
+
+    if (Number.isNaN(dueA)) return 1
+    if (Number.isNaN(dueB)) return -1
+
+    if (dueA === dueB) {
+      return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    }
+
+    return dueA - dueB
+  })
+}
+
+function formatDate(value: string | null, fallback?: string) {
+  if (!value) return fallback ?? null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return fallback ?? null
+  }
+  return format(parsed, "MMM d, yyyy")
+}
+
+function formatDateTime(value: string | null) {
+  if (!value) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+  return format(parsed, "MMM d, yyyy 'at' p")
+}
+
+function getPublicProofUrl(client: TypedSupabaseClient, path: string) {
+  return client.storage.from(proofBucket).getPublicUrl(path).data.publicUrl
+}
+
+export default function ChoreAssignmentsClient({ initialAssignments, tenantId }: Props) {
+  const supabase = useSupabaseBrowser()
+  const [assignments, setAssignments] = useState<ChoreAssignment[]>(() => sortAssignments(initialAssignments))
+  const [updatingId, setUpdatingId] = useState<string | null>(null)
+  const [uploadingId, setUploadingId] = useState<string | null>(null)
+  const fileInputs = useRef<Record<string, HTMLInputElement | null>>({})
+
+  useEffect(() => {
+    setAssignments(sortAssignments(initialAssignments))
+  }, [initialAssignments])
+
+  const statusSummary = useMemo(() => {
+    return statusOrder.map((status) => ({
+      status,
+      count: assignments.filter((assignment) => assignment.status === status).length,
+    }))
+  }, [assignments])
+
+  const proofUrls = useMemo(() => {
+    const urls: Record<string, string> = {}
+
+    assignments.forEach((assignment) => {
+      if (assignment.proof_url) {
+        urls[assignment.id] = getPublicProofUrl(supabase, assignment.proof_url)
+      }
+    })
+
+    return urls
+  }, [assignments, supabase])
+
+  const upsertAssignment = useCallback((updated: ChoreAssignment) => {
+    setAssignments((current) => {
+      const next = [...current]
+      const index = next.findIndex((item) => item.id === updated.id)
+
+      if (index === -1) {
+        next.push(updated)
+      } else {
+        next[index] = updated
+      }
+
+      return sortAssignments(next)
+    })
+  }, [])
+
+  const removeAssignment = useCallback((removed: ChoreAssignment) => {
+    setAssignments((current) => current.filter((item) => item.id !== removed.id))
+  }, [])
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(`chore-assignments-${tenantId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "chore_assignments",
+          filter: `tenant_id=eq.${tenantId}`,
+        },
+        (payload) => {
+          const data = payload as unknown as RealtimePayload
+
+          if (data.eventType === "DELETE") {
+            removeAssignment(data.old)
+            return
+          }
+
+          upsertAssignment(data.new)
+        },
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [removeAssignment, supabase, tenantId, upsertAssignment])
+
+  const handleToggleCompletion = useCallback(
+    async (assignment: ChoreAssignment) => {
+      const isCompleted = assignment.status === "completed" || assignment.status === "approved"
+      const nextStatus: ChoreStatus = isCompleted ? "pending" : "completed"
+      const completedAt = isCompleted ? null : new Date().toISOString()
+
+      setUpdatingId(assignment.id)
+
+      const { error } = await supabase
+        .from("chore_assignments")
+        .update({ status: nextStatus, completed_at: completedAt })
+        .eq("id", assignment.id)
+
+      if (error) {
+        console.error("Failed to toggle chore assignment", error)
+        toast({
+          title: "Something went wrong",
+          description: "We couldn't update the chore status. Please try again.",
+          variant: "destructive",
+        })
+      } else {
+        upsertAssignment({ ...assignment, status: nextStatus, completed_at: completedAt })
+        toast({
+          title: isCompleted ? "Marked as not done" : "Chore completed",
+          description: isCompleted
+            ? "The chore has been moved back to pending."
+            : "Nice work! We'll let everyone know this chore is complete.",
+        })
+      }
+
+      setUpdatingId(null)
+    },
+    [supabase, upsertAssignment],
+  )
+
+  const handleUploadProof = useCallback(
+    async (assignment: ChoreAssignment, file: File) => {
+      setUploadingId(assignment.id)
+
+      const path = `${assignment.id}/${Date.now()}-${file.name}`
+
+      const { error: uploadError } = await supabase.storage.from(proofBucket).upload(path, file, {
+        upsert: true,
+        cacheControl: "3600",
+      })
+
+      if (uploadError) {
+        console.error("Failed to upload chore proof", uploadError)
+        toast({
+          title: "Upload failed",
+          description: "We couldn't upload your proof image. Please try again.",
+          variant: "destructive",
+        })
+        setUploadingId(null)
+        return
+      }
+
+      const completedAt = new Date().toISOString()
+
+      const { error: updateError } = await supabase
+        .from("chore_assignments")
+        .update({
+          proof_url: path,
+          status: "completed",
+          completed_at: completedAt,
+        })
+        .eq("id", assignment.id)
+
+      if (updateError) {
+        console.error("Failed to update chore after proof upload", updateError)
+        toast({
+          title: "Couldn't save proof",
+          description: "Your file uploaded but we couldn't link it to the chore. Please try again.",
+          variant: "destructive",
+        })
+      } else {
+        const updated: ChoreAssignment = {
+          ...assignment,
+          proof_url: path,
+          status: "completed",
+          completed_at: completedAt,
+        }
+        upsertAssignment(updated)
+        toast({
+          title: "Proof uploaded",
+          description: "Your photo is ready for review.",
+        })
+      }
+
+      setUploadingId(null)
+    },
+    [supabase, upsertAssignment],
+  )
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {statusSummary.map(({ status, count }) => (
+          <Card key={status} className="border-dashed">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">{statusLabels[status]}</CardTitle>
+              {status === "approved" ? (
+                <CheckCircle2 className="size-4 text-emerald-500" />
+              ) : status === "rejected" ? (
+                <XCircle className="size-4 text-rose-500" />
+              ) : (
+                <CircleDot className="size-4 text-muted-foreground" />
+              )}
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{count}</div>
+              <p className="text-xs text-muted-foreground">Assignments marked as {statusLabels[status].toLowerCase()}.</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {assignments.length === 0 ? (
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle>No chores assigned yet</CardTitle>
+            <CardDescription>
+              When your property manager assigns a chore you&apos;ll see it here with the option to mark it complete or upload a proof photo.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {assignments.map((assignment) => {
+            const isCompleted = assignment.status === "completed" || assignment.status === "approved"
+            const proofUrl = assignment.proof_url ? proofUrls[assignment.id] : null
+
+            return (
+              <Card key={assignment.id} className="flex h-full flex-col">
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <CardTitle className="text-lg font-semibold leading-tight">
+                        {assignment.chore_title}
+                      </CardTitle>
+                      <CardDescription>
+                        {assignment.due_date
+                          ? `Due ${formatDate(assignment.due_date)}`
+                          : "No due date provided"}
+                      </CardDescription>
+                    </div>
+                    <div className="flex flex-col items-end gap-2">
+                      <Badge className={cn("border text-xs font-semibold uppercase", statusStyles[assignment.status])}>
+                        {statusLabels[assignment.status]}
+                      </Badge>
+                      {assignment.point_awarded ? (
+                        <span className="text-xs font-medium text-emerald-600 dark:text-emerald-300">
+                          +{assignment.points ?? 0} pts awarded
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">Worth {assignment.points ?? 0} pts</span>
+                      )}
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-muted-foreground">
+                  {assignment.description && <p>{assignment.description}</p>}
+
+                  {assignment.completed_at && (
+                    <p className="text-xs">
+                      Marked complete {formatDateTime(assignment.completed_at) ?? "recently"}
+                    </p>
+                  )}
+
+                  {proofUrl && (
+                    <div className="flex items-center justify-between rounded-lg border bg-muted/50 p-3 text-xs">
+                      <span className="font-medium text-muted-foreground">Proof uploaded</span>
+                      <a
+                        href={proofUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-semibold text-primary hover:underline"
+                      >
+                        View file
+                      </a>
+                    </div>
+                  )}
+                </CardContent>
+                <CardFooter className="mt-auto flex flex-wrap items-center gap-2">
+                  <Button
+                    onClick={() => handleToggleCompletion(assignment)}
+                    disabled={updatingId === assignment.id}
+                    variant={isCompleted ? "secondary" : "default"}
+                  >
+                    {updatingId === assignment.id
+                      ? "Saving..."
+                      : isCompleted
+                        ? "Mark as not done"
+                        : "Mark complete"}
+                  </Button>
+
+                  <div>
+                    <input
+                      accept="image/*,video/*"
+                      className="hidden"
+                      onChange={(event) => {
+                        const file = event.target.files?.[0]
+                        if (file) {
+                          void handleUploadProof(assignment, file)
+                        }
+                        event.target.value = ""
+                      }}
+                      ref={(element) => {
+                        fileInputs.current[assignment.id] = element
+                      }}
+                      type="file"
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => fileInputs.current[assignment.id]?.click()}
+                      disabled={uploadingId === assignment.id}
+                    >
+                      {uploadingId === assignment.id ? (
+                        "Uploading..."
+                      ) : assignment.proof_url ? (
+                        "Replace proof"
+                      ) : (
+                        <span className="flex items-center gap-2">
+                          <UploadCloud className="size-4" />
+                          Upload proof
+                        </span>
+                      )}
+                    </Button>
+                  </div>
+                </CardFooter>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/chores/page.tsx
+++ b/app/dashboard/chores/page.tsx
@@ -1,0 +1,56 @@
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+import type { Database } from "@/lib/supabase"
+import { createClient } from "@/utils/supa-server-actions"
+
+import ChoreAssignmentsClient from "./components/chore-assignments-client"
+
+type ChoreAssignment = Database["public"]["Tables"]["chore_assignments"]["Row"]
+
+export const revalidate = 0
+
+export default async function ChoresPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    console.error("Failed to load authenticated user", userError)
+  }
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const { data, error } = await supabase
+    .from("chore_assignments")
+    .select(
+      "id, chore_title, description, due_date, status, proof_url, completed_at, point_awarded, points, created_at, assigned_by, tenant_id"
+    )
+    .eq("tenant_id", user.id)
+    .order("due_date", { ascending: true, nullsFirst: false })
+    .order("created_at", { ascending: true })
+
+  if (error) {
+    console.error("Unable to load chore assignments", error)
+  }
+
+  const assignments: ChoreAssignment[] = data ?? []
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">My chore assignments</h1>
+        <p className="text-muted-foreground">
+          Stay on top of your shared responsibilities. Upload proof when you finish a chore or toggle completion to keep your roommates in the loop.
+        </p>
+      </div>
+      <ChoreAssignmentsClient initialAssignments={assignments} tenantId={user.id} />
+    </div>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,10 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import {
+        PersonIcon,
+        CrumpledPaperIcon,
+        CheckCircledIcon,
+} from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,16 +12,21 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/chores",
+                        text: "Chores",
+                        Icon: CheckCircledIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
 		},
 	];
 

--- a/app/dashboard/components/overview.tsx
+++ b/app/dashboard/components/overview.tsx
@@ -1,62 +1,86 @@
 "use client"
 
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts"
 
-const data = [
-  {
-    name: "Jan",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Feb",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Mar",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Apr",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "May",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Jun",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Jul",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Aug",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Sep",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Oct",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Nov",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-  {
-    name: "Dec",
-    total: Math.floor(Math.random() * 5000) + 1000,
-  },
-]
+import type { Database } from "@/lib/supabase"
+import useSupabaseBrowser from "@/utils/supabase-browser"
 
-export function Overview() {
+type ChoreStatus = Database["public"]["Enums"]["chore_assignment_status"]
+type StatusRow = Pick<Database["public"]["Tables"]["chore_assignments"]["Row"], "status">
+
+type ChartDatum = {
+  name: string
+  total: number
+}
+
+const statusOrder: ChoreStatus[] = ["pending", "completed", "approved", "rejected"]
+
+const statusLabels: Record<ChoreStatus, string> = {
+  pending: "Pending",
+  completed: "Completed",
+  approved: "Approved",
+  rejected: "Rejected",
+}
+
+export function Overview({ tenantId }: { tenantId?: string | null }) {
+  const supabase = useSupabaseBrowser()
+  const [data, setData] = useState<ChartDatum[]>(() =>
+    statusOrder.map((status) => ({ name: statusLabels[status], total: 0 })),
+  )
+
+  const loadStatusBreakdown = useCallback(async () => {
+    let query = supabase.from("chore_assignments").select("status")
+    if (tenantId) {
+      query = query.eq("tenant_id", tenantId)
+    }
+
+    const { data: rows, error } = await query
+
+    if (error) {
+      console.error("Failed to load chore assignment breakdown", error)
+      return
+    }
+
+    const result = statusOrder.map((status) => ({
+      name: statusLabels[status],
+      total: (rows ?? []).filter((row: StatusRow) => row.status === status).length,
+    }))
+
+    setData(result)
+  }, [supabase, tenantId])
+
+  useEffect(() => {
+    void loadStatusBreakdown()
+  }, [loadStatusBreakdown])
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(`overview-chore-assignments-${tenantId ?? "all"}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "chore_assignments",
+          ...(tenantId ? { filter: `tenant_id=eq.${tenantId}` } : {}),
+        },
+        () => {
+          void loadStatusBreakdown()
+        },
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [loadStatusBreakdown, supabase, tenantId])
+
+  const chartData = useMemo(() => data, [data])
+
   return (
     <ResponsiveContainer width="100%" height={350}>
-      <BarChart data={data}>
+      <BarChart data={chartData}>
         <XAxis
           dataKey="name"
           stroke="#888888"
@@ -65,11 +89,12 @@ export function Overview() {
           axisLine={false}
         />
         <YAxis
+          allowDecimals={false}
+          domain={[0, "dataMax + 1"]}
           stroke="#888888"
           fontSize={12}
           tickLine={false}
           axisLine={false}
-          tickFormatter={(value) => `$${value}`}
         />
         <Bar
           dataKey="total"

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -483,6 +483,66 @@ export type Database = {
         }
         Relationships: []
       }
+      chore_assignments: {
+        Row: {
+          assigned_by: string | null
+          chore_title: string
+          completed_at: string | null
+          created_at: string
+          description: string | null
+          due_date: string | null
+          id: string
+          point_awarded: boolean
+          points: number
+          proof_url: string | null
+          status: Database["public"]["Enums"]["chore_assignment_status"]
+          tenant_id: string
+        }
+        Insert: {
+          assigned_by?: string | null
+          chore_title: string
+          completed_at?: string | null
+          created_at?: string
+          description?: string | null
+          due_date?: string | null
+          id?: string
+          point_awarded?: boolean
+          points?: number
+          proof_url?: string | null
+          status?: Database["public"]["Enums"]["chore_assignment_status"]
+          tenant_id: string
+        }
+        Update: {
+          assigned_by?: string | null
+          chore_title?: string
+          completed_at?: string | null
+          created_at?: string
+          description?: string | null
+          due_date?: string | null
+          id?: string
+          point_awarded?: boolean
+          points?: number
+          proof_url?: string | null
+          status?: Database["public"]["Enums"]["chore_assignment_status"]
+          tenant_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chore_assignments_assigned_by_fkey"
+            columns: ["assigned_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chore_assignments_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       countries: {
         Row: {
           continent: Database["public"]["Enums"]["continents"] | null
@@ -1766,6 +1826,11 @@ export type Database = {
       }
     }
     Enums: {
+      chore_assignment_status:
+        | "pending"
+        | "completed"
+        | "approved"
+        | "rejected"
       continents:
         | "Africa"
         | "Antarctica"

--- a/supabase/migrations/20241011_chore_assignments.sql
+++ b/supabase/migrations/20241011_chore_assignments.sql
@@ -1,0 +1,117 @@
+create extension if not exists "pgcrypto";
+
+create type if not exists public.chore_assignment_status as enum (
+  'pending',
+  'completed',
+  'approved',
+  'rejected'
+);
+
+create table if not exists public.chore_assignments (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  tenant_id uuid not null,
+  chore_title text not null,
+  description text,
+  due_date timestamptz,
+  status public.chore_assignment_status not null default 'pending',
+  proof_url text,
+  completed_at timestamptz,
+  point_awarded boolean not null default false,
+  points integer not null default 0,
+  assigned_by uuid,
+  constraint chore_assignments_tenant_id_fkey foreign key (tenant_id) references public.profiles (id) on delete cascade,
+  constraint chore_assignments_assigned_by_fkey foreign key (assigned_by) references public.profiles (id) on delete set null
+);
+
+alter table if exists public.chore_assignments
+  add column if not exists status public.chore_assignment_status not null default 'pending';
+
+alter table if exists public.chore_assignments
+  alter column status set default 'pending';
+
+update public.chore_assignments
+set status = 'pending'
+where status is null;
+
+alter table if exists public.chore_assignments
+  add column if not exists proof_url text;
+
+alter table if exists public.chore_assignments
+  add column if not exists completed_at timestamptz;
+
+alter table if exists public.chore_assignments
+  add column if not exists point_awarded boolean not null default false;
+
+alter table if exists public.chore_assignments
+  alter column point_awarded set default false;
+
+alter table if exists public.chore_assignments
+  add column if not exists points integer not null default 0;
+
+alter table if exists public.chore_assignments
+  add column if not exists description text;
+
+alter table if exists public.chore_assignments
+  add column if not exists due_date timestamptz;
+
+alter table if exists public.chore_assignments
+  add column if not exists assigned_by uuid;
+
+alter table if exists public.chore_assignments
+  add column if not exists created_at timestamptz not null default now();
+
+alter table if exists public.chore_assignments
+  alter column created_at set default now();
+
+alter table if exists public.chore_assignments
+  add column if not exists chore_title text;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'chore_assignments_tenant_id_fkey'
+  ) then
+    alter table public.chore_assignments
+      add constraint chore_assignments_tenant_id_fkey foreign key (tenant_id)
+      references public.profiles (id)
+      on delete cascade;
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'chore_assignments_assigned_by_fkey'
+  ) then
+    alter table public.chore_assignments
+      add constraint chore_assignments_assigned_by_fkey foreign key (assigned_by)
+      references public.profiles (id)
+      on delete set null;
+  end if;
+end $$;
+
+alter table if exists public.chore_assignments enable row level security;
+
+drop policy if exists "Chore assignments tenants select" on public.chore_assignments;
+create policy "Chore assignments tenants select"
+  on public.chore_assignments
+  for select
+  using (auth.uid() = tenant_id or auth.uid() = assigned_by);
+
+drop policy if exists "Chore assignments tenants update" on public.chore_assignments;
+create policy "Chore assignments tenants update"
+  on public.chore_assignments
+  for update
+  using (auth.uid() = tenant_id or auth.uid() = assigned_by)
+  with check (auth.uid() = tenant_id or auth.uid() = assigned_by);
+
+drop policy if exists "Chore assignments tenants insert" on public.chore_assignments;
+create policy "Chore assignments tenants insert"
+  on public.chore_assignments
+  for insert
+  with check (auth.uid() = tenant_id or auth.uid() = assigned_by);


### PR DESCRIPTION
## Summary
- add a Supabase migration that defines the `chore_assignment_status` enum, ensures required chore assignment columns, and configures row-level security policies
- introduce a tenant chore assignments page that supports proof uploads, completion toggles, and realtime syncing of Supabase changes
- wire the dashboard overview chart and navigation to chore data using the typed Supabase client

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d0a0f4cb888328a4aae533dce5ba70