### PR TITLE
Add supply purchases table

### DIFF
--- a/supabase/migrations/20250104_supply_purchases.sql
+++ b/supabase/migrations/20250104_supply_purchases.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public.supply_purchases (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  supply_item_id UUID NOT NULL REFERENCES public.supply_items(id) ON DELETE CASCADE,
+  household_id UUID NOT NULL REFERENCES public.households(id),
+  member_id UUID NOT NULL REFERENCES public.members(id),
+  quantity INTEGER NOT NULL CHECK (quantity > 0),
+  price_cents INTEGER NOT NULL CHECK (price_cents > 0),
+  receipt_url TEXT,
+  purchased_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- create a `supply_purchases` table that links to supply items, households, and members
- enforce positive quantity and price constraints and cascade deletions from supply items

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0d165c5f4832886402dfb9757f980