### PR TITLE
Add demo seed script for Supabase data

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ complete Supabase SSR Auth and DB integration, Zod validation, Tanstack React Qu
     - Configure the SUPABASE_WORKOS_CONNECTION_ID environment variable with the copied value
 
   - Ensure your Supabase tables match the tables and types found in '@/lib/supabase'.
-  - Add authorized development and production URL's to Supabase URL config. 
-### Run  
+  - Add authorized development and production URL's to Supabase URL config.
+  - (Optional) Seed demo data after migrations with `pnpm db:seed-demo` to populate a household, residents, amenities, a lease, and starter chores.
+
+### Run
 - Development server:
 
 ```bash
@@ -79,6 +81,13 @@ bun i && bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+
+### Demo data
+
+- After configuring your environment variables, run `pnpm db:seed-demo` to insert a sample "Harbor House" household with four members, five amenities, an active lease, and pre-assigned chores. The script uses deterministic IDs and `UPSERT` logic so it can be executed repeatedly without creating duplicates.
+- The seeding command expects `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` to be available (they are automatically loaded from `.env.local`).
+- Rerun the script any time you want to reset the portal to its initial demo state for walkthroughs or testing.
 
 
 ### Deploy on Vercel

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "db:seed-demo": "pnpm exec tsx scripts/seed-demo.ts"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.8",
@@ -111,6 +112,7 @@
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "tsx": "^4.7.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,12 +303,15 @@ importers:
       tailwindcss:
         specifier: ^3.4.0
         version: 3.4.0
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.5
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
 
 packages:
 
@@ -2762,9 +2765,6 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -3792,9 +3792,6 @@ packages:
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
 
-  es-module-lexer@1.6.0:
-    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
-
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -4158,6 +4155,9 @@ packages:
   get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   get-tsconfig@4.7.2:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
@@ -5389,10 +5389,6 @@ packages:
     resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6157,6 +6153,11 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -9346,11 +9347,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.12
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   '@types/eslint@8.56.12':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/eslint@8.56.2':
@@ -9365,8 +9366,6 @@ snapshots:
   '@types/estree@0.0.39': {}
 
   '@types/estree@1.0.5': {}
-
-  '@types/estree@1.0.7': {}
 
   '@types/estree@1.0.8': {}
 
@@ -9522,13 +9521,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))':
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9580,7 +9579,7 @@ snapshots:
       '@vue/shared': 3.4.35
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
     optional: true
 
@@ -10126,7 +10125,7 @@ snapshots:
   code-red@1.0.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -10488,8 +10487,6 @@ snapshots:
       internal-slot: 1.0.6
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
-
-  es-module-lexer@1.6.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -10978,6 +10975,10 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
 
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   get-tsconfig@4.7.2:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -11356,7 +11357,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
     optional: true
 
   is-regex@1.1.4:
@@ -12473,13 +12474,6 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  postcss@8.5.3:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    optional: true
-
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -13172,7 +13166,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -13377,6 +13371,13 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.5.4
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -13595,13 +13596,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+  vite-node@3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13616,7 +13617,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+  vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13629,12 +13630,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.0
       terser: 5.39.0
+      tsx: 4.20.5
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13652,8 +13654,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
-      vite-node: 3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)
+      vite: 7.1.6(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
+      vite-node: 3.2.4(@types/node@20.14.15)(jiti@1.21.0)(terser@5.39.0)(tsx@4.20.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -13706,7 +13708,7 @@ snapshots:
   webpack@5.93.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
@@ -13715,7 +13717,7 @@ snapshots:
       browserslist: 4.23.3
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1
-      es-module-lexer: 1.6.0
+      es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -1,0 +1,373 @@
+import { loadEnvConfig } from '@next/env'
+import { createClient, type PostgrestError } from '@supabase/supabase-js'
+
+loadEnvConfig(process.cwd())
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  console.error('Missing Supabase credentials. Ensure NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are set.')
+  process.exit(1)
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+const columnCache = new Map<string, Set<string>>()
+
+const buildingId = 'dbb43b8d-33cf-4964-afac-01721f5fd23e'
+const householdId = 'e603ebc6-d610-4d12-bc4a-6ef3e8a3aa54'
+const leaseId = 'e1330cd3-5053-4a87-9955-25ad782b9cd4'
+
+const now = new Date().toISOString()
+const iso = (date: string) => new Date(date).toISOString()
+
+const householdRow = {
+  id: householdId,
+  building_id: buildingId,
+  slug: 'harbor-house-coop',
+  name: 'Harbor House Co-op',
+  nickname: 'Unit 3A',
+  address_line1: '123 Harbor View Ave',
+  city: 'Seattle',
+  state: 'WA',
+  postal_code: '98101',
+  timezone: 'America/Los_Angeles',
+  status: 'active',
+  created_at: now,
+  updated_at: now,
+}
+
+const householdMembers = [
+  {
+    id: '7cadfc8c-20d5-4238-8933-b2653141aefa',
+    building_id: buildingId,
+    household_id: householdId,
+    full_name: 'Avery Johnson',
+    preferred_name: 'Avery',
+    email: 'avery.johnson@example.com',
+    phone: '+1-555-0101',
+    role: 'resident',
+    rent_share: 850,
+    is_primary: true,
+    move_in_date: iso('2023-08-01'),
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: 'b85e9b41-e666-41e0-be29-8757fd24ddc4',
+    building_id: buildingId,
+    household_id: householdId,
+    full_name: 'Blair Morgan',
+    preferred_name: 'Blair',
+    email: 'blair.morgan@example.com',
+    phone: '+1-555-0102',
+    role: 'resident',
+    rent_share: 800,
+    is_primary: false,
+    move_in_date: iso('2023-09-15'),
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '8b368283-ef12-4409-8e53-ec05bfa87bd4',
+    building_id: buildingId,
+    household_id: householdId,
+    full_name: 'Casey Nguyen',
+    preferred_name: 'Casey',
+    email: 'casey.nguyen@example.com',
+    phone: '+1-555-0103',
+    role: 'resident',
+    rent_share: 775,
+    is_primary: false,
+    move_in_date: iso('2023-11-01'),
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '23d79425-9089-4acf-b7f7-76f600742a5f',
+    building_id: buildingId,
+    household_id: householdId,
+    full_name: 'Devon Patel',
+    preferred_name: 'Devon',
+    email: 'devon.patel@example.com',
+    phone: '+1-555-0104',
+    role: 'resident',
+    rent_share: 775,
+    is_primary: false,
+    move_in_date: iso('2024-01-05'),
+    created_at: now,
+    updated_at: now,
+  },
+]
+
+const amenities = [
+  {
+    id: '84e20659-ce1a-4204-825d-8845c0d2cf64',
+    building_id: buildingId,
+    household_id: householdId,
+    slug: 'chef-kitchen',
+    name: 'Chef Kitchen',
+    category: 'kitchen',
+    description: 'Induction range, double ovens, and prep island stocked for meal prep nights.',
+    booking_required: true,
+    access_notes: 'Reserve via portal; wipe surfaces and run dishwasher after use.',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: 'e4e64814-42b0-49e4-87be-dd62d9e77f33',
+    building_id: buildingId,
+    household_id: householdId,
+    slug: 'laundry-station',
+    name: 'Laundry Station',
+    category: 'laundry',
+    description: 'High-capacity washer/dryer with folding table and shared supplies.',
+    booking_required: false,
+    access_notes: 'Use signup board for weekend slots; leave supplies stocked.',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '6675911b-b7cb-42b4-a464-2012043693f6',
+    building_id: buildingId,
+    household_id: householdId,
+    slug: 'media-den',
+    name: 'Media Den',
+    category: 'media',
+    description: 'Projector, surround sound, and gaming consoles for group movie nights.',
+    booking_required: true,
+    access_notes: 'Limit sessions to 3 hours; log any new streaming purchases.',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '60d209c9-c8dc-45c9-a587-55b15d918ea8',
+    building_id: buildingId,
+    household_id: householdId,
+    slug: 'rooftop-garden',
+    name: 'Rooftop Garden',
+    category: 'outdoor',
+    description: 'Shared herb planters, lounge seating, and grill with storage for tools.',
+    booking_required: false,
+    access_notes: 'Quiet hours after 10pm; log grill propane levels weekly.',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: 'e8007543-28f7-4aa0-b02d-84256d720d0d',
+    building_id: buildingId,
+    household_id: householdId,
+    slug: 'parking-bay-2',
+    name: 'Parking Bay 2',
+    category: 'parking',
+    description: 'Assigned EV-ready parking bay with shared charging schedule.',
+    booking_required: true,
+    access_notes: 'Submit vehicle plate updates before swapping cars.',
+    created_at: now,
+    updated_at: now,
+  },
+]
+
+const leaseRow = {
+  id: leaseId,
+  building_id: buildingId,
+  household_id: householdId,
+  start_date: iso('2024-01-01'),
+  end_date: iso('2024-12-31'),
+  rent_amount: 3200,
+  security_deposit: 3200,
+  rent_due_day: 1,
+  status: 'active',
+  document_url: 'https://example.com/docs/harbor-house-lease.pdf',
+  created_at: now,
+  updated_at: now,
+}
+
+const chores = [
+  {
+    id: '5b19bc91-3eca-4515-aedc-e4ebb8df1160',
+    building_id: buildingId,
+    household_id: householdId,
+    title: 'Kitchen reset',
+    description: 'Sanitize countertops, restock shared pantry bins, and run dishwasher if needed.',
+    frequency: 'weekly',
+    weekday: 'monday',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: 'a1f8a6e1-849d-42ef-a3e0-f4e1f9ec64c9',
+    building_id: buildingId,
+    household_id: householdId,
+    title: 'Trash & recycling',
+    description: 'Empty interior bins, consolidate compost, and wheel carts to curb.',
+    frequency: 'weekly',
+    weekday: 'wednesday',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '3d2637c8-9bcf-4beb-a9e5-345bee446855',
+    building_id: buildingId,
+    household_id: householdId,
+    title: 'Bathroom refresh',
+    description: 'Clean sinks, mirrors, and restock shared toiletries.',
+    frequency: 'weekly',
+    weekday: 'friday',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '2a72b418-3e83-429e-96be-7d5637bb3128',
+    building_id: buildingId,
+    household_id: householdId,
+    title: 'Common area tidy',
+    description: 'Vacuum living room, wipe coffee table, and reset mail organizer.',
+    frequency: 'weekly',
+    weekday: 'sunday',
+    created_at: now,
+    updated_at: now,
+  },
+]
+
+const assignments = [
+  {
+    id: 'c3c45c28-1ec8-4de9-a070-c7cba1bfb84f',
+    building_id: buildingId,
+    household_id: householdId,
+    chore_id: '5b19bc91-3eca-4515-aedc-e4ebb8df1160',
+    household_member_id: '7cadfc8c-20d5-4238-8933-b2653141aefa',
+    assigned_for: iso('2024-06-24'),
+    due_date: iso('2024-06-30'),
+    status: 'assigned',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '4452c3b9-08b1-4887-b4c9-05508655e3a8',
+    building_id: buildingId,
+    household_id: householdId,
+    chore_id: 'a1f8a6e1-849d-42ef-a3e0-f4e1f9ec64c9',
+    household_member_id: 'b85e9b41-e666-41e0-be29-8757fd24ddc4',
+    assigned_for: iso('2024-06-24'),
+    due_date: iso('2024-07-01'),
+    status: 'assigned',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '18cefc0b-82e9-49ad-8e1c-6a55f77b0a9b',
+    building_id: buildingId,
+    household_id: householdId,
+    chore_id: '3d2637c8-9bcf-4beb-a9e5-345bee446855',
+    household_member_id: '8b368283-ef12-4409-8e53-ec05bfa87bd4',
+    assigned_for: iso('2024-06-24'),
+    due_date: iso('2024-07-02'),
+    status: 'assigned',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: '970b2827-f099-4e1f-9ae7-3e2c6b894ed6',
+    building_id: buildingId,
+    household_id: householdId,
+    chore_id: '2a72b418-3e83-429e-96be-7d5637bb3128',
+    household_member_id: '23d79425-9089-4acf-b7f7-76f600742a5f',
+    assigned_for: iso('2024-06-24'),
+    due_date: iso('2024-07-03'),
+    status: 'assigned',
+    created_at: now,
+    updated_at: now,
+  },
+]
+
+async function getColumnSet(table: string): Promise<Set<string>> {
+  if (columnCache.has(table)) {
+    return columnCache.get(table) as Set<string>
+  }
+
+  const { data, error } = await supabase
+    .schema('information_schema')
+    .from('columns')
+    .select('column_name')
+    .eq('table_schema', 'public')
+    .eq('table_name', table)
+
+  if (error) {
+    throw new Error(`Unable to inspect columns for "${table}": ${error.message}`)
+  }
+
+  const columnNames = (data ?? [])
+    .map(entry => entry.column_name)
+    .filter((name): name is string => Boolean(name))
+
+  if (columnNames.length === 0) {
+    throw new Error(`Table "${table}" was not found. Run migrations before seeding.`)
+  }
+
+  const columnSet = new Set(columnNames)
+  columnCache.set(table, columnSet)
+  return columnSet
+}
+
+function filterRow(row: Record<string, unknown>, columns: Set<string>) {
+  return Object.fromEntries(
+    Object.entries(row).filter(([key, value]) => value !== undefined && columns.has(key))
+  )
+}
+
+function handlePostgrestError(table: string, error: PostgrestError): never {
+  if (error.code === '42P01') {
+    throw new Error(`Table "${table}" does not exist. Apply the latest Supabase migrations and try again.`)
+  }
+
+  throw new Error(`Failed to seed ${table}: ${error.message}`)
+}
+
+async function upsertRows(table: string, rows: Record<string, unknown>[], label: string) {
+  if (rows.length === 0) {
+    console.log(`Skipping ${label}; no rows provided.`)
+    return
+  }
+
+  const columns = await getColumnSet(table)
+
+  if (!columns.has('id')) {
+    throw new Error(`Table "${table}" must expose an 'id' column for deterministic seeding.`)
+  }
+
+  const payload = rows.map(row => filterRow(row, columns))
+
+  const { error } = await supabase
+    .from(table)
+    .upsert(payload, { onConflict: 'id', ignoreDuplicates: false, returning: 'minimal' })
+
+  if (error) {
+    handlePostgrestError(table, error)
+  }
+
+  console.log(`✓ Seeded ${label}`)
+}
+
+async function run() {
+  try {
+    console.log('Seeding demo household data...')
+
+    await upsertRows('households', [householdRow], 'household record')
+    await upsertRows('household_members', householdMembers, 'household members')
+    await upsertRows('amenities', amenities, 'amenities')
+    await upsertRows('leases', [leaseRow], 'lease')
+    await upsertRows('chores', chores, 'chores')
+    await upsertRows('chore_assignments', assignments, 'chore assignments')
+
+    console.log('Demo dataset ready!')
+  } catch (error) {
+    console.error((error as Error).message)
+    process.exitCode = 1
+  }
+}
+
+run()


### PR DESCRIPTION
## Summary
- add an idempotent Supabase seeding script that creates a demo household, members, amenities, lease, and chore assignments
- wire the script into the package manifest and add the tsx runtime so it can be executed via `pnpm db:seed-demo`
- document demo data usage and onboarding notes in the README

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a0c39bbc8328a45bd04d3c4a4a5f