### PR TITLE
Add billing invoice API route and tests

### DIFF
--- a/app/api/billing/create-invoice/route.ts
+++ b/app/api/billing/create-invoice/route.ts
@@ -1,0 +1,325 @@
+import createSupabaseServerClient from '@/lib/supabaseServer'
+import { z } from 'zod'
+
+type HouseholdMemberRecord = {
+  profile_id: string
+  rent_share: number | null
+}
+
+type PerMemberLineItem = {
+  description: string
+  amount: number
+  quantity: number
+}
+
+const lineItemSchema = z.object({
+  description: z.string().min(1, 'Line item description is required.'),
+  amount: z.number().nonnegative(),
+  quantity: z.number().int().positive().optional(),
+})
+
+const lateFeeSchema = z
+  .object({
+    flatAmount: z.number().nonnegative().optional(),
+    percentage: z.number().nonnegative().max(100).optional(),
+    gracePeriodDays: z.number().int().nonnegative().optional(),
+    maximumAmount: z.number().nonnegative().optional(),
+    dailyRate: z.number().nonnegative().optional(),
+  })
+  .refine(
+    (value) => value.flatAmount !== undefined || value.percentage !== undefined,
+    {
+      message: 'Provide either a flatAmount or percentage for late fees.',
+      path: ['flatAmount'],
+    },
+  )
+
+const createInvoiceSchema = z.object({
+  householdId: z.string().min(1, 'householdId is required.'),
+  billingPeriod: z
+    .object({
+      start: z.coerce.date(),
+      end: z.coerce.date(),
+    })
+    .refine((period) => period.end >= period.start, {
+      message: 'Billing period end must be after the start date.',
+      path: ['end'],
+    }),
+  dueDate: z.coerce.date(),
+  totalAmount: z.number().positive(),
+  memo: z.string().max(2000).optional(),
+  lineItems: z.array(lineItemSchema).optional(),
+  lateFee: lateFeeSchema.optional(),
+})
+
+type CreateInvoicePayload = z.infer<typeof createInvoiceSchema>
+type LateFeeConfig = NonNullable<CreateInvoicePayload['lateFee']>
+
+type InvoiceInsertPayload = {
+  household_id: string
+  resident_id: string
+  amount_due: number
+  due_date: string
+  billing_period_start: string
+  billing_period_end: string
+  status: string
+  memo: string | null
+  metadata: Record<string, unknown>
+}
+
+type InvoiceLineItemInsertPayload = {
+  invoice_id: string | number
+  description: string
+  amount: number
+  quantity: number
+}
+
+export async function POST(request: Request) {
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid JSON payload.'
+    return Response.json({ error: message }, { status: 400 })
+  }
+
+  const parsed = createInvoiceSchema.safeParse(payload)
+
+  if (!parsed.success) {
+    return Response.json(
+      {
+        error: 'Invalid invoice payload.',
+        details: parsed.error.flatten(),
+      },
+      { status: 400 },
+    )
+  }
+
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return Response.json({ error: 'Unauthorized.' }, { status: 401 })
+  }
+
+  const invoiceInput = parsed.data
+
+  const { data: membershipData, error: membershipError } = await supabase
+    .from('household_members' as any)
+    .select('profile_id, rent_share')
+    .eq('household_id', invoiceInput.householdId)
+
+  if (membershipError) {
+    return Response.json(
+      { error: 'Unable to verify household membership.' },
+      { status: 500 },
+    )
+  }
+
+  const members = (membershipData ?? []) as HouseholdMemberRecord[]
+
+  if (!members.length) {
+    return Response.json(
+      { error: 'Household must have at least one member to create invoices.' },
+      { status: 422 },
+    )
+  }
+
+  const callerIsMember = members.some((member) => member.profile_id === user.id)
+
+  if (!callerIsMember) {
+    return Response.json(
+      { error: 'You do not have permission to create invoices for this household.' },
+      { status: 403 },
+    )
+  }
+
+  const shareWeights = members.map((member) => Math.max(member.rent_share ?? 0, 0))
+  const totalShare = shareWeights.reduce((sum, share) => sum + share, 0)
+
+  if (totalShare <= 0) {
+    return Response.json(
+      { error: 'Unable to calculate rent splits because no member has a rent share.' },
+      { status: 422 },
+    )
+  }
+
+  const lineItems = invoiceInput.lineItems ?? []
+  const billingPeriodStartIso = invoiceInput.billingPeriod.start.toISOString()
+  const billingPeriodEndIso = invoiceInput.billingPeriod.end.toISOString()
+  const dueDateIso = invoiceInput.dueDate.toISOString()
+  const invoiceAmounts = allocateByShares(invoiceInput.totalAmount, shareWeights)
+  const lineItemAllocations = lineItems.map((item) =>
+    allocateByShares(item.amount, shareWeights),
+  )
+
+  let lateFeeAllocations: number[] = []
+  let lateFeeScheduleIso: string | null = null
+
+  if (invoiceInput.lateFee) {
+    const lateFeeTotal = computeLateFeeTotal(invoiceInput.lateFee, invoiceInput.totalAmount)
+    lateFeeAllocations = allocateByShares(lateFeeTotal, shareWeights)
+    lateFeeScheduleIso = addDays(
+      invoiceInput.dueDate,
+      invoiceInput.lateFee.gracePeriodDays ?? 0,
+    ).toISOString()
+  }
+
+  const invoiceLineItemsByMember: PerMemberLineItem[][] = []
+
+  const invoicesPayload: InvoiceInsertPayload[] = members.map((member, index) => {
+    const perMemberLineItems = lineItems.map((item, itemIndex) => ({
+      description: item.description,
+      quantity: item.quantity ?? 1,
+      amount: lineItemAllocations[itemIndex]?.[index] ?? 0,
+    }))
+
+    invoiceLineItemsByMember.push(perMemberLineItems)
+
+    const metadata: Record<string, unknown> = {
+      rentShare: shareWeights[index] / totalShare,
+      billingPeriod: {
+        start: billingPeriodStartIso,
+        end: billingPeriodEndIso,
+      },
+      totalHouseholdAmount: invoiceInput.totalAmount,
+    }
+
+    if (perMemberLineItems.length) {
+      metadata.lineItems = perMemberLineItems
+    }
+
+    if (invoiceInput.lateFee) {
+      metadata.lateFee = {
+        ...invoiceInput.lateFee,
+        amount: lateFeeAllocations[index] ?? 0,
+        scheduleDate: lateFeeScheduleIso,
+        basis: invoiceInput.lateFee.flatAmount !== undefined ? 'flat' : 'percentage',
+      }
+    }
+
+    return {
+      household_id: invoiceInput.householdId,
+      resident_id: member.profile_id,
+      amount_due: invoiceAmounts[index] ?? 0,
+      due_date: dueDateIso,
+      billing_period_start: billingPeriodStartIso,
+      billing_period_end: billingPeriodEndIso,
+      status: 'open',
+      memo: invoiceInput.memo ?? null,
+      metadata,
+    }
+  })
+
+  const {
+    data: insertedInvoices,
+    error: invoiceError,
+  } = await supabase
+    .from('invoices' as any)
+    .insert(invoicesPayload)
+    .select('*')
+
+  if (invoiceError) {
+    return Response.json(
+      { error: 'Unable to create invoices.' },
+      { status: 500 },
+    )
+  }
+
+  if (lineItems.length && insertedInvoices?.length) {
+    const flattenedLineItems: InvoiceLineItemInsertPayload[] = insertedInvoices.flatMap(
+      (invoice, index) => {
+        const perMemberLineItems = invoiceLineItemsByMember[index] ?? []
+
+        return perMemberLineItems.map((lineItem) => ({
+          invoice_id: (invoice as { id: string | number }).id,
+          description: lineItem.description,
+          amount: lineItem.amount,
+          quantity: lineItem.quantity,
+        }))
+      },
+    )
+
+    if (flattenedLineItems.length) {
+      const { error: lineItemsError } = await supabase
+        .from('invoice_line_items' as any)
+        .insert(flattenedLineItems)
+
+      if (lineItemsError) {
+        return Response.json(
+          {
+            error: 'Invoices were created but line items failed to persist.',
+          },
+          { status: 500 },
+        )
+      }
+    }
+  }
+
+  return Response.json(
+    { invoices: insertedInvoices ?? [] },
+    { status: 201 },
+  )
+}
+
+function allocateByShares(total: number, weights: number[]): number[] {
+  const sanitizedWeights = weights.map((weight) => Math.max(weight, 0))
+  const totalShare = sanitizedWeights.reduce((sum, share) => sum + share, 0)
+
+  if (total <= 0) {
+    return sanitizedWeights.map(() => 0)
+  }
+
+  if (totalShare <= 0) {
+    throw new Error('Allocation requires at least one positive share weight.')
+  }
+
+  const totalCents = Math.round(total * 100)
+  let allocatedCents = 0
+
+  return sanitizedWeights.map((weight, index) => {
+    if (index === sanitizedWeights.length - 1) {
+      const remaining = Math.max(totalCents - allocatedCents, 0)
+      return centsToCurrency(remaining)
+    }
+
+    const ratio = weight / totalShare
+    const cents = Math.round(totalCents * ratio)
+    allocatedCents += cents
+
+    return centsToCurrency(cents)
+  })
+}
+
+function centsToCurrency(cents: number) {
+  return Number((cents / 100).toFixed(2))
+}
+
+function computeLateFeeTotal(lateFee: LateFeeConfig, totalAmount: number) {
+  if (!lateFee) {
+    return 0
+  }
+
+  let calculated = 0
+
+  if (lateFee.flatAmount !== undefined) {
+    calculated = lateFee.flatAmount
+  } else if (lateFee.percentage !== undefined) {
+    calculated = (totalAmount * lateFee.percentage) / 100
+  }
+
+  if (lateFee.maximumAmount !== undefined) {
+    calculated = Math.min(calculated, lateFee.maximumAmount)
+  }
+
+  return Number(calculated.toFixed(2))
+}
+
+function addDays(date: Date, days: number) {
+  const result = new Date(date)
+  result.setDate(result.getDate() + days)
+  return result
+}

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -1,0 +1,34 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+import type { Database } from '@/lib/supabase'
+
+export default function createSupabaseServerClient() {
+  const cookieStore = cookies()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error('Supabase environment variables are not configured.')
+  }
+
+  return createServerClient<Database>(supabaseUrl, supabaseKey, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value
+      },
+      set(name: string, value: string, options: { path?: string }) {
+        void name
+        void value
+        void options
+        // Route handlers run in a server context where mutation is unnecessary for our use case.
+      },
+      remove(name: string, options: { path?: string }) {
+        void name
+        void options
+        // Route handlers run in a server context where mutation is unnecessary for our use case.
+      },
+    },
+  })
+}

