### PR TITLE
Add household-scoped storage buckets and policies

### DIFF
--- a/docs/security/storage.md
+++ b/docs/security/storage.md
@@ -1,0 +1,91 @@
+# Supabase Storage Hardening
+
+This document captures how Share House Portal provisions and protects Supabase
+Storage buckets for household scoped content such as floorplans, payment
+receipts, and lease paperwork.
+
+## Bucket Provisioning
+
+Buckets are provisioned via the Supabase CLI to guarantee consistent defaults
+and prevent accidental public access. Run the script below in each environment
+after authenticating with `supabase login`:
+
+```bash
+./supabase/scripts/create-storage-buckets.sh
+```
+
+The script issues the following commands to create locked-down buckets:
+
+```bash
+supabase storage create-bucket floorplans --public=false \
+  --file-size-limit=5242880 \
+  --allowed-mime-types="image/svg+xml,image/png,application/pdf"
+
+supabase storage create-bucket receipts --public=false \
+  --file-size-limit=10485760 \
+  --allowed-mime-types="application/pdf,image/png,image/jpeg"
+
+supabase storage create-bucket docs --public=false \
+  --file-size-limit=10485760 \
+  --allowed-mime-types="application/pdf,image/png,image/jpeg,text/plain"
+```
+
+All buckets are private by default and scoped to household membership through
+row-level security (RLS) policies defined in the migration
+`supabase/migrations/202505061200_storage_policies.sql`.
+
+## Metadata Requirements
+
+Uploads must include two metadata keys:
+
+| Key | Description |
+| --- | --- |
+| `member_id` | The authenticated user's UUID returned by `auth.uid()` at upload time. |
+| `household_id` | The UUID of the household the uploader belongs to. Stored on `public.profiles.household_id`. |
+
+The upload helper `utils/supabase/storage.ts` enforces these requirements and
+throws an error when either identifier is missing. Example usage:
+
+```ts
+const { data, error } = await uploadToManagedBucket({
+  bucket: "receipts",
+  client: supabase,
+  file: fileBlob,
+  path: `receipts/${invoiceId}.pdf`,
+  memberId: session.user.id,
+  householdId,
+  contentType: "application/pdf",
+});
+```
+
+The helper merges any additional metadata passed into the call while
+prioritising the required identifiers, ensuring policies evaluate consistently.
+
+## Storage Policies
+
+The migration enforces the following access controls across the managed
+buckets:
+
+- **Read** – Any authenticated user can fetch objects when their profile's
+  `household_id` matches the object's `metadata.household_id`.
+- **Insert** – Allowed only when the uploader tags the object with their own
+  `member_id` and the household they belong to.
+- **Update** – Restricted to the original uploader (`owner = auth.uid()`) while
+  retaining the same metadata requirements.
+- **Delete** – Granted solely to profiles whose `role` is `admin`, regardless of
+  who uploaded the file.
+
+These policies apply uniformly to the `floorplans`, `receipts`, and `docs`
+buckets by referencing the `storage.managed_buckets` view created in the same
+migration. Any new bucket that should follow the same rules can be appended to
+that view to inherit the policies automatically.
+
+## Operational Notes
+
+- Ensure onboarding flows populate `public.profiles.household_id`; uploads will
+  be rejected when the value is missing.
+- Admin tooling should surface metadata in audit logs so deletions can be traced
+  to the acting administrator.
+- Scheduled jobs that upload documents with the service role must continue to
+  set the `member_id` and `household_id` metadata to align with policy
+  constraints, even when run server-side.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1236,6 +1236,7 @@ export type Database = {
           created_at: string | null
           email: string | null
           full_name: string | null
+          household_id: string | null
           id: string
           job_title: string | null
           linkedin_url: string | null
@@ -1256,6 +1257,7 @@ export type Database = {
           created_at?: string | null
           email?: string | null
           full_name?: string | null
+          household_id?: string | null
           id?: string
           job_title?: string | null
           linkedin_url?: string | null
@@ -1276,6 +1278,7 @@ export type Database = {
           created_at?: string | null
           email?: string | null
           full_name?: string | null
+          household_id?: string | null
           id?: string
           job_title?: string | null
           linkedin_url?: string | null

--- a/supabase/migrations/202505061200_storage_policies.sql
+++ b/supabase/migrations/202505061200_storage_policies.sql
@@ -1,0 +1,112 @@
+-- Storage policies and metadata enforcement for household scoped buckets.
+
+-- Ensure household scoping is available on profiles so membership checks can
+-- be performed during RLS evaluation.
+alter table public.profiles
+  add column if not exists household_id uuid;
+
+create index if not exists profiles_household_id_idx
+  on public.profiles (household_id);
+
+-- Enable row level security on storage objects in case it was disabled.
+alter table storage.objects enable row level security;
+
+-- Drop legacy policies to avoid duplicates when re-running migrations.
+drop policy if exists "Allow authenticated users to select objects" on storage.objects;
+drop policy if exists "Allow authenticated users to insert objects" on storage.objects;
+drop policy if exists "Allow authenticated users to update objects" on storage.objects;
+drop policy if exists "Allow authenticated users to delete objects" on storage.objects;
+drop policy if exists "Household members can read managed objects" on storage.objects;
+drop policy if exists "Household members can insert managed objects" on storage.objects;
+drop policy if exists "Household members can update managed objects" on storage.objects;
+drop policy if exists "Admins can delete managed objects" on storage.objects;
+
+-- Shared predicate for the managed buckets.
+create or replace view storage.managed_buckets as
+select unnest(array['floorplans', 'receipts', 'docs']) as bucket_id;
+
+-- Household members can read from managed buckets when the metadata matches
+-- their household membership.
+create policy "Household members can read managed objects"
+  on storage.objects
+  for select
+  to authenticated
+  using (
+    bucket_id in (select bucket_id from storage.managed_buckets)
+    and metadata ? 'household_id'
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id is not null
+        and p.household_id::text = metadata ->> 'household_id'
+    )
+  );
+
+-- Only members of the household can create objects and must set metadata to
+-- their own identifiers.
+create policy "Household members can insert managed objects"
+  on storage.objects
+  for insert
+  to authenticated
+  with check (
+    bucket_id in (select bucket_id from storage.managed_buckets)
+    and metadata ? 'household_id'
+    and metadata ? 'member_id'
+    and metadata ->> 'member_id' = auth.uid()::text
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id is not null
+        and p.household_id::text = metadata ->> 'household_id'
+    )
+  );
+
+-- Allow the uploader to update their own objects while keeping household
+-- membership enforced.
+create policy "Household members can update managed objects"
+  on storage.objects
+  for update
+  to authenticated
+  using (
+    bucket_id in (select bucket_id from storage.managed_buckets)
+    and owner = auth.uid()
+    and metadata ? 'member_id'
+    and metadata ->> 'member_id' = auth.uid()::text
+    and metadata ? 'household_id'
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id is not null
+        and p.household_id::text = metadata ->> 'household_id'
+    )
+  )
+  with check (
+    metadata ? 'member_id'
+    and metadata ->> 'member_id' = auth.uid()::text
+    and metadata ? 'household_id'
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.household_id is not null
+        and p.household_id::text = metadata ->> 'household_id'
+    )
+  );
+
+-- Admins can delete any object inside managed buckets regardless of uploader.
+create policy "Admins can delete managed objects"
+  on storage.objects
+  for delete
+  to authenticated
+  using (
+    bucket_id in (select bucket_id from storage.managed_buckets)
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.role = 'admin'
+    )
+  );

