### PR TITLE
Add compound indexes for household, chore, and invoice queries

### DIFF
--- a/docs/engineering/supabase-indexing.md
+++ b/docs/engineering/supabase-indexing.md
@@ -1,0 +1,36 @@
+# Supabase Compound Index Coverage
+
+This note tracks the multi-column indexes that support building-scoped queries across
+household membership, chore coordination, and billing history.
+
+## Index Summary
+
+| Table | Index name | Column order | Use case |
+| --- | --- | --- | --- |
+| `member_households` | `idx_member_households_building_member` | `(building_id, member_id)` | Resolve the active households for a signed-in roommate without scanning other buildings. |
+| `member_households` | `idx_member_households_building_household` | `(building_id, household_id)` | Enumerate household rosters within a building for staff dashboards. |
+| `chore_assignments` | `idx_chore_assignments_building_assigned_status_due` | `(building_id, assigned_to, status, due_date DESC)` | Show outstanding chores for a roommate ordered by due date. |
+| `chore_assignments` | `idx_chore_assignments_building_household_due` | `(building_id, household_id, due_date DESC)` | List upcoming chores for a unit during building walk-throughs. |
+| `invoices` | `idx_invoices_building_tenant_status_due` | `(building_id, tenant_id, status, due_date DESC)` | Fetch a tenant's open balances in a building without a sequential scan. |
+| `invoices` | `idx_invoices_building_household_due` | `(building_id, household_id, due_date DESC)` | Reconcile invoices per household during rent roll reviews. |
+
+## Verifying Query Plans
+
+Run the following checks on staging after deploying the migration:
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT *
+FROM public.member_households
+WHERE building_id = '00000000-0000-0000-0000-000000000000'
+  AND member_id = '00000000-0000-0000-0000-000000000000';
+```
+
+The plan should report `Index Scan using idx_member_households_building_member`. Similar
+checks for `chore_assignments` and `invoices` should highlight their respective indexes.
+This ensures Supabase queries leverage the new indexes instead of default sequential scans.
+
+## Test Coverage
+
+`pnpm test -- supabase-indexes` reads the migration and asserts that the expected index
+statements remain in place, providing lightweight protection against accidental removal.

--- a/supabase/migrations/20250116_compound_indexes.sql
+++ b/supabase/migrations/20250116_compound_indexes.sql
@@ -1,0 +1,20 @@
+-- disable-transaction
+-- Optimize member, chore, and invoice filters for building-scoped workflows
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_member_households_building_member
+  ON public.member_households (building_id, member_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_member_households_building_household
+  ON public.member_households (building_id, household_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chore_assignments_building_assigned_status_due
+  ON public.chore_assignments (building_id, assigned_to, status, due_date DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chore_assignments_building_household_due
+  ON public.chore_assignments (building_id, household_id, due_date DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invoices_building_tenant_status_due
+  ON public.invoices (building_id, tenant_id, status, due_date DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invoices_building_household_due
+  ON public.invoices (building_id, household_id, due_date DESC);

--- a/tests/supabase-indexes.test.ts
+++ b/tests/supabase-indexes.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const migrationPath = resolve(
+  __dirname,
+  "../supabase/migrations/20250116_compound_indexes.sql",
+)
+
+const migrationSql = readFileSync(migrationPath, "utf8")
+
+const expectedIndexStatements = [
+  "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_member_households_building_member",
+  "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_member_households_building_household",
+  "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chore_assignments_building_assigned_status_due",
+  "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chore_assignments_building_household_due",
+  "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invoices_building_tenant_status_due",
+  "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invoices_building_household_due",
+]
+
+describe("supabase compound index migration", () => {
+  it("is marked as non-transactional for concurrent index creation", () => {
+    expect(migrationSql.startsWith("-- disable-transaction"))
+      .toBe(true)
+  })
+
+  it("includes all expected compound index statements", () => {
+    for (const statement of expectedIndexStatements) {
+      expect(migrationSql).toContain(statement)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add concurrent compound indexes to member_households, chore_assignments, and invoices to speed up building-scoped lookups
- document the new index coverage and verification steps in the Supabase engineering notes
- add a Vitest guard that ensures the migration keeps the expected index statements

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0d177e3c083289074d505d3f990b1