### PR TITLE
Add visitor request poll workflow

### DIFF
--- a/app/api/visitor-requests/[id]/override/route.ts
+++ b/app/api/visitor-requests/[id]/override/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+
+import { overrideVisitorRequestStatus, type OverrideStatus } from "@/lib/visitor-requests";
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const client = await createSupbaseServerClient();
+  const body = await request.json().catch(() => null);
+
+  const {
+    data: { user },
+    error: authError,
+  } = await client.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!params?.id) {
+    return NextResponse.json({ error: "Missing request identifier" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { status, reason } = body as { status?: string; reason?: string };
+
+  if (status !== "approved" && status !== "denied") {
+    return NextResponse.json({ error: "Unsupported status override" }, { status: 400 });
+  }
+
+  try {
+    const updated = await overrideVisitorRequestStatus(client, {
+      requestId: params.id,
+      nextStatus: status as OverrideStatus,
+      actorId: user.id,
+      reason,
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to override request";
+
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/visitor-requests/route.ts
+++ b/app/api/visitor-requests/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import { createSupbaseServerClient } from "@/utils/supaone";
+import { createVisitorRequest, type CreateVisitorRequestInput } from "@/lib/visitor-requests";
+
+export async function POST(request: Request) {
+  const client = await createSupbaseServerClient();
+  const body = await request.json().catch(() => null);
+
+  const {
+    data: { user },
+    error: authError,
+  } = await client.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  try {
+    const payload = { ...(body as Record<string, unknown>), actorId: user.id } as CreateVisitorRequestInput;
+    const result = await createVisitorRequest(client, payload);
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unable to create visitor request.";
+
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,40 @@
+import type { Json } from "@/lib/supabase";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+
+export type LogEventInput = {
+  buildingId: string;
+  entityType: string;
+  entityId: string;
+  eventType: string;
+  actorId?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+function normaliseMetadata(metadata?: Record<string, unknown> | null): Json | null {
+  if (!metadata) {
+    return null;
+  }
+
+  return JSON.parse(JSON.stringify(metadata)) as Json;
+}
+
+export async function logEvent(client: TypedSupabaseClient, input: LogEventInput) {
+  const { data, error } = await client
+    .from("events")
+    .insert({
+      building_id: input.buildingId,
+      entity_type: input.entityType,
+      entity_id: input.entityId,
+      event_type: input.eventType,
+      actor_id: input.actorId ?? null,
+      metadata: normaliseMetadata(input.metadata),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1595,6 +1595,219 @@ export type Database = {
             referencedColumns: ["member_id"]
           },
         ]
+      },
+      events: {
+        Row: {
+          actor_id: string | null
+          building_id: string
+          created_at: string
+          entity_id: string
+          entity_type: string
+          event_type: string
+          id: string
+          metadata: Json | null
+        }
+        Insert: {
+          actor_id?: string | null
+          building_id: string
+          created_at?: string
+          entity_id: string
+          entity_type: string
+          event_type: string
+          id?: string
+          metadata?: Json | null
+        }
+        Update: {
+          actor_id?: string | null
+          building_id?: string
+          created_at?: string
+          entity_id?: string
+          entity_type?: string
+          event_type?: string
+          id?: string
+          metadata?: Json | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "events_actor_id_fkey"
+            columns: ["actor_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      },
+      poll_votes: {
+        Row: {
+          choice: Database["public"]["Enums"]["poll_vote_choice"]
+          created_at: string
+          id: string
+          poll_id: string
+          voter_id: string
+        }
+        Insert: {
+          choice: Database["public"]["Enums"]["poll_vote_choice"]
+          created_at?: string
+          id?: string
+          poll_id: string
+          voter_id: string
+        }
+        Update: {
+          choice?: Database["public"]["Enums"]["poll_vote_choice"]
+          created_at?: string
+          id?: string
+          poll_id?: string
+          voter_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "poll_votes_poll_id_fkey"
+            columns: ["poll_id"]
+            isOneToOne: false
+            referencedRelation: "polls"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "poll_votes_voter_id_fkey"
+            columns: ["voter_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      },
+      polls: {
+        Row: {
+          building_id: string
+          created_at: string
+          created_by: string | null
+          id: string
+          metadata: Json | null
+          outcome: Database["public"]["Enums"]["poll_outcome"] | null
+          question: string
+          required_votes: number
+          status: Database["public"]["Enums"]["poll_status"]
+          updated_at: string
+          visitor_request_id: string | null
+        }
+        Insert: {
+          building_id: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          metadata?: Json | null
+          outcome?: Database["public"]["Enums"]["poll_outcome"] | null
+          question: string
+          required_votes: number
+          status?: Database["public"]["Enums"]["poll_status"]
+          updated_at?: string
+          visitor_request_id?: string | null
+        }
+        Update: {
+          building_id?: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          metadata?: Json | null
+          outcome?: Database["public"]["Enums"]["poll_outcome"] | null
+          question?: string
+          required_votes?: number
+          status?: Database["public"]["Enums"]["poll_status"]
+          updated_at?: string
+          visitor_request_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "polls_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "polls_visitor_request_id_fkey"
+            columns: ["visitor_request_id"]
+            isOneToOne: false
+            referencedRelation: "visitor_requests"
+            referencedColumns: ["id"]
+          },
+        ]
+      },
+      visitor_requests: {
+        Row: {
+          approved_at: string | null
+          approved_by: string | null
+          arrival_date: string
+          building_id: string
+          created_at: string
+          denied_at: string | null
+          denied_by: string | null
+          departure_date: string
+          guest_name: string
+          host_profile_id: string
+          id: string
+          reason: string | null
+          requires_vote: boolean
+          status: Database["public"]["Enums"]["visitor_request_status"]
+          updated_at: string
+        }
+        Insert: {
+          approved_at?: string | null
+          approved_by?: string | null
+          arrival_date: string
+          building_id: string
+          created_at?: string
+          denied_at?: string | null
+          denied_by?: string | null
+          departure_date: string
+          guest_name: string
+          host_profile_id: string
+          id?: string
+          reason?: string | null
+          requires_vote?: boolean
+          status?: Database["public"]["Enums"]["visitor_request_status"]
+          updated_at?: string
+        }
+        Update: {
+          approved_at?: string | null
+          approved_by?: string | null
+          arrival_date?: string
+          building_id?: string
+          created_at?: string
+          denied_at?: string | null
+          denied_by?: string | null
+          departure_date?: string
+          guest_name?: string
+          host_profile_id?: string
+          id?: string
+          reason?: string | null
+          requires_vote?: boolean
+          status?: Database["public"]["Enums"]["visitor_request_status"]
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "visitor_requests_approved_by_fkey"
+            columns: ["approved_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_requests_denied_by_fkey"
+            columns: ["denied_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "visitor_requests_host_profile_id_fkey"
+            columns: ["host_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Views: {
@@ -1774,7 +1987,11 @@ export type Database = {
         | "Oceania"
         | "North America"
         | "South America"
+      poll_outcome: "approved" | "denied" | "tie"
+      poll_status: "open" | "closed"
+      poll_vote_choice: "approve" | "deny"
       user_role: "user" | "admin"
+      visitor_request_status: "pending_vote" | "approved" | "denied"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/lib/visitor-requests.ts
+++ b/lib/visitor-requests.ts
@@ -1,0 +1,250 @@
+import { z } from "zod";
+
+import type { Database } from "@/lib/supabase";
+import { logEvent } from "@/lib/events";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+
+const dateSchema = z
+  .string()
+  .transform((value) => new Date(value))
+  .pipe(z.date());
+
+const createVisitorRequestSchema = z.object({
+  buildingId: z.string().uuid(),
+  hostProfileId: z.string().uuid(),
+  guestName: z.string().min(1),
+  arrivalDate: dateSchema,
+  departureDate: dateSchema,
+  reason: z.string().max(2000).optional(),
+  requiresVote: z.boolean().optional(),
+  eligibleVoterIds: z.array(z.string().uuid()).default([]),
+  actorId: z.string().uuid(),
+});
+
+export type CreateVisitorRequestInput = z.input<typeof createVisitorRequestSchema>;
+
+type VisitorRequestStatus = Database["public"]["Enums"]["visitor_request_status"];
+type PollOutcome = Database["public"]["Enums"]["poll_outcome"];
+
+type VisitorRequestRow = Database["public"]["Tables"]["visitor_requests"]["Row"];
+type PollRow = Database["public"]["Tables"]["polls"]["Row"];
+
+type CreatePollResult = PollRow | null;
+
+type CreateVisitorRequestResult = {
+  request: VisitorRequestRow;
+  poll: CreatePollResult;
+};
+
+function toIsoDate(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+export async function createVisitorRequest(
+  client: TypedSupabaseClient,
+  payload: CreateVisitorRequestInput,
+): Promise<CreateVisitorRequestResult> {
+  const parsed = createVisitorRequestSchema.parse(payload);
+
+  if (parsed.departureDate < parsed.arrivalDate) {
+    throw new Error("Departure date must be on or after the arrival date.");
+  }
+
+  const eligibleVoterCount = parsed.eligibleVoterIds.length;
+  const shouldSeekVote = parsed.requiresVote ?? eligibleVoterCount > 0;
+  const requiresVote = shouldSeekVote && eligibleVoterCount > 0;
+  const initialStatus: VisitorRequestStatus = requiresVote ? "pending_vote" : "approved";
+
+  const { data: request, error } = await client
+    .from("visitor_requests")
+    .insert({
+      building_id: parsed.buildingId,
+      host_profile_id: parsed.hostProfileId,
+      guest_name: parsed.guestName,
+      arrival_date: toIsoDate(parsed.arrivalDate),
+      departure_date: toIsoDate(parsed.departureDate),
+      reason: parsed.reason ?? null,
+      status: initialStatus,
+      requires_vote: requiresVote,
+      approved_at: requiresVote ? null : new Date().toISOString(),
+      approved_by: requiresVote ? null : parsed.actorId,
+    })
+    .select()
+    .single();
+
+  if (error || !request) {
+    throw error ?? new Error("Failed to create visitor request.");
+  }
+
+  let poll: CreatePollResult = null;
+
+  if (requiresVote) {
+    poll = await createApprovalPoll(client, {
+      request,
+      eligibleVoterIds: parsed.eligibleVoterIds,
+      actorId: parsed.actorId,
+    });
+  } else {
+    await logEvent(client, {
+      buildingId: request.building_id,
+      entityType: "visitor_request",
+      entityId: request.id,
+      eventType: "visitor_request.approved",
+      actorId: parsed.actorId,
+      metadata: {
+        method: "auto",
+        requestedVote: shouldSeekVote,
+        eligibleVoterCount,
+      },
+    });
+  }
+
+  return { request, poll };
+}
+
+const createPollSchema = z.object({
+  request: z.custom<VisitorRequestRow>(),
+  eligibleVoterIds: z.array(z.string().uuid()),
+  actorId: z.string().uuid(),
+});
+
+type CreatePollInput = z.input<typeof createPollSchema>;
+
+async function createApprovalPoll(
+  client: TypedSupabaseClient,
+  input: CreatePollInput,
+): Promise<PollRow | null> {
+  const parsed = createPollSchema.parse(input);
+
+  if (!parsed.eligibleVoterIds.length) {
+    return null;
+  }
+
+  const requiredVotes = Math.max(parsed.eligibleVoterIds.length, 1);
+
+  const { data: poll, error } = await client
+    .from("polls")
+    .insert({
+      building_id: parsed.request.building_id,
+      created_by: parsed.actorId,
+      visitor_request_id: parsed.request.id,
+      question: `Approve overnight visitor ${parsed.request.guest_name}?`,
+      required_votes: requiredVotes,
+      metadata: {
+        eligibleVoterIds: parsed.eligibleVoterIds,
+        requestId: parsed.request.id,
+      },
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return poll;
+}
+
+export type OverrideStatus = Extract<VisitorRequestStatus, "approved" | "denied">;
+
+export async function overrideVisitorRequestStatus(
+  client: TypedSupabaseClient,
+  params: {
+    requestId: string;
+    nextStatus: OverrideStatus;
+    actorId: string;
+    reason?: string;
+  },
+): Promise<VisitorRequestRow> {
+  const { requestId, nextStatus, actorId } = params;
+
+  const { data: existing, error: existingError } = await client
+    .from("visitor_requests")
+    .select()
+    .eq("id", requestId)
+    .single();
+
+  if (existingError || !existing) {
+    throw existingError ?? new Error("Visitor request not found.");
+  }
+
+  const updates: Partial<VisitorRequestRow> = {
+    status: nextStatus,
+    requires_vote: false,
+  };
+
+  if (nextStatus === "approved") {
+    updates.approved_at = new Date().toISOString();
+    updates.approved_by = actorId;
+    updates.denied_at = null;
+    updates.denied_by = null;
+  } else {
+    updates.denied_at = new Date().toISOString();
+    updates.denied_by = actorId;
+    updates.approved_at = null;
+    updates.approved_by = null;
+  }
+
+  const { data: updated, error: updateError } = await client
+    .from("visitor_requests")
+    .update(updates)
+    .eq("id", requestId)
+    .select()
+    .single();
+
+  if (updateError || !updated) {
+    throw updateError ?? new Error("Unable to update visitor request status.");
+  }
+
+  const eventType = nextStatus === "approved" ? "visitor_request.approved" : "visitor_request.denied";
+
+  await logEvent(client, {
+    buildingId: updated.building_id,
+    entityType: "visitor_request",
+    entityId: updated.id,
+    eventType,
+    actorId,
+    metadata: {
+      method: "admin_override",
+      reason: params.reason ?? null,
+    },
+  });
+
+  await syncAssociatedPoll(client, {
+    requestId: updated.id,
+    nextStatus,
+    actorId,
+  });
+
+  return updated;
+}
+
+async function syncAssociatedPoll(
+  client: TypedSupabaseClient,
+  input: { requestId: string; nextStatus: OverrideStatus; actorId: string },
+) {
+  const { data: poll, error } = await client
+    .from("polls")
+    .select()
+    .eq("visitor_request_id", input.requestId)
+    .maybeSingle();
+
+  if (error || !poll) {
+    return;
+  }
+
+  if (poll.status === "closed") {
+    return;
+  }
+
+  const outcome: PollOutcome = input.nextStatus === "approved" ? "approved" : "denied";
+
+  await client
+    .from("polls")
+    .update({
+      status: "closed",
+      outcome,
+      created_by: poll.created_by ?? input.actorId,
+    })
+    .eq("id", poll.id);
+}

--- a/supabase/migrations/20240703_visitor_polls.sql
+++ b/supabase/migrations/20240703_visitor_polls.sql
@@ -1,0 +1,200 @@
+create extension if not exists "pgcrypto";
+
+create type if not exists public.visitor_request_status as enum ('pending_vote', 'approved', 'denied');
+create type if not exists public.poll_status as enum ('open', 'closed');
+create type if not exists public.poll_outcome as enum ('approved', 'denied', 'tie');
+create type if not exists public.poll_vote_choice as enum ('approve', 'deny');
+
+create table if not exists public.events (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default timezone('utc', now()),
+  building_id uuid not null,
+  entity_type text not null,
+  entity_id uuid not null,
+  event_type text not null,
+  actor_id uuid references auth.users(id),
+  metadata jsonb
+);
+
+create table if not exists public.visitor_requests (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  building_id uuid not null,
+  host_profile_id uuid not null references public.profiles(id),
+  guest_name text not null,
+  arrival_date date not null,
+  departure_date date not null,
+  reason text,
+  status public.visitor_request_status not null default 'pending_vote',
+  requires_vote boolean not null default true,
+  approved_at timestamptz,
+  denied_at timestamptz,
+  approved_by uuid references auth.users(id),
+  denied_by uuid references auth.users(id),
+  constraint visitor_requests_date_check check (departure_date >= arrival_date)
+);
+
+create table if not exists public.polls (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  building_id uuid not null,
+  created_by uuid references auth.users(id),
+  visitor_request_id uuid unique references public.visitor_requests(id),
+  question text not null,
+  status public.poll_status not null default 'open',
+  outcome public.poll_outcome,
+  required_votes integer not null,
+  metadata jsonb
+);
+
+create table if not exists public.poll_votes (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default timezone('utc', now()),
+  poll_id uuid not null references public.polls(id) on delete cascade,
+  voter_id uuid not null references auth.users(id),
+  choice public.poll_vote_choice not null,
+  constraint poll_votes_unique_vote unique (poll_id, voter_id)
+);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := timezone('utc', now());
+  return new;
+end;
+$$;
+
+create trigger set_visitor_requests_updated_at
+before update on public.visitor_requests
+for each row
+execute function public.set_updated_at();
+
+create trigger set_polls_updated_at
+before update on public.polls
+for each row
+execute function public.set_updated_at();
+
+create or replace function public.handle_poll_vote_change()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_poll_id uuid;
+  v_required integer;
+  v_approvals integer;
+  v_denials integer;
+  v_total integer;
+  v_outcome public.poll_outcome;
+begin
+  v_poll_id := coalesce(new.poll_id, old.poll_id);
+  if v_poll_id is null then
+    return null;
+  end if;
+
+  select required_votes
+    into v_required
+    from public.polls
+   where id = v_poll_id
+   for update;
+
+  if not found then
+    return null;
+  end if;
+
+  select count(*) filter (where choice = 'approve'),
+         count(*) filter (where choice = 'deny')
+    into v_approvals, v_denials
+    from public.poll_votes
+   where poll_id = v_poll_id;
+
+  v_total := coalesce(v_approvals, 0) + coalesce(v_denials, 0);
+  v_required := greatest(coalesce(v_required, 0), 1);
+
+  if v_total >= v_required then
+    if coalesce(v_approvals, 0) = coalesce(v_denials, 0) then
+      v_outcome := 'tie';
+    elsif coalesce(v_approvals, 0) > coalesce(v_denials, 0) then
+      v_outcome := 'approved';
+    else
+      v_outcome := 'denied';
+    end if;
+
+    update public.polls
+       set status = 'closed',
+           outcome = v_outcome
+     where id = v_poll_id
+       and status <> 'closed';
+  end if;
+
+  return null;
+end;
+$$;
+
+create trigger poll_votes_handle_change
+after insert or update or delete on public.poll_votes
+for each row
+execute function public.handle_poll_vote_change();
+
+create or replace function public.handle_poll_completion()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_building_id uuid;
+  v_event_type text;
+  v_metadata jsonb;
+begin
+  if (new.status is distinct from old.status) or (new.outcome is distinct from old.outcome) then
+    if new.status = 'closed' and new.visitor_request_id is not null and new.outcome is not null then
+      if new.outcome = 'approved' then
+        update public.visitor_requests
+           set status = 'approved',
+               approved_at = timezone('utc', now()),
+               approved_by = new.created_by,
+               denied_at = null,
+               denied_by = null,
+               requires_vote = false
+         where id = new.visitor_request_id
+           and status <> 'approved'
+        returning building_id into v_building_id;
+
+        if found then
+          v_event_type := 'visitor_request.approved';
+          v_metadata := jsonb_build_object('poll_id', new.id, 'outcome', new.outcome);
+          insert into public.events (building_id, entity_type, entity_id, event_type, actor_id, metadata)
+          values (v_building_id, 'visitor_request', new.visitor_request_id, v_event_type, new.created_by, v_metadata);
+        end if;
+      else
+        update public.visitor_requests
+           set status = 'denied',
+               denied_at = timezone('utc', now()),
+               denied_by = new.created_by,
+               approved_at = null,
+               approved_by = null,
+               requires_vote = false
+         where id = new.visitor_request_id
+           and status <> 'denied'
+        returning building_id into v_building_id;
+
+        if found then
+          v_event_type := 'visitor_request.denied';
+          v_metadata := jsonb_build_object('poll_id', new.id, 'outcome', new.outcome);
+          insert into public.events (building_id, entity_type, entity_id, event_type, actor_id, metadata)
+          values (v_building_id, 'visitor_request', new.visitor_request_id, v_event_type, new.created_by, v_metadata);
+        end if;
+      end if;
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger poll_completion
+after update on public.polls
+for each row
+execute function public.handle_poll_completion();


### PR DESCRIPTION
## Summary
- add Supabase schema changes for visitor requests, polls, poll votes, and event logging triggers
- extend Supabase typings and helpers to drive visitor request creation, poll orchestration, and admin overrides
- expose Next.js API routes that log audit events, auto-create polls when required, and allow admin status overrides

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0ddcb708328baf7d075ce911f2e