### PR TITLE
Add household domain schema and documentation

### DIFF
--- a/docs/engineering/conventions.md
+++ b/docs/engineering/conventions.md
@@ -66,4 +66,62 @@ The repository is organized to keep infrastructure, services, clients, and share
 - Follow least-privilege principles when defining IAM roles or service accounts.
 - Ensure dependency scanning and container image scanning steps succeed before requesting review.
 
+### Supabase Entity Relationships
+
+- **households** — Anchor record for each shared property; all tenant data links back here via `household_id` and each row carries `created_at`/`updated_at` metadata for auditing.
+- **members** — Roommates, property managers, and admins scoped to a household.
+  - `members.household_id → households.id`
+  - `members.user_id → auth.users.id`
+- **amenities** — Household-specific shared resources (kitchen, parking, TV room, etc.).
+  - `amenities.household_id → households.id`
+- **bookings** — Time-bound reservations against amenities.
+  - `bookings.household_id → households.id`
+  - `bookings.amenity_id → amenities.id`
+  - `bookings.member_id → members.id`
+- **chores** — Recurring or ad hoc household responsibilities.
+  - `chores.household_id → households.id`
+- **chore_assignments** — Links chores to the members responsible for completing them.
+  - `chore_assignments.household_id → households.id`
+  - `chore_assignments.chore_id → chores.id`
+  - `chore_assignments.member_id → members.id`
+- **supply_items** — Consumables the household tracks jointly.
+  - `supply_items.household_id → households.id`
+- **supply_purchases** — Purchases of tracked supplies and who bought them.
+  - `supply_purchases.household_id → households.id`
+  - `supply_purchases.supply_item_id → supply_items.id`
+  - `supply_purchases.member_id → members.id`
+- **supply_shares** — Cost-splitting records for each purchase.
+  - `supply_shares.household_id → households.id`
+  - `supply_shares.supply_purchase_id → supply_purchases.id`
+  - `supply_shares.member_id → members.id`
+- **threads** — Discussion topics per household with optional author attribution.
+  - `threads.household_id → households.id`
+  - `threads.member_id → members.id`
+- **messages** — Posts within a thread authored by members.
+  - `messages.household_id → households.id`
+  - `messages.thread_id → threads.id`
+  - `messages.member_id → members.id`
+- **leases** — Active or historical contractual agreements for a household.
+  - `leases.household_id → households.id`
+  - `leases.member_id → members.id`
+- **invoices** — Rent and fee statements tied to a lease or individual member share.
+  - `invoices.household_id → households.id`
+  - `invoices.lease_id → leases.id`
+  - `invoices.member_id → members.id`
+- **payments** — Tenant payments recorded against invoices.
+  - `payments.household_id → households.id`
+  - `payments.invoice_id → invoices.id`
+  - `payments.member_id → members.id`
+- **floorplans** — Uploaded floorplan assets for a household.
+  - `floorplans.household_id → households.id`
+- **overlay_shapes** — Member-specific annotations layered on top of a floorplan.
+  - `overlay_shapes.household_id → households.id`
+  - `overlay_shapes.floorplan_id → floorplans.id`
+  - `overlay_shapes.member_id → members.id`
+- **garbage_events** — Scheduled trash, recycling, or compost pickups with optional assignees.
+  - `garbage_events.household_id → households.id`
+  - `garbage_events.member_id → members.id`
+
+All household-scoped tables share consistent `created_at` and `updated_at` columns to support reconciliation and time-based analytics.
+
 These conventions will evolve with the platform. Propose updates via a new ADR or an update to this document and circulate it in the Platform Engineering Guild for approval.

