### PR TITLE
Store Cal.com booking metadata

### DIFF
--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { buildBookingRecord, normalizeCalcomBookingPayload } from "@/lib/calcom"
+import { upsertBooking } from "@/lib/bookings"
+import { createServiceRoleClient } from "@/utils/supabase/service-role"
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+
+  try {
+    body = await request.json()
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 })
+  }
+
+  const booking = normalizeCalcomBookingPayload(body)
+  if (!booking) {
+    return NextResponse.json({ error: "Booking details are missing required fields" }, { status: 400 })
+  }
+
+  const triggerEvent =
+    typeof body === "object" &&
+    body !== null &&
+    "triggerEvent" in body &&
+    typeof (body as Record<string, unknown>).triggerEvent === "string"
+      ? (body as Record<string, string>).triggerEvent
+      : undefined
+
+  const client = createServiceRoleClient()
+  if (!client) {
+    return NextResponse.json(
+      { error: "Supabase service role credentials are not configured" },
+      { status: 500 }
+    )
+  }
+
+  const record = buildBookingRecord({ booking, triggerEvent })
+
+  const { data, error } = await upsertBooking(client, record)
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message ?? "Failed to persist booking record" },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ data }, { status: 201 })
+}

--- a/app/api/calcom/webhook/route.ts
+++ b/app/api/calcom/webhook/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { buildBookingRecord, parseCalcomWebhookPayload } from "@/lib/calcom"
+import { upsertBooking } from "@/lib/bookings"
+import { createServiceRoleClient } from "@/utils/supabase/service-role"
+
+export async function POST(request: NextRequest) {
+  let payload: unknown
+
+  try {
+    payload = await request.json()
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 })
+  }
+
+  const parsed = parseCalcomWebhookPayload(payload)
+  if (!parsed) {
+    return NextResponse.json({ message: "No booking payload found" }, { status: 202 })
+  }
+
+  const client = createServiceRoleClient()
+  if (!client) {
+    return NextResponse.json(
+      { error: "Supabase service role credentials are not configured" },
+      { status: 500 }
+    )
+  }
+
+  const record = buildBookingRecord(parsed)
+
+  const { data, error } = await upsertBooking(client, record)
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message ?? "Failed to persist booking record" },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ data }, { status: 200 })
+}

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -22,6 +22,7 @@ import { RecentSales } from "@/app/dashboard/components/recent-sales"
 import { Search } from "@/app/dashboard/components/search"
 import TeamSwitcher from "@/app/dashboard/components/team-switcher"
 import { UserNav } from "@/app/dashboard/components/user-nav"
