### PR TITLE
feat: automate weekly chore rotation

### DIFF
--- a/app/api/cron/chore-rotation/route.ts
+++ b/app/api/cron/chore-rotation/route.ts
@@ -1,0 +1,178 @@
+import { addDays, addWeeks, formatISO } from 'date-fns'
+import { NextResponse } from 'next/server'
+
+import {
+  DEFAULT_CHORE_TEMPLATES,
+  computeWeeklyAssignments,
+  deriveChoreCatalog,
+  normalizeWeekStart,
+  type WeeklyAssignmentPlan,
+} from '@/lib/chore-scheduler'
+import type { Tables } from '@/lib/supabase'
+import { createServiceRoleClient } from '@/utils/supabase/service-role'
+
+function isAuthorized(request: Request) {
+  const cronHeader = request.headers.get('x-vercel-cron')
+  if (cronHeader) {
+    return true
+  }
+
+  const secret = process.env.CRON_SECRET
+  if (!secret) {
+    return true
+  }
+
+  const authHeader = request.headers.get('authorization')
+  return authHeader === `Bearer ${secret}`
+}
+
+async function runScheduler(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createServiceRoleClient()
+  const targetWeekStart = normalizeWeekStart(addWeeks(new Date(), 1))
+  const targetWeekEnd = addDays(targetWeekStart, 6)
+  const targetWeekStartISO = formatISO(targetWeekStart, { representation: 'date' })
+  const targetWeekEndISO = formatISO(targetWeekEnd, { representation: 'date' })
+
+  type ProfileRow = Pick<Tables<'profiles'>, 'id' | 'full_name' | 'role'>
+
+  const { data: profiles, error: profilesError } = await supabase
+    .from('profiles')
+    .select('id, full_name, role')
+  if (profilesError) {
+    return NextResponse.json(
+      { error: 'failed_to_load_profiles', details: profilesError.message },
+      { status: 500 }
+    )
+  }
+
+  const roommates: ProfileRow[] = (profiles ?? []).filter((profile) =>
+    profile?.role ? ['tenant', 'roommate'].includes(profile.role) : true
+  )
+
+  type VacationRow = Pick<Tables<'member_vacations'>, 'profile_id' | 'starts_on' | 'ends_on'>
+  const { data: vacations, error: vacationsError } = await supabase
+    .from('member_vacations')
+    .select('profile_id, starts_on, ends_on')
+    .lte('starts_on', targetWeekEndISO)
+    .gte('ends_on', targetWeekStartISO)
+  if (vacationsError) {
+    return NextResponse.json(
+      { error: 'failed_to_load_vacations', details: vacationsError.message },
+      { status: 500 }
+    )
+  }
+
+  type AssignmentRow = Pick<
+    Tables<'chore_assignments'>,
+    'assigned_to' | 'chore_name' | 'week_start' | 'weight' | 'missed_count' | 'completed'
+  >
+  const { data: historicalAssignments, error: historyError } = await supabase
+    .from('chore_assignments')
+    .select('assigned_to, chore_name, week_start, weight, missed_count, completed')
+    .lt('week_start', targetWeekStartISO)
+  if (historyError) {
+    return NextResponse.json(
+      { error: 'failed_to_load_history', details: historyError.message },
+      { status: 500 }
+    )
+  }
+
+  const choreCatalog = deriveChoreCatalog(
+    historicalAssignments ?? [],
+    DEFAULT_CHORE_TEMPLATES
+  )
+
+  const plan: WeeklyAssignmentPlan = computeWeeklyAssignments({
+    weekStart: targetWeekStart,
+    roommates,
+    vacations: (vacations ?? []) as VacationRow[],
+    historicalAssignments: (historicalAssignments ?? []) as AssignmentRow[],
+    chores: choreCatalog,
+  })
+
+  if (plan.assignments.length === 0) {
+    return NextResponse.json(
+      {
+        message: 'no_assignments_generated',
+        weekStart: plan.weekStartISO,
+        metadata: plan.metadata,
+      },
+      { status: 200 }
+    )
+  }
+
+  const { error: existingDeleteError } = await supabase
+    .from('chore_assignments')
+    .delete()
+    .eq('week_start', plan.weekStartISO)
+  if (existingDeleteError) {
+    return NextResponse.json(
+      { error: 'failed_to_reset_existing_assignments', details: existingDeleteError.message },
+      { status: 500 }
+    )
+  }
+
+  const insertPayload = plan.assignments.map((assignment) => ({
+    week_start: plan.weekStartISO,
+    chore_name: assignment.chore_name,
+    assigned_to: assignment.assigned_to,
+    weight: assignment.weight,
+    missed_count: assignment.missed_count_snapshot,
+    load_before: assignment.load_before,
+    fairness_score: assignment.fairness_score,
+  }))
+
+  const { data: insertedAssignments, error: insertError } = await supabase
+    .from('chore_assignments')
+    .insert(insertPayload)
+    .select('id, chore_name, assigned_to, weight, missed_count, load_before, fairness_score')
+  if (insertError) {
+    return NextResponse.json(
+      { error: 'failed_to_insert_assignments', details: insertError.message },
+      { status: 500 }
+    )
+  }
+
+  const realtimePayload = {
+    generated_at: new Date().toISOString(),
+    week_start: plan.weekStartISO,
+    assignments: insertedAssignments,
+    metadata: plan.metadata,
+  }
+
+  const { error: realtimeError } = await supabase.rpc('publish_chore_rotation', {
+    assignments: realtimePayload,
+  })
+  if (realtimeError) {
+    return NextResponse.json(
+      {
+        error: 'failed_to_publish_realtime_update',
+        details: realtimeError.message,
+        assignments: insertedAssignments,
+      },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json(
+    {
+      weekStart: plan.weekStartISO,
+      assignments: insertedAssignments,
+      unassigned: plan.unassigned,
+      metadata: plan.metadata,
+    },
+    { status: 200 }
+  )
+}
+
+export async function GET(request: Request) {
+  return runScheduler(request)
+}
+
+export async function POST(request: Request) {
+  return runScheduler(request)
+}

--- a/lib/chore-scheduler.ts
+++ b/lib/chore-scheduler.ts
@@ -1,0 +1,244 @@
+import { addDays, differenceInCalendarWeeks, isAfter, isBefore, isValid, parseISO, startOfWeek } from 'date-fns'
+
+export type RoommateProfile = {
+  id: string
+  full_name: string | null
+}
+
+export type VacationRange = {
+  profile_id: string
+  starts_on: string
+  ends_on: string
+}
+
+export type HistoricalChoreAssignment = {
+  assigned_to: string
+  chore_name: string
+  week_start: string
+  weight: number | null
+  missed_count: number | null
+  completed: boolean | null
+}
+
+export type ChoreTemplate = {
+  name: string
+  weight: number
+}
+
+export type AssignmentDecision = {
+  chore_name: string
+  assigned_to: string
+  weight: number
+  missed_count_snapshot: number
+  load_before: number
+  fairness_score: number
+}
+
+export type WeeklyAssignmentPlan = {
+  weekStartISO: string
+  assignments: AssignmentDecision[]
+  unassigned: ChoreTemplate[]
+  metadata: {
+    availableRoommates: string[]
+    onVacation: string[]
+  }
+}
+
+export const DEFAULT_CHORE_TEMPLATES: ChoreTemplate[] = [
+  { name: 'Kitchen Deep Clean', weight: 3 },
+  { name: 'Trash & Recycling', weight: 2 },
+  { name: 'Bathroom Refresh', weight: 2 },
+  { name: 'Living Room Reset', weight: 2 },
+  { name: 'Entryway & Mail', weight: 1 },
+]
+
+const WEEK_START_OPTIONS = { weekStartsOn: 1 as const }
+const MISSED_ASSIGNMENT_PENALTY = 2
+const RECENCY_WINDOW_WEEKS = 3
+const RECENCY_WEIGHT = 1.5
+const ADDITIONAL_ASSIGNMENT_WEIGHT = 1
+
+export function normalizeWeekStart(date: Date): Date {
+  return startOfWeek(date, WEEK_START_OPTIONS)
+}
+
+function parseDate(value: string): Date | null {
+  const parsed = parseISO(value)
+  return isValid(parsed) ? parsed : null
+}
+
+export function deriveChoreCatalog(
+  history: HistoricalChoreAssignment[],
+  fallback: ChoreTemplate[] = DEFAULT_CHORE_TEMPLATES
+): ChoreTemplate[] {
+  const choreMap = new Map<string, number>()
+
+  for (const entry of history) {
+    if (!entry?.chore_name) continue
+    const weight = entry.weight ?? 1
+    choreMap.set(entry.chore_name, weight)
+  }
+
+  for (const template of fallback) {
+    if (!choreMap.has(template.name)) {
+      choreMap.set(template.name, template.weight)
+    }
+  }
+
+  return Array.from(choreMap.entries())
+    .map(([name, weight]) => ({ name, weight }))
+    .sort((a, b) => b.weight - a.weight || a.name.localeCompare(b.name))
+}
+
+export function computeWeeklyAssignments(args: {
+  weekStart: Date
+  roommates: RoommateProfile[]
+  vacations: VacationRange[]
+  historicalAssignments: HistoricalChoreAssignment[]
+  chores: ChoreTemplate[]
+}): WeeklyAssignmentPlan {
+  const weekStart = normalizeWeekStart(args.weekStart)
+  const weekEnd = addDays(weekStart, 6)
+  const weekStartISO = weekStart.toISOString().slice(0, 10)
+
+  const vacationingMembers = new Set<string>()
+  for (const vacation of args.vacations ?? []) {
+    const vacationStart = parseDate(vacation.starts_on)
+    const vacationEnd = parseDate(vacation.ends_on)
+    if (!vacationStart || !vacationEnd) continue
+    if (isAfter(vacationStart, weekEnd) || isBefore(vacationEnd, weekStart)) continue
+    vacationingMembers.add(vacation.profile_id)
+  }
+
+  type MemberStats = {
+    totalLoad: number
+    missed: number
+    assignmentsThisWeek: number
+    lastAssigned: Map<string, Date>
+  }
+
+  const memberStats = new Map<string, MemberStats>()
+  for (const roommate of args.roommates ?? []) {
+    memberStats.set(roommate.id, {
+      totalLoad: 0,
+      missed: 0,
+      assignmentsThisWeek: 0,
+      lastAssigned: new Map<string, Date>(),
+    })
+  }
+
+  for (const entry of args.historicalAssignments ?? []) {
+    if (!entry?.assigned_to) continue
+    const stats = memberStats.get(entry.assigned_to)
+    if (!stats) continue
+
+    const assignmentWeek = parseDate(entry.week_start)
+    if (!assignmentWeek) continue
+    if (!isBefore(assignmentWeek, weekStart)) continue
+
+    const weight = entry.weight ?? 1
+    stats.totalLoad += weight
+    stats.lastAssigned.set(entry.chore_name, assignmentWeek)
+
+    const missesFromHistory = entry.missed_count ?? 0
+    stats.missed = Math.max(stats.missed, missesFromHistory)
+    if (entry.completed === false) {
+      stats.missed += 1
+    }
+  }
+
+  const availableRoommates = (args.roommates ?? []).filter(
+    (roommate) => !vacationingMembers.has(roommate.id)
+  )
+
+  const assignments: AssignmentDecision[] = []
+  const unassigned: ChoreTemplate[] = []
+
+  const choresSorted = [...(args.chores ?? [])].sort(
+    (a, b) => b.weight - a.weight || a.name.localeCompare(b.name)
+  )
+
+  for (const chore of choresSorted) {
+    const candidates = [] as Array<{
+      roommate: RoommateProfile
+      stats: MemberStats
+      loadBefore: number
+      missedSnapshot: number
+      fairnessScore: number
+    }>
+
+    for (const roommate of availableRoommates) {
+      const stats = memberStats.get(roommate.id)
+      if (!stats) continue
+
+      const loadBefore = stats.totalLoad
+      const missedSnapshot = stats.missed
+      const lastAssignedDate = stats.lastAssigned.get(chore.name)
+      let recencyPenalty = 0
+      if (lastAssignedDate) {
+        const weeksSince = differenceInCalendarWeeks(
+          weekStart,
+          lastAssignedDate,
+          WEEK_START_OPTIONS
+        )
+        if (weeksSince <= RECENCY_WINDOW_WEEKS) {
+          const proximity = Math.max(RECENCY_WINDOW_WEEKS + 1 - weeksSince, 0)
+          recencyPenalty = proximity * chore.weight * RECENCY_WEIGHT
+        }
+      }
+
+      const fairnessScore =
+        loadBefore +
+        chore.weight +
+        missedSnapshot * MISSED_ASSIGNMENT_PENALTY +
+        stats.assignmentsThisWeek * ADDITIONAL_ASSIGNMENT_WEIGHT +
+        recencyPenalty
+
+      candidates.push({
+        roommate,
+        stats,
+        loadBefore,
+        missedSnapshot,
+        fairnessScore,
+      })
+    }
+
+    if (candidates.length === 0) {
+      unassigned.push(chore)
+      continue
+    }
+
+    candidates.sort((a, b) => {
+      if (a.fairnessScore !== b.fairnessScore) {
+        return a.fairnessScore - b.fairnessScore
+      }
+      return (a.roommate.full_name ?? a.roommate.id).localeCompare(
+        b.roommate.full_name ?? b.roommate.id
+      )
+    })
+
+    const selected = candidates[0]
+    assignments.push({
+      chore_name: chore.name,
+      assigned_to: selected.roommate.id,
+      weight: chore.weight,
+      missed_count_snapshot: selected.missedSnapshot,
+      load_before: selected.loadBefore,
+      fairness_score: Number(selected.fairnessScore.toFixed(2)),
+    })
+
+    selected.stats.totalLoad += chore.weight
+    selected.stats.assignmentsThisWeek += 1
+    selected.stats.lastAssigned.set(chore.name, weekStart)
+  }
+
+  return {
+    weekStartISO,
+    assignments,
+    unassigned,
+    metadata: {
+      availableRoommates: availableRoommates.map((roommate) => roommate.id),
+      onVacation: Array.from(vacationingMembers),
+    },
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1202,6 +1202,91 @@ export type Database = {
         }
         Relationships: []
       }
+      chore_assignments: {
+        Row: {
+          assigned_to: string
+          completed: boolean
+          completed_at: string | null
+          created_at: string
+          fairness_score: number
+          id: number
+          load_before: number
+          missed_count: number
+          notes: string | null
+          week_start: string
+          weight: number
+        }
+        Insert: {
+          assigned_to: string
+          completed?: boolean
+          completed_at?: string | null
+          created_at?: string
+          fairness_score?: number
+          id?: number
+          load_before?: number
+          missed_count?: number
+          notes?: string | null
+          week_start: string
+          weight?: number
+        }
+        Update: {
+          assigned_to?: string
+          completed?: boolean
+          completed_at?: string | null
+          created_at?: string
+          fairness_score?: number
+          id?: number
+          load_before?: number
+          missed_count?: number
+          notes?: string | null
+          week_start?: string
+          weight?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chore_assignments_assigned_to_fkey",
+            columns: ["assigned_to"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+        ]
+      },
+      member_vacations: {
+        Row: {
+          created_at: string
+          ends_on: string
+          id: number
+          profile_id: string
+          reason: string | null
+          starts_on: string
+        }
+        Insert: {
+          created_at?: string
+          ends_on: string
+          id?: number
+          profile_id: string
+          reason?: string | null
+          starts_on: string
+        }
+        Update: {
+          created_at?: string
+          ends_on?: string
+          id?: number
+          profile_id?: string
+          reason?: string | null
+          starts_on?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "member_vacations_profile_id_fkey",
+            columns: ["profile_id"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"],
+          },
+        ]
+      },
       permission_table: {
         Row: {
           created_at: string
@@ -1631,6 +1716,10 @@ export type Database = {
       }
     }
     Functions: {
+      publish_chore_rotation: {
+        Args: { assignments: Json }
+        Returns: undefined
+      },
       binary_quantize: {
         Args: { "": string } | { "": unknown }
         Returns: unknown

--- a/supabase/migrations/20250708_weekly_chore_scheduler.sql
+++ b/supabase/migrations/20250708_weekly_chore_scheduler.sql
@@ -1,0 +1,92 @@
+create table if not exists public.chore_assignments (
+  id bigint generated always as identity primary key,
+  created_at timestamptz not null default now(),
+  week_start date not null,
+  chore_name text not null,
+  assigned_to uuid not null references public.profiles (id) on delete cascade,
+  weight integer not null default 1,
+  missed_count integer not null default 0,
+  load_before integer not null default 0,
+  fairness_score double precision not null default 0,
+  completed boolean not null default false,
+  completed_at timestamptz,
+  notes text,
+  constraint chore_assignments_unique_week_chore unique (week_start, chore_name)
+);
+
+create index if not exists idx_chore_assignments_week on public.chore_assignments (week_start);
+create index if not exists idx_chore_assignments_assignee on public.chore_assignments (assigned_to);
+
+alter table public.chore_assignments enable row level security;
+
+create policy if not exists "roommates can view their own assignments" on public.chore_assignments
+  for select to authenticated
+  using (
+    assigned_to = auth.uid()
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and coalesce(p.role, '') in ('property_manager', 'admin')
+    )
+  );
+
+create policy if not exists "roommates can update completion of their assignments" on public.chore_assignments
+  for update to authenticated
+  using (
+    assigned_to = auth.uid()
+  )
+  with check (
+    assigned_to = auth.uid()
+  );
+
+create table if not exists public.member_vacations (
+  id bigint generated always as identity primary key,
+  profile_id uuid not null references public.profiles (id) on delete cascade,
+  starts_on date not null,
+  ends_on date not null,
+  reason text,
+  created_at timestamptz not null default now(),
+  constraint member_vacations_valid_range check (starts_on <= ends_on)
+);
+
+create index if not exists idx_member_vacations_profile on public.member_vacations (profile_id);
+create index if not exists idx_member_vacations_period on public.member_vacations (starts_on, ends_on);
+
+alter table public.member_vacations enable row level security;
+
+create policy if not exists "roommates manage their vacations" on public.member_vacations
+  for all to authenticated
+  using (
+    profile_id = auth.uid()
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and coalesce(p.role, '') in ('property_manager', 'admin')
+    )
+  )
+  with check (
+    profile_id = auth.uid()
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and coalesce(p.role, '') in ('property_manager', 'admin')
+    )
+  );
+
+create or replace function public.publish_chore_rotation(assignments jsonb)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  perform pg_notify('chore_assignments', assignments::text);
+end;
+$$;
+
+grant execute on function public.publish_chore_rotation(jsonb) to authenticated;
+
+grant execute on function public.publish_chore_rotation(jsonb) to service_role;

--- a/tests/chore-scheduler.test.ts
+++ b/tests/chore-scheduler.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeWeeklyAssignments,
+  deriveChoreCatalog,
+  type ChoreTemplate,
+  type HistoricalChoreAssignment,
+  type VacationRange,
+} from '@/lib/chore-scheduler'
+
+const WEEK_START = new Date('2024-06-03T09:00:00Z')
+
+function buildHistory(entries: Partial<HistoricalChoreAssignment>[]): HistoricalChoreAssignment[] {
+  return entries.map((entry) => ({
+    assigned_to: entry.assigned_to ?? 'missing',
+    chore_name: entry.chore_name ?? 'Unset',
+    week_start: entry.week_start ?? '2024-05-27',
+    weight: entry.weight ?? 1,
+    missed_count: entry.missed_count ?? 0,
+    completed: entry.completed ?? true,
+  }))
+}
+
+describe('deriveChoreCatalog', () => {
+  it('merges fallback chores when history is empty', () => {
+    const fallback: ChoreTemplate[] = [
+      { name: 'Test Chore', weight: 1 },
+    ]
+
+    const result = deriveChoreCatalog([], fallback)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ name: 'Test Chore', weight: 1 })
+  })
+
+  it('uses historical weights when available', () => {
+    const history = buildHistory([
+      {
+        chore_name: 'Kitchen',
+        weight: 4,
+      },
+      {
+        chore_name: 'Kitchen',
+        weight: 2,
+      },
+    ])
+
+    const result = deriveChoreCatalog(history)
+    expect(result).toContainEqual(expect.objectContaining({ name: 'Kitchen', weight: 2 }))
+  })
+})
+
+describe('computeWeeklyAssignments', () => {
+  const roommates = [
+    { id: 'alex', full_name: 'Alex' },
+    { id: 'blake', full_name: 'Blake' },
+    { id: 'casey', full_name: 'Casey' },
+  ]
+
+  it('skips roommates that are on vacation during the target week', () => {
+    const vacations: VacationRange[] = [
+      { profile_id: 'blake', starts_on: '2024-06-02', ends_on: '2024-06-10' },
+    ]
+
+    const plan = computeWeeklyAssignments({
+      weekStart: WEEK_START,
+      roommates: roommates.slice(0, 2),
+      vacations,
+      historicalAssignments: [],
+      chores: [{ name: 'Trash', weight: 1 }],
+    })
+
+    expect(plan.assignments).toHaveLength(1)
+    expect(plan.assignments[0].assigned_to).toBe('alex')
+    expect(plan.metadata.onVacation).toContain('blake')
+  })
+
+  it('rotates chores away from the most recent assignee when possible', () => {
+    const history = buildHistory([
+      {
+        assigned_to: 'alex',
+        chore_name: 'Trash',
+        week_start: '2024-05-27',
+        weight: 1,
+        completed: true,
+      },
+    ])
+
+    const plan = computeWeeklyAssignments({
+      weekStart: WEEK_START,
+      roommates: roommates.slice(0, 2),
+      vacations: [],
+      historicalAssignments: history,
+      chores: [{ name: 'Trash', weight: 1 }],
+    })
+
+    expect(plan.assignments).toHaveLength(1)
+    expect(plan.assignments[0].assigned_to).toBe('blake')
+  })
+
+  it('favours roommates with lower historical load and fewer misses', () => {
+    const history = buildHistory([
+      {
+        assigned_to: 'alex',
+        chore_name: 'Kitchen',
+        week_start: '2024-05-13',
+        weight: 3,
+      },
+      {
+        assigned_to: 'alex',
+        chore_name: 'Bathroom',
+        week_start: '2024-05-20',
+        weight: 3,
+      },
+      {
+        assigned_to: 'blake',
+        chore_name: 'Trash',
+        week_start: '2024-05-20',
+        weight: 1,
+      },
+      {
+        assigned_to: 'casey',
+        chore_name: 'Trash',
+        week_start: '2024-05-20',
+        weight: 1,
+        missed_count: 1,
+        completed: false,
+      },
+    ])
+
+    const plan = computeWeeklyAssignments({
+      weekStart: WEEK_START,
+      roommates,
+      vacations: [],
+      historicalAssignments: history,
+      chores: [
+        { name: 'Kitchen', weight: 3 },
+        { name: 'Trash', weight: 1 },
+      ],
+    })
+
+    expect(plan.assignments.map((assignment) => assignment.assigned_to)).toEqual([
+      'blake',
+      'alex',
+    ])
+    expect(plan.assignments.find((assignment) => assignment.assigned_to === 'blake')).toMatchObject({
+      load_before: 1,
+      missed_count_snapshot: 0,
+    })
+    expect(plan.assignments.find((assignment) => assignment.assigned_to === 'alex')).toMatchObject({
+      load_before: 6,
+      missed_count_snapshot: 0,
+    })
+    expect(plan.assignments.some((assignment) => assignment.assigned_to === 'casey')).toBe(false)
+  })
+})

--- a/utils/supabase/service-role.ts
+++ b/utils/supabase/service-role.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/supabase'
+
+export function createServiceRoleClient() {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL is not configured')
+  }
+
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is not configured')
+  }
+
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    }
+  )
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,11 @@
     "app/api/**/*.rs": {
       "runtime": "vercel-rust@4.0.8"
     }
-  }
+  },
+  "crons": [
+    {
+      "path": "/api/cron/chore-rotation",
+      "schedule": "0 9 * * 1"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add Supabase tables, policies, and notification function to support chore assignments with fairness metadata
- implement weekly chore rotation scheduler with service-role Supabase access and Vercel cron trigger
- cover rotation fairness behaviour with new Vitest scenarios

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0f52dd883289cecf6da2f01a408