### PR TITLE
feat: add admin billing adjustments

### DIFF
--- a/app/(admin)/billing/actions.ts
+++ b/app/(admin)/billing/actions.ts
@@ -1,0 +1,156 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { ADMIN_ROLE, BILLING_EVENT_TYPE } from "./constants"
+import { invoiceAdjustmentSchema, type InvoiceAdjustmentInput } from "./schemas"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+type InvoiceRow = {
+  id: string
+  balance_cents: number
+  currency?: string | null
+}
+
+type AdjustmentInsert = {
+  invoice_id: string
+  amount_cents: number
+  reason: string
+  memo?: string | null
+  type: InvoiceAdjustmentInput["type"]
+  created_by: string
+}
+
+type AdjustmentRow = AdjustmentInsert & {
+  id: string
+  created_at: string
+}
+
+type AuditEventInsert = {
+  actor_id: string
+  event_type: string
+  resource: string
+  resource_id: string
+  payload: Record<string, unknown>
+}
+
+function formatSupabaseError(message: string, error: unknown) {
+  if (error && typeof error === "object" && "message" in error && typeof error.message === "string") {
+    return `${message}: ${error.message}`
+  }
+
+  return message
+}
+
+export async function applyInvoiceAdjustment(input: InvoiceAdjustmentInput) {
+  const payload = invoiceAdjustmentSchema.parse(input)
+  const supabase = await createSupbaseServerClient()
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError) {
+    throw new Error(formatSupabaseError("Unable to verify session", authError))
+  }
+
+  if (!user) {
+    throw new Error("You must be signed in to record billing adjustments.")
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, role, full_name, email")
+    .eq("id", user.id)
+    .single()
+
+  if (profileError) {
+    throw new Error(formatSupabaseError("Failed to load admin profile", profileError))
+  }
+
+  if (!profile || profile.role !== ADMIN_ROLE) {
+    throw new Error("Only administrators can create billing adjustments.")
+  }
+
+  const { data: invoice, error: invoiceError } = await supabase
+    .from("invoices")
+    .select("id, balance_cents, currency")
+    .eq("id", payload.invoiceId)
+    .single()
+
+  if (invoiceError || !invoice) {
+    throw new Error(formatSupabaseError("Invoice could not be found", invoiceError))
+  }
+
+  const adjustmentCents = Math.round(payload.amount * 100)
+  const signedAmountCents = payload.type === "credit" ? adjustmentCents * -1 : adjustmentCents
+  const nextBalanceCents = invoice.balance_cents + signedAmountCents
+
+  if (nextBalanceCents < 0) {
+    throw new Error("Adjustments cannot reduce an invoice balance below zero.")
+  }
+
+  const adjustmentInsert: AdjustmentInsert = {
+    invoice_id: invoice.id,
+    amount_cents: signedAmountCents,
+    reason: payload.reason,
+    memo: payload.memo ?? null,
+    type: payload.type,
+    created_by: user.id,
+  }
+
+  const { data: adjustment, error: adjustmentError } = await supabase
+    .from("invoice_adjustments")
+    .insert(adjustmentInsert)
+    .select("id, created_at, invoice_id, amount_cents, reason, memo, type, created_by")
+    .single()
+
+  if (adjustmentError || !adjustment) {
+    throw new Error(formatSupabaseError("Failed to create adjustment entry", adjustmentError))
+  }
+
+  const { error: invoiceUpdateError } = await supabase
+    .from("invoices")
+    .update({ balance_cents: nextBalanceCents, updated_at: new Date().toISOString() })
+    .eq("id", invoice.id)
+
+  if (invoiceUpdateError) {
+    throw new Error(formatSupabaseError("Failed to update invoice balance", invoiceUpdateError))
+  }
+
+  const auditEvent: AuditEventInsert = {
+    actor_id: user.id,
+    event_type: BILLING_EVENT_TYPE,
+    resource: "invoice",
+    resource_id: invoice.id,
+    payload: {
+      adjustment_id: adjustment.id,
+      amount_cents: signedAmountCents,
+      reason: payload.reason,
+      memo: payload.memo ?? null,
+      type: payload.type,
+      previous_balance_cents: invoice.balance_cents,
+      next_balance_cents: nextBalanceCents,
+      currency: invoice.currency ?? "USD",
+    },
+  }
+
+  const { error: auditError } = await supabase.from("events").insert(auditEvent)
+
+  if (auditError) {
+    throw new Error(formatSupabaseError("Failed to record billing audit event", auditError))
+  }
+
+  revalidatePath("/payments")
+  revalidatePath("/admin/billing")
+  revalidatePath(`/admin/billing/${invoice.id}`)
+
+  return {
+    adjustment: adjustment as AdjustmentRow,
+    invoice: {
+      ...invoice,
+      balance_cents: nextBalanceCents,
+    } satisfies InvoiceRow,
+  }
+}

