### PR TITLE
Add quiet hours enforcement for visitor requests

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { CalendarIcon, CrumpledPaperIcon, PersonIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -14,11 +14,16 @@ export default function NavLinks() {
 			text: "Members",
 			Icon: PersonIcon,
 		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
+                {
+                        href: "/dashboard/visitors",
+                        text: "Visitor requests",
+                        Icon: CalendarIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
 	];
 
 	return (

--- a/app/dashboard/visitors/actions.ts
+++ b/app/dashboard/visitors/actions.ts
@@ -1,0 +1,148 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { cookies } from "next/headers"
+import { z } from "zod"
+
+import { isDateWithinQuietHours } from "@/lib/quiet-hours"
+import { ensureHouseholdQuietHours, ensureProfileHousehold } from "@/lib/server/quiet-hours"
+import type { Tables } from "@/lib/supabase"
+import { createClient } from "@/utils/supa-server-actions"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+const visitorRequestSchema = z
+  .object({
+    visitorName: z
+      .string({ required_error: "Visitor name is required." })
+      .trim()
+      .min(1, { message: "Visitor name is required." })
+      .max(120, { message: "Visitor name must be 120 characters or fewer." }),
+    arrivalAt: z.coerce.date({
+      invalid_type_error: "Arrival date and time are required.",
+      required_error: "Arrival date and time are required.",
+    }),
+    departureAt: z.coerce.date({
+      invalid_type_error: "Departure date and time are required.",
+      required_error: "Departure date and time are required.",
+    }),
+    reason: z
+      .string()
+      .max(500, { message: "Reason must be 500 characters or fewer." })
+      .optional(),
+  })
+  .refine((data) => data.departureAt > data.arrivalAt, {
+    message: "Departure must be after arrival.",
+    path: ["departureAt"],
+  })
+
+export type VisitorRequestState = {
+  status: "idle" | "success" | "error"
+  message: string | null
+  policyMessage?: string | null
+}
+
+export const initialVisitorRequestState: VisitorRequestState = {
+  status: "idle",
+  message: null,
+  policyMessage: null,
+}
+
+export async function submitVisitorRequest(
+  _prevState: VisitorRequestState,
+  formData: FormData
+): Promise<VisitorRequestState> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore) as TypedSupabaseClient
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return {
+      status: "error",
+      message: "You must be signed in to register a visitor.",
+      policyMessage: null,
+    }
+  }
+
+  const rawInput = {
+    visitorName: formData.get("visitorName"),
+    arrivalAt: formData.get("arrivalAt"),
+    departureAt: formData.get("departureAt"),
+    reason: formData.get("reason") ?? undefined,
+  }
+
+  const parsedInput = visitorRequestSchema.safeParse(rawInput)
+
+  if (!parsedInput.success) {
+    const issues = parsedInput.error.flatten()
+    const message = [...Object.values(issues.fieldErrors), issues.formErrors]
+      .flat()
+      .filter(Boolean)
+      .join(" ")
+
+    return {
+      status: "error",
+      message: message || "Please review the visitor request details and try again.",
+      policyMessage: null,
+    }
+  }
+
+  const { visitorName, arrivalAt, departureAt, reason } = parsedInput.data
+
+  try {
+    const { profile, householdId } = await ensureProfileHousehold(supabase, user.id)
+    const settings = await ensureHouseholdQuietHours(supabase, householdId)
+
+    if (
+      isDateWithinQuietHours(arrivalAt, settings) ||
+      isDateWithinQuietHours(departureAt, settings)
+    ) {
+      return {
+        status: "error",
+        message: "The requested arrival or departure falls within your quiet hours.",
+        policyMessage: settings.policy_message,
+      }
+    }
+
+    const trimmedReason = typeof reason === "string" ? reason.trim() : null
+    const finalReason = trimmedReason && trimmedReason.length > 0 ? trimmedReason : null
+
+    const { error: insertError } = await supabase.from("visitor_requests").insert({
+      household_id: householdId,
+      host_profile_id: profile.id,
+      visitor_name: visitorName,
+      arrival_at: arrivalAt.toISOString(),
+      departure_at: departureAt.toISOString(),
+      reason: finalReason,
+      status: "pending",
+    })
+
+    if (insertError) {
+      return {
+        status: "error",
+        message: "We could not save the visitor request. Please try again.",
+        policyMessage: null,
+      }
+    }
+
+    revalidatePath("/dashboard/visitors")
+
+    return {
+      status: "success",
+      message: "Visitor request submitted for review.",
+      policyMessage: settings.policy_message,
+    }
+  } catch (error) {
+    console.error("Visitor request submission failed", error)
+    return {
+      status: "error",
+      message: "We were unable to process the visitor request. Please try again later.",
+      policyMessage: null,
+    }
+  }
+}
+
+export type VisitorRequest = Tables<"visitor_requests">

