### PR TITLE
Add admin rent invoicing workflow

### DIFF
--- a/app/(admin)/rent/_components/invoice-form.tsx
+++ b/app/(admin)/rent/_components/invoice-form.tsx
@@ -1,0 +1,549 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+import { useForm, useFieldArray } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { format } from "date-fns"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+
+import { createMonthlyInvoices } from "../actions"
+import {
+  type CreateMonthlyInvoicesInput,
+  type InvoiceMemberInput,
+  type SupplyShareSelection,
+  createMonthlyInvoicesSchema,
+} from "../schema"
+
+export interface InvoiceMemberOption {
+  id: string
+  name: string
+  email?: string | null
+  defaultRent?: number | null
+}
+
+export interface SupplyShareOption {
+  id: string
+  memberId: string
+  amount: number
+  label: string
+  billingMonth?: string | null
+  createdAt?: string | null
+}
+
+export interface RecentInvoiceSummary {
+  id: string
+  memberId: string
+  memberName: string
+  status: string
+  billingMonth: string
+  dueDate: string
+  totalAmount: number
+  rentAmount?: number | null
+  supplyTotal?: number | null
+  createdAt?: string | null
+  memo?: string | null
+}
+
+interface InvoiceBuilderProps {
+  members: InvoiceMemberOption[]
+  supplyShares: SupplyShareOption[]
+  recentInvoices: RecentInvoiceSummary[]
+}
+
+const now = new Date()
+const defaultMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`
+const defaultDueDate = new Date(now.getFullYear(), now.getMonth(), Math.min(now.getDate() + 7, 28))
+
+const defaultValues: CreateMonthlyInvoicesInput = {
+  billingMonth: defaultMonth,
+  dueDate: format(defaultDueDate, "yyyy-MM-dd"),
+  memo: "",
+  members: [],
+}
+
+type ActionResult =
+  | { status: "success"; message: string; insertedCount: number }
+  | { status: "error"; message: string }
+
+export function InvoiceBuilder({ members, supplyShares, recentInvoices }: InvoiceBuilderProps) {
+  const [selectedMemberId, setSelectedMemberId] = useState<string | undefined>()
+  const [actionState, setActionState] = useState<ActionResult | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<CreateMonthlyInvoicesInput>({
+    resolver: zodResolver(createMonthlyInvoicesSchema),
+    defaultValues,
+  })
+
+  const fieldArray = useFieldArray({ control: form.control, name: "members" })
+
+  const selectedMembers = form.watch("members")
+
+  const availableMembers = useMemo(
+    () =>
+      members.filter(
+        (memberOption) =>
+          !selectedMembers.some((selectedMember) => selectedMember.memberId === memberOption.id),
+      ),
+    [members, selectedMembers],
+  )
+
+  const supplySharesByMember = useMemo(() => {
+    return supplyShares.reduce<Record<string, SupplyShareOption[]>>((acc, share) => {
+      if (!acc[share.memberId]) {
+        acc[share.memberId] = []
+      }
+      acc[share.memberId].push(share)
+      return acc
+    }, {})
+  }, [supplyShares])
+
+  const handleAddMember = (memberId: string) => {
+    const member = members.find((option) => option.id === memberId)
+    if (!member) return
+
+    const rentAmount = typeof member.defaultRent === "number" ? member.defaultRent : 0
+
+    const entry: InvoiceMemberInput = {
+      memberId: member.id,
+      memberName: member.name,
+      rentAmount,
+      supplyShares: [],
+      note: "",
+    }
+
+    fieldArray.append(entry)
+    setSelectedMemberId(undefined)
+  }
+
+  const handleRemoveMember = (index: number) => {
+    fieldArray.remove(index)
+  }
+
+  const handleSupplyToggle = (index: number, share: SupplyShareOption, checked: boolean) => {
+    const currentShares = form.getValues(`members.${index}.supplyShares`)
+    const payload: SupplyShareSelection = {
+      id: share.id,
+      amount: share.amount,
+      label: share.label,
+    }
+
+    if (checked) {
+      form.setValue(`members.${index}.supplyShares`, [...currentShares, payload], {
+        shouldDirty: true,
+        shouldTouch: true,
+      })
+    } else {
+      form.setValue(
+        `members.${index}.supplyShares`,
+        currentShares.filter((item) => item.id !== share.id),
+        { shouldDirty: true, shouldTouch: true },
+      )
+    }
+  }
+
+  const onSubmit = (values: CreateMonthlyInvoicesInput) => {
+    startTransition(async () => {
+      setActionState(null)
+      const result = await createMonthlyInvoices({
+        ...values,
+        members: values.members.map((member) => ({
+          ...member,
+          rentAmount: Number(member.rentAmount ?? 0),
+          supplyShares: member.supplyShares.map((share) => ({
+            ...share,
+            amount: Number(share.amount ?? 0),
+          })),
+        })),
+      })
+
+      setActionState(result)
+
+      if (result.status === "success") {
+        form.reset({
+          ...values,
+          members: [],
+        })
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-8">
+      <Card className="border-dashed">
+        <CardHeader className="space-y-1">
+          <CardTitle>Create monthly invoices</CardTitle>
+          <CardDescription>
+            Select the roommates you need to bill, define their rent share, and roll in any shared supply costs before publishing.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {actionState ? (
+            <div
+              className={cn(
+                "rounded-md border px-4 py-3 text-sm",
+                actionState.status === "success"
+                  ? "border-green-200 bg-green-50 text-green-700 dark:border-green-900/50 dark:bg-green-950/50 dark:text-green-300"
+                  : "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/60 dark:text-red-300",
+              )}
+            >
+              <div className="font-medium">
+                {actionState.status === "success" ? "Invoices created" : "Unable to create invoices"}
+              </div>
+              <p className="mt-1 text-sm">
+                {actionState.message}
+                {actionState.status === "success" && actionState.insertedCount > 0
+                  ? ` (${actionState.insertedCount} draft${actionState.insertedCount === 1 ? "" : "s"} ready)`
+                  : null}
+              </p>
+            </div>
+          ) : null}
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="billingMonth"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Billing month</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="month"
+                          disabled={isPending}
+                          value={field.value}
+                          onChange={(event) => field.onChange(event.target.value)}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="dueDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Due date</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="date"
+                          disabled={isPending}
+                          value={field.value}
+                          onChange={(event) => field.onChange(event.target.value)}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="memo"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Admin memo (optional)</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Add context for this batch (only admins can see this memo)."
+                        disabled={isPending}
+                        value={field.value ?? ""}
+                        onChange={(event) => field.onChange(event.target.value)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Separator />
+
+              <div className="space-y-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold">Assign roommates</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Add each roommate that needs an invoice this cycle and adjust their rent share below.
+                    </p>
+                  </div>
+                  <div className="flex w-full items-center gap-2 sm:w-auto">
+                    <Select
+                      value={selectedMemberId}
+                      onValueChange={(value) => {
+                        setSelectedMemberId(value)
+                        handleAddMember(value)
+                      }}
+                      disabled={availableMembers.length === 0 || isPending}
+                    >
+                      <SelectTrigger className="w-full min-w-[200px]">
+                        <SelectValue placeholder="Select roommate" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {availableMembers.length === 0 ? (
+                          <SelectItem value="__empty" disabled>
+                            No roommates available
+                          </SelectItem>
+                        ) : (
+                          availableMembers.map((memberOption) => (
+                            <SelectItem key={memberOption.id} value={memberOption.id}>
+                              <div className="flex flex-col text-left">
+                                <span>{memberOption.name}</span>
+                                {memberOption.email ? (
+                                  <span className="text-xs text-muted-foreground">{memberOption.email}</span>
+                                ) : null}
+                              </div>
+                            </SelectItem>
+                          ))
+                        )}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={availableMembers.length === 0 || isPending}
+                      onClick={() => {
+                        if (availableMembers[0]) {
+                          handleAddMember(availableMembers[0].id)
+                        }
+                      }}
+                    >
+                      Quick add
+                    </Button>
+                  </div>
+                </div>
+
+                {(() => {
+                  const rootError = form.formState.errors.members as
+                    | { root?: { message?: string } }
+                    | undefined
+                  const arrayMessage = rootError?.root?.message ??
+                    (rootError as { message?: string } | undefined)?.message
+
+                  return arrayMessage ? (
+                    <p className="text-sm font-medium text-destructive">{arrayMessage}</p>
+                  ) : null
+                })()}
+
+                {selectedMembers.length === 0 ? (
+                  <div className="rounded-md border border-dashed bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+                    Select at least one roommate to start building invoices.
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    {fieldArray.fields.map((field, index) => {
+                      const memberSupplies = supplySharesByMember[field.memberId] ?? []
+                      const supplySelections = selectedMembers[index]?.supplyShares ?? []
+                      const supplyTotal = supplySelections.reduce((sum, item) => sum + (item.amount ?? 0), 0)
+                      const invoiceTotal = (selectedMembers[index]?.rentAmount ?? 0) + supplyTotal
+
+                      return (
+                        <Card key={field.id}>
+                          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                            <div>
+                              <CardTitle className="text-lg">{selectedMembers[index]?.memberName}</CardTitle>
+                              <CardDescription>
+                                {members.find((member) => member.id === field.memberId)?.email ?? "No email on file"}
+                              </CardDescription>
+                            </div>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleRemoveMember(index)}
+                              disabled={isPending}
+                              className="text-destructive hover:text-destructive"
+                            >
+                              Remove
+                            </Button>
+                          </CardHeader>
+                          <CardContent className="space-y-4">
+                            <div className="grid gap-4 md:grid-cols-2">
+                              <FormField
+                                control={form.control}
+                                name={`members.${index}.rentAmount`}
+                                render={({ field: rentField }) => (
+                                  <FormItem>
+                                    <FormLabel>Monthly rent</FormLabel>
+                                    <FormControl>
+                                      <Input
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        disabled={isPending}
+                                        value={Number.isFinite(rentField.value) ? rentField.value : ""}
+                                        onChange={(event) => {
+                                          const value = event.target.value
+                                          rentField.onChange(value === "" ? 0 : Number(event.target.value))
+                                        }}
+                                      />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                              <FormField
+                                control={form.control}
+                                name={`members.${index}.note`}
+                                render={({ field: noteField }) => (
+                                  <FormItem>
+                                    <FormLabel>Private note</FormLabel>
+                                    <FormControl>
+                                      <Input
+                                        type="text"
+                                        placeholder="Optional memo for this roommate"
+                                        disabled={isPending}
+                                        value={noteField.value ?? ""}
+                                        onChange={(event) => noteField.onChange(event.target.value)}
+                                      />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                            </div>
+
+                            <div className="space-y-3">
+                              <div className="flex items-center justify-between">
+                                <h4 className="text-sm font-medium">Supply roll-ins</h4>
+                                {supplySelections.length > 0 ? (
+                                  <Badge variant="secondary">
+                                    +${supplyTotal.toFixed(2)} from supplies
+                                  </Badge>
+                                ) : null}
+                              </div>
+                              {memberSupplies.length === 0 ? (
+                                <p className="text-sm text-muted-foreground">
+                                  No open supply shares for this roommate.
+                                </p>
+                              ) : (
+                                <div className="space-y-2">
+                                  {memberSupplies.map((share) => {
+                                    const isChecked = supplySelections.some((item) => item.id === share.id)
+                                    const createdDate = share.createdAt
+                                      ? new Date(share.createdAt)
+                                      : null
+                                    const createdDateLabel =
+                                      createdDate && !Number.isNaN(createdDate.getTime())
+                                        ? format(createdDate, "MMM d")
+                                        : null
+                                    return (
+                                      <label
+                                        key={share.id}
+                                        className="flex items-start gap-3 rounded-md border p-3 text-sm shadow-sm transition hover:border-primary"
+                                      >
+                                        <Checkbox
+                                          checked={isChecked}
+                                          onCheckedChange={(value) =>
+                                            handleSupplyToggle(index, share, value === true)
+                                          }
+                                          disabled={isPending}
+                                        />
+                                        <span className="space-y-1">
+                                          <span className="block font-medium">
+                                            {share.label}
+                                            <span className="ml-2 font-normal text-muted-foreground">
+                                              ${share.amount.toFixed(2)}
+                                            </span>
+                                          </span>
+                                          <span className="block text-xs text-muted-foreground">
+                                            {share.billingMonth
+                                              ? `Month ${share.billingMonth}`
+                                              : "Uncategorized"}
+                                            {createdDateLabel ? ` • added ${createdDateLabel}` : ""}
+                                          </span>
+                                        </span>
+                                      </label>
+                                    )
+                                  })}
+                                </div>
+                              )}
+                            </div>
+                          </CardContent>
+                          <CardFooter className="flex flex-wrap items-center justify-between gap-2 border-t bg-muted/40 px-6 py-3 text-sm">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium">Draft total</span>
+                              <span className="text-base font-semibold">
+                                ${invoiceTotal.toFixed(2)}
+                              </span>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                              <Badge variant="outline">Rent ${ (selectedMembers[index]?.rentAmount ?? 0).toFixed(2) }</Badge>
+                              <Badge variant="outline">Supplies ${ supplyTotal.toFixed(2) }</Badge>
+                            </div>
+                          </CardFooter>
+                        </Card>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+
+              <div className="flex justify-end">
+                <Button type="submit" disabled={isPending || selectedMembers.length === 0}>
+                  {isPending ? "Creating drafts…" : "Create drafts"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent draft & open invoices</CardTitle>
+          <CardDescription>
+            Track the most recent invoices that still need to be sent or collected.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {recentInvoices.length === 0 ? (
+            <p className="rounded-md border border-dashed bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+              No draft or open invoices yet. Create one above to see it here.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {recentInvoices.map((invoice) => (
+                <div
+                  key={invoice.id}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-muted/40 p-4"
+                >
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold">{invoice.memberName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {invoice.billingMonth} · Due {invoice.dueDate}
+                    </p>
+                    {invoice.memo ? (
+                      <p className="text-xs text-muted-foreground">Memo: {invoice.memo}</p>
+                    ) : null}
+                  </div>
+                  <div className="text-right">
+                    <div className="text-sm font-semibold">${invoice.totalAmount.toFixed(2)}</div>
+                    <div className="text-xs text-muted-foreground">
+                      Rent ${(invoice.rentAmount ?? 0).toFixed(2)} · Supplies ${(invoice.supplyTotal ?? 0).toFixed(2)}
+                    </div>
+                    <Badge className="mt-1" variant="secondary">
+                      {invoice.status}
+                    </Badge>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/(admin)/rent/actions.ts
+++ b/app/(admin)/rent/actions.ts
@@ -1,0 +1,125 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { createClient } from "@/utils/supabase/server"
+
+import {
+  type CreateMonthlyInvoicesInput,
+  createMonthlyInvoicesSchema,
+} from "./schema"
+
+export type CreateMonthlyInvoicesResult =
+  | { status: "success"; message: string; insertedCount: number }
+  | { status: "error"; message: string }
+
+export async function createMonthlyInvoices(
+  input: CreateMonthlyInvoicesInput,
+): Promise<CreateMonthlyInvoicesResult> {
+  const parsed = createMonthlyInvoicesSchema.safeParse(input)
+
+  if (!parsed.success) {
+    const issue = parsed.error.issues.at(0)
+    return {
+      status: "error",
+      message: issue?.message ?? "Invalid invoice details supplied.",
+    }
+  }
+
+  const payload = parsed.data
+
+  if (payload.members.length === 0) {
+    return { status: "error", message: "Add at least one roommate to create invoices." }
+  }
+
+  const supabase = createClient()
+
+  const invoiceRows = payload.members.map((member) => {
+    const supplyTotal = member.supplyShares.reduce((sum, share) => sum + share.amount, 0)
+    const totalAmount = member.rentAmount + supplyTotal
+
+    return {
+      member_id: member.memberId,
+      billing_month: payload.billingMonth,
+      due_date: payload.dueDate,
+      rent_amount: member.rentAmount,
+      supply_total: supplyTotal,
+      total_amount: totalAmount,
+      status: "draft",
+      memo: member.note ?? payload.memo ?? null,
+      metadata: {
+        adminMemo: payload.memo ?? null,
+        memberNote: member.note ?? null,
+        supplyShareIds: member.supplyShares.map((share) => share.id),
+      },
+    }
+  })
+
+  try {
+    const { data: insertedInvoices, error: insertError } = await supabase
+      .from("rent_invoices")
+      .insert(invoiceRows)
+      .select("id")
+
+    if (insertError || !insertedInvoices) {
+      throw insertError ?? new Error("Failed to insert invoices")
+    }
+
+    const supplyLinks: { invoice_id: string; supply_share_id: string; amount: number }[] = []
+    const supplyShareIds = new Set<string>()
+
+    insertedInvoices.forEach((invoice, index) => {
+      const member = payload.members[index]
+      if (!member) return
+
+      member.supplyShares.forEach((share) => {
+        supplyLinks.push({
+          invoice_id: invoice.id,
+          supply_share_id: share.id,
+          amount: share.amount,
+        })
+        supplyShareIds.add(share.id)
+      })
+    })
+
+    if (supplyLinks.length > 0) {
+      const { error: linkError } = await supabase
+        .from("rent_invoice_supply_shares")
+        .insert(supplyLinks)
+
+      if (linkError) {
+        await supabase.from("rent_invoices").delete().in(
+          "id",
+          insertedInvoices.map((invoice) => invoice.id),
+        )
+        throw linkError
+      }
+
+      const shareIdList = Array.from(supplyShareIds)
+      if (shareIdList.length > 0) {
+        const { error: updateError } = await supabase
+          .from("supply_shares")
+          .update({ status: "invoiced" })
+          .in("id", shareIdList)
+
+        if (updateError) {
+          console.error("Failed to update supply share status", updateError)
+        }
+      }
+    }
+
+    await revalidatePath("/rent")
+
+    return {
+      status: "success",
+      message: "Draft invoices created successfully.",
+      insertedCount: insertedInvoices.length,
+    }
+  } catch (error) {
+    console.error("createMonthlyInvoices", error)
+    return {
+      status: "error",
+      message: "We couldn't save the invoices. Please try again in a moment.",
+    }
+  }
+}

--- a/app/(admin)/rent/page.tsx
+++ b/app/(admin)/rent/page.tsx
@@ -1,0 +1,155 @@
+import { createClient } from "@/utils/supabase/server"
+
+import {
+  type InvoiceMemberOption,
+  type RecentInvoiceSummary,
+  type SupplyShareOption,
+  InvoiceBuilder,
+} from "./_components/invoice-form"
+
+async function loadMembers(client: ReturnType<typeof createClient>) {
+  const { data, error } = await client
+    .from("profiles")
+    .select("id, full_name, email")
+    .order("full_name", { ascending: true })
+
+  if (error) {
+    console.error("Failed to load profiles", error)
+    return [] as InvoiceMemberOption[]
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    name: row.full_name ?? row.email ?? "Unnamed roommate",
+    email: row.email,
+    defaultRent: null,
+  })) satisfies InvoiceMemberOption[]
+}
+
+async function loadSupplyShares(client: ReturnType<typeof createClient>) {
+  const { data, error } = await client
+    .from("supply_shares")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(50)
+
+  if (error) {
+    console.error("Failed to load supply shares", error)
+    return [] as SupplyShareOption[]
+  }
+
+  return (data ?? [])
+    .filter((row) => {
+      if (!row.member_id) return false
+      const status = typeof row.status === "string" ? row.status.toLowerCase() : ""
+      return ["", "open", "pending", "unbilled", "draft"].includes(status)
+    })
+    .map((row) => {
+      const amountCandidate =
+        typeof row.share_amount === "number"
+          ? row.share_amount
+          : typeof row.amount === "number"
+            ? row.amount
+            : 0
+
+      return {
+        id: row.id as string,
+        memberId: row.member_id as string,
+        amount: amountCandidate ?? 0,
+        label:
+          (row.label as string | null) ??
+          (row.description as string | null) ??
+          (row.name as string | null) ??
+          "Shared supply",
+        billingMonth:
+          (row.billing_month as string | null) ??
+          (row.month as string | null) ??
+          (row.period as string | null) ??
+          null,
+        createdAt: (row.created_at as string | null) ?? null,
+      }
+    }) satisfies SupplyShareOption[]
+}
+
+async function loadRecentInvoices(
+  client: ReturnType<typeof createClient>,
+  members: InvoiceMemberOption[],
+) {
+  const { data, error } = await client
+    .from("rent_invoices")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(15)
+
+  if (error) {
+    console.error("Failed to load invoices", error)
+    return [] as RecentInvoiceSummary[]
+  }
+
+  const memberMap = new Map(members.map((member) => [member.id, member]))
+
+  return (data ?? [])
+    .filter((row) => {
+      const status = typeof row.status === "string" ? row.status.toLowerCase() : ""
+      return ["draft", "open", "pending"].includes(status)
+    })
+    .map((row) => {
+      const rentAmount = typeof row.rent_amount === "number" ? row.rent_amount : null
+      const supplyTotal = typeof row.supply_total === "number" ? row.supply_total : null
+      const totalAmountCandidate =
+        typeof row.total_amount === "number"
+          ? row.total_amount
+          : rentAmount && supplyTotal
+            ? rentAmount + supplyTotal
+            : typeof row.amount === "number"
+              ? row.amount
+              : 0
+
+      const member = memberMap.get(row.member_id as string)
+
+      return {
+        id: row.id as string,
+        memberId: (row.member_id as string) ?? "",
+        memberName: member?.name ?? "Unassigned roommate",
+        status: (row.status as string | null) ?? "draft",
+        billingMonth:
+          (row.billing_month as string | null) ??
+          (row.month as string | null) ??
+          "",
+        dueDate: (row.due_date as string | null) ?? "",
+        totalAmount: Number(totalAmountCandidate ?? 0),
+        rentAmount,
+        supplyTotal,
+        createdAt: (row.created_at as string | null) ?? null,
+        memo: (row.memo as string | null) ?? (row.notes as string | null) ?? null,
+      }
+    }) satisfies RecentInvoiceSummary[]
+}
+
+export default async function RentAdminPage() {
+  const supabase = createClient()
+  const members = await loadMembers(supabase)
+
+  const [supplyShares, recentInvoices] = await Promise.all([
+    loadSupplyShares(supabase),
+    loadRecentInvoices(supabase, members),
+  ])
+
+  return (
+    <div className="container max-w-6xl space-y-10 py-10">
+      <header className="space-y-2">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Rent & invoices</h1>
+          <p className="text-base text-muted-foreground sm:text-lg">
+            Draft monthly charges for each roommate, fold in outstanding supply splits, and keep tabs on open invoices.
+          </p>
+        </div>
+      </header>
+      <InvoiceBuilder
+        members={members}
+        supplyShares={supplyShares}
+        recentInvoices={recentInvoices}
+      />
+    </div>
+  )
+}

--- a/app/(admin)/rent/schema.ts
+++ b/app/(admin)/rent/schema.ts
@@ -1,0 +1,34 @@
+import { z } from "zod"
+
+export const supplyShareSchema = z.object({
+  id: z.string().min(1, "Supply share id is required"),
+  amount: z.number().min(0, "Amount must be zero or greater"),
+  label: z.string().min(1, "Supply label is required"),
+})
+
+export const invoiceMemberSchema = z.object({
+  memberId: z.string().min(1, "Member is required"),
+  memberName: z.string().min(1, "Member name is required"),
+  rentAmount: z
+    .number({ invalid_type_error: "Enter a valid amount" })
+    .min(0, "Amount cannot be negative"),
+  supplyShares: z.array(supplyShareSchema).default([]),
+  note: z.string().max(500, "Note is too long").optional(),
+})
+
+export const createMonthlyInvoicesSchema = z.object({
+  billingMonth: z
+    .string()
+    .min(1, "Billing month is required")
+    .regex(/\d{4}-\d{2}/, "Use YYYY-MM format"),
+  dueDate: z
+    .string()
+    .min(1, "Due date is required")
+    .regex(/\d{4}-\d{2}-\d{2}/, "Use YYYY-MM-DD format"),
+  memo: z.string().max(1000, "Memo is too long").optional(),
+  members: z.array(invoiceMemberSchema).min(1, "Add at least one member"),
+})
+
+export type SupplyShareSelection = z.infer<typeof supplyShareSchema>
+export type InvoiceMemberInput = z.infer<typeof invoiceMemberSchema>
+export type CreateMonthlyInvoicesInput = z.infer<typeof createMonthlyInvoicesSchema>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1289,6 +1289,142 @@ export type Database = {
         }
         Relationships: []
       }
+      rent_invoice_supply_shares: {
+        Row: {
+          amount: number
+          created_at: string | null
+          id: string
+          invoice_id: string
+          supply_share_id: string
+        }
+        Insert: {
+          amount?: number
+          created_at?: string | null
+          id?: string
+          invoice_id: string
+          supply_share_id: string
+        }
+        Update: {
+          amount?: number
+          created_at?: string | null
+          id?: string
+          invoice_id?: string
+          supply_share_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "rent_invoice_supply_shares_invoice_id_fkey"
+            columns: ["invoice_id"]
+            isOneToOne: false
+            referencedRelation: "rent_invoices"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rent_invoice_supply_shares_supply_share_id_fkey"
+            columns: ["supply_share_id"]
+            isOneToOne: false
+            referencedRelation: "supply_shares"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      rent_invoices: {
+        Row: {
+          billing_month: string
+          created_at: string | null
+          due_date: string
+          id: string
+          member_id: string
+          memo: string | null
+          metadata: Json | null
+          rent_amount: number
+          status: string
+          supply_total: number
+          total_amount: number
+          updated_at: string | null
+        }
+        Insert: {
+          billing_month: string
+          created_at?: string | null
+          due_date: string
+          id?: string
+          member_id: string
+          memo?: string | null
+          metadata?: Json | null
+          rent_amount?: number
+          status?: string
+          supply_total?: number
+          total_amount?: number
+          updated_at?: string | null
+        }
+        Update: {
+          billing_month?: string
+          created_at?: string | null
+          due_date?: string
+          id?: string
+          member_id?: string
+          memo?: string | null
+          metadata?: Json | null
+          rent_amount?: number
+          status?: string
+          supply_total?: number
+          total_amount?: number
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "rent_invoices_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      supply_shares: {
+        Row: {
+          billing_month: string | null
+          created_at: string | null
+          id: string
+          label: string
+          member_id: string
+          metadata: Json | null
+          share_amount: number
+          status: string
+          updated_at: string | null
+        }
+        Insert: {
+          billing_month?: string | null
+          created_at?: string | null
+          id?: string
+          label: string
+          member_id: string
+          metadata?: Json | null
+          share_amount?: number
+          status?: string
+          updated_at?: string | null
+        }
+        Update: {
+          billing_month?: string | null
+          created_at?: string | null
+          id?: string
+          label?: string
+          member_id?: string
+          metadata?: Json | null
+          share_amount?: number
+          status?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supply_shares_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       reusable_packages: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250105_rent_invoices.sql
+++ b/supabase/migrations/20250105_rent_invoices.sql
@@ -1,0 +1,129 @@
+-- Schema for rent invoices and shared supply roll-ins
+
+CREATE TABLE IF NOT EXISTS public.supply_shares (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  member_id UUID NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  share_amount NUMERIC(10, 2) NOT NULL DEFAULT 0,
+  billing_month TEXT,
+  status TEXT NOT NULL DEFAULT 'open'
+    CHECK (status IN ('open', 'pending', 'invoiced', 'paid', 'dismissed')),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.rent_invoices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  member_id UUID NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  billing_month TEXT NOT NULL,
+  due_date DATE NOT NULL,
+  rent_amount NUMERIC(10, 2) NOT NULL DEFAULT 0,
+  supply_total NUMERIC(10, 2) NOT NULL DEFAULT 0,
+  total_amount NUMERIC(10, 2) NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'open', 'paid', 'overdue', 'cancelled')),
+  memo TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.rent_invoice_supply_shares (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  invoice_id UUID NOT NULL REFERENCES public.rent_invoices (id) ON DELETE CASCADE,
+  supply_share_id UUID NOT NULL REFERENCES public.supply_shares (id) ON DELETE CASCADE,
+  amount NUMERIC(10, 2) NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (invoice_id, supply_share_id)
+);
+
+CREATE INDEX IF NOT EXISTS supply_shares_member_id_idx ON public.supply_shares (member_id);
+CREATE INDEX IF NOT EXISTS supply_shares_status_idx ON public.supply_shares (status);
+CREATE INDEX IF NOT EXISTS rent_invoices_member_id_idx ON public.rent_invoices (member_id);
+CREATE INDEX IF NOT EXISTS rent_invoices_status_idx ON public.rent_invoices (status);
+CREATE INDEX IF NOT EXISTS rent_invoices_billing_month_idx ON public.rent_invoices (billing_month);
+CREATE INDEX IF NOT EXISTS rent_invoice_supply_shares_invoice_idx ON public.rent_invoice_supply_shares (invoice_id);
+
+-- Keep updated_at timestamps in sync
+CREATE TRIGGER update_supply_shares_updated_at
+  BEFORE UPDATE ON public.supply_shares
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_rent_invoices_updated_at
+  BEFORE UPDATE ON public.rent_invoices
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Enable row level security
+ALTER TABLE public.supply_shares ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rent_invoices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rent_invoice_supply_shares ENABLE ROW LEVEL SECURITY;
+
+-- Roommates can view their own supply shares
+CREATE POLICY IF NOT EXISTS "Roommates can view their supply shares" ON public.supply_shares
+  FOR SELECT
+  USING (member_id = auth.uid());
+
+-- Admins and property managers can manage supply shares
+CREATE POLICY IF NOT EXISTS "Admins manage supply shares" ON public.supply_shares
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('admin', 'property_manager')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('admin', 'property_manager')
+    )
+  );
+
+-- Roommates can view their rent invoices
+CREATE POLICY IF NOT EXISTS "Roommates view rent invoices" ON public.rent_invoices
+  FOR SELECT
+  USING (member_id = auth.uid());
+
+-- Admins and property managers manage rent invoices
+CREATE POLICY IF NOT EXISTS "Admins manage rent invoices" ON public.rent_invoices
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('admin', 'property_manager')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('admin', 'property_manager')
+    )
+  );
+
+-- Admin access to invoice supply links
+CREATE POLICY IF NOT EXISTS "Admins manage invoice supply links" ON public.rent_invoice_supply_shares
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('admin', 'property_manager')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('admin', 'property_manager')
+    )
+  );
+
+-- Allow roommates to view their own supply links
+CREATE POLICY IF NOT EXISTS "Roommates view invoice supply links" ON public.rent_invoice_supply_shares
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.rent_invoices ri
+      WHERE ri.id = rent_invoice_supply_shares.invoice_id AND ri.member_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- add an admin rent invoicing page with roommate selection, rent inputs, and supply roll-in controls
- implement server actions that validate payloads, insert rent invoices in batch, and link supply share records
- capture supporting schema changes and type definitions for rent invoices and supply shares, including RLS policies

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d15a8bc08328ac39bf9356a928f3