### PR TITLE
Add household feature flags and admin toggles

### DIFF
--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react"
+import { notFound } from "next/navigation"
+
+import { ensureFeatureEnabled } from "@/lib/features"
+
+interface AdminLayoutProps {
+  children: ReactNode
+}
+
+export default async function AdminLayout({ children }: AdminLayoutProps) {
+  const { enabled } = await ensureFeatureEnabled({
+    key: "feature_management",
+    fallbackToDefault: true,
+  })
+
+  if (!enabled) {
+    notFound()
+  }
+
+  return <>{children}</>
+}

--- a/app/(admin)/settings/features/actions.ts
+++ b/app/(admin)/settings/features/actions.ts
@@ -1,0 +1,73 @@
+'use server'
+
+import { revalidatePath } from "next/cache"
+import { z } from "zod"
+
+import {
+  FEATURE_DEFINITIONS,
+  type FeatureToggleInput,
+} from "@/lib/features"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+const featureKeySchema = z.enum(
+  FEATURE_DEFINITIONS.map((definition) => definition.key) as [
+    FeatureToggleInput["key"],
+    ...FeatureToggleInput["key"][],
+  ]
+)
+
+const payloadSchema = z.object({
+  householdId: z.string().uuid(),
+  key: featureKeySchema,
+  enabled: z.boolean(),
+})
+
+interface ActionResult {
+  success: boolean
+  message?: string
+}
+
+export async function updateFeatureFlagAction(
+  input: FeatureToggleInput
+): Promise<ActionResult> {
+  const parsed = payloadSchema.safeParse(input)
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: "Invalid feature toggle payload.",
+    }
+  }
+
+  try {
+    const supabase = await createSupbaseServerClient()
+    const { error } = await supabase
+      .from("features")
+      .upsert(
+        {
+          household_id: parsed.data.householdId,
+          key: parsed.data.key,
+          enabled: parsed.data.enabled,
+        },
+        { onConflict: "household_id,key" }
+      )
+
+    if (error) {
+      return {
+        success: false,
+        message: error.message,
+      }
+    }
+
+    revalidatePath("/settings/features")
+
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+
+    return {
+      success: false,
+      message,
+    }
+  }
+}

