### PR TITLE
feat(payments): add invoice payment intents with stripe elements

### DIFF
--- a/app/api/stripe/invoices/[invoiceId]/intent/route.ts
+++ b/app/api/stripe/invoices/[invoiceId]/intent/route.ts
@@ -1,0 +1,224 @@
+import { cookies } from "next/headers"
+import { NextRequest } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs"
+import type Stripe from "stripe"
+
+import { getStripe } from "@/lib/stripe"
+import type { Database } from "@/lib/supabase"
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+const serviceRoleClient =
+  supabaseUrl && serviceRoleKey
+    ? createClient<Database>(supabaseUrl, serviceRoleKey, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      })
+    : null
+
+const CLOSED_INVOICE_STATUSES = new Set([
+  "paid",
+  "closed",
+  "void",
+  "forgiven",
+  "canceled",
+])
+
+type InvoiceRecord = {
+  id: string
+  tenant_id: string | null
+  unit_id?: string | null
+  amount_due: number | string | null
+  currency: string | null
+  status?: string | null
+  stripe_payment_intent_id?: string | null
+  stripe_customer_id?: string | null
+  stripe_invoice_id?: string | null
+  description?: string | null
+}
+
+function parseAmount(amount: InvoiceRecord["amount_due"]): number | null {
+  if (typeof amount === "number") {
+    return Number.isFinite(amount) ? amount : null
+  }
+  if (typeof amount === "string" && amount.trim().length > 0) {
+    const value = Number(amount)
+    return Number.isFinite(value) ? value : null
+  }
+  return null
+}
+
+function resolveCurrency(currency: string | null | undefined): string {
+  return currency?.toUpperCase() ?? "USD"
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { invoiceId: string } },
+) {
+  if (!serviceRoleClient) {
+    return Response.json(
+      { error: "Supabase service role key is not configured." },
+      { status: 500 },
+    )
+  }
+
+  try {
+    const invoiceId = params?.invoiceId
+    if (!invoiceId || typeof invoiceId !== "string" || invoiceId.trim().length === 0) {
+      return Response.json({ error: "Invoice id is required." }, { status: 400 })
+    }
+
+    let stripe: Stripe
+    try {
+      stripe = getStripe()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Stripe is not configured."
+      return Response.json({ error: message }, { status: 500 })
+    }
+
+    const supabase = createRouteHandlerClient<Database>({ cookies })
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError) {
+      console.error("Failed to verify user session", authError)
+      return Response.json({ error: "Unable to verify session." }, { status: 401 })
+    }
+
+    if (!user) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { data, error: invoiceError } = await serviceRoleClient
+      .from("rent_invoices")
+      .select(
+        [
+          "id",
+          "tenant_id",
+          "unit_id",
+          "amount_due",
+          "currency",
+          "status",
+          "stripe_payment_intent_id",
+          "stripe_customer_id",
+          "stripe_invoice_id",
+          "description",
+        ].join(","),
+      )
+      .eq("id", invoiceId)
+      .maybeSingle()
+
+    if (invoiceError) {
+      console.error("Unable to load invoice", invoiceError)
+      return Response.json({ error: "Invoice could not be retrieved." }, { status: 500 })
+    }
+
+    const invoice = data ?? null
+
+    if (!invoice || !invoice.tenant_id || invoice.tenant_id !== user.id) {
+      return Response.json({ error: "Invoice not found." }, { status: 404 })
+    }
+
+    const invoiceAmount = parseAmount(invoice.amount_due)
+    if (!invoiceAmount || invoiceAmount <= 0) {
+      return Response.json({ error: "Invoice does not have a payable balance." }, { status: 400 })
+    }
+
+    const invoiceCurrency = resolveCurrency(invoice.currency)
+
+    if (invoice.status && CLOSED_INVOICE_STATUSES.has(invoice.status.toLowerCase())) {
+      return Response.json({ error: "Invoice is not payable." }, { status: 400 })
+    }
+
+    const amountInSmallestUnit = Math.round(invoiceAmount * 100)
+
+    let paymentIntent: Stripe.PaymentIntent | null = null
+
+    if (invoice.stripe_payment_intent_id) {
+      try {
+        paymentIntent = await stripe.paymentIntents.retrieve(
+          invoice.stripe_payment_intent_id,
+        )
+
+        if (paymentIntent.status === "succeeded") {
+          return Response.json({ error: "Invoice has already been paid." }, { status: 400 })
+        }
+
+        const needsUpdate =
+          paymentIntent.amount !== amountInSmallestUnit ||
+          paymentIntent.currency.toUpperCase() !== invoiceCurrency ||
+          (invoice.stripe_customer_id &&
+            typeof paymentIntent.customer === "string" &&
+            paymentIntent.customer !== invoice.stripe_customer_id)
+
+        if (needsUpdate) {
+          paymentIntent = await stripe.paymentIntents.update(paymentIntent.id, {
+            amount: amountInSmallestUnit,
+            currency: invoiceCurrency.toLowerCase(),
+            customer: invoice.stripe_customer_id ?? undefined,
+            metadata: {
+              invoice_id: invoice.id,
+              tenant_id: invoice.tenant_id,
+              ...(invoice.unit_id ? { unit_id: invoice.unit_id } : {}),
+            },
+          })
+        }
+      } catch (error) {
+        console.error("Failed to reuse existing payment intent", error)
+        paymentIntent = null
+      }
+    }
+
+    if (!paymentIntent) {
+      paymentIntent = await stripe.paymentIntents.create({
+        amount: amountInSmallestUnit,
+        currency: invoiceCurrency.toLowerCase(),
+        customer: invoice.stripe_customer_id ?? undefined,
+        description: invoice.description ?? `Payment for invoice ${invoice.id}`,
+        metadata: {
+          invoice_id: invoice.id,
+          tenant_id: invoice.tenant_id,
+          ...(invoice.unit_id ? { unit_id: invoice.unit_id } : {}),
+        },
+        automatic_payment_methods: { enabled: true },
+      })
+
+      const { error: updateError } = await serviceRoleClient
+        .from("rent_invoices")
+        .update({ stripe_payment_intent_id: paymentIntent.id })
+        .eq("id", invoice.id)
+
+      if (updateError) {
+        console.error("Failed to persist payment intent on invoice", updateError)
+      }
+    }
+
+    if (!paymentIntent.client_secret) {
+      paymentIntent = await stripe.paymentIntents.retrieve(paymentIntent.id)
+    }
+
+    if (!paymentIntent.client_secret) {
+      return Response.json(
+        { error: "Payment intent was created without a client secret." },
+        { status: 500 },
+      )
+    }
+
+    return Response.json({
+      invoiceId: invoice.id,
+      paymentIntentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: invoiceAmount,
+      currency: invoiceCurrency,
+      status: paymentIntent.status,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error creating payment intent."
+    console.error("Error creating invoice payment intent", error)
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/payments/_components/invoice-payment.tsx
+++ b/app/payments/_components/invoice-payment.tsx
@@ -1,0 +1,276 @@
+"use client"
+
+import { FormEvent, useMemo, useState } from "react"
+import { Elements, PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js"
+import { loadStripe } from "@stripe/stripe-js"
+import type { StripeElementsOptions } from "@stripe/stripe-js"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
+
+const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+const stripePromise = publishableKey ? loadStripe(publishableKey) : null
+
+type IntentDetails = {
+  invoiceId: string
+  paymentIntentId: string
+  clientSecret: string
+  amount: number
+  currency: string
+  status?: string
+}
+
+export function InvoicePayment() {
+  const [invoiceId, setInvoiceId] = useState("")
+  const [intent, setIntent] = useState<IntentDetails | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const elementOptions = useMemo<StripeElementsOptions | undefined>(() => {
+    if (!intent) return undefined
+    return {
+      clientSecret: intent.clientSecret,
+      appearance: { theme: "stripe" },
+    }
+  }, [intent])
+
+  const handleCreateIntent = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmedInvoiceId = invoiceId.trim()
+    if (!trimmedInvoiceId) {
+      setError("Enter an invoice ID before continuing.")
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch(
+        `/api/stripe/invoices/${encodeURIComponent(trimmedInvoiceId)}/intent`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({}),
+        },
+      )
+
+      const payload = await response.json().catch(() => null)
+
+      if (!response.ok) {
+        const message =
+          payload && typeof payload.error === "string" && payload.error.length > 0
+            ? payload.error
+            : "Unable to create a payment intent for this invoice."
+        throw new Error(message)
+      }
+
+      if (!payload?.clientSecret) {
+        throw new Error("Payment intent response was missing a client secret.")
+      }
+
+      const rawAmount =
+        typeof payload.amount === "number" ? payload.amount : Number(payload.amount)
+      const parsedAmount = Number.isFinite(rawAmount) ? rawAmount : 0
+
+      setIntent({
+        invoiceId: typeof payload.invoiceId === "string" ? payload.invoiceId : trimmedInvoiceId,
+        paymentIntentId:
+          typeof payload.paymentIntentId === "string" ? payload.paymentIntentId : "",
+        clientSecret: payload.clientSecret,
+        amount: parsedAmount,
+        currency:
+          typeof payload.currency === "string" && payload.currency.length > 0
+            ? payload.currency.toUpperCase()
+            : "USD",
+        status: typeof payload.status === "string" ? payload.status : undefined,
+      })
+    } catch (fetchError) {
+      const message =
+        fetchError instanceof Error
+          ? fetchError.message
+          : "Unable to create a payment intent for this invoice."
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const reset = () => {
+    setIntent(null)
+    setError(null)
+  }
+
+  if (!publishableKey) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Configure <code className="font-mono text-xs">NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY</code> to
+        enable invoice payments.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {!intent ? (
+        <form onSubmit={handleCreateIntent} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="invoice-id">Invoice ID</Label>
+            <Input
+              id="invoice-id"
+              value={invoiceId}
+              onChange={(event) => setInvoiceId(event.target.value)}
+              placeholder="inv_123 or invoice UUID"
+              autoComplete="off"
+              required
+            />
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="submit" disabled={loading || invoiceId.trim().length === 0}>
+              {loading ? "Creating intent..." : "Create payment intent"}
+            </Button>
+          </div>
+        </form>
+      ) : stripePromise && elementOptions ? (
+        <Elements stripe={stripePromise} options={elementOptions}>
+          <ConfirmInvoicePayment
+            intent={intent}
+            onReset={() => {
+              reset()
+              setInvoiceId("")
+            }}
+          />
+        </Elements>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Stripe is not configured in this environment.
+        </p>
+      )}
+    </div>
+  )
+}
+
+type ConfirmInvoicePaymentProps = {
+  intent: IntentDetails
+  onReset: () => void
+}
+
+type MessageVariant = "default" | "success" | "error"
+
+function ConfirmInvoicePayment({ intent, onReset }: ConfirmInvoicePaymentProps) {
+  const stripe = useStripe()
+  const elements = useElements()
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [messageVariant, setMessageVariant] = useState<MessageVariant>("default")
+
+  const formattedAmount = useMemo(() => {
+    const amount = Number.isFinite(intent.amount) ? intent.amount : 0
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency: intent.currency || "USD",
+      }).format(amount)
+    } catch (error) {
+      console.error("Unable to format currency", error)
+      return `${amount.toFixed(2)} ${intent.currency}`
+    }
+  }, [intent.amount, intent.currency])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!stripe || !elements) {
+      setMessage("Stripe has not finished loading. Please try again in a moment.")
+      setMessageVariant("error")
+      return
+    }
+
+    setIsProcessing(true)
+    setMessage(null)
+
+    const { error, paymentIntent } = await stripe.confirmPayment({
+      elements,
+      confirmParams: {
+        return_url: `${window.location.origin}/payments?invoice=${encodeURIComponent(intent.invoiceId)}`,
+      },
+      redirect: "if_required",
+    })
+
+    if (error) {
+      setMessage(error.message ?? "Unable to confirm payment.")
+      setMessageVariant("error")
+      setIsProcessing(false)
+      return
+    }
+
+    if (paymentIntent) {
+      switch (paymentIntent.status) {
+        case "succeeded":
+          setMessage("Payment succeeded! A receipt will be emailed to you shortly.")
+          setMessageVariant("success")
+          break
+        case "processing":
+          setMessage("Your payment is processing. We'll update you when it's complete.")
+          setMessageVariant("default")
+          break
+        case "requires_payment_method":
+          setMessage("Payment failed. Please try another payment method.")
+          setMessageVariant("error")
+          break
+        default:
+          setMessage(`Payment status: ${paymentIntent.status}.`)
+          setMessageVariant("default")
+          break
+      }
+    } else {
+      setMessage("Payment confirmation submitted.")
+      setMessageVariant("default")
+    }
+
+    setIsProcessing(false)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-3 rounded-lg border p-4">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Invoice {intent.invoiceId}</p>
+          <p className="text-sm text-muted-foreground">Amount due: {formattedAmount}</p>
+          {intent.paymentIntentId && (
+            <p className="text-xs text-muted-foreground">Payment Intent: {intent.paymentIntentId}</p>
+          )}
+          {intent.status && (
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Current status: {intent.status}
+            </p>
+          )}
+        </div>
+        <PaymentElement />
+      </div>
+      {message && (
+        <p
+          className={cn("text-sm", {
+            "text-destructive": messageVariant === "error",
+            "text-emerald-600": messageVariant === "success",
+            "text-muted-foreground": messageVariant === "default",
+          })}
+        >
+          {message}
+        </p>
+      )}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button type="submit" disabled={isProcessing || !stripe || !elements}>
+          {isProcessing ? "Confirming..." : "Confirm payment"}
+        </Button>
+        <Button type="button" variant="outline" onClick={onReset} disabled={isProcessing}>
+          Use a different invoice
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -10,6 +10,7 @@ import {
 import { Separator } from "@/components/ui/separator"
 import { Button } from "@/components/ui/button"
 import { StripeActions } from "./_components/stripe-actions"
+import { InvoicePayment } from "./_components/invoice-payment"
 import { CatchUpPaymentCard } from "./_components/catch-up-payment-card"
 import {
   calculateOutstanding,
@@ -211,6 +212,17 @@ export default function PaymentsPage() {
             </CardHeader>
             <CardContent className="space-y-3">
               <StripeActions />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Settle an invoice</CardTitle>
+              <CardDescription>
+                Generate a Payment Intent for an outstanding invoice and confirm it with Stripe Elements.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <InvoicePayment />
             </CardContent>
           </Card>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "onyx",
+  "name": "shared-house-portal",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "onyx",
+      "name": "shared-house-portal",
       "version": "0.1.0",
       "dependencies": {
         "@ducanh2912/next-pwa": "^10.2.8",
@@ -39,6 +39,8 @@
         "@radix-ui/react-toast": "^1.1.5",
         "@react-three/drei": "9.92.7",
         "@react-three/fiber": "8.15.12",
+        "@stripe/react-stripe-js": "^4.0.2",
+        "@stripe/stripe-js": "^7.9.0",
         "@supabase-cache-helpers/postgrest-react-query": "^1.4.0",
         "@supabase/auth-helpers-nextjs": "^0.9.0",
         "@supabase/auth-helpers-react": "^0.4.2",
@@ -5625,6 +5627,29 @@
       },
       "funding": {
         "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-4.0.2.tgz",
+      "integrity": "sha512-l2wau+8/LOlHl+Sz8wQ1oDuLJvyw51nQCsu6/ljT6smqzTszcMHifjAJoXlnMfcou3+jK/kQyVe04u/ufyTXgg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.9.0.tgz",
+      "integrity": "sha512-ggs5k+/0FUJcIgNY08aZTqpBTtbExkJMYMLSMwyucrhtWexVOEY1KJmhBsxf+E/Q15f5rbwBpj+t0t2AW2oCsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@supabase-cache-helpers/postgrest-core": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "@supabase/auth-helpers-react": "^0.4.2",
     "@supabase/ssr": "^0.0.10",
     "@supabase/supabase-js": "^2.39.3",
+    "@stripe/react-stripe-js": "^4.0.2",
+    "@stripe/stripe-js": "^7.9.0",
     "@tanstack/react-query": "^5.51.9",
     "@tanstack/react-query-devtools": "^5.51.9",
     "@tanstack/react-table": "^8.19.3",


### PR DESCRIPTION
## Summary
- add a secure Stripe API route that validates invoice ownership and issues client secrets for payment intents
- introduce an invoice payment flow on the payments page that creates intents and confirms them with Stripe Elements
- wire up the new UI and dependencies required to use Stripe.js in the client

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0d15949d4832880f814e7e73c6a96