### PR TITLE
Add member fairness metrics view and profile display

### DIFF
--- a/app/(tenant)/profile/[id]/page.tsx
+++ b/app/(tenant)/profile/[id]/page.tsx
@@ -1,0 +1,157 @@
+import { notFound } from 'next/navigation'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { createSupbaseServerClient } from '@/utils/supaone'
+import { getMemberFairnessMetric } from '@/queries/member-fairness-metric'
+
+function getInitials(name?: string | null) {
+  if (!name) return 'RM'
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 0) return 'RM'
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase()
+  return `${parts[0]![0] ?? ''}${parts[parts.length - 1]![0] ?? ''}`.toUpperCase()
+}
+
+function formatRole(role?: string | null) {
+  if (!role) return 'Roommate'
+  return role
+    .split('_')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function formatSigned(value: number) {
+  if (value > 0) return `+${value}`
+  return value.toString()
+}
+
+function formatLastRecorded(lastRecordedAt: string | null) {
+  if (!lastRecordedAt) {
+    return 'No chore activity recorded yet'
+  }
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+
+  return `Last recorded ${formatter.format(new Date(lastRecordedAt))}`
+}
+
+function describeFairness(fairnessScore: number) {
+  if (fairnessScore > 0) {
+    return {
+      badgeVariant: 'complete' as const,
+      label: 'On track',
+      detail: 'This member has cleared more chores than they have missed recently.',
+    }
+  }
+  if (fairnessScore < 0) {
+    return {
+      badgeVariant: 'destructive' as const,
+      label: 'Needs attention',
+      detail: 'This member has missed more chore assignments than they completed.',
+    }
+  }
+  return {
+    badgeVariant: 'secondary' as const,
+    label: 'Balanced',
+    detail: 'Completed and missed chore assignments are currently in balance.',
+  }
+}
+
+export default async function MemberProfilePage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const supabase = await createSupbaseServerClient()
+  const memberId = params.id
+
+  const [profileResult, fairnessResult] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('full_name, email, role, avatar_url')
+      .eq('id', memberId)
+      .maybeSingle(),
+    getMemberFairnessMetric(supabase, memberId),
+  ])
+
+  if (profileResult.error) {
+    console.error('Failed to load member profile', profileResult.error)
+  }
+
+  if (fairnessResult.error) {
+    console.error('Failed to load fairness metric', fairnessResult.error)
+  }
+
+  if (!profileResult.data) {
+    notFound()
+  }
+
+  const fairnessData = fairnessResult.data ?? {
+    member_id: memberId,
+    full_name: profileResult.data.full_name,
+    email: profileResult.data.email,
+    avatar_url: profileResult.data.avatar_url,
+    role: profileResult.data.role,
+    completed_count: 0,
+    missed_count: 0,
+    fairness_score: 0,
+    last_recorded_at: null,
+  }
+
+  const summary = describeFairness(fairnessData.fairness_score)
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-10">
+      <Card>
+        <CardHeader className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-4">
+            <Avatar className="size-16">
+              <AvatarImage src={profileResult.data.avatar_url ?? undefined} alt={profileResult.data.full_name ?? 'Roommate avatar'} />
+              <AvatarFallback>{getInitials(profileResult.data.full_name)}</AvatarFallback>
+            </Avatar>
+            <div className="space-y-2">
+              <div>
+                <CardTitle className="text-2xl font-semibold">
+                  {profileResult.data.full_name ?? 'Unnamed roommate'}
+                </CardTitle>
+                <CardDescription>
+                  {formatRole(profileResult.data.role)} • {profileResult.data.email ?? 'Email unavailable'}
+                </CardDescription>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {summary.detail}
+              </p>
+            </div>
+          </div>
+          <Badge variant={summary.badgeVariant} className="whitespace-nowrap px-3 py-1 text-sm">
+            {summary.label}
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-lg border p-4 shadow-sm">
+              <p className="text-sm text-muted-foreground">Completed</p>
+              <p className="text-3xl font-semibold">{fairnessData.completed_count}</p>
+            </div>
+            <div className="rounded-lg border p-4 shadow-sm">
+              <p className="text-sm text-muted-foreground">Missed</p>
+              <p className="text-3xl font-semibold">{fairnessData.missed_count}</p>
+            </div>
+            <div className="rounded-lg border p-4 shadow-sm">
+              <p className="text-sm text-muted-foreground">Fairness score</p>
+              <p className="text-3xl font-semibold">{formatSigned(fairnessData.fairness_score)}</p>
+            </div>
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {formatLastRecorded(fairnessData.last_recorded_at)}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -510,6 +510,44 @@ export type Database = {
         }
         Relationships: []
       }
