### PR TITLE
Implement tenant supplies dashboard with Supabase integration

### DIFF
--- a/app/supplies/page.tsx
+++ b/app/supplies/page.tsx
@@ -1,10 +1,5 @@
-export default function SuppliesPage() {
-  return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Shared Supplies</h1>
-      <p className="text-muted-foreground">Track and split costs for cleaning supplies and essentials.</p>
-    </div>
-  )
-}
+export { metadata } from '@/src/app/(tenant)/supplies/page'
+
+export { default } from '@/src/app/(tenant)/supplies/page'
 
 

--- a/components/feature-prism.tsx
+++ b/components/feature-prism.tsx
@@ -61,53 +61,49 @@ class ErrorBoundary extends React.Component {
 // Define our features
 const features = [
   {
-    name: "Traceability",
+    name: "Pantry planning",
     icon: CuboidIcon,
-    description:
-      "End-to-end visibility of products throughout the supply chain, ensuring authenticity and origin verification.",
+    description: "Shared shopping lists keep staples in sync and prevent duplicate grocery runs.",
     color: "#3b82f6",
     icon3D: "Cube",
     pulseOffset: 0, // Offset for pulsing effect
   },
   {
-    name: "Security",
+    name: "Roommate transparency",
     icon: Shield,
-    description:
-      "Immutable and encrypted data storage protecting sensitive information across the entire logistics network.",
+    description: "See who restocked essentials last so chores and reimbursements stay fair for everyone.",
     color: "#10b981",
     icon3D: "Shield",
     pulseOffset: 1, // Offset for pulsing effect
   },
   {
-    name: "Efficiency",
+    name: "Smart reminders",
     icon: Zap,
-    description:
-      "Streamlined processes and reduced costs through optimized routing and real-time inventory management.",
+    description: "Automated nudges surface when household supplies are running low or overdue for replacement.",
     color: "#f59e0b",
     icon3D: "Lightning",
     pulseOffset: 2, // Offset for pulsing effect
   },
   {
-    name: "Integration",
+    name: "Connected receipts",
     icon: Link,
-    description:
-      "Seamless connection with existing systems including ERP, WMS, and other supply chain management tools.",
+    description: "Attach digital receipts and share payment links so reimbursements happen without group chat chaos.",
     color: "#8b5cf6",
     icon3D: "Chain",
     pulseOffset: 3, // Offset for pulsing effect
   },
   {
-    name: "Automation",
+    name: "Auto-split costs",
     icon: Cog,
-    description: "AI-driven decision making and operations that reduce human error and increase operational speed.",
+    description: "Suggested cost splits and ledger entries cut down on manual math after each supply run.",
     color: "#ec4899",
     icon3D: "Gear",
     pulseOffset: 5, // Offset for pulsing effect (Fibonacci)
   },
   {
-    name: "Data",
+    name: "Household insights",
     icon: Database,
-    description: "Comprehensive analytics and insights derived from blockchain-secured supply chain data.",
+    description: "Track monthly spend, identify trends, and forecast the next big restock before anyone runs out.",
     color: "#06b6d4",
     icon3D: "Database",
     pulseOffset: 8, // Offset for pulsing effect (Fibonacci)

--- a/src/app/(tenant)/supplies/_components/add-supply-item-form.tsx
+++ b/src/app/(tenant)/supplies/_components/add-supply-item-form.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useState, useTransition, FormEvent } from 'react'
+import { Plus, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { useToast } from '@/components/ui/use-toast'
+
+import { addSupplyItem } from '../actions'
+
+export function AddSupplyItemForm() {
+  const { toast } = useToast()
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const form = event.currentTarget
+    const formData = new FormData(form)
+
+    const payload = {
+      name: (formData.get('name') as string | null)?.trim() ?? '',
+      quantity: (formData.get('quantity') as string | null)?.trim() ?? undefined,
+      category: (formData.get('category') as string | null)?.trim() ?? undefined,
+      notes: (formData.get('notes') as string | null)?.trim() ?? undefined,
+    }
+
+    startTransition(async () => {
+      const result = await addSupplyItem(payload)
+
+      if (!result.success) {
+        toast({
+          title: 'Could not add item',
+          description: result.error ?? 'Please try again.',
+          variant: 'destructive',
+        })
+        return
+      }
+
+      toast({
+        title: 'Item added',
+        description: result.message ?? 'The household shopping list has been updated.',
+      })
+
+      form.reset()
+      setOpen(false)
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" className="gap-2">
+          <Plus className="size-4" aria-hidden />
+          Add item
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add to the shopping list</DialogTitle>
+          <DialogDescription>
+            Log what needs to be restocked so roommates know what to grab on the next run.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Item name</Label>
+            <Input id="name" name="name" placeholder="Paper towels" required disabled={isPending} />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="quantity">Quantity or size</Label>
+              <Input
+                id="quantity"
+                name="quantity"
+                placeholder="2 rolls"
+                disabled={isPending}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="category">Category</Label>
+              <Input id="category" name="category" placeholder="Cleaning" disabled={isPending} />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <Textarea
+              id="notes"
+              name="notes"
+              placeholder="Check for the eco-friendly brand if available"
+              disabled={isPending}
+              rows={3}
+            />
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setOpen(false)} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? <Loader2 className="mr-2 size-4 animate-spin" aria-hidden /> : null}
+              Save item
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(tenant)/supplies/_components/mark-acquired-button.tsx
+++ b/src/app/(tenant)/supplies/_components/mark-acquired-button.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useTransition } from 'react'
+import { CheckCircle2, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+
+import { markSupplyItemAcquired } from '../actions'
+
+interface MarkAcquiredButtonProps {
+  itemId: string
+  itemName: string
+}
+
+export function MarkAcquiredButton({ itemId, itemName }: MarkAcquiredButtonProps) {
+  const { toast } = useToast()
+  const [isPending, startTransition] = useTransition()
+
+  const handleClick = () => {
+    startTransition(async () => {
+      const result = await markSupplyItemAcquired({ itemId, itemName })
+
+      if (!result.success) {
+        toast({
+          title: 'Could not mark as acquired',
+          description: result.error ?? 'Please try again.',
+          variant: 'destructive',
+        })
+        return
+      }
+
+      toast({
+        title: 'Marked as acquired',
+        description: result.message ?? `${itemName} has been moved to recent purchases.`,
+      })
+    })
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="gap-2"
+      onClick={handleClick}
+      disabled={isPending}
+    >
+      {isPending ? <Loader2 className="size-4 animate-spin" aria-hidden /> : <CheckCircle2 className="size-4" aria-hidden />}
+      {isPending ? 'Saving…' : 'Mark acquired'}
+    </Button>
+  )
+}

--- a/src/app/(tenant)/supplies/_components/recent-purchases.tsx
+++ b/src/app/(tenant)/supplies/_components/recent-purchases.tsx
@@ -1,0 +1,77 @@
+import { format, formatDistanceToNow } from 'date-fns'
+import { Receipt, Wallet } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+
+import type { SupplyPurchase } from '../types'
+
+interface RecentPurchasesProps {
+  purchases: SupplyPurchase[]
+}
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+})
+
+export function RecentPurchases({ purchases }: RecentPurchasesProps) {
+  if (!purchases.length) {
+    return (
+      <Card className="border-dashed">
+        <CardHeader className="items-start gap-2">
+          <Receipt className="size-10 text-muted-foreground" aria-hidden />
+          <div>
+            <CardTitle>No purchases logged yet</CardTitle>
+            <CardDescription>
+              Once roommates mark items as acquired you will see the purchase history here.
+            </CardDescription>
+          </div>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {purchases.map(purchase => {
+        const costLabel =
+          typeof purchase.totalCost === 'number' && !Number.isNaN(purchase.totalCost)
+            ? currencyFormatter.format(purchase.totalCost)
+            : null
+
+        return (
+          <Card key={purchase.id}>
+            <CardHeader className="flex-row items-start justify-between gap-4">
+              <div className="space-y-1">
+                <CardTitle className="text-lg font-semibold">{purchase.itemName}</CardTitle>
+                <CardDescription className="flex flex-wrap items-center gap-2 text-sm">
+                  <span>
+                    Purchased {formatDistanceToNow(new Date(purchase.purchasedAt), { addSuffix: true })}
+                  </span>
+                  {purchase.purchaserName ? <Badge variant="outline">{purchase.purchaserName}</Badge> : null}
+                  {purchase.quantity ? <Badge variant="secondary">{purchase.quantity}</Badge> : null}
+                </CardDescription>
+              </div>
+              {costLabel ? (
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <Wallet className="size-4 text-muted-foreground" aria-hidden />
+                  {costLabel}
+                </div>
+              ) : null}
+            </CardHeader>
+            {purchase.notes ? (
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{purchase.notes}</p>
+              </CardContent>
+            ) : null}
+            <CardFooter className="pt-0 text-xs text-muted-foreground">
+              Logged on {format(new Date(purchase.purchasedAt), 'MMM d, yyyy h:mm a')}
+            </CardFooter>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/(tenant)/supplies/_components/shopping-list.tsx
+++ b/src/app/(tenant)/supplies/_components/shopping-list.tsx
@@ -1,0 +1,73 @@
+import { formatDistanceToNow } from 'date-fns'
+import { ClipboardList, PackageOpen } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+
+import type { SupplyListEntry } from '../types'
+import { MarkAcquiredButton } from './mark-acquired-button'
+
+interface ShoppingListProps {
+  items: SupplyListEntry[]
+}
+
+export function ShoppingList({ items }: ShoppingListProps) {
+  if (!items.length) {
+    return (
+      <Card className="border-dashed">
+        <CardHeader className="items-start gap-2">
+          <ClipboardList className="size-10 text-muted-foreground" aria-hidden />
+          <div>
+            <CardTitle>No open errands</CardTitle>
+            <CardDescription>
+              Add items to the household shopping list so everyone knows what to pick up next.
+            </CardDescription>
+          </div>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {items.map(item => {
+        const lastPurchase = item.lastPurchase ?? null
+        const lastPurchaseTimestamp = lastPurchase?.purchasedAt ?? item.lastPurchasedAt
+        const lastPurchaseLabel = lastPurchaseTimestamp
+          ? `Last purchased ${formatDistanceToNow(new Date(lastPurchaseTimestamp), { addSuffix: true })}${
+              lastPurchase?.purchaserName ? ` by ${lastPurchase.purchaserName}` : ''
+            }`
+          : 'No purchases logged yet'
+
+        return (
+          <Card key={item.id}>
+            <CardHeader className="flex-row items-center justify-between gap-4">
+              <div className="space-y-1">
+                <CardTitle className="text-lg font-semibold">{item.name}</CardTitle>
+                <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                  {item.quantity ? (
+                    <span>
+                      <PackageOpen className="mr-1 inline-block size-4 align-middle" aria-hidden />
+                      {item.quantity}
+                    </span>
+                  ) : null}
+                  {item.category ? <Badge variant="secondary">{item.category}</Badge> : null}
+                </div>
+              </div>
+              <MarkAcquiredButton itemId={item.id} itemName={item.name} />
+            </CardHeader>
+            {item.notes ? (
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{item.notes}</p>
+              </CardContent>
+            ) : null}
+            <CardFooter className="flex flex-col items-start gap-2 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+              <span>{lastPurchaseLabel}</span>
+              <span>Added {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}</span>
+            </CardFooter>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/(tenant)/supplies/actions.ts
+++ b/src/app/(tenant)/supplies/actions.ts
@@ -1,0 +1,204 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import { createClient } from '@/utils/supabase/server'
+
+import type { ActionResult } from './types'
+
+const addItemSchema = z.object({
+  name: z
+    .string({ required_error: 'Item name is required' })
+    .trim()
+    .min(1, 'Item name is required'),
+  quantity: z
+    .string()
+    .trim()
+    .max(120, 'Keep the quantity under 120 characters')
+    .optional()
+    .transform(value => (value && value.length ? value : null)),
+  category: z
+    .string()
+    .trim()
+    .max(120, 'Keep the category under 120 characters')
+    .optional()
+    .transform(value => (value && value.length ? value : null)),
+  notes: z
+    .string()
+    .trim()
+    .max(500, 'Notes should be 500 characters or fewer')
+    .optional()
+    .transform(value => (value && value.length ? value : null)),
+  neededBy: z
+    .string()
+    .trim()
+    .optional()
+    .transform(value => (value && value.length ? value : null)),
+})
+
+type AddItemInput = z.input<typeof addItemSchema>
+
+type NormalisedAddItemInput = z.infer<typeof addItemSchema>
+
+const markAcquiredSchema = z.object({
+  itemId: z
+    .string({ required_error: 'Missing supply identifier' })
+    .uuid('Supply identifier is malformed'),
+  itemName: z
+    .string({ required_error: 'Missing item name' })
+    .trim()
+    .min(1, 'Missing item name'),
+  quantity: z
+    .string()
+    .trim()
+    .optional()
+    .transform(value => (value && value.length ? value : null)),
+  totalCost: z
+    .string()
+    .trim()
+    .optional()
+    .transform(value => (value && value.length ? Number(value.replace(/[^0-9.-]/g, '')) : null)),
+  notes: z
+    .string()
+    .trim()
+    .optional()
+    .transform(value => (value && value.length ? value : null)),
+})
+
+type MarkAcquiredInput = z.input<typeof markAcquiredSchema>
+
+type NormalisedMarkInput = z.infer<typeof markAcquiredSchema>
+
+async function getAuthenticatedContext() {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return { supabase, user: null as const, error: 'You need to be signed in to manage supplies.' }
+  }
+
+  const { data: profileData, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, unit_id, full_name')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    console.error('Error loading profile for supplies', profileError)
+    return { supabase, user: null as const, error: 'We could not load your profile details.' }
+  }
+
+  const profile = (profileData ?? null) as { id: string; unit_id: string | null; full_name: string | null } | null
+
+  if (!profile?.unit_id) {
+    return { supabase, user: null as const, error: 'Assign a household unit before managing supplies.' }
+  }
+
+  return { supabase, user, profile }
+}
+
+export async function addSupplyItem(rawInput: AddItemInput): Promise<ActionResult> {
+  const parsed = addItemSchema.safeParse(rawInput)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0]?.message ?? 'Invalid input.' }
+  }
+
+  const input: NormalisedAddItemInput = parsed.data
+  const context = await getAuthenticatedContext()
+
+  if ('error' in context) {
+    return { success: false, error: context.error }
+  }
+
+  const { supabase, user, profile } = context
+
+  const payload = {
+    name: input.name,
+    quantity: input.quantity,
+    category: input.category,
+    notes: input.notes,
+    needed_by: input.neededBy,
+    status: 'needed',
+    unit_id: profile.unit_id,
+    created_by: user.id,
+  }
+
+  const { error } = await supabase.from('household_supply_items').insert(payload)
+
+  if (error) {
+    console.error('Failed to add supply item', error)
+    return { success: false, error: 'Could not add the supply item. Please try again.' }
+  }
+
+  revalidatePath('/supplies')
+
+  return { success: true, message: 'Item added to the shopping list.' }
+}
+
+export async function markSupplyItemAcquired(rawInput: MarkAcquiredInput): Promise<ActionResult> {
+  const parsed = markAcquiredSchema.safeParse(rawInput)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0]?.message ?? 'Invalid input.' }
+  }
+
+  const input: NormalisedMarkInput = parsed.data
+  const context = await getAuthenticatedContext()
+
+  if ('error' in context) {
+    return { success: false, error: context.error }
+  }
+
+  const { supabase, user, profile } = context
+
+  const timestamp = new Date().toISOString()
+
+  const { error: updateError } = await supabase
+    .from('household_supply_items')
+    .update({
+      status: 'acquired',
+      last_purchased_at: timestamp,
+      updated_at: timestamp,
+    })
+    .eq('id', input.itemId)
+    .eq('unit_id', profile.unit_id)
+
+  if (updateError) {
+    console.error('Failed to mark supply item as acquired', updateError)
+    return { success: false, error: 'We were unable to mark this item as acquired.' }
+  }
+
+  const purchasePayload: Record<string, unknown> = {
+    item_id: input.itemId,
+    unit_id: profile.unit_id,
+    item_name: input.itemName,
+    purchased_at: timestamp,
+    purchased_by: user.id,
+  }
+
+  if (input.quantity) {
+    purchasePayload.quantity = input.quantity
+  }
+  if (typeof input.totalCost === 'number' && !Number.isNaN(input.totalCost)) {
+    purchasePayload.total_cost = input.totalCost
+  }
+  if (input.notes) {
+    purchasePayload.notes = input.notes
+  }
+
+  const { error: purchaseError } = await supabase.from('household_supply_purchases').insert(purchasePayload)
+
+  if (purchaseError) {
+    console.error('Failed to log supply purchase', purchaseError)
+  }
+
+  revalidatePath('/supplies')
+
+  return {
+    success: true,
+    message: purchaseError ? 'Item marked as acquired, but logging the purchase failed.' : 'Marked item as acquired.',
+  }
+}

--- a/src/app/(tenant)/supplies/page.tsx
+++ b/src/app/(tenant)/supplies/page.tsx
@@ -1,0 +1,219 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { createClient } from '@/utils/supabase/server'
+
+import { AddSupplyItemForm } from './_components/add-supply-item-form'
+import { RecentPurchases } from './_components/recent-purchases'
+import { ShoppingList } from './_components/shopping-list'
+import type { SupplyListEntry, SupplyListItem, SupplyPurchase } from './types'
+
+export const metadata: Metadata = {
+  title: 'Shared supplies',
+  description: 'Coordinate shared household purchases, track last restock dates, and keep everyone on the same page.',
+}
+
+function normalisePurchases(
+  rows: Array<Record<string, any>>,
+  fallbackUnitId: string
+): SupplyPurchase[] {
+  return rows
+    .map(row => {
+      const totalCostRaw = row.total_cost
+      let totalCost: number | null = null
+      if (typeof totalCostRaw === 'number') {
+        totalCost = totalCostRaw
+      } else if (typeof totalCostRaw === 'string' && totalCostRaw.trim().length) {
+        const parsed = Number(totalCostRaw)
+        totalCost = Number.isFinite(parsed) ? parsed : null
+      }
+
+      const purchaserName =
+        row.purchaser?.full_name ?? row.purchaser_name ?? row.profiles?.full_name ?? null
+
+      const quantityRaw = row.quantity ?? row.item_quantity ?? null
+      const quantity = quantityRaw != null ? String(quantityRaw) : null
+
+      if (!row.purchased_at) {
+        return null
+      }
+
+      return {
+        id: row.id as string,
+        itemId: (row.item_id as string | null) ?? null,
+        itemName: (row.item_name as string | null) ?? (row.item?.name as string | null) ?? 'Household item',
+        purchasedAt: row.purchased_at as string,
+        purchasedBy: (row.purchased_by as string | null) ?? null,
+        purchaserName,
+        quantity,
+        totalCost,
+        notes: (row.notes as string | null) ?? null,
+        unitId: (row.unit_id as string | null) ?? fallbackUnitId,
+      }
+    })
+    .filter((value): value is SupplyPurchase => Boolean(value && value.purchasedAt))
+}
+
+function normaliseShoppingList(
+  rows: Array<Record<string, any>>,
+  lastPurchaseById: Map<string, SupplyPurchase>,
+  lastPurchaseByName: Map<string, SupplyPurchase>
+): SupplyListEntry[] {
+  return rows.map(row => {
+    const quantityRaw = row.quantity
+
+    const item: SupplyListItem = {
+      id: row.id as string,
+      name: (row.name as string | null) ?? 'Untitled item',
+      category: (row.category as string | null) ?? null,
+      quantity: quantityRaw != null ? String(quantityRaw) : null,
+      notes: (row.notes as string | null) ?? null,
+      status: (row.status as string | null) ?? 'needed',
+      neededBy: (row.needed_by as string | null) ?? null,
+      lastPurchasedAt: (row.last_purchased_at as string | null) ?? null,
+      unitId: (row.unit_id as string | null) ?? '',
+      createdAt: (row.created_at as string | null) ?? new Date().toISOString(),
+      updatedAt: (row.updated_at as string | null) ?? null,
+    }
+
+    const byId = lastPurchaseById.get(item.id)
+    const byName = lastPurchaseByName.get(item.name.toLowerCase())
+
+    return {
+      ...item,
+      lastPurchase: byId ?? byName ?? null,
+    }
+  })
+}
+
+export default async function TenantSuppliesPage() {
+  const supabase = createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth')
+  }
+
+  const { data: profileData, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, unit_id, full_name')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    console.error('Unable to load profile for supplies page', profileError)
+  }
+
+  const profile = (profileData ?? null) as { id: string; unit_id: string | null; full_name: string | null } | null
+
+  if (!profile?.unit_id) {
+    return (
+      <div className="container max-w-3xl space-y-6 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Set up your household</CardTitle>
+            <CardDescription>
+              We need to know which unit you belong to before showing shared supplies. Update your profile with a unit
+              assignment to continue.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Visit the account settings page to confirm your household details and invite your roommates once everything is
+            in place.
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const unitId = profile.unit_id
+
+  const [itemsResponse, purchasesResponse] = await Promise.all([
+    supabase
+      .from('household_supply_items')
+      .select('id, name, category, quantity, notes, status, needed_by, last_purchased_at, unit_id, created_at, updated_at')
+      .eq('unit_id', unitId)
+      .eq('status', 'needed')
+      .order('created_at', { ascending: true }),
+    supabase
+      .from('household_supply_purchases')
+      .select(
+        `id, item_id, item_name, purchased_at, purchased_by, quantity, total_cost, notes, unit_id, purchaser:profiles(full_name)`
+      )
+      .eq('unit_id', unitId)
+      .order('purchased_at', { ascending: false })
+      .limit(20),
+  ])
+
+  const errors: string[] = []
+
+  if (itemsResponse.error) {
+    console.error('Failed to fetch household supply list', itemsResponse.error)
+    errors.push('We could not load the latest shopping list.')
+  }
+
+  if (purchasesResponse.error) {
+    console.error('Failed to fetch household supply purchases', purchasesResponse.error)
+    errors.push('We could not load recent purchases.')
+  }
+
+  const purchases = normalisePurchases(purchasesResponse.data ?? [], unitId)
+
+  const lastPurchaseById = new Map<string, SupplyPurchase>()
+  const lastPurchaseByName = new Map<string, SupplyPurchase>()
+
+  for (const purchase of purchases) {
+    if (purchase.itemId && !lastPurchaseById.has(purchase.itemId)) {
+      lastPurchaseById.set(purchase.itemId, purchase)
+    }
+
+    const normalisedName = purchase.itemName?.toLowerCase?.()
+    if (normalisedName && !lastPurchaseByName.has(normalisedName)) {
+      lastPurchaseByName.set(normalisedName, purchase)
+    }
+  }
+
+  const shoppingList = normaliseShoppingList(itemsResponse.data ?? [], lastPurchaseById, lastPurchaseByName)
+
+  return (
+    <div className="container max-w-6xl space-y-8 py-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Shared supplies</h1>
+        <p className="text-base text-muted-foreground">
+          Keep track of staples, coordinate shopping runs, and record reimbursements in one place for your household.
+        </p>
+      </header>
+
+      {errors.length ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+          {errors.map(message => (
+            <p key={message}>{message}</p>
+          ))}
+        </div>
+      ) : null}
+
+      <Tabs defaultValue="list" className="space-y-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <TabsList className="w-full sm:w-auto">
+            <TabsTrigger value="list">Shopping list ({shoppingList.length})</TabsTrigger>
+            <TabsTrigger value="purchases">Recent purchases ({purchases.length})</TabsTrigger>
+          </TabsList>
+          <AddSupplyItemForm />
+        </div>
+
+        <TabsContent value="list">
+          <ShoppingList items={shoppingList} />
+        </TabsContent>
+
+        <TabsContent value="purchases">
+          <RecentPurchases purchases={purchases} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/src/app/(tenant)/supplies/types.ts
+++ b/src/app/(tenant)/supplies/types.ts
@@ -1,0 +1,36 @@
+export interface SupplyListItem {
+  id: string
+  name: string
+  category: string | null
+  quantity: string | null
+  notes: string | null
+  status: string
+  neededBy: string | null
+  lastPurchasedAt: string | null
+  unitId: string
+  createdAt: string
+  updatedAt: string | null
+}
+
+export interface SupplyPurchase {
+  id: string
+  itemId: string | null
+  itemName: string
+  purchasedAt: string
+  purchasedBy: string | null
+  purchaserName: string | null
+  quantity: string | null
+  totalCost: number | null
+  notes: string | null
+  unitId: string
+}
+
+export interface SupplyListEntry extends SupplyListItem {
+  lastPurchase?: SupplyPurchase | null
+}
+
+export interface ActionResult {
+  success: boolean
+  message?: string
+  error?: string
+}


### PR DESCRIPTION
## Summary
- add a Supabase-backed tenant supplies page with shopping vs. purchases tabs and error handling
- create client components and server actions for adding items, marking purchases, and presenting last restock details
- update the existing supplies route export and refresh feature copy to focus on shared household workflows

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68d0d1626dd4832893f8d6ea21cdeca5