### PR TITLE
Add membership-aware supply share recalculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ A comprehensive web application designed for shared house roommates to manage re
 - **Lease Agreements**: Digital lease management with version history
 - **Audit Trails**: Complete document access logging for compliance
 
+### 🧺 **Shared Supplies**
+- **Automatic Cost Splitting**: Household purchases are divided equally across active members using the generator in `lib/supplies/share-generator.ts`.
+- **Membership-Aware Calculations**: The `handleHouseholdMembershipChange` server action (`app/supplies/actions/household-membership.ts`) detects additions or departures and only recalculates `supply_shares` for purchases on or after the change date, leaving existing records untouched.
+- **Verified by Tests**: `tests/supply-shares.test.ts` covers both join and departure scenarios to ensure historical purchases remain unchanged while future splits use the updated roster.
+
 ### 💬 **Communication**
 - **Realtime Messaging**: Roommate-to-roommate communication with threads
 - **Notifications**: In-app and email notifications for important events

--- a/app/supplies/actions/household-membership.ts
+++ b/app/supplies/actions/household-membership.ts
@@ -1,0 +1,72 @@
+"use server"
+
+import {
+  detectMembershipChanges,
+  generateSupplyShares,
+  type GenerateSupplySharesParams,
+  type GenerateSupplySharesResult,
+  type HouseholdMembership,
+  type MemberIdentifier,
+  type MembershipChangeSummary,
+  type SupplyPurchase,
+  type SupplyShare,
+} from "@/lib/supplies/share-generator"
+
+export interface HandleHouseholdMembershipChangeParams {
+  householdId: string
+  previousMembers: MemberIdentifier[]
+  nextMembers: MemberIdentifier[]
+  memberships: HouseholdMembership[]
+  purchases: SupplyPurchase[]
+  existingShares?: SupplyShare[]
+  effectiveFrom: string
+  calculationTime?: string
+}
+
+export interface HandleHouseholdMembershipChangeResult
+  extends MembershipChangeSummary,
+    GenerateSupplySharesResult {}
+
+export async function handleHouseholdMembershipChange(
+  params: HandleHouseholdMembershipChangeParams,
+): Promise<HandleHouseholdMembershipChangeResult> {
+  const {
+    householdId,
+    previousMembers,
+    nextMembers,
+    memberships,
+    purchases,
+    existingShares,
+    effectiveFrom,
+    calculationTime,
+  } = params
+
+  const summary = detectMembershipChanges(previousMembers, nextMembers)
+
+  if (!summary.changed) {
+    return {
+      ...summary,
+      createdShares: [],
+      skippedPurchases: [],
+    }
+  }
+
+  const generationParams: GenerateSupplySharesParams = {
+    householdId,
+    memberships,
+    purchases,
+    existingShares,
+    effectiveFrom,
+    calculationTime,
+  }
+
+  const { createdShares, skippedPurchases } = generateSupplyShares(
+    generationParams,
+  )
+
+  return {
+    ...summary,
+    createdShares,
+    skippedPurchases,
+  }
+}

