### PR TITLE
Add Supabase member role tables and session helpers

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,109 @@
+import type { Session } from '@supabase/supabase-js'
+import { ApplicationError } from '@/lib/errors'
+import type { Database } from '@/lib/supabase'
+import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+
+export type RoleKey = Database['public']['Tables']['roles']['Row']['key']
+
+export type SessionWithRoles = Session & {
+  roles: RoleKey[]
+  user: Session['user'] & {
+    app_metadata: Session['user']['app_metadata'] & { roles?: RoleKey[] }
+    user_metadata: Session['user']['user_metadata'] & { roles?: RoleKey[] }
+  }
+}
+
+function dedupeRoles(roles: RoleKey[]): RoleKey[] {
+  return Array.from(new Set(roles))
+}
+
+async function resolveMemberRoles(
+  client: TypedSupabaseClient,
+  memberId: string
+): Promise<RoleKey[]> {
+  const { data, error } = await client
+    .from('member_roles')
+    .select('role')
+    .eq('member_id', memberId)
+
+  if (error) {
+    throw new ApplicationError('Failed to load member roles', { cause: error })
+  }
+
+  if (!data) {
+    return []
+  }
+
+  return dedupeRoles(data.map((entry) => entry.role as RoleKey))
+}
+
+function attachRoles(session: Session, roles: RoleKey[]): SessionWithRoles {
+  const normalized = dedupeRoles(roles)
+
+  return {
+    ...session,
+    roles: normalized,
+    user: {
+      ...session.user,
+      app_metadata: {
+        ...session.user.app_metadata,
+        roles: normalized,
+      },
+      user_metadata: {
+        ...session.user.user_metadata,
+        roles: normalized,
+      },
+    },
+  }
+}
+
+export async function getSessionWithRoles(
+  client?: TypedSupabaseClient
+): Promise<SessionWithRoles | null> {
+  const supabase =
+    client ?? ((await createSupbaseServerClientReadOnly()) as TypedSupabaseClient)
+
+  const {
+    data: { session },
+    error,
+  } = await supabase.auth.getSession()
+
+  if (error) {
+    throw new ApplicationError('Failed to load session', { cause: error })
+  }
+
+  if (!session) {
+    return null
+  }
+
+  const roles = await resolveMemberRoles(supabase, session.user.id)
+
+  return attachRoles(session, roles)
+}
+
+function normaliseRequiredRoles(required: RoleKey | RoleKey[]): RoleKey[] {
+  return Array.isArray(required) ? required : [required]
+}
+
+export function hasRequiredRole(
+  session: SessionWithRoles | null,
+  required: RoleKey | RoleKey[]
+): boolean {
+  if (!session) {
+    return false
+  }
+
+  const ownedRoles = new Set(session.roles)
+  return normaliseRequiredRoles(required).some((role) => ownedRoles.has(role))
+}
+
+export function assertHasRole(
+  session: SessionWithRoles | null,
+  required: RoleKey | RoleKey[],
+  message = 'You do not have permission to access this resource.'
+): asserts session is SessionWithRoles {
+  if (!hasRequiredRole(session, required)) {
+    throw new ApplicationError(message, { requiredRoles: normaliseRequiredRoles(required) })
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1031,6 +1031,39 @@ export type Database = {
         }
         Relationships: []
       }
+      member_roles: {
+        Row: {
+          created_at: string
+          member_id: string
+          role: string
+        }
+        Insert: {
+          created_at?: string
+          member_id: string
+          role: string
+        }
+        Update: {
+          created_at?: string
+          member_id?: string
+          role?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "member_roles_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "member_roles_role_fkey"
+            columns: ["role"]
+            isOneToOne: false
+            referencedRelation: "roles"
+            referencedColumns: ["key"]
+          },
+        ]
+      }
       moralis_users: {
         Row: {
           created_at: string
@@ -1223,6 +1256,27 @@ export type Database = {
           member_id?: string
           role?: string
           status?: string
+        }
+        Relationships: []
+      }
+      roles: {
+        Row: {
+          created_at: string
+          description: string | null
+          key: string
+          label: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          key: string
+          label: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          key?: string
+          label?: string
         }
         Relationships: []
       }

--- a/supabase/migrations/20250922_add_roles.sql
+++ b/supabase/migrations/20250922_add_roles.sql
@@ -1,0 +1,24 @@
+create table public.roles (
+  key text primary key,
+  label text not null,
+  description text,
+  created_at timestamp with time zone not null default now()
+);
+
+insert into public.roles (key, label)
+values
+  ('tenant', 'Tenant'),
+  ('moderator', 'Moderator'),
+  ('admin', 'Admin'),
+  ('landlord', 'Landlord')
+on conflict (key) do update set label = excluded.label;
+
+create table public.member_roles (
+  member_id uuid not null references public.members(id) on delete cascade,
+  role text not null references public.roles(key) on delete restrict,
+  created_at timestamp with time zone not null default now(),
+  constraint member_roles_member_id_role_key unique (member_id, role)
+);
+
+create index member_roles_member_id_idx on public.member_roles (member_id);
+create index member_roles_role_idx on public.member_roles (role);


### PR DESCRIPTION
## Summary
- add a roles lookup table and member_roles join table with seeds and supporting indexes
- refresh generated Supabase types to expose the new tables
- add auth helpers to hydrate session roles and perform role checks

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0c3872c8328a79f2524fdd22208