--- a/lib/schemas/share-house.ts
+++ b/lib/schemas/share-house.ts
@@ -1,0 +1,252 @@
+import { z } from 'zod';
+
+import type { Json } from '../supabase';
+
+type JsonValue = Json;
+
+const jsonSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonSchema),
+    z.record(z.union([jsonSchema, z.undefined()])),
+  ]),
+);
+
+const timestampString = z.string().datetime({ offset: true });
+const optionalTimestamp = timestampString.nullable();
+const dateString = z.string().date();
+const positiveId = z.number().int().positive();
+const optionalPositiveId = positiveId.nullable();
+const nonNegativeAmount = z.number().nonnegative();
+
+const memberRoleEnum = z.enum(['roommate', 'tenant', 'property_manager', 'admin']);
+
+export const householdRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  name: z.string().min(1),
+  timezone: z.string().nullable(),
+  metadata: jsonSchema,
+});
+
+export const memberRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  user_id: z.string().uuid(),
+  role: memberRoleEnum,
+  display_name: z.string().nullable(),
+  email: z.string().nullable(),
+  phone_number: z.string().nullable(),
+});
+
+export const amenityRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  name: z.string().min(1),
+  description: z.string().nullable(),
+  location: z.string().nullable(),
+  is_active: z.boolean(),
+});
+
+export const bookingRowSchema = z
+  .object({
+    id: positiveId,
+    created_at: timestampString,
+    updated_at: timestampString,
+    household_id: positiveId,
+    amenity_id: positiveId,
+    member_id: positiveId,
+    start_time: timestampString,
+    end_time: timestampString,
+    status: z.string().min(1),
+    notes: z.string().nullable(),
+  })
+  .refine(
+    ({ start_time, end_time }) => new Date(end_time).getTime() > new Date(start_time).getTime(),
+    {
+      message: 'end_time must be after start_time',
+      path: ['end_time'],
+    },
+  );
+
+export const choreRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  title: z.string().min(1),
+  description: z.string().nullable(),
+  frequency: z.string().nullable(),
+  recurrence_rule: z.string().nullable(),
+});
+
+export const choreAssignmentRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  chore_id: positiveId,
+  member_id: positiveId,
+  due_at: optionalTimestamp,
+  completed_at: optionalTimestamp,
+  status: z.string().min(1),
+});
+
+export const supplyItemRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  name: z.string().min(1),
+  description: z.string().nullable(),
+  category: z.string().nullable(),
+  restock_interval_days: z.number().int().nonnegative().nullable(),
+});
+
+export const supplyPurchaseRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  supply_item_id: positiveId,
+  member_id: positiveId,
+  purchased_at: timestampString,
+  total_cost: nonNegativeAmount,
+  receipt_url: z.string().nullable(),
+  notes: z.string().nullable(),
+});
+
+export const supplyShareRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  supply_purchase_id: positiveId,
+  member_id: positiveId,
+  amount: nonNegativeAmount,
+  status: z.string().min(1),
+});
+
+export const leaseRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  member_id: optionalPositiveId,
+  title: z.string().min(1),
+  document_url: z.string().nullable(),
+  start_date: dateString,
+  end_date: dateString.nullable(),
+  status: z.string().min(1),
+});
+
+export const invoiceRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  lease_id: optionalPositiveId,
+  member_id: optionalPositiveId,
+  amount: nonNegativeAmount,
+  due_date: dateString,
+  issued_date: dateString,
+  status: z.string().min(1),
+  description: z.string().nullable(),
+});
+
+export const paymentRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  invoice_id: positiveId,
+  member_id: positiveId,
+  amount: nonNegativeAmount,
+  paid_at: optionalTimestamp,
+  status: z.string().min(1),
+  provider_payment_id: z.string().nullable(),
+  method: z.string().nullable(),
+});
+
+export const threadRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  member_id: optionalPositiveId,
+  title: z.string().min(1),
+  description: z.string().nullable(),
+  last_activity_at: timestampString,
+});
+
+export const messageRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  thread_id: positiveId,
+  member_id: positiveId,
+  body: z.string().min(1),
+  metadata: jsonSchema,
+  edited_at: optionalTimestamp,
+});
+
+export const floorplanRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  name: z.string().min(1),
+  storage_path: z.string().min(1),
+  description: z.string().nullable(),
+});
+
+export const overlayShapeRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  floorplan_id: positiveId,
+  member_id: optionalPositiveId,
+  label: z.string().min(1),
+  geometry: jsonSchema,
+  color: z.string().nullable(),
+  metadata: jsonSchema,
+});
+
+export const garbageEventRowSchema = z.object({
+  id: positiveId,
+  created_at: timestampString,
+  updated_at: timestampString,
+  household_id: positiveId,
+  member_id: optionalPositiveId,
+  scheduled_for: timestampString,
+  status: z.string().min(1),
+  notes: z.string().nullable(),
+});
+
+export type HouseholdRow = z.infer<typeof householdRowSchema>;
+export type MemberRow = z.infer<typeof memberRowSchema>;
+export type AmenityRow = z.infer<typeof amenityRowSchema>;
+export type BookingRow = z.infer<typeof bookingRowSchema>;
+export type ChoreRow = z.infer<typeof choreRowSchema>;
+export type ChoreAssignmentRow = z.infer<typeof choreAssignmentRowSchema>;
+export type SupplyItemRow = z.infer<typeof supplyItemRowSchema>;
+export type SupplyPurchaseRow = z.infer<typeof supplyPurchaseRowSchema>;
+export type SupplyShareRow = z.infer<typeof supplyShareRowSchema>;
+export type LeaseRow = z.infer<typeof leaseRowSchema>;
+export type InvoiceRow = z.infer<typeof invoiceRowSchema>;
+export type PaymentRow = z.infer<typeof paymentRowSchema>;
+export type ThreadRow = z.infer<typeof threadRowSchema>;
+export type MessageRow = z.infer<typeof messageRowSchema>;
+export type FloorplanRow = z.infer<typeof floorplanRowSchema>;
+export type OverlayShapeRow = z.infer<typeof overlayShapeRowSchema>;
+export type GarbageEventRow = z.infer<typeof garbageEventRowSchema>;

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -183,6 +183,870 @@ export type Database = {
   }
   public: {
     Tables: {
+      amenities: {
+        Row: {
+          created_at: string
+          description: string | null
+          household_id: number
+          id: number
+          is_active: boolean
+          location: string | null
+          name: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          household_id: number
+          id?: number
+          is_active?: boolean
+          location?: string | null
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          household_id?: number
+          id?: number
+          is_active?: boolean
+          location?: string | null
+          name?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "amenities_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      bookings: {
+        Row: {
+          amenity_id: number
+          created_at: string
+          end_time: string
+          household_id: number
+          id: number
+          member_id: number
+          notes: string | null
+          start_time: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          amenity_id: number
+          created_at?: string
+          end_time: string
+          household_id: number
+          id?: number
+          member_id: number
+          notes?: string | null
+          start_time: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          amenity_id?: number
+          created_at?: string
+          end_time?: string
+          household_id?: number
+          id?: number
+          member_id?: number
+          notes?: string | null
+          start_time?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bookings_amenity_id_fkey",
+            columns: ["amenity_id"],
+            isOneToOne: false,
+            referencedRelation: "amenities",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "bookings_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "bookings_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      chore_assignments: {
+        Row: {
+          chore_id: number
+          completed_at: string | null
+          created_at: string
+          due_at: string | null
+          household_id: number
+          id: number
+          member_id: number
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          chore_id: number
+          completed_at?: string | null
+          created_at?: string
+          due_at?: string | null
+          household_id: number
+          id?: number
+          member_id: number
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          chore_id?: number
+          completed_at?: string | null
+          created_at?: string
+          due_at?: string | null
+          household_id?: number
+          id?: number
+          member_id?: number
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chore_assignments_chore_id_fkey",
+            columns: ["chore_id"],
+            isOneToOne: false,
+            referencedRelation: "chores",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "chore_assignments_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "chore_assignments_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      chores: {
+        Row: {
+          created_at: string
+          description: string | null
+          frequency: string | null
+          household_id: number
+          id: number
+          recurrence_rule: string | null
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          frequency?: string | null
+          household_id: number
+          id?: number
+          recurrence_rule?: string | null
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          frequency?: string | null
+          household_id?: number
+          id?: number
+          recurrence_rule?: string | null
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chores_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      floorplans: {
+        Row: {
+          created_at: string
+          description: string | null
+          household_id: number
+          id: number
+          name: string
+          storage_path: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          household_id: number
+          id?: number
+          name: string
+          storage_path: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          household_id?: number
+          id?: number
+          name?: string
+          storage_path?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "floorplans_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      garbage_events: {
+        Row: {
+          created_at: string
+          household_id: number
+          id: number
+          member_id: number | null
+          notes: string | null
+          scheduled_for: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          household_id: number
+          id?: number
+          member_id?: number | null
+          notes?: string | null
+          scheduled_for: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          household_id?: number
+          id?: number
+          member_id?: number | null
+          notes?: string | null
+          scheduled_for?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "garbage_events_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "garbage_events_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      households: {
+        Row: {
+          created_at: string
+          id: number
+          metadata: Json
+          name: string
+          timezone: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          metadata?: Json
+          name: string
+          timezone?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          metadata?: Json
+          name?: string
+          timezone?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      invoices: {
+        Row: {
+          amount: number
+          created_at: string
+          description: string | null
+          due_date: string
+          household_id: number
+          id: number
+          issued_date: string
+          lease_id: number | null
+          member_id: number | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          description?: string | null
+          due_date: string
+          household_id: number
+          id?: number
+          issued_date?: string
+          lease_id?: number | null
+          member_id?: number | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          description?: string | null
+          due_date?: string
+          household_id?: number
+          id?: number
+          issued_date?: string
+          lease_id?: number | null
+          member_id?: number | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "invoices_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "invoices_lease_id_fkey",
+            columns: ["lease_id"],
+            isOneToOne: false,
+            referencedRelation: "leases",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "invoices_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      leases: {
+        Row: {
+          created_at: string
+          document_url: string | null
+          end_date: string | null
+          household_id: number
+          id: number
+          member_id: number | null
+          start_date: string
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          document_url?: string | null
+          end_date?: string | null
+          household_id: number
+          id?: number
+          member_id?: number | null
+          start_date: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          document_url?: string | null
+          end_date?: string | null
+          household_id?: number
+          id?: number
+          member_id?: number | null
+          start_date?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "leases_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "leases_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      members: {
+        Row: {
+          created_at: string
+          display_name: string | null
+          email: string | null
+          household_id: number
+          id: number
+          phone_number: string | null
+          role: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          display_name?: string | null
+          email?: string | null
+          household_id: number
+          id?: number
+          phone_number?: string | null
+          role?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string | null
+          email?: string | null
+          household_id?: number
+          id?: number
+          phone_number?: string | null
+          role?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "members_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      messages: {
+        Row: {
+          body: string
+          created_at: string
+          edited_at: string | null
+          household_id: number
+          id: number
+          member_id: number
+          metadata: Json
+          thread_id: number
+          updated_at: string
+        }
+        Insert: {
+          body: string
+          created_at?: string
+          edited_at?: string | null
+          household_id: number
+          id?: number
+          member_id: number
+          metadata?: Json
+          thread_id: number
+          updated_at?: string
+        }
+        Update: {
+          body?: string
+          created_at?: string
+          edited_at?: string | null
+          household_id?: number
+          id?: number
+          member_id?: number
+          metadata?: Json
+          thread_id?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "messages_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "messages_thread_id_fkey",
+            columns: ["thread_id"],
+            isOneToOne: false,
+            referencedRelation: "threads",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      overlay_shapes: {
+        Row: {
+          color: string | null
+          created_at: string
+          floorplan_id: number
+          geometry: Json
+          household_id: number
+          id: number
+          label: string
+          member_id: number | null
+          metadata: Json
+          updated_at: string
+        }
+        Insert: {
+          color?: string | null
+          created_at?: string
+          floorplan_id: number
+          geometry: Json
+          household_id: number
+          id?: number
+          label: string
+          member_id?: number | null
+          metadata?: Json
+          updated_at?: string
+        }
+        Update: {
+          color?: string | null
+          created_at?: string
+          floorplan_id?: number
+          geometry?: Json
+          household_id?: number
+          id?: number
+          label?: string
+          member_id?: number | null
+          metadata?: Json
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "overlay_shapes_floorplan_id_fkey",
+            columns: ["floorplan_id"],
+            isOneToOne: false,
+            referencedRelation: "floorplans",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "overlay_shapes_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "overlay_shapes_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      payments: {
+        Row: {
+          amount: number
+          created_at: string
+          household_id: number
+          id: number
+          invoice_id: number
+          member_id: number
+          method: string | null
+          paid_at: string | null
+          provider_payment_id: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          household_id: number
+          id?: number
+          invoice_id: number
+          member_id: number
+          method?: string | null
+          paid_at?: string | null
+          provider_payment_id?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          household_id?: number
+          id?: number
+          invoice_id?: number
+          member_id?: number
+          method?: string | null
+          paid_at?: string | null
+          provider_payment_id?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "payments_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "payments_invoice_id_fkey",
+            columns: ["invoice_id"],
+            isOneToOne: false,
+            referencedRelation: "invoices",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "payments_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      supply_items: {
+        Row: {
+          category: string | null
+          created_at: string
+          description: string | null
+          household_id: number
+          id: number
+          name: string
+          restock_interval_days: number | null
+          updated_at: string
+        }
+        Insert: {
+          category?: string | null
+          created_at?: string
+          description?: string | null
+          household_id: number
+          id?: number
+          name: string
+          restock_interval_days?: number | null
+          updated_at?: string
+        }
+        Update: {
+          category?: string | null
+          created_at?: string
+          description?: string | null
+          household_id?: number
+          id?: number
+          name?: string
+          restock_interval_days?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_items_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      supply_purchases: {
+        Row: {
+          created_at: string
+          household_id: number
+          id: number
+          member_id: number
+          notes: string | null
+          purchased_at: string
+          receipt_url: string | null
+          supply_item_id: number
+          total_cost: number
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          household_id: number
+          id?: number
+          member_id: number
+          notes?: string | null
+          purchased_at?: string
+          receipt_url?: string | null
+          supply_item_id: number
+          total_cost: number
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          household_id?: number
+          id?: number
+          member_id?: number
+          notes?: string | null
+          purchased_at?: string
+          receipt_url?: string | null
+          supply_item_id?: number
+          total_cost?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_purchases_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "supply_purchases_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "supply_purchases_supply_item_id_fkey",
+            columns: ["supply_item_id"],
+            isOneToOne: false,
+            referencedRelation: "supply_items",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      supply_shares: {
+        Row: {
+          amount: number
+          created_at: string
+          household_id: number
+          id: number
+          member_id: number
+          status: string
+          supply_purchase_id: number
+          updated_at: string
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          household_id: number
+          id?: number
+          member_id: number
+          status?: string
+          supply_purchase_id: number
+          updated_at?: string
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          household_id?: number
+          id?: number
+          member_id?: number
+          status?: string
+          supply_purchase_id?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_shares_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "supply_shares_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "supply_shares_supply_purchase_id_fkey",
+            columns: ["supply_purchase_id"],
+            isOneToOne: false,
+            referencedRelation: "supply_purchases",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
+      threads: {
+        Row: {
+          created_at: string
+          description: string | null
+          household_id: number
+          id: number
+          last_activity_at: string
+          member_id: number | null
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          household_id: number
+          id?: number
+          last_activity_at?: string
+          member_id?: number | null
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          household_id?: number
+          id?: number
+          last_activity_at?: string
+          member_id?: number | null
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "threads_household_id_fkey",
+            columns: ["household_id"],
+            isOneToOne: false,
+            referencedRelation: "households",
+            referencedColumns: ["id"],
+          },
+          {
+            foreignKeyName: "threads_member_id_fkey",
+            columns: ["member_id"],
+            isOneToOne: false,
+            referencedRelation: "members",
+            referencedColumns: ["id"],
+          },
+        ]
+      }
       ai_agents: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250716_household_features.sql
+++ b/supabase/migrations/20250716_household_features.sql
@@ -1,0 +1,212 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.households (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  name TEXT NOT NULL,
+  timezone TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS public.members (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'roommate',
+  display_name TEXT,
+  email TEXT,
+  phone_number TEXT,
+  UNIQUE (household_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.amenities (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  location TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  UNIQUE (household_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS public.threads (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  member_id BIGINT REFERENCES public.members(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  last_activity_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.messages (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  thread_id BIGINT NOT NULL REFERENCES public.threads(id) ON DELETE CASCADE,
+  member_id BIGINT NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  body TEXT NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  edited_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE IF NOT EXISTS public.bookings (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  amenity_id BIGINT NOT NULL REFERENCES public.amenities(id) ON DELETE CASCADE,
+  member_id BIGINT NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  start_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  end_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  notes TEXT,
+  CHECK (end_time > start_time)
+);
+
+CREATE TABLE IF NOT EXISTS public.chores (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  frequency TEXT,
+  recurrence_rule TEXT,
+  UNIQUE (household_id, title)
+);
+
+CREATE TABLE IF NOT EXISTS public.chore_assignments (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  chore_id BIGINT NOT NULL REFERENCES public.chores(id) ON DELETE CASCADE,
+  member_id BIGINT NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  due_at TIMESTAMP WITH TIME ZONE,
+  completed_at TIMESTAMP WITH TIME ZONE,
+  status TEXT NOT NULL DEFAULT 'assigned'
+);
+
+CREATE TABLE IF NOT EXISTS public.supply_items (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  category TEXT,
+  restock_interval_days INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS public.supply_purchases (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  supply_item_id BIGINT NOT NULL REFERENCES public.supply_items(id) ON DELETE CASCADE,
+  member_id BIGINT NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  purchased_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  total_cost NUMERIC(12, 2) NOT NULL,
+  receipt_url TEXT,
+  notes TEXT,
+  CHECK (total_cost >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.supply_shares (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  supply_purchase_id BIGINT NOT NULL REFERENCES public.supply_purchases(id) ON DELETE CASCADE,
+  member_id BIGINT NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  amount NUMERIC(12, 2) NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  CHECK (amount >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.leases (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  member_id BIGINT REFERENCES public.members(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  document_url TEXT,
+  start_date DATE NOT NULL,
+  end_date DATE,
+  status TEXT NOT NULL DEFAULT 'draft'
+);
+
+CREATE TABLE IF NOT EXISTS public.invoices (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  lease_id BIGINT REFERENCES public.leases(id) ON DELETE SET NULL,
+  member_id BIGINT REFERENCES public.members(id) ON DELETE SET NULL,
+  amount NUMERIC(12, 2) NOT NULL,
+  due_date DATE NOT NULL,
+  issued_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  status TEXT NOT NULL DEFAULT 'draft',
+  description TEXT,
+  CHECK (amount >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.payments (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  invoice_id BIGINT NOT NULL REFERENCES public.invoices(id) ON DELETE CASCADE,
+  member_id BIGINT NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  amount NUMERIC(12, 2) NOT NULL,
+  paid_at TIMESTAMP WITH TIME ZONE,
+  status TEXT NOT NULL DEFAULT 'pending',
+  provider_payment_id TEXT,
+  method TEXT,
+  CHECK (amount >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.floorplans (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  storage_path TEXT NOT NULL,
+  description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS public.overlay_shapes (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  floorplan_id BIGINT NOT NULL REFERENCES public.floorplans(id) ON DELETE CASCADE,
+  member_id BIGINT REFERENCES public.members(id) ON DELETE SET NULL,
+  label TEXT NOT NULL,
+  geometry JSONB NOT NULL,
+  color TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS public.garbage_events (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  household_id BIGINT NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  member_id BIGINT REFERENCES public.members(id) ON DELETE SET NULL,
+  scheduled_for TIMESTAMP WITH TIME ZONE NOT NULL,
+  status TEXT NOT NULL DEFAULT 'scheduled',
+  notes TEXT
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a Supabase migration for the household, member, amenity, booking, supply, finance, and messaging tables with foreign key constraints
- regenerate the generated Supabase TypeScript types and add Zod schemas mirroring the new tables
- document the tenant-focused entity relationships in the engineering conventions guide

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0bfdc2c8328aa2ff2b0f7396bdc