--- a/lib/supplies/share-generator.ts
+++ b/lib/supplies/share-generator.ts
@@ -1,0 +1,275 @@
+// Utilities for calculating supply cost shares across household members.
+// The generator is intentionally pure so it can be reused from server actions
+// and unit tests without touching the database.
+
+export interface HouseholdMembership {
+  householdId: string
+  memberId: string
+  joinedAt: string
+  leftAt?: string | null
+}
+
+export interface SupplyPurchase {
+  id: string
+  householdId: string
+  purchasedAt: string
+  amount: number
+  description?: string
+}
+
+export interface SupplyShare {
+  purchaseId: string
+  memberId: string
+  householdId: string
+  amount: number
+  calculatedAt: string
+  membershipSnapshot: string[]
+  purchaseDate: string
+}
+
+export type SkipReason =
+  | "household_mismatch"
+  | "before_effective_from"
+  | "existing_share"
+  | "no_active_members"
+
+export interface SkippedPurchase {
+  purchaseId: string
+  reason: SkipReason
+}
+
+export interface GenerateSupplySharesParams {
+  householdId: string
+  purchases: SupplyPurchase[]
+  memberships: HouseholdMembership[]
+  existingShares?: SupplyShare[]
+  effectiveFrom?: string
+  calculationTime?: string
+}
+
+export interface GenerateSupplySharesResult {
+  createdShares: SupplyShare[]
+  skippedPurchases: SkippedPurchase[]
+}
+
+export type MemberIdentifier = string | Pick<HouseholdMembership, "memberId">
+
+export interface MembershipChangeSummary {
+  added: string[]
+  removed: string[]
+  unchanged: string[]
+  changed: boolean
+}
+
+interface NormalizedMembership extends HouseholdMembership {
+  joinedAtTs: number
+  leftAtTs: number | null
+}
+
+interface NormalizedPurchase extends SupplyPurchase {
+  purchasedAtTs: number
+}
+
+function toTimestamp(value: string, label: string): number {
+  const time = new Date(value).getTime()
+  if (Number.isNaN(time)) {
+    throw new Error(`Invalid ${label} value "${value}"`)
+  }
+  return time
+}
+
+function normalizeCalculationTime(value?: string): string {
+  if (!value) {
+    return new Date().toISOString()
+  }
+  const instant = new Date(value)
+  if (Number.isNaN(instant.getTime())) {
+    throw new Error(`Invalid calculation time "${value}"`)
+  }
+  return instant.toISOString()
+}
+
+function normalizeMemberships(
+  memberships: HouseholdMembership[],
+  householdId: string,
+): NormalizedMembership[] {
+  return memberships
+    .filter((membership) => membership.householdId === householdId)
+    .map<NormalizedMembership>((membership) => ({
+      ...membership,
+      joinedAtTs: toTimestamp(membership.joinedAt, "joinedAt"),
+      leftAtTs:
+        membership.leftAt === undefined || membership.leftAt === null
+          ? null
+          : toTimestamp(membership.leftAt, "leftAt"),
+    }))
+    .sort((a, b) => {
+      if (a.joinedAtTs === b.joinedAtTs) {
+        return a.memberId.localeCompare(b.memberId)
+      }
+      return a.joinedAtTs - b.joinedAtTs
+    })
+}
+
+function normalizePurchases(purchases: SupplyPurchase[]): NormalizedPurchase[] {
+  return [...purchases].map<NormalizedPurchase>((purchase) => ({
+    ...purchase,
+    purchasedAtTs: toTimestamp(purchase.purchasedAt, "purchasedAt"),
+  }))
+}
+
+function getActiveMembers(
+  memberships: NormalizedMembership[],
+  timestamp: number,
+): NormalizedMembership[] {
+  return memberships.filter((membership) => {
+    const started = membership.joinedAtTs <= timestamp
+    const notLeft =
+      membership.leftAtTs === null || timestamp < membership.leftAtTs
+    return started && notLeft
+  })
+}
+
+function allocateEvenly(amount: number, count: number): number[] {
+  if (count <= 0) {
+    return []
+  }
+  const totalCents = Math.round(amount * 100)
+  const baseCents = Math.floor(totalCents / count)
+  const remainder = totalCents - baseCents * count
+  return Array.from({ length: count }, (_, index) => {
+    const cents = baseCents + (index < remainder ? 1 : 0)
+    return Number((cents / 100).toFixed(2))
+  })
+}
+
+function createSnapshot(members: NormalizedMembership[]): string[] {
+  return members.map((member) => member.memberId)
+}
+
+function toMemberId(identifier: MemberIdentifier): string {
+  return typeof identifier === "string" ? identifier : identifier.memberId
+}
+
+export function detectMembershipChanges(
+  previous: MemberIdentifier[],
+  next: MemberIdentifier[],
+): MembershipChangeSummary {
+  const previousIds = new Set(previous.map(toMemberId))
+  const nextIds = new Set(next.map(toMemberId))
+
+  const added: string[] = []
+  const removed: string[] = []
+  const unchanged: string[] = []
+
+  for (const id of next.map(toMemberId)) {
+    if (!previousIds.has(id)) {
+      if (!added.includes(id)) {
+        added.push(id)
+      }
+    } else if (!unchanged.includes(id)) {
+      unchanged.push(id)
+    }
+  }
+
+  for (const id of previous.map(toMemberId)) {
+    if (!nextIds.has(id) && !removed.includes(id)) {
+      removed.push(id)
+    }
+  }
+
+  return {
+    added,
+    removed,
+    unchanged,
+    changed: added.length > 0 || removed.length > 0,
+  }
+}
+
+export function generateSupplyShares({
+  householdId,
+  purchases,
+  memberships,
+  existingShares = [],
+  effectiveFrom,
+  calculationTime,
+}: GenerateSupplySharesParams): GenerateSupplySharesResult {
+  if (!householdId) {
+    throw new Error("householdId is required to generate supply shares")
+  }
+
+  const normalizedMemberships = normalizeMemberships(memberships, householdId)
+  const normalizedPurchases = normalizePurchases(purchases)
+  const effectiveFromTs =
+    effectiveFrom === undefined
+      ? Number.NEGATIVE_INFINITY
+      : toTimestamp(effectiveFrom, "effectiveFrom")
+  const calculatedAt = normalizeCalculationTime(calculationTime)
+
+  const existingPurchaseIds = new Set(
+    existingShares
+      .filter((share) => share.householdId === householdId)
+      .map((share) => share.purchaseId),
+  )
+
+  const createdShares: SupplyShare[] = []
+  const skippedPurchases: SkippedPurchase[] = []
+
+  for (const purchase of normalizedPurchases.sort(
+    (a, b) => a.purchasedAtTs - b.purchasedAtTs,
+  )) {
+    if (purchase.householdId !== householdId) {
+      skippedPurchases.push({
+        purchaseId: purchase.id,
+        reason: "household_mismatch",
+      })
+      continue
+    }
+
+    if (purchase.purchasedAtTs < effectiveFromTs) {
+      skippedPurchases.push({
+        purchaseId: purchase.id,
+        reason: "before_effective_from",
+      })
+      continue
+    }
+
+    if (existingPurchaseIds.has(purchase.id)) {
+      skippedPurchases.push({
+        purchaseId: purchase.id,
+        reason: "existing_share",
+      })
+      continue
+    }
+
+    const activeMembers = getActiveMembers(
+      normalizedMemberships,
+      purchase.purchasedAtTs,
+    )
+
+    if (activeMembers.length === 0) {
+      skippedPurchases.push({
+        purchaseId: purchase.id,
+        reason: "no_active_members",
+      })
+      continue
+    }
+
+    const snapshot = createSnapshot(activeMembers)
+    const allocations = allocateEvenly(purchase.amount, activeMembers.length)
+
+    allocations.forEach((shareAmount, index) => {
+      createdShares.push({
+        purchaseId: purchase.id,
+        memberId: activeMembers[index].memberId,
+        householdId,
+        amount: shareAmount,
+        calculatedAt,
+        membershipSnapshot: [...snapshot],
+        purchaseDate: purchase.purchasedAt,
+      })
+    })
+  }
+
+  return { createdShares, skippedPurchases }
+}

