### PR TITLE
feat: capture household activity events

### DIFF
--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,0 +1,66 @@
+import type { Json } from '@/lib/supabase';
+import { getServiceRoleClient, insertEvent } from '@/queries/events';
+import type { EventAction } from '@/queries/events';
+import { z } from 'zod';
+
+const jsonValue: z.ZodType<Json> = z.lazy(() =>
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(jsonValue), z.record(jsonValue)]),
+);
+
+const jsonRecord = z.record(jsonValue);
+
+const bookingEventSchema = z.object({
+  householdId: z.string().uuid(),
+  memberId: z.string().uuid().optional(),
+  bookingId: z.string().min(1),
+  action: z.enum(['created', 'rescheduled', 'cancelled']),
+  payload: jsonRecord.optional(),
+});
+
+export async function POST(request: Request) {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return Response.json({ error: 'Invalid JSON payload.' }, { status: 400 });
+  }
+
+  const parsed = bookingEventSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return Response.json(
+      {
+        error: 'Invalid booking event payload.',
+        details: parsed.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const { householdId, memberId, bookingId, action, payload: eventDetails } = parsed.data;
+
+  try {
+    const client = getServiceRoleClient();
+    const eventAction = `booking.${action}` as EventAction;
+    const eventPayload = {
+      bookingId,
+      actorMemberId: memberId ?? null,
+      ...(eventDetails ?? {}),
+    } satisfies Json;
+
+    const event = await insertEvent(client, {
+      household_id: householdId,
+      member_id: memberId ?? null,
+      action: eventAction,
+      entity_type: 'booking',
+      entity_id: bookingId,
+      payload: eventPayload,
+    });
+
+    return Response.json({ event }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/chores/route.ts
+++ b/app/api/chores/route.ts
@@ -1,0 +1,66 @@
+import type { Json } from '@/lib/supabase';
+import { getServiceRoleClient, insertEvent } from '@/queries/events';
+import type { EventAction } from '@/queries/events';
+import { z } from 'zod';
+
+const jsonValue: z.ZodType<Json> = z.lazy(() =>
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(jsonValue), z.record(jsonValue)]),
+);
+
+const jsonRecord = z.record(jsonValue);
+
+const choreEventSchema = z.object({
+  householdId: z.string().uuid(),
+  memberId: z.string().uuid().optional(),
+  choreId: z.string().min(1),
+  action: z.enum(['assigned', 'completed', 'skipped']),
+  payload: jsonRecord.optional(),
+});
+
+export async function POST(request: Request) {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return Response.json({ error: 'Invalid JSON payload.' }, { status: 400 });
+  }
+
+  const parsed = choreEventSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return Response.json(
+      {
+        error: 'Invalid chore event payload.',
+        details: parsed.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const { householdId, memberId, choreId, action, payload: eventDetails } = parsed.data;
+
+  try {
+    const client = getServiceRoleClient();
+    const eventAction = `chore.${action}` as EventAction;
+    const eventPayload = {
+      choreId,
+      actorMemberId: memberId ?? null,
+      ...(eventDetails ?? {}),
+    } satisfies Json;
+
+    const event = await insertEvent(client, {
+      household_id: householdId,
+      member_id: memberId ?? null,
+      action: eventAction,
+      entity_type: 'chore',
+      entity_id: choreId,
+      payload: eventPayload,
+    });
+
+    return Response.json({ event }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/payments/receipt/route.ts
+++ b/app/api/payments/receipt/route.ts
@@ -1,4 +1,6 @@
 import { PaymentReceiptEmail } from '@/components/emails/payment-receipt';
+import type { Json } from '@/lib/supabase';
+import { getServiceRoleClient, insertEvent } from '@/queries/events';
 import { Resend } from 'resend';
 import { z } from 'zod';
 
@@ -25,6 +27,8 @@ const paymentReceiptSchema = z.object({
   taxAmount: z.number().nonnegative().optional(),
   discountAmount: z.number().nonnegative().optional(),
   sendCopyTo: z.array(z.string().email()).optional(),
+  householdId: z.string().uuid(),
+  memberId: z.string().uuid().optional(),
 });
 
 export async function POST(request: Request) {
@@ -74,6 +78,8 @@ export async function POST(request: Request) {
     taxAmount,
     discountAmount,
     sendCopyTo,
+    householdId,
+    memberId,
   } = parsed.data;
 
   const resend = new Resend(resendApiKey);
@@ -82,6 +88,7 @@ export async function POST(request: Request) {
   const emailRecipients = [customerEmail, ...(sendCopyTo ?? [])];
 
   try {
+    const paymentDateToUse = paymentDate ?? new Date();
     const { data, error } = await resend.emails.send({
       from: fromAddress,
       to: emailRecipients,
@@ -91,7 +98,7 @@ export async function POST(request: Request) {
         paymentId,
         amountPaid,
         currency,
-        paymentDate: paymentDate ?? new Date(),
+        paymentDate: paymentDateToUse,
         items,
         businessName,
         supportEmail,
@@ -107,6 +114,31 @@ export async function POST(request: Request) {
       const message = error instanceof Error ? error.message : String(error);
       return Response.json({ error: message }, { status: 502 });
     }
+
+    const client = getServiceRoleClient();
+    const payload = {
+      amountPaid,
+      currency,
+      paymentDate: paymentDateToUse.toISOString(),
+      items: (items ?? []) as unknown as Json,
+      businessName,
+      supportEmail,
+      billingAddress,
+      notes,
+      subtotalAmount,
+      taxAmount,
+      discountAmount,
+      recipients: emailRecipients as unknown as Json,
+    } satisfies Json;
+
+    await insertEvent(client, {
+      household_id: householdId,
+      member_id: memberId ?? null,
+      action: 'payment.receipt_sent',
+      entity_type: 'payment',
+      entity_id: paymentId,
+      payload,
+    });
 
     return Response.json({ id: data?.id ?? null });
   } catch (error) {

--- a/docs/engineering/conventions.md
+++ b/docs/engineering/conventions.md
@@ -66,4 +66,12 @@ The repository is organized to keep infrastructure, services, clients, and share
 - Follow least-privilege principles when defining IAM roles or service accounts.
 - Ensure dependency scanning and container image scanning steps succeed before requesting review.
 
+### Household Event Stream
+
+- Persist high-signal roommate activity (payments, bookings, chores, etc.) in the `public.events` table. Columns capture multi-tenant context (`household_id`, `member_id`), a canonical action string, entity metadata, and an auditable JSON payload.
+- Action names follow a `domain.verb` convention (`payment.receipt_sent`, `booking.rescheduled`, `chore.completed`) so downstream consumers can filter and aggregate consistently.
+- `entity_type` stores the broad domain (`payment`, `booking`, `chore`) while `entity_id` links back to the originating record (Stripe payment ID, booking reference, chore slug). Leave `entity_id` `null` only when no durable record exists.
+- `payload` should remain compact—store immutable context like amounts, schedule windows, or participants; avoid duplicating large blobs when an identifier will do.
+- Application code should add events via the helpers in `queries/events.ts` to centralize Supabase wiring and ensure consistent error handling.
+
 These conventions will evolve with the platform. Propose updates via a new ADR or an update to this document and circulate it in the Platform Engineering Guild for approval.

--- a/lib/supabase-service-role.ts
+++ b/lib/supabase-service-role.ts
@@ -1,0 +1,19 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+import type { Database } from '@/lib/supabase';
+
+export function createServiceRoleClient(): SupabaseClient<Database> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error('Supabase service role environment variables are not configured.');
+  }
+
+  return createClient<Database>(url, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -411,6 +411,39 @@ export type Database = {
         }
         Relationships: []
       }
+      events: {
+        Row: {
+          action: string
+          created_at: string
+          entity_id: string | null
+          entity_type: string
+          household_id: string
+          id: number
+          member_id: string | null
+          payload: Json | null
+        }
+        Insert: {
+          action: string
+          created_at?: string
+          entity_id?: string | null
+          entity_type: string
+          household_id: string
+          id?: number
+          member_id?: string | null
+          payload?: Json | null
+        }
+        Update: {
+          action?: string
+          created_at?: string
+          entity_id?: string | null
+          entity_type?: string
+          household_id?: string
+          id?: number
+          member_id?: string | null
+          payload?: Json | null
+        }
+        Relationships: []
+      }
       business_cards: {
         Row: {
           businesscard_name: string | null

--- a/queries/events.ts
+++ b/queries/events.ts
@@ -1,0 +1,70 @@
+import { createServiceRoleClient } from '@/lib/supabase-service-role';
+import type { Database } from '@/lib/supabase';
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+
+export type EventEntityType = 'payment' | 'booking' | 'chore';
+
+export type EventAction =
+  | 'payment.receipt_sent'
+  | 'booking.created'
+  | 'booking.rescheduled'
+  | 'booking.cancelled'
+  | 'chore.assigned'
+  | 'chore.completed'
+  | 'chore.skipped';
+
+export type EventRow = Database['public']['Tables']['events']['Row'];
+export type EventInsert = Database['public']['Tables']['events']['Insert'];
+
+export function getServiceRoleClient(): TypedSupabaseClient {
+  return createServiceRoleClient();
+}
+
+export async function insertEvent(
+  client: TypedSupabaseClient,
+  event: EventInsert,
+): Promise<EventRow> {
+  const { data, error } = await client.from('events').insert(event).select().single();
+
+  if (error) {
+    throw new Error(`Failed to insert event: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function getEventsForHousehold(
+  client: TypedSupabaseClient,
+  householdId: string,
+  options: {
+    limit?: number;
+    entityType?: EventEntityType;
+    since?: string;
+  } = {},
+): Promise<EventRow[]> {
+  const { limit = 50, entityType, since } = options;
+
+  let query = client
+    .from('events')
+    .select('*')
+    .eq('household_id', householdId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (entityType) {
+    query = query.eq('entity_type', entityType);
+  }
+
+  if (since) {
+    query = query.gte('created_at', since);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Failed to fetch events: ${error.message}`);
+  }
+
+  return data ?? [];
+}
+

--- a/supabase/migrations/20250411_add_events_table.sql
+++ b/supabase/migrations/20250411_add_events_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE public.events (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  household_id uuid NOT NULL,
+  member_id uuid NULL,
+  action text NOT NULL,
+  entity_type text NOT NULL,
+  entity_id text NULL,
+  payload jsonb NULL DEFAULT '{}'::jsonb,
+  created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX events_household_id_idx ON public.events (household_id);
+CREATE INDEX events_entity_type_idx ON public.events (entity_type);
+CREATE INDEX events_created_at_idx ON public.events (created_at DESC);


### PR DESCRIPTION
## Summary
- add `events` audit log table and Supabase typings
- provide event logging helper utilities and service-role client factory
- emit booking, chore, and payment events from server actions and document event conventions

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0c4205c8328901f2d44a79d0d32