### PR TITLE
Implement household document storage

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -1,596 +1,217 @@
 'use server';
 
-import { createClient } from '@/utils/supa-server-actions';
+import { randomUUID } from 'crypto';
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { z } from 'zod';
-import { documensoService } from '@/lib/documenso';
-import {
-  Document,
-  DocumentWithLease,
-  DocumentListFilters,
-  DocumentUploadRequest,
-  DocumentSigningRequest,
-  DocumentStats
-} from '@/types/documents';
 
-// Validation schemas
-const documentUploadSchema = z.object({
-  title: z.string().min(1, 'Title is required'),
-  description: z.string().optional(),
-  document_type: z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other']),
-  tenant_id: z.string().uuid().optional(),
-  unit_id: z.string().optional(),
-  requires_signature: z.boolean().default(false),
-  expires_at: z.string().datetime().optional(),
-});
+import { createClient } from '@/utils/supa-server-actions';
 
-const documentSigningSchema = z.object({
-  document_id: z.string().uuid(),
-  signer_email: z.string().email(),
-  signer_name: z.string().optional(),
-  message: z.string().optional(),
-  expires_in_days: z.number().min(1).max(365).optional(),
-});
-
-const documentListFiltersSchema = z.object({
-  status: z.array(z.enum(['draft', 'pending_signature', 'signed', 'expired', 'cancelled'])).optional(),
-  type: z.array(z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other'])).optional(),
-  tenant_id: z.string().uuid().optional(),
-  unit_id: z.string().optional(),
-  date_from: z.string().datetime().optional(),
-  date_to: z.string().datetime().optional(),
-});
-
-// Action result interface
-interface ActionResult<T = any> {
+interface ActionResult<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
-  message?: string;
 }
 
-// Get documents with optional filters
-export async function getDocumentsAction(
-  filters?: DocumentListFilters
-): Promise<ActionResult<DocumentWithLease[]>> {
+const uploadLeaseSchema = z.object({
+  unit_id: z.string().min(1, 'Household is required'),
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().optional(),
+  lease_start: z.string().optional(),
+  lease_end: z.string().optional(),
+  rent_amount: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+function normaliseDate(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+function buildMetadata(input: { rent_amount?: string | null; notes?: string | null }) {
+  const metadata: Record<string, unknown> = {};
+
+  if (input.rent_amount && input.rent_amount.trim()) {
+    const rentAmount = Number.parseFloat(input.rent_amount);
+    if (Number.isFinite(rentAmount)) {
+      metadata.rent_amount = rentAmount;
+    }
+  }
+
+  if (input.notes && input.notes.trim()) {
+    metadata.notes = input.notes.trim();
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : null;
+}
+
+function toStringValue(value: FormDataEntryValue | null) {
+  return typeof value === 'string' ? value : undefined;
+}
+
+export async function uploadHouseholdLease(formData: FormData): Promise<ActionResult> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
 
+  const file = formData.get('file');
+
+  const parsed = uploadLeaseSchema.safeParse({
+    unit_id: toStringValue(formData.get('unit_id')),
+    title: toStringValue(formData.get('title')),
+    description: toStringValue(formData.get('description')),
+    lease_start: toStringValue(formData.get('lease_start')),
+    lease_end: toStringValue(formData.get('lease_end')),
+    rent_amount: toStringValue(formData.get('rent_amount')),
+    notes: toStringValue(formData.get('notes')),
+  });
+
+  if (!parsed.success) {
+    const firstError = parsed.error.errors[0]?.message ?? 'Invalid form data provided.';
+    return { success: false, error: firstError };
+  }
+
+  if (!(file instanceof File) || file.size === 0) {
+    return { success: false, error: 'Please attach a lease PDF before submitting.' };
+  }
+
+  if (file.type && file.type !== 'application/pdf') {
+    return { success: false, error: 'Only PDF files are supported for leases.' };
+  }
+
   try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
     if (authError || !user) {
-      return { success: false, error: 'You must be logged in to view documents.' };
+      return { success: false, error: 'You must be signed in to upload documents.' };
     }
 
-    // Validate filters
-    const validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
-
-    // Determine role for scoping
-    const { data: profile } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from('profiles')
-      .select('role')
+      .select('id, role')
       .eq('id', user.id)
       .single();
 
-    let query = supabase
-      .from('documents')
-      .select(`
-        *,
-        lease:leases(*),
-        signatures:document_signatures(*),
-        access_logs:document_access_logs(*, profiles:signer_id(username, full_name))
-      `)
-      .order('created_at', { ascending: false });
-
-    // Scope non-admin/property_manager users to their own documents or ones they need to sign
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
-      query = query.or(
-        `tenant_id.eq.${user.id},signatures.signer_id.eq.${user.id}`
-      );
+    if (profileError || !profile) {
+      return { success: false, error: 'Unable to load your profile.' };
     }
 
-    // Apply filters
-    if (validatedFilters.status?.length) {
-      query = query.in('status', validatedFilters.status);
-    }
-    if (validatedFilters.type?.length) {
-      query = query.in('document_type', validatedFilters.type);
-    }
-    if (validatedFilters.tenant_id) {
-      query = query.eq('tenant_id', validatedFilters.tenant_id);
-    }
-    if (validatedFilters.unit_id) {
-      query = query.eq('unit_id', validatedFilters.unit_id);
-    }
-    if (validatedFilters.date_from) {
-      query = query.gte('created_at', validatedFilters.date_from);
-    }
-    if (validatedFilters.date_to) {
-      query = query.lte('created_at', validatedFilters.date_to);
+    if (profile.role !== 'admin') {
+      return { success: false, error: 'Only admins can upload lease documents.' };
     }
 
-    const { data: documents, error } = await query;
+    const unitId = parsed.data.unit_id.trim();
+    const filePath = `${unitId}/${randomUUID()}-${Date.now()}.pdf`;
 
-    if (error) {
-      console.error('Error fetching documents:', error);
-      return { success: false, error: 'Failed to fetch documents.' };
-    }
-
-    // Log access
-    for (const doc of documents || []) {
-      await supabase.rpc('log_document_access', {
-        p_document_id: doc.id,
-        p_action: 'view',
-        p_metadata: { source: 'documents_page' }
-      });
-    }
-
-    return { success: true, data: documents || [] };
-  } catch (error) {
-    console.error('Unexpected error in getDocumentsAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
-}
-
-// Upload and create a new document
-export async function uploadDocumentAction(
-  formData: FormData
-): Promise<ActionResult<Document>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
-
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to upload documents.' };
-    }
-
-    // Get file from form data
-    const file = formData.get('file') as File;
-    if (!file) {
-      return { success: false, error: 'No file provided.' };
-    }
-
-    // Validate other form data
-    const rawData = {
-      title: formData.get('title'),
-      description: formData.get('description'),
-      document_type: formData.get('document_type'),
-      tenant_id: formData.get('tenant_id'),
-      unit_id: formData.get('unit_id'),
-      requires_signature: formData.get('requires_signature') === 'true',
-      expires_at: formData.get('expires_at'),
-    };
-
-    const validationResult = documentUploadSchema.safeParse(rawData);
-    if (!validationResult.success) {
-      const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
-        .map(errors => errors?.join('. '))
-        .filter(Boolean)
-        .join(' ');
-      return { success: false, error: errorMessages || 'Invalid form data provided.' };
-    }
-
-    const validatedData = validationResult.data;
-
-    // Upload file to Supabase Storage
-    const fileExt = file.name.split('.').pop();
-    const fileName = `${Date.now()}-${Math.random().toString(36).substring(2)}.${fileExt}`;
-    const filePath = `documents/${fileName}`;
-
-    const { data: uploadData, error: uploadError } = await supabase.storage
-      .from('documents')
-      .upload(filePath, file);
+    const { error: uploadError } = await supabase.storage.from('docs').upload(filePath, file, {
+      contentType: 'application/pdf',
+      upsert: false,
+    });
 
     if (uploadError) {
-      console.error('Error uploading file:', uploadError);
-      return { success: false, error: 'Failed to upload file.' };
+      console.error('Error uploading lease PDF', uploadError);
+      return { success: false, error: 'Uploading the lease PDF failed. Please try again.' };
     }
 
-    // Get public URL
-    const { data: { publicUrl } } = supabase.storage
-      .from('documents')
-      .getPublicUrl(filePath);
-
-    // Create document record
-    const { data: document, error: dbError } = await supabase
-      .from('documents')
-      .insert({
-        title: validatedData.title,
-        description: validatedData.description,
-        document_type: validatedData.document_type,
-        file_url: publicUrl,
-        tenant_id: validatedData.tenant_id,
-        unit_id: validatedData.unit_id,
-        requires_signature: validatedData.requires_signature,
-        expires_at: validatedData.expires_at,
-        created_by: user.id,
-      })
-      .select()
-      .single();
-
-    if (dbError) {
-      console.error('Error creating document:', dbError);
-      // Clean up uploaded file if document creation fails
-      await supabase.storage.from('documents').remove([filePath]);
-      return { success: false, error: 'Failed to create document record.' };
-    }
-
-    // Log document creation
-    await supabase.rpc('log_document_access', {
-      p_document_id: document.id,
-      p_action: 'upload',
-      p_metadata: { file_name: file.name, file_size: file.size }
+    const leaseStart = normaliseDate(parsed.data.lease_start);
+    const leaseEnd = normaliseDate(parsed.data.lease_end);
+    const metadata = buildMetadata({
+      rent_amount: parsed.data.rent_amount,
+      notes: parsed.data.notes,
     });
 
+    const { error: insertError } = await supabase.from('household_documents').insert({
+      unit_id: unitId,
+      title: parsed.data.title.trim(),
+      description: parsed.data.description?.trim() || null,
+      file_name: file.name,
+      file_path: filePath,
+      lease_start: leaseStart,
+      lease_end: leaseEnd,
+      metadata,
+      file_size: file.size,
+      content_type: 'application/pdf',
+      uploaded_by: profile.id,
+    });
+
+    if (insertError) {
+      console.error('Error storing lease metadata', insertError);
+      await supabase.storage.from('docs').remove([filePath]);
+      return { success: false, error: 'Saving lease metadata failed. The upload was cancelled.' };
+    }
+
     revalidatePath('/documents');
-    return { success: true, data: document, message: 'Document uploaded successfully.' };
+    return { success: true };
   } catch (error) {
-    console.error('Unexpected error in uploadDocumentAction:', error);
+    console.error('Unexpected error uploading lease', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+      error: 'An unexpected error occurred while uploading the lease. Please try again.',
     };
   }
 }
 
-// Create a signing request for a document
-export async function createSigningRequestAction(
-  formData: FormData
-): Promise<ActionResult<{ signing_url?: string; envelope_id?: string }>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
-
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to create signing requests.' };
-    }
-
-    // Validate form data
-    const rawData = {
-      document_id: formData.get('document_id'),
-      signer_email: formData.get('signer_email'),
-      signer_name: formData.get('signer_name'),
-      message: formData.get('message'),
-      expires_in_days: formData.get('expires_in_days') ? parseInt(formData.get('expires_in_days') as string) : undefined,
-    };
-
-    const validationResult = documentSigningSchema.safeParse(rawData);
-    if (!validationResult.success) {
-      const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
-        .map(errors => errors?.join('. '))
-        .filter(Boolean)
-        .join(' ');
-      return { success: false, error: errorMessages || 'Invalid form data provided.' };
-    }
-
-    const validatedData = validationResult.data;
-
-    // Get document details
-    const { data: document, error: docError } = await supabase
-      .from('documents')
-      .select('*')
-      .eq('id', validatedData.document_id)
-      .single();
-
-    if (docError || !document) {
-      return { success: false, error: 'Document not found.' };
-    }
-
-    // Check permissions (user must be property manager or admin, or document owner)
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .single();
-
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin' && document.tenant_id !== user.id) {
-      return { success: false, error: 'You do not have permission to create signing requests for this document.' };
-    }
-
-    // Download file from Supabase Storage
-    const fileResponse = await fetch(document.file_url!);
-    if (!fileResponse.ok) {
-      return { success: false, error: 'Failed to download document file.' };
-    }
-
-    const fileBlob = await fileResponse.blob();
-    const file = new File([fileBlob], `${document.title}.pdf`, { type: 'application/pdf' });
-
-    // Upload file to Documenso to obtain documentDataId
-    const uploadResult = await documensoService.uploadDocument(file);
-
-    // Get tenant emails for lease documents
-    let tenantEmails = [validatedData.signer_email];
-    let tenantNames = [validatedData.signer_name];
-    let tenantProfiles: { id: string; email: string | null; full_name: string | null }[] = [];
-
-    if (document.document_type === 'lease') {
-      const { data: lease } = await supabase
-        .from('leases')
-        .select('tenant_ids')
-        .eq('document_id', document.id)
-        .single();
-
-      if (lease) {
-        const { data: profiles } = await supabase
-          .from('profiles')
-          .select('id, email, full_name')
-          .in('id', lease.tenant_ids);
-
-        tenantProfiles = profiles || [];
-        tenantEmails = tenantProfiles.map(p => p.email || '').filter(Boolean);
-        tenantNames = tenantProfiles.map(p => p.full_name || '');
-      }
-    }
-
-    // Create signing request via Documenso
-    const signingResult = await documensoService.createDocumentSigningEnvelope({
-      title: document.title,
-      documentDataId: uploadResult.documentDataId,
-      recipients: tenantEmails.map((email, index) => ({
-        email,
-        name: tenantNames[index] || email.split('@')[0],
-        role: 'SIGNER' as const,
-        signingOrder: index + 1,
-      })),
-      message: validatedData.message,
-      expiresAt: validatedData.expires_in_days
-        ? new Date(Date.now() + validatedData.expires_in_days * 24 * 60 * 60 * 1000).toISOString()
-        : undefined,
-    });
-
-    if (!signingResult) {
-      return { success: false, error: 'Failed to create signing request.' };
-    }
-
-    // Update document with Documenso envelope ID
-    await supabase
-      .from('documents')
-      .update({
-        documenso_envelope_id: signingResult.id,
-        status: 'pending_signature'
-      })
-      .eq('id', document.id);
-
-    // Create signature records with signer_id mapping
-    const emailToProfileId = new Map<string, string>();
-    if (tenantProfiles.length === 0) {
-      // Fallback: try to resolve signer from provided email
-      const { data: maybeProfile } = await supabase
-        .from('profiles')
-        .select('id, email')
-        .eq('email', validatedData.signer_email)
-        .single();
-      if (maybeProfile?.id && maybeProfile.email) {
-        emailToProfileId.set(maybeProfile.email, maybeProfile.id);
-      }
-    } else {
-      for (const p of tenantProfiles) {
-        if (p.email && p.id) emailToProfileId.set(p.email, p.id);
-      }
-    }
-
-    for (const recipient of signingResult.recipients) {
-      const signerId = emailToProfileId.get(recipient.email);
-      if (!signerId) {
-        continue; // skip recipients we cannot map to a user
-      }
-      await supabase
-        .from('document_signatures')
-        .insert({
-          document_id: document.id,
-          signer_id: signerId,
-          signer_email: recipient.email,
-          signer_name: recipient.name || null,
-          status: 'pending',
-          documenso_signature_id: recipient.id,
-        });
-    }
-
-    // Log signing request creation
-    await supabase.rpc('log_document_access', {
-      p_document_id: document.id,
-      p_action: 'signing_request_created',
-      p_metadata: { envelope_id: signingResult.id, recipients: tenantEmails }
-    });
-
-    revalidatePath('/documents');
-    return {
-      success: true,
-      data: { envelope_id: signingResult.id },
-      message: 'Signing request created successfully.'
-    };
-  } catch (error) {
-    console.error('Unexpected error in createSigningRequestAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
-}
-
-// Sign a document (mark as signed)
-export async function signDocumentAction(
+export async function createLeaseDownloadLink(
   documentId: string,
-  signatureData?: Record<string, any>
-): Promise<ActionResult> {
+): Promise<ActionResult<{ url: string }>> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
 
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to sign documents.' };
-    }
-
-    // Get signature record
-    const { data: signature, error: sigError } = await supabase
-      .from('document_signatures')
-      .select('*')
-      .eq('document_id', documentId)
-      .eq('signer_id', user.id)
-      .single();
-
-    if (sigError || !signature) {
-      return { success: false, error: 'Signature record not found.' };
-    }
-
-    // Update signature
-    await supabase
-      .from('document_signatures')
-      .update({
-        status: 'signed',
-        signed_at: new Date().toISOString(),
-        signature_data: signatureData,
-      })
-      .eq('id', signature.id);
-
-    // Check if all signatures are complete
-    const { data: allSignatures } = await supabase
-      .from('document_signatures')
-      .select('status')
-      .eq('document_id', documentId);
-
-    const allSigned = allSignatures?.every(sig => sig.status === 'signed');
-
-    if (allSigned) {
-      // Update document status
-      await supabase
-        .from('documents')
-        .update({
-          status: 'signed',
-          signed_at: new Date().toISOString(),
-        })
-        .eq('id', documentId);
-    }
-
-    // Log signing action
-    await supabase.rpc('log_document_access', {
-      p_document_id: documentId,
-      p_action: 'signed',
-      p_metadata: signatureData
-    });
-
-    revalidatePath('/documents');
-    return { success: true, message: 'Document signed successfully.' };
-  } catch (error) {
-    console.error('Unexpected error in signDocumentAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
+  if (!documentId) {
+    return { success: false, error: 'Invalid document identifier.' };
   }
-}
-
-// Get Documenso signing URL for the current user for a document
-export async function getSigningUrlAction(
-  documentId: string
-): Promise<ActionResult<{ signing_url: string }>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
 
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
     if (authError || !user) {
-      return { success: false, error: 'You must be logged in to sign documents.' };
+      return { success: false, error: 'You must be signed in to download documents.' };
     }
 
-    // Get document with envelope id
-    const { data: document } = await supabase
-      .from('documents')
-      .select('id, documenso_envelope_id')
+    const { data: document, error: documentError } = await supabase
+      .from('household_documents')
+      .select('file_path')
       .eq('id', documentId)
       .single();
 
-    if (!document?.documenso_envelope_id) {
-      return { success: false, error: 'Signing session is not available for this document.' };
+    if (documentError || !document) {
+      console.error('Unable to locate household document', documentError);
+      return { success: false, error: 'We could not find that document.' };
     }
 
-    // Find the signature record for this user
-    const { data: signature } = await supabase
-      .from('document_signatures')
-      .select('id, documenso_signature_id')
-      .eq('document_id', documentId)
-      .eq('signer_id', user.id)
-      .single();
+    const { data: signed, error: signedError } = await supabase.storage
+      .from('docs')
+      .createSignedUrl(document.file_path, 300);
 
-    if (!signature?.documenso_signature_id) {
-      return { success: false, error: 'No signing request found for your account.' };
+    if (signedError || !signed?.signedUrl) {
+      console.error('Unable to create signed lease URL', signedError);
+      return { success: false, error: 'Failed to create a download link.' };
     }
 
-    // Get signing URL from Documenso
-    const url = await documensoService.getSigningUrl(
-      document.documenso_envelope_id,
-      signature.documenso_signature_id
-    );
-
-    return { success: true, data: { signing_url: url } };
+    return { success: true, data: { url: signed.signedUrl } };
   } catch (error) {
-    console.error('Unexpected error in getSigningUrlAction:', error);
+    console.error('Unexpected error creating lease download link', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
-}
-
-// Get document statistics
-export async function getDocumentStatsAction(): Promise<ActionResult<DocumentStats>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
-
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to view document statistics.' };
-    }
-
-    // Get stats based on user role
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .single();
-
-    let query = supabase.from('documents').select('status');
-
-    // If not admin/property manager, filter by tenant_id
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
-      query = query.eq('tenant_id', user.id);
-    }
-
-    const { data: documents, error } = await query;
-
-    if (error) {
-      console.error('Error fetching document stats:', error);
-      return { success: false, error: 'Failed to fetch document statistics.' };
-    }
-
-    const stats: DocumentStats = {
-      total_documents: documents?.length || 0,
-      pending_signatures: documents?.filter(d => d.status === 'pending_signature').length || 0,
-      signed_documents: documents?.filter(d => d.status === 'signed').length || 0,
-      expired_documents: documents?.filter(d => d.status === 'expired').length || 0,
-      draft_documents: documents?.filter(d => d.status === 'draft').length || 0,
-    };
-
-    return { success: true, data: stats };
-  } catch (error) {
-    console.error('Unexpected error in getDocumentStatsAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+      error: 'Something went wrong while preparing your download.',
     };
   }
 }

--- a/app/documents/components/download-document-button.tsx
+++ b/app/documents/components/download-document-button.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useTransition } from 'react';
+import { Download } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+
+import { createLeaseDownloadLink } from '../actions';
+
+interface DownloadDocumentButtonProps {
+  documentId: string;
+}
+
+export function DownloadDocumentButton({ documentId }: DownloadDocumentButtonProps) {
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+
+  const handleDownload = () => {
+    startTransition(async () => {
+      const result = await createLeaseDownloadLink(documentId);
+
+      if (!result.success || !result.data?.url) {
+        toast({
+          title: 'Download failed',
+          description: result.error ?? 'We could not prepare that download link. Please try again.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      window.location.assign(result.data.url);
+    });
+  };
+
+  return (
+    <Button type="button" variant="secondary" onClick={handleDownload} disabled={isPending}>
+      <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+      {isPending ? 'Preparing…' : 'Download'}
+    </Button>
+  );
+}

--- a/app/documents/components/household-document-list.tsx
+++ b/app/documents/components/household-document-list.tsx
@@ -1,0 +1,197 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+
+import type { Database } from '@/lib/supabase';
+import type { HouseholdLeaseDocument } from '@/types/documents';
+
+import { DownloadDocumentButton } from './download-document-button';
+
+type HouseholdDocumentRow = Database['public']['Tables']['household_documents']['Row'];
+type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
+type DocumentWithUploader = HouseholdDocumentRow &
+  HouseholdLeaseDocument & {
+    uploader?: Pick<ProfileRow, 'full_name' | 'email'> | null;
+  };
+
+interface HouseholdDocumentListProps {
+  documents: DocumentWithUploader[];
+  selectedUnitId?: string;
+  isAdmin?: boolean;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return 'Not provided';
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatDateTime(value: string) {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatFileSize(size?: number | null) {
+  if (!size || size <= 0) {
+    return 'Unknown size';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let index = 0;
+  let value = size;
+
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+
+  return `${value.toFixed(value >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+function extractMetadata(metadata: HouseholdLeaseDocument['metadata']) {
+  const data = (metadata ?? {}) as Record<string, unknown>;
+
+  let rentAmount: number | null = null;
+  if (typeof data.rent_amount === 'number') {
+    rentAmount = data.rent_amount;
+  } else if (typeof data.rent_amount === 'string') {
+    const parsed = Number.parseFloat(data.rent_amount);
+    rentAmount = Number.isFinite(parsed) ? parsed : null;
+  }
+
+  const notes = typeof data.notes === 'string' ? data.notes : undefined;
+
+  return { rentAmount, notes };
+}
+
+export function HouseholdDocumentList({
+  documents,
+  selectedUnitId,
+  isAdmin,
+}: HouseholdDocumentListProps) {
+  if (!selectedUnitId) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>No household selected</CardTitle>
+          <CardDescription>
+            {isAdmin
+              ? 'Choose a household to review its lease archive.'
+              : 'Ask your property manager to link your profile to a household to access shared documents.'}
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (documents.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>No documents yet</CardTitle>
+          <CardDescription>
+            {isAdmin
+              ? 'Upload the first lease PDF so residents have a single source of truth.'
+              : 'Your household has not uploaded any lease PDFs yet.'}
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {documents.map((document) => {
+        const { rentAmount, notes } = extractMetadata(document.metadata);
+
+        return (
+          <Card key={document.id} className="border border-muted">
+            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <CardTitle className="text-lg font-semibold">{document.title}</CardTitle>
+                <CardDescription className="flex flex-col text-sm text-muted-foreground sm:flex-row sm:items-center sm:gap-2">
+                  <span>{document.file_name}</span>
+                  <span className="hidden sm:inline">•</span>
+                  <span>{formatFileSize(document.file_size)}</span>
+                </CardDescription>
+              </div>
+              <DownloadDocumentButton documentId={document.id} />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {document.description ? (
+                <p className="text-sm text-muted-foreground">{document.description}</p>
+              ) : null}
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <dl className="space-y-1">
+                  <dt className="text-xs uppercase text-muted-foreground">Lease start</dt>
+                  <dd className="font-medium">{formatDate(document.lease_start)}</dd>
+                </dl>
+                <dl className="space-y-1">
+                  <dt className="text-xs uppercase text-muted-foreground">Lease end</dt>
+                  <dd className="font-medium">{formatDate(document.lease_end)}</dd>
+                </dl>
+                <dl className="space-y-1">
+                  <dt className="text-xs uppercase text-muted-foreground">Uploaded on</dt>
+                  <dd className="font-medium">{formatDateTime(document.uploaded_at)}</dd>
+                </dl>
+                <dl className="space-y-1">
+                  <dt className="text-xs uppercase text-muted-foreground">Uploaded by</dt>
+                  <dd className="font-medium">
+                    {document.uploader?.full_name || document.uploader?.email || 'Unknown user'}
+                  </dd>
+                </dl>
+              </div>
+
+              {rentAmount !== null || notes ? <Separator /> : null}
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                {rentAmount !== null ? (
+                  <dl className="space-y-1">
+                    <dt className="text-xs uppercase text-muted-foreground">Monthly rent</dt>
+                    <dd className="font-medium">
+                      {new Intl.NumberFormat(undefined, {
+                        style: 'currency',
+                        currency: 'USD',
+                        maximumFractionDigits: 0,
+                      }).format(rentAmount)}
+                    </dd>
+                  </dl>
+                ) : null}
+                {notes ? (
+                  <div className="space-y-1">
+                    <p className="text-xs uppercase text-muted-foreground">Notes</p>
+                    <p className="text-sm text-muted-foreground">{notes}</p>
+                  </div>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/documents/components/household-selector.tsx
+++ b/app/documents/components/household-selector.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+interface HouseholdSelectorProps {
+  availableUnits: { id: string; label?: string }[];
+  selectedUnit?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function HouseholdSelector({
+  availableUnits,
+  selectedUnit,
+  disabled,
+  className,
+}: HouseholdSelectorProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const options = useMemo(() => {
+    const deduped = new Map<string, { id: string; label?: string }>();
+
+    availableUnits.forEach((unit) => {
+      if (unit.id) {
+        deduped.set(unit.id, unit);
+      }
+    });
+
+    if (selectedUnit && !deduped.has(selectedUnit)) {
+      deduped.set(selectedUnit, { id: selectedUnit, label: selectedUnit });
+    }
+
+    return Array.from(deduped.values());
+  }, [availableUnits, selectedUnit]);
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  const handleChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (value) {
+      params.set('unit', value);
+    } else {
+      params.delete('unit');
+    }
+
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  };
+
+  const currentValue = selectedUnit ?? options[0]?.id ?? '';
+
+  return (
+    <div className={className}>
+      <Label htmlFor="household-select">Household</Label>
+      <Select
+        value={currentValue}
+        onValueChange={handleChange}
+        disabled={disabled || options.length === 0}
+      >
+        <SelectTrigger id="household-select">
+          <SelectValue placeholder="Choose a household" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.id} value={option.id}>
+              {option.label ?? option.id}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/app/documents/components/upload-lease-form.tsx
+++ b/app/documents/components/upload-lease-form.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useRef, useState, useTransition } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/use-toast';
+
+import { uploadHouseholdLease } from '../actions';
+
+interface UploadLeaseFormProps {
+  availableUnits: string[];
+  defaultUnitId?: string;
+}
+
+export function UploadLeaseForm({ availableUnits, defaultUnitId }: UploadLeaseFormProps) {
+  const { toast } = useToast();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const datalistId = availableUnits.length > 0 ? 'household-unit-options' : undefined;
+
+  const handleSubmit = (formData: FormData) => {
+    setError(null);
+    startTransition(async () => {
+      const result = await uploadHouseholdLease(formData);
+
+      if (!result.success) {
+        setError(result.error ?? 'Uploading the lease failed. Please try again.');
+        return;
+      }
+
+      toast({
+        title: 'Lease uploaded',
+        description: 'Household members can now download the updated lease PDF.',
+      });
+      formRef.current?.reset();
+    });
+  };
+
+  return (
+    <form
+      ref={formRef}
+      action={handleSubmit}
+      className="space-y-6"
+      encType="multipart/form-data"
+    >
+      <div className="grid gap-2">
+        <Label htmlFor="unit_id">Household ID</Label>
+        <Input
+          id="unit_id"
+          name="unit_id"
+          defaultValue={defaultUnitId ?? ''}
+          required
+          list={datalistId}
+          placeholder="unit-uuid-or-slug"
+        />
+        {datalistId ? (
+          <datalist id={datalistId}>
+            {availableUnits.map((unit) => (
+              <option key={unit} value={unit} />
+            ))}
+          </datalist>
+        ) : null}
+        <p className="text-xs text-muted-foreground">
+          Files are stored per household inside the secure docs bucket. Use the exact unit identifier
+          that residents see in their profile.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="title">Lease title</Label>
+        <Input id="title" name="title" defaultValue="Lease Agreement" required />
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="description">Description</Label>
+        <Textarea
+          id="description"
+          name="description"
+          placeholder="Add context such as renewal terms or roommate coverage."
+          rows={3}
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-2">
+          <Label htmlFor="lease_start">Lease start</Label>
+          <Input id="lease_start" name="lease_start" type="date" />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="lease_end">Lease end</Label>
+          <Input id="lease_end" name="lease_end" type="date" />
+        </div>
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="rent_amount">Monthly rent</Label>
+        <Input
+          id="rent_amount"
+          name="rent_amount"
+          type="number"
+          min="0"
+          step="0.01"
+          placeholder="e.g. 4200"
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="notes">Private notes</Label>
+        <Textarea
+          id="notes"
+          name="notes"
+          placeholder="Optional notes for property managers or renewal reminders."
+          rows={3}
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="file">Lease PDF</Label>
+        <Input id="file" name="file" type="file" accept="application/pdf" required />
+        <p className="text-xs text-muted-foreground">Only PDF uploads are allowed. Maximum size 25 MB.</p>
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <Button type="submit" className="w-full" disabled={isPending}>
+        {isPending ? 'Uploading…' : 'Upload lease'}
+      </Button>
+    </form>
+  );
+}

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,170 +1,201 @@
-import { Suspense } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { FileText, Users, Clock, Upload } from 'lucide-react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { UploadDocumentDialog } from "./components/upload-document-dialog";
-import { DocumentsStats } from "./components/documents-stats";
-import { DocumentsList } from "./components/documents-list";
-import { DocumentsFilters } from "./components/documents-filters";
-import { DocumentListFilters } from '@/types/documents';
+import { redirect } from 'next/navigation';
 
-export default function DocumentsPage() {
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import type { Database } from '@/lib/supabase';
+import { createClient } from '@/utils/supabase/server';
+
+import { HouseholdDocumentList } from './components/household-document-list';
+import { HouseholdSelector } from './components/household-selector';
+import { UploadLeaseForm } from './components/upload-lease-form';
+
+type HouseholdDocumentRow = Database['public']['Tables']['household_documents']['Row'];
+type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
+type DocumentWithUploader = HouseholdDocumentRow & {
+  uploader?: Pick<ProfileRow, 'full_name' | 'email'> | null;
+};
+
+type DocumentsPageProps = {
+  searchParams?: { [key: string]: string | string[] | undefined };
+};
+
+function toSingleValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function formatHouseholdLabel(unitId: string) {
+  if (!unitId) {
+    return 'Household';
+  }
+
+  return `Household ${unitId.slice(0, 8)}`;
+}
+
+export default async function DocumentsPage({ searchParams }: DocumentsPageProps) {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/auth');
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, role, unit_id, full_name, email')
+    .eq('id', user.id)
+    .single();
+
+  if (profileError || !profile) {
+    return (
+      <div className="container max-w-4xl py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile required</CardTitle>
+            <CardDescription>
+              We could not load your household information. Please update your profile and try again.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  const isAdmin = profile.role === 'admin';
+
+  const unitCandidates = new Set<string>();
+  if (profile.unit_id) {
+    unitCandidates.add(profile.unit_id);
+  }
+
+  const { data: knownUnits } = await supabase
+    .from('household_documents')
+    .select('unit_id')
+    .not('unit_id', 'is', null);
+
+  knownUnits?.forEach((row) => {
+    if (row.unit_id) {
+      unitCandidates.add(row.unit_id);
+    }
+  });
+
+  const availableUnitIds = Array.from(unitCandidates).filter(Boolean).sort();
+
+  const requestedUnit = toSingleValue(searchParams?.unit);
+
+  let selectedUnitId: string | undefined;
+  if (isAdmin) {
+    selectedUnitId = requestedUnit || availableUnitIds[0];
+  } else {
+    selectedUnitId = profile.unit_id ?? undefined;
+  }
+
+  if (selectedUnitId && !availableUnitIds.includes(selectedUnitId)) {
+    availableUnitIds.push(selectedUnitId);
+    availableUnitIds.sort();
+  }
+
+  const unitOptions = availableUnitIds.map((unitId) => ({
+    id: unitId,
+    label: formatHouseholdLabel(unitId),
+  }));
+
+  let documents: DocumentWithUploader[] = [];
+
+  if (selectedUnitId) {
+    const { data: rows, error: documentError } = await supabase
+      .from('household_documents')
+      .select(
+        `
+          id,
+          unit_id,
+          title,
+          description,
+          file_name,
+          file_path,
+          lease_start,
+          lease_end,
+          metadata,
+          file_size,
+          content_type,
+          uploaded_by,
+          uploaded_at,
+          uploader:profiles!household_documents_uploaded_by_fkey(full_name, email)
+        `,
+      )
+      .eq('unit_id', selectedUnitId)
+      .order('uploaded_at', { ascending: false });
+
+    if (documentError) {
+      console.error('Error loading household documents', documentError);
+    }
+
+    documents = (rows ?? []) as DocumentWithUploader[];
+  }
+
+  const showHouseholdSelector = isAdmin && unitOptions.length > 0;
+
   return (
-    <div className="container max-w-7xl space-y-8 py-8">
+    <div className="container max-w-6xl space-y-8 py-10">
       <header className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div className="space-y-2">
-            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Documents</h1>
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Household documents</h1>
             <p className="text-base text-muted-foreground sm:text-lg">
-              Manage leases, agreements, and household documents with secure signing and version control.
+              Review lease PDFs stored in the docs bucket and keep every roommate on the same page.
             </p>
           </div>
-          <UploadDocumentDialog />
+          {showHouseholdSelector ? (
+            <HouseholdSelector
+              availableUnits={unitOptions}
+              selectedUnit={selectedUnitId}
+              className="w-full max-w-xs"
+            />
+          ) : null}
         </div>
+        {!isAdmin && selectedUnitId ? (
+          <p className="text-sm text-muted-foreground">
+            Documents are scoped to <span className="font-medium">{formatHouseholdLabel(selectedUnitId)}</span>.
+          </p>
+        ) : null}
         <Separator />
       </header>
 
-      {/* Stats Overview */}
-      <Suspense fallback={<div className="grid gap-4 md:grid-cols-4">
-        {[...Array(4)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader className="pb-2">
-              <div className="h-4 bg-muted rounded w-3/4"></div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-8 bg-muted rounded w-1/2"></div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>}>
-        <DocumentsStats />
-      </Suspense>
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <section className="space-y-4">
+          <HouseholdDocumentList
+            documents={documents}
+            selectedUnitId={selectedUnitId}
+            isAdmin={isAdmin}
+          />
+        </section>
 
-      {/* Main Content Tabs */}
-      <Tabs defaultValue="all" className="space-y-6">
-        <div className="flex items-center justify-between">
-          <TabsList className="grid w-full max-w-md grid-cols-4">
-            <TabsTrigger value="all">All</TabsTrigger>
-            <TabsTrigger value="leases">Leases</TabsTrigger>
-            <TabsTrigger value="pending">Pending</TabsTrigger>
-            <TabsTrigger value="signed">Signed</TabsTrigger>
-          </TabsList>
-          <DocumentsFilters />
-        </div>
-
-        <TabsContent value="all" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{}} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="leases" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ type: ['lease'] }} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="pending" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['pending_signature'] }} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="signed" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['signed'] }} />
-          </Suspense>
-        </TabsContent>
-      </Tabs>
-
-      {/* Feature Highlights */}
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center space-x-2">
-              <FileText className="h-5 w-5 text-primary" />
-              <CardTitle className="text-sm font-medium">Secure Storage</CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-xs">
-              Encrypted document storage with access logging for compliance.
-            </CardDescription>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center space-x-2">
-              <Users className="h-5 w-5 text-primary" />
-              <CardTitle className="text-sm font-medium">Multi-Signature</CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-xs">
-              Collect signatures from all tenants and property managers.
-            </CardDescription>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center space-x-2">
-              <Clock className="h-5 w-5 text-primary" />
-              <CardTitle className="text-sm font-medium">Version History</CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-xs">
-              Track document changes with complete audit trails.
-            </CardDescription>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center space-x-2">
-              <Upload className="h-5 w-5 text-primary" />
-              <CardTitle className="text-sm font-medium">Bulk Operations</CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <CardDescription className="text-xs">
-              Upload multiple documents and manage permissions at scale.
-            </CardDescription>
-          </CardContent>
-        </Card>
+        {isAdmin ? (
+          <aside>
+            <Card>
+              <CardHeader>
+                <CardTitle>Upload lease PDF</CardTitle>
+                <CardDescription>
+                  Admin uploads are limited to PDF files and automatically scoped to the selected household.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <UploadLeaseForm
+                  availableUnits={availableUnitIds}
+                  defaultUnitId={selectedUnitId}
+                />
+              </CardContent>
+            </Card>
+          </aside>
+        ) : null}
       </div>
-    </div>
-  );
-}
-
-function DocumentsListSkeleton() {
-  return (
-    <div className="space-y-4">
-      {[...Array(5)].map((_, i) => (
-        <Card key={i} className="animate-pulse">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <div className="space-y-2">
-                <div className="h-5 bg-muted rounded w-48"></div>
-                <div className="h-4 bg-muted rounded w-32"></div>
-              </div>
-              <div className="h-6 bg-muted rounded w-20"></div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between">
-              <div className="h-4 bg-muted rounded w-24"></div>
-              <div className="flex space-x-2">
-                <div className="h-8 bg-muted rounded w-16"></div>
-                <div className="h-8 bg-muted rounded w-16"></div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
     </div>
   );
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1665,6 +1665,62 @@ export type Database = {
         }
         Relationships: []
       }
+      household_documents: {
+        Row: {
+          id: string
+          unit_id: string
+          title: string
+          description: string | null
+          file_name: string
+          file_path: string
+          lease_start: string | null
+          lease_end: string | null
+          metadata: Json | null
+          file_size: number | null
+          content_type: string | null
+          uploaded_by: string | null
+          uploaded_at: string
+        }
+        Insert: {
+          id?: string
+          unit_id: string
+          title: string
+          description?: string | null
+          file_name: string
+          file_path: string
+          lease_start?: string | null
+          lease_end?: string | null
+          metadata?: Json | null
+          file_size?: number | null
+          content_type?: string | null
+          uploaded_by?: string | null
+          uploaded_at?: string
+        }
+        Update: {
+          id?: string
+          unit_id?: string
+          title?: string
+          description?: string | null
+          file_name?: string
+          file_path?: string
+          lease_start?: string | null
+          lease_end?: string | null
+          metadata?: Json | null
+          file_size?: number | null
+          content_type?: string | null
+          uploaded_by?: string | null
+          uploaded_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "household_documents_uploaded_by_fkey"
+            columns: ["uploaded_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       document_signatures: {
         Row: {
           id: string

--- a/supabase/migrations/20250207_household_documents.sql
+++ b/supabase/migrations/20250207_household_documents.sql
@@ -1,0 +1,135 @@
+-- Create a table to track household lease documents stored in the docs bucket
+CREATE TABLE IF NOT EXISTS public.household_documents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  unit_id UUID NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  file_name TEXT NOT NULL,
+  file_path TEXT NOT NULL,
+  lease_start DATE,
+  lease_end DATE,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  file_size BIGINT,
+  content_type TEXT,
+  uploaded_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  uploaded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Helpful indexes for filtering by household and ordering
+CREATE INDEX IF NOT EXISTS household_documents_unit_uploaded_at_idx
+  ON public.household_documents (unit_id, uploaded_at DESC);
+
+-- Enable row level security
+ALTER TABLE public.household_documents ENABLE ROW LEVEL SECURITY;
+
+-- Allow members of a household (or admins) to view documents for their unit
+CREATE POLICY "Household members can view lease documents" ON public.household_documents
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE id = auth.uid()
+        AND (
+          role = 'admin'
+          OR (unit_id IS NOT NULL AND unit_id = household_documents.unit_id)
+        )
+    )
+  );
+
+-- Restrict inserts/updates/deletes to admins
+CREATE POLICY "Admins can insert lease documents" ON public.household_documents
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins can update lease documents" ON public.household_documents
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins can delete lease documents" ON public.household_documents
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+-- Ensure the docs bucket exists
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('docs', 'docs', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+-- Harden access controls for the docs bucket
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Household members can download docs" ON storage.objects
+  FOR SELECT
+  USING (
+    bucket_id = 'docs'
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE id = auth.uid() AND role = 'admin'
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE id = auth.uid()
+          AND unit_id IS NOT NULL
+          AND unit_id::text = split_part(objects.name, '/', 1)
+      )
+    )
+  );
+
+CREATE POLICY "Admins can upload docs" ON storage.objects
+  FOR INSERT
+  WITH CHECK (
+    bucket_id = 'docs'
+    AND EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins can update docs" ON storage.objects
+  FOR UPDATE
+  USING (
+    bucket_id = 'docs'
+    AND EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  )
+  WITH CHECK (
+    bucket_id = 'docs'
+    AND EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins can delete docs" ON storage.objects
+  FOR DELETE
+  USING (
+    bucket_id = 'docs'
+    AND EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -4,6 +4,27 @@ export type DocumentStatus = 'draft' | 'pending_signature' | 'signed' | 'expired
 
 export type SignatureStatus = 'pending' | 'signed' | 'declined' | 'expired';
 
+export interface HouseholdLeaseDocument {
+  id: string;
+  unit_id: string;
+  title: string;
+  description?: string | null;
+  file_name: string;
+  file_path: string;
+  lease_start?: string | null;
+  lease_end?: string | null;
+  metadata?: Record<string, any> | null;
+  file_size?: number | null;
+  content_type?: string | null;
+  uploaded_by?: string | null;
+  uploaded_at: string;
+  download_url?: string;
+  uploader?: {
+    full_name?: string | null;
+    email?: string | null;
+  } | null;
+}
+
 export interface Document {
   id: string;
   created_at: string;


### PR DESCRIPTION
## Summary
- replace the documents page with a household-scoped lease list and admin tools
- add server actions and components to upload and download docs via the docs bucket
- introduce a Supabase migration, types, and RLS policies for household_documents

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d14dd0688328b8c65e220c171961