### PR TITLE
Add supply share settlement ledger

### DIFF
--- a/app/supplies/_components/supply-ledger.tsx
+++ b/app/supplies/_components/supply-ledger.tsx
@@ -1,0 +1,390 @@
+"use client"
+
+import { FormEvent, useMemo, useState, useTransition } from "react"
+import { format } from "date-fns"
+import { useRouter } from "next/navigation"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/components/ui/use-toast"
+import { formatCurrency } from "@/lib/payments/currency"
+import type {
+  SupplyShareLedgerEntry,
+  SupplyShareSettlementMethod,
+  SupplyShareStatus,
+} from "@/types/supplies"
+
+import { settleSupplyShare } from "../actions"
+
+interface SupplyLedgerProps {
+  shares: SupplyShareLedgerEntry[]
+}
+
+const statusCopy: Record<SupplyShareStatus, { label: string; variant: "secondary" | "complete" }> = {
+  open: { label: "Open", variant: "secondary" },
+  settled: { label: "Settled", variant: "complete" },
+}
+
+const methodCopy: Record<SupplyShareSettlementMethod, string> = {
+  off_app: "Settled off platform",
+  rent_roll_in: "Rolled into next rent invoice",
+}
+
+function formatDisplayDate(value?: string | null, includeTime = false) {
+  if (!value) {
+    return ""
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return ""
+  }
+
+  return format(parsed, includeTime ? "MMM d, yyyy p" : "MMM d, yyyy")
+}
+
+export function SupplyLedger({ shares }: SupplyLedgerProps) {
+  const router = useRouter()
+  const [isSettlementDialogOpen, setSettlementDialogOpen] = useState(false)
+  const [selectedShare, setSelectedShare] = useState<SupplyShareLedgerEntry | null>(null)
+  const [selectedMethod, setSelectedMethod] = useState<SupplyShareSettlementMethod>("off_app")
+  const [invoiceId, setInvoiceId] = useState("")
+  const [note, setNote] = useState("")
+  const [historyDialogOpen, setHistoryDialogOpen] = useState(false)
+  const [historyShare, setHistoryShare] = useState<SupplyShareLedgerEntry | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const hasShares = shares.length > 0
+
+  const openSettlementDialog = (
+    share: SupplyShareLedgerEntry,
+    method: SupplyShareSettlementMethod = "off_app",
+  ) => {
+    setSelectedShare(share)
+    setSelectedMethod(method)
+    setInvoiceId("")
+    setNote("")
+    setSettlementDialogOpen(true)
+  }
+
+  const openHistoryDialog = (share: SupplyShareLedgerEntry) => {
+    setHistoryShare(share)
+    setHistoryDialogOpen(true)
+  }
+
+  const disableSubmit = useMemo(() => {
+    if (!selectedShare) {
+      return true
+    }
+
+    if (selectedMethod === "rent_roll_in") {
+      return invoiceId.trim().length === 0 || isPending
+    }
+
+    return isPending
+  }, [selectedShare, selectedMethod, invoiceId, isPending])
+
+  const handleSettleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedShare) {
+      return
+    }
+
+    const trimmedNote = note.trim()
+    const trimmedInvoice = invoiceId.trim()
+
+    startTransition(async () => {
+      try {
+        await settleSupplyShare({
+          shareId: selectedShare.id,
+          method: selectedMethod,
+          note: trimmedNote.length > 0 ? trimmedNote : undefined,
+          invoiceId:
+            selectedMethod === "rent_roll_in" && trimmedInvoice.length > 0
+              ? trimmedInvoice
+              : undefined,
+        })
+
+        toast({
+          title: "Share settled",
+          description:
+            selectedMethod === "rent_roll_in"
+              ? `Rolled ${selectedShare.roommateName}'s share into rent invoice ${trimmedInvoice}.`
+              : `Marked ${selectedShare.roommateName}'s share as settled off platform.`,
+        })
+
+        setSettlementDialogOpen(false)
+        setSelectedShare(null)
+        setNote("")
+        setInvoiceId("")
+        router.refresh()
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unable to update the supply share."
+        toast({
+          variant: "destructive",
+          title: "Settlement failed",
+          description: message,
+        })
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Supply share ledger</CardTitle>
+          <CardDescription>
+            Manage reimbursements for communal supplies and keep everyone aligned on how shares were settled.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {hasShares ? (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[720px] table-fixed text-sm">
+                <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-4 py-3 font-semibold">Share</th>
+                    <th className="px-4 py-3 font-semibold">Roommate</th>
+                    <th className="px-4 py-3 text-right font-semibold">Amount</th>
+                    <th className="px-4 py-3 font-semibold">Status</th>
+                    <th className="px-4 py-3 text-right font-semibold">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {shares.map((share) => {
+                    const statusMeta = statusCopy[share.status]
+                    return (
+                      <tr key={share.id} className="border-b last:border-0">
+                        <td className="px-4 py-4 align-top">
+                          <div className="font-medium text-foreground">{share.description}</div>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            Created {formatDisplayDate(share.createdAt)}
+                            {share.createdBy ? ` • ${share.createdByName}` : ""}
+                          </div>
+                          {share.settlementNote ? (
+                            <p className="mt-2 text-xs text-muted-foreground">
+                              Note: {share.settlementNote}
+                            </p>
+                          ) : null}
+                          {share.settlementInvoiceId ? (
+                            <p className="text-xs text-muted-foreground">
+                              Invoice: {share.settlementInvoiceId}
+                            </p>
+                          ) : null}
+                        </td>
+                        <td className="px-4 py-4 align-top">
+                          <div className="font-medium">{share.roommateName}</div>
+                          {share.settledBy && share.status === "settled" ? (
+                            <p className="text-xs text-muted-foreground">
+                              Settled by {share.settledByName}
+                            </p>
+                          ) : null}
+                        </td>
+                        <td className="px-4 py-4 text-right align-top font-semibold">
+                          {formatCurrency(share.amount, share.currency)}
+                        </td>
+                        <td className="px-4 py-4 align-top">
+                          <Badge variant={statusMeta.variant}>{statusMeta.label}</Badge>
+                          {share.settlementMethod ? (
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {methodCopy[share.settlementMethod]}
+                              {share.settledAt ? ` • ${formatDisplayDate(share.settledAt)}` : ""}
+                            </p>
+                          ) : share.status === "settled" && share.settledAt ? (
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              Settled {formatDisplayDate(share.settledAt)}
+                            </p>
+                          ) : null}
+                        </td>
+                        <td className="px-4 py-4 text-right align-top">
+                          <div className="flex justify-end gap-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => openHistoryDialog(share)}
+                            >
+                              History
+                            </Button>
+                            {share.status === "open" ? (
+                              <Button
+                                size="sm"
+                                onClick={() => openSettlementDialog(share)}
+                                disabled={isPending && selectedShare?.id === share.id}
+                              >
+                                Mark settled
+                              </Button>
+                            ) : null}
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center space-y-3 py-16 text-center">
+              <p className="text-base font-medium text-foreground">No supply shares yet</p>
+              <p className="text-sm text-muted-foreground">
+                Add household purchases to start tracking what each roommate owes.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={isSettlementDialogOpen}
+        onOpenChange={(open) => {
+          setSettlementDialogOpen(open)
+          if (!open) {
+            setSelectedShare(null)
+            setNote("")
+            setInvoiceId("")
+          }
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Settle share</DialogTitle>
+            <DialogDescription>
+              {selectedShare
+                ? `Update ${selectedShare.roommateName}'s ${selectedShare.description.toLowerCase()} share.`
+                : "Update the selected share."}
+            </DialogDescription>
+          </DialogHeader>
+          <form className="space-y-4" onSubmit={handleSettleSubmit}>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="settlement-method">
+                Settlement method
+              </label>
+              <Select value={selectedMethod} onValueChange={(value) => setSelectedMethod(value as SupplyShareSettlementMethod)}>
+                <SelectTrigger id="settlement-method">
+                  <SelectValue placeholder="Select method" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="off_app">Settled off platform</SelectItem>
+                  <SelectItem value="rent_roll_in">Roll into next rent invoice</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {selectedMethod === "rent_roll_in" ? (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground" htmlFor="invoice-id">
+                  Rent invoice ID
+                </label>
+                <Input
+                  id="invoice-id"
+                  placeholder="e.g. INV-2024-0612"
+                  value={invoiceId}
+                  onChange={(event) => setInvoiceId(event.target.value)}
+                  disabled={isPending}
+                />
+              </div>
+            ) : null}
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="settlement-note">
+                Optional note
+              </label>
+              <Textarea
+                id="settlement-note"
+                placeholder="Share any context for this settlement (visible to roommates)."
+                value={note}
+                onChange={(event) => setNote(event.target.value)}
+                rows={3}
+                maxLength={280}
+                disabled={isPending}
+              />
+              <p className="text-xs text-muted-foreground">
+                {note.length}/280 characters
+              </p>
+            </div>
+            <DialogFooter className="flex items-center justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => setSettlementDialogOpen(false)} disabled={isPending}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={disableSubmit}>
+                {isPending ? "Saving..." : "Confirm settlement"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={historyDialogOpen}
+        onOpenChange={(open) => {
+          setHistoryDialogOpen(open)
+          if (!open) {
+            setHistoryShare(null)
+          }
+        }}
+      >
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Settlement history</DialogTitle>
+            <DialogDescription>
+              {historyShare
+                ? `${historyShare.roommateName}'s ${historyShare.description.toLowerCase()} share`
+                : "Review settlement events."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            {historyShare && historyShare.auditTrail.length > 0 ? (
+              historyShare.auditTrail.map((event) => (
+                <div key={event.id} className="rounded-lg border p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 text-sm font-semibold capitalize">
+                      {event.eventType.replace(/_/g, " ")}
+                      {event.newStatus ? (
+                        <Badge variant={event.newStatus === "settled" ? "complete" : "secondary"}>
+                          {event.newStatus}
+                        </Badge>
+                      ) : null}
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      {formatDisplayDate(event.createdAt, true)}
+                    </span>
+                  </div>
+                  <Separator className="my-3" />
+                  <div className="space-y-2 text-sm text-muted-foreground">
+                    <p>
+                      {event.createdByName ? `By ${event.createdByName}` : "System generated"}
+                      {event.settlementMethod ? ` • ${methodCopy[event.settlementMethod]}` : ""}
+                      {event.settlementInvoiceId ? ` • Invoice ${event.settlementInvoiceId}` : ""}
+                    </p>
+                    {event.note ? <p>Note: {event.note}</p> : null}
+                    {event.context && Object.keys(event.context).length > 0 ? (
+                      <div className="rounded-md bg-muted/40 p-3 text-xs">
+                        <pre className="whitespace-pre-wrap break-words">
+                          {JSON.stringify(event.context, null, 2)}
+                        </pre>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted-foreground">No audit activity has been recorded for this share yet.</p>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/supplies/actions.ts
+++ b/app/supplies/actions.ts
@@ -1,0 +1,101 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { cookies } from "next/headers"
+import { z } from "zod"
+
+import createSupabaseServer from "@/utils/supabase-server"
+
+const settleSupplyShareSchema = z
+  .object({
+    shareId: z.string().uuid(),
+    method: z.enum(["off_app", "rent_roll_in"]),
+    note: z.string().trim().max(280).optional(),
+    invoiceId: z.string().trim().max(64).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.method === "rent_roll_in") {
+      if (!value.invoiceId || value.invoiceId.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Invoice ID is required when rolling a share into rent.",
+          path: ["invoiceId"],
+        })
+      }
+    }
+  })
+
+export type SettleSupplyShareInput = z.infer<typeof settleSupplyShareSchema>
+
+export async function settleSupplyShare(input: SettleSupplyShareInput) {
+  const parsed = settleSupplyShareSchema.safeParse(input)
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues[0]?.message ?? "Invalid settlement request.")
+  }
+
+  const { shareId, method } = parsed.data
+  const note = parsed.data.note && parsed.data.note.length > 0 ? parsed.data.note : undefined
+  const invoiceId =
+    method === "rent_roll_in" && parsed.data.invoiceId && parsed.data.invoiceId.length > 0
+      ? parsed.data.invoiceId
+      : null
+
+  const cookieStore = cookies()
+  const supabase = createSupabaseServer(cookieStore)
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError) {
+    console.error("settleSupplyShare auth error", authError)
+  }
+
+  if (!user) {
+    throw new Error("You must be signed in to settle supply shares.")
+  }
+
+  const { data: share, error: shareError } = await supabase
+    .from("supply_shares")
+    .select("id, status")
+    .eq("id", shareId)
+    .single()
+
+  if (shareError || !share) {
+    console.error("settleSupplyShare share lookup failed", shareError)
+    throw new Error("Unable to locate the selected supply share.")
+  }
+
+  if (share.status === "settled") {
+    throw new Error("This share has already been settled.")
+  }
+
+  const now = new Date().toISOString()
+
+  const { error: updateError } = await supabase
+    .from("supply_shares")
+    .update({
+      status: "settled",
+      settled_at: now,
+      settled_by: user.id,
+      settlement_method: method,
+      settlement_invoice_id: invoiceId,
+      settlement_note: note ?? null,
+    })
+    .eq("id", shareId)
+
+  if (updateError) {
+    console.error("settleSupplyShare update error", updateError)
+    throw new Error("We couldn't mark this share as settled. Please try again.")
+  }
+
+  revalidatePath("/supplies")
+
+  return {
+    shareId,
+    status: "settled" as const,
+    settlementMethod: method,
+    settlementInvoiceId: invoiceId,
+  }
+}

--- a/app/supplies/page.tsx
+++ b/app/supplies/page.tsx
@@ -1,10 +1,170 @@
-export default function SuppliesPage() {
+import { cookies } from "next/headers"
+
+import { formatCurrency } from "@/lib/payments/currency"
+import createSupabaseServer from "@/utils/supabase-server"
+import type { SupplyShareLedgerEntry } from "@/types/supplies"
+
+import { SupplyLedger } from "./_components/supply-ledger"
+
+function getProfileLabel(
+  id: string | null | undefined,
+  profiles: Map<string, { full_name: string | null; email: string | null }>,
+  fallbackLabel = "Unknown roommate",
+) {
+  if (!id) {
+    return fallbackLabel
+  }
+
+  const profile = profiles.get(id)
+  if (!profile) {
+    return fallbackLabel
+  }
+
+  return profile.full_name ?? profile.email ?? fallbackLabel
+}
+
+export default async function SuppliesPage() {
+  const cookieStore = cookies()
+  const supabase = createSupabaseServer(cookieStore)
+
+  const { data: shareRows, error: shareError } = await supabase
+    .from("supply_shares")
+    .select(
+      "id, description, amount, currency, roommate_id, status, created_at, updated_at, created_by, settled_at, settled_by, settlement_method, settlement_invoice_id, settlement_note",
+    )
+    .order("created_at", { ascending: false })
+
+  if (shareError) {
+    console.error("supplies ledger fetch error", shareError)
+  }
+
+  const sharesData = shareRows ?? []
+  const shareIds = sharesData.map((share) => share.id)
+
+  const { data: auditRows, error: auditError } =
+    shareIds.length > 0
+      ? await supabase
+          .from("supply_share_audit_events")
+          .select(
+            "id, share_id, event_type, previous_status, new_status, settlement_method, settlement_invoice_id, note, context, created_at, created_by",
+          )
+          .in("share_id", shareIds)
+          .order("created_at", { ascending: false })
+      : { data: [], error: null }
+
+  if (auditError) {
+    console.error("supplies ledger audit fetch error", auditError)
+  }
+
+  const auditData = auditRows ?? []
+  const participantIds = new Set<string>()
+
+  for (const share of sharesData) {
+    if (share.roommate_id) {
+      participantIds.add(share.roommate_id)
+    }
+    if (share.created_by) {
+      participantIds.add(share.created_by)
+    }
+    if (share.settled_by) {
+      participantIds.add(share.settled_by)
+    }
+  }
+
+  for (const event of auditData) {
+    if (event.created_by) {
+      participantIds.add(event.created_by)
+    }
+  }
+
+  const profileLookup: Map<string, { full_name: string | null; email: string | null }> = new Map()
+
+  if (participantIds.size > 0) {
+    const { data: profileRows, error: profileError } = await supabase
+      .from("profiles")
+      .select("id, full_name, email")
+      .in("id", Array.from(participantIds))
+
+    if (profileError) {
+      console.error("supplies ledger profile fetch error", profileError)
+    }
+
+    for (const profile of profileRows ?? []) {
+      profileLookup.set(profile.id, {
+        full_name: profile.full_name,
+        email: profile.email,
+      })
+    }
+  }
+
+  const shares: SupplyShareLedgerEntry[] = sharesData.map((share) => {
+    const relatedEvents = auditData
+      .filter((event) => event.share_id === share.id)
+      .map((event) => ({
+        id: event.id,
+        shareId: event.share_id,
+        eventType: event.event_type,
+        createdAt: event.created_at,
+        createdBy: event.created_by,
+        createdByName: getProfileLabel(event.created_by, profileLookup, "System"),
+        previousStatus: event.previous_status ?? undefined,
+        newStatus: event.new_status ?? undefined,
+        settlementMethod: event.settlement_method ?? undefined,
+        settlementInvoiceId: event.settlement_invoice_id ?? undefined,
+        note: event.note ?? undefined,
+        context: (event.context as Record<string, unknown>) ?? undefined,
+      }))
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+
+    return {
+      id: share.id,
+      description: share.description,
+      amount: typeof share.amount === "number" ? share.amount : Number(share.amount),
+      currency: share.currency,
+      roommateId: share.roommate_id,
+      roommateName: getProfileLabel(share.roommate_id, profileLookup),
+      status: share.status,
+      createdAt: share.created_at,
+      updatedAt: share.updated_at,
+      createdBy: share.created_by ?? undefined,
+      createdByName: getProfileLabel(share.created_by, profileLookup, "Unknown"),
+      settledAt: share.settled_at ?? undefined,
+      settledBy: share.settled_by ?? undefined,
+      settledByName: getProfileLabel(share.settled_by, profileLookup, "Unknown"),
+      settlementMethod: share.settlement_method ?? undefined,
+      settlementInvoiceId: share.settlement_invoice_id ?? undefined,
+      settlementNote: share.settlement_note ?? undefined,
+      auditTrail: relatedEvents,
+    }
+  })
+
+  const totalOpen = shares.filter((share) => share.status === "open").reduce((sum, share) => sum + share.amount, 0)
+  const totalSettled = shares
+    .filter((share) => share.status === "settled")
+    .reduce((sum, share) => sum + share.amount, 0)
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Shared Supplies</h1>
-      <p className="text-muted-foreground">Track and split costs for cleaning supplies and essentials.</p>
+    <div className="container max-w-5xl space-y-8 py-10">
+      <header className="space-y-3">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold tracking-tight">Shared supplies ledger</h1>
+          <p className="text-muted-foreground">
+            Track household supply reimbursements, mark shares as settled, and keep an audit trail of adjustments.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+          <span>
+            Open balance: <span className="font-semibold text-foreground">{formatCurrency(totalOpen, shares[0]?.currency ?? "USD")}</span>
+          </span>
+          <span aria-hidden="true">•</span>
+          <span>
+            Settled this cycle: <span className="font-semibold text-foreground">{formatCurrency(totalSettled, shares[0]?.currency ?? "USD")}</span>
+          </span>
+          <span aria-hidden="true">•</span>
+          <span>{shares.length} share{shares.length === 1 ? "" : "s"} tracked</span>
+        </div>
+      </header>
+      <SupplyLedger shares={shares} />
     </div>
   )
 }
-
-

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1558,6 +1558,148 @@ export type Database = {
         }
         Relationships: []
       }
+      supply_share_audit_events: {
+        Row: {
+          context: Json
+          created_at: string
+          created_by: string | null
+          event_type: Database["public"]["Enums"]["supply_share_event_type"]
+          id: string
+          new_status: Database["public"]["Enums"]["supply_share_status"] | null
+          note: string | null
+          previous_status: Database["public"]["Enums"]["supply_share_status"] | null
+          settlement_invoice_id: string | null
+          settlement_method:
+            | Database["public"]["Enums"]["supply_share_settlement_method"]
+            | null
+          share_id: string
+        }
+        Insert: {
+          context?: Json
+          created_at?: string
+          created_by?: string | null
+          event_type: Database["public"]["Enums"]["supply_share_event_type"]
+          id?: string
+          new_status?: Database["public"]["Enums"]["supply_share_status"] | null
+          note?: string | null
+          previous_status?: Database["public"]["Enums"]["supply_share_status"] | null
+          settlement_invoice_id?: string | null
+          settlement_method?:
+            | Database["public"]["Enums"]["supply_share_settlement_method"]
+            | null
+          share_id: string
+        }
+        Update: {
+          context?: Json
+          created_at?: string
+          created_by?: string | null
+          event_type?: Database["public"]["Enums"]["supply_share_event_type"]
+          id?: string
+          new_status?: Database["public"]["Enums"]["supply_share_status"] | null
+          note?: string | null
+          previous_status?: Database["public"]["Enums"]["supply_share_status"] | null
+          settlement_invoice_id?: string | null
+          settlement_method?:
+            | Database["public"]["Enums"]["supply_share_settlement_method"]
+            | null
+          share_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_share_audit_events_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supply_share_audit_events_share_id_fkey"
+            columns: ["share_id"]
+            isOneToOne: false
+            referencedRelation: "supply_shares"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      supply_shares: {
+        Row: {
+          amount: number
+          created_at: string
+          created_by: string | null
+          currency: string
+          description: string
+          id: string
+          roommate_id: string
+          settled_at: string | null
+          settled_by: string | null
+          settlement_invoice_id: string | null
+          settlement_method:
+            | Database["public"]["Enums"]["supply_share_settlement_method"]
+            | null
+          settlement_note: string | null
+          status: Database["public"]["Enums"]["supply_share_status"]
+          updated_at: string
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          created_by?: string | null
+          currency?: string
+          description: string
+          id?: string
+          roommate_id: string
+          settled_at?: string | null
+          settled_by?: string | null
+          settlement_invoice_id?: string | null
+          settlement_method?:
+            | Database["public"]["Enums"]["supply_share_settlement_method"]
+            | null
+          settlement_note?: string | null
+          status?: Database["public"]["Enums"]["supply_share_status"]
+          updated_at?: string
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          created_by?: string | null
+          currency?: string
+          description?: string
+          id?: string
+          roommate_id?: string
+          settled_at?: string | null
+          settled_by?: string | null
+          settlement_invoice_id?: string | null
+          settlement_method?:
+            | Database["public"]["Enums"]["supply_share_settlement_method"]
+            | null
+          settlement_note?: string | null
+          status?: Database["public"]["Enums"]["supply_share_status"]
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_shares_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supply_shares_roommate_id_fkey"
+            columns: ["roommate_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supply_shares_settled_by_fkey"
+            columns: ["settled_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       todos: {
         Row: {
           created_at: string
@@ -2017,6 +2159,9 @@ export type Database = {
         | "Oceania"
         | "North America"
         | "South America"
+      supply_share_event_type: "created" | "settled" | "reopened"
+      supply_share_settlement_method: "off_app" | "rent_roll_in"
+      supply_share_status: "open" | "settled"
       user_role: "user" | "admin"
     }
     CompositeTypes: {

--- a/supabase/migrations/20250201_supply_shares_ledger.sql
+++ b/supabase/migrations/20250201_supply_shares_ledger.sql
@@ -1,0 +1,229 @@
+-- Supply share settlement ledger tables and automation
+
+-- Enum types for supply shares
+CREATE TYPE public.supply_share_status AS ENUM ('open', 'settled');
+CREATE TYPE public.supply_share_settlement_method AS ENUM ('off_app', 'rent_roll_in');
+CREATE TYPE public.supply_share_event_type AS ENUM ('created', 'settled', 'reopened');
+
+-- Shared supplies ledger table
+CREATE TABLE public.supply_shares (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  roommate_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES public.profiles(id),
+  description TEXT NOT NULL,
+  amount NUMERIC(12, 2) NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'USD',
+  status public.supply_share_status NOT NULL DEFAULT 'open',
+  settled_at TIMESTAMP WITH TIME ZONE,
+  settled_by UUID REFERENCES public.profiles(id),
+  settlement_method public.supply_share_settlement_method,
+  settlement_invoice_id TEXT,
+  settlement_note TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_supply_shares_roommate_id ON public.supply_shares(roommate_id);
+CREATE INDEX idx_supply_shares_status ON public.supply_shares(status);
+CREATE INDEX idx_supply_shares_created_at ON public.supply_shares(created_at DESC);
+
+-- Audit events for supply share changes
+CREATE TABLE public.supply_share_audit_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  share_id UUID NOT NULL REFERENCES public.supply_shares(id) ON DELETE CASCADE,
+  event_type public.supply_share_event_type NOT NULL,
+  previous_status public.supply_share_status,
+  new_status public.supply_share_status,
+  settlement_method public.supply_share_settlement_method,
+  settlement_invoice_id TEXT,
+  note TEXT,
+  context JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES public.profiles(id)
+);
+
+CREATE INDEX idx_supply_share_events_share_id ON public.supply_share_audit_events(share_id);
+CREATE INDEX idx_supply_share_events_type ON public.supply_share_audit_events(event_type);
+CREATE INDEX idx_supply_share_events_created_at ON public.supply_share_audit_events(created_at DESC);
+
+-- Ensure timestamps stay fresh
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER supply_shares_updated_at
+  BEFORE UPDATE ON public.supply_shares
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Audit helpers
+CREATE OR REPLACE FUNCTION public.log_supply_share_created()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.supply_share_audit_events (
+    share_id,
+    event_type,
+    new_status,
+    context,
+    created_by
+  )
+  VALUES (
+    NEW.id,
+    'created',
+    NEW.status,
+    jsonb_build_object(
+      'amount', NEW.amount,
+      'currency', NEW.currency,
+      'description', NEW.description,
+      'roommate_id', NEW.roommate_id
+    ),
+    NEW.created_by
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION public.log_supply_share_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.status = 'settled' AND (OLD.status IS DISTINCT FROM NEW.status) THEN
+    INSERT INTO public.supply_share_audit_events (
+      share_id,
+      event_type,
+      previous_status,
+      new_status,
+      settlement_method,
+      settlement_invoice_id,
+      note,
+      context,
+      created_by
+    )
+    VALUES (
+      NEW.id,
+      'settled',
+      OLD.status,
+      NEW.status,
+      NEW.settlement_method,
+      NEW.settlement_invoice_id,
+      NEW.settlement_note,
+      jsonb_build_object(
+        'settled_at', NEW.settled_at,
+        'settled_by', NEW.settled_by
+      ),
+      NEW.settled_by
+    );
+  ELSIF NEW.status = 'open' AND OLD.status = 'settled' THEN
+    INSERT INTO public.supply_share_audit_events (
+      share_id,
+      event_type,
+      previous_status,
+      new_status,
+      context,
+      created_by
+    )
+    VALUES (
+      NEW.id,
+      'reopened',
+      OLD.status,
+      NEW.status,
+      jsonb_build_object(
+        'reopened_at', NOW(),
+        'updated_by', NEW.settled_by
+      ),
+      NEW.settled_by
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER supply_shares_insert_audit
+  AFTER INSERT ON public.supply_shares
+  FOR EACH ROW EXECUTE FUNCTION public.log_supply_share_created();
+
+CREATE TRIGGER supply_shares_status_audit
+  AFTER UPDATE ON public.supply_shares
+  FOR EACH ROW EXECUTE FUNCTION public.log_supply_share_status_change();
+
+-- Row level security
+ALTER TABLE public.supply_shares ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.supply_share_audit_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Supply share viewers" ON public.supply_shares
+  FOR SELECT
+  USING (
+    roommate_id = auth.uid()
+    OR created_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Supply share creators" ON public.supply_shares
+  FOR INSERT
+  WITH CHECK (
+    created_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Supply share maintainers" ON public.supply_shares
+  FOR UPDATE
+  USING (
+    created_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('property_manager', 'admin')
+    )
+  )
+  WITH CHECK (
+    created_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Supply share removers" ON public.supply_shares
+  FOR DELETE
+  USING (
+    created_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Supply share audit readers" ON public.supply_share_audit_events
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.supply_shares s
+      WHERE s.id = supply_share_audit_events.share_id
+        AND (
+          s.roommate_id = auth.uid()
+          OR s.created_by = auth.uid()
+          OR EXISTS (
+            SELECT 1 FROM public.profiles p
+            WHERE p.id = auth.uid() AND p.role IN ('property_manager', 'admin')
+          )
+        )
+    )
+  );
+
+CREATE POLICY "Supply share audit writers" ON public.supply_share_audit_events
+  FOR INSERT
+  WITH CHECK (
+    created_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role IN ('property_manager', 'admin')
+    )
+  );

--- a/types/supplies.ts
+++ b/types/supplies.ts
@@ -1,0 +1,41 @@
+export type SupplyShareStatus = "open" | "settled"
+
+export type SupplyShareSettlementMethod = "off_app" | "rent_roll_in"
+
+export type SupplyShareEventType = "created" | "settled" | "reopened"
+
+export interface SupplyShareAuditEvent {
+  id: string
+  shareId: string
+  eventType: SupplyShareEventType
+  createdAt: string
+  createdBy?: string | null
+  createdByName?: string | null
+  previousStatus?: SupplyShareStatus | null
+  newStatus?: SupplyShareStatus | null
+  settlementMethod?: SupplyShareSettlementMethod | null
+  settlementInvoiceId?: string | null
+  note?: string | null
+  context?: Record<string, unknown>
+}
+
+export interface SupplyShareLedgerEntry {
+  id: string
+  description: string
+  amount: number
+  currency: string
+  roommateId: string
+  roommateName: string
+  status: SupplyShareStatus
+  createdAt: string
+  updatedAt: string
+  createdBy?: string | null
+  createdByName?: string | null
+  settledAt?: string | null
+  settledBy?: string | null
+  settledByName?: string | null
+  settlementMethod?: SupplyShareSettlementMethod | null
+  settlementInvoiceId?: string | null
+  settlementNote?: string | null
+  auditTrail: SupplyShareAuditEvent[]
+}


### PR DESCRIPTION
## Summary
- add supply share tables, enums, triggers, and RLS policies to capture settlement activity
- expose the new tables in the supabase client typings and add typed supply share models
- build a supplies ledger page with settlement controls, history display, and a server action to mark shares settled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0d15e81ec83288e13a7d0a9cfca0d