--- a/app/dashboard/visitors/page.tsx
+++ b/app/dashboard/visitors/page.tsx
@@ -1,0 +1,130 @@
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { formatQuietHoursWindow } from "@/lib/quiet-hours"
+import { ensureHouseholdQuietHours, ensureProfileHousehold } from "@/lib/server/quiet-hours"
+import { createClient } from "@/utils/supa-server-actions"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+import { VisitorRequestForm } from "./visitor-request-form"
+import type { VisitorRequest } from "./actions"
+
+export default async function VisitorRequestsPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore) as TypedSupabaseClient
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const { householdId } = await ensureProfileHousehold(supabase, user.id)
+  const settings = await ensureHouseholdQuietHours(supabase, householdId)
+
+  const { data: requests, error: requestsError } = await supabase
+    .from("visitor_requests")
+    .select("id, visitor_name, arrival_at, departure_at, status, created_at, reason")
+    .eq("household_id", householdId)
+    .order("arrival_at", { ascending: true })
+
+  if (requestsError) {
+    console.error("Failed to load visitor requests", requestsError)
+  }
+
+  const resolvedRequests = (requests ?? []) as VisitorRequest[]
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: settings.timezone,
+  })
+
+  const quietHoursWindow = formatQuietHoursWindow(settings)
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">Visitor requests</h1>
+          <p className="text-muted-foreground">
+            Log overnight guests, keep roommates informed, and respect quiet hours for your
+            household.
+          </p>
+        </div>
+        <div className="rounded-md border border-blue-500/30 bg-blue-500/10 px-4 py-3 text-sm text-blue-900 dark:text-blue-100">
+          <p>{settings.policy_message}</p>
+          <p className="mt-1 text-xs opacity-80">
+            Quiet hours: {quietHoursWindow} ({settings.timezone})
+          </p>
+        </div>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
+        <Card className="order-2 lg:order-1">
+          <CardHeader>
+            <CardTitle>Upcoming stays</CardTitle>
+            <CardDescription>Review approved and pending visitor requests.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {resolvedRequests.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No visitor requests yet. Submit the form to log an overnight stay.
+              </p>
+            ) : (
+              <ul className="space-y-4">
+                {resolvedRequests.map((request) => {
+                  const statusLabel = request.status
+                    .replace(/_/g, " ")
+                    .replace(/^([a-z])/, (match) => match.toUpperCase())
+
+                  return (
+                    <li
+                      key={request.id}
+                      className="rounded-md border border-muted bg-background p-4 shadow-sm"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <p className="font-medium">{request.visitor_name}</p>
+                          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                            {statusLabel}
+                          </p>
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          <p>Arrives: {formatter.format(new Date(request.arrival_at))}</p>
+                          <p>Departs: {formatter.format(new Date(request.departure_at))}</p>
+                        </div>
+                      </div>
+                      {request.reason && (
+                        <p className="mt-3 text-sm text-muted-foreground">{request.reason}</p>
+                      )}
+                      <p className="mt-3 text-xs text-muted-foreground">
+                        Logged {formatter.format(new Date(request.created_at ?? request.arrival_at))}
+                      </p>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="order-1 lg:order-2">
+          <CardHeader>
+            <CardTitle>Request overnight visitor</CardTitle>
+            <CardDescription>
+              Share arrival and departure windows so roommates and property managers can
+              review the stay in advance.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <VisitorRequestForm settings={settings} />
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  )
+}

--- a/app/dashboard/visitors/visitor-request-form.tsx
+++ b/app/dashboard/visitors/visitor-request-form.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useFormState } from "react-dom"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { formatQuietHoursWindow, isDateWithinQuietHours } from "@/lib/quiet-hours"
+import type { QuietHoursSettings } from "@/lib/quiet-hours"
+
+import {
+  initialVisitorRequestState,
+  submitVisitorRequest,
+  type VisitorRequestState,
+} from "./actions"
+
+type VisitorRequestFormProps = {
+  settings: QuietHoursSettings
+}
+
+export function VisitorRequestForm({ settings }: VisitorRequestFormProps) {
+  const [state, formAction] = useFormState(submitVisitorRequest, initialVisitorRequestState)
+  const [arrival, setArrival] = useState("")
+  const [departure, setDeparture] = useState("")
+  const formRef = useRef<HTMLFormElement>(null)
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset()
+      setArrival("")
+      setDeparture("")
+    }
+  }, [state.status])
+
+  const quietHoursWindow = useMemo(() => formatQuietHoursWindow(settings), [settings])
+
+  const { arrivalConflict, departureConflict, hasConflict } = useMemo(() => {
+    const arrivalDate = arrival ? new Date(arrival) : null
+    const departureDate = departure ? new Date(departure) : null
+
+    const arrivalConflict = arrivalDate
+      ? isDateWithinQuietHours(arrivalDate, settings)
+      : false
+    const departureConflict = departureDate
+      ? isDateWithinQuietHours(departureDate, settings)
+      : false
+
+    return {
+      arrivalConflict,
+      departureConflict,
+      hasConflict: arrivalConflict || departureConflict,
+    }
+  }, [arrival, departure, settings])
+
+  const renderFeedback = (formState: VisitorRequestState) => {
+    if (!formState.message) {
+      return null
+    }
+
+    const tone = formState.status === "success" ? "success" : "error"
+    const baseStyles =
+      tone === "success"
+        ? "border-green-500/40 bg-green-500/10 text-green-900 dark:text-green-200"
+        : "border-red-500/50 bg-red-500/10 text-red-900 dark:text-red-200"
+
+    return (
+      <div className={`rounded-md border px-4 py-3 text-sm ${baseStyles}`}>
+        <p>{formState.message}</p>
+        {formState.policyMessage && (
+          <p className="mt-1 text-xs opacity-80">{formState.policyMessage}</p>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-4">
+      <div className="space-y-1">
+        <Label htmlFor="visitorName">Visitor name</Label>
+        <Input
+          id="visitorName"
+          name="visitorName"
+          placeholder="Who is staying over?"
+          required
+        />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor="arrivalAt">Arrival</Label>
+          <Input
+            id="arrivalAt"
+            name="arrivalAt"
+            type="datetime-local"
+            onChange={(event) => setArrival(event.target.value)}
+            required
+          />
+          {arrivalConflict && (
+            <p className="text-xs text-amber-600">Arrival overlaps quiet hours.</p>
+          )}
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="departureAt">Departure</Label>
+          <Input
+            id="departureAt"
+            name="departureAt"
+            type="datetime-local"
+            onChange={(event) => setDeparture(event.target.value)}
+            required
+          />
+          {departureConflict && (
+            <p className="text-xs text-amber-600">Departure overlaps quiet hours.</p>
+          )}
+        </div>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="reason">Visit notes (optional)</Label>
+        <Textarea
+          id="reason"
+          name="reason"
+          placeholder="Share the reason or any helpful notes for your roommates."
+          rows={3}
+        />
+        <p className="text-xs text-muted-foreground">
+          Quiet hours run {quietHoursWindow}. Arrivals and departures should stay outside
+          this window.
+        </p>
+      </div>
+      {hasConflict && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-100">
+          <p>
+            Your selected times overlap with quiet hours. Adjust the schedule or share an
+            alternate hand-off plan before submitting.
+          </p>
+          <p className="mt-1 text-xs opacity-80">{settings.policy_message}</p>
+        </div>
+      )}
+      {renderFeedback(state)}
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={hasConflict}>
+          Submit visitor request
+        </Button>
+        {hasConflict && (
+          <p className="text-xs text-muted-foreground">
+            Update times outside quiet hours to enable submission.
+          </p>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/docs/overnight-visitors.md
+++ b/docs/overnight-visitors.md
@@ -1,0 +1,45 @@
+# Overnight Visitor Quiet Hours Policy
+
+Quiet hours help each household coordinate guest arrivals and departures without disrupting
+roommates. This document summarises how the portal enforces the policy and how to update
+it when the household guidelines change.
+
+## Household settings
+
+- Quiet hours are stored in `household_settings` alongside the household timezone and the
+  policy message presented to residents.
+- A default window of **10:00 PM – 7:00 AM (UTC)** is created automatically whenever a
+  household is provisioned. Property managers can update the window or policy message via
+  Supabase or an administrative surface.
+- Each setting row is unique per household. Updating the record will immediately affect
+  the visitor request form and any validation logic.
+
+## Visitor request flow
+
+1. Residents submit the visitor form from the dashboard by providing the guest’s name,
+   arrival time, departure time, and optional context.
+2. The server action ensures the resident belongs to a household, provisions one if
+   necessary, and guarantees a quiet-hours record exists.
+3. Arrival and departure times are evaluated in the household’s timezone. If either time
+   falls inside the quiet-hours window, the request is rejected with the household’s
+   policy message.
+4. Successful requests are stored in the `visitor_requests` table with a pending status for
+   follow-up by roommates or property managers.
+
+## UI guidance
+
+- The visitor form surfaces the quiet-hours window and disables submission when selected
+  times overlap with the restricted period.
+- Policy copy is shown both in the dashboard header and in server-action responses to
+  reinforce expectations.
+- Document any exceptions or overrides within the policy message so residents understand
+  the approval criteria before submitting.
+
+## Updating the policy
+
+1. Adjust `quiet_hours_start`, `quiet_hours_end`, `timezone`, or `policy_message` in the
+   `household_settings` record for the household.
+2. The dashboard will pick up the changes immediately; no additional deployment steps are
+   required.
+3. Communicate updates to residents via announcements or the messaging module to ensure
+   everyone understands the new guidelines.

--- a/lib/quiet-hours.ts
+++ b/lib/quiet-hours.ts
@@ -1,0 +1,98 @@
+import type { Tables } from "@/lib/supabase"
+
+export type QuietHoursSettings = Pick<
+  Tables<"household_settings">,
+  "quiet_hours_start" | "quiet_hours_end" | "timezone" | "policy_message"
+>
+
+export const DEFAULT_QUIET_HOURS: QuietHoursSettings = {
+  quiet_hours_start: "22:00",
+  quiet_hours_end: "07:00",
+  timezone: "UTC",
+  policy_message:
+    "Quiet hours are 10:00 PM – 7:00 AM. Please schedule visitor arrivals and departures outside this window.",
+}
+
+const MINUTES_IN_HOUR = 60
+
+export function parseTimeToMinutes(timeValue: string): number {
+  const [hourStr, minuteStr = "0"] = timeValue.split(":")
+  const hours = Number.parseInt(hourStr, 10)
+  const minutes = Number.parseInt(minuteStr, 10)
+
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    throw new Error(`Invalid time value: ${timeValue}`)
+  }
+
+  return hours * MINUTES_IN_HOUR + minutes
+}
+
+export function getMinutesForDateInTimezone(date: Date, timezone: string): number {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "numeric",
+      hour12: false,
+      timeZone: timezone,
+    })
+
+    const parts = formatter.formatToParts(date)
+    const hourPart = parts.find((part) => part.type === "hour")
+    const minutePart = parts.find((part) => part.type === "minute")
+
+    const hours = Number.parseInt(hourPart?.value ?? "0", 10)
+    const minutes = Number.parseInt(minutePart?.value ?? "0", 10)
+
+    return hours * MINUTES_IN_HOUR + minutes
+  } catch (error) {
+    console.warn(`Failed to resolve timezone ${timezone}. Falling back to UTC.`, error)
+    return date.getUTCHours() * MINUTES_IN_HOUR + date.getUTCMinutes()
+  }
+}
+
+export function isMinutesWithinQuietHours(
+  minutes: number,
+  quietStartMinutes: number,
+  quietEndMinutes: number
+): boolean {
+  if (quietStartMinutes === quietEndMinutes) {
+    return false
+  }
+
+  if (quietStartMinutes < quietEndMinutes) {
+    return minutes >= quietStartMinutes && minutes < quietEndMinutes
+  }
+
+  return minutes >= quietStartMinutes || minutes < quietEndMinutes
+}
+
+export function isDateWithinQuietHours(date: Date, settings: QuietHoursSettings): boolean {
+  const quietStartMinutes = parseTimeToMinutes(settings.quiet_hours_start)
+  const quietEndMinutes = parseTimeToMinutes(settings.quiet_hours_end)
+  const minutes = getMinutesForDateInTimezone(date, settings.timezone)
+
+  return isMinutesWithinQuietHours(minutes, quietStartMinutes, quietEndMinutes)
+}
+
+export function formatQuietHoursWindow(settings: QuietHoursSettings): string {
+  const referenceDate = new Date(Date.UTC(2020, 0, 1))
+  const start = new Date(referenceDate)
+  const end = new Date(referenceDate)
+
+  const [startHoursStr, startMinutesStr = "0"] = settings.quiet_hours_start.split(":")
+  const [endHoursStr, endMinutesStr = "0"] = settings.quiet_hours_end.split(":")
+
+  start.setUTCHours(Number(startHoursStr), Number(startMinutesStr), 0, 0)
+  end.setUTCHours(Number(endHoursStr), Number(endMinutesStr), 0, 0)
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: settings.timezone,
+  })
+
+  const startLabel = formatter.format(start)
+  const endLabel = formatter.format(end)
+
+  return `${startLabel} – ${endLabel}`
+}

