### PR TITLE
Add admin chore assignment roll action

### DIFF
--- a/app/chores/actions.ts
+++ b/app/chores/actions.ts
@@ -1,0 +1,106 @@
+"use server"
+
+import { addWeeks, format, startOfWeek } from "date-fns"
+import { revalidatePath } from "next/cache"
+
+import { generateChoreAssignmentsForWeek } from "@/lib/chores/generator"
+import type { ChoreAssignmentRollSummary } from "@/lib/chores/generator"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+export type RollAssignmentsState = {
+  status: "idle" | "success" | "error"
+  message?: string
+  details?: string
+  summary?: ChoreAssignmentRollSummary
+}
+
+export const rollAssignmentsInitialState: RollAssignmentsState = {
+  status: "idle",
+}
+
+const AUDIT_ACTION = "chores.roll_assignments"
+
+export async function rollAssignments(
+  _prevState: RollAssignmentsState,
+  _formData: FormData
+): Promise<RollAssignmentsState> {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return {
+      status: "error",
+      message: "You must be signed in as an admin to roll assignments.",
+    }
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, role, full_name")
+    .eq("id", user.id)
+    .single()
+
+  if (profileError) {
+    console.error("Failed to load profile for rollAssignments", profileError)
+    return {
+      status: "error",
+      message: "Unable to verify permissions.",
+    }
+  }
+
+  if (profile?.role !== "admin") {
+    return {
+      status: "error",
+      message: "Only administrators can roll assignments.",
+    }
+  }
+
+  const nextWeekStart = startOfWeek(addWeeks(new Date(), 1), { weekStartsOn: 1 })
+
+  try {
+    const summary = await generateChoreAssignmentsForWeek(supabase, nextWeekStart)
+
+    const auditPayload = {
+      actor_id: user.id,
+      action: AUDIT_ACTION,
+      metadata: {
+        week_start: summary.weekStart,
+        week_end: summary.weekEnd,
+        assignments_created: summary.assignmentsCreated,
+        trigger: "manual_admin",
+        actor_name: profile?.full_name ?? undefined,
+      },
+      created_at: new Date().toISOString(),
+    }
+
+    const { error: auditError } = await (supabase as any)
+      .from("audit_logs")
+      .insert(auditPayload)
+
+    if (auditError) {
+      console.error("Failed to log audit event for chore roll", auditError)
+    }
+
+    revalidatePath("/chores")
+
+    return {
+      status: "success",
+      message: `Assignments rolled for the week of ${format(nextWeekStart, "MMMM d")}.`,
+      summary,
+    }
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unexpected error while rolling assignments."
+
+    console.error("Failed to roll chore assignments", error)
+
+    return {
+      status: "error",
+      message: "Unable to roll assignments.",
+      details: errorMessage,
+    }
+  }
+}

--- a/app/chores/page.tsx
+++ b/app/chores/page.tsx
@@ -1,10 +1,44 @@
-export default function ChoresPage() {
+import { RollAssignmentsButton } from "@/components/chores/roll-assignments-button"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+
+export default async function ChoresPage() {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  let isAdmin = false
+
+  if (user) {
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .single()
+
+    if (!profileError && profile?.role === "admin") {
+      isAdmin = true
+    }
+  }
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Chores</h1>
-      <p className="text-muted-foreground">Shared chore assignments and schedule will appear here.</p>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Chores</h1>
+          <p className="text-muted-foreground">
+            Shared chore assignments and schedule will appear here.
+          </p>
+        </div>
+        {isAdmin ? (
+          <RollAssignmentsButton />
+        ) : null}
+      </div>
+
+      <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+        Use the manual roll to regenerate assignments if you need to adjust the rotation for the upcoming week.
+      </div>
     </div>
   )
 }
-
 

--- a/components/chores/roll-assignments-button.tsx
+++ b/components/chores/roll-assignments-button.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import * as React from "react"
+import { useFormState, useFormStatus } from "react-dom"
+
+import { rollAssignments, rollAssignmentsInitialState } from "@/app/chores/actions"
+import type { RollAssignmentsState } from "@/app/chores/actions"
+import { Button } from "@/components/ui/button"
+import { toast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+
+interface RollAssignmentsButtonProps {
+  className?: string
+  children?: React.ReactNode
+}
+
+function SubmitButton({ children }: { children?: React.ReactNode }) {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" isLoading={pending} disabled={pending}>
+      {children ?? "Roll assignments"}
+    </Button>
+  )
+}
+
+export function RollAssignmentsButton({
+  className,
+  children,
+}: RollAssignmentsButtonProps) {
+  const [state, action] = useFormState<RollAssignmentsState, FormData>(
+    rollAssignments,
+    rollAssignmentsInitialState
+  )
+
+  React.useEffect(() => {
+    if (state.status === "idle") {
+      return
+    }
+
+    if (state.status === "success") {
+      const description =
+        state.message ??
+        (state.summary
+          ? `${state.summary.assignmentsCreated} assignment${state.summary.assignmentsCreated === 1 ? "" : "s"} generated for the week starting ${state.summary.weekStart}.`
+          : undefined)
+
+      toast({
+        title: "Assignments rolled",
+        description,
+      })
+    }
+
+    if (state.status === "error") {
+      toast({
+        title: state.message ?? "Unable to roll assignments",
+        description: state.details,
+        variant: "destructive",
+      })
+    }
+  }, [state])
+
+  return (
+    <form action={action} className={cn("inline-flex", className)}>
+      <SubmitButton>{children}</SubmitButton>
+    </form>
+  )
+}
+

--- a/lib/chores/generator.ts
+++ b/lib/chores/generator.ts
@@ -1,0 +1,43 @@
+import { addDays, formatISO } from "date-fns"
+
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+export type ChoreAssignmentRollSummary = {
+  weekStart: string
+  weekEnd: string
+  assignmentsCreated: number
+}
+
+const DEFAULT_ASSIGNMENT_COUNT_KEY = "assignments_created"
+
+export async function generateChoreAssignmentsForWeek(
+  supabase: TypedSupabaseClient,
+  weekStart: Date
+): Promise<ChoreAssignmentRollSummary> {
+  const weekStartIso = formatISO(weekStart, { representation: "date" })
+  const weekEndIso = formatISO(addDays(weekStart, 6), { representation: "date" })
+
+  const { data, error } = await (supabase as any).rpc(
+    "generate_chore_assignments_for_week",
+    {
+      week_start: weekStartIso,
+    }
+  )
+
+  if (error) {
+    throw new Error(error.message ?? "Failed to generate chore assignments.")
+  }
+
+  const assignmentsCreated =
+    (data && typeof data === "object" && DEFAULT_ASSIGNMENT_COUNT_KEY in data
+      ? Number((data as Record<string, unknown>)[DEFAULT_ASSIGNMENT_COUNT_KEY])
+      : typeof data === "number"
+        ? data
+        : 0) || 0
+
+  return {
+    weekStart: weekStartIso,
+    weekEnd: weekEndIso,
+    assignmentsCreated,
+  }
+}


### PR DESCRIPTION
## Summary
- add a server action that validates admin access, runs the chore assignment generator for the upcoming week, and records an audit trail entry
- expose a manual "Roll assignments" control on the chores overview that is only visible to admins and surfaces success or failure feedback
- extract a helper that wraps the next-week chore assignment RPC so the action can reuse a consistent summary payload

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d1677a208328bba591d9445a17e4