+      chore_participation_logs: {
+        Row: {
+          chore_name: string
+          id: string
+          member_id: string
+          metadata: Json | null
+          occurrence_date: string
+          recorded_at: string
+          status: string
+        }
+        Insert: {
+          chore_name: string
+          id?: string
+          member_id: string
+          metadata?: Json | null
+          occurrence_date: string
+          recorded_at?: string
+          status: string
+        }
+        Update: {
+          chore_name?: string
+          id?: string
+          member_id?: string
+          metadata?: Json | null
+          occurrence_date?: string
+          recorded_at?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chore_participation_logs_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       crm_activities: {
         Row: {
           completed_date: string | null
@@ -1841,6 +1879,20 @@ export type Database = {
       }
     }
     Views: {
+      member_fairness_metrics: {
+        Row: {
+          avatar_url: string | null
+          completed_count: number
+          email: string | null
+          fairness_score: number
+          full_name: string | null
+          last_recorded_at: string | null
+          member_id: string
+          missed_count: number
+          role: string | null
+        }
+        Relationships: []
+      }
       package_utilization: {
         Row: {
           created_at: string | null

--- a/queries/member-fairness-metric.ts
+++ b/queries/member-fairness-metric.ts
@@ -1,0 +1,33 @@
+import type { Database } from '@/lib/supabase'
+import { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+
+export type MemberFairnessMetric =
+  Database['public']['Views']['member_fairness_metrics']['Row']
+
+const VIEW_NAME = 'member_fairness_metrics'
+const FAIRNESS_FIELDS = `
+  member_id,
+  full_name,
+  email,
+  avatar_url,
+  role,
+  completed_count,
+  missed_count,
+  fairness_score,
+  last_recorded_at
+`
+
+export function getMemberFairnessMetric(
+  client: TypedSupabaseClient,
+  memberId: string
+) {
+  return client
+    .from(VIEW_NAME)
+    .select(FAIRNESS_FIELDS)
+    .eq('member_id', memberId)
+    .maybeSingle()
+}
+
+export function listMemberFairnessMetrics(client: TypedSupabaseClient) {
+  return client.from(VIEW_NAME).select(FAIRNESS_FIELDS)
+}

--- a/supabase/migrations/20250220090000_member_fairness_metrics.sql
+++ b/supabase/migrations/20250220090000_member_fairness_metrics.sql
@@ -1,0 +1,59 @@
+-- Track chore participation outcomes so we can derive fairness metrics per member
+CREATE TABLE IF NOT EXISTS public.chore_participation_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  member_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  chore_name TEXT NOT NULL,
+  occurrence_date DATE NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('completed', 'missed')),
+  recorded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT timezone('utc', now()),
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS chore_participation_logs_member_id_idx
+  ON public.chore_participation_logs(member_id);
+
+CREATE INDEX IF NOT EXISTS chore_participation_logs_occurrence_date_idx
+  ON public.chore_participation_logs(occurrence_date DESC);
+
+ALTER TABLE public.chore_participation_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Members can manage their own chore participation logs"
+  ON public.chore_participation_logs
+  FOR ALL
+  USING (member_id = auth.uid())
+  WITH CHECK (member_id = auth.uid());
+
+CREATE POLICY IF NOT EXISTS "Property managers can view all chore participation logs"
+  ON public.chore_participation_logs
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE OR REPLACE VIEW public.member_fairness_metrics AS
+WITH member_counts AS (
+  SELECT
+    member_id,
+    COUNT(*) FILTER (WHERE status = 'completed') AS completed_count,
+    COUNT(*) FILTER (WHERE status = 'missed') AS missed_count,
+    MAX(recorded_at) AS last_recorded_at
+  FROM public.chore_participation_logs
+  GROUP BY member_id
+)
+SELECT
+  p.id AS member_id,
+  p.full_name,
+  p.email,
+  p.role,
+  p.avatar_url,
+  COALESCE(mc.completed_count, 0)::int AS completed_count,
+  COALESCE(mc.missed_count, 0)::int AS missed_count,
+  (COALESCE(mc.completed_count, 0) - COALESCE(mc.missed_count, 0))::int AS fairness_score,
+  mc.last_recorded_at
+FROM public.profiles p
+LEFT JOIN member_counts mc ON mc.member_id = p.id;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,38 @@
+-- Seed demo roommate profiles so fairness metrics are visible immediately in development
+INSERT INTO public.profiles (id, full_name, email, role, avatar_url)
+VALUES
+  ('11111111-1111-1111-1111-111111111111', 'Avery Chen', 'avery.chen@example.com', 'roommate', NULL),
+  ('22222222-2222-2222-2222-222222222222', 'Jordan Blake', 'jordan.blake@example.com', 'roommate', NULL),
+  ('33333333-3333-3333-3333-333333333333', 'Priya Desai', 'priya.desai@example.com', 'roommate', NULL)
+ON CONFLICT (id) DO UPDATE
+SET
+  full_name = EXCLUDED.full_name,
+  email = EXCLUDED.email,
+  role = EXCLUDED.role,
+  avatar_url = EXCLUDED.avatar_url;
+
+-- Provide chore participation history with a mix of completed and missed runs
+INSERT INTO public.chore_participation_logs (id, member_id, chore_name, occurrence_date, status, recorded_at, metadata)
+VALUES
+  ('aaaa1111-aaaa-1111-aaaa-111111111111', '11111111-1111-1111-1111-111111111111', 'Kitchen deep clean', DATE '2024-06-01', 'completed', '2024-06-01T15:00:00Z', jsonb_build_object('weight', 2)),
+  ('aaaa1111-aaaa-1111-aaaa-111111111112', '11111111-1111-1111-1111-111111111111', 'Trash night', DATE '2024-06-04', 'completed', '2024-06-04T20:30:00Z', jsonb_build_object('weight', 1)),
+  ('aaaa1111-aaaa-1111-aaaa-111111111113', '11111111-1111-1111-1111-111111111111', 'Bathroom reset', DATE '2024-06-08', 'missed', '2024-06-08T09:00:00Z', jsonb_build_object('weight', 1)),
+  ('aaaa1111-aaaa-1111-aaaa-111111111114', '11111111-1111-1111-1111-111111111111', 'Living room dusting', DATE '2024-06-12', 'completed', '2024-06-12T18:45:00Z', jsonb_build_object('weight', 1)),
+
+  ('bbbb2222-bbbb-2222-bbbb-222222222221', '22222222-2222-2222-2222-222222222222', 'Kitchen deep clean', DATE '2024-06-01', 'missed', '2024-06-01T15:30:00Z', jsonb_build_object('weight', 2)),
+  ('bbbb2222-bbbb-2222-bbbb-222222222222', '22222222-2222-2222-2222-222222222222', 'Trash night', DATE '2024-06-05', 'completed', '2024-06-05T21:15:00Z', jsonb_build_object('weight', 1)),
+  ('bbbb2222-bbbb-2222-bbbb-222222222223', '22222222-2222-2222-2222-222222222222', 'Bathroom reset', DATE '2024-06-09', 'completed', '2024-06-09T10:15:00Z', jsonb_build_object('weight', 1)),
+  ('bbbb2222-bbbb-2222-bbbb-222222222224', '22222222-2222-2222-2222-222222222222', 'Living room dusting', DATE '2024-06-13', 'missed', '2024-06-13T19:00:00Z', jsonb_build_object('weight', 1)),
+
+  ('cccc3333-cccc-3333-cccc-333333333331', '33333333-3333-3333-3333-333333333333', 'Kitchen deep clean', DATE '2024-06-01', 'missed', '2024-06-01T14:30:00Z', jsonb_build_object('weight', 2)),
+  ('cccc3333-cccc-3333-cccc-333333333332', '33333333-3333-3333-3333-333333333333', 'Trash night', DATE '2024-06-04', 'missed', '2024-06-04T20:00:00Z', jsonb_build_object('weight', 1)),
+  ('cccc3333-cccc-3333-cccc-333333333333', '33333333-3333-3333-3333-333333333333', 'Bathroom reset', DATE '2024-06-08', 'missed', '2024-06-08T09:30:00Z', jsonb_build_object('weight', 1)),
+  ('cccc3333-cccc-3333-cccc-333333333334', '33333333-3333-3333-3333-333333333333', 'Living room dusting', DATE '2024-06-12', 'completed', '2024-06-12T18:00:00Z', jsonb_build_object('weight', 1))
+ON CONFLICT (id) DO UPDATE
+SET
+  member_id = EXCLUDED.member_id,
+  chore_name = EXCLUDED.chore_name,
+  occurrence_date = EXCLUDED.occurrence_date,
+  status = EXCLUDED.status,
+  recorded_at = EXCLUDED.recorded_at,
+  metadata = EXCLUDED.metadata;


### PR DESCRIPTION
## Summary
- create a chore participation log table and member_fairness_metrics view to aggregate completed versus missed chores per roommate
- seed demo roommate profiles and chore history so fairness scores are visible immediately
- surface the fairness metric via a tenant profile route and reusable Supabase query helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d16981f883289649dc1989c7f0db