### PR TITLE
Add chore swap workflow and messaging updates

### DIFF
--- a/app/chores/actions.ts
+++ b/app/chores/actions.ts
@@ -1,0 +1,208 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+
+import type { Database } from '@/lib/supabase'
+import { createClient } from '@/utils/supa-server-actions'
+
+interface ProposeSwapInput {
+  assignmentId: string
+  responderId: string
+  message?: string
+}
+
+interface RespondToSwapInput {
+  swapId: string
+  response: 'accepted' | 'declined'
+}
+
+type TypedChoreAssignment = Database['public']['Tables']['chore_assignments']['Row']
+type TypedChoreSwap = Database['public']['Tables']['chore_swaps']['Row']
+type ProfileRow = Database['public']['Tables']['profiles']['Row']
+
+function formatName(profile?: Pick<ProfileRow, 'full_name'> | null) {
+  return profile?.full_name || 'A roommate'
+}
+
+async function getCurrentUser() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    return { supabase, user: null as const }
+  }
+
+  return { supabase, user }
+}
+
+export async function proposeChoreSwap({ assignmentId, responderId, message }: ProposeSwapInput) {
+  const { supabase, user } = await getCurrentUser()
+  if (!user) {
+    return { success: false, error: 'You must be signed in to request a chore swap.' }
+  }
+
+  const { data: assignment, error: assignmentError } = await supabase
+    .from('chore_assignments')
+    .select('id, assigned_to, unit_id')
+    .eq('id', assignmentId)
+    .single<TypedChoreAssignment>()
+
+  if (assignmentError || !assignment) {
+    return { success: false, error: 'Unable to locate the selected chore assignment.' }
+  }
+
+  if (assignment.assigned_to !== user.id) {
+    return { success: false, error: 'Only the current assignee can propose a swap for this chore.' }
+  }
+
+  if (responderId === user.id) {
+    return { success: false, error: 'Choose a different roommate to complete a swap.' }
+  }
+
+  const { data: responderProfile } = await supabase
+    .from('profiles')
+    .select('id, unit_id')
+    .eq('id', responderId)
+    .single<Pick<ProfileRow, 'id' | 'unit_id'>>()
+
+  if (!responderProfile) {
+    return { success: false, error: 'The selected roommate could not be found.' }
+  }
+
+  if (assignment.unit_id && responderProfile.unit_id && assignment.unit_id !== responderProfile.unit_id) {
+    return { success: false, error: 'You can only request swaps with roommates from the same unit.' }
+  }
+
+  const { count: pendingCount } = await supabase
+    .from('chore_swaps')
+    .select('id', { count: 'exact', head: true })
+    .eq('assignment_id', assignmentId)
+    .eq('status', 'pending')
+
+  if ((pendingCount || 0) > 0) {
+    return { success: false, error: 'There is already a pending swap request for this chore.' }
+  }
+
+  const { error: insertError } = await supabase.from('chore_swaps').insert({
+    assignment_id: assignmentId,
+    requester_id: user.id,
+    responder_id: responderId,
+    message: message?.trim() ? message.trim() : null,
+  })
+
+  if (insertError) {
+    return { success: false, error: 'Failed to create the swap request. Please try again.' }
+  }
+
+  revalidatePath('/chores')
+  return { success: true }
+}
+
+async function postSwapMessage(
+  supabase: ReturnType<typeof createClient>,
+  params: {
+    assignment: Pick<TypedChoreAssignment, 'id' | 'title' | 'unit_id'>
+    swap: Pick<TypedChoreSwap, 'id' | 'requester_id' | 'responder_id'>
+  }
+) {
+  if (!params.assignment.unit_id) {
+    return
+  }
+
+  const [{ data: requesterProfile }, { data: responderProfile }] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('id, full_name')
+      .eq('id', params.swap.requester_id)
+      .single<Pick<ProfileRow, 'id' | 'full_name'>>(),
+    supabase
+      .from('profiles')
+      .select('id, full_name')
+      .eq('id', params.swap.responder_id)
+      .single<Pick<ProfileRow, 'id' | 'full_name'>>(),
+  ])
+
+  const requesterName = formatName(requesterProfile)
+  const responderName = formatName(responderProfile)
+
+  const messageBody = `${responderName} accepted ${requesterName}'s swap for “${params.assignment.title}”.`
+
+  const { error: messageError } = await supabase.from('messages').insert({
+    unit_id: params.assignment.unit_id,
+    channel: 'chores',
+    author_id: params.swap.responder_id,
+    body: messageBody,
+    message_type: 'system',
+    metadata: {
+      assignment_id: params.assignment.id,
+      swap_id: params.swap.id,
+      requester_id: params.swap.requester_id,
+      responder_id: params.swap.responder_id,
+    },
+  })
+
+  if (messageError) {
+    console.error('Failed to post swap message', messageError)
+  }
+}
+
+export async function respondToChoreSwap({ swapId, response }: RespondToSwapInput) {
+  const { supabase, user } = await getCurrentUser()
+  if (!user) {
+    return { success: false, error: 'You must be signed in to respond to a chore swap.' }
+  }
+
+  const { data: swap, error: swapError } = await supabase
+    .from('chore_swaps')
+    .select('*')
+    .eq('id', swapId)
+    .single<TypedChoreSwap>()
+
+  if (swapError || !swap) {
+    return { success: false, error: 'Unable to locate the requested swap.' }
+  }
+
+  if (swap.responder_id !== user.id) {
+    return { success: false, error: 'Only the invited roommate can respond to this swap.' }
+  }
+
+  if (swap.status !== 'pending') {
+    return { success: false, error: 'This swap has already been processed.' }
+  }
+
+  const { error: updateSwapError } = await supabase
+    .from('chore_swaps')
+    .update({
+      status: response,
+      responded_at: new Date().toISOString(),
+    })
+    .eq('id', swapId)
+
+  if (updateSwapError) {
+    return { success: false, error: 'Could not update the swap status. Please try again.' }
+  }
+
+  if (response === 'accepted') {
+    const { data: assignment, error: assignmentError } = await supabase
+      .from('chore_assignments')
+      .update({ assigned_to: swap.responder_id })
+      .eq('id', swap.assignment_id)
+      .select('id, title, unit_id')
+      .single<Pick<TypedChoreAssignment, 'id' | 'title' | 'unit_id'>>()
+
+    if (assignmentError || !assignment) {
+      return { success: false, error: 'Swap accepted, but the chore could not be reassigned.' }
+    }
+
+    await postSwapMessage(supabase, { assignment, swap })
+  }
+
+  revalidatePath('/chores')
+  return { success: true }
+}