--- a/app/(admin)/billing/constants.ts
+++ b/app/(admin)/billing/constants.ts
@@ -1,0 +1,2 @@
+export const ADMIN_ROLE = "admin"
+export const BILLING_EVENT_TYPE = "billing.invoice.adjustment"

--- a/app/(admin)/billing/page.tsx
+++ b/app/(admin)/billing/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from "next"
+
+import { BillingAuditLog, type BillingAuditEvent } from "@/components/billing/audit-log"
+import { InvoiceAdjustmentForm, type InvoiceSummary } from "@/components/billing/adjustment-form"
+import { LedgerTable, type LedgerEntry } from "@/components/billing/ledger-table"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+import { BILLING_EVENT_TYPE } from "./constants"
+
+export const metadata: Metadata = {
+  title: "Billing adjustments",
+  description: "Administer invoice credits, reversals, and audit trails for resident accounts.",
+}
+
+type InvoiceRow = {
+  id: string
+  reference?: string | null
+  balance_cents: number
+  currency?: string | null
+}
+
+type AdjustmentRow = {
+  id: string
+  created_at: string
+  amount_cents: number
+  reason: string
+  memo?: string | null
+  type: "credit" | "reversal"
+  created_by: string
+  invoice?: {
+    id: string
+    reference?: string | null
+    currency?: string | null
+  } | null
+  actor?: {
+    full_name?: string | null
+    email?: string | null
+  } | null
+}
+
+type AuditEventRow = {
+  id: string
+  created_at: string
+  event_type: string
+  payload?: Record<string, unknown> | null
+  actor?: {
+    full_name?: string | null
+    email?: string | null
+  } | null
+}
+
+export default async function BillingAdminPage() {
+  const supabase = await createSupbaseServerClient()
+
+  const [invoicesResult, adjustmentsResult, auditResult] = await Promise.all([
+    supabase
+      .from("invoices")
+      .select("id, reference, balance_cents, currency")
+      .order("created_at", { ascending: false })
+      .limit(50),
+    supabase
+      .from("invoice_adjustments")
+      .select(
+        "id, created_at, amount_cents, reason, memo, type, created_by, invoice:invoices(id, reference, currency), actor:profiles(full_name, email)"
+      )
+      .order("created_at", { ascending: false })
+      .limit(50),
+    supabase
+      .from("events")
+      .select("id, created_at, event_type, payload, actor:profiles(full_name, email)")
+      .eq("event_type", BILLING_EVENT_TYPE)
+      .order("created_at", { ascending: false })
+      .limit(25),
+  ])
+
+  if (invoicesResult.error) {
+    console.error("Failed to load invoices", invoicesResult.error)
+  }
+
+  if (adjustmentsResult.error) {
+    console.error("Failed to load invoice adjustments", adjustmentsResult.error)
+  }
+
+  if (auditResult.error) {
+    console.error("Failed to load audit events", auditResult.error)
+  }
+
+  const invoices: InvoiceSummary[] = (invoicesResult.data as InvoiceRow[] | null)?.map((invoice) => ({
+    id: invoice.id,
+    reference: invoice.reference,
+    balance_cents: invoice.balance_cents,
+    currency: invoice.currency ?? "USD",
+  })) ?? []
+
+  const adjustments: LedgerEntry[] = (adjustmentsResult.data as AdjustmentRow[] | null)?.map((entry) => ({
+    id: entry.id,
+    created_at: entry.created_at,
+    amount_cents: entry.amount_cents,
+    reason: entry.reason,
+    memo: entry.memo,
+    type: entry.type,
+    created_by: entry.created_by,
+    invoice: entry.invoice ?? null,
+    actor: entry.actor ?? null,
+  })) ?? []
+
+  const auditEvents: BillingAuditEvent[] = (auditResult.data as AuditEventRow[] | null)?.map((event) => ({
+    id: event.id,
+    created_at: event.created_at,
+    event_type: event.event_type,
+    payload: event.payload ?? {},
+    actor: event.actor ?? null,
+  })) ?? []
+
+  return (
+    <div className="container max-w-6xl space-y-10 py-12">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Billing adjustments</h1>
+        <p className="text-sm text-muted-foreground sm:text-base">
+          Issue ledger credits and reversals when rent, deposits, or utility balances need manual intervention. Every action is
+          fully audited.
+        </p>
+      </div>
+
+      <InvoiceAdjustmentForm invoices={invoices} />
+
+      <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+        <LedgerTable adjustments={adjustments} />
+        <BillingAuditLog events={auditEvents} />
+      </div>
+    </div>
+  )
+}