--- a/lib/server/quiet-hours.ts
+++ b/lib/server/quiet-hours.ts
@@ -1,0 +1,89 @@
+import { DEFAULT_QUIET_HOURS } from "@/lib/quiet-hours"
+import type { Tables } from "@/lib/supabase"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+export type ProfileWithHousehold = Pick<
+  Tables<"profiles">,
+  "id" | "full_name" | "household_id"
+>
+
+export async function ensureProfileHousehold(
+  client: TypedSupabaseClient,
+  userId: string
+): Promise<{ profile: ProfileWithHousehold; householdId: string }> {
+  const { data: profile, error } = await client
+    .from("profiles")
+    .select("id, full_name, household_id")
+    .eq("id", userId)
+    .single()
+
+  if (error || !profile) {
+    throw new Error("Unable to load profile for the current user.")
+  }
+
+  if (profile.household_id) {
+    return { profile, householdId: profile.household_id }
+  }
+
+  const householdName = profile.full_name
+    ? `${profile.full_name}'s Household`
+    : "Shared Household"
+
+  const { data: household, error: householdError } = await client
+    .from("households")
+    .insert({ name: householdName, created_by: profile.id })
+    .select("id")
+    .single()
+
+  if (householdError || !household) {
+    throw new Error("Unable to create a household for the current user.")
+  }
+
+  const { error: updateError } = await client
+    .from("profiles")
+    .update({ household_id: household.id })
+    .eq("id", profile.id)
+
+  if (updateError) {
+    throw new Error("Unable to link the profile to the household.")
+  }
+
+  return { profile: { ...profile, household_id: household.id }, householdId: household.id }
+}
+
+export async function ensureHouseholdQuietHours(
+  client: TypedSupabaseClient,
+  householdId: string
+): Promise<Tables<"household_settings">> {
+  const { data, error } = await client
+    .from("household_settings")
+    .select("*")
+    .eq("household_id", householdId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error("Unable to load quiet hours configuration.")
+  }
+
+  if (data) {
+    return data
+  }
+
+  const { data: inserted, error: insertError } = await client
+    .from("household_settings")
+    .insert({
+      household_id: householdId,
+      quiet_hours_start: DEFAULT_QUIET_HOURS.quiet_hours_start,
+      quiet_hours_end: DEFAULT_QUIET_HOURS.quiet_hours_end,
+      timezone: DEFAULT_QUIET_HOURS.timezone,
+      policy_message: DEFAULT_QUIET_HOURS.policy_message,
+    })
+    .select("*")
+    .single()
+
+  if (insertError || !inserted) {
+    throw new Error("Unable to create default quiet hours settings for the household.")
+  }
+
+  return inserted
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -510,6 +510,76 @@ export type Database = {
         }
         Relationships: []
       }
