### PR TITLE
Redesign tenant profile settings with avatar upload

### DIFF
--- a/app/(tenant)/settings/profile/page.tsx
+++ b/app/(tenant)/settings/profile/page.tsx
@@ -1,0 +1,2 @@
+export { metadata } from "@/src/app/(tenant)/settings/profile/page";
+export { default } from "@/src/app/(tenant)/settings/profile/page";

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1004,6 +1004,27 @@ export type Database = {
         }
         Relationships: []
       }
+      households: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       members_table: {
         Row: {
           created_at: string
@@ -1028,6 +1049,36 @@ export type Database = {
           member_id?: string
           name?: string | null
           password?: string
+        }
+        Relationships: []
+      }
+      members: {
+        Row: {
+          avatar_url: string | null
+          created_at: string | null
+          default_household_id: string | null
+          full_name: string | null
+          id: string
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          avatar_url?: string | null
+          created_at?: string | null
+          default_household_id?: string | null
+          full_name?: string | null
+          id?: string
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          avatar_url?: string | null
+          created_at?: string | null
+          default_household_id?: string | null
+          full_name?: string | null
+          id?: string
+          updated_at?: string | null
+          user_id?: string
         }
         Relationships: []
       }

--- a/src/app/(tenant)/settings/profile/actions.ts
+++ b/src/app/(tenant)/settings/profile/actions.ts
@@ -1,0 +1,193 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+const profileUpdateSchema = z.object({
+        full_name: z
+                .string()
+                .trim()
+                .min(2, { message: "Name must be at least 2 characters." })
+                .max(120, { message: "Name must be 120 characters or less." }),
+        default_household_id: z
+                .string()
+                .trim()
+                .max(64, { message: "Household identifier is too long." })
+                .nullable(),
+});
+
+export type UpdateMemberProfileResult = {
+        success: boolean;
+        error?: string;
+        data?: {
+                avatarUrl?: string | null;
+        };
+};
+
+export async function updateMemberProfileAction(formData: FormData): Promise<UpdateMemberProfileResult> {
+        const supabase = await createSupbaseServerClient();
+
+        const {
+                data: { user },
+                error: authError,
+        } = await supabase.auth.getUser();
+
+        if (authError || !user) {
+                return {
+                        success: false,
+                        error: "You need to be signed in to update your profile.",
+                };
+        }
+
+        const rawFullName = formData.get("full_name");
+        const rawHouseholdId = formData.get("default_household_id");
+        const avatarFile = formData.get("avatar");
+
+        const parsedInput = profileUpdateSchema.safeParse({
+                full_name: typeof rawFullName === "string" ? rawFullName : "",
+                default_household_id:
+                        typeof rawHouseholdId === "string" && rawHouseholdId.length > 0
+                                ? rawHouseholdId
+                                : null,
+        });
+
+        if (!parsedInput.success) {
+                const message = parsedInput.error.errors
+                        .map((err) => err.message)
+                        .join(" ");
+
+                return {
+                        success: false,
+                        error: message || "Invalid profile details provided.",
+                };
+        }
+
+        const parsedData = parsedInput.data;
+
+        const {
+                data: existingMember,
+                error: memberLookupError,
+        } = await supabase
+                .from("members")
+                .select("id, avatar_url")
+                .eq("user_id", user.id)
+                .maybeSingle();
+
+        if (memberLookupError) {
+                console.error("Failed to load member profile", memberLookupError);
+                return {
+                        success: false,
+                        error: "Unable to load your profile record right now.",
+                };
+        }
+
+        let avatarPath = existingMember?.avatar_url ?? null;
+        let publicAvatarUrl: string | null = null;
+
+        if (avatarFile instanceof File && avatarFile.size > 0) {
+                if (!avatarFile.type.startsWith("image/")) {
+                        return {
+                                success: false,
+                                error: "Avatar uploads must be image files.",
+                        };
+                }
+
+                const maxFileSize = 5 * 1024 * 1024;
+                if (avatarFile.size > maxFileSize) {
+                        return {
+                                success: false,
+                                error: "Avatars must be 5MB or smaller.",
+                        };
+                }
+
+                const extension = avatarFile.name.split(".").pop()?.toLowerCase() ?? "png";
+                const fileName = `${crypto.randomUUID()}.${extension}`;
+                const filePath = `avatars/${user.id}/${fileName}`;
+
+                const { error: uploadError } = await supabase.storage
+                        .from("docs")
+                        .upload(filePath, avatarFile, {
+                                cacheControl: "3600",
+                                upsert: true,
+                                contentType: avatarFile.type,
+                        });
+
+                if (uploadError) {
+                        console.error("Avatar upload failed", uploadError);
+                        return {
+                                success: false,
+                                error: "We couldn't save your avatar. Please try again.",
+                        };
+                }
+
+                if (avatarPath && avatarPath !== filePath) {
+                        try {
+                                await supabase.storage.from("docs").remove([avatarPath]);
+                        } catch (removalError) {
+                                console.warn("Failed to clean up previous avatar", removalError);
+                        }
+                }
+
+                avatarPath = filePath;
+
+                const { data: publicUrlData } = supabase.storage
+                        .from("docs")
+                        .getPublicUrl(filePath);
+
+                publicAvatarUrl = publicUrlData?.publicUrl ?? null;
+        } else if (avatarPath) {
+                const { data: publicUrlData } = supabase.storage
+                        .from("docs")
+                        .getPublicUrl(avatarPath);
+
+                publicAvatarUrl = publicUrlData?.publicUrl ?? null;
+        }
+
+        const timestamp = new Date().toISOString();
+        const updates = {
+                full_name: parsedData.full_name,
+                default_household_id: parsedData.default_household_id,
+                avatar_url: avatarPath,
+                updated_at: timestamp,
+        };
+
+        if (existingMember?.id) {
+                const { error: updateError } = await supabase
+                        .from("members")
+                        .update(updates)
+                        .eq("id", existingMember.id);
+
+                if (updateError) {
+                        console.error("Failed to update member", updateError);
+                        return {
+                                success: false,
+                                error: "We couldn't update your profile. Please try again.",
+                        };
+                }
+        } else {
+                const { error: insertError } = await supabase.from("members").insert({
+                        ...updates,
+                        user_id: user.id,
+                        created_at: timestamp,
+                });
+
+                if (insertError) {
+                        console.error("Failed to create member", insertError);
+                        return {
+                                success: false,
+                                error: "We couldn't create your profile record.",
+                        };
+                }
+        }
+
+        revalidatePath("/settings/profile");
+
+        return {
+                success: true,
+                data: {
+                        avatarUrl: publicAvatarUrl,
+                },
+        };
+}

--- a/src/app/(tenant)/settings/profile/page.tsx
+++ b/src/app/(tenant)/settings/profile/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+import ProfileForm, { type HouseholdOption } from "./profile-form";
+
+export const metadata: Metadata = {
+        title: "Profile settings",
+        description:
+                "Update the details your roommates see – upload an avatar, refresh your display name, and set your default household view.",
+};
+
+export default async function TenantProfileSettingsPage() {
+        const supabase = await createSupbaseServerClient();
+
+        const {
+                data: { user },
+        } = await supabase.auth.getUser();
+
+        if (!user) {
+                redirect("/auth");
+        }
+
+        const { data: member, error: memberError } = await supabase
+                .from("members")
+                .select("id, full_name, avatar_url, default_household_id")
+                .eq("user_id", user.id)
+                .maybeSingle();
+
+        if (memberError) {
+                console.error("Failed to load member details", memberError);
+        }
+
+        let avatarPublicUrl: string | null = null;
+        if (member?.avatar_url) {
+                const { data: publicUrlData } = supabase.storage
+                        .from("docs")
+                        .getPublicUrl(member.avatar_url);
+
+                avatarPublicUrl = publicUrlData?.publicUrl ?? null;
+        }
+
+        const { data: householdsData, error: householdsError } = await supabase
+                .from("households")
+                .select("id, name")
+                .order("name", { ascending: true });
+
+        if (householdsError) {
+                console.error("Failed to load households", householdsError);
+        }
+
+        const households: HouseholdOption[] =
+                householdsData?.map((household) => ({
+                        id: household.id,
+                        name: household.name ?? null,
+                })) ?? [];
+
+        return (
+                <div className="container mx-auto max-w-3xl space-y-8 px-4 py-10">
+                        <div className="space-y-2">
+                                <h1 className="text-3xl font-bold tracking-tight">Profile preferences</h1>
+                                <p className="text-muted-foreground">
+                                        Keep your roommate profile current so shared payments, chores, and booking reminders reach the right person.
+                                </p>
+                        </div>
+                        <ProfileForm
+                                member={{
+                                        id: member?.id ?? null,
+                                        fullName: member?.full_name ?? user.email ?? "",
+                                        avatarUrl: avatarPublicUrl,
+                                        defaultHouseholdId: member?.default_household_id ?? null,
+                                }}
+                                households={households}
+                        />
+                </div>
+        );
+}

--- a/src/app/(tenant)/settings/profile/profile-form.tsx
+++ b/src/app/(tenant)/settings/profile/profile-form.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import {
+        Form,
+        FormControl,
+        FormDescription,
+        FormField,
+        FormItem,
+        FormLabel,
+        FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { updateMemberProfileAction } from "./actions";
+
+const profileSchema = z.object({
+        fullName: z
+                .string()
+                .trim()
+                .min(2, { message: "Name must be at least 2 characters." })
+                .max(120, { message: "Name must be 120 characters or less." }),
+        defaultHouseholdId: z
+                .union([
+                        z.string().trim().min(1, { message: "Select a household or choose none." }),
+                        z.literal("none"),
+                ])
+                .default("none"),
+});
+
+type ProfileFormValues = z.infer<typeof profileSchema>;
+
+export type HouseholdOption = {
+        id: string;
+        name: string | null;
+};
+
+type MemberProfile = {
+        id: string | null;
+        fullName: string;
+        avatarUrl: string | null;
+        defaultHouseholdId: string | null;
+};
+
+type ProfileFormProps = {
+        member: MemberProfile;
+        households: HouseholdOption[];
+};
+
+export function ProfileForm({ member, households }: ProfileFormProps) {
+        const { toast } = useToast();
+        const fileInputRef = useRef<HTMLInputElement | null>(null);
+        const [avatarPreview, setAvatarPreview] = useState<string | null>(member.avatarUrl);
+        const [selectedFile, setSelectedFile] = useState<File | null>(null);
+        const [isPending, startTransition] = useTransition();
+
+        const defaultHouseholdValue = useMemo(() => {
+                if (!member.defaultHouseholdId) {
+                        return "none";
+                }
+
+                return member.defaultHouseholdId;
+        }, [member.defaultHouseholdId]);
+
+        const form = useForm<ProfileFormValues>({
+                resolver: zodResolver(profileSchema),
+                defaultValues: {
+                        fullName: member.fullName,
+                        defaultHouseholdId: defaultHouseholdValue,
+                },
+        });
+
+        const handleAvatarChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+                const file = event.target.files?.[0];
+                if (!file) {
+                        return;
+                }
+
+                if (!file.type.startsWith("image/")) {
+                        toast({
+                                title: "Unsupported file",
+                                description: "Please choose a JPG, PNG, or GIF image.",
+                                variant: "destructive",
+                        });
+                        return;
+                }
+
+                const maxFileSize = 5 * 1024 * 1024;
+                if (file.size > maxFileSize) {
+                        toast({
+                                title: "File too large",
+                                description: "Avatars can be a maximum of 5MB.",
+                                variant: "destructive",
+                        });
+                        return;
+                }
+
+                setSelectedFile(file);
+        };
+
+        useEffect(() => {
+                if (!selectedFile) {
+                        return;
+                }
+
+                const nextPreview = URL.createObjectURL(selectedFile);
+                setAvatarPreview(nextPreview);
+
+                return () => {
+                        URL.revokeObjectURL(nextPreview);
+                };
+        }, [selectedFile]);
+
+        const onSubmit = (values: ProfileFormValues) => {
+                const formData = new FormData();
+                formData.append("full_name", values.fullName.trim());
+
+                if (values.defaultHouseholdId === "none") {
+                        formData.append("default_household_id", "");
+                } else {
+                        formData.append("default_household_id", values.defaultHouseholdId);
+                }
+
+                if (selectedFile) {
+                        formData.append("avatar", selectedFile);
+                }
+
+                startTransition(() => {
+                        updateMemberProfileAction(formData)
+                                .then((result) => {
+                                        if (!result.success) {
+                                                toast({
+                                                        title: "Profile update failed",
+                                                        description: result.error ?? "We couldn't save your changes.",
+                                                        variant: "destructive",
+                                                });
+                                                return;
+                                        }
+
+                                        if (result.data?.avatarUrl) {
+                                                setAvatarPreview(result.data.avatarUrl);
+                                        }
+
+                                        setSelectedFile(null);
+                                        if (fileInputRef.current) {
+                                                fileInputRef.current.value = "";
+                                        }
+
+                                        toast({
+                                                title: "Profile updated",
+                                                description: "Your roommate profile is up to date.",
+                                        });
+                                })
+                                .catch((error) => {
+                                        console.error("Profile update error", error);
+                                        toast({
+                                                title: "Profile update failed",
+                                                description: "Something went wrong while saving your profile.",
+                                                variant: "destructive",
+                                        });
+                                });
+                });
+        };
+
+        const householdOptions = useMemo(() => {
+                if (!households.length) {
+                        return [];
+                }
+
+                return households.map((household) => ({
+                        id: household.id,
+                        name: household.name ?? "Unnamed household",
+                }));
+        }, [households]);
+
+        return (
+                <Card>
+                        <CardHeader>
+                                <CardTitle>Roommate profile</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-8">
+                                <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                                        <Avatar className="size-20">
+                                                {avatarPreview ? (
+                                                        <AvatarImage
+                                                                alt="Member avatar"
+                                                                src={avatarPreview}
+                                                                className="size-20 rounded-full object-cover"
+                                                        />
+                                                ) : (
+                                                        <AvatarFallback className="text-lg font-medium">
+                                                                {member.fullName
+                                                                        .split(" ")
+                                                                        .map((part) => part.charAt(0))
+                                                                        .join("")
+                                                                        .slice(0, 2)
+                                                                        .toUpperCase() || "RM"}
+                                                        </AvatarFallback>
+                                                )}
+                                        </Avatar>
+                                        <div className="space-y-2">
+                                                <Button
+                                                        type="button"
+                                                        variant="outline"
+                                                        onClick={() => fileInputRef.current?.click()}
+                                                >
+                                                        Change avatar
+                                                </Button>
+                                                <FormDescription>
+                                                        Use a clear photo so roommates can recognise you. PNG, JPG, or GIF up to 5MB.
+                                                </FormDescription>
+                                                <input
+                                                        ref={fileInputRef}
+                                                        type="file"
+                                                        accept="image/*"
+                                                        className="hidden"
+                                                        onChange={handleAvatarChange}
+                                                />
+                                        </div>
+                                </div>
+                                <Form {...form}>
+                                        <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+                                                <FormField
+                                                        control={form.control}
+                                                        name="fullName"
+                                                        render={({ field }) => (
+                                                                <FormItem>
+                                                                        <FormLabel>Display name</FormLabel>
+                                                                        <FormControl>
+                                                                                <Input placeholder="e.g. Alex Johnson" {...field} />
+                                                                        </FormControl>
+                                                                        <FormDescription>
+                                                                                This name appears on bookings, payments, and shared messages.
+                                                                        </FormDescription>
+                                                                        <FormMessage />
+                                                                </FormItem>
+                                                        )}
+                                                />
+                                                <FormField
+                                                        control={form.control}
+                                                        name="defaultHouseholdId"
+                                                        render={({ field }) => (
+                                                                <FormItem>
+                                                                        <FormLabel>Default household</FormLabel>
+                                                                        <Select
+                                                                                onValueChange={field.onChange}
+                                                                                value={field.value}
+                                                                                disabled={!householdOptions.length}
+                                                                        >
+                                                                                <FormControl>
+                                                                                        <SelectTrigger>
+                                                                                                <SelectValue placeholder="Choose a household" />
+                                                                                        </SelectTrigger>
+                                                                                </FormControl>
+                                                                                <SelectContent>
+                                                                                        <SelectItem value="none">No default household</SelectItem>
+                                                                                        {householdOptions.map((option) => (
+                                                                                                <SelectItem key={option.id} value={option.id}>
+                                                                                                        {option.name}
+                                                                                                </SelectItem>
+                                                                                        ))}
+                                                                                </SelectContent>
+                                                                        </Select>
+                                                                        <FormDescription>
+                                                                                We’ll open this household by default when you sign in.
+                                                                        </FormDescription>
+                                                                        <FormMessage />
+                                                                </FormItem>
+                                                        )}
+                                                />
+                                                <CardFooter className="px-0">
+                                                        <Button type="submit" disabled={isPending}>
+                                                                {isPending ? "Saving changes…" : "Save profile"}
+                                                        </Button>
+                                                </CardFooter>
+                                        </form>
+                                </Form>
+                        </CardContent>
+                </Card>
+        );
+}
+
+export default ProfileForm;


### PR DESCRIPTION
## Summary
- add a tenant profile settings page that loads the current member record and available households from Supabase
- create a client-side form that validates the member name, handles avatar uploads, and lets tenants choose a default household preference
- implement a server action that stores avatars in the docs bucket, persists updates to the members table, and extend Supabase types for the new tables

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d1501c3c8328b515d432c10d8037