### PR TITLE
Implement Supabase claim enforcement in middleware

### DIFF
--- a/docs/engineering/conventions.md
+++ b/docs/engineering/conventions.md
@@ -65,5 +65,6 @@ The repository is organized to keep infrastructure, services, clients, and share
 - Secrets must never be committed; use the centralized secret manager integration referenced in `infra/secrets/`.
 - Follow least-privilege principles when defining IAM roles or service accounts.
 - Ensure dependency scanning and container image scanning steps succeed before requesting review.
+- Supabase auth tokens must embed the `https://share.house/claims` payload with a `household_id` string and an array of `roles` (e.g. `tenant`, `admin`). Middleware enforces RBAC using these fields and will redirect or block requests that omit them.
 
 These conventions will evolve with the platform. Propose updates via a new ADR or an update to this document and circulate it in the Platform Engineering Guild for approval.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,122 @@
 // content security policy requirements vary from app to app head to https://nextjs.org/docs/pages/building-your-application/configuring/content-security-policy to learn how to configure nonces within middleware and or how to set policies within your next.config file
 
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import type { Session } from '@supabase/supabase-js'
 import { NextResponse, type NextRequest } from 'next/server'
+
+const AUTH_REDIRECT_PATH = '/auth'
+const TENANT_REDIRECT_PATH = '/account'
+const TENANT_ROLE = 'tenant'
+const ADMIN_ROLE = 'admin'
+const TENANT_ROUTE_GROUP_PATTERN = /\/\(tenant\)(\/|$)/i
+const ADMIN_ROUTE_GROUP_PATTERN = /\/\(admin\)(\/|$)/i
+const TENANT_PATH_PREFIX = /^\/tenant(\/|$)/i
+const ADMIN_PATH_PREFIX = /^\/admin(\/|$)/i
+
+export const PORTAL_CLAIM_NAMESPACE = 'https://share.house/claims'
+
+type PortalClaim = {
+  household_id: string
+  roles: string[]
+}
+
+function decodeBase64Url(value: string): string {
+  const normalised = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalised.padEnd(
+    normalised.length + ((4 - (normalised.length % 4)) % 4),
+    '='
+  )
+
+  if (typeof atob === 'function') {
+    return atob(padded)
+  }
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(padded, 'base64').toString('utf8')
+  }
+
+  throw new Error('No base64 decoder available in this runtime')
+}
+
+function normaliseJwtPayload(token: string | undefined): unknown {
+  if (!token) return null
+
+  const segments = token.split('.')
+  if (segments.length < 2) return null
+
+  try {
+    const payload = segments[1]
+    const decoded = decodeBase64Url(payload)
+    return JSON.parse(decoded)
+  } catch (error) {
+    console.warn('Failed to decode Supabase access token payload', error)
+    return null
+  }
+}
+
+function isPortalClaim(value: unknown): value is PortalClaim {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const claim = value as Partial<PortalClaim>
+  return (
+    typeof claim.household_id === 'string' &&
+    Array.isArray(claim.roles) &&
+    claim.roles.every((role) => typeof role === 'string')
+  )
+}
+
+function extractPortalClaim(session: Session | null): PortalClaim | null {
+  if (!session) return null
+
+  const payload = normaliseJwtPayload(session.access_token)
+
+  const potentialSources: unknown[] = [
+    payload && typeof payload === 'object'
+      ? (payload as Record<string, unknown>)[PORTAL_CLAIM_NAMESPACE]
+      : null,
+    session.user?.app_metadata?.[PORTAL_CLAIM_NAMESPACE],
+    session.user?.user_metadata?.[PORTAL_CLAIM_NAMESPACE],
+  ]
+
+  for (const source of potentialSources) {
+    if (isPortalClaim(source)) {
+      return source
+    }
+  }
+
+  return null
+}
+
+function resolveInvokePath(request: NextRequest): string {
+  const invokePath = request.headers.get('x-invoke-path')
+  if (invokePath) {
+    return invokePath
+  }
+
+  return request.nextUrl.pathname
+}
+
+function isTenantRoute(request: NextRequest): boolean {
+  const path = resolveInvokePath(request)
+  return (
+    TENANT_ROUTE_GROUP_PATTERN.test(path) ||
+    TENANT_PATH_PREFIX.test(request.nextUrl.pathname)
+  )
+}
+
+function isAdminRoute(request: NextRequest): boolean {
+  const path = resolveInvokePath(request)
+  return (
+    ADMIN_ROUTE_GROUP_PATTERN.test(path) ||
+    ADMIN_PATH_PREFIX.test(request.nextUrl.pathname)
+  )
+}
+
+function redirectTo(pathname: string, request: NextRequest) {
+  return NextResponse.redirect(new URL(pathname, request.url))
+}
 
 export async function middleware(request: NextRequest) {
   let response = NextResponse.next({
@@ -56,7 +171,32 @@ export async function middleware(request: NextRequest) {
     }
   )
 
-  await supabase.auth.getUser()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  const claim = extractPortalClaim(session ?? null)
+  const roles = claim?.roles ?? []
+
+  const tenantRoute = isTenantRoute(request)
+  const adminRoute = isAdminRoute(request)
+
+  if ((tenantRoute || adminRoute) && !session) {
+    return redirectTo(AUTH_REDIRECT_PATH, request)
+  }
+
+  if (tenantRoute && (!claim || !roles.includes(TENANT_ROLE))) {
+    return redirectTo(TENANT_REDIRECT_PATH, request)
+  }
+
+  if (adminRoute && (!claim || !roles.includes(ADMIN_ROLE))) {
+    return new NextResponse(null, { status: 403 })
+  }
+
+  if (claim) {
+    response.headers.set('x-onyx-household-id', claim.household_id)
+    response.headers.set('x-onyx-roles', roles.join(','))
+  }
 
   return response
 }

--- a/tests/middleware/role-protection.test.ts
+++ b/tests/middleware/role-protection.test.ts
@@ -1,0 +1,125 @@
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createServerClientMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: createServerClientMock,
+}))
+
+import { middleware, PORTAL_CLAIM_NAMESPACE } from '@/middleware'
+import type { Session } from '@supabase/supabase-js'
+
+type ClaimShape = {
+  household_id: string
+  roles: string[]
+}
+
+const JWT_HEADER = Buffer.from(
+  JSON.stringify({ alg: 'HS256', typ: 'JWT' })
+).toString('base64url')
+
+function encodeToken(claim: ClaimShape): string {
+  const payload = {
+    sub: 'user-123',
+    [PORTAL_CLAIM_NAMESPACE]: claim,
+  }
+
+  const payloadSegment = Buffer.from(JSON.stringify(payload)).toString(
+    'base64url'
+  )
+
+  return `${JWT_HEADER}.${payloadSegment}.signature`
+}
+
+function createSession(claim: ClaimShape | null): Session | null {
+  if (!claim) return null
+
+  return {
+    access_token: encodeToken(claim),
+    refresh_token: 'refresh-token',
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: {
+      app_metadata: {
+        provider: 'email',
+        [PORTAL_CLAIM_NAMESPACE]: claim,
+      },
+      user_metadata: {},
+    },
+  } as unknown as Session
+}
+
+function mockSupabaseSession(session: Session | null) {
+  createServerClientMock.mockReturnValue({
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session } }),
+    },
+  })
+}
+
+function buildRequest(path: string, invokePath?: string) {
+  const headers = new Headers()
+  if (invokePath) {
+    headers.set('x-invoke-path', invokePath)
+  }
+
+  return new NextRequest(new URL(`http://localhost${path}`), {
+    headers,
+  })
+}
+
+beforeEach(() => {
+  createServerClientMock.mockReset()
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('middleware role enforcement', () => {
+  it('redirects unauthenticated tenant requests to auth', async () => {
+    mockSupabaseSession(null)
+
+    const request = buildRequest('/dashboard', '/(tenant)/dashboard')
+    const response = await middleware(request)
+
+    expect(response.headers.get('location')).toBe('http://localhost/auth')
+  })
+
+  it('blocks users missing the tenant role', async () => {
+    mockSupabaseSession(
+      createSession({ household_id: 'house-1', roles: ['roommate'] })
+    )
+
+    const request = buildRequest('/dashboard', '/(tenant)/dashboard')
+    const response = await middleware(request)
+
+    expect(response.headers.get('location')).toBe('http://localhost/account')
+  })
+
+  it('denies access to admin areas without admin role', async () => {
+    mockSupabaseSession(
+      createSession({ household_id: 'house-1', roles: ['tenant'] })
+    )
+
+    const request = buildRequest('/settings', '/(admin)/settings')
+    const response = await middleware(request)
+
+    expect(response.status).toBe(403)
+  })
+
+  it('allows admin claims to pass through', async () => {
+    const claim = { household_id: 'house-42', roles: ['tenant', 'admin'] }
+    mockSupabaseSession(createSession(claim))
+
+    const request = buildRequest('/settings', '/(admin)/settings')
+    const response = await middleware(request)
+
+    expect(response.headers.get('x-onyx-household-id')).toBe(claim.household_id)
+    expect(response.headers.get('x-onyx-roles')).toBe('tenant,admin')
+    expect(response.headers.get('location')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- parse Supabase access tokens in the middleware to extract household roles and enforce admin/tenant access rules
- add middleware integration tests covering redirects and claim header propagation
- document the required https://share.house/claims payload fields for Supabase-issued tokens

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a0c1b6948328adc32939283b492a