--- a/supabase/scripts/create-storage-buckets.sh
+++ b/supabase/scripts/create-storage-buckets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Scripted bucket provisioning for Share House Portal storage.
+#
+# Usage:
+#   ./supabase/scripts/create-storage-buckets.sh
+#
+# Requires:
+#   - Supabase CLI installed and authenticated against the target project.
+#   - SUPABASE_ACCESS_TOKEN exported or `supabase login` session available.
+#
+# The script is idempotent. If a bucket already exists the CLI will return an
+# error which is suppressed so the workflow can continue.
+
+set -euo pipefail
+
+create_bucket() {
+  local bucket_name="$1"
+  shift
+  if supabase storage list-buckets --output=json | grep -q "\"${bucket_name}\""; then
+    echo "Bucket '${bucket_name}' already exists. Skipping create command."
+    return 0
+  fi
+
+  echo "Creating bucket '${bucket_name}'"
+  supabase storage create-bucket "${bucket_name}" "$@"
+}
+
+# Floorplans bucket holds annotated SVG/PDF layouts that should never be public.
+create_bucket "floorplans" --public=false --file-size-limit=5242880 --allowed-mime-types="image/svg+xml,image/png,application/pdf"
+
+# Receipts bucket stores payment confirmations and sensitive billing artifacts.
+create_bucket "receipts" --public=false --file-size-limit=10485760 --allowed-mime-types="application/pdf,image/png,image/jpeg"
+
+# Docs bucket captures general lease attachments and shared paperwork.
+create_bucket "docs" --public=false --file-size-limit=10485760 --allowed-mime-types="application/pdf,image/png,image/jpeg,text/plain"

--- a/utils/supabase/storage.ts
+++ b/utils/supabase/storage.ts
@@ -1,0 +1,70 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase";
+
+type ManagedBucket = "floorplans" | "receipts" | "docs";
+
+type UploadBody = Blob | File | ArrayBuffer | ArrayBufferView;
+
+type UploadOptions = {
+        cacheControl?: string;
+        contentType?: string;
+        upsert?: boolean;
+};
+
+export type ManagedUploadParams = UploadOptions & {
+        bucket: ManagedBucket;
+        client: SupabaseClient<Database>;
+        file: UploadBody;
+        householdId: string;
+        memberId: string;
+        metadata?: Record<string, string>;
+        path: string;
+};
+
+export type ManagedUpdateParams = ManagedUploadParams;
+
+export function buildManagedMetadata(
+        memberId: string,
+        householdId: string,
+        extra: Record<string, string> = {}
+): Record<string, string> {
+        if (!memberId) {
+                throw new Error("memberId is required to tag storage objects");
+        }
+
+        if (!householdId) {
+                throw new Error("householdId is required to tag storage objects");
+        }
+
+        return {
+                ...extra,
+                household_id: householdId,
+                member_id: memberId,
+        };
+}
+
+export async function uploadToManagedBucket({
+        bucket,
+        cacheControl,
+        client,
+        contentType,
+        file,
+        householdId,
+        memberId,
+        metadata,
+        path,
+        upsert = false,
+}: ManagedUploadParams) {
+        const mergedMetadata = buildManagedMetadata(memberId, householdId, metadata);
+
+        return client.storage.from(bucket).upload(path, file, {
+                cacheControl,
+                contentType,
+                metadata: mergedMetadata,
+                upsert,
+        });
+}
+
+export async function updateManagedObject(params: ManagedUpdateParams) {
+        return uploadToManagedBucket({ ...params, upsert: true });
+}


### PR DESCRIPTION
## Summary
- add a Supabase CLI script that provisions the floorplans, receipts, and docs buckets with consistent defaults
- apply a migration that records profile household membership and enforces storage RLS policies for managed buckets
- expose a storage helper that automatically tags uploads with member/household metadata and document the security posture

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0c28fac832889510cddd3f524a5