### PR TITLE
Add invoices table and seed data

### DIFF
--- a/supabase/migrations/20250103_notifications_schema.sql
+++ b/supabase/migrations/20250103_notifications_schema.sql
@@ -64,6 +64,32 @@ CREATE TABLE public.email_notifications (
   metadata JSONB
 );
 
+-- Invoice status enum ensures consistent lifecycle values
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'invoice_status'
+      AND typnamespace = 'public'::regnamespace
+  ) THEN
+    CREATE TYPE public.invoice_status AS ENUM ('draft', 'sent', 'paid', 'overdue', 'void');
+  END IF;
+END;
+$$;
+
+-- Create invoices table for household billing
+CREATE TABLE public.invoices (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  household_id UUID NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  member_id UUID NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  amount_cents INTEGER NOT NULL CHECK (amount_cents >= 0),
+  due_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  status public.invoice_status NOT NULL DEFAULT 'draft',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
 -- Create indexes for better performance
 CREATE INDEX idx_maintenance_requests_requested_by ON public.maintenance_requests(requested_by);
 CREATE INDEX idx_maintenance_requests_assigned_to ON public.maintenance_requests(assigned_to);
@@ -82,6 +108,7 @@ CREATE INDEX idx_notifications_read ON public.notifications(read);
 CREATE INDEX idx_notifications_created_at ON public.notifications(created_at DESC);
 CREATE INDEX idx_email_notifications_user_id ON public.email_notifications(user_id);
 CREATE INDEX idx_email_notifications_sent_at ON public.email_notifications(sent_at DESC);
+CREATE INDEX idx_invoices_household_due_at ON public.invoices(household_id, due_at);
 
 -- Enable RLS
 ALTER TABLE public.maintenance_requests ENABLE ROW LEVEL SECURITY;
@@ -184,4 +211,8 @@ CREATE TRIGGER update_visitor_logs_updated_at
 
 CREATE TRIGGER update_notifications_updated_at
   BEFORE UPDATE ON public.notifications
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_invoices_updated_at
+  BEFORE UPDATE ON public.invoices
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,64 @@
+-- Seed sample invoices so each member has current and historical billing records
+DO $$
+DECLARE
+  member_column_count integer;
+BEGIN
+  SELECT COUNT(*)
+  INTO member_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'members'
+    AND column_name IN ('id', 'household_id');
+
+  IF member_column_count = 2 THEN
+    EXECUTE format($sql$
+      WITH member_data AS (
+        SELECT
+          m.id,
+          m.household_id,
+          ROW_NUMBER() OVER (PARTITION BY m.household_id ORDER BY m.id) AS rn
+        FROM public.members m
+      ),
+      invoice_samples AS (
+        SELECT
+          id,
+          household_id,
+          (95000 + (rn * 5000))::int AS amount_cents,
+          date_trunc('month', now()) - interval '15 days' AS due_at,
+          %L::public.invoice_status AS status
+        FROM member_data
+        UNION ALL
+        SELECT
+          id,
+          household_id,
+          (100000 + (rn * 5000))::int AS amount_cents,
+          date_trunc('month', now()) + interval '15 days' AS due_at,
+          %L::public.invoice_status AS status
+        FROM member_data
+        UNION ALL
+        SELECT
+          id,
+          household_id,
+          (105000 + (rn * 4000))::int AS amount_cents,
+          date_trunc('month', now()) - interval '45 days' AS due_at,
+          %L::public.invoice_status AS status
+        FROM member_data
+      )
+      INSERT INTO public.invoices (household_id, member_id, amount_cents, due_at, status)
+      SELECT
+        household_id,
+        id,
+        amount_cents,
+        due_at,
+        status
+      FROM invoice_samples sample
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM public.invoices i
+        WHERE i.member_id = sample.id
+          AND i.due_at = sample.due_at
+      );
+    $sql$, 'paid', 'sent', 'overdue');
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- add a reusable `invoice_status` enum and the `public.invoices` table with lifecycle metadata
- index invoices by household and due date and hook the table into the shared `updated_at` trigger
- seed sample paid, sent, and overdue invoices for every existing member

## Testing
- not run (SQL-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0d15bd9608328b831b5f7c43553bb