+      household_settings: {
+        Row: {
+          created_at: string
+          household_id: string
+          id: string
+          policy_message: string
+          quiet_hours_end: string
+          quiet_hours_start: string
+          timezone: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          household_id: string
+          id?: string
+          policy_message?: string
+          quiet_hours_end: string
+          quiet_hours_start: string
+          timezone?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          household_id?: string
+          id?: string
+          policy_message?: string
+          quiet_hours_end?: string
+          quiet_hours_start?: string
+          timezone?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "household_settings_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: true
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      households: {
+        Row: {
+          created_at: string | null
+          created_by: string | null
+          id: string
+          name: string
+        }
+        Insert: {
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          name: string
+        }
+        Update: {
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "households_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       crm_activities: {
         Row: {
           completed_date: string | null
@@ -1236,6 +1306,7 @@ export type Database = {
           created_at: string | null
           email: string | null
           full_name: string | null
+          household_id: string | null
           id: string
           job_title: string | null
           linkedin_url: string | null
@@ -1256,6 +1327,7 @@ export type Database = {
           created_at?: string | null
           email?: string | null
           full_name?: string | null
+          household_id?: string | null
           id?: string
           job_title?: string | null
           linkedin_url?: string | null
@@ -1276,6 +1348,7 @@ export type Database = {
           created_at?: string | null
           email?: string | null
           full_name?: string | null
+          household_id?: string | null
           id?: string
           job_title?: string | null
           linkedin_url?: string | null
@@ -1287,7 +1360,15 @@ export type Database = {
           website?: string | null
           xhandle?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "profiles_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       reusable_packages: {
         Row: {
@@ -1593,6 +1674,57 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "members_table"
             referencedColumns: ["member_id"]
+          },
+        ]
+      }
+      visitor_requests: {
+        Row: {
+          arrival_at: string
+          created_at: string
+          departure_at: string
+          household_id: string
+          host_profile_id: string
+          id: string
+          reason: string | null
+          status: string
+          visitor_name: string
+        }
+        Insert: {
+          arrival_at: string
+          created_at?: string
+          departure_at: string
+          household_id: string
+          host_profile_id: string
+          id?: string
+          reason?: string | null
+          status?: string
+          visitor_name: string
+        }
+        Update: {
+          arrival_at?: string
+          created_at?: string
+          departure_at?: string
+          household_id?: string
+          host_profile_id?: string
+          id?: string
+          reason?: string | null
+          status?: string
+          visitor_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "visitor_requests_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_requests_host_profile_id_fkey"
+            columns: ["host_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
         ]
       }

--- a/supabase/migrations/20240611_quiet_hours.sql
+++ b/supabase/migrations/20240611_quiet_hours.sql
@@ -1,0 +1,157 @@
+-- Quiet hours and visitor request infrastructure
+create extension if not exists "pgcrypto";
+
+create table if not exists public.households (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamp with time zone not null default now(),
+  created_by uuid null references public.profiles(id)
+);
+
+alter table public.households enable row level security;
+
+alter table public.profiles
+  add column if not exists household_id uuid references public.households(id);
+
+create table if not exists public.household_settings (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  quiet_hours_start time without time zone not null,
+  quiet_hours_end time without time zone not null,
+  timezone text not null default 'UTC',
+  policy_message text not null default 'Quiet hours are in effect. Please plan visitor arrivals and departures outside this window.',
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint household_settings_household_unique unique (household_id),
+  constraint household_settings_quiet_hours_valid check (quiet_hours_start <> quiet_hours_end)
+);
+
+create or replace function public.set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger set_household_settings_updated_at
+before update on public.household_settings
+for each row execute procedure public.set_updated_at();
+
+create table if not exists public.visitor_requests (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  host_profile_id uuid not null references public.profiles(id) on delete cascade,
+  visitor_name text not null,
+  arrival_at timestamp with time zone not null,
+  departure_at timestamp with time zone not null,
+  reason text null,
+  status text not null default 'pending',
+  created_at timestamp with time zone not null default now(),
+  constraint visitor_requests_chronology check (arrival_at < departure_at)
+);
+
+alter table public.household_settings enable row level security;
+alter table public.visitor_requests enable row level security;
+
+create or replace function public.create_default_household_settings()
+returns trigger as $$
+begin
+  insert into public.household_settings (household_id, quiet_hours_start, quiet_hours_end, timezone, policy_message)
+  values (new.id, time '22:00', time '07:00', 'UTC', 'Quiet hours are 10:00 PM – 7:00 AM. Please schedule visitor arrivals and departures outside this window.')
+  on conflict (household_id) do nothing;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger create_household_settings_after_insert
+after insert on public.households
+for each row execute procedure public.create_default_household_settings();
+
+create policy "Residents can create households" on public.households
+  for insert to authenticated
+  with check (created_by = auth.uid());
+
+create policy "Residents can view their household" on public.households
+  for select using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = households.id
+    )
+    or created_by = auth.uid()
+  );
+
+create policy "Residents can update their household" on public.households
+  for update to authenticated
+  using (created_by = auth.uid())
+  with check (created_by = auth.uid());
+
+create policy "Residents can read settings" on public.household_settings
+  for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = household_settings.household_id
+    )
+  );
+
+create policy "Residents manage settings" on public.household_settings
+  for insert to authenticated
+  with check (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = household_settings.household_id
+    )
+  );
+
+create policy "Residents update settings" on public.household_settings
+  for update to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = household_settings.household_id
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = household_settings.household_id
+    )
+  );
+
+create policy "Residents view visitor requests" on public.visitor_requests
+  for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = visitor_requests.household_id
+    )
+  );
+
+create policy "Residents create visitor requests" on public.visitor_requests
+  for insert to authenticated
+  with check (
+    host_profile_id = auth.uid()
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id = visitor_requests.household_id
+    )
+  );
+
+create policy "Residents manage their visitor requests" on public.visitor_requests
+  for update to authenticated
+  using (host_profile_id = auth.uid());


### PR DESCRIPTION
## Summary
- add Supabase tables, triggers, and policies to persist household quiet hours and visitor requests
- extend Supabase types and shared helpers to provision default quiet hours for each household
- build a visitor request dashboard with quiet-hour validation, warnings, and documentation updates

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0def2e083289e8963f027161814