### PR TITLE
Add floorplan metadata storage and UI

### DIFF
--- a/app/(tenant)/floorplan/floorplan-client.tsx
+++ b/app/(tenant)/floorplan/floorplan-client.tsx
@@ -1,0 +1,236 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import type { FloorplanOverlay } from "@/lib/floorplans"
+
+type FloorplanViewModel = {
+  id: number
+  name: string
+  description: string | null
+  width: number
+  height: number
+  publicUrl: string | null
+  overlaysParsed: FloorplanOverlay[]
+  household_id: string | null
+}
+
+export function FloorplanClient({ floorplans }: { floorplans: FloorplanViewModel[] }) {
+  const [activeId, setActiveId] = useState(() => (floorplans[0] ? String(floorplans[0].id) : ""))
+  const [selectedOverlayId, setSelectedOverlayId] = useState<string | null>(null)
+  const [hoveredOverlayId, setHoveredOverlayId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!activeId && floorplans[0]) {
+      setActiveId(String(floorplans[0].id))
+    }
+  }, [activeId, floorplans])
+
+  const activeFloorplan = useMemo(() => {
+    return floorplans.find((plan) => String(plan.id) === activeId) ?? null
+  }, [floorplans, activeId])
+
+  useEffect(() => {
+    if (activeFloorplan) {
+      setSelectedOverlayId(activeFloorplan.overlaysParsed[0]?.id ?? null)
+    }
+  }, [activeFloorplan])
+
+  if (floorplans.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-muted/30 p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          Your household doesn&apos;t have any shared floorplans yet. Once an administrator uploads one it will appear here with
+          roommate overlays.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Household floorplans</h1>
+          <p className="text-sm text-muted-foreground">
+            Explore shared spaces and roommate assignments. Overlays scale with your device for a crisp viewing experience.
+          </p>
+        </div>
+        {floorplans.length > 1 && (
+          <div className="w-full sm:w-64">
+            <Select value={activeId || undefined} onValueChange={(value) => setActiveId(value)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a floorplan" />
+              </SelectTrigger>
+              <SelectContent>
+                {floorplans.map((plan) => (
+                  <SelectItem key={plan.id} value={String(plan.id)}>
+                    {plan.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+
+      {activeFloorplan ? (
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <div className="space-y-4">
+            <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+              {activeFloorplan.publicUrl ? (
+                <svg
+                  viewBox={`0 0 ${activeFloorplan.width} ${activeFloorplan.height}`}
+                  className="h-auto w-full"
+                  role="img"
+                  aria-label={`Floorplan for ${activeFloorplan.name}`}
+                  preserveAspectRatio="xMidYMid meet"
+                >
+                  <image
+                    href={activeFloorplan.publicUrl}
+                    width={activeFloorplan.width}
+                    height={activeFloorplan.height}
+                    preserveAspectRatio="xMidYMid meet"
+                  />
+                  {activeFloorplan.overlaysParsed.map((overlay) => {
+                    const isActive = selectedOverlayId === overlay.id || hoveredOverlayId === overlay.id
+                    const strokeColor = overlay.color ?? "#2563eb"
+
+                    return (
+                      <g key={overlay.id} className="cursor-pointer" onClick={() => setSelectedOverlayId(overlay.id)}>
+                        <title>{overlay.label}</title>
+                        <rect
+                          x={overlay.x}
+                          y={overlay.y}
+                          width={overlay.width}
+                          height={overlay.height}
+                          fill={overlay.color ?? "#2563eb"}
+                          fillOpacity={isActive ? 0.35 : 0.18}
+                          stroke={strokeColor}
+                          strokeWidth={isActive ? 3 : 2}
+                          rx={8}
+                          onMouseEnter={() => setHoveredOverlayId(overlay.id)}
+                          onMouseLeave={() => setHoveredOverlayId(null)}
+                          tabIndex={0}
+                          onFocus={() => setHoveredOverlayId(overlay.id)}
+                          onBlur={() => setHoveredOverlayId(null)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault()
+                              setSelectedOverlayId(overlay.id)
+                            }
+                          }}
+                        />
+                        <text
+                          x={overlay.x + overlay.width / 2}
+                          y={overlay.y + overlay.height / 2}
+                          textAnchor="middle"
+                          dominantBaseline="middle"
+                          fontSize={Math.max(12, Math.min(18, overlay.width / 6))}
+                          fontWeight={600}
+                          fill="#ffffff"
+                          style={{ paintOrder: "stroke" }}
+                        >
+                          {overlay.label}
+                        </text>
+                      </g>
+                    )
+                  })}
+                </svg>
+              ) : (
+                <div className="flex h-80 items-center justify-center bg-muted text-sm text-muted-foreground">
+                  Floorplan preview unavailable.
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+              <Badge variant="secondary" className="text-sm font-medium">
+                {activeFloorplan.width}×{activeFloorplan.height}px
+              </Badge>
+              {activeFloorplan.household_id && (
+                <span>
+                  Household ID: <span className="font-medium text-foreground">{activeFloorplan.household_id}</span>
+                </span>
+              )}
+              {activeFloorplan.description && <span>{activeFloorplan.description}</span>}
+            </div>
+          </div>
+
+          <aside className="space-y-4 rounded-lg border bg-card p-4 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold">Overlay regions</h2>
+              <Badge variant="outline">
+                {activeFloorplan.overlaysParsed.length === 1
+                  ? "1 region"
+                  : `${activeFloorplan.overlaysParsed.length} regions`}
+              </Badge>
+            </div>
+
+            {activeFloorplan.overlaysParsed.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                This floorplan doesn&apos;t have any overlays yet. Ask your household admin to assign storage zones or roommate areas.
+              </p>
+            ) : (
+              <ScrollArea className="max-h-[420px] pr-2">
+                <div className="space-y-2">
+                  {activeFloorplan.overlaysParsed.map((overlay) => {
+                    const isSelected = selectedOverlayId === overlay.id
+
+                    return (
+                      <button
+                        key={overlay.id}
+                        type="button"
+                        onClick={() => setSelectedOverlayId(overlay.id)}
+                        onMouseEnter={() => setHoveredOverlayId(overlay.id)}
+                        onMouseLeave={() => setHoveredOverlayId(null)}
+                        className={cn(
+                          "w-full rounded-md border px-3 py-2 text-left transition",
+                          isSelected
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-border bg-background hover:border-primary/40 hover:bg-muted",
+                        )}
+                      >
+                        <div className="flex items-center justify-between text-sm font-medium">
+                          <span>{overlay.label}</span>
+                          <Badge variant="outline" className="text-[10px]">
+                            {Math.round(overlay.width)}×{Math.round(overlay.height)}
+                          </Badge>
+                        </div>
+                        <div className="mt-1 space-y-1 text-xs text-muted-foreground">
+                          <p>
+                            Position: {Math.round(overlay.x)}, {Math.round(overlay.y)}
+                          </p>
+                          {overlay.occupant && (
+                            <p>
+                              Assigned to <span className="font-medium text-foreground">{overlay.occupant}</span>
+                            </p>
+                          )}
+                          {overlay.description && <p>{overlay.description}</p>}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              </ScrollArea>
+            )}
+          </aside>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+          Select a floorplan to view overlays and assignments.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(tenant)/floorplan/page.tsx
+++ b/app/(tenant)/floorplan/page.tsx
@@ -1,0 +1,56 @@
+import type { Tables } from "@/lib/supabase"
+import { parseFloorplanOverlays } from "@/lib/floorplans"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+import { FloorplanClient } from "./floorplan-client"
+
+type FloorplanRow = Tables<"floorplans">
+
+type FloorplanWithPresentation = FloorplanRow & {
+  publicUrl: string | null
+  overlaysParsed: ReturnType<typeof parseFloorplanOverlays>
+}
+
+interface FloorplanPageProps {
+  searchParams?: {
+    household?: string
+  }
+}
+
+export const dynamic = "force-dynamic"
+
+export default async function FloorplanPage({ searchParams }: FloorplanPageProps) {
+  const supabase = await createSupbaseServerClient()
+
+  let query = supabase
+    .from("floorplans")
+    .select("*")
+    .order("created_at", { ascending: false })
+
+  const householdFilter = searchParams?.household?.trim()
+  if (householdFilter) {
+    query = query.eq("household_id", householdFilter)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    console.error("Failed to load floorplans", error)
+  }
+
+  const floorplans: FloorplanWithPresentation[] = (data ?? []).map((row) => {
+    const { data: publicUrlData } = supabase.storage.from("floorplans").getPublicUrl(row.storage_path)
+
+    return {
+      ...row,
+      publicUrl: publicUrlData?.publicUrl ?? null,
+      overlaysParsed: parseFloorplanOverlays(row.overlays),
+    }
+  })
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8">
+      <FloorplanClient floorplans={floorplans} />
+    </div>
+  )
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { PersonIcon, CrumpledPaperIcon, LayersIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,17 +8,22 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/floorplans",
+                        text: "Floorplans",
+                        Icon: LayersIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
 	];
 
 	return (

--- a/app/dashboard/floorplans/actions.ts
+++ b/app/dashboard/floorplans/actions.ts
@@ -1,0 +1,187 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { Buffer } from "node:buffer"
+import { extname } from "node:path"
+import { z } from "zod"
+
+import type { Json } from "@/lib/supabase"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export type FloorplanUploadState = {
+  status: "idle" | "success" | "error"
+  message?: string
+  fieldErrors?: Partial<Record<"name" | "width" | "height" | "householdId" | "overlays" | "file", string>>
+}
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(1, "A descriptive name is required.")
+    .max(120, "Names must be 120 characters or fewer."),
+  description: z
+    .string()
+    .max(500, "Descriptions must be 500 characters or fewer.")
+    .optional()
+    .or(z.literal("")),
+  width: z.coerce.number().min(1, "Width must be greater than 0."),
+  height: z.coerce.number().min(1, "Height must be greater than 0."),
+  householdId: z.string().uuid("Household ID must be a valid UUID."),
+})
+
+const overlaySchema = z.object({
+  id: z.string().min(1, "Overlay IDs are required."),
+  label: z.string().min(1, "Overlay labels are required."),
+  x: z.coerce.number().min(0, "X position cannot be negative."),
+  y: z.coerce.number().min(0, "Y position cannot be negative."),
+  width: z.coerce.number().min(1, "Overlay width must be greater than 0."),
+  height: z.coerce.number().min(1, "Overlay height must be greater than 0."),
+  description: z.string().optional(),
+  color: z.string().optional(),
+  occupant: z.string().optional(),
+})
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "floorplan"
+}
+
+export async function uploadFloorplan(
+  prevState: FloorplanUploadState,
+  formData: FormData,
+): Promise<FloorplanUploadState> {
+  const supabase = await createSupbaseServerClient()
+
+  const file = formData.get("file")
+  if (!file || !(file instanceof File) || file.size === 0) {
+    return {
+      status: "error",
+      message: "A floorplan image is required before uploading.",
+      fieldErrors: { file: "Please choose an image file to upload." },
+    }
+  }
+
+  if (!file.type || !file.type.startsWith("image/")) {
+    return {
+      status: "error",
+      message: "Unsupported file type. Floorplans must be uploaded as images.",
+      fieldErrors: { file: "Upload a PNG, JPEG, or SVG floorplan image." },
+    }
+  }
+
+  if (file.size > 10 * 1024 * 1024) {
+    return {
+      status: "error",
+      message: "The uploaded file is too large.",
+      fieldErrors: { file: "Images must be 10MB or smaller." },
+    }
+  }
+
+  const parsed = formSchema.safeParse({
+    name: formData.get("name"),
+    description: formData.get("description"),
+    width: formData.get("width"),
+    height: formData.get("height"),
+    householdId: formData.get("householdId"),
+  })
+
+  if (!parsed.success) {
+    const fieldErrors = Object.fromEntries(
+      Object.entries(parsed.error.flatten().fieldErrors).map(([key, value]) => [
+        key as keyof FloorplanUploadState["fieldErrors"],
+        value?.join(" "),
+      ]),
+    ) as FloorplanUploadState["fieldErrors"]
+
+    return {
+      status: "error",
+      message: "Please correct the highlighted fields and try again.",
+      fieldErrors,
+    }
+  }
+
+  const { name, description, width, height, householdId } = parsed.data
+  let overlays: Json = []
+  const overlaysRaw = formData.get("overlays")
+
+  if (typeof overlaysRaw === "string" && overlaysRaw.trim().length > 0) {
+    let overlaysJson: unknown
+
+    try {
+      overlaysJson = JSON.parse(overlaysRaw)
+    } catch (error) {
+      console.error("Failed to parse overlay JSON", error)
+      return {
+        status: "error",
+        message: "Overlays must be valid JSON.",
+        fieldErrors: { overlays: "Enter valid JSON for overlay regions." },
+      }
+    }
+
+    const overlaysResult = overlaySchema.array().safeParse(overlaysJson)
+    if (!overlaysResult.success) {
+      return {
+        status: "error",
+        message: "One or more overlays are invalid.",
+        fieldErrors: {
+          overlays: overlaysResult.error.issues
+            .map((issue) => issue.message)
+            .join(" "),
+        },
+      }
+    }
+
+    overlays = overlaysResult.data as unknown as Json
+  }
+
+  const extension = (extname(file.name) || ".png").toLowerCase()
+  const fileName = `${slugify(name)}-${Date.now()}${extension}`
+  const storagePath = `${householdId}/${fileName}`
+
+  const fileBuffer = Buffer.from(await file.arrayBuffer())
+
+  const { error: uploadError } = await supabase.storage.from("floorplans").upload(storagePath, fileBuffer, {
+    cacheControl: "3600",
+    upsert: false,
+    contentType: file.type,
+  })
+
+  if (uploadError) {
+    console.error("Failed to upload floorplan image", uploadError)
+    return {
+      status: "error",
+      message: "We could not upload the image to storage. Please try again.",
+    }
+  }
+
+  const { error: insertError } = await supabase.from("floorplans").insert({
+    name,
+    description: description?.toString().trim() ? description.toString().trim() : null,
+    width,
+    height,
+    household_id: householdId,
+    storage_path: storagePath,
+    overlays,
+  })
+
+  if (insertError) {
+    console.error("Failed to create floorplan record", insertError)
+    await supabase.storage.from("floorplans").remove([storagePath])
+    return {
+      status: "error",
+      message: "The floorplan metadata could not be saved. Please try again.",
+    }
+  }
+
+  revalidatePath("/dashboard/floorplans")
+  revalidatePath("/floorplan")
+
+  return {
+    status: "success",
+    message: "Floorplan uploaded successfully.",
+  }
+}

--- a/app/dashboard/floorplans/floorplan-upload-form.tsx
+++ b/app/dashboard/floorplans/floorplan-upload-form.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useFormState, useFormStatus } from "react-dom"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+import { uploadFloorplan, type FloorplanUploadState } from "./actions"
+
+type HouseholdOption = {
+  id: string
+  name: string | null
+  slug: string | null
+}
+
+const initialState: FloorplanUploadState = {
+  status: "idle",
+}
+
+export function FloorplanUploadForm({ households }: { households: HouseholdOption[] }) {
+  const formRef = useRef<HTMLFormElement>(null)
+  const [state, formAction] = useFormState(uploadFloorplan, initialState)
+  const [householdId, setHouseholdId] = useState(households[0]?.id ?? "")
+
+  useEffect(() => {
+    if (!householdId && households.length > 0) {
+      setHouseholdId(households[0].id)
+    }
+  }, [householdId, households])
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset()
+      setHouseholdId(households[0]?.id ?? "")
+    }
+  }, [state.status, households])
+
+  const selectedHouseholdOption = useMemo(() => {
+    return households.find((household) => household.id === householdId) ?? null
+  }, [householdId, households])
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      className="space-y-6 rounded-lg border bg-card p-6 shadow-sm"
+    >
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Upload a new floorplan</h2>
+        <p className="text-sm text-muted-foreground">
+          Floorplans are stored in the Supabase <code className="rounded bg-muted px-1 py-0.5">floorplans</code> bucket.
+          Supply pixel dimensions and optional overlay metadata to unlock roommate-specific views.
+        </p>
+      </div>
+
+      <fieldset className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" name="name" placeholder="e.g. Unit 2A Main Level" required />
+          {state.fieldErrors?.name && (
+            <p className="text-xs text-destructive">{state.fieldErrors.name}</p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="description">Description (optional)</Label>
+          <Input id="description" name="description" placeholder="Highlight storage zones or unique notes" />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="width">Width (px)</Label>
+          <Input id="width" name="width" type="number" min={1} step={1} placeholder="1200" required />
+          {state.fieldErrors?.width && (
+            <p className="text-xs text-destructive">{state.fieldErrors.width}</p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="height">Height (px)</Label>
+          <Input id="height" name="height" type="number" min={1} step={1} placeholder="900" required />
+          {state.fieldErrors?.height && (
+            <p className="text-xs text-destructive">{state.fieldErrors.height}</p>
+          )}
+        </div>
+      </fieldset>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label>Household</Label>
+          {households.length > 0 ? (
+            <Select
+              value={selectedHouseholdOption ? selectedHouseholdOption.id : undefined}
+              onValueChange={(value) => setHouseholdId(value)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a household" />
+              </SelectTrigger>
+              <SelectContent>
+                {households.map((household) => (
+                  <SelectItem key={household.id} value={household.id}>
+                    {household.name ?? household.slug ?? household.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <p className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-3 text-sm text-muted-foreground">
+              No households were found. Paste a valid household identifier below to associate this floorplan.
+            </p>
+          )}
+          <Input
+            id="householdId"
+            name="householdId"
+            value={householdId}
+            onChange={(event) => setHouseholdId(event.target.value)}
+            placeholder="Paste or type a household UUID"
+            required
+          />
+          <p className="text-xs text-muted-foreground">
+            {households.length > 0
+              ? "Select a household from the list or override it with a specific UUID."
+              : "Enter the UUID of the household that should see this floorplan."}
+          </p>
+          {state.fieldErrors?.householdId && (
+            <p className="text-xs text-destructive">{state.fieldErrors.householdId}</p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="file">Floorplan image</Label>
+          <Input id="file" name="file" type="file" accept="image/*" required />
+          <p className="text-xs text-muted-foreground">
+            Upload a high-resolution PNG, JPEG, or SVG. Files up to 10MB are supported.
+          </p>
+          {state.fieldErrors?.file && (
+            <p className="text-xs text-destructive">{state.fieldErrors.file}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="overlays">Overlay JSON (optional)</Label>
+        <Textarea
+          id="overlays"
+          name="overlays"
+          placeholder='[
+  {"id":"kitchen","label":"Kitchen","x":64,"y":48,"width":320,"height":280,"color":"#2563eb4d"}
+]'
+          className="min-h-[160px] font-mono text-xs"
+        />
+        <p className="text-xs text-muted-foreground">
+          Provide an array of overlay objects with <code>id</code>, <code>label</code>, <code>x</code>, <code>y</code>,
+          <code>width</code>, and <code>height</code> fields to highlight zones on the tenant view. Colors and notes are optional.
+        </p>
+        {state.fieldErrors?.overlays && (
+          <p className="text-xs text-destructive">{state.fieldErrors.overlays}</p>
+        )}
+      </div>
+
+      <StatusMessage state={state} />
+
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-muted-foreground">
+          Tip: use consistent pixel dimensions so overlays scale correctly across devices.
+        </p>
+        <SubmitButton />
+      </div>
+    </form>
+  )
+}
+
+function StatusMessage({ state }: { state: FloorplanUploadState }) {
+  if (state.status === "idle") {
+    return null
+  }
+
+  const variant = state.status === "success" ? "bg-emerald-600/10 text-emerald-600" : "bg-destructive/10 text-destructive"
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      className={cn("rounded-md px-3 py-2 text-sm", variant)}
+    >
+      {state.message}
+    </div>
+  )
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" disabled={pending} className="min-w-[180px]">
+      {pending ? "Uploading…" : "Upload floorplan"}
+    </Button>
+  )
+}

--- a/app/dashboard/floorplans/page.tsx
+++ b/app/dashboard/floorplans/page.tsx
@@ -1,0 +1,156 @@
+import Image from "next/image"
+import Link from "next/link"
+
+import { Badge } from "@/components/ui/badge"
+import { parseFloorplanOverlays, type FloorplanOverlay } from "@/lib/floorplans"
+import type { Tables } from "@/lib/supabase"
+import { createSupbaseServerClient } from "@/utils/supaone"
+import { FloorplanUploadForm } from "./floorplan-upload-form"
+
+type Household = Pick<Tables<"households">, "id" | "name" | "slug">
+
+type FloorplanRecord = Tables<"floorplans">
+
+type FloorplanWithPresentation = FloorplanRecord & {
+  publicUrl: string | null
+  overlaysParsed: FloorplanOverlay[]
+}
+
+export const dynamic = "force-dynamic"
+
+export default async function FloorplansPage() {
+  const supabase = await createSupbaseServerClient()
+
+  const { data: householdData, error: householdsError } = await supabase
+    .from("households")
+    .select("id, name, slug")
+    .order("name", { ascending: true })
+
+  if (householdsError) {
+    console.error("Failed to load households", householdsError)
+  }
+
+  const households: Household[] = householdData ?? []
+
+  const { data: floorplanData, error: floorplansError } = await supabase
+    .from("floorplans")
+    .select("*")
+    .order("created_at", { ascending: false })
+
+  if (floorplansError) {
+    console.error("Failed to load floorplans", floorplansError)
+  }
+
+  const floorplans: FloorplanWithPresentation[] = (floorplanData ?? []).map((floorplan) => {
+    const { data: publicUrlData } = supabase.storage.from("floorplans").getPublicUrl(floorplan.storage_path)
+
+    return {
+      ...floorplan,
+      publicUrl: publicUrlData?.publicUrl ?? null,
+      overlaysParsed: parseFloorplanOverlays(floorplan.overlays),
+    }
+  })
+
+  return (
+    <div className="space-y-10">
+      <FloorplanUploadForm households={households} />
+      <ExistingFloorplans floorplans={floorplans} />
+    </div>
+  )
+}
+
+function ExistingFloorplans({ floorplans }: { floorplans: FloorplanWithPresentation[] }) {
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Existing floorplans</h2>
+        <p className="text-sm text-muted-foreground">
+          Review uploaded floorplans, overlay counts, and quick links to the tenant view.
+        </p>
+      </div>
+
+      {floorplans.length === 0 ? (
+        <p className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+          No floorplans have been uploaded yet.
+        </p>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {floorplans.map((floorplan) => {
+            const overlayCount = floorplan.overlaysParsed.length
+            const tenantHref = floorplan.household_id
+              ? `/floorplan?household=${encodeURIComponent(floorplan.household_id)}`
+              : "/floorplan"
+
+            return (
+              <article
+                key={floorplan.id}
+                className="flex h-full flex-col overflow-hidden rounded-lg border bg-card shadow-sm"
+              >
+                {floorplan.publicUrl ? (
+                  <div className="relative h-48 w-full bg-muted">
+                    <Image
+                      src={floorplan.publicUrl}
+                      alt={`Preview of ${floorplan.name}`}
+                      fill
+                      sizes="(min-width: 1280px) 33vw, (min-width: 768px) 50vw, 100vw"
+                      className="object-cover"
+                      priority={false}
+                      unoptimized
+                    />
+                  </div>
+                ) : (
+                  <div className="flex h-48 items-center justify-center bg-muted text-sm text-muted-foreground">
+                    Preview unavailable
+                  </div>
+                )}
+
+                <div className="flex flex-1 flex-col gap-4 p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h3 className="text-base font-semibold leading-tight">{floorplan.name}</h3>
+                      <p className="text-xs text-muted-foreground">
+                        {floorplan.created_at
+                          ? new Date(floorplan.created_at).toLocaleString()
+                          : "Creation date unavailable"}
+                      </p>
+                    </div>
+                    <Badge variant="secondary">
+                      {floorplan.width}×{floorplan.height}px
+                    </Badge>
+                  </div>
+
+                  {floorplan.description ? (
+                    <p className="text-sm text-muted-foreground">{floorplan.description}</p>
+                  ) : (
+                    <p className="text-sm italic text-muted-foreground">No description provided.</p>
+                  )}
+
+                  <div className="space-y-1 text-xs text-muted-foreground">
+                    <p>
+                      <span className="font-medium text-foreground">Household:</span> {floorplan.household_id ?? "—"}
+                    </p>
+                    <p>
+                      <span className="font-medium text-foreground">Overlays:</span> {overlayCount}
+                    </p>
+                  </div>
+
+                  <div className="mt-auto flex items-center justify-between gap-3 text-xs">
+                    <Badge variant="outline">
+                      {overlayCount === 1 ? "1 overlay" : `${overlayCount} overlays`}
+                    </Badge>
+                    <Link
+                      href={tenantHref}
+                      className="font-medium text-primary underline-offset-4 hover:underline"
+                    >
+                      View tenant preview
+                    </Link>
+                  </div>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/lib/floorplans.ts
+++ b/lib/floorplans.ts
@@ -1,0 +1,104 @@
+import type { Json } from "@/lib/supabase"
+
+export type FloorplanOverlay = {
+  id: string
+  label: string
+  x: number
+  y: number
+  width: number
+  height: number
+  description?: string
+  color?: string
+  occupant?: string
+}
+
+function coerceNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+function asOverlayRecord(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+
+  return null
+}
+
+function normaliseOverlaySource(source: Json | null | undefined): Json[] {
+  if (!source) {
+    return []
+  }
+
+  if (Array.isArray(source)) {
+    return source
+  }
+
+  if (typeof source === "string") {
+    try {
+      const parsed = JSON.parse(source) as unknown
+      return Array.isArray(parsed) ? (parsed as Json[]) : []
+    } catch (error) {
+      console.error("Failed to parse overlay JSON string", error)
+      return []
+    }
+  }
+
+  return []
+}
+
+export function parseFloorplanOverlays(raw: Json | null | undefined): FloorplanOverlay[] {
+  const overlays = normaliseOverlaySource(raw)
+
+  return overlays
+    .map((entry) => {
+      const record = asOverlayRecord(entry)
+      if (!record) {
+        return null
+      }
+
+      const id = typeof record.id === "string" && record.id.trim().length > 0 ? record.id.trim() : null
+      const label =
+        typeof record.label === "string" && record.label.trim().length > 0 ? record.label.trim() : null
+
+      const x = coerceNumber(record.x)
+      const y = coerceNumber(record.y)
+      const width = coerceNumber(record.width)
+      const height = coerceNumber(record.height)
+
+      if (!id || !label || x === null || y === null || width === null || height === null) {
+        return null
+      }
+
+      if (width <= 0 || height <= 0) {
+        return null
+      }
+
+      if (x < 0 || y < 0) {
+        return null
+      }
+
+      return {
+        id,
+        label,
+        x,
+        y,
+        width,
+        height,
+        description: typeof record.description === "string" ? record.description : undefined,
+        color: typeof record.color === "string" ? record.color : undefined,
+        occupant: typeof record.occupant === "string" ? record.occupant : undefined,
+      }
+    })
+    .filter((overlay): overlay is FloorplanOverlay => overlay !== null)
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -914,6 +914,53 @@ export type Database = {
         }
         Relationships: []
       }
+      floorplans: {
+        Row: {
+          created_at: string | null
+          description: string | null
+          height: number
+          household_id: string | null
+          id: number
+          name: string
+          overlays: Json
+          storage_path: string
+          updated_at: string | null
+          width: number
+        }
+        Insert: {
+          created_at?: string | null
+          description?: string | null
+          height: number
+          household_id: string
+          id?: number
+          name: string
+          overlays?: Json
+          storage_path: string
+          updated_at?: string | null
+          width: number
+        }
+        Update: {
+          created_at?: string | null
+          description?: string | null
+          height?: number
+          household_id?: string
+          id?: number
+          name?: string
+          overlays?: Json
+          storage_path?: string
+          updated_at?: string | null
+          width?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "floorplans_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       gpt_one: {
         Row: {
           created_at: string
@@ -938,6 +985,30 @@ export type Database = {
           messages?: string | null
           user_input?: string | null
           vector_one?: string | null
+        }
+        Relationships: []
+      }
+      households: {
+        Row: {
+          created_at: string
+          id: string
+          name: string
+          slug: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          name: string
+          slug?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          name?: string
+          slug?: string | null
+          updated_at?: string
         }
         Relationships: []
       }

--- a/supabase/migrations/20250717_floorplans.sql
+++ b/supabase/migrations/20250717_floorplans.sql
@@ -1,0 +1,212 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.households (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text unique,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.households enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from information_schema.tables
+    where table_schema = 'public'
+      and table_name = 'floorplans'
+  ) then
+    create table public.floorplans (
+      id bigint generated always as identity primary key,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now(),
+      name text not null,
+      description text,
+      storage_path text not null,
+      width integer not null,
+      height integer not null,
+      household_id uuid not null references public.households(id) on delete cascade,
+      overlays jsonb not null default '[]'::jsonb
+    );
+  else
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'created_at'
+    ) then
+      alter table public.floorplans
+        add column created_at timestamptz not null default now();
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'updated_at'
+    ) then
+      alter table public.floorplans
+        add column updated_at timestamptz not null default now();
+    else
+      update public.floorplans
+         set updated_at = coalesce(updated_at, now());
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'name'
+    ) then
+      alter table public.floorplans
+        add column name text;
+      update public.floorplans
+         set name = coalesce(name, 'Floorplan ' || id);
+      alter table public.floorplans
+        alter column name set not null;
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'description'
+    ) then
+      alter table public.floorplans
+        add column description text;
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'storage_path'
+    ) then
+      alter table public.floorplans
+        add column storage_path text;
+    end if;
+    update public.floorplans
+       set storage_path = coalesce(storage_path, '');
+    alter table public.floorplans
+      alter column storage_path set default '';
+    alter table public.floorplans
+      alter column storage_path set not null;
+    alter table public.floorplans
+      alter column storage_path drop default;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'width'
+    ) then
+      alter table public.floorplans
+        add column width integer;
+    end if;
+    update public.floorplans
+       set width = coalesce(width, 0);
+    alter table public.floorplans
+      alter column width set default 0;
+    alter table public.floorplans
+      alter column width set not null;
+    alter table public.floorplans
+      alter column width drop default;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'height'
+    ) then
+      alter table public.floorplans
+        add column height integer;
+    end if;
+    update public.floorplans
+       set height = coalesce(height, 0);
+    alter table public.floorplans
+      alter column height set default 0;
+    alter table public.floorplans
+      alter column height set not null;
+    alter table public.floorplans
+      alter column height drop default;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'household_id'
+    ) then
+      alter table public.floorplans
+        add column household_id uuid;
+    end if;
+
+    if not exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'overlays'
+    ) then
+      alter table public.floorplans
+        add column overlays jsonb not null default '[]'::jsonb;
+    else
+      update public.floorplans
+         set overlays = coalesce(overlays, '[]'::jsonb);
+      alter table public.floorplans
+        alter column overlays set default '[]'::jsonb;
+      alter table public.floorplans
+        alter column overlays set not null;
+    end if;
+  end if;
+end $$;
+
+alter table public.floorplans enable row level security;
+
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'floorplans'
+      and column_name = 'household_id'
+  ) then
+    if exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'floorplans'
+        and column_name = 'household_id'
+    ) then
+      if not exists (
+        select 1
+        from pg_constraint
+        where conrelid = 'public.floorplans'::regclass
+          and conname = 'floorplans_household_id_fkey'
+      ) then
+        alter table public.floorplans
+          add constraint floorplans_household_id_fkey
+          foreign key (household_id)
+          references public.households(id)
+          on delete cascade;
+      end if;
+    end if;
+
+    if not exists (
+      select 1
+      from public.floorplans
+      where household_id is null
+      limit 1
+    ) then
+      begin
+        alter table public.floorplans
+          alter column household_id set not null;
+      exception
+        when others then
+          null;
+      end;
+    end if;
+  end if;
+end $$;
+
+create index if not exists floorplans_household_id_idx
+  on public.floorplans (household_id);


### PR DESCRIPTION
## Summary
- extend the Supabase schema with a households table and richer floorplan metadata columns to capture storage paths, dimensions, and overlay data
- add an admin dashboard floorplan uploader that writes to the storage bucket, validates overlay JSON, and lists existing floorplans with public previews
- create a tenant-facing floorplan viewer with responsive SVG overlays and update the dashboard navigation to include the floorplan tools

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0e7191483288be622f91c7a5f75