--- a/tests/api/billing.spec.ts
+++ b/tests/api/billing.spec.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabaseServer', () => ({
+  default: vi.fn(),
+}))
+
+import createSupabaseServerClient from '@/lib/supabaseServer'
+import { POST } from '@/app/api/billing/create-invoice/route'
+
+type SupabaseStubConfig = {
+  userId?: string
+  membershipData?: Array<{ profile_id: string; rent_share: number | null }>
+  membershipError?: { message: string } | null
+  insertedInvoices?: Array<Record<string, unknown>>
+  invoiceInsertError?: { message: string } | null
+  lineItemsError?: { message: string } | null
+}
+
+type SupabaseStub = {
+  supabase: {
+    auth: {
+      getUser: ReturnType<typeof vi.fn>
+    }
+    from: ReturnType<typeof vi.fn>
+  }
+  spies: {
+    membershipSelect: ReturnType<typeof vi.fn>
+    membershipEq: ReturnType<typeof vi.fn>
+    invoiceInsert: ReturnType<typeof vi.fn>
+    invoiceSelect: ReturnType<typeof vi.fn>
+    invoiceLineItemsInsert: ReturnType<typeof vi.fn>
+    from: ReturnType<typeof vi.fn>
+    getUser: ReturnType<typeof vi.fn>
+  }
+  insertedInvoices: Array<Record<string, unknown>>
+}
+
+type SupabaseMock = SupabaseStub['supabase']
+
+function createSupabaseStub(config: SupabaseStubConfig = {}): SupabaseStub {
+  const membershipResponse = {
+    data: config.membershipData ?? [],
+    error: config.membershipError ?? null,
+  }
+
+  const insertedInvoices = config.insertedInvoices ?? []
+
+  const membershipEq = vi.fn().mockResolvedValue(membershipResponse)
+  const membershipSelect = vi.fn().mockReturnValue({ eq: membershipEq })
+  const invoiceSelect = vi
+    .fn()
+    .mockResolvedValue({ data: insertedInvoices, error: config.invoiceInsertError ?? null })
+  const invoiceInsert = vi.fn().mockReturnValue({ select: invoiceSelect })
+  const invoiceLineItemsInsert = vi
+    .fn()
+    .mockResolvedValue({ data: null, error: config.lineItemsError ?? null })
+
+  const from = vi.fn((table: string) => {
+    if (table === 'household_members') {
+      return { select: membershipSelect }
+    }
+
+    if (table === 'invoices') {
+      return { insert: invoiceInsert }
+    }
+
+    if (table === 'invoice_line_items') {
+      return { insert: invoiceLineItemsInsert }
+    }
+
+    throw new Error(`Unexpected table requested in mock: ${table}`)
+  })
+
+  const getUser = vi.fn().mockResolvedValue({
+    data: { user: { id: config.userId ?? 'user-123' } },
+    error: null,
+  })
+
+  const supabase = {
+    auth: {
+      getUser,
+    },
+    from,
+  }
+
+  return {
+    supabase,
+    spies: {
+      membershipSelect,
+      membershipEq,
+      invoiceInsert,
+      invoiceSelect,
+      invoiceLineItemsInsert,
+      from,
+      getUser,
+    },
+    insertedInvoices,
+  }
+}
+
+describe('POST /api/billing/create-invoice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates invoices for each household member', async () => {
+    const stub = createSupabaseStub({
+      membershipData: [
+        { profile_id: 'user-123', rent_share: 60 },
+        { profile_id: 'user-456', rent_share: 40 },
+      ],
+      insertedInvoices: [{ id: 'inv-1' }, { id: 'inv-2' }],
+    })
+
+    vi.mocked(createSupabaseServerClient).mockReturnValue(stub.supabase as SupabaseMock)
+
+    const payload = {
+      householdId: 'household-1',
+      billingPeriod: { start: '2024-06-01', end: '2024-06-30' },
+      dueDate: '2024-07-05',
+      totalAmount: 2000,
+    }
+
+    const request = new Request('http://localhost/api/billing/create-invoice', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+
+    const response = await POST(request)
+    const responseBody = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(responseBody.invoices).toEqual(stub.insertedInvoices)
+
+    expect(stub.spies.invoiceInsert).toHaveBeenCalledTimes(1)
+    const insertedPayload = stub.spies.invoiceInsert.mock.calls[0][0] as Array<
+      Record<string, any>
+    >
+
+    expect(insertedPayload).toHaveLength(2)
+    expect(insertedPayload[0]).toMatchObject({
+      household_id: 'household-1',
+      resident_id: 'user-123',
+      amount_due: 1200,
+      status: 'open',
+    })
+    expect(insertedPayload[0].metadata?.rentShare).toBeCloseTo(0.6)
+    expect(insertedPayload[1]).toMatchObject({
+      household_id: 'household-1',
+      resident_id: 'user-456',
+      amount_due: 800,
+      status: 'open',
+    })
+    expect(insertedPayload[1].metadata?.rentShare).toBeCloseTo(0.4)
+    expect(insertedPayload[0].metadata?.lineItems).toBeUndefined()
+
+    expect(stub.spies.invoiceLineItemsInsert).not.toHaveBeenCalled()
+  })
+
+  it('rejects callers that are not household members', async () => {
+    const stub = createSupabaseStub({
+      membershipData: [{ profile_id: 'another-user', rent_share: 100 }],
+    })
+
+    vi.mocked(createSupabaseServerClient).mockReturnValue(stub.supabase as SupabaseMock)
+
+    const payload = {
+      householdId: 'household-2',
+      billingPeriod: { start: '2024-06-01', end: '2024-06-30' },
+      dueDate: '2024-07-05',
+      totalAmount: 1500,
+    }
+
+    const request = new Request('http://localhost/api/billing/create-invoice', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toMatch(/do not have permission/i)
+    expect(stub.spies.invoiceInsert).not.toHaveBeenCalled()
+  })
+
+  it('calculates late fee metadata and line items for each tenant', async () => {
+    const stub = createSupabaseStub({
+      membershipData: [
+        { profile_id: 'user-123', rent_share: 70 },
+        { profile_id: 'user-789', rent_share: 30 },
+      ],
+      insertedInvoices: [{ id: 'inv-1' }, { id: 'inv-2' }],
+    })
+
+    vi.mocked(createSupabaseServerClient).mockReturnValue(stub.supabase as SupabaseMock)
+
+    const payload = {
+      householdId: 'household-3',
+      billingPeriod: { start: '2024-06-01', end: '2024-06-30' },
+      dueDate: '2024-07-05',
+      totalAmount: 2500.5,
+      lineItems: [
+        { description: 'Base rent', amount: 2200, quantity: 1 },
+        { description: 'Utilities', amount: 300.5, quantity: 1 },
+      ],
+      lateFee: {
+        percentage: 8,
+        gracePeriodDays: 3,
+        maximumAmount: 150,
+      },
+    }
+
+    const request = new Request('http://localhost/api/billing/create-invoice', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+
+    const response = await POST(request)
+    const responseJson = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(responseJson.invoices).toEqual(stub.insertedInvoices)
+
+    const insertedPayload = stub.spies.invoiceInsert.mock.calls[0][0] as Array<
+      Record<string, any>
+    >
+    expect(insertedPayload).toHaveLength(2)
+
+    const firstMetadata = insertedPayload[0].metadata
+    const secondMetadata = insertedPayload[1].metadata
+
+    expect(firstMetadata?.lateFee).toMatchObject({ amount: 105, scheduleDate: '2024-07-08T00:00:00.000Z' })
+    expect(secondMetadata?.lateFee).toMatchObject({ amount: 45, scheduleDate: '2024-07-08T00:00:00.000Z' })
+
+    expect(firstMetadata?.lineItems).toEqual([
+      { description: 'Base rent', amount: 1540, quantity: 1 },
+      { description: 'Utilities', amount: 210.35, quantity: 1 },
+    ])
+    expect(secondMetadata?.lineItems).toEqual([
+      { description: 'Base rent', amount: 660, quantity: 1 },
+      { description: 'Utilities', amount: 90.15, quantity: 1 },
+    ])
+
+    expect(stub.spies.invoiceLineItemsInsert).toHaveBeenCalledTimes(1)
+    const lineItemPayload = stub.spies.invoiceLineItemsInsert.mock.calls[0][0] as Array<
+      Record<string, any>
+    >
+
+    expect(lineItemPayload).toEqual([
+      { invoice_id: 'inv-1', description: 'Base rent', amount: 1540, quantity: 1 },
+      { invoice_id: 'inv-1', description: 'Utilities', amount: 210.35, quantity: 1 },
+      { invoice_id: 'inv-2', description: 'Base rent', amount: 660, quantity: 1 },
+      { invoice_id: 'inv-2', description: 'Utilities', amount: 90.15, quantity: 1 },
+    ])
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.{test,spec}.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add billing create invoice route that validates household membership, splits rent, and persists invoice records with late fee metadata
- add a server-side Supabase client helper for route handlers
- cover the new API logic with Vitest and extend the test config to pick up spec files

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0c5e23c832894898b6ef8374972