### PR TITLE
feat: add Stripe webhook handler and tests

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,200 @@
+import { NextResponse } from "next/server"
+import Stripe from "stripe"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+export const runtime = "nodejs"
+
+type DatabaseClient = SupabaseClient<Database>
+
+type InvoiceIdentifiers = {
+  invoiceId?: string
+  stripeInvoiceId?: string
+}
+
+export async function POST(request: Request) {
+  const signature = request.headers.get("stripe-signature")
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+
+  if (!signature || !webhookSecret) {
+    return NextResponse.json(
+      { error: "Missing Stripe signature or webhook secret" },
+      { status: 400 }
+    )
+  }
+
+  const payload = await request.text()
+
+  let event: Stripe.Event
+  try {
+    event = Stripe.webhooks.constructEvent(payload, signature, webhookSecret)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown signature error"
+    return NextResponse.json(
+      { error: `Webhook signature verification failed: ${message}` },
+      { status: 400 }
+    )
+  }
+
+  let supabase: DatabaseClient
+  try {
+    supabase = createServiceRoleClient()
+  } catch (error) {
+    console.error("Failed to configure Supabase client", error)
+    return NextResponse.json({ error: "Server configuration error" }, { status: 500 })
+  }
+
+  await logEvent(supabase, event)
+
+  try {
+    switch (event.type) {
+      case "payment_intent.succeeded": {
+        const paymentIntent = event.data.object as Stripe.PaymentIntent
+        await updatePaymentStatus(supabase, paymentIntent.id, "succeeded")
+        await updateInvoiceStatus(
+          supabase,
+          "paid",
+          extractInvoiceIdentifiersFromPaymentIntent(paymentIntent)
+        )
+        break
+      }
+      case "payment_intent.payment_failed": {
+        const paymentIntent = event.data.object as Stripe.PaymentIntent
+        await updatePaymentStatus(supabase, paymentIntent.id, "failed")
+        await updateInvoiceStatus(
+          supabase,
+          "payment_failed",
+          extractInvoiceIdentifiersFromPaymentIntent(paymentIntent)
+        )
+        break
+      }
+      case "charge.refunded": {
+        const charge = event.data.object as Stripe.Charge
+        const paymentIntentId =
+          typeof charge.payment_intent === "string"
+            ? charge.payment_intent
+            : charge.payment_intent?.id
+        await updatePaymentStatus(supabase, paymentIntentId, "refunded")
+        await updateInvoiceStatus(
+          supabase,
+          "refunded",
+          extractInvoiceIdentifiersFromCharge(charge)
+        )
+        break
+      }
+      default: {
+        break
+      }
+    }
+  } catch (error) {
+    console.error(`Error handling Stripe webhook ${event.id}`, error)
+    return NextResponse.json({ error: "Webhook processing failed" }, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}
+
+function createServiceRoleClient(): DatabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceRoleKey) {
+    throw new Error("Missing Supabase configuration")
+  }
+
+  return createClient<Database>(url, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}
+
+async function logEvent(client: DatabaseClient, event: Stripe.Event) {
+  const { error } = await client
+    .from("events")
+    .insert([{ type: event.type, payload: event }])
+
+  if (error) {
+    console.error("Failed to record Stripe webhook event", error)
+  }
+}
+
+async function updatePaymentStatus(
+  client: DatabaseClient,
+  paymentIntentId: string | null | undefined,
+  status: string
+) {
+  if (!paymentIntentId) {
+    return
+  }
+
+  const { error } = await client
+    .from("payments")
+    .update({ status })
+    .eq("stripe_payment_intent_id", paymentIntentId)
+
+  if (error) {
+    throw new Error(`Failed to update payment ${paymentIntentId}: ${error.message}`)
+  }
+}
+
+async function updateInvoiceStatus(
+  client: DatabaseClient,
+  status: string,
+  identifiers: InvoiceIdentifiers
+) {
+  const { invoiceId, stripeInvoiceId } = identifiers
+
+  if (invoiceId) {
+    const { error } = await client.from("invoices").update({ status }).eq("id", invoiceId)
+    if (error) {
+      throw new Error(`Failed to update invoice ${invoiceId}: ${error.message}`)
+    }
+    return
+  }
+
+  if (stripeInvoiceId) {
+    const { error } = await client
+      .from("invoices")
+      .update({ status })
+      .eq("stripe_invoice_id", stripeInvoiceId)
+
+    if (error) {
+      throw new Error(`Failed to update invoice ${stripeInvoiceId}: ${error.message}`)
+    }
+  }
+}
+
+function extractInvoiceIdentifiersFromPaymentIntent(
+  paymentIntent: Stripe.PaymentIntent
+): InvoiceIdentifiers {
+  return {
+    invoiceId: getMetadataValue(paymentIntent.metadata, "invoice_id"),
+    stripeInvoiceId:
+      typeof paymentIntent.invoice === "string"
+        ? paymentIntent.invoice
+        : paymentIntent.invoice?.id,
+  }
+}
+
+function extractInvoiceIdentifiersFromCharge(charge: Stripe.Charge): InvoiceIdentifiers {
+  return {
+    invoiceId: getMetadataValue(charge.metadata, "invoice_id"),
+    stripeInvoiceId:
+      typeof charge.invoice === "string" ? charge.invoice : charge.invoice?.id ?? undefined,
+  }
+}
+
+function getMetadataValue(
+  metadata: Stripe.Metadata | null | undefined,
+  key: string
+): string | undefined {
+  if (!metadata) {
+    return undefined
+  }
+
+  const value = metadata[key]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "resend": "^4.1.2",
     "sharp": "^0.32.6",
     "sonner": "^1.5.0",
+    "stripe": "^18.5.0",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "0.160.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       sonner:
         specifier: ^1.5.0
         version: 1.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      stripe:
+        specifier: ^18.5.0
+        version: 18.5.0(@types/node@20.14.15)
       tailwind-merge:
         specifier: ^2.2.0
         version: 2.2.0
@@ -2762,9 +2765,6 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -3791,9 +3791,6 @@ packages:
 
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
-
-  es-module-lexer@1.6.0:
-    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -5389,10 +5386,6 @@ packages:
     resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5939,6 +5932,15 @@ packages:
 
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
+  stripe@18.5.0:
+    resolution: {integrity: sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==}
+    engines: {node: '>=12.*'}
+    peerDependencies:
+      '@types/node': '>=12.x.x'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -9346,11 +9348,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.12
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   '@types/eslint@8.56.12':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/eslint@8.56.2':
@@ -9365,8 +9367,6 @@ snapshots:
   '@types/estree@0.0.39': {}
 
   '@types/estree@1.0.5': {}
-
-  '@types/estree@1.0.7': {}
 
   '@types/estree@1.0.8': {}
 
@@ -9580,7 +9580,7 @@ snapshots:
       '@vue/shared': 3.4.35
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
     optional: true
 
@@ -10126,7 +10126,7 @@ snapshots:
   code-red@1.0.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -10488,8 +10488,6 @@ snapshots:
       internal-slot: 1.0.6
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
-
-  es-module-lexer@1.6.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -11245,7 +11243,7 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.2
       hasown: 2.0.0
-      side-channel: 1.0.4
+      side-channel: 1.1.0
 
   internmap@2.0.3: {}
 
@@ -11356,7 +11354,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
     optional: true
 
   is-regex@1.1.4:
@@ -12473,13 +12471,6 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  postcss@8.5.3:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    optional: true
-
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -13122,6 +13113,12 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  stripe@18.5.0(@types/node@20.14.15):
+    dependencies:
+      qs: 6.14.0
+    optionalDependencies:
+      '@types/node': 20.14.15
+
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -13172,7 +13169,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -13706,7 +13703,7 @@ snapshots:
   webpack@5.93.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
@@ -13715,7 +13712,7 @@ snapshots:
       browserslist: 4.23.3
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
+      es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/tests/api/stripe-webhook.spec.ts
+++ b/tests/api/stripe-webhook.spec.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const constructEventMock = vi.fn()
+const createClientMock = vi.fn()
+
+vi.mock("stripe", () => ({
+  __esModule: true,
+  default: class StripeMock {
+    static webhooks = {
+      constructEvent: constructEventMock,
+    }
+  },
+}))
+
+vi.mock("@supabase/supabase-js", () => ({
+  __esModule: true,
+  createClient: createClientMock,
+}))
+
+describe("POST /api/stripe/webhook", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    constructEventMock.mockReset()
+    createClientMock.mockReset()
+
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test"
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co"
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key"
+  })
+
+  afterEach(() => {
+    delete process.env.STRIPE_WEBHOOK_SECRET
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+  })
+
+  it("returns 400 when the Stripe signature header is missing", async () => {
+    const supabase = createMockSupabase()
+    createClientMock.mockReturnValue(supabase.client)
+
+    const { POST } = await import("@/app/api/stripe/webhook/route")
+    const request = new Request("http://localhost/api/stripe/webhook", {
+      method: "POST",
+      body: JSON.stringify({}),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+    expect(constructEventMock).not.toHaveBeenCalled()
+    expect(supabase.eventsInsert).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid webhook signatures", async () => {
+    const supabase = createMockSupabase()
+    createClientMock.mockReturnValue(supabase.client)
+    constructEventMock.mockImplementationOnce(() => {
+      throw new Error("invalid signature")
+    })
+
+    const { POST } = await import("@/app/api/stripe/webhook/route")
+    const request = new Request("http://localhost/api/stripe/webhook", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "stripe-signature": "sig_header" },
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+    expect(supabase.eventsInsert).not.toHaveBeenCalled()
+  })
+
+  it("marks successful payment intents as paid and logs the event", async () => {
+    const event = {
+      id: "evt_1",
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_123",
+          metadata: { invoice_id: "inv_db_1" },
+          invoice: "in_123",
+        },
+      },
+    }
+
+    const supabase = createMockSupabase()
+    createClientMock.mockReturnValue(supabase.client)
+    constructEventMock.mockReturnValueOnce(event as any)
+
+    const { POST } = await import("@/app/api/stripe/webhook/route")
+    const request = new Request("http://localhost/api/stripe/webhook", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "stripe-signature": "sig_header" },
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(constructEventMock).toHaveBeenCalledWith(expect.any(String), "sig_header", "whsec_test")
+    expect(supabase.eventsInsert).toHaveBeenCalledWith([{ type: event.type, payload: event }])
+    expect(supabase.paymentsUpdate).toHaveBeenCalledWith({ status: "succeeded" })
+    expect(supabase.paymentsEq).toHaveBeenCalledWith("stripe_payment_intent_id", "pi_123")
+    expect(supabase.invoicesUpdate).toHaveBeenCalledWith({ status: "paid" })
+    expect(supabase.invoicesEq).toHaveBeenCalledWith("id", "inv_db_1")
+  })
+
+  it("handles failed payment intents", async () => {
+    const event = {
+      id: "evt_2",
+      type: "payment_intent.payment_failed",
+      data: {
+        object: {
+          id: "pi_failed",
+          metadata: { invoice_id: "inv_failed" },
+          invoice: "in_failed",
+        },
+      },
+    }
+
+    const supabase = createMockSupabase()
+    createClientMock.mockReturnValue(supabase.client)
+    constructEventMock.mockReturnValueOnce(event as any)
+
+    const { POST } = await import("@/app/api/stripe/webhook/route")
+    const request = new Request("http://localhost/api/stripe/webhook", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "stripe-signature": "sig_header" },
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(supabase.eventsInsert).toHaveBeenCalled()
+    expect(supabase.paymentsUpdate).toHaveBeenCalledWith({ status: "failed" })
+    expect(supabase.invoicesUpdate).toHaveBeenCalledWith({ status: "payment_failed" })
+  })
+
+  it("updates records for refunded charges using charge metadata", async () => {
+    const event = {
+      id: "evt_3",
+      type: "charge.refunded",
+      data: {
+        object: {
+          id: "ch_123",
+          payment_intent: "pi_789",
+          invoice: "in_789",
+          metadata: {},
+        },
+      },
+    }
+
+    const supabase = createMockSupabase()
+    createClientMock.mockReturnValue(supabase.client)
+    constructEventMock.mockReturnValueOnce(event as any)
+
+    const { POST } = await import("@/app/api/stripe/webhook/route")
+    const request = new Request("http://localhost/api/stripe/webhook", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "stripe-signature": "sig_header" },
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(supabase.paymentsUpdate).toHaveBeenCalledWith({ status: "refunded" })
+    expect(supabase.paymentsEq).toHaveBeenCalledWith("stripe_payment_intent_id", "pi_789")
+    expect(supabase.invoicesUpdate).toHaveBeenCalledWith({ status: "refunded" })
+    expect(supabase.invoicesEq).toHaveBeenCalledWith("stripe_invoice_id", "in_789")
+  })
+
+  it("returns 500 when payment updates fail", async () => {
+    const event = {
+      id: "evt_4",
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_error",
+          metadata: { invoice_id: "inv_error" },
+        },
+      },
+    }
+
+    const supabase = createMockSupabase()
+    supabase.paymentsEq.mockResolvedValueOnce({ error: { message: "update failed" } })
+    createClientMock.mockReturnValue(supabase.client)
+    constructEventMock.mockReturnValueOnce(event as any)
+
+    const { POST } = await import("@/app/api/stripe/webhook/route")
+    const request = new Request("http://localhost/api/stripe/webhook", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "stripe-signature": "sig_header" },
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(500)
+  })
+})
+
+function createMockSupabase() {
+  const eventsInsert = vi.fn().mockResolvedValue({ data: null, error: null })
+  const paymentsEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const paymentsUpdate = vi.fn(() => ({ eq: paymentsEq }))
+  const invoicesEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const invoicesUpdate = vi.fn(() => ({ eq: invoicesEq }))
+
+  const from = vi.fn((table: string) => {
+    switch (table) {
+      case "events":
+        return { insert: eventsInsert }
+      case "payments":
+        return { update: paymentsUpdate }
+      case "invoices":
+        return { update: invoicesUpdate }
+      default:
+        throw new Error(`Unexpected table ${table}`)
+    }
+  })
+
+  return {
+    client: { from } as any,
+    eventsInsert,
+    paymentsUpdate,
+    paymentsEq,
+    invoicesUpdate,
+    invoicesEq,
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.spec.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a Stripe webhook route that verifies signatures, records webhook payloads, and updates related payment and invoice records
- create mocked Vitest coverage for success, failure, and refund webhook paths plus error handling
- enable Vitest to pick up .spec.ts suites and add the Stripe SDK dependency required for signature verification

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d0a0c8e3b4832898f00997eb6e40a8