### PR TITLE
Add supply ledger schema and tenant ledger page

### DIFF
--- a/app/(tenant)/supplies/ledger/_components/ledger-filters.tsx
+++ b/app/(tenant)/supplies/ledger/_components/ledger-filters.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Download, RotateCcw } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+export interface MonthOption {
+  label: string
+  value: string
+}
+
+interface LedgerFiltersProps {
+  months: MonthOption[]
+  selectedMonth?: string
+}
+
+export function LedgerFilters({ months, selectedMonth }: LedgerFiltersProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const handleMonthChange = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+
+      if (value === 'all') {
+        params.delete('month')
+      } else {
+        params.set('month', value)
+      }
+
+      const queryString = params.toString()
+      router.push(queryString ? `?${queryString}` : '?', { scroll: false })
+    },
+    [router, searchParams]
+  )
+
+  const exportHref = selectedMonth
+    ? `/supplies/ledger/export?month=${selectedMonth}`
+    : '/supplies/ledger/export'
+
+  const currentValue = selectedMonth ?? 'all'
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <Select value={currentValue} onValueChange={handleMonthChange}>
+          <SelectTrigger className="w-[220px]">
+            <SelectValue placeholder="Filter by month" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All months</SelectItem>
+            {months.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          variant="outline"
+          onClick={() => handleMonthChange('all')}
+          disabled={currentValue === 'all'}
+        >
+          <RotateCcw className="mr-2 size-4" />
+          Reset
+        </Button>
+      </div>
+      <Button asChild variant="secondary">
+        <a href={exportHref}>
+          <Download className="mr-2 size-4" />
+          Export CSV
+        </a>
+      </Button>
+    </div>
+  )
+}