+import { BookingsInsightsCard } from "@/app/dashboard/components/bookings-insights"
 
 export const metadata: Metadata = {
   title: "Onyx Dashboard",
@@ -176,17 +177,20 @@ export default function DashboardPage() {
                     <Overview />
                   </CardContent>
                 </Card>
-                <Card className="col-span-3">
-                  <CardHeader>
-                    <CardTitle>Recent Sales</CardTitle>
-                    <CardDescription>
-                      You made 265 sales this month.
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <RecentSales />
-                  </CardContent>
-                </Card>
+                <div className="col-span-3 space-y-4">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Recent Sales</CardTitle>
+                      <CardDescription>
+                        You made 265 sales this month.
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <RecentSales />
+                    </CardContent>
+                  </Card>
+                  <BookingsInsightsCard />
+                </div>
               </div>
             </TabsContent>
           </Tabs>

--- a/app/dashboard/components/bookings-insights.tsx
+++ b/app/dashboard/components/bookings-insights.tsx
@@ -1,0 +1,154 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { coerceBookingMetadata, type BookingMetadata } from "@/lib/calcom"
+import type { BookingRow } from "@/lib/calcom"
+import type { Json } from "@/lib/supabase"
+import { createClient } from "@/utils/supabase/server"
+
+const EXCLUDED_METADATA_KEYS = new Set(["event_title", "event_slug", "last_calcom_event"])
+
+function formatMetadataValue(value: Json): string {
+  if (Array.isArray(value)) {
+    return value.map((entry) => formatMetadataValue(entry as Json)).join(", ") || "—"
+  }
+
+  if (value === null) {
+    return "—"
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value)
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No"
+  }
+
+  return String(value)
+}
+
+function formatStartTime(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date)
+}
+
+function getDisplayableMetadata(metadata: BookingMetadata) {
+  return Object.entries(metadata)
+    .filter(([key]) => !EXCLUDED_METADATA_KEYS.has(key))
+    .slice(0, 3)
+}
+
+function getAttendeeSummary(booking: BookingRow) {
+  if (booking.attendee_name) {
+    return booking.attendee_email
+      ? `${booking.attendee_name} · ${booking.attendee_email}`
+      : booking.attendee_name
+  }
+
+  return booking.attendee_email ?? "—"
+}
+
+function hasSupabaseCredentials() {
+  return Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
+}
+
+export async function BookingsInsightsCard() {
+  if (!hasSupabaseCredentials()) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Cal.com bookings</CardTitle>
+          <CardDescription>Configure Supabase credentials to load booking metadata.</CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  const client = createClient()
+  const { data, error } = await client
+    .from("bookings")
+    .select("calcom_booking_id, start_time, event_slug, attendee_name, attendee_email, status, metadata")
+    .order("start_time", { ascending: false })
+    .limit(5)
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Cal.com bookings</CardTitle>
+          <CardDescription>We were unable to load booking metadata.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">{error.message}</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!data?.length) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Cal.com bookings</CardTitle>
+          <CardDescription>No bookings have been synced from Cal.com yet.</CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent Cal.com bookings</CardTitle>
+        <CardDescription>Custom responses captured from the latest amenity reservations.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {data.map((booking) => {
+          const metadata = coerceBookingMetadata(booking.metadata)
+          const displayableMetadata = getDisplayableMetadata(metadata)
+
+          return (
+            <div key={booking.calcom_booking_id} className="rounded-md border border-muted p-4">
+              <div className="flex items-center justify-between text-sm font-medium text-foreground">
+                <span>
+                  {(booking.event_slug ?? "amenity").replace(/[-_]+/g, " ")}
+                  <span className="text-muted-foreground"> · {formatStartTime(booking.start_time)}</span>
+                </span>
+                {booking.status ? (
+                  <span className="text-xs uppercase tracking-wide text-muted-foreground">{booking.status}</span>
+                ) : null}
+              </div>
+              <dl className="mt-3 space-y-1 text-sm text-muted-foreground">
+                <div className="flex justify-between gap-4">
+                  <dt className="font-medium text-foreground">Attendee</dt>
+                  <dd className="text-right">{getAttendeeSummary(booking)}</dd>
+                </div>
+                {displayableMetadata.length ? (
+                  displayableMetadata.map(([key, entry]) => (
+                    <div key={key} className="flex justify-between gap-4">
+                      <dt className="font-medium text-foreground">{entry.label}</dt>
+                      <dd className="text-right">{formatMetadataValue(entry.value)}</dd>
+                    </div>
+                  ))
+                ) : (
+                  <div className="flex justify-between gap-4">
+                    <dt className="font-medium text-foreground">Responses</dt>
+                    <dd className="text-right">No custom responses</dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -1,0 +1,23 @@
+import type { PostgrestSingleResponse, SupabaseClient } from "@supabase/supabase-js"
+
+import type { BookingInsert, BookingRow } from "@/lib/calcom"
+import type { Database } from "@/lib/supabase"
+
+const CONFLICT_COLUMN = "calcom_booking_id"
+
+export async function upsertBooking(
+  client: SupabaseClient<Database>,
+  record: BookingInsert
+): Promise<PostgrestSingleResponse<BookingRow>> {
+  const response = await client
+    .from("bookings")
+    .upsert(record, { onConflict: CONFLICT_COLUMN })
+    .select()
+    .maybeSingle()
+
+  if (response.error && response.error.code === "42703") {
+    return client.from("bookings").insert(record).select().maybeSingle()
+  }
+
+  return response
+}

--- a/lib/calcom.ts
+++ b/lib/calcom.ts
@@ -1,0 +1,568 @@
+import type { Database, Json } from "@/lib/supabase"
+
+export type BookingTable = Database["public"]["Tables"]["bookings"]
+export type BookingInsert = BookingTable["Insert"]
+export type BookingRow = BookingTable["Row"]
+
+export interface CalcomResponse {
+  label?: string
+  identifier?: string | null
+  name?: string | null
+  question?: string | null
+  key?: string | null
+  type?: string | null
+  responseType?: string | null
+  questionType?: string | null
+  value?: unknown
+  response?: unknown
+  answer?: unknown
+}
+
+export interface CalcomAttendee {
+  email?: string | null
+  name?: string | null
+  fullName?: string | null
+  username?: string | null
+}
+
+export interface CalcomBookingInput {
+  id: number | string
+  uid?: string | null
+  startTime: string
+  endTime: string
+  status?: string | null
+  responses?: CalcomResponse[] | null
+  attendees?: CalcomAttendee[] | null
+  eventType?: unknown
+  eventSlug?: string | null
+  title?: string | null
+  metadata?: unknown
+  createdAt?: string | null
+  updatedAt?: string | null
+}
+
+export interface BuildBookingRecordArgs {
+  booking: CalcomBookingInput
+  triggerEvent?: string | null
+}
+
+export interface NormalizedCalcomResponse {
+  label: string
+  value: Json
+  type: string
+}
+
+export type BookingMetadata = Record<string, NormalizedCalcomResponse>
+
+const TRIGGER_STATUS_MAP: Record<string, string> = {
+  BOOKING_CREATED: "confirmed",
+  BOOKING_UPDATED: "updated",
+  BOOKING_RESCHEDULED: "rescheduled",
+  BOOKING_CANCELLED: "cancelled",
+  BOOKING_CANCELED: "cancelled",
+}
+
+const DEFAULT_KEY_FALLBACK = "custom_field"
+
+export function normalizeCalcomResponses(
+  responses: CalcomResponse[] | null | undefined
+): BookingMetadata {
+  if (!responses?.length) {
+    return {}
+  }
+
+  const metadata: BookingMetadata = {}
+  const usedKeys = new Set<string>()
+
+  for (const response of responses) {
+    if (!response) continue
+
+    const keySource =
+      response.identifier ?? response.name ?? response.key ?? response.label ?? response.question
+    if (!keySource) continue
+
+    const baseKey = slugifyKey(keySource)
+    const key = ensureUniqueKey(baseKey, usedKeys)
+    const label = response.label ?? response.question ?? toLabelFromKey(baseKey)
+    const rawValue = extractResponseValue(response)
+    const value = toJson(rawValue)
+
+    metadata[key] = {
+      label,
+      value,
+      type: response.type ?? response.responseType ?? response.questionType ?? inferJsonType(value),
+    }
+  }
+
+  return metadata
+}
+
+export function coerceBookingMetadata(input: unknown): BookingMetadata {
+  if (!isRecord(input)) {
+    return {}
+  }
+
+  const metadata: BookingMetadata = {}
+
+  for (const [rawKey, rawValue] of Object.entries(input)) {
+    const key = typeof rawKey === "string" && rawKey.length > 0 ? rawKey : DEFAULT_KEY_FALLBACK
+
+    if (isNormalizedResponse(rawValue)) {
+      const jsonValue = toJson(rawValue.value)
+      metadata[key] = {
+        label: rawValue.label,
+        value: jsonValue,
+        type: typeof rawValue.type === "string" && rawValue.type.length > 0
+          ? rawValue.type
+          : inferJsonType(jsonValue),
+      }
+      continue
+    }
+
+    const jsonValue = toJson(rawValue)
+    metadata[key] = {
+      label: toLabelFromKey(key),
+      value: jsonValue,
+      type: inferJsonType(jsonValue),
+    }
+  }
+
+  return metadata
+}
+
+export function buildBookingRecord({ booking, triggerEvent }: BuildBookingRecordArgs): BookingInsert {
+  const attendees = normalizeAttendees(booking.attendees)
+  const primaryAttendee = attendees[0]
+
+  const baseMetadata = coerceBookingMetadata(booking.metadata)
+  const responseMetadata = normalizeCalcomResponses(booking.responses)
+  const metadata: BookingMetadata = { ...baseMetadata, ...responseMetadata }
+
+  if (triggerEvent) {
+    metadata.last_calcom_event = {
+      label: "Last Cal.com event",
+      value: triggerEvent,
+      type: "system",
+    }
+  }
+
+  if (booking.title && !metadata.event_title) {
+    metadata.event_title = {
+      label: "Event title",
+      value: booking.title,
+      type: "text",
+    }
+  }
+
+  const eventSlug = extractEventSlug(booking)
+  if (eventSlug && !metadata.event_slug) {
+    metadata.event_slug = {
+      label: "Event slug",
+      value: eventSlug,
+      type: "text",
+    }
+  }
+
+  const record: BookingInsert = {
+    calcom_booking_id: String(booking.id),
+    uid: booking.uid ? String(booking.uid) : null,
+    start_time: booking.startTime,
+    end_time: booking.endTime,
+    status: deriveStatus(booking.status, triggerEvent),
+    attendee_email: primaryAttendee?.email ?? null,
+    attendee_name: primaryAttendee?.name ?? null,
+    event_slug: eventSlug ?? null,
+    metadata,
+  }
+
+  if (booking.createdAt) {
+    record.created_at = booking.createdAt
+  }
+
+  if (booking.updatedAt) {
+    record.updated_at = booking.updatedAt
+  }
+
+  return record
+}
+
+export function normalizeCalcomBookingPayload(input: unknown): CalcomBookingInput | null {
+  if (!isRecord(input)) {
+    return null
+  }
+
+  const bookingObject = extractBookingObject(input)
+  if (!bookingObject) {
+    return null
+  }
+
+  return mapBooking(bookingObject)
+}
+
+export function parseCalcomWebhookPayload(body: unknown): BuildBookingRecordArgs | null {
+  if (!isRecord(body)) {
+    return null
+  }
+
+  const booking = normalizeCalcomBookingPayload(body)
+  if (!booking) {
+    return null
+  }
+
+  const triggerEvent = extractTriggerEvent(body)
+
+  return { booking, triggerEvent }
+}
+
+function mapBooking(record: Record<string, unknown>): CalcomBookingInput | null {
+  const idCandidate = record.id ?? record.uid ?? record.eventId ?? record.hash ?? record.reference
+  if (idCandidate === null || idCandidate === undefined) {
+    return null
+  }
+
+  const start = record.startTime ?? record.start_time
+  const end = record.endTime ?? record.end_time
+  if (typeof start !== "string" || typeof end !== "string") {
+    return null
+  }
+
+  const responses = Array.isArray(record.responses)
+    ? (record.responses as unknown[])
+        .map((item) => parseResponse(item))
+        .filter((item): item is CalcomResponse => item !== null)
+    : undefined
+
+  const attendees = normalizeAttendees(record.attendees)
+
+  const metadataSource = record.metadata ?? record.meta
+  const metadata = isRecord(metadataSource) ? metadataSource : undefined
+
+  const createdAt =
+    typeof record.createdAt === "string"
+      ? record.createdAt
+      : typeof record.created_at === "string"
+        ? record.created_at
+        : undefined
+
+  const updatedAt =
+    typeof record.updatedAt === "string"
+      ? record.updatedAt
+      : typeof record.updated_at === "string"
+        ? record.updated_at
+        : undefined
+
+  const eventSlug =
+    typeof record.eventSlug === "string"
+      ? record.eventSlug
+      : typeof record.event_slug === "string"
+        ? record.event_slug
+        : undefined
+
+  const eventType = record.eventType ?? record.event_type ?? record.event ?? undefined
+
+  return {
+    id: idCandidate as number | string,
+    uid: typeof record.uid === "string" ? record.uid : null,
+    startTime: start,
+    endTime: end,
+    status: typeof record.status === "string" ? record.status : undefined,
+    responses,
+    attendees,
+    metadata,
+    createdAt: createdAt ?? null,
+    updatedAt: updatedAt ?? null,
+    eventSlug: eventSlug ?? null,
+    eventType,
+    title: typeof record.title === "string" ? record.title : undefined,
+  }
+}
+
+function normalizeAttendees(input: unknown): { email: string | null; name: string | null }[] {
+  if (!Array.isArray(input)) {
+    return []
+  }
+
+  const attendees: { email: string | null; name: string | null }[] = []
+
+  for (const value of input) {
+    if (!isRecord(value)) continue
+
+    const email = typeof value.email === "string"
+      ? value.email
+      : typeof value.address === "string"
+        ? value.address
+        : null
+    const name = typeof value.name === "string"
+      ? value.name
+      : typeof value.fullName === "string"
+        ? value.fullName
+        : typeof value.username === "string"
+          ? value.username
+          : null
+
+    if (email !== null || name !== null) {
+      attendees.push({ email, name })
+    }
+  }
+
+  return attendees
+}
+
+function parseResponse(value: unknown): CalcomResponse | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const label =
+    typeof value.label === "string"
+      ? value.label
+      : typeof value.question === "string"
+        ? value.question
+        : typeof value.name === "string"
+          ? value.name
+          : null
+
+  if (!label) {
+    return null
+  }
+
+  const identifier =
+    typeof value.identifier === "string"
+      ? value.identifier
+      : typeof value.name === "string"
+        ? value.name
+        : typeof value.key === "string"
+          ? value.key
+          : null
+
+  const type =
+    typeof value.type === "string"
+      ? value.type
+      : typeof value.responseType === "string"
+        ? value.responseType
+        : typeof value.questionType === "string"
+          ? value.questionType
+          : null
+
+  const response: CalcomResponse = {
+    label,
+    identifier,
+    type,
+    value: extractResponseValue(value),
+  }
+
+  return response
+}
+
+function extractResponseValue(value: CalcomResponse | Record<string, unknown>): unknown {
+  const candidate =
+    "value" in value && value.value !== undefined
+      ? value.value
+      : "response" in value && value.response !== undefined
+        ? value.response
+        : "answer" in value && value.answer !== undefined
+          ? value.answer
+          : null
+
+  if (Array.isArray(candidate)) {
+    return candidate.map((entry) => {
+      if (isRecord(entry)) {
+        if ("value" in entry && entry.value !== undefined) {
+          return entry.value
+        }
+        if ("label" in entry && entry.label !== undefined) {
+          return entry.label
+        }
+      }
+      return entry
+    })
+  }
+
+  if (isRecord(candidate)) {
+    if ("value" in candidate && candidate.value !== undefined) {
+      return candidate.value
+    }
+    if ("label" in candidate && candidate.label !== undefined) {
+      return candidate.label
+    }
+  }
+
+  return candidate
+}
+
+function extractBookingObject(source: Record<string, unknown>): Record<string, unknown> | null {
+  if ("booking" in source && isRecord(source.booking)) {
+    const bookingCandidate = source.booking
+    if (looksLikeBooking(bookingCandidate)) {
+      return bookingCandidate
+    }
+  }
+
+  if ("data" in source && isRecord(source.data)) {
+    const nested = extractBookingObject(source.data)
+    if (nested) {
+      return nested
+    }
+  }
+
+  if ("payload" in source && isRecord(source.payload)) {
+    const nested = extractBookingObject(source.payload)
+    if (nested) {
+      return nested
+    }
+  }
+
+  if (looksLikeBooking(source)) {
+    return source
+  }
+
+  return null
+}
+
+function looksLikeBooking(value: Record<string, unknown>): boolean {
+  const hasStart = typeof value.startTime === "string" || typeof value.start_time === "string"
+  const hasEnd = typeof value.endTime === "string" || typeof value.end_time === "string"
+  const hasIdentifier =
+    value.id !== undefined || value.uid !== undefined || value.eventId !== undefined || value.hash !== undefined
+
+  return Boolean(hasStart && hasEnd && hasIdentifier)
+}
+
+function deriveStatus(status?: string | null, triggerEvent?: string | null): string | null {
+  if (typeof status === "string" && status.length > 0) {
+    return status.toLowerCase()
+  }
+  if (typeof triggerEvent === "string" && triggerEvent.length > 0) {
+    const upper = triggerEvent.toUpperCase()
+    return TRIGGER_STATUS_MAP[upper] ?? triggerEvent.toLowerCase()
+  }
+  return null
+}
+
+function extractEventSlug(booking: CalcomBookingInput): string | null {
+  if (booking.eventSlug && booking.eventSlug.length > 0) {
+    return booking.eventSlug
+  }
+
+  const { eventType } = booking
+  if (typeof eventType === "string" && eventType.length > 0) {
+    return eventType
+  }
+
+  if (isRecord(eventType)) {
+    if (typeof eventType.slug === "string" && eventType.slug.length > 0) {
+      return eventType.slug
+    }
+    if (typeof eventType.name === "string" && eventType.name.length > 0) {
+      return slugifyKey(eventType.name)
+    }
+    if (typeof eventType.title === "string" && eventType.title.length > 0) {
+      return slugifyKey(eventType.title)
+    }
+  }
+
+  if (typeof booking.title === "string" && booking.title.length > 0) {
+    return slugifyKey(booking.title)
+  }
+
+  return null
+}
+
+function extractTriggerEvent(source: Record<string, unknown>): string | undefined {
+  const candidate =
+    source.triggerEvent ??
+    source.event ??
+    source.type ??
+    source.action
+
+  return typeof candidate === "string" ? candidate : undefined
+}
+
+function ensureUniqueKey(baseKey: string, usedKeys: Set<string>): string {
+  if (!usedKeys.has(baseKey)) {
+    usedKeys.add(baseKey)
+    return baseKey
+  }
+
+  let index = 2
+  let unique = `${baseKey}_${index}`
+  while (usedKeys.has(unique)) {
+    index += 1
+    unique = `${baseKey}_${index}`
+  }
+
+  usedKeys.add(unique)
+  return unique
+}
+
+function slugifyKey(value: string): string {
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+
+  return cleaned.length > 0 ? cleaned : DEFAULT_KEY_FALLBACK
+}
+
+function toLabelFromKey(key: string): string {
+  const spaced = key.replace(/[_-]+/g, " ").trim()
+  if (!spaced) {
+    return "Custom field"
+  }
+  return spaced.replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function inferJsonType(value: Json): string {
+  if (Array.isArray(value)) {
+    return "multi-value"
+  }
+  if (value === null) {
+    return "text"
+  }
+  if (typeof value === "object") {
+    return "object"
+  }
+  return typeof value
+}
+
+function isNormalizedResponse(value: unknown): value is NormalizedCalcomResponse {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as { label?: unknown }).label === "string" &&
+    ("value" in (value as object))
+  )
+}
+
+function toJson(value: unknown): Json {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value
+  }
+
+  if (typeof value === "bigint") {
+    return Number(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => toJson(entry)) as Json
+  }
+
+  if (isRecord(value)) {
+    const record: { [key: string]: Json | undefined } = {}
+    for (const [key, entry] of Object.entries(value)) {
+      record[key] = toJson(entry)
+    }
+    return record
+  }
+
+  return String(value)
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -283,6 +283,51 @@ export type Database = {
           },
         ]
       }
+      bookings: {
+        Row: {
+          attendee_email: string | null
+          attendee_name: string | null
+          calcom_booking_id: string
+          created_at: string | null
+          end_time: string
+          event_slug: string | null
+          id: string
+          metadata: Json
+          start_time: string
+          status: string | null
+          uid: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          attendee_email?: string | null
+          attendee_name?: string | null
+          calcom_booking_id: string
+          created_at?: string | null
+          end_time: string
+          event_slug?: string | null
+          id?: string
+          metadata?: Json
+          start_time: string
+          status?: string | null
+          uid?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          attendee_email?: string | null
+          attendee_name?: string | null
+          calcom_booking_id?: string
+          created_at?: string | null
+          end_time?: string
+          event_slug?: string | null
+          id?: string
+          metadata?: Json
+          start_time?: string
+          status?: string | null
+          uid?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       ai_models: {
         Row: {
           capabilities: Json | null

--- a/supabase/migrations/20250716_add_metadata_to_bookings.sql
+++ b/supabase/migrations/20250716_add_metadata_to_bookings.sql
@@ -1,0 +1,26 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'bookings'
+  ) THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'bookings'
+        AND column_name = 'metadata'
+    ) THEN
+      ALTER TABLE public.bookings
+        ADD COLUMN metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+      COMMENT ON COLUMN public.bookings.metadata IS
+        'Key/value map of Cal.com custom responses persisted from scheduling flows.';
+    END IF;
+  ELSE
+    RAISE NOTICE 'Table public.bookings does not exist yet. Skipping metadata column migration.';
+  END IF;
+END;
+$$;

--- a/tests/bookings-metadata.test.ts
+++ b/tests/bookings-metadata.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildBookingRecord,
+  coerceBookingMetadata,
+  normalizeCalcomBookingPayload,
+  normalizeCalcomResponses,
+  parseCalcomWebhookPayload,
+  type BookingMetadata,
+} from "@/lib/calcom"
+
+const sampleResponses = [
+  { label: "Guest Name", value: "Jamie" },
+  { label: "Dietary Needs", identifier: "dietary_needs", value: ["vegan", "gluten-free"] },
+  { label: "Parking", value: [{ value: "garage" }, { value: "street" }] },
+  { label: "Overnight", type: "boolean", value: true },
+]
+
+describe("Cal.com response normalization", () => {
+  it("creates slugified metadata entries for responses", () => {
+    const metadata = normalizeCalcomResponses(sampleResponses)
+
+    expect(metadata.guest_name.value).toBe("Jamie")
+    expect(metadata.dietary_needs.value).toEqual(["vegan", "gluten-free"])
+    expect(metadata.parking.value).toEqual(["garage", "street"])
+    expect(metadata.overnight.type).toBe("boolean")
+  })
+
+  it("coerces plain metadata into structured booking metadata", () => {
+    const metadata = coerceBookingMetadata({
+      host: "Riley",
+      internal_notes: { keyholder: "Suite 2" },
+    })
+
+    expect(metadata.host.label).toBe("Host")
+    expect(metadata.host.value).toBe("Riley")
+    expect(metadata.internal_notes.type).toBe("object")
+  })
+})
+
+describe("Booking persistence payloads", () => {
+  it("merges existing metadata and normalized responses", () => {
+    const record = buildBookingRecord({
+      booking: {
+        id: 42,
+        startTime: "2024-07-01T10:00:00.000Z",
+        endTime: "2024-07-01T11:00:00.000Z",
+        attendees: [{ email: "guest@example.com", name: "Jamie" }],
+        metadata: {
+          host_room: { label: "Host room", value: "B3", type: "text" },
+          reminder: "Bring spare key",
+        },
+        responses: sampleResponses,
+        status: "ACCEPTED",
+        eventType: { slug: "kitchen" },
+        title: "Kitchen reservation",
+      },
+      triggerEvent: "BOOKING_CREATED",
+    })
+
+    const metadata = record.metadata as BookingMetadata
+
+    expect(record.calcom_booking_id).toBe("42")
+    expect(record.status).toBe("accepted")
+    expect(record.attendee_email).toBe("guest@example.com")
+    expect(record.event_slug).toBe("kitchen")
+
+    expect(metadata.host_room.value).toBe("B3")
+    expect(metadata.reminder.value).toBe("Bring spare key")
+    expect(metadata.dietary_needs.value).toEqual(["vegan", "gluten-free"])
+    expect(metadata.last_calcom_event.value).toBe("BOOKING_CREATED")
+  })
+
+  it("parses nested webhook payloads", () => {
+    const payload = {
+      triggerEvent: "BOOKING_CANCELLED",
+      payload: {
+        data: {
+          booking: {
+            id: "abc123",
+            startTime: "2024-07-02T09:00:00.000Z",
+            endTime: "2024-07-02T10:00:00.000Z",
+            attendees: [{ email: "guest@example.com" }],
+            responses: [{ label: "Apartment", value: "12B" }],
+          },
+        },
+      },
+    }
+
+    const parsed = parseCalcomWebhookPayload(payload)
+    expect(parsed).not.toBeNull()
+    expect(parsed?.triggerEvent).toBe("BOOKING_CANCELLED")
+    expect(parsed?.booking.startTime).toBe("2024-07-02T09:00:00.000Z")
+
+    const record = buildBookingRecord(parsed!)
+    const metadata = record.metadata as BookingMetadata
+
+    expect(metadata.apartment.value).toBe("12B")
+    expect(record.status).toBe("cancelled")
+  })
+
+  it("supports manual booking payloads without webhook wrapper", () => {
+    const booking = normalizeCalcomBookingPayload({
+      id: "manual-1",
+      startTime: "2024-07-03T18:00:00.000Z",
+      endTime: "2024-07-03T19:00:00.000Z",
+      attendees: [{ email: "manual@example.com" }],
+      responses: [{ label: "Guest", value: "Kai" }],
+    })
+
+    expect(booking).not.toBeNull()
+    const record = buildBookingRecord({ booking: booking!, triggerEvent: null })
+    const metadata = record.metadata as BookingMetadata
+
+    expect(metadata.guest.value).toBe("Kai")
+    expect(record.status).toBeNull()
+  })
+})

--- a/utils/supabase/service-role.ts
+++ b/utils/supabase/service-role.ts
@@ -1,0 +1,19 @@
+import { createClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+export function createServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceKey) {
+    return null
+  }
+
+  return createClient<Database>(url, serviceKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add a safe migration for the bookings metadata column and extend the generated Supabase types
- normalize Cal.com booking responses and persist them via new webhook/manual booking endpoints
- surface the captured metadata in the admin dashboard card and cover the flow with unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0dada18832892f540cff5d2e206