--- a/app/(admin)/settings/features/feature-toggle-list.tsx
+++ b/app/(admin)/settings/features/feature-toggle-list.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState, useTransition } from "react"
+
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Switch } from "@/components/ui/switch"
+import { useToast } from "@/components/ui/use-toast"
+import type {
+  FeatureDefinition,
+  FeatureFlags,
+  FeatureToggleInput,
+} from "@/lib/features"
+
+import { updateFeatureFlagAction } from "./actions"
+
+interface FeatureToggleListProps {
+  definitions: readonly FeatureDefinition[]
+  householdId: string
+  initialFlags: FeatureFlags
+}
+
+export default function FeatureToggleList({
+  definitions,
+  householdId,
+  initialFlags,
+}: FeatureToggleListProps) {
+  const [flags, setFlags] = useState(initialFlags)
+  const [isPending, startTransition] = useTransition()
+  const { toast } = useToast()
+
+  const handleToggle = (definition: FeatureDefinition) => (checked: boolean) => {
+    const payload: FeatureToggleInput = {
+      householdId,
+      key: definition.key,
+      enabled: checked,
+    }
+
+    const previousValue = Boolean(flags[definition.key])
+
+    setFlags((current) => ({ ...current, [definition.key]: checked }))
+
+    startTransition(async () => {
+      const result = await updateFeatureFlagAction(payload)
+
+      if (!result.success) {
+        setFlags((current) => ({ ...current, [definition.key]: previousValue }))
+        toast({
+          title: "Unable to update feature",
+          description: result.message ?? "Please try again in a few moments.",
+          variant: "destructive",
+        })
+        return
+      }
+
+      toast({
+        title: `${definition.label} ${checked ? "enabled" : "disabled"}`,
+        description: checked
+          ? "Residents will immediately see the related workflows."
+          : "The experience will hide this workflow for the household.",
+      })
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      {definitions.map((definition) => {
+        const checked = Boolean(flags[definition.key])
+
+        return (
+          <Card key={definition.key} className="border-border/60">
+            <CardHeader className="flex flex-row items-start justify-between gap-4">
+              <div className="space-y-1">
+                <CardTitle>{definition.label}</CardTitle>
+                <CardDescription>{definition.description}</CardDescription>
+              </div>
+              <Switch
+                aria-label={`Toggle ${definition.label}`}
+                checked={checked}
+                disabled={isPending}
+                onCheckedChange={handleToggle(definition)}
+              />
+            </CardHeader>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/(admin)/settings/features/loading.tsx
+++ b/app/(admin)/settings/features/loading.tsx
@@ -1,0 +1,26 @@
+export default function FeatureSettingsLoading() {
+  return (
+    <div className="container max-w-4xl space-y-8 py-10">
+      <div className="space-y-3">
+        <div className="h-10 w-48 animate-pulse rounded-md bg-muted" />
+        <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />
+      </div>
+      <div className="space-y-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="rounded-lg border border-border/60 bg-background p-6 shadow-sm"
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-2">
+                <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+                <div className="h-4 w-64 animate-pulse rounded-md bg-muted" />
+              </div>
+              <div className="h-6 w-12 animate-pulse rounded-full bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/(admin)/settings/features/page.tsx
+++ b/app/(admin)/settings/features/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from "next"
+
+import {
+  FEATURE_DEFINITIONS,
+  type FeatureKey,
+  getFeatureFlags,
+} from "@/lib/features"
+
+import FeatureToggleList from "./feature-toggle-list"
+
+export const metadata: Metadata = {
+  title: "Feature flags",
+}
+
+interface FeatureSettingsPageProps {
+  searchParams?: Record<string, string | string[] | undefined>
+}
+
+export default async function FeatureSettingsPage({
+  searchParams,
+}: FeatureSettingsPageProps) {
+  const searchParamHousehold = getHouseholdFromSearchParams(searchParams)
+  const featureKeys = FEATURE_DEFINITIONS.map((definition) => definition.key) as FeatureKey[]
+  const { flags, householdId } = await getFeatureFlags({
+    householdId: searchParamHousehold,
+    keys: featureKeys,
+  })
+
+  const header = (
+    <header className="space-y-2">
+      <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Feature flags</h1>
+      <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+        Toggle payments, bookings, documents, and messaging workflows at the household level
+        to coordinate gradual rollouts and staged pilots.
+      </p>
+    </header>
+  )
+
+  if (!householdId) {
+    return (
+      <div className="container max-w-4xl space-y-6 py-10">
+        {header}
+        <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-6">
+          <h2 className="text-lg font-semibold">Select a household</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Provide a household id via the <code className="rounded bg-muted px-1 py-0.5">?household=&lt;uuid&gt;</code> search
+            parameter or by setting a <code className="rounded bg-muted px-1 py-0.5">household_id</code> cookie to manage feature
+            availability.
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Once supplied, toggles update instantly without requiring a redeploy or page refresh.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container max-w-4xl space-y-8 py-10">
+      {header}
+      <FeatureToggleList
+        definitions={FEATURE_DEFINITIONS}
+        householdId={householdId}
+        initialFlags={flags}
+      />
+    </div>
+  )
+}
+
+function getHouseholdFromSearchParams(
+  searchParams?: Record<string, string | string[] | undefined>
+): string | undefined {
+  if (!searchParams) {
+    return undefined
+  }
+
+  const value = searchParams.household
+  if (typeof value === "string" && value.length > 0) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.at(-1) ?? undefined
+  }
+
+  return undefined
+}

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -1,0 +1,243 @@
+import { cookies, headers } from "next/headers"
+
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export const FEATURE_DEFINITIONS = [
+  {
+    key: "rent_payments",
+    label: "Rent payments",
+    description:
+      "Controls access to Stripe-powered autopay, payment history, and rent ledger workflows.",
+    defaultEnabled: true,
+  },
+  {
+    key: "amenity_bookings",
+    label: "Amenity bookings",
+    description:
+      "Enables Cal.com scheduling, conflict detection, and shared amenity calendars for each property.",
+    defaultEnabled: true,
+  },
+  {
+    key: "documents",
+    label: "Documents & leases",
+    description:
+      "Gates Documenso-powered lease management, document storage, and audit trail exports.",
+    defaultEnabled: true,
+  },
+  {
+    key: "messaging",
+    label: "Household messaging",
+    description:
+      "Turns on realtime threads, reactions, polls, and moderation tooling for the roommate feed.",
+    defaultEnabled: true,
+  },
+  {
+    key: "feature_management",
+    label: "Feature management",
+    description:
+      "Allow property managers to view and toggle feature availability for each household.",
+    defaultEnabled: true,
+  },
+] as const
+
+export type FeatureDefinition = (typeof FEATURE_DEFINITIONS)[number]
+export type FeatureKey = FeatureDefinition["key"]
+export type FeatureFlags = Record<string, boolean>
+export type FeatureFlagSource = "database" | "defaults"
+
+export interface FeatureToggleInput {
+  householdId: string
+  key: FeatureKey
+  enabled: boolean
+}
+
+export class MissingHouseholdError extends Error {
+  constructor(message = "A household id is required to resolve feature flags.") {
+    super(message)
+    this.name = "MissingHouseholdError"
+  }
+}
+
+export class FeatureFetchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "FeatureFetchError"
+  }
+}
+
+type FeatureRow = { key: string; enabled: boolean }
+
+const featureDefaultMap: Record<FeatureKey, boolean> = FEATURE_DEFINITIONS.reduce(
+  (acc, definition) => {
+    acc[definition.key] = definition.defaultEnabled
+    return acc
+  },
+  {} as Record<FeatureKey, boolean>
+)
+
+async function fetchAllFlags(householdId: string) {
+  const supabase = await createSupbaseServerClient()
+  return fetchFlagRows(supabase, householdId)
+}
+
+export function resolveHouseholdId(candidate?: string | null): string | null {
+  if (candidate) {
+    return candidate
+  }
+
+  try {
+    const headerStore = headers()
+    const headerValue = headerStore.get("x-household-id")
+    if (headerValue) {
+      return headerValue
+    }
+  } catch (error) {
+    // Ignored – headers() can throw outside of a request context.
+  }
+
+  try {
+    const cookieStore = cookies()
+    const cookieValue = cookieStore.get("household_id")?.value
+    if (cookieValue) {
+      return cookieValue
+    }
+  } catch (error) {
+    // Ignored – cookies() can throw outside of a request context.
+  }
+
+  return null
+}
+
+export async function getFeatureFlags({
+  householdId,
+  keys,
+  strict = false,
+  supabase,
+}: {
+  householdId?: string | null
+  keys?: FeatureKey[]
+  strict?: boolean
+  supabase?: TypedSupabaseClient
+} = {}): Promise<{
+  householdId: string | null
+  flags: FeatureFlags
+  source: FeatureFlagSource
+}> {
+  const resolvedHouseholdId = resolveHouseholdId(householdId)
+
+  if (!resolvedHouseholdId) {
+    if (strict) {
+      throw new MissingHouseholdError()
+    }
+    return {
+      householdId: null,
+      flags: buildDefaultFlags(keys),
+      source: "defaults",
+    }
+  }
+
+  let rows: FeatureRow[]
+  if (supabase) {
+    rows = await fetchFlagRows(supabase, resolvedHouseholdId, keys)
+  } else if (keys && keys.length > 0) {
+    const client = await createSupbaseServerClient()
+    rows = await fetchFlagRows(client, resolvedHouseholdId, keys)
+  } else {
+    rows = await fetchAllFlags(resolvedHouseholdId)
+  }
+
+  return {
+    householdId: resolvedHouseholdId,
+    flags: mergeFlags(rows, keys),
+    source: "database",
+  }
+}
+
+export function getDefaultFeatureFlag(key: FeatureKey): boolean {
+  return featureDefaultMap[key]
+}
+
+export async function ensureFeatureEnabled({
+  fallbackToDefault = false,
+  householdId,
+  key,
+  strict,
+  supabase,
+}: {
+  fallbackToDefault?: boolean
+  householdId?: string | null
+  key: FeatureKey
+  strict?: boolean
+  supabase?: TypedSupabaseClient
+}): Promise<{
+  enabled: boolean
+  flags: FeatureFlags
+  householdId: string | null
+  source: FeatureFlagSource
+}> {
+  const { flags, householdId: resolvedHouseholdId, source } = await getFeatureFlags({
+    householdId,
+    keys: [key],
+    strict,
+    supabase,
+  })
+
+  const flagValue = flags[key]
+
+  if (typeof flagValue === "boolean") {
+    return { enabled: flagValue, flags, householdId: resolvedHouseholdId, source }
+  }
+
+  if (fallbackToDefault) {
+    return {
+      enabled: featureDefaultMap[key] ?? false,
+      flags,
+      householdId: resolvedHouseholdId,
+      source,
+    }
+  }
+
+  return { enabled: false, flags, householdId: resolvedHouseholdId, source }
+}
+
+function buildDefaultFlags(keys?: FeatureKey[]): FeatureFlags {
+  if (!keys || keys.length === 0) {
+    return { ...featureDefaultMap }
+  }
+
+  return keys.reduce<FeatureFlags>((acc, key) => {
+    acc[key] = featureDefaultMap[key] ?? false
+    return acc
+  }, {})
+}
+
+function mergeFlags(rows: FeatureRow[], keys?: FeatureKey[]): FeatureFlags {
+  const flags = buildDefaultFlags(keys)
+
+  for (const row of rows) {
+    flags[row.key] = row.enabled
+  }
+
+  return flags
+}
+
+async function fetchFlagRows(
+  client: TypedSupabaseClient,
+  householdId: string,
+  keys?: readonly FeatureKey[]
+): Promise<FeatureRow[]> {
+  let query = client.from("features").select("key, enabled").eq("household_id", householdId)
+
+  if (keys && keys.length > 0) {
+    query = query.in("key", keys as string[])
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    throw new FeatureFetchError(error.message)
+  }
+
+  return data ?? []
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -914,6 +914,32 @@ export type Database = {
         }
         Relationships: []
       }
+      features: {
+        Row: {
+          enabled: boolean
+          household_id: string
+          key: string
+        }
+        Insert: {
+          enabled?: boolean
+          household_id: string
+          key: string
+        }
+        Update: {
+          enabled?: boolean
+          household_id?: string
+          key?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "features_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       gpt_one: {
         Row: {
           created_at: string

--- a/supabase/migrations/20250429_feature_flags.sql
+++ b/supabase/migrations/20250429_feature_flags.sql
@@ -1,0 +1,11 @@
+create table if not exists public.features (
+  household_id uuid not null references public.households (id) on delete cascade,
+  key text not null,
+  enabled boolean not null default false,
+  constraint features_pkey primary key (household_id, key)
+);
+
+create index if not exists features_key_idx on public.features using btree (key);
+create index if not exists features_enabled_idx on public.features using btree (household_id, enabled);
+
+alter table public.features enable row level security;

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ensureFeatureEnabled,
+  getFeatureFlags,
+  type FeatureKey,
+} from "@/lib/features"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+type FeatureRow = { household_id: string; key: FeatureKey; enabled: boolean }
+
+function createSupabaseStub(rows: FeatureRow[]): TypedSupabaseClient {
+  const tableData = rows.map(({ household_id, key, enabled }) => ({
+    household_id,
+    key,
+    enabled,
+  }))
+
+  return {
+    from(table: string) {
+      if (table !== "features") {
+        throw new Error(`Unexpected table requested: ${table}`)
+      }
+
+      return {
+        select() {
+          return new MockQueryBuilder(tableData)
+        },
+      } as never
+    },
+  } as unknown as TypedSupabaseClient
+}
+
+class MockQueryBuilder {
+  private householdId?: string
+  private keys?: readonly string[]
+
+  constructor(private readonly rows: Array<{ household_id: string; key: string; enabled: boolean }>) {}
+
+  select() {
+    return this
+  }
+
+  eq(column: string, value: string) {
+    if (column === "household_id") {
+      this.householdId = value
+    }
+    return this
+  }
+
+  in(column: string, values: readonly string[]) {
+    if (column === "key") {
+      this.keys = values
+    }
+    return this
+  }
+
+  then<TResult1 = { data: Array<{ key: string; enabled: boolean }>; error: null }, TResult2 = never>(
+    onfulfilled?: ((value: TResult1) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | undefined | null
+  ): Promise<TResult1 | TResult2> {
+    try {
+      const payload = this.execute()
+      return Promise.resolve(payload).then(onfulfilled, onrejected)
+    } catch (error) {
+      return Promise.reject(error).then(onfulfilled, onrejected)
+    }
+  }
+
+  catch<TResult = never>(
+    onrejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | undefined | null
+  ): Promise<TResult> {
+    try {
+      const payload = this.execute()
+      return Promise.resolve(payload).catch(onrejected)
+    } catch (error) {
+      return Promise.reject(error).catch(onrejected)
+    }
+  }
+
+  finally(onfinally?: (() => void) | undefined | null): Promise<void> {
+    try {
+      const payload = this.execute()
+      return Promise.resolve(payload).finally(onfinally)
+    } catch (error) {
+      return Promise.reject(error).finally(onfinally)
+    }
+  }
+
+  private execute() {
+    const filtered = this.rows.filter((row) => {
+      if (this.householdId && row.household_id !== this.householdId) {
+        return false
+      }
+      if (this.keys && !this.keys.includes(row.key)) {
+        return false
+      }
+      return true
+    })
+
+    const data = filtered.map(({ key, enabled }) => ({ key, enabled }))
+
+    return { data, error: null as null }
+  }
+}
+
+describe("feature flag helpers", () => {
+  it("returns defaults when no overrides exist", async () => {
+    const supabase = createSupabaseStub([])
+
+    const gate = await ensureFeatureEnabled({
+      householdId: "household-001",
+      key: "documents",
+      supabase,
+    })
+
+    expect(gate.enabled).toBe(true)
+  })
+
+  it("merges overrides from the database", async () => {
+    const supabase = createSupabaseStub([
+      { household_id: "household-002", key: "messaging", enabled: false },
+    ])
+
+    const result = await ensureFeatureEnabled({
+      householdId: "household-002",
+      key: "messaging",
+      supabase,
+    })
+
+    expect(result.enabled).toBe(false)
+  })
+
+  it("returns feature maps scoped to requested keys", async () => {
+    const supabase = createSupabaseStub([
+      { household_id: "household-003", key: "rent_payments", enabled: false },
+    ])
+
+    const keys: FeatureKey[] = ["rent_payments", "documents"]
+    const { flags } = await getFeatureFlags({
+      householdId: "household-003",
+      keys,
+      supabase,
+    })
+
+    expect(flags["rent_payments"]).toBe(false)
+    expect(flags["documents"]).toBe(true)
+    expect(Object.keys(flags)).toEqual(["rent_payments", "documents"])
+  })
+})


### PR DESCRIPTION
## Summary
- add a Supabase migration for the household-scoped `features` table with indexes and RLS enabled
- introduce `lib/features.ts` helpers to resolve per-request flags and gate layouts
- build an admin settings page with optimistic toggles backed by server actions
- cover feature evaluation helpers with unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0c484948328827e89f2b3397562