--- a/tests/supply-shares.test.ts
+++ b/tests/supply-shares.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest"
+
+import { handleHouseholdMembershipChange } from "@/app/supplies/actions/household-membership"
+import {
+  detectMembershipChanges,
+  generateSupplyShares,
+  type HouseholdMembership,
+  type SupplyPurchase,
+  type SupplyShare,
+} from "@/lib/supplies/share-generator"
+
+const HOUSEHOLD_ID = "house_apricot"
+
+function buildExistingShare(
+  purchaseId: string,
+  memberId: string,
+  amount: number,
+  membershipSnapshot: string[],
+  purchaseDate: string,
+): SupplyShare {
+  return {
+    purchaseId,
+    memberId,
+    amount,
+    householdId: HOUSEHOLD_ID,
+    calculatedAt: "2024-01-01T00:00:00.000Z",
+    membershipSnapshot,
+    purchaseDate,
+  }
+}
+
+const baseMemberships: HouseholdMembership[] = [
+  {
+    householdId: HOUSEHOLD_ID,
+    memberId: "avery",
+    joinedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    householdId: HOUSEHOLD_ID,
+    memberId: "jordan",
+    joinedAt: "2024-01-01T00:00:00Z",
+  },
+]
+
+const purchases: SupplyPurchase[] = [
+  {
+    id: "jan_cleaning",
+    householdId: HOUSEHOLD_ID,
+    amount: 30,
+    purchasedAt: "2024-01-10T12:00:00Z",
+    description: "Cleaning supplies",
+  },
+  {
+    id: "feb_detergent",
+    householdId: HOUSEHOLD_ID,
+    amount: 45,
+    purchasedAt: "2024-02-14T12:00:00Z",
+    description: "Laundry detergent",
+  },
+  {
+    id: "mar_detergent",
+    householdId: HOUSEHOLD_ID,
+    amount: 36,
+    purchasedAt: "2024-03-20T12:00:00Z",
+    description: "Bulk cleaning essentials",
+  },
+  {
+    id: "apr_sponges",
+    householdId: HOUSEHOLD_ID,
+    amount: 28,
+    purchasedAt: "2024-04-04T12:00:00Z",
+    description: "Sponges and dish soap",
+  },
+]
+
+const existingShares: SupplyShare[] = [
+  buildExistingShare("jan_cleaning", "avery", 15, ["avery", "jordan"], purchases[0].purchasedAt),
+  buildExistingShare("jan_cleaning", "jordan", 15, ["avery", "jordan"], purchases[0].purchasedAt),
+  buildExistingShare("feb_detergent", "avery", 22.5, ["avery", "jordan"], purchases[1].purchasedAt),
+  buildExistingShare("feb_detergent", "jordan", 22.5, ["avery", "jordan"], purchases[1].purchasedAt),
+]
+
+describe("detectMembershipChanges", () => {
+  it("flags additions and removals between snapshots", () => {
+    const summary = detectMembershipChanges(
+      ["avery", "jordan"],
+      ["avery", "jordan", "priya"],
+    )
+
+    expect(summary.changed).toBe(true)
+    expect(summary.added).toEqual(["priya"])
+    expect(summary.removed).toEqual([])
+    expect(summary.unchanged).toEqual(["avery", "jordan"])
+  })
+})
+
+describe("generateSupplyShares", () => {
+  it("only recalculates purchases on or after the effective date", () => {
+    const memberships: HouseholdMembership[] = [
+      ...baseMemberships,
+      {
+        householdId: HOUSEHOLD_ID,
+        memberId: "priya",
+        joinedAt: "2024-03-05T00:00:00Z",
+      },
+    ]
+
+    const { createdShares, skippedPurchases } = generateSupplyShares({
+      householdId: HOUSEHOLD_ID,
+      memberships,
+      purchases,
+      existingShares,
+      effectiveFrom: "2024-03-05T00:00:00Z",
+      calculationTime: "2024-03-05T08:30:00Z",
+    })
+
+    expect(skippedPurchases).toEqual([
+      { purchaseId: "jan_cleaning", reason: "before_effective_from" },
+      { purchaseId: "feb_detergent", reason: "before_effective_from" },
+    ])
+
+    const marchShares = createdShares.filter(
+      (share) => share.purchaseId === "mar_detergent",
+    )
+    expect(marchShares).toHaveLength(3)
+    expect(marchShares.map((share) => share.memberId)).toEqual([
+      "avery",
+      "jordan",
+      "priya",
+    ])
+    expect(marchShares.map((share) => share.amount)).toEqual([12, 12, 12])
+    expect(marchShares[0]?.calculatedAt).toBe("2024-03-05T08:30:00.000Z")
+    expect(marchShares[0]?.membershipSnapshot).toEqual([
+      "avery",
+      "jordan",
+      "priya",
+    ])
+
+    const aprilShares = createdShares.filter(
+      (share) => share.purchaseId === "apr_sponges",
+    )
+    expect(aprilShares).toHaveLength(3)
+    expect(aprilShares.map((share) => share.memberId)).toEqual([
+      "avery",
+      "jordan",
+      "priya",
+    ])
+    expect(aprilShares.map((share) => share.amount)).toEqual([9.34, 9.33, 9.33])
+  })
+
+  it("drops departed members for future purchases while preserving history", () => {
+    const memberships: HouseholdMembership[] = [
+      ...baseMemberships,
+      {
+        householdId: HOUSEHOLD_ID,
+        memberId: "priya",
+        joinedAt: "2024-03-05T00:00:00Z",
+        leftAt: "2024-07-01T00:00:00Z",
+      },
+    ]
+
+    const laterPurchases: SupplyPurchase[] = [
+      {
+        id: "jun_gloves",
+        householdId: HOUSEHOLD_ID,
+        amount: 18,
+        purchasedAt: "2024-06-12T12:00:00Z",
+        description: "Gloves and brushes",
+      },
+      {
+        id: "jul_cleaner",
+        householdId: HOUSEHOLD_ID,
+        amount: 24,
+        purchasedAt: "2024-07-12T12:00:00Z",
+        description: "All-purpose cleaner",
+      },
+    ]
+
+    const historicalShares: SupplyShare[] = [
+      ...existingShares,
+      buildExistingShare(
+        "jun_gloves",
+        "avery",
+        6,
+        ["avery", "jordan", "priya"],
+        laterPurchases[0].purchasedAt,
+      ),
+      buildExistingShare(
+        "jun_gloves",
+        "jordan",
+        6,
+        ["avery", "jordan", "priya"],
+        laterPurchases[0].purchasedAt,
+      ),
+      buildExistingShare(
+        "jun_gloves",
+        "priya",
+        6,
+        ["avery", "jordan", "priya"],
+        laterPurchases[0].purchasedAt,
+      ),
+    ]
+
+    const { createdShares, skippedPurchases } = generateSupplyShares({
+      householdId: HOUSEHOLD_ID,
+      memberships,
+      purchases: laterPurchases,
+      existingShares: historicalShares,
+      effectiveFrom: "2024-07-01T00:00:00Z",
+      calculationTime: "2024-07-01T08:00:00Z",
+    })
+
+    expect(skippedPurchases).toEqual([
+      { purchaseId: "jun_gloves", reason: "before_effective_from" },
+    ])
+
+    expect(createdShares).toHaveLength(2)
+    expect(createdShares.map((share) => share.purchaseId)).toEqual([
+      "jul_cleaner",
+      "jul_cleaner",
+    ])
+    expect(createdShares.map((share) => share.memberId)).toEqual([
+      "avery",
+      "jordan",
+    ])
+    expect(createdShares.map((share) => share.amount)).toEqual([12, 12])
+    createdShares.forEach((share) => {
+      expect(share.membershipSnapshot).toEqual(["avery", "jordan"])
+      expect(share.calculatedAt).toBe("2024-07-01T08:00:00.000Z")
+    })
+  })
+})
+
+describe("handleHouseholdMembershipChange", () => {
+  it("detects roster updates and only recalculates future supply shares", async () => {
+    const updatedMemberships: HouseholdMembership[] = [
+      ...baseMemberships,
+      {
+        householdId: HOUSEHOLD_ID,
+        memberId: "priya",
+        joinedAt: "2024-03-05T00:00:00Z",
+      },
+    ]
+
+    const result = await handleHouseholdMembershipChange({
+      householdId: HOUSEHOLD_ID,
+      previousMembers: baseMemberships.map((member) => member.memberId),
+      nextMembers: [...baseMemberships.map((member) => member.memberId), "priya"],
+      memberships: updatedMemberships,
+      purchases,
+      existingShares,
+      effectiveFrom: "2024-03-05T00:00:00Z",
+      calculationTime: "2024-03-05T08:30:00Z",
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.added).toEqual(["priya"])
+    expect(result.removed).toEqual([])
+    expect(result.skippedPurchases).toEqual([
+      { purchaseId: "jan_cleaning", reason: "before_effective_from" },
+      { purchaseId: "feb_detergent", reason: "before_effective_from" },
+    ])
+
+    const recalculatedPurchaseIds = Array.from(
+      new Set(result.createdShares.map((share) => share.purchaseId)),
+    )
+    expect(recalculatedPurchaseIds).toEqual(["mar_detergent", "apr_sponges"])
+
+    const aprilShares = result.createdShares.filter(
+      (share) => share.purchaseId === "apr_sponges",
+    )
+    expect(aprilShares.map((share) => share.amount)).toEqual([9.34, 9.33, 9.33])
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable supply share generator that detects roster changes and skips historical purchases
- expose a `handleHouseholdMembershipChange` server action so membership updates only recalc future supply shares
- document the behaviour in the README and cover join/departure flows with new Vitest coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0d15ecb34832896ee2e5cb3c0e980