--- a/app/(tenant)/supplies/ledger/export/route.ts
+++ b/app/(tenant)/supplies/ledger/export/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import {
+  LedgerDataError,
+  getSupplyLedgerData,
+  supplyLedgerToCsv,
+} from '@/lib/supplies/ledger'
+
+const exportQuerySchema = z.object({
+  month: z
+    .string()
+    .regex(/^[0-9]{4}-(0[1-9]|1[0-2])$/, 'Month must be in YYYY-MM format')
+    .optional(),
+})
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const potentialFilters = {
+    month: searchParams.get('month') ?? undefined,
+  }
+
+  try {
+    const filters = exportQuerySchema.parse(potentialFilters)
+    const ledger = await getSupplyLedgerData(filters)
+    const csv = supplyLedgerToCsv(ledger.entries)
+    const filename = `supply-ledger${filters.month ? `-${filters.month}` : ''}.csv`
+
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Invalid filter parameters.' }, { status: 400 })
+    }
+
+    if (error instanceof LedgerDataError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to export the supply ledger. Please try again.' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/(tenant)/supplies/ledger/page.tsx
+++ b/app/(tenant)/supplies/ledger/page.tsx
@@ -1,0 +1,283 @@
+import { format, parseISO } from 'date-fns'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatCurrency } from '@/lib/payments/currency'
+import {
+  SupplyLedgerMemberPosition,
+  SupplyLedgerEntry,
+  getSupplyLedgerData,
+} from '@/lib/supplies/ledger'
+
+import { LedgerFilters, MonthOption } from './_components/ledger-filters'
+
+const DEFAULT_CURRENCY = 'USD'
+
+interface LedgerPageProps {
+  searchParams?: {
+    month?: string | string[]
+  }
+}
+
+function formatMonthOption(value: string): MonthOption {
+  try {
+    const label = format(parseISO(`${value}-01`), 'MMMM yyyy')
+    return { value, label }
+  } catch (error) {
+    return { value, label: value }
+  }
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) {
+    return '—'
+  }
+
+  try {
+    return format(parseISO(value), 'MMM d, yyyy')
+  } catch (error) {
+    return value.split('T')[0] ?? value
+  }
+}
+
+function groupMembers(
+  positions: SupplyLedgerMemberPosition[],
+  variant: 'owed' | 'owing'
+): SupplyLedgerMemberPosition[] {
+  const filtered = positions.filter((position) =>
+    variant === 'owed' ? position.totalOwed > 0 : position.totalOwing > 0
+  )
+
+  const sorted = filtered.sort((a, b) => {
+    const aTotal = variant === 'owed' ? a.totalOwed : a.totalOwing
+    const bTotal = variant === 'owed' ? b.totalOwed : b.totalOwing
+    return bTotal - aTotal
+  })
+
+  return sorted
+}
+
+function LedgerGroupCard({
+  title,
+  description,
+  members,
+  variant,
+}: {
+  title: string
+  description: string
+  members: SupplyLedgerMemberPosition[]
+  variant: 'owed' | 'owing'
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {members.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Everyone is square — no unsettled shares.</p>
+        ) : (
+          <ul className="space-y-4">
+            {members.map((member) => {
+              const total = variant === 'owed' ? member.totalOwed : member.totalOwing
+              const entries = variant === 'owed' ? member.owedEntries : member.owingEntries
+
+              return (
+                <li
+                  key={member.profileId}
+                  className="flex items-start justify-between gap-4 rounded-lg border border-border/70 bg-muted/30 p-4"
+                >
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">{member.displayName}</p>
+                    {entries.slice(0, 3).map((entry) => (
+                      <p key={`${entry.shareId}-${variant}`} className="text-xs text-muted-foreground">
+                        {entry.supplyName} ·
+                        {variant === 'owed'
+                          ? ` Owes ${entry.creditor.name}`
+                          : ` Owed by ${entry.debtor.name}`}{' '}
+                        ({formatCurrency(entry.amount, DEFAULT_CURRENCY)})
+                      </p>
+                    ))}
+                    {entries.length > 3 ? (
+                      <p className="text-xs text-muted-foreground">
+                        +{entries.length - 3} more item{entries.length - 3 === 1 ? '' : 's'}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-semibold">
+                      {formatCurrency(total, DEFAULT_CURRENCY)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {entries.length} unsettled share{entries.length === 1 ? '' : 's'}
+                    </p>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function LedgerTable({ entries }: { entries: SupplyLedgerEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Supply ledger</CardTitle>
+          <CardDescription>Track cost splits and reimbursement status.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No unsettled shares right now. Add a new supply purchase to populate the ledger.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Supply ledger</CardTitle>
+        <CardDescription>Itemised view of every unsettled supply share.</CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="px-4 py-3 text-left font-semibold">Supply</th>
+              <th className="px-4 py-3 text-left font-semibold">Owes</th>
+              <th className="px-4 py-3 text-left font-semibold">Owed to</th>
+              <th className="px-4 py-3 text-left font-semibold">Purchased</th>
+              <th className="px-4 py-3 text-left font-semibold">Due</th>
+              <th className="px-4 py-3 text-right font-semibold">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => (
+              <tr key={entry.shareId} className="border-b last:border-b-0">
+                <td className="px-4 py-3 align-top">
+                  <div className="space-y-1">
+                    <p className="font-medium text-foreground">{entry.supplyName}</p>
+                    {entry.note ? (
+                      <p className="text-xs text-muted-foreground">{entry.note}</p>
+                    ) : null}
+                  </div>
+                </td>
+                <td className="px-4 py-3 align-top">
+                  <div className="space-y-1">
+                    <p className="font-medium">{entry.debtor.name}</p>
+                    {entry.debtor.email ? (
+                      <p className="text-xs text-muted-foreground">{entry.debtor.email}</p>
+                    ) : null}
+                  </div>
+                </td>
+                <td className="px-4 py-3 align-top">
+                  <div className="space-y-1">
+                    <p className="font-medium">{entry.creditor.name}</p>
+                    {entry.creditor.email ? (
+                      <p className="text-xs text-muted-foreground">{entry.creditor.email}</p>
+                    ) : null}
+                  </div>
+                </td>
+                <td className="px-4 py-3 align-top">{formatDate(entry.purchasedAt)}</td>
+                <td className="px-4 py-3 align-top">{formatDate(entry.dueDate)}</td>
+                <td className="px-4 py-3 text-right align-top font-semibold">
+                  {formatCurrency(entry.amount, DEFAULT_CURRENCY)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default async function SupplyLedgerPage({ searchParams }: LedgerPageProps) {
+  const rawMonth = Array.isArray(searchParams?.month)
+    ? searchParams?.month[0]
+    : searchParams?.month
+
+  const ledger = await getSupplyLedgerData({ month: rawMonth })
+
+  const monthOptions = ledger.availableMonths.map(formatMonthOption)
+  const owedMembers = groupMembers(ledger.positions, 'owed')
+  const owingMembers = groupMembers(ledger.positions, 'owing')
+
+  return (
+    <div className="container max-w-6xl space-y-10 py-12">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Supply ledger</h1>
+          <p className="text-base text-muted-foreground sm:text-lg">
+            Review unsettled supply splits, see who owes what, and export a CSV snapshot for reconciliations.
+          </p>
+        </div>
+        <LedgerFilters months={monthOptions} selectedMonth={ledger.selectedMonth} />
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total outstanding
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">
+              {formatCurrency(ledger.totals.totalOutstanding, DEFAULT_CURRENCY)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Across {ledger.totals.totalEntries} unsettled share
+              {ledger.totals.totalEntries === 1 ? '' : 's'}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Roommates who owe
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">{ledger.totals.roommatesWhoOwe}</p>
+            <p className="text-xs text-muted-foreground">With open reimbursements due</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Roommates owed
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">{ledger.totals.roommatesOwedTo}</p>
+            <p className="text-xs text-muted-foreground">Awaiting repayment from others</p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <LedgerGroupCard
+          title="You owe"
+          description="Roommates and supply shares you still need to reimburse."
+          members={owedMembers}
+          variant="owed"
+        />
+        <LedgerGroupCard
+          title="Roommates owe you"
+          description="Balances other roommates need to settle with you."
+          members={owingMembers}
+          variant="owing"
+        />
+      </section>
+
+      <LedgerTable entries={ledger.entries} />
+    </div>
+  )
+}

--- a/lib/supplies/ledger.ts
+++ b/lib/supplies/ledger.ts
@@ -1,0 +1,366 @@
+import { cookies } from 'next/headers'
+import { z } from 'zod'
+
+import { createClient } from '@/utils/supa-server-actions'
+
+const ledgerFilterSchema = z.object({
+  month: z
+    .string()
+    .regex(/^[0-9]{4}-(0[1-9]|1[0-2])$/, 'Month must be in YYYY-MM format')
+    .optional(),
+})
+
+export type SupplyLedgerFilters = z.infer<typeof ledgerFilterSchema>
+
+type LedgerEntryRow = {
+  share_id: string
+  supply_id: string
+  item_name: string | null
+  total_cost: string | number | null
+  share_amount: string | number | null
+  due_date: string | null
+  status: string
+  note: string | null
+  purchased_at: string
+  purchased_month: string | null
+  creditor_id: string | null
+  creditor_name: string | null
+  creditor_email: string | null
+  creditor_avatar_url: string | null
+  debtor_id: string | null
+  debtor_name: string | null
+  debtor_email: string | null
+  debtor_avatar_url: string | null
+}
+
+type LedgerBalanceRow = {
+  profile_id: string | null
+  period_start: string | null
+  full_name: string | null
+  email: string | null
+  avatar_url: string | null
+  total_owed: string | number | null
+  total_owing: string | number | null
+  net_balance: string | number | null
+}
+
+export interface LedgerParty {
+  id: string | null
+  name: string
+  email: string | null
+  avatarUrl: string | null
+}
+
+export interface SupplyLedgerEntry {
+  shareId: string
+  supplyId: string
+  supplyName: string
+  totalCost: number
+  amount: number
+  dueDate: string | null
+  status: string
+  note: string | null
+  purchasedAt: string
+  purchasedMonth: string | null
+  debtor: LedgerParty
+  creditor: LedgerParty
+}
+
+export interface SupplyLedgerMemberPosition {
+  profileId: string
+  displayName: string
+  email: string | null
+  avatarUrl: string | null
+  totalOwed: number
+  totalOwing: number
+  netBalance: number
+  owedEntries: SupplyLedgerEntry[]
+  owingEntries: SupplyLedgerEntry[]
+}
+
+export interface SupplyLedgerTotals {
+  totalEntries: number
+  totalOutstanding: number
+  roommatesWhoOwe: number
+  roommatesOwedTo: number
+}
+
+export interface SupplyLedgerData {
+  entries: SupplyLedgerEntry[]
+  positions: SupplyLedgerMemberPosition[]
+  totals: SupplyLedgerTotals
+  availableMonths: string[]
+  selectedMonth?: string
+}
+
+export class LedgerDataError extends Error {
+  constructor(message: string, public status = 500) {
+    super(message)
+    this.name = 'LedgerDataError'
+  }
+}
+
+function parseNumeric(value: string | number | null | undefined): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+function normaliseMonth(month: string): string {
+  const [year, rawMonth] = month.split('-')
+  return `${year}-${rawMonth.padStart(2, '0')}`
+}
+
+function escapeCsvField(value: string | null | undefined): string {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  const stringValue = String(value)
+  if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+    return `"${stringValue.replace(/"/g, '""')}"`
+  }
+
+  return stringValue
+}
+
+export function supplyLedgerToCsv(entries: SupplyLedgerEntry[]): string {
+  const header = [
+    'share_id',
+    'purchased_at',
+    'item_name',
+    'share_amount',
+    'debtor_name',
+    'debtor_email',
+    'creditor_name',
+    'creditor_email',
+    'due_date',
+    'note',
+  ]
+
+  const rows = entries.map((entry) => [
+    entry.shareId,
+    entry.purchasedAt,
+    entry.supplyName,
+    entry.amount.toFixed(2),
+    entry.debtor.name,
+    entry.debtor.email ?? '',
+    entry.creditor.name,
+    entry.creditor.email ?? '',
+    entry.dueDate ?? '',
+    entry.note ?? '',
+  ])
+
+  return [header, ...rows]
+    .map((row) => row.map((value) => escapeCsvField(value)).join(','))
+    .join('\n')
+}
+
+export async function getSupplyLedgerData(
+  rawFilters?: Partial<SupplyLedgerFilters>
+): Promise<SupplyLedgerData> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    throw new LedgerDataError('You must be signed in to view the supply ledger.', 401)
+  }
+
+  const validatedFilters = ledgerFilterSchema.partial().parse(rawFilters ?? {})
+  const selectedMonth = validatedFilters.month
+    ? normaliseMonth(validatedFilters.month)
+    : undefined
+  const monthStart = selectedMonth ? `${selectedMonth}-01` : undefined
+
+  const { data: monthRows, error: monthError } = await supabase
+    .from('v_supply_ledger_months')
+    .select('period_start')
+    .order('period_start', { ascending: false })
+
+  if (monthError) {
+    throw new LedgerDataError('Unable to load ledger periods.')
+  }
+
+  const availableMonths = Array.from(
+    new Set(
+      (monthRows ?? [])
+        .map((row) => row.period_start)
+        .filter((value): value is string => Boolean(value))
+        .map((value) => value.slice(0, 7))
+    )
+  ).sort((a, b) => b.localeCompare(a))
+
+  if (selectedMonth && !availableMonths.includes(selectedMonth)) {
+    availableMonths.push(selectedMonth)
+    availableMonths.sort((a, b) => b.localeCompare(a))
+  }
+
+  let entriesQuery = supabase
+    .from('v_supply_ledger_unsettled')
+    .select('*')
+    .order('purchased_at', { ascending: false })
+
+  if (monthStart) {
+    entriesQuery = entriesQuery.eq('purchased_month', monthStart)
+  }
+
+  const { data: entryRowsRaw, error: entryError } = await entriesQuery
+
+  if (entryError) {
+    throw new LedgerDataError('Failed to load unsettled supply shares.')
+  }
+
+  const entryRows = (entryRowsRaw ?? []) as LedgerEntryRow[]
+
+  let balanceQuery = supabase.from('v_supply_ledger_member_balances').select('*')
+
+  if (monthStart) {
+    balanceQuery = balanceQuery.eq('period_start', monthStart)
+  }
+
+  const { data: balanceRowsRaw, error: balanceError } = await balanceQuery
+
+  if (balanceError) {
+    throw new LedgerDataError('Failed to load roommate balance summaries.')
+  }
+
+  const balanceRows = (balanceRowsRaw ?? []) as LedgerBalanceRow[]
+
+  const entries: SupplyLedgerEntry[] = entryRows.map((row) => ({
+    shareId: row.share_id,
+    supplyId: row.supply_id,
+    supplyName: row.item_name ?? 'Shared supply',
+    totalCost: parseNumeric(row.total_cost),
+    amount: parseNumeric(row.share_amount),
+    dueDate: row.due_date,
+    status: row.status,
+    note: row.note,
+    purchasedAt: row.purchased_at,
+    purchasedMonth: row.purchased_month,
+    creditor: {
+      id: row.creditor_id,
+      name: row.creditor_name ?? 'Unassigned roommate',
+      email: row.creditor_email,
+      avatarUrl: row.creditor_avatar_url,
+    },
+    debtor: {
+      id: row.debtor_id,
+      name: row.debtor_name ?? 'Unassigned roommate',
+      email: row.debtor_email,
+      avatarUrl: row.debtor_avatar_url,
+    },
+  }))
+
+  const positionMap = new Map<string, SupplyLedgerMemberPosition>()
+
+  for (const row of balanceRows) {
+    if (!row.profile_id) {
+      continue
+    }
+
+    const owed = parseNumeric(row.total_owed)
+    const owing = parseNumeric(row.total_owing)
+
+    const existing = positionMap.get(row.profile_id)
+    if (existing) {
+      existing.totalOwed += owed
+      existing.totalOwing += owing
+      existing.netBalance = existing.totalOwing - existing.totalOwed
+      continue
+    }
+
+    positionMap.set(row.profile_id, {
+      profileId: row.profile_id,
+      displayName: row.full_name ?? 'Unassigned roommate',
+      email: row.email,
+      avatarUrl: row.avatar_url,
+      totalOwed: owed,
+      totalOwing: owing,
+      netBalance: owing - owed,
+      owedEntries: [],
+      owingEntries: [],
+    })
+  }
+
+  for (const entry of entries) {
+    if (entry.debtor.id) {
+      const existing = positionMap.get(entry.debtor.id) ?? {
+        profileId: entry.debtor.id,
+        displayName: entry.debtor.name,
+        email: entry.debtor.email,
+        avatarUrl: entry.debtor.avatarUrl,
+        totalOwed: 0,
+        totalOwing: 0,
+        netBalance: 0,
+        owedEntries: [],
+        owingEntries: [],
+      }
+
+      existing.owedEntries.push(entry)
+      positionMap.set(entry.debtor.id, existing)
+    }
+
+    if (entry.creditor.id) {
+      const existing = positionMap.get(entry.creditor.id) ?? {
+        profileId: entry.creditor.id,
+        displayName: entry.creditor.name,
+        email: entry.creditor.email,
+        avatarUrl: entry.creditor.avatarUrl,
+        totalOwed: 0,
+        totalOwing: 0,
+        netBalance: 0,
+        owedEntries: [],
+        owingEntries: [],
+      }
+
+      existing.owingEntries.push(entry)
+      positionMap.set(entry.creditor.id, existing)
+    }
+  }
+
+  const positions = Array.from(positionMap.values()).map((position) => {
+    const owedFromEntries = position.owedEntries.reduce(
+      (sum, entry) => sum + entry.amount,
+      0
+    )
+    const owingFromEntries = position.owingEntries.reduce(
+      (sum, entry) => sum + entry.amount,
+      0
+    )
+
+    const totalOwed = position.totalOwed || owedFromEntries
+    const totalOwing = position.totalOwing || owingFromEntries
+
+    return {
+      ...position,
+      totalOwed,
+      totalOwing,
+      netBalance: totalOwing - totalOwed,
+    }
+  })
+
+  const totals: SupplyLedgerTotals = {
+    totalEntries: entries.length,
+    totalOutstanding: entries.reduce((sum, entry) => sum + entry.amount, 0),
+    roommatesWhoOwe: positions.filter((position) => position.totalOwed > 0).length,
+    roommatesOwedTo: positions.filter((position) => position.totalOwing > 0).length,
+  }
+
+  return {
+    entries,
+    positions,
+    totals,
+    availableMonths,
+    selectedMonth,
+  }
+}

--- a/supabase/migrations/20250120120000_supply_ledger.sql
+++ b/supabase/migrations/20250120120000_supply_ledger.sql
@@ -1,0 +1,154 @@
+-- Shared supply ledger schema for tracking purchases and roommate balances
+
+-- Create table for supply purchases
+CREATE TABLE IF NOT EXISTS public.supply_purchases (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  item_name TEXT NOT NULL,
+  total_cost NUMERIC(12,2) NOT NULL CHECK (total_cost >= 0),
+  purchased_by UUID NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  purchased_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  category TEXT,
+  notes TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Create table for roommate shares of each supply purchase
+CREATE TABLE IF NOT EXISTS public.supply_shares (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  supply_id UUID NOT NULL REFERENCES public.supply_purchases(id) ON DELETE CASCADE,
+  creditor_profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  debtor_profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  share_amount NUMERIC(12,2) NOT NULL CHECK (share_amount >= 0),
+  status TEXT NOT NULL DEFAULT 'unsettled' CHECK (status IN ('unsettled', 'settled', 'waived')),
+  due_date DATE,
+  settled_at TIMESTAMP WITH TIME ZONE,
+  note TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Helpful indexes for common lookups
+CREATE INDEX IF NOT EXISTS idx_supply_purchases_purchased_by ON public.supply_purchases(purchased_by);
+CREATE INDEX IF NOT EXISTS idx_supply_purchases_purchased_at ON public.supply_purchases(purchased_at DESC);
+CREATE INDEX IF NOT EXISTS idx_supply_shares_supply_id ON public.supply_shares(supply_id);
+CREATE INDEX IF NOT EXISTS idx_supply_shares_creditor_id ON public.supply_shares(creditor_profile_id);
+CREATE INDEX IF NOT EXISTS idx_supply_shares_debtor_id ON public.supply_shares(debtor_profile_id);
+CREATE INDEX IF NOT EXISTS idx_supply_shares_status ON public.supply_shares(status);
+CREATE INDEX IF NOT EXISTS idx_supply_shares_due_date ON public.supply_shares(due_date);
+
+-- Updated_at triggers reuse the shared helper
+CREATE TRIGGER IF NOT EXISTS update_supply_purchases_updated_at
+  BEFORE UPDATE ON public.supply_purchases
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER IF NOT EXISTS update_supply_shares_updated_at
+  BEFORE UPDATE ON public.supply_shares
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Enable row level security with authenticated access policies
+ALTER TABLE public.supply_purchases ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.supply_shares ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Authenticated users can view supply purchases"
+  ON public.supply_purchases FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY IF NOT EXISTS "Purchasers can insert supply purchases"
+  ON public.supply_purchases FOR INSERT
+  WITH CHECK (auth.uid() = purchased_by);
+
+CREATE POLICY IF NOT EXISTS "Purchasers can update supply purchases"
+  ON public.supply_purchases FOR UPDATE
+  USING (auth.uid() = purchased_by)
+  WITH CHECK (auth.uid() = purchased_by);
+
+CREATE POLICY IF NOT EXISTS "Authenticated users can view supply shares"
+  ON public.supply_shares FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY IF NOT EXISTS "Participants can insert supply shares"
+  ON public.supply_shares FOR INSERT
+  WITH CHECK (auth.uid() = creditor_profile_id OR auth.uid() = debtor_profile_id);
+
+CREATE POLICY IF NOT EXISTS "Participants can update supply shares"
+  ON public.supply_shares FOR UPDATE
+  USING (auth.uid() = creditor_profile_id OR auth.uid() = debtor_profile_id)
+  WITH CHECK (auth.uid() = creditor_profile_id OR auth.uid() = debtor_profile_id);
+
+-- View with the full set of unsettled ledger entries
+CREATE OR REPLACE VIEW public.v_supply_ledger_unsettled AS
+SELECT
+  ss.id AS share_id,
+  ss.supply_id,
+  sp.item_name,
+  sp.total_cost,
+  ss.share_amount,
+  ss.due_date,
+  ss.status,
+  ss.note,
+  sp.purchased_at,
+  DATE_TRUNC('month', sp.purchased_at)::DATE AS purchased_month,
+  ss.creditor_profile_id AS creditor_id,
+  creditor.full_name AS creditor_name,
+  creditor.email AS creditor_email,
+  creditor.avatar_url AS creditor_avatar_url,
+  ss.debtor_profile_id AS debtor_id,
+  debtor.full_name AS debtor_name,
+  debtor.email AS debtor_email,
+  debtor.avatar_url AS debtor_avatar_url
+FROM public.supply_shares ss
+JOIN public.supply_purchases sp ON sp.id = ss.supply_id
+LEFT JOIN public.profiles creditor ON creditor.id = ss.creditor_profile_id
+LEFT JOIN public.profiles debtor ON debtor.id = ss.debtor_profile_id
+WHERE ss.status = 'unsettled';
+
+-- Aggregated balances per roommate and month
+CREATE OR REPLACE VIEW public.v_supply_ledger_member_balances AS
+WITH unsettled AS (
+  SELECT
+    ss.share_amount,
+    ss.creditor_profile_id,
+    ss.debtor_profile_id,
+    DATE_TRUNC('month', sp.purchased_at)::DATE AS period_start
+  FROM public.supply_shares ss
+  JOIN public.supply_purchases sp ON sp.id = ss.supply_id
+  WHERE ss.status = 'unsettled'
+),
+owed AS (
+  SELECT
+    debtor_profile_id AS profile_id,
+    period_start,
+    SUM(share_amount) AS total_owed
+  FROM unsettled
+  GROUP BY debtor_profile_id, period_start
+),
+owing AS (
+  SELECT
+    creditor_profile_id AS profile_id,
+    period_start,
+    SUM(share_amount) AS total_owing
+  FROM unsettled
+  GROUP BY creditor_profile_id, period_start
+)
+SELECT
+  COALESCE(owed.profile_id, owing.profile_id) AS profile_id,
+  COALESCE(owed.period_start, owing.period_start) AS period_start,
+  pr.full_name,
+  pr.email,
+  pr.avatar_url,
+  COALESCE(owed.total_owed, 0) AS total_owed,
+  COALESCE(owing.total_owing, 0) AS total_owing,
+  COALESCE(owing.total_owing, 0) - COALESCE(owed.total_owed, 0) AS net_balance
+FROM owed
+FULL OUTER JOIN owing
+  ON owed.profile_id = owing.profile_id AND owed.period_start = owing.period_start
+LEFT JOIN public.profiles pr ON pr.id = COALESCE(owed.profile_id, owing.profile_id);
+
+-- View for quickly retrieving available unsettled months
+CREATE OR REPLACE VIEW public.v_supply_ledger_months AS
+SELECT DISTINCT
+  DATE_TRUNC('month', sp.purchased_at)::DATE AS period_start
+FROM public.supply_shares ss
+JOIN public.supply_purchases sp ON sp.id = ss.supply_id
+WHERE ss.status = 'unsettled';


### PR DESCRIPTION
## Summary
- add supply_purchases / supply_shares tables plus aggregated ledger views for unsettled shares
- implement server-side helpers for filtering, grouping, and exporting supply ledger data
- build the tenant supply ledger page with filters, grouped summaries, details table, and CSV export route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d15f7f808328a1e728896035735a