### PR TITLE
Add supply catalog defaults and admin management

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { ArchiveIcon, PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -8,18 +8,23 @@ import { usePathname } from "next/navigation";
 export default function NavLinks() {
 	const pathname = usePathname();
 
-	const links = [
-		{
-			href: "/dashboard/members",
-			text: "Members",
-			Icon: PersonIcon,
-		},
-		{
-			href: "/dashboard/todo",
-			text: "Todo",
-			Icon: CrumpledPaperIcon,
-		},
-	];
+        const links = [
+                {
+                        href: "/dashboard/members",
+                        text: "Members",
+                        Icon: PersonIcon,
+                },
+                {
+                        href: "/dashboard/todo",
+                        text: "Todo",
+                        Icon: CrumpledPaperIcon,
+                },
+                {
+                        href: "/dashboard/supplies",
+                        text: "Supplies",
+                        Icon: ArchiveIcon,
+                },
+        ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/supplies/actions.ts
+++ b/app/dashboard/supplies/actions.ts
@@ -1,0 +1,212 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { createSupbaseServerClient } from "@/utils/supaone";
+import type { SupplyActionState } from "@/types/supplies";
+
+const SUPPLY_SPLIT_VALUES = ["equal", "weighted"] as const;
+
+const booleanFromString = z
+        .union([z.literal("true"), z.literal("false")])
+        .transform((value) => value === "true");
+
+const quantitySchema = z
+        .coerce
+        .number({ invalid_type_error: "Default quantity must be a number" })
+        .int({ message: "Default quantity must be a whole number" })
+        .min(1, { message: "Default quantity must be at least 1" })
+        .max(9999, { message: "Default quantity must be below 10,000" });
+
+const createItemSchema = z.object({
+        name: z
+                .string({ required_error: "Name is required" })
+                .trim()
+                .min(1, { message: "Name is required" })
+                .max(120, { message: "Name must be 120 characters or fewer" }),
+        category: z
+                .string({ required_error: "Category is required" })
+                .trim()
+                .min(1, { message: "Category is required" })
+                .max(60, { message: "Category must be 60 characters or fewer" }),
+        description: z
+                .string({ invalid_type_error: "Description must be text" })
+                .trim()
+                .max(500, { message: "Description must be 500 characters or fewer" })
+                .optional(),
+        unit: z
+                .string({ required_error: "Unit is required" })
+                .trim()
+                .min(1, { message: "Unit is required" })
+                .max(20, { message: "Unit must be 20 characters or fewer" }),
+        default_quantity: quantitySchema,
+        default_split: z.enum(SUPPLY_SPLIT_VALUES),
+        is_active: booleanFromString,
+});
+
+const updateItemSchema = z.object({
+        id: z
+                .string({ required_error: "Supply item id is required" })
+                .uuid({ message: "Invalid supply item id" }),
+        unit: z
+                .string({ required_error: "Unit is required" })
+                .trim()
+                .min(1, { message: "Unit is required" })
+                .max(20, { message: "Unit must be 20 characters or fewer" }),
+        default_quantity: quantitySchema,
+        default_split: z.enum(SUPPLY_SPLIT_VALUES),
+        is_active: booleanFromString,
+});
+
+const formatFieldErrors = (error: z.ZodError): Record<string, string> => {
+        const fieldErrors = error.flatten().fieldErrors;
+        return Object.fromEntries(
+                Object.entries(fieldErrors)
+                        .filter(([, messages]) => messages && messages.length)
+                        .map(([field, messages]) => [field, messages![0] as string])
+        );
+};
+
+const sanitizeOptionalText = (value: FormDataEntryValue | null | undefined) => {
+        if (typeof value !== "string") {
+                return undefined;
+        }
+
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const sanitizeString = (value: FormDataEntryValue | null | undefined) =>
+        (typeof value === "string" ? value : "");
+
+export async function createSupplyItem(
+        _prevState: SupplyActionState,
+        formData: FormData
+): Promise<SupplyActionState> {
+        const submission = {
+                name: sanitizeString(formData.get("name")),
+                category: sanitizeString(formData.get("category")),
+                description: sanitizeOptionalText(formData.get("description")),
+                unit: sanitizeString(formData.get("unit")),
+                default_quantity: sanitizeString(formData.get("default_quantity")),
+                default_split: sanitizeString(formData.get("default_split")),
+                is_active: sanitizeString(formData.get("is_active")) || "true",
+        };
+
+        const parsed = createItemSchema.safeParse(submission);
+
+        if (!parsed.success) {
+                return {
+                        status: "error",
+                        message: "Please review the highlighted fields.",
+                        fieldErrors: formatFieldErrors(parsed.error),
+                };
+        }
+
+        const payload = parsed.data;
+
+        const supabase = await createSupbaseServerClient();
+        const { error } = await supabase.from("supply_items").insert({
+                name: payload.name,
+                category: payload.category,
+                description: payload.description ?? null,
+                unit: payload.unit,
+                default_quantity: payload.default_quantity,
+                default_split: payload.default_split,
+                is_active: payload.is_active,
+        });
+
+        if (error) {
+                console.error("createSupplyItem", error);
+                return {
+                        status: "error",
+                        message: "Unable to create supply item. Please try again.",
+                };
+        }
+
+        revalidatePath("/dashboard/supplies");
+
+        return {
+                status: "success",
+                message: `${payload.name} added to the catalog.`,
+        };
+}
+
+export async function updateSupplyItem(
+        _prevState: SupplyActionState,
+        formData: FormData
+): Promise<SupplyActionState> {
+        const submission = {
+                id: sanitizeString(formData.get("id")),
+                unit: sanitizeString(formData.get("unit")),
+                default_quantity: sanitizeString(formData.get("default_quantity")),
+                default_split: sanitizeString(formData.get("default_split")),
+                is_active: sanitizeString(formData.get("is_active")) || "true",
+        };
+
+        const parsed = updateItemSchema.safeParse(submission);
+
+        if (!parsed.success) {
+                return {
+                        status: "error",
+                        message: "Unable to save your changes.",
+                        fieldErrors: formatFieldErrors(parsed.error),
+                };
+        }
+
+        const payload = parsed.data;
+        const supabase = await createSupbaseServerClient();
+        const { data, error } = await supabase
+                .from("supply_items")
+                .update({
+                        unit: payload.unit,
+                        default_quantity: payload.default_quantity,
+                        default_split: payload.default_split,
+                        is_active: payload.is_active,
+                        updated_at: new Date().toISOString(),
+                })
+                .eq("id", payload.id)
+                .select("name")
+                .maybeSingle();
+
+        if (error) {
+                console.error("updateSupplyItem", error);
+                return {
+                        status: "error",
+                        message: "Unable to save your changes. Please try again.",
+                };
+        }
+
+        if (!data) {
+                return {
+                        status: "error",
+                        message: "That supply item no longer exists.",
+                };
+        }
+
+        revalidatePath("/dashboard/supplies");
+
+        return {
+                status: "success",
+                message: `${data.name} defaults updated.`,
+        };
+}
+
+export async function deleteSupplyItem(formData: FormData) {
+        const id = sanitizeString(formData.get("id"));
+
+        if (!id) {
+                return;
+        }
+
+        const supabase = await createSupbaseServerClient();
+        const { error } = await supabase.from("supply_items").delete().eq("id", id);
+
+        if (error) {
+                console.error("deleteSupplyItem", error);
+                throw new Error("Unable to delete supply item");
+        }
+
+        revalidatePath("/dashboard/supplies");
+}

--- a/app/dashboard/supplies/components/create-supply-item-form.tsx
+++ b/app/dashboard/supplies/components/create-supply-item-form.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import * as React from "react";
+import { useFormState, useFormStatus } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { createSupplyItem } from "../actions";
+import {
+        SUPPLY_ACTION_INITIAL_STATE,
+        SUPPLY_SPLIT_OPTIONS,
+        type SupplyActionState,
+        type SupplyDefaultSplit,
+} from "@/types/supplies";
+
+function FieldError({ message }: { message?: string }) {
+        if (!message) {
+                return null;
+        }
+
+        return <p className="text-sm text-red-600">{message}</p>;
+}
+
+function SubmitButton() {
+        const { pending } = useFormStatus();
+        return (
+                <Button type="submit" disabled={pending}>
+                        {pending ? "Saving…" : "Add item"}
+                </Button>
+        );
+}
+
+export default function CreateSupplyItemForm() {
+        const formRef = React.useRef<HTMLFormElement>(null);
+        const [defaultSplit, setDefaultSplit] = React.useState<SupplyDefaultSplit>("equal");
+        const [isActive, setIsActive] = React.useState(true);
+        const [state, formAction] = useFormState<SupplyActionState, FormData>(
+                createSupplyItem,
+                SUPPLY_ACTION_INITIAL_STATE
+        );
+
+        React.useEffect(() => {
+                if (state.status === "success") {
+                        formRef.current?.reset();
+                        setDefaultSplit("equal");
+                        setIsActive(true);
+                }
+        }, [state.status]);
+
+        return (
+                <Card>
+                        <CardHeader>
+                                <CardTitle>Add a catalog item</CardTitle>
+                                <CardDescription>
+                                        Capture the baseline details for a shared supply so future orders inherit the
+                                        right defaults.
+                                </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                                <form ref={formRef} action={formAction} className="space-y-6">
+                                        <div className="grid gap-4 sm:grid-cols-2">
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="supply-name">Name</Label>
+                                                        <Input
+                                                                id="supply-name"
+                                                                name="name"
+                                                                placeholder="Paper towels"
+                                                                required
+                                                                autoComplete="off"
+                                                        />
+                                                        <FieldError message={state.fieldErrors?.name} />
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="supply-category">Category</Label>
+                                                        <Input
+                                                                id="supply-category"
+                                                                name="category"
+                                                                placeholder="Cleaning"
+                                                                required
+                                                                autoComplete="off"
+                                                        />
+                                                        <FieldError message={state.fieldErrors?.category} />
+                                                </div>
+                                        </div>
+
+                                        <div className="space-y-2">
+                                                <Label htmlFor="supply-description">Description (optional)</Label>
+                                                <Textarea
+                                                        id="supply-description"
+                                                        name="description"
+                                                        placeholder="Brand preference, restock cadence, storage notes…"
+                                                        rows={3}
+                                                />
+                                                <FieldError message={state.fieldErrors?.description} />
+                                        </div>
+
+                                        <div className="grid gap-4 sm:grid-cols-3">
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="supply-unit">Unit</Label>
+                                                        <Input
+                                                                id="supply-unit"
+                                                                name="unit"
+                                                                placeholder="roll"
+                                                                required
+                                                                autoComplete="off"
+                                                        />
+                                                        <FieldError message={state.fieldErrors?.unit} />
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="supply-default-quantity">Default quantity</Label>
+                                                        <Input
+                                                                id="supply-default-quantity"
+                                                                name="default_quantity"
+                                                                type="number"
+                                                                min={1}
+                                                                defaultValue={1}
+                                                                required
+                                                        />
+                                                        <FieldError message={state.fieldErrors?.default_quantity} />
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="supply-default-split">Default split</Label>
+                                                        <Select
+                                                                value={defaultSplit}
+                                                                onValueChange={(value) =>
+                                                                        setDefaultSplit(value as SupplyDefaultSplit)
+                                                                }
+                                                        >
+                                                                <SelectTrigger id="supply-default-split">
+                                                                        <SelectValue placeholder="Choose split" />
+                                                                </SelectTrigger>
+                                                                <SelectContent>
+                                                                        {SUPPLY_SPLIT_OPTIONS.map((option) => (
+                                                                                <SelectItem key={option.value} value={option.value}>
+                                                                                        <div className="flex flex-col text-left">
+                                                                                                <span>{option.label}</span>
+                                                                                                <span className="text-xs text-muted-foreground">
+                                                                                                        {option.description}
+                                                                                                </span>
+                                                                                        </div>
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                        <input type="hidden" name="default_split" value={defaultSplit} />
+                                                        <FieldError message={state.fieldErrors?.default_split} />
+                                                </div>
+                                        </div>
+
+                                        <div className="flex flex-col gap-4 rounded-md border border-dashed border-muted-foreground/40 p-4 sm:flex-row sm:items-center sm:justify-between">
+                                                <div>
+                                                        <Label htmlFor="supply-is-active" className="text-sm font-medium">
+                                                                Active in catalog
+                                                        </Label>
+                                                        <p className="text-sm text-muted-foreground">
+                                                                Inactive items stay saved but are hidden from roommate ordering flows.
+                                                        </p>
+                                                </div>
+                                                <div className="flex items-center gap-3">
+                                                        <Switch
+                                                                id="supply-is-active"
+                                                                checked={isActive}
+                                                                onCheckedChange={setIsActive}
+                                                        />
+                                                        <span className="text-sm text-muted-foreground">
+                                                                {isActive ? "Visible" : "Hidden"}
+                                                        </span>
+                                                </div>
+                                        </div>
+                                        <input type="hidden" name="is_active" value={String(isActive)} />
+
+                                        {state.message ? (
+                                                <p
+                                                        className={cn(
+                                                                "text-sm",
+                                                                state.status === "error"
+                                                                        ? "text-red-600"
+                                                                        : "text-emerald-600"
+                                                        )}
+                                                >
+                                                        {state.message}
+                                                </p>
+                                        ) : null}
+
+                                        <div className="flex justify-end">
+                                                <SubmitButton />
+                                        </div>
+                                </form>
+                        </CardContent>
+                </Card>
+        );
+}

--- a/app/dashboard/supplies/components/supply-catalog-table.tsx
+++ b/app/dashboard/supplies/components/supply-catalog-table.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import * as React from "react";
+import { formatDistanceToNow } from "date-fns";
+import { useFormState, useFormStatus } from "react-dom";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { deleteSupplyItem, updateSupplyItem } from "../actions";
+import {
+        SUPPLY_ACTION_INITIAL_STATE,
+        SUPPLY_SPLIT_OPTIONS,
+        type SupplyActionState,
+        type SupplyDefaultSplit,
+        type SupplyItem,
+} from "@/types/supplies";
+
+function FieldError({ message }: { message?: string }) {
+        if (!message) {
+                return null;
+        }
+
+        return <p className="text-xs text-red-600">{message}</p>;
+}
+
+function SaveButton({ children }: { children?: React.ReactNode }) {
+        const { pending } = useFormStatus();
+        return (
+                <Button type="submit" disabled={pending}>
+                        {pending ? "Saving…" : children ?? "Save"}
+                </Button>
+        );
+}
+
+function SupplyCatalogRow({ item }: { item: SupplyItem }) {
+        const [defaultSplit, setDefaultSplit] = React.useState<SupplyDefaultSplit>(item.default_split);
+        const [isActive, setIsActive] = React.useState(item.is_active);
+        const [state, formAction] = useFormState<SupplyActionState, FormData>(
+                updateSupplyItem,
+                SUPPLY_ACTION_INITIAL_STATE
+        );
+
+        const updatedLabel = React.useMemo(() => {
+                try {
+                        return formatDistanceToNow(new Date(item.updated_at), { addSuffix: true });
+                } catch (error) {
+                        return null;
+                }
+        }, [item.updated_at]);
+
+        return (
+                <form
+                        action={formAction}
+                        className="grid gap-4 border-t px-4 py-6 text-sm sm:grid-cols-[2fr_1.25fr_1.2fr_1.2fr_1.2fr_1.5fr] sm:items-start"
+                >
+                        <input type="hidden" name="id" value={item.id} />
+                        <div className="space-y-2">
+                                <div className="flex flex-wrap items-center gap-2">
+                                        <p className="text-base font-semibold leading-tight">{item.name}</p>
+                                        <Badge variant="secondary" className="capitalize">
+                                                {item.category}
+                                        </Badge>
+                                </div>
+                                {item.description ? (
+                                        <p className="text-sm text-muted-foreground">{item.description}</p>
+                                ) : null}
+                                {updatedLabel ? (
+                                        <p className="text-xs text-muted-foreground">Updated {updatedLabel}</p>
+                                ) : null}
+                        </div>
+                        <div className="space-y-2">
+                                <Label htmlFor={`unit-${item.id}`}>Unit</Label>
+                                <Input id={`unit-${item.id}`} name="unit" defaultValue={item.unit} required />
+                                <FieldError message={state.fieldErrors?.unit} />
+                        </div>
+                        <div className="space-y-2">
+                                <Label htmlFor={`quantity-${item.id}`}>Default qty</Label>
+                                <Input
+                                        id={`quantity-${item.id}`}
+                                        name="default_quantity"
+                                        type="number"
+                                        min={1}
+                                        defaultValue={item.default_quantity}
+                                        required
+                                />
+                                <FieldError message={state.fieldErrors?.default_quantity} />
+                        </div>
+                        <div className="space-y-2">
+                                <Label htmlFor={`split-${item.id}`}>Split</Label>
+                                <Select
+                                        value={defaultSplit}
+                                        onValueChange={(value) => setDefaultSplit(value as SupplyDefaultSplit)}
+                                >
+                                        <SelectTrigger id={`split-${item.id}`}>
+                                                <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                                {SUPPLY_SPLIT_OPTIONS.map((option) => (
+                                                        <SelectItem key={option.value} value={option.value}>
+                                                                {option.label}
+                                                        </SelectItem>
+                                                ))}
+                                        </SelectContent>
+                                </Select>
+                                <input type="hidden" name="default_split" value={defaultSplit} />
+                                <FieldError message={state.fieldErrors?.default_split} />
+                        </div>
+                        <div className="space-y-2">
+                                <Label htmlFor={`active-${item.id}`}>Status</Label>
+                                <div className="flex items-center gap-3 rounded-md border border-muted-foreground/30 px-3 py-2">
+                                        <Switch
+                                                id={`active-${item.id}`}
+                                                checked={isActive}
+                                                onCheckedChange={setIsActive}
+                                        />
+                                        <span className="text-sm text-muted-foreground">
+                                                {isActive ? "Visible" : "Hidden"}
+                                        </span>
+                                </div>
+                                <input type="hidden" name="is_active" value={String(isActive)} />
+                        </div>
+                        <div className="flex flex-col items-start justify-between gap-3 sm:items-end">
+                                {state.message ? (
+                                        <p
+                                                className={cn(
+                                                        "text-xs",
+                                                        state.status === "error"
+                                                                ? "text-red-600"
+                                                                : "text-emerald-600"
+                                                )}
+                                        >
+                                                {state.message}
+                                        </p>
+                                ) : null}
+                                <div className="flex items-center gap-2">
+                                        <Button variant="outline" type="submit" formAction={deleteSupplyItem}>
+                                                Remove
+                                        </Button>
+                                        <SaveButton>Save</SaveButton>
+                                </div>
+                        </div>
+                </form>
+        );
+}
+
+function EmptyState() {
+        return (
+                <div className="rounded-xl border border-dashed border-muted-foreground/40 p-10 text-center">
+                        <p className="font-medium">No catalog items yet</p>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                                Create a supply item to define default purchase expectations for your property.
+                        </p>
+                </div>
+        );
+}
+
+export default function SupplyCatalogTable({ items }: { items: SupplyItem[] }) {
+        if (!items.length) {
+                return <EmptyState />;
+        }
+
+        return (
+                <div className="overflow-hidden rounded-xl border border-border bg-card">
+                        <div className="hidden grid-cols-[2fr_1.25fr_1.2fr_1.2fr_1.2fr_1.5fr] gap-4 border-b px-4 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:grid">
+                                <span>Item</span>
+                                <span>Unit</span>
+                                <span>Quantity</span>
+                                <span>Split</span>
+                                <span>Status</span>
+                                <span className="text-right">Actions</span>
+                        </div>
+                        <div>
+                                {items.map((item) => (
+                                        <SupplyCatalogRow key={item.id} item={item} />
+                                ))}
+                        </div>
+                </div>
+        );
+}

--- a/app/dashboard/supplies/page.tsx
+++ b/app/dashboard/supplies/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+
+import CreateSupplyItemForm from "./components/create-supply-item-form";
+import SupplyCatalogTable from "./components/supply-catalog-table";
+import { createSupbaseServerClient } from "@/utils/supaone";
+import type { SupplyItem } from "@/types/supplies";
+
+export const metadata: Metadata = {
+        title: "Supply catalog",
+};
+
+export default async function SupplyCatalogPage() {
+        const supabase = await createSupbaseServerClient();
+        const { data, error } = await supabase
+                .from("supply_items")
+                .select("*")
+                .order("name", { ascending: true });
+
+        if (error) {
+                console.error("Failed to load supply catalog", error);
+        }
+
+        const items: SupplyItem[] = data ?? [];
+
+        return (
+                <div className="space-y-8">
+                        <div className="space-y-2">
+                                <h1 className="text-3xl font-bold tracking-tight">Supply catalog</h1>
+                                <p className="text-muted-foreground">
+                                        Configure the default units, quantities, and roommate split behavior for shared supplies.
+                                </p>
+                        </div>
+                        <CreateSupplyItemForm />
+                        <SupplyCatalogTable items={items} />
+                </div>
+        );
+}

--- a/docs/supplies.md
+++ b/docs/supplies.md
@@ -1,0 +1,50 @@
+# Supplies catalog management
+
+The supplies catalog keeps a curated list of common household items that property admins maintain for each building. These records provide a single source of truth for how bulk purchases should default across shared units.
+
+## Database model
+
+`supabase/migrations/20250709_add_supply_item_defaults.sql` establishes the schema for the `public.supply_items` table and the supporting `public.supply_default_split` enum. Key columns include:
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key generated with `gen_random_uuid()` |
+| `name` | `text` | Human-friendly item name. |
+| `category` | `text` | Category label (e.g. `cleaning`, `bathroom`). |
+| `description` | `text` | Optional context such as brand preferences or storage guidance. |
+| `unit` | `text` | The measurement unit shown to roommates (e.g. `roll`, `bottle`). |
+| `default_quantity` | `integer` | Number of units expected per restock event (defaults to `1`). |
+| `default_split` | `supply_default_split` | Enum with values `equal` or `weighted` controlling how costs are divided. |
+| `is_active` | `boolean` | When false the item remains in the catalog but is hidden from roommate ordering flows. |
+| `created_at` / `updated_at` | `timestamptz` | Timestamps maintained automatically for auditing. |
+
+The migration backfills missing columns when an existing `supply_items` table is present, coercing any legacy `default_split` data into the new enum.
+
+## TypeScript helpers
+
+`types/supplies.ts` exports strongly typed helpers for working with catalog data:
+
+- `SupplyItem`, `SupplyItemInsert`, `SupplyItemUpdate` map directly to the Supabase row/insert/update shapes.
+- `SupplyDefaultSplit` reflects the enum values and powers type-safe selects.
+- `SUPPLY_SPLIT_OPTIONS` is a UI-friendly array of label/description pairs for rendering selection controls.
+- `SupplyActionState` and `SUPPLY_ACTION_INITIAL_STATE` standardise server action responses for the create/update flows.
+
+Use these helpers when building features that need to read or mutate the catalog so that schema changes remain type-safe across the app.
+
+## Admin workflow UI
+
+`/dashboard/supplies` introduces an authenticated admin surface that stitches the pieces together:
+
+1. **Catalog overview** – The table lists every supply item with its unit, default quantity, split behaviour, and active status. Inline forms allow admins to adjust defaults in place.
+2. **Quick creation** – The “Add a catalog item” card captures new entries, validating input and resetting the form on success. `default_split` defaults to `equal` and the toggle controls whether the item is immediately visible to roommates.
+3. **Inline editing** – Changing fields and clicking “Save” persists updates through the typed Supabase client, refreshing the data grid after each mutation.
+4. **Soft removal** – “Remove” deletes the record outright when an item is no longer needed.
+
+Validation feedback displays per-field and per-row status messages so admins understand when changes succeed or need attention.
+
+## Default split semantics
+
+- **Equal** – every roommate contributes the same share towards the restock cost.
+- **Weighted** – contributions honour roommate-specific weightings configured at the unit level (for example, larger rooms cover a higher percentage).
+
+When `default_split` is set to `weighted`, downstream billing flows should query the unit’s stored weights to apportion charges; otherwise, divide the total evenly.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1414,9 +1414,48 @@ export type Database = {
             columns: ["package_id"]
             isOneToOne: false
             referencedRelation: "reusable_packages"
-            referencedColumns: ["id"]
-          },
-        ]
+          referencedColumns: ["id"]
+        },
+      ]
+      }
+      supply_items: {
+        Row: {
+          category: string
+          created_at: string
+          default_quantity: number
+          default_split: Database["public"]["Enums"]["supply_default_split"]
+          description: string | null
+          id: string
+          is_active: boolean
+          name: string
+          unit: string
+          updated_at: string
+        }
+        Insert: {
+          category?: string
+          created_at?: string
+          default_quantity?: number
+          default_split?: Database["public"]["Enums"]["supply_default_split"]
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          name: string
+          unit?: string
+          updated_at?: string
+        }
+        Update: {
+          category?: string
+          created_at?: string
+          default_quantity?: number
+          default_split?: Database["public"]["Enums"]["supply_default_split"]
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          name?: string
+          unit?: string
+          updated_at?: string
+        }
+        Relationships: []
       }
       shipping: {
         Row: {
@@ -1774,6 +1813,7 @@ export type Database = {
         | "Oceania"
         | "North America"
         | "South America"
+      supply_default_split: "equal" | "weighted"
       user_role: "user" | "admin"
     }
     CompositeTypes: {
@@ -2233,6 +2273,7 @@ export const Constants = {
         "North America",
         "South America",
       ],
+      supply_default_split: ["equal", "weighted"],
       user_role: ["user", "admin"],
     },
   },

--- a/supabase/migrations/20250709_add_supply_item_defaults.sql
+++ b/supabase/migrations/20250709_add_supply_item_defaults.sql
@@ -1,0 +1,75 @@
+-- Ensure supply_items includes unit + default split columns and supporting enum
+create type if not exists public.supply_default_split as enum ('equal', 'weighted');
+
+-- Create the supply_items table if it does not exist so deployments remain idempotent
+-- The table captures catalog metadata for common household supplies
+-- enabling admins to configure default purchasing expectations per unit.
+do $$
+begin
+        if to_regclass('public.supply_items') is null then
+                create table public.supply_items (
+                        id uuid primary key default gen_random_uuid(),
+                        created_at timestamptz not null default now(),
+                        updated_at timestamptz not null default now(),
+                        name text not null,
+                        category text not null,
+                        description text,
+                        unit text not null default 'each',
+                        default_quantity integer not null default 1,
+                        default_split public.supply_default_split not null default 'equal',
+                        is_active boolean not null default true
+                );
+        end if;
+end
+$$;
+
+-- Align existing columns with the new defaults
+alter table if exists public.supply_items
+        add column if not exists unit text not null default 'each';
+
+alter table if exists public.supply_items
+        add column if not exists default_split public.supply_default_split not null default 'equal';
+
+alter table if exists public.supply_items
+        add column if not exists default_quantity integer not null default 1;
+
+alter table if exists public.supply_items
+        add column if not exists is_active boolean not null default true;
+
+alter table if exists public.supply_items
+        add column if not exists created_at timestamptz not null default now();
+
+alter table if exists public.supply_items
+        add column if not exists updated_at timestamptz not null default now();
+
+alter table if exists public.supply_items
+        add column if not exists category text not null default 'general';
+
+alter table if exists public.supply_items
+        add column if not exists name text not null default 'Unnamed supply';
+
+-- Coerce any pre-existing default_split text column to the enum type
+-- and normalize existing rows.
+do $$
+begin
+        if exists (
+                select 1
+                from information_schema.columns
+                where table_schema = 'public'
+                  and table_name = 'supply_items'
+                  and column_name = 'default_split'
+        ) then
+                alter table public.supply_items
+                        alter column default_split type public.supply_default_split
+                        using default_split::public.supply_default_split;
+        end if;
+end
+$$;
+
+update public.supply_items
+set
+        unit = coalesce(nullif(trim(unit), ''), 'each'),
+        default_split = coalesce(default_split, 'equal'::public.supply_default_split),
+        default_quantity = greatest(default_quantity, 1),
+        updated_at = now()
+where true;

--- a/types/supplies.ts
+++ b/types/supplies.ts
@@ -1,0 +1,31 @@
+import type { Database } from "@/lib/supabase";
+
+export type SupplyDefaultSplit = Database["public"]["Enums"]["supply_default_split"];
+export type SupplyItem = Database["public"]["Tables"]["supply_items"]["Row"];
+export type SupplyItemInsert = Database["public"]["Tables"]["supply_items"]["Insert"];
+export type SupplyItemUpdate = Database["public"]["Tables"]["supply_items"]["Update"];
+
+export type SupplyActionState = {
+        status: "idle" | "success" | "error";
+        message?: string;
+        fieldErrors?: Record<string, string>;
+};
+
+export const SUPPLY_ACTION_INITIAL_STATE: SupplyActionState = { status: "idle" };
+
+export const SUPPLY_SPLIT_OPTIONS: Array<{
+        value: SupplyDefaultSplit;
+        label: string;
+        description: string;
+}> = [
+        {
+                value: "equal",
+                label: "Equal split",
+                description: "Share supply costs evenly across all roommates.",
+        },
+        {
+                value: "weighted",
+                label: "Weighted split",
+                description: "Use roommate weightings defined on the unit to apportion costs.",
+        },
+];


### PR DESCRIPTION
## Summary
- add a migration that backfills `supply_items` with `unit`, `default_quantity`, and the new `supply_default_split` enum
- expose typed helpers, server actions, and an admin dashboard surface to manage supply catalog entries and defaults
- document the supply workflow, schema, and default split behaviour for future contributors

## Testing
- pnpm lint *(fails with existing Tailwind ordering warnings in app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a0efae288328be77ab7efa4c6f00