--- a/app/(admin)/billing/schemas.ts
+++ b/app/(admin)/billing/schemas.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+
+export const invoiceAdjustmentSchema = z.object({
+  invoiceId: z.string({ required_error: "Invoice is required." }).uuid("Invoice must be a valid UUID."),
+  amount: z
+    .coerce.number({ invalid_type_error: "Amount is required." })
+    .positive("Amount must be greater than zero."),
+  reason: z
+    .string({ required_error: "Reason is required." })
+    .min(3, "Reason must be at least 3 characters."),
+  memo: z
+    .string()
+    .max(280, "Memo must be 280 characters or fewer.")
+    .optional()
+    .transform((value) => (value?.trim() ? value.trim() : undefined)),
+  type: z.enum(["credit", "reversal"], {
+    required_error: "Adjustment type is required.",
+  }),
+})
+
+export type InvoiceAdjustmentInput = z.infer<typeof invoiceAdjustmentSchema>

--- a/components/billing/adjustment-form.tsx
+++ b/components/billing/adjustment-form.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import { useEffect, useMemo, useState, useTransition } from "react"
+import { Controller, useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import { applyInvoiceAdjustment } from "@/app/(admin)/billing/actions"
+import {
+  invoiceAdjustmentSchema,
+  type InvoiceAdjustmentInput,
+} from "@/app/(admin)/billing/schemas"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { formatCurrencyFromCents } from "@/lib/utils"
+
+export type InvoiceSummary = {
+  id: string
+  reference?: string | null
+  balance_cents: number
+  currency?: string | null
+}
+
+type AdjustmentFormProps = {
+  invoices: InvoiceSummary[]
+}
+
+type FormValues = InvoiceAdjustmentInput
+
+export function InvoiceAdjustmentForm({ invoices }: AdjustmentFormProps) {
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(invoiceAdjustmentSchema),
+    defaultValues: {
+      type: "credit",
+    },
+  })
+
+  const selectedInvoiceId = watch("invoiceId")
+
+  useEffect(() => {
+    if (!selectedInvoiceId && invoices.length > 0) {
+      setValue("invoiceId", invoices[0].id, { shouldDirty: false })
+    }
+  }, [invoices, selectedInvoiceId, setValue])
+
+  const selectedInvoice = useMemo(
+    () => invoices.find((invoice) => invoice.id === selectedInvoiceId) ?? invoices[0],
+    [invoices, selectedInvoiceId]
+  )
+
+  const onSubmit = (values: FormValues) => {
+    setError(null)
+    setMessage(null)
+
+    startTransition(async () => {
+      try {
+        const result = await applyInvoiceAdjustment(values)
+        setMessage(
+          `Adjustment recorded. Updated balance: ${formatCurrencyFromCents(
+            result.invoice.balance_cents,
+            result.invoice.currency ?? "USD"
+          )}`
+        )
+        reset({
+          invoiceId: values.invoiceId,
+          type: values.type,
+          amount: undefined,
+          reason: "",
+          memo: undefined,
+        } as Partial<FormValues>)
+      } catch (actionError) {
+        setError(actionError instanceof Error ? actionError.message : "Failed to submit adjustment.")
+      }
+    })
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Issue a billing adjustment</CardTitle>
+        <CardDescription>
+          Credit or reverse balances for residents. All adjustments are audit logged and reflected in the shared ledger.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Controller
+              control={control}
+              name="invoiceId"
+              render={({ field }) => (
+                <div className="space-y-2">
+                  <Label htmlFor="invoiceId">Invoice</Label>
+                  <Select onValueChange={field.onChange} value={field.value} disabled={isPending || invoices.length === 0}>
+                    <SelectTrigger id="invoiceId" aria-label="Select invoice">
+                      <SelectValue placeholder="Choose an invoice" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {invoices.map((invoice) => (
+                        <SelectItem key={invoice.id} value={invoice.id}>
+                          {invoice.reference ?? invoice.id}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {errors.invoiceId && <p className="text-sm text-destructive">{errors.invoiceId.message}</p>}
+                  {selectedInvoice && (
+                    <p className="text-sm text-muted-foreground">
+                      Current balance: {" "}
+                      {formatCurrencyFromCents(selectedInvoice.balance_cents, selectedInvoice.currency ?? "USD")}
+                    </p>
+                  )}
+                </div>
+              )}
+            />
+
+            <Controller
+              control={control}
+              name="type"
+              render={({ field }) => (
+                <div className="space-y-2">
+                  <Label htmlFor="adjustment-type">Adjustment type</Label>
+                  <Select onValueChange={field.onChange} value={field.value} disabled={isPending}>
+                    <SelectTrigger id="adjustment-type">
+                      <SelectValue placeholder="Select type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="credit">Credit - reduce balance</SelectItem>
+                      <SelectItem value="reversal">Reversal - restore balance</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {errors.type && <p className="text-sm text-destructive">{errors.type.message}</p>}
+                </div>
+              )}
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="amount">Amount</Label>
+              <Input
+                id="amount"
+                inputMode="decimal"
+                placeholder="150.00"
+                {...register("amount")}
+                disabled={isPending}
+              />
+              {errors.amount && <p className="text-sm text-destructive">{errors.amount.message}</p>}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="reason">Reason</Label>
+              <Input id="reason" placeholder="Late fee waiver" {...register("reason")} disabled={isPending} />
+              {errors.reason && <p className="text-sm text-destructive">{errors.reason.message}</p>}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="memo">Internal memo</Label>
+            <Textarea
+              id="memo"
+              placeholder="Add internal context (optional)"
+              rows={3}
+              {...register("memo")}
+              disabled={isPending}
+            />
+            {errors.memo && <p className="text-sm text-destructive">{errors.memo.message}</p>}
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {message && <p className="text-sm text-emerald-600">{message}</p>}
+
+          <Button type="submit" disabled={isPending || invoices.length === 0}>
+            {isPending ? "Saving adjustment…" : "Record adjustment"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/billing/audit-log.tsx
+++ b/components/billing/audit-log.tsx
@@ -1,0 +1,120 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { formatCurrencyFromCents } from "@/lib/utils"
+
+export type BillingAuditEvent = {
+  id: string
+  created_at: string
+  event_type: string
+  actor?: {
+    full_name?: string | null
+    email?: string | null
+  } | null
+  payload?: Record<string, unknown> | null
+}
+
+type BillingAuditLogProps = {
+  events: BillingAuditEvent[]
+}
+
+const adjustmentCopy: Record<string, string> = {
+  credit: "issued a credit",
+  reversal: "reversed a credit",
+}
+
+function getActorName(event: BillingAuditEvent) {
+  return event.actor?.full_name ?? event.actor?.email ?? "System"
+}
+
+function getPayload(event: BillingAuditEvent) {
+  const payload = event.payload ?? {}
+  return {
+    type: typeof payload.type === "string" ? payload.type : undefined,
+    amount_cents: typeof payload.amount_cents === "number" ? payload.amount_cents : undefined,
+    previous_balance_cents:
+      typeof payload.previous_balance_cents === "number" ? payload.previous_balance_cents : undefined,
+    next_balance_cents: typeof payload.next_balance_cents === "number" ? payload.next_balance_cents : undefined,
+    reason: typeof payload.reason === "string" ? payload.reason : undefined,
+    memo: typeof payload.memo === "string" ? payload.memo : undefined,
+    currency: typeof payload.currency === "string" ? payload.currency : undefined,
+  }
+}
+
+function formatDateTime(iso: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(iso))
+}
+
+export function BillingAuditLog({ events }: BillingAuditLogProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Audit trail</CardTitle>
+        <CardDescription>Events captured for compliance whenever a balance adjustment is applied.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {events.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No audit events recorded yet.</p>
+        ) : (
+          <ul className="space-y-4">
+            {events.map((event) => {
+              const payload = getPayload(event)
+              const adjustment = payload.type ? adjustmentCopy[payload.type] ?? "adjusted an invoice" : "adjusted an invoice"
+              const actor = getActorName(event)
+              const currency = payload.currency ?? "USD"
+              const amount = payload.amount_cents ? formatCurrencyFromCents(Math.abs(payload.amount_cents), currency) : null
+              const previousBalance =
+                typeof payload.previous_balance_cents === "number"
+                  ? formatCurrencyFromCents(payload.previous_balance_cents, currency)
+                  : null
+              const nextBalance =
+                typeof payload.next_balance_cents === "number"
+                  ? formatCurrencyFromCents(payload.next_balance_cents, currency)
+                  : null
+
+              return (
+                <li key={event.id} className="rounded-lg border border-border/60 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">{actor}</span>
+                    <span>{formatDateTime(event.created_at)}</span>
+                  </div>
+                  <p className="mt-1 text-sm text-foreground">
+                    {actor} {adjustment}
+                    {amount ? ` (${amount})` : ""}
+                    {payload.reason ? ` — ${payload.reason}` : ""}
+                  </p>
+                  {(payload.memo || previousBalance || nextBalance) && (
+                    <dl className="mt-3 grid gap-x-6 gap-y-1 text-xs text-muted-foreground sm:grid-cols-2">
+                      {previousBalance && (
+                        <div>
+                          <dt className="font-medium text-foreground">Previous balance</dt>
+                          <dd>{previousBalance}</dd>
+                        </div>
+                      )}
+                      {nextBalance && (
+                        <div>
+                          <dt className="font-medium text-foreground">New balance</dt>
+                          <dd>{nextBalance}</dd>
+                        </div>
+                      )}
+                      {payload.memo && (
+                        <div className="sm:col-span-2">
+                          <dt className="font-medium text-foreground">Internal memo</dt>
+                          <dd>{payload.memo}</dd>
+                        </div>
+                      )}
+                    </dl>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/billing/ledger-table.tsx
+++ b/components/billing/ledger-table.tsx
@@ -1,0 +1,102 @@
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { formatCurrencyFromCents } from "@/lib/utils"
+
+export type LedgerEntry = {
+  id: string
+  created_at: string
+  amount_cents: number
+  reason: string
+  memo?: string | null
+  type: "credit" | "reversal"
+  created_by: string
+  invoice?: {
+    id: string
+    reference?: string | null
+    currency?: string | null
+  } | null
+  actor?: {
+    full_name?: string | null
+    email?: string | null
+  } | null
+}
+
+type LedgerTableProps = {
+  adjustments: LedgerEntry[]
+}
+
+const adjustmentLabels: Record<LedgerEntry["type"], { label: string; tone: string }> = {
+  credit: { label: "Credit", tone: "bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300" },
+  reversal: { label: "Reversal", tone: "bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300" },
+}
+
+function formatDateTime(iso: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(iso))
+}
+
+export function LedgerTable({ adjustments }: LedgerTableProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Ledger adjustments</CardTitle>
+        <CardDescription>Recent credits and reversals applied to resident invoices.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {adjustments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No adjustments have been recorded yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full table-fixed text-sm">
+              <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th className="w-[160px] py-2 pr-4">Timestamp</th>
+                  <th className="w-[160px] py-2 pr-4">Invoice</th>
+                  <th className="w-[120px] py-2 pr-4">Type</th>
+                  <th className="w-[140px] py-2 pr-4">Amount</th>
+                  <th className="py-2 pr-4">Reason</th>
+                  <th className="w-[180px] py-2">Entered by</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {adjustments.map((entry) => {
+                  const invoiceLabel = entry.invoice?.reference ?? entry.invoice?.id ?? "Invoice"
+                  const actorLabel = entry.actor?.full_name ?? entry.actor?.email ?? "System"
+                  const currency = entry.invoice?.currency ?? "USD"
+                  const amount = formatCurrencyFromCents(Math.abs(entry.amount_cents), currency)
+                  const adjustment = adjustmentLabels[entry.type]
+
+                  return (
+                    <tr key={entry.id} className="align-top">
+                      <td className="py-3 pr-4 font-medium text-foreground">{formatDateTime(entry.created_at)}</td>
+                      <td className="py-3 pr-4 text-muted-foreground">{invoiceLabel}</td>
+                      <td className="py-3 pr-4">
+                        <Badge variant="secondary" className={adjustment.tone}>
+                          {adjustment.label}
+                        </Badge>
+                      </td>
+                      <td className="py-3 pr-4 font-medium text-foreground">
+                        {entry.type === "credit" ? "-" : "+"}
+                        {amount}
+                      </td>
+                      <td className="py-3 pr-4 text-muted-foreground">
+                        <div>{entry.reason}</div>
+                        {entry.memo && <div className="text-xs text-muted-foreground/80">{entry.memo}</div>}
+                      </td>
+                      <td className="py-3 text-muted-foreground">{actorLabel}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -45,6 +45,14 @@ export const formatNumber = (value: number) =>
     currency: 'USD'
   }).format(value)
 
+export const formatCurrencyFromCents = (valueInCents: number, currency = 'USD') =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(valueInCents / 100)
+
 export const runAsyncFnWithoutBlocking = (
   fn: (...args: any) => Promise<any>
 ) => {

--- a/tests/billing.e2e.test.ts
+++ b/tests/billing.e2e.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/utils/supaone", () => ({
+  createSupbaseServerClient: vi.fn(),
+}))
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}))
+
+const { createSupbaseServerClient } = await import("@/utils/supaone")
+const { revalidatePath } = await import("next/cache")
+const { applyInvoiceAdjustment } = await import("@/app/(admin)/billing/actions")
+
+const createSupbaseServerClientMock = createSupbaseServerClient as unknown as vi.Mock
+
+type StubOptions = {
+  invoice?: {
+    id?: string
+    balance_cents: number
+    currency?: string
+  }
+  profileRole?: string
+}
+
+function createSupabaseStub(options: StubOptions = {}) {
+  const invoiceId = options.invoice?.id ?? "11111111-1111-4111-8111-111111111111"
+  const invoiceRow = {
+    id: invoiceId,
+    balance_cents: options.invoice?.balance_cents ?? 125_00,
+    currency: options.invoice?.currency ?? "USD",
+  }
+
+  const adjustments: any[] = []
+  const events: any[] = []
+  const invoiceUpdates: any[] = []
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "admin-user" } }, error: null }),
+    },
+    from: vi.fn((table: string) => {
+      switch (table) {
+        case "profiles":
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi
+              .fn()
+              .mockResolvedValue({ data: { id: "admin-user", role: options.profileRole ?? "admin" }, error: null }),
+          }
+        case "invoices":
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { ...invoiceRow }, error: null }),
+            update: vi.fn((values: any) => {
+              invoiceUpdates.push(values)
+              invoiceRow.balance_cents = values.balance_cents
+              return {
+                eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+              }
+            }),
+          }
+        case "invoice_adjustments":
+          return {
+            insert: vi.fn((values: any) => {
+              adjustments.push(values)
+              return {
+                select: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({
+                    data: {
+                      id: `adjustment-${adjustments.length}`,
+                      created_at: new Date().toISOString(),
+                      ...values,
+                    },
+                    error: null,
+                  }),
+                }),
+              }
+            }),
+          }
+        case "events":
+          return {
+            insert: vi.fn((value: any) => {
+              events.push(value)
+              return Promise.resolve({ data: [{ id: `event-${events.length}`, ...value }], error: null })
+            }),
+          }
+        default:
+          throw new Error(`Unexpected table: ${table}`)
+      }
+    }),
+    insertCalls: { adjustments, events },
+    invoiceUpdates,
+    invoiceRow,
+  }
+}
+
+describe("applyInvoiceAdjustment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createSupbaseServerClientMock.mockReset()
+    ;(revalidatePath as unknown as vi.Mock).mockReset()
+  })
+
+  it("creates a credit adjustment and decreases the balance", async () => {
+    const supabase = createSupabaseStub({ invoice: { balance_cents: 120_00 } })
+    createSupbaseServerClientMock.mockResolvedValue(supabase)
+
+    const result = await applyInvoiceAdjustment({
+      invoiceId: supabase.invoiceRow.id,
+      amount: 50,
+      reason: "Appliance refund",
+      type: "credit",
+      memo: "Approved by property manager",
+    })
+
+    expect(result.invoice.balance_cents).toBe(70_00)
+    expect(supabase.insertCalls.adjustments[0]).toMatchObject({
+      invoice_id: supabase.invoiceRow.id,
+      amount_cents: -5000,
+      reason: "Appliance refund",
+      type: "credit",
+    })
+    expect(supabase.invoiceUpdates[0]).toMatchObject({ balance_cents: 70_00 })
+    expect(supabase.insertCalls.events[0]).toMatchObject({
+      event_type: "billing.invoice.adjustment",
+      resource_id: supabase.invoiceRow.id,
+      payload: expect.objectContaining({
+        amount_cents: -5000,
+        previous_balance_cents: 120_00,
+        next_balance_cents: 70_00,
+        type: "credit",
+      }),
+    })
+    expect(revalidatePath).toHaveBeenCalledWith("/payments")
+    expect(revalidatePath).toHaveBeenCalledWith("/admin/billing")
+  })
+
+  it("records a reversal that restores the outstanding balance", async () => {
+    const supabase = createSupabaseStub({ invoice: { balance_cents: 32_00 } })
+    createSupbaseServerClientMock.mockResolvedValue(supabase)
+
+    const result = await applyInvoiceAdjustment({
+      invoiceId: supabase.invoiceRow.id,
+      amount: 15.5,
+      reason: "Reversed roommate credit",
+      type: "reversal",
+    })
+
+    expect(result.invoice.balance_cents).toBe(47_50)
+    expect(supabase.insertCalls.adjustments[0]).toMatchObject({
+      amount_cents: 1550,
+      type: "reversal",
+    })
+    expect(supabase.insertCalls.events[0].payload).toMatchObject({
+      amount_cents: 1550,
+      previous_balance_cents: 32_00,
+      next_balance_cents: 47_50,
+      type: "reversal",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add an admin-only billing adjustment server action that updates invoice balances and emits audit events
- build an admin billing page, ledger display, and audit log components showing adjustment attribution
- validate the adjustment form with zod and cover credit/reversal flows with vitest e2e tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0cb3eb083288416cc439db9dd83