### PR TITLE
Add payments table and seed demo payments

### DIFF
--- a/supabase/migrations/20250104_add_payments_table.sql
+++ b/supabase/migrations/20250104_add_payments_table.sql
@@ -1,0 +1,23 @@
+-- Create payments table linked to invoices and mirroring Stripe PaymentIntent states
+CREATE TABLE public.payments (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  invoice_id UUID NOT NULL REFERENCES public.invoices(id) ON DELETE CASCADE,
+  stripe_pi_id TEXT NOT NULL UNIQUE,
+  amount_cents INTEGER NOT NULL CHECK (amount_cents >= 0),
+  status TEXT NOT NULL CHECK (
+    status IN (
+      'requires_payment_method',
+      'requires_confirmation',
+      'requires_action',
+      'processing',
+      'requires_capture',
+      'canceled',
+      'succeeded'
+    )
+  ),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_payments_invoice_id ON public.payments(invoice_id);
+CREATE INDEX idx_payments_status ON public.payments(status);
+CREATE INDEX idx_payments_created_at ON public.payments(created_at DESC);

--- a/supabase/seed/demo.sql
+++ b/supabase/seed/demo.sql
@@ -1,0 +1,11 @@
+-- Seed demo payments ensuring each invoice has a mock Stripe payment intent
+INSERT INTO public.payments (invoice_id, stripe_pi_id, amount_cents, status)
+SELECT
+  i.id,
+  'pi_demo_' || substr(md5(i.id::text), 1, 24),
+  GREATEST(100, (get_byte(decode(md5(i.id::text), 'hex'), 0) + 1) * 100),
+  'succeeded'
+FROM public.invoices i
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.payments p WHERE p.invoice_id = i.id
+);


### PR DESCRIPTION
## Summary
- add a payments table migration that enforces Stripe payment intent statuses and references invoices
- add a demo seed script to generate a mock payment for each invoice

## Testing
- not run (SQL-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0d15b5bc483289df781b085b19eda