--- a/app/chores/page.tsx
+++ b/app/chores/page.tsx
@@ -1,10 +1,134 @@
-export default function ChoresPage() {
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { ChoreAssignmentsList, type AssignmentWithSwaps } from '@/components/chores/chore-assignments-list'
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import type { Database } from '@/lib/supabase'
+import { createClient } from '@/utils/supa-server-actions'
+
+interface RoommateProfile
+  extends Pick<Database['public']['Tables']['profiles']['Row'], 'id' | 'full_name' | 'avatar_url' | 'unit_id'> {}
+
+export default async function ChoresPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, full_name, avatar_url, unit_id')
+    .eq('id', user.id)
+    .single<RoommateProfile>()
+
+  if (!profile) {
+    return (
+      <div className="container max-w-4xl space-y-6 py-12">
+        <header className="space-y-4">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Chore assignments</h1>
+            <p className="text-base text-muted-foreground sm:text-lg">
+              Stay on top of shared responsibilities and coordinate swaps with your roommates.
+            </p>
+          </div>
+          <Separator />
+        </header>
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle>Profile not found</CardTitle>
+            <CardDescription>
+              We could not load your roommate profile. Please complete onboarding or contact support for help.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+
+  if (!profile.unit_id) {
+    return (
+      <div className="container max-w-4xl space-y-6 py-12">
+        <header className="space-y-4">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Chore assignments</h1>
+            <p className="text-base text-muted-foreground sm:text-lg">
+              Stay on top of shared responsibilities and coordinate swaps with your roommates.
+            </p>
+          </div>
+          <Separator />
+        </header>
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle>Join your household</CardTitle>
+            <CardDescription>
+              Once a property manager links you to a unit you&apos;ll see your chore schedule and swap requests here.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+
+  const { data: roommateRows } = await supabase
+    .from('profiles')
+    .select('id, full_name, avatar_url, unit_id')
+    .eq('unit_id', profile.unit_id)
+    .order('full_name', { ascending: true })
+  const roommateMap = new Map<string, RoommateProfile>()
+  ;(roommateRows ?? []).forEach((roommate) => {
+    roommateMap.set(roommate.id, roommate)
+  })
+  if (!roommateMap.has(profile.id)) {
+    roommateMap.set(profile.id, {
+      id: profile.id,
+      full_name: profile.full_name,
+      avatar_url: profile.avatar_url,
+      unit_id: profile.unit_id,
+    })
+  }
+  const roommates = Array.from(roommateMap.values())
+
+  const { data: assignmentsRows } = await supabase
+    .from('chore_assignments')
+    .select('id, title, description, scheduled_for, status, assigned_to, unit_id, metadata, created_at, updated_at')
+    .eq('unit_id', profile.unit_id)
+    .order('scheduled_for', { ascending: true })
+
+  const assignmentIds = (assignmentsRows ?? []).map((assignment) => assignment.id)
+
+  const { data: swapsRows } = assignmentIds.length
+    ? await supabase
+        .from('chore_swaps')
+        .select('*')
+        .in('assignment_id', assignmentIds)
+    : { data: [] as Database['public']['Tables']['chore_swaps']['Row'][] }
+
+  const roommateLookup = new Map(roommates.map((roommate) => [roommate.id, roommate]))
+  const assignments: AssignmentWithSwaps[] = (assignmentsRows ?? []).map((assignment) => ({
+    ...assignment,
+    assignee: roommateLookup.get(assignment.assigned_to) ?? null,
+    swaps: (swapsRows ?? []).filter((swap) => swap.assignment_id === assignment.id),
+  }))
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Chores</h1>
-      <p className="text-muted-foreground">Shared chore assignments and schedule will appear here.</p>
+    <div className="container max-w-5xl space-y-10 py-12">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Chore assignments</h1>
+          <p className="text-base text-muted-foreground sm:text-lg">
+            See what&apos;s on your plate, propose swaps, and keep everyone in sync without leaving the portal.
+          </p>
+        </div>
+        <Separator />
+      </header>
+      <ChoreAssignmentsList assignments={assignments} roommates={roommates} currentUserId={profile.id} />
     </div>
   )
 }
-
-

--- a/components/chores/chore-assignments-list.tsx
+++ b/components/chores/chore-assignments-list.tsx
@@ -1,0 +1,400 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { format } from 'date-fns'
+import { ArrowLeftRight, Loader2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+
+import { proposeChoreSwap, respondToChoreSwap } from '@/app/chores/actions'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { useToast } from '@/components/ui/use-toast'
+import type { Database } from '@/lib/supabase'
+import { cn } from '@/lib/utils'
+
+type ChoreAssignmentRow = Database['public']['Tables']['chore_assignments']['Row']
+type ChoreSwapRow = Database['public']['Tables']['chore_swaps']['Row']
+
+type Roommate = {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+}
+
+export type AssignmentWithSwaps = ChoreAssignmentRow & {
+  assignee: Roommate | null
+  swaps: ChoreSwapRow[]
+}
+
+const statusConfigs: Record<ChoreAssignmentRow['status'], { label: string; className: string }> = {
+  assigned: { label: 'Assigned', className: 'border border-blue-200 bg-blue-50 text-blue-700' },
+  completed: { label: 'Completed', className: 'border border-emerald-200 bg-emerald-50 text-emerald-700' },
+  skipped: { label: 'Skipped', className: 'border border-amber-200 bg-amber-50 text-amber-700' },
+}
+
+const getStatusConfig = (status: ChoreAssignmentRow['status']) => statusConfigs[status]
+
+interface ChoreAssignmentsListProps {
+  assignments: AssignmentWithSwaps[]
+  roommates: Roommate[]
+  currentUserId: string
+}
+
+interface ProcessingState {
+  swapId: string
+  response: 'accepted' | 'declined'
+}
+
+export function ChoreAssignmentsList({ assignments, roommates, currentUserId }: ChoreAssignmentsListProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const roommateMap = useMemo(() => new Map(roommates.map((roommate) => [roommate.id, roommate])), [roommates])
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [dialogAssignment, setDialogAssignment] = useState<AssignmentWithSwaps | null>(null)
+  const [selectedResponderId, setSelectedResponderId] = useState('')
+  const [swapMessage, setSwapMessage] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [processing, setProcessing] = useState<ProcessingState | null>(null)
+
+  const dialogEligibleResponders = useMemo(() => {
+    if (!dialogAssignment) return [] as Roommate[]
+    return roommates.filter(
+      (roommate) => roommate.id !== dialogAssignment.assigned_to && roommate.id !== currentUserId
+    )
+  }, [dialogAssignment, roommates, currentUserId])
+
+  const openSwapDialog = (assignment: AssignmentWithSwaps) => {
+    setDialogAssignment(assignment)
+    const firstEligible = roommates.find(
+      (roommate) => roommate.id !== assignment.assigned_to && roommate.id !== currentUserId
+    )
+    setSelectedResponderId(firstEligible?.id ?? '')
+    setSwapMessage('')
+    setDialogOpen(true)
+  }
+
+  const closeSwapDialog = () => {
+    setDialogOpen(false)
+    setDialogAssignment(null)
+    setSelectedResponderId('')
+    setSwapMessage('')
+  }
+
+  const handleProposeSwap = async () => {
+    if (!dialogAssignment || !selectedResponderId) return
+
+    setIsSubmitting(true)
+    const result = await proposeChoreSwap({
+      assignmentId: dialogAssignment.id,
+      responderId: selectedResponderId,
+      message: swapMessage,
+    })
+
+    setIsSubmitting(false)
+
+    if (!result.success) {
+      toast({
+        title: 'Unable to send swap request',
+        description: result.error ?? 'Please try again.',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    toast({
+      title: 'Swap request sent',
+      description: 'Your roommate will be notified about the proposed swap.',
+    })
+    closeSwapDialog()
+    router.refresh()
+  }
+
+  const handleRespond = async (swapId: string, response: 'accepted' | 'declined') => {
+    setProcessing({ swapId, response })
+    const result = await respondToChoreSwap({ swapId, response })
+    setProcessing(null)
+
+    if (!result.success) {
+      toast({
+        title: 'Unable to update swap',
+        description: result.error ?? 'Please try again.',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    toast({
+      title: response === 'accepted' ? 'Swap accepted' : 'Swap declined',
+      description:
+        response === 'accepted'
+          ? 'The chore assignment has been updated and everyone has been notified.'
+          : 'The requester has been notified of your decision.',
+    })
+    router.refresh()
+  }
+
+  const renderSwapMessage = (swap: ChoreSwapRow, type: 'incoming' | 'outgoing') => {
+    const otherRoommateId = type === 'incoming' ? swap.requester_id : swap.responder_id
+    const otherRoommate = roommateMap.get(otherRoommateId)
+    const otherName = otherRoommate?.full_name || 'A roommate'
+
+    if (swap.status === 'pending') {
+      return type === 'incoming'
+        ? `${otherName} asked to swap this chore with you.`
+        : `Waiting for ${otherName} to respond to your swap request.`
+    }
+
+    if (swap.status === 'accepted') {
+      return `${otherName} accepted this swap request.`
+    }
+
+    if (swap.status === 'declined') {
+      return `${otherName} declined this swap request.`
+    }
+
+    return `${otherName} cancelled this swap request.`
+  }
+
+  if (assignments.length === 0) {
+    return (
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle>No chore assignments yet</CardTitle>
+          <CardDescription>
+            When assignments are published for your unit they will show up here so you can collaborate with roommates.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {assignments.map((assignment) => {
+        const isAssignee = assignment.assigned_to === currentUserId
+        const assigneeName = assignment.assignee?.full_name || 'Unassigned'
+        const formattedDate = assignment.scheduled_for
+          ? format(new Date(assignment.scheduled_for), 'PPP')
+          : 'No due date'
+
+        const pendingIncoming = assignment.swaps.find(
+          (swap) => swap.status === 'pending' && swap.responder_id === currentUserId
+        )
+        const pendingOutgoing = assignment.swaps.find(
+          (swap) => swap.status === 'pending' && swap.requester_id === currentUserId
+        )
+        const availableResponders = roommates.filter(
+          (roommate) => roommate.id !== assignment.assigned_to && roommate.id !== currentUserId
+        )
+        const latestCompletedSwap = [...assignment.swaps]
+          .filter((swap) => swap.status !== 'pending')
+          .sort((a, b) => {
+            const dateA = new Date(a.responded_at ?? a.requested_at ?? '').getTime()
+            const dateB = new Date(b.responded_at ?? b.requested_at ?? '').getTime()
+            return dateB - dateA
+          })[0]
+
+        const statusConfig = getStatusConfig(assignment.status)
+
+        const dialogIsOpen = dialogOpen && dialogAssignment?.id === assignment.id
+
+        return (
+          <Card key={assignment.id} className="shadow-sm">
+            <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+                  <ArrowLeftRight className="hidden size-4 text-muted-foreground sm:inline" />
+                  {assignment.title}
+                </CardTitle>
+                <CardDescription>Due {formattedDate}</CardDescription>
+              </div>
+              <Badge className={cn('self-start text-xs font-medium', statusConfig.className)}>
+                {statusConfig.label}
+              </Badge>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center gap-3">
+                <Avatar className="size-10">
+                  {assignment.assignee?.avatar_url ? (
+                    <AvatarImage src={assignment.assignee.avatar_url} alt={assigneeName} />
+                  ) : (
+                    <AvatarFallback>{assigneeName.charAt(0).toUpperCase()}</AvatarFallback>
+                  )}
+                </Avatar>
+                <div>
+                  <p className="text-sm font-medium">
+                    {assigneeName}
+                    {isAssignee ? ' (You)' : ''}
+                  </p>
+                  <p className="text-xs text-muted-foreground">Assigned roommate</p>
+                </div>
+              </div>
+
+              {assignment.description && (
+                <p className="text-sm text-muted-foreground">{assignment.description}</p>
+              )}
+
+              {pendingIncoming && (
+                <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-3 text-sm">
+                  <p className="font-medium">Swap request pending your response</p>
+                  <p className="text-muted-foreground">{renderSwapMessage(pendingIncoming, 'incoming')}</p>
+                  {pendingIncoming.message && (
+                    <p className="mt-1 text-muted-foreground">“{pendingIncoming.message}”</p>
+                  )}
+                </div>
+              )}
+
+              {pendingOutgoing && (
+                <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/30 p-3 text-sm">
+                  <p className="font-medium">Waiting for a roommate</p>
+                  <p className="text-muted-foreground">{renderSwapMessage(pendingOutgoing, 'outgoing')}</p>
+                  {pendingOutgoing.message && (
+                    <p className="mt-1 text-muted-foreground">“{pendingOutgoing.message}”</p>
+                  )}
+                </div>
+              )}
+
+              {!pendingIncoming && !pendingOutgoing && latestCompletedSwap && (
+                <div className="rounded-md border border-muted-foreground/30 bg-muted/20 p-3 text-sm">
+                  <p className="font-medium">Recent swap update</p>
+                  <p className="text-muted-foreground">
+                    {renderSwapMessage(
+                      latestCompletedSwap,
+                      latestCompletedSwap.responder_id === currentUserId ? 'incoming' : 'outgoing'
+                    )}
+                  </p>
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                {isAssignee && !pendingOutgoing && availableResponders.length > 0 && (
+                  <Dialog open={dialogIsOpen} onOpenChange={(open) => (!open ? closeSwapDialog() : null)}>
+                    <DialogTrigger asChild>
+                      <Button variant="outline" size="sm" onClick={() => openSwapDialog(assignment)}>
+                        Propose swap
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent>
+                      <DialogHeader>
+                        <DialogTitle>Propose a swap</DialogTitle>
+                        <DialogDescription>
+                          Choose a roommate to take over “{assignment.title}”. We will message them with your request.
+                        </DialogDescription>
+                      </DialogHeader>
+                      <div className="space-y-4 py-2">
+                        <div className="space-y-2">
+                          <Label htmlFor="swap-roommate">Roommate</Label>
+                          <Select
+                            value={selectedResponderId}
+                            onValueChange={setSelectedResponderId}
+                            disabled={dialogEligibleResponders.length === 0}
+                          >
+                            <SelectTrigger id="swap-roommate">
+                              <SelectValue placeholder="Select a roommate" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {dialogEligibleResponders.map((roommate) => (
+                                <SelectItem key={roommate.id} value={roommate.id}>
+                                  {roommate.full_name || 'Roommate'}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="swap-message">Message (optional)</Label>
+                          <Textarea
+                            id="swap-message"
+                            value={swapMessage}
+                            onChange={(event) => setSwapMessage(event.target.value)}
+                            placeholder="Share context or offer to cover another chore."
+                            rows={3}
+                          />
+                        </div>
+                      </div>
+                      <DialogFooter>
+                        <Button
+                          type="button"
+                          disabled={isSubmitting || !selectedResponderId}
+                          onClick={handleProposeSwap}
+                        >
+                          {isSubmitting ? (
+                            <>
+                              <Loader2 className="mr-2 size-4 animate-spin" /> Sending
+                            </>
+                          ) : (
+                            'Send request'
+                          )}
+                        </Button>
+                      </DialogFooter>
+                    </DialogContent>
+                  </Dialog>
+                )}
+
+                {pendingIncoming && (
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      onClick={() => handleRespond(pendingIncoming.id, 'accepted')}
+                      disabled={processing?.swapId === pendingIncoming.id}
+                    >
+                      {processing?.swapId === pendingIncoming.id && processing.response === 'accepted' ? (
+                        <>
+                          <Loader2 className="mr-2 size-4 animate-spin" /> Accepting
+                        </>
+                      ) : (
+                        'Accept'
+                      )}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleRespond(pendingIncoming.id, 'declined')}
+                      disabled={processing?.swapId === pendingIncoming.id}
+                    >
+                      {processing?.swapId === pendingIncoming.id && processing.response === 'declined' ? (
+                        <>
+                          <Loader2 className="mr-2 size-4 animate-spin" /> Declining
+                        </>
+                      ) : (
+                        'Decline'
+                      )}
+                    </Button>
+                  </div>
+                )}
+
+                {isAssignee && availableResponders.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    Invite more roommates to your unit to enable swaps.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -183,6 +183,155 @@ export type Database = {
   }
   public: {
     Tables: {
+      chore_assignments: {
+        Row: {
+          assigned_to: string
+          created_at: string | null
+          description: string | null
+          id: string
+          metadata: Json | null
+          scheduled_for: string
+          status: 'assigned' | 'completed' | 'skipped'
+          title: string
+          unit_id: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          assigned_to: string
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          metadata?: Json | null
+          scheduled_for: string
+          status?: 'assigned' | 'completed' | 'skipped'
+          title: string
+          unit_id?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          assigned_to?: string
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          metadata?: Json | null
+          scheduled_for?: string
+          status?: 'assigned' | 'completed' | 'skipped'
+          title?: string
+          unit_id?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'chore_assignments_assigned_to_fkey'
+            columns: ['assigned_to']
+            isOneToOne: false
+            referencedRelation: 'profiles'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      chore_swaps: {
+        Row: {
+          assignment_id: string
+          id: string
+          metadata: Json | null
+          message: string | null
+          requested_at: string | null
+          requester_id: string
+          responder_id: string
+          responded_at: string | null
+          status: 'pending' | 'accepted' | 'declined' | 'cancelled'
+        }
+        Insert: {
+          assignment_id: string
+          id?: string
+          metadata?: Json | null
+          message?: string | null
+          requested_at?: string | null
+          requester_id: string
+          responder_id: string
+          responded_at?: string | null
+          status?: 'pending' | 'accepted' | 'declined' | 'cancelled'
+        }
+        Update: {
+          assignment_id?: string
+          id?: string
+          metadata?: Json | null
+          message?: string | null
+          requested_at?: string | null
+          requester_id?: string
+          responder_id?: string
+          responded_at?: string | null
+          status?: 'pending' | 'accepted' | 'declined' | 'cancelled'
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'chore_swaps_assignment_id_fkey'
+            columns: ['assignment_id']
+            isOneToOne: false
+            referencedRelation: 'chore_assignments'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'chore_swaps_requester_id_fkey'
+            columns: ['requester_id']
+            isOneToOne: false
+            referencedRelation: 'profiles'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'chore_swaps_responder_id_fkey'
+            columns: ['responder_id']
+            isOneToOne: false
+            referencedRelation: 'profiles'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      messages: {
+        Row: {
+          author_id: string | null
+          body: string
+          channel: string
+          created_at: string | null
+          id: string
+          message_type: 'system' | 'user' | 'alert'
+          metadata: Json | null
+          unit_id: string
+          updated_at: string | null
+        }
+        Insert: {
+          author_id?: string | null
+          body: string
+          channel?: string
+          created_at?: string | null
+          id?: string
+          message_type?: 'system' | 'user' | 'alert'
+          metadata?: Json | null
+          unit_id: string
+          updated_at?: string | null
+        }
+        Update: {
+          author_id?: string | null
+          body?: string
+          channel?: string
+          created_at?: string | null
+          id?: string
+          message_type?: 'system' | 'user' | 'alert'
+          metadata?: Json | null
+          unit_id?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'messages_author_id_fkey'
+            columns: ['author_id']
+            isOneToOne: false
+            referencedRelation: 'profiles'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       ai_agents: {
         Row: {
           created_at: string | null
@@ -1241,6 +1390,7 @@ export type Database = {
           linkedin_url: string | null
           public_id: string | null
           role: string | null
+          unit_id: string | null
           updated_at: string | null
           username: string | null
           waddress: string | null
@@ -1261,6 +1411,7 @@ export type Database = {
           linkedin_url?: string | null
           public_id?: string | null
           role?: string | null
+          unit_id?: string | null
           updated_at?: string | null
           username?: string | null
           waddress?: string | null
@@ -1281,6 +1432,7 @@ export type Database = {
           linkedin_url?: string | null
           public_id?: string | null
           role?: string | null
+          unit_id?: string | null
           updated_at?: string | null
           username?: string | null
           waddress?: string | null

--- a/supabase/migrations/20250107_chore_swaps.sql
+++ b/supabase/migrations/20250107_chore_swaps.sql
@@ -1,0 +1,135 @@
+-- Chore assignments and swap workflow
+
+-- Create chore_assignments table
+CREATE TABLE public.chore_assignments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  description TEXT,
+  unit_id UUID,
+  assigned_to UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  scheduled_for DATE NOT NULL,
+  status TEXT NOT NULL DEFAULT 'assigned' CHECK (status IN ('assigned', 'completed', 'skipped')),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Create chore_swaps table to manage swap proposals
+CREATE TABLE public.chore_swaps (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assignment_id UUID NOT NULL REFERENCES public.chore_assignments(id) ON DELETE CASCADE,
+  requester_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  responder_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'declined', 'cancelled')),
+  message TEXT,
+  requested_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  responded_at TIMESTAMP WITH TIME ZONE,
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+-- Household messages channel for swap notifications
+CREATE TABLE public.messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  unit_id UUID NOT NULL,
+  channel TEXT NOT NULL DEFAULT 'household',
+  author_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  body TEXT NOT NULL,
+  message_type TEXT NOT NULL DEFAULT 'system' CHECK (message_type IN ('system', 'user', 'alert')),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for query performance
+CREATE INDEX idx_chore_assignments_unit_id ON public.chore_assignments(unit_id);
+CREATE INDEX idx_chore_assignments_assigned_to ON public.chore_assignments(assigned_to);
+CREATE INDEX idx_chore_assignments_scheduled_for ON public.chore_assignments(scheduled_for DESC);
+
+CREATE INDEX idx_chore_swaps_assignment_id ON public.chore_swaps(assignment_id);
+CREATE INDEX idx_chore_swaps_requester_id ON public.chore_swaps(requester_id);
+CREATE INDEX idx_chore_swaps_responder_id ON public.chore_swaps(responder_id);
+CREATE INDEX idx_chore_swaps_status ON public.chore_swaps(status);
+
+CREATE INDEX idx_messages_unit_channel ON public.messages(unit_id, channel);
+CREATE INDEX idx_messages_created_at ON public.messages(created_at DESC);
+
+-- Updated at triggers
+CREATE TRIGGER update_chore_assignments_updated_at
+  BEFORE UPDATE ON public.chore_assignments
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_chore_swaps_updated_at
+  BEFORE UPDATE ON public.chore_swaps
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_messages_updated_at
+  BEFORE UPDATE ON public.messages
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Enable row level security
+ALTER TABLE public.chore_assignments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chore_swaps ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.messages ENABLE ROW LEVEL SECURITY;
+
+-- Chore assignments policies
+CREATE POLICY "Roommates can view unit chore assignments" ON public.chore_assignments
+  FOR SELECT USING (
+    assigned_to = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles requester
+      JOIN public.profiles viewer ON requester.unit_id = viewer.unit_id
+      WHERE requester.id = chore_assignments.assigned_to
+        AND viewer.id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Swap responders can update chore assignments" ON public.chore_assignments
+  FOR UPDATE USING (
+    assigned_to = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.chore_swaps cs
+      WHERE cs.assignment_id = chore_assignments.id
+        AND cs.responder_id = auth.uid()
+        AND cs.status = 'pending'
+    )
+  ) WITH CHECK (TRUE);
+
+-- Chore swap policies
+CREATE POLICY "Participants can view chore swaps" ON public.chore_swaps
+  FOR SELECT USING (
+    requester_id = auth.uid()
+    OR responder_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.chore_assignments ca
+      JOIN public.profiles viewer ON viewer.id = auth.uid()
+      JOIN public.profiles assignee ON assignee.id = ca.assigned_to
+      WHERE ca.id = chore_swaps.assignment_id
+        AND viewer.unit_id = assignee.unit_id
+    )
+  );
+
+CREATE POLICY "Assignees can propose chore swaps" ON public.chore_swaps
+  FOR INSERT WITH CHECK (requester_id = auth.uid());
+
+CREATE POLICY "Responders can update chore swaps" ON public.chore_swaps
+  FOR UPDATE USING (responder_id = auth.uid()) WITH CHECK (responder_id = auth.uid());
+
+-- Messaging policies scoped to unit
+CREATE POLICY "Roommates can read unit messages" ON public.messages
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles viewer
+      WHERE viewer.id = auth.uid()
+        AND viewer.unit_id = messages.unit_id
+    )
+  );
+
+CREATE POLICY "Roommates can post unit messages" ON public.messages
+  FOR INSERT WITH CHECK (
+    author_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM public.profiles viewer
+      WHERE viewer.id = auth.uid()
+        AND viewer.unit_id = messages.unit_id
+    )
+  );


### PR DESCRIPTION
## Summary
- add Supabase schema for chore assignments, swap requests, and unit-scoped messages
- expose server actions to propose and respond to chore swaps, updating assignments and messaging roommates
- build a chores page component that lists assignments and surfaces swap request and response controls

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d168dae483289261262dfc103a48