### PR TITLE
Add chore templates seed and admin management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ complete Supabase SSR Auth and DB integration, Zod validation, Tanstack React Qu
     - RBAC configured admin dashboard with data visualization, members administration and todo lists
     - Contact form with toast, Zod validation, server side table insert  
 - TanStack React Query, Table, and Dev Tools
-  - Demo SSR with Supabase DB & cache helpers 
+  - Demo SSR with Supabase DB & cache helpers
 - Zod data validation, schemas, event handling.
 - Shadcn-UI, Radix-UI primitives, Tailwind CSS
 - Markdown pages with Next/MDX - create page.mdx and layout.tsx for each markdown page
@@ -64,8 +64,22 @@ complete Supabase SSR Auth and DB integration, Zod validation, Tanstack React Qu
     - Configure the SUPABASE_WORKOS_CONNECTION_ID environment variable with the copied value
 
   - Ensure your Supabase tables match the tables and types found in '@/lib/supabase'.
-  - Add authorized development and production URL's to Supabase URL config. 
-### Run  
+- Add authorized development and production URL's to Supabase URL config.
+### Demo
+
+The Supabase migration seeds a default set of chore templates that appear in the admin chore template manager. These templates power the demo experience out of the box:
+
+| Title                          | Cadence  | Points | Proof required |
+| ------------------------------ | -------- | ------ | -------------- |
+| Take out trash & recycling     | Daily    | 10     | No             |
+| Sanitize kitchen surfaces      | Weekly   | 25     | Yes            |
+| Deep clean shared bathroom     | Weekly   | 30     | Yes            |
+| Vacuum and mop common areas    | Weekly   | 20     | No             |
+| Restock household supplies     | Biweekly | 15     | No             |
+| Coordinate shared grocery run  | Biweekly | 20     | Yes            |
+| Water shared plants            | Weekly   | 10     | No             |
+
+### Run
 - Development server:
 
 ```bash

--- a/app/(admin)/chores/templates/actions.ts
+++ b/app/(admin)/chores/templates/actions.ts
@@ -1,0 +1,144 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { createActionClient } from "@/utils/supabase/actions";
+import type { TablesInsert, TablesUpdate } from "@/lib/supabase";
+
+import {
+  CHORE_CADENCES,
+  type ChoreTemplateFormValues,
+} from "./config";
+
+const choreTemplateSchema = z.object({
+  title: z
+    .string()
+    .min(2, "Title must be at least 2 characters long")
+    .max(120, "Title must be 120 characters or fewer"),
+  cadence: z.enum(CHORE_CADENCES),
+  point_value: z
+    .number({ invalid_type_error: "Point value must be a number" })
+    .refine((value) => Number.isFinite(value), {
+      message: "Point value must be a valid number",
+    })
+    .int({ message: "Point value must be a whole number" })
+    .min(0, "Point value cannot be negative")
+    .max(1000, "Point value must be 1000 points or fewer"),
+  requires_proof: z.boolean(),
+});
+
+type ActionResult = { success: true } | { success: false; error: string };
+
+type ValidatedPayload = z.infer<typeof choreTemplateSchema>;
+
+function validateInput(
+  values: ChoreTemplateFormValues
+): { success: true; data: ValidatedPayload } | { success: false; error: string } {
+  const result = choreTemplateSchema.safeParse(values);
+
+  if (!result.success) {
+    const message =
+      result.error.issues[0]?.message ?? "Invalid chore template data";
+
+    return { success: false, error: message };
+  }
+
+  return { success: true, data: result.data };
+}
+
+export async function createChoreTemplate(
+  values: ChoreTemplateFormValues
+): Promise<ActionResult> {
+  const validation = validateInput(values);
+
+  if (!validation.success) {
+    return validation;
+  }
+
+  const supabase = await createActionClient();
+
+  const payload: TablesInsert<"chores"> = {
+    cadence: validation.data.cadence,
+    point_value: validation.data.point_value,
+    requires_proof: validation.data.requires_proof,
+    title: validation.data.title,
+  };
+
+  const { error } = await supabase.from("chores").insert(payload);
+
+  if (error) {
+    console.error("Failed to create chore template", error);
+    return {
+      success: false,
+      error: "Unable to create chore template. Please try again.",
+    };
+  }
+
+  revalidatePath("/chores/templates", "page");
+
+  return { success: true };
+}
+
+export async function updateChoreTemplate(
+  id: number,
+  values: ChoreTemplateFormValues
+): Promise<ActionResult> {
+  if (!Number.isFinite(id)) {
+    return { success: false, error: "Invalid chore template identifier" };
+  }
+
+  const validation = validateInput(values);
+
+  if (!validation.success) {
+    return validation;
+  }
+
+  const supabase = await createActionClient();
+
+  const payload: TablesUpdate<"chores"> = {
+    cadence: validation.data.cadence,
+    point_value: validation.data.point_value,
+    requires_proof: validation.data.requires_proof,
+    title: validation.data.title,
+  };
+
+  const { error } = await supabase
+    .from("chores")
+    .update(payload)
+    .eq("id", id);
+
+  if (error) {
+    console.error("Failed to update chore template", error);
+    return {
+      success: false,
+      error: "Unable to update chore template. Please try again.",
+    };
+  }
+
+  revalidatePath("/chores/templates", "page");
+
+  return { success: true };
+}
+
+export async function deleteChoreTemplate(id: number): Promise<ActionResult> {
+  if (!Number.isFinite(id)) {
+    return { success: false, error: "Invalid chore template identifier" };
+  }
+
+  const supabase = await createActionClient();
+
+  const { error } = await supabase.from("chores").delete().eq("id", id);
+
+  if (error) {
+    console.error("Failed to delete chore template", error);
+    return {
+      success: false,
+      error: "Unable to delete chore template. Please try again.",
+    };
+  }
+
+  revalidatePath("/chores/templates", "page");
+
+  return { success: true };
+}

--- a/app/(admin)/chores/templates/config.ts
+++ b/app/(admin)/chores/templates/config.ts
@@ -1,0 +1,26 @@
+export const CHORE_CADENCES = [
+  "daily",
+  "weekly",
+  "biweekly",
+  "monthly",
+  "seasonal",
+  "as_needed",
+] as const;
+
+export type ChoreCadence = (typeof CHORE_CADENCES)[number];
+
+export type ChoreTemplateFormValues = {
+  title: string;
+  cadence: ChoreCadence;
+  point_value: number;
+  requires_proof: boolean;
+};
+
+export const CHORE_CADENCE_LABELS: Record<ChoreCadence, string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+  biweekly: "Every 2 Weeks",
+  monthly: "Monthly",
+  seasonal: "Seasonal",
+  as_needed: "As Needed",
+};

--- a/app/(admin)/chores/templates/page.tsx
+++ b/app/(admin)/chores/templates/page.tsx
@@ -1,0 +1,34 @@
+import TemplateManager from "./template-manager";
+
+import { createSupbaseServerClient } from "@/utils/supaone";
+import type { Tables } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+export default async function ChoreTemplatesPage() {
+  const supabase = await createSupbaseServerClient();
+
+  const { data, error } = await supabase
+    .from("chores")
+    .select("*")
+    .order("title", { ascending: true });
+
+  const templates = (data ?? []) as Tables<"chores">[];
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Chore templates</h1>
+        <p className="text-muted-foreground">
+          Manage the baseline tasks that populate every property&apos;s chore board.
+        </p>
+      </div>
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          Failed to load chore templates from the database. Please refresh the page.
+        </div>
+      )}
+      <TemplateManager templates={templates} />
+    </div>
+  );
+}

--- a/app/(admin)/chores/templates/template-manager.tsx
+++ b/app/(admin)/chores/templates/template-manager.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import Table from "@/components/ui/Table";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/use-toast";
+import type { Tables } from "@/lib/supabase";
+
+import {
+  CHORE_CADENCE_LABELS,
+  CHORE_CADENCES,
+  type ChoreCadence,
+  type ChoreTemplateFormValues,
+} from "./config";
+import {
+  createChoreTemplate,
+  deleteChoreTemplate,
+  updateChoreTemplate,
+} from "./actions";
+
+type ChoreTemplate = Tables<"chores">;
+
+type TemplateFormState = {
+  title: string;
+  cadence: ChoreCadence;
+  point_value: string;
+  requires_proof: boolean;
+};
+
+const defaultFormState: TemplateFormState = {
+  title: "",
+  cadence: "weekly",
+  point_value: "10",
+  requires_proof: false,
+};
+
+function toPayload(state: TemplateFormState): ChoreTemplateFormValues {
+  return {
+    title: state.title.trim(),
+    cadence: state.cadence,
+    point_value: Number(state.point_value),
+    requires_proof: state.requires_proof,
+  };
+}
+
+export default function TemplateManager({
+  templates,
+}: {
+  templates: ChoreTemplate[];
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const [createForm, setCreateForm] = useState<TemplateFormState>(defaultFormState);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<TemplateFormState>(defaultFormState);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const cadenceOptions = CHORE_CADENCES.map((value) => ({
+    value,
+    label: CHORE_CADENCE_LABELS[value],
+  }));
+
+  const handleCreateSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setCreateError(null);
+
+    const payload = toPayload(createForm);
+
+    startTransition(async () => {
+      const result = await createChoreTemplate(payload);
+
+      if (!result.success) {
+        setCreateError(result.error);
+        toast({
+          title: "Unable to add chore template",
+          description: result.error,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      toast({
+        title: "Chore template added",
+        description: `${payload.title} is ready to assign.`,
+      });
+
+      setCreateForm(defaultFormState);
+      router.refresh();
+    });
+  };
+
+  const beginEdit = (template: ChoreTemplate) => {
+    setEditError(null);
+    setEditingId(template.id);
+    setEditForm({
+      title: template.title,
+      cadence: (template.cadence as ChoreCadence) ?? "weekly",
+      point_value: template.point_value.toString(),
+      requires_proof: template.requires_proof ?? false,
+    });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditError(null);
+    setEditForm(defaultFormState);
+  };
+
+  const handleEditSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (editingId === null) {
+      return;
+    }
+
+    const payload = toPayload(editForm);
+    setEditError(null);
+
+    startTransition(async () => {
+      const result = await updateChoreTemplate(editingId, payload);
+
+      if (!result.success) {
+        setEditError(result.error);
+        toast({
+          title: "Unable to update chore template",
+          description: result.error,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      toast({
+        title: "Chore template updated",
+        description: `${payload.title} has been saved.`,
+      });
+
+      cancelEdit();
+      router.refresh();
+    });
+  };
+
+  const handleDelete = (template: ChoreTemplate) => {
+    if (!confirm(`Delete "${template.title}"?`)) {
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await deleteChoreTemplate(template.id);
+
+      if (!result.success) {
+        toast({
+          title: "Unable to delete chore template",
+          description: result.error,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      if (editingId === template.id) {
+        cancelEdit();
+      }
+
+      toast({
+        title: "Chore template removed",
+        description: `${template.title} has been removed from the template list.`,
+      });
+
+      router.refresh();
+    });
+  };
+
+  const headers = ["Title", "Cadence", "Points", "Proof", "Actions"];
+
+  return (
+    <div className="space-y-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Add a chore template</CardTitle>
+          <CardDescription>
+            Configure the default chores that populate new roommate schedules.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-6" onSubmit={handleCreateSubmit}>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-2 sm:col-span-2">
+                <Label htmlFor="template-title">Title</Label>
+                <Input
+                  id="template-title"
+                  placeholder="E.g. Take out trash & recycling"
+                  value={createForm.title}
+                  onChange={(event) =>
+                    setCreateForm((previous) => ({
+                      ...previous,
+                      title: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="template-cadence">Cadence</Label>
+                <Select
+                  value={createForm.cadence}
+                  onValueChange={(value) =>
+                    setCreateForm((previous) => ({
+                      ...previous,
+                      cadence: value as ChoreCadence,
+                    }))
+                  }
+                >
+                  <SelectTrigger id="template-cadence">
+                    <SelectValue placeholder="Select cadence" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {cadenceOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="template-points">Point value</Label>
+                <Input
+                  id="template-points"
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={createForm.point_value}
+                  onChange={(event) =>
+                    setCreateForm((previous) => ({
+                      ...previous,
+                      point_value: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </div>
+              <div className="flex items-center gap-3">
+                <Checkbox
+                  id="template-proof"
+                  checked={createForm.requires_proof}
+                  onCheckedChange={(checked) =>
+                    setCreateForm((previous) => ({
+                      ...previous,
+                      requires_proof: checked === true,
+                    }))
+                  }
+                />
+                <div className="space-y-1">
+                  <Label htmlFor="template-proof" className="font-medium">
+                    Requires proof of completion
+                  </Label>
+                  <p className="text-sm text-muted-foreground">
+                    Toggle on when roommates should upload a receipt or photo.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {createError && (
+              <p className="text-sm text-destructive">{createError}</p>
+            )}
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+              <Button
+                type="submit"
+                className="w-full sm:w-auto"
+                disabled={isPending}
+              >
+                Add template
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Template library</CardTitle>
+          <CardDescription>
+            Edit, duplicate, or remove the chores that new houses inherit by default.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Table headers={headers}>
+            {templates.length === 0 ? (
+              <div className="px-5 py-8 text-sm text-muted-foreground">
+                No chore templates have been created yet.
+              </div>
+            ) : (
+              templates.map((template) => {
+                const isEditing = editingId === template.id;
+
+                if (isEditing) {
+                  return (
+                    <form
+                      key={template.id}
+                      onSubmit={handleEditSubmit}
+                      className="grid grid-cols-5 gap-3 px-5 py-3 text-sm"
+                    >
+                      <div className="flex items-center">
+                        <Input
+                          value={editForm.title}
+                          onChange={(event) =>
+                            setEditForm((previous) => ({
+                              ...previous,
+                              title: event.target.value,
+                            }))
+                          }
+                          required
+                        />
+                      </div>
+                      <div className="flex items-center">
+                        <Select
+                          value={editForm.cadence}
+                          onValueChange={(value) =>
+                            setEditForm((previous) => ({
+                              ...previous,
+                              cadence: value as ChoreCadence,
+                            }))
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {cadenceOptions.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="flex items-center">
+                        <Input
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={editForm.point_value}
+                          onChange={(event) =>
+                            setEditForm((previous) => ({
+                              ...previous,
+                              point_value: event.target.value,
+                            }))
+                          }
+                          required
+                        />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id={`requires-proof-${template.id}`}
+                          checked={editForm.requires_proof}
+                          onCheckedChange={(checked) =>
+                            setEditForm((previous) => ({
+                              ...previous,
+                              requires_proof: checked === true,
+                            }))
+                          }
+                        />
+                        <Label htmlFor={`requires-proof-${template.id}`}>
+                          Proof required
+                        </Label>
+                      </div>
+                      <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:justify-end">
+                        {editError && (
+                          <p className="text-sm text-destructive sm:max-w-xs sm:text-right">
+                            {editError}
+                          </p>
+                        )}
+                        <div className="flex gap-2">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={cancelEdit}
+                            disabled={isPending}
+                          >
+                            Cancel
+                          </Button>
+                          <Button type="submit" disabled={isPending}>
+                            Save
+                          </Button>
+                        </div>
+                      </div>
+                    </form>
+                  );
+                }
+
+                return (
+                  <div
+                    key={template.id}
+                    className="grid grid-cols-5 items-center gap-3 px-5 py-3 text-sm"
+                  >
+                    <div className="font-medium">{template.title}</div>
+                    <div>{CHORE_CADENCE_LABELS[template.cadence as ChoreCadence] ?? template.cadence}</div>
+                    <div>{template.point_value} pts</div>
+                    <div>
+                      <Badge variant={template.requires_proof ? "default" : "secondary"}>
+                        {template.requires_proof ? "Proof required" : "No proof"}
+                      </Badge>
+                    </div>
+                    <div className="flex items-center justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => beginEdit(template)}
+                        disabled={isPending}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={() => handleDelete(template)}
+                        disabled={isPending}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { readUserSession } from "@/utils/actions";
+import { redirect } from "next/navigation";
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const { data: userSession } = await readUserSession();
+
+  if (!userSession.session) {
+    return redirect("/auth");
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-8 px-4 py-10 sm:px-6 lg:px-8">
+      {children}
+    </div>
+  );
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,10 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import {
+        PersonIcon,
+        CrumpledPaperIcon,
+        CheckCircledIcon,
+} from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,18 +12,23 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+                {
+                        href: "/chores/templates",
+                        text: "Chore templates",
+                        Icon: CheckCircledIcon,
+                },
+        ];
 
 	return (
 		<div className="space-y-5">

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -483,6 +483,33 @@ export type Database = {
         }
         Relationships: []
       }
+      chores: {
+        Row: {
+          cadence: string
+          created_at: string
+          id: number
+          point_value: number
+          requires_proof: boolean
+          title: string
+        }
+        Insert: {
+          cadence?: string
+          created_at?: string
+          id?: number
+          point_value?: number
+          requires_proof?: boolean
+          title: string
+        }
+        Update: {
+          cadence?: string
+          created_at?: string
+          id?: number
+          point_value?: number
+          requires_proof?: boolean
+          title?: string
+        }
+        Relationships: []
+      }
       countries: {
         Row: {
           continent: Database["public"]["Enums"]["continents"] | null

--- a/supabase/migrations/20250717_add_chore_templates.sql
+++ b/supabase/migrations/20250717_add_chore_templates.sql
@@ -1,0 +1,75 @@
+create table if not exists public.chores (
+  id bigserial primary key,
+  title text not null,
+  cadence text not null default 'weekly',
+  point_value integer not null default 0,
+  requires_proof boolean not null default false,
+  created_at timestamp with time zone not null default now()
+);
+
+alter table public.chores
+  add column if not exists title text;
+
+alter table public.chores
+  alter column title set not null;
+
+alter table public.chores
+  add column if not exists cadence text default 'weekly';
+
+alter table public.chores
+  alter column cadence set not null;
+
+alter table public.chores
+  add column if not exists point_value integer default 0;
+
+alter table public.chores
+  alter column point_value set not null;
+
+alter table public.chores
+  add column if not exists requires_proof boolean default false;
+
+alter table public.chores
+  alter column requires_proof set not null;
+
+alter table public.chores
+  add column if not exists created_at timestamp with time zone default now();
+
+alter table public.chores
+  alter column created_at set not null;
+
+create unique index if not exists chores_title_key on public.chores (title);
+
+alter table public.chores enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'chores'
+      and policyname = 'Authenticated users manage chore templates'
+  ) then
+    create policy "Authenticated users manage chore templates"
+      on public.chores
+      for all
+      to authenticated
+      using (true)
+      with check (true);
+  end if;
+end
+$$;
+
+insert into public.chores (title, cadence, point_value, requires_proof)
+values
+  ('Take out trash & recycling', 'daily', 10, false),
+  ('Sanitize kitchen surfaces', 'weekly', 25, true),
+  ('Deep clean shared bathroom', 'weekly', 30, true),
+  ('Vacuum and mop common areas', 'weekly', 20, false),
+  ('Restock household supplies', 'biweekly', 15, false),
+  ('Coordinate shared grocery run', 'biweekly', 20, true),
+  ('Water shared plants', 'weekly', 10, false)
+on conflict (title) do update set
+  cadence = excluded.cadence,
+  point_value = excluded.point_value,
+  requires_proof = excluded.requires_proof;


### PR DESCRIPTION
## Summary
- create a chores migration that ensures the table exists with required columns, enables RLS, and seeds default templates
- add an admin chore template manager backed by Supabase server actions plus shared cadence configuration
- surface the new route in the dashboard navigation, extend Supabase typings, and document the default demo templates

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0f64280832894fce491a0fe6257