### PR TITLE
Add tenant chore dashboard with member and household tabs

### DIFF
--- a/app/chores/page.tsx
+++ b/app/chores/page.tsx
@@ -1,10 +1,1 @@
-export default function ChoresPage() {
-  return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Chores</h1>
-      <p className="text-muted-foreground">Shared chore assignments and schedule will appear here.</p>
-    </div>
-  )
-}
-
-
+export { default } from '@/src/app/(tenant)/chores/page'

--- a/src/app/(tenant)/chores/components/chore-list.tsx
+++ b/src/app/(tenant)/chores/components/chore-list.tsx
@@ -1,0 +1,305 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { format, formatDistanceToNow, isValid } from 'date-fns'
+import {
+  CalendarDays,
+  Clock3,
+  Paperclip,
+  Repeat2,
+  Sparkles,
+  UserRound,
+} from 'lucide-react'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+import type { ChoreAssignment, PageInfo } from '../types'
+
+type TabValue = 'mine' | 'household'
+
+type EmptyState = {
+  title: string
+  description: string
+}
+
+interface ChoreListProps {
+  scope: 'member' | 'household'
+  tabValue: TabValue
+  assignments: ChoreAssignment[]
+  pageInfo: PageInfo
+  paginationParam: string
+  searchParams: Record<string, string>
+  emptyState: EmptyState
+}
+
+const statusStyles: Record<ChoreAssignment['status'], { label: string; className: string }> = {
+  upcoming: { label: 'Upcoming', className: 'border-sky-100 bg-sky-50 text-sky-700' },
+  due_today: { label: 'Due today', className: 'border-amber-100 bg-amber-50 text-amber-700' },
+  pending: { label: 'Scheduled', className: 'border-muted bg-muted text-muted-foreground' },
+  in_progress: { label: 'In progress', className: 'border-primary/20 bg-primary/10 text-primary' },
+  overdue: { label: 'Overdue', className: 'border-destructive/20 bg-destructive/10 text-destructive' },
+  completed: { label: 'Completed', className: 'border-emerald-100 bg-emerald-50 text-emerald-700' },
+  skipped: { label: 'Skipped', className: 'border-slate-200 bg-slate-100 text-slate-600' },
+}
+
+const DEFAULT_STATUS_STYLE = { label: 'Scheduled', className: 'border-muted bg-muted text-muted-foreground' }
+
+export function ChoreList({
+  scope,
+  tabValue,
+  assignments,
+  pageInfo,
+  paginationParam,
+  searchParams,
+  emptyState,
+}: ChoreListProps) {
+  const pathname = usePathname()
+
+  if (assignments.length === 0) {
+    return (
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle className="text-lg">{emptyState.title}</CardTitle>
+          <CardDescription>{emptyState.description}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Sparkles className="size-4" />
+          <span>Check back later as new chores are assigned.</span>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {assignments.map((assignment) => (
+        <Card
+          key={assignment.id}
+          className="transition-shadow hover:shadow-md"
+        >
+          <CardHeader className="flex flex-col gap-4 space-y-0 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-2">
+              <CardTitle className="text-lg font-semibold">{assignment.title}</CardTitle>
+              {assignment.description ? (
+                <CardDescription>{assignment.description}</CardDescription>
+              ) : null}
+              <ChoreMeta assignment={assignment} />
+            </div>
+            <StatusBadge status={assignment.status} />
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+              {scope === 'household' && assignment.assignedMember ? (
+                <div className="flex items-center gap-2">
+                  <Avatar className="size-10">
+                    <AvatarImage src={assignment.assignedMember.avatarUrl ?? undefined} alt={assignment.assignedMember.fullName} />
+                    <AvatarFallback>
+                      {getInitials(assignment.assignedMember.fullName)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{assignment.assignedMember.fullName}</p>
+                    <p className="text-xs text-muted-foreground">Assigned roommate</p>
+                  </div>
+                </div>
+              ) : null}
+
+              {typeof assignment.points === 'number' ? (
+                <Badge variant="outline" className="border-amber-100 bg-amber-50 text-amber-700">
+                  +{assignment.points} pts
+                </Badge>
+              ) : null}
+
+              {assignment.attachmentsCount ? (
+                <span className="flex items-center gap-1 text-xs">
+                  <Paperclip className="size-4" />
+                  {assignment.attachmentsCount} attachment{assignment.attachmentsCount === 1 ? '' : 's'}
+                </span>
+              ) : null}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              {scope === 'member' ? (
+                <>
+                  <Button size="sm">Log completion</Button>
+                  <Button size="sm" variant="outline">
+                    View history
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button size="sm" variant="secondary">
+                    Reassign
+                  </Button>
+                  <Button size="sm" variant="outline">
+                    Send reminder
+                  </Button>
+                </>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+
+      <PaginationControls
+        pathname={pathname}
+        pageInfo={pageInfo}
+        paginationParam={paginationParam}
+        searchParams={searchParams}
+        tabValue={tabValue}
+      />
+    </div>
+  )
+}
+
+function ChoreMeta({ assignment }: { assignment: ChoreAssignment }) {
+  const dueDate = new Date(assignment.dueDate)
+  const isDueValid = isValid(dueDate)
+  const dueLabel = isDueValid ? format(dueDate, 'EEE, MMM d') : 'No due date'
+  const dueDistance = isDueValid ? formatDistanceToNow(dueDate, { addSuffix: true }) : null
+
+  const lastCompleted = assignment.lastCompletedAt
+    ? new Date(assignment.lastCompletedAt)
+    : null
+
+  const lastCompletedDistance = lastCompleted && isValid(lastCompleted)
+    ? formatDistanceToNow(lastCompleted, { addSuffix: true })
+    : null
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted-foreground">
+      <span className="flex items-center gap-1">
+        <CalendarDays className="size-4" />
+        <span>Due {dueLabel}{dueDistance ? ` · ${dueDistance}` : ''}</span>
+      </span>
+
+      {assignment.frequency ? (
+        <span className="flex items-center gap-1">
+          <Repeat2 className="size-4" />
+          <span>{assignment.frequency}</span>
+        </span>
+      ) : null}
+
+      {lastCompletedDistance ? (
+        <span className="flex items-center gap-1">
+          <Clock3 className="size-4" />
+          <span>Last completed {lastCompletedDistance}</span>
+        </span>
+      ) : null}
+
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: ChoreAssignment['status'] }) {
+  const meta = statusStyles[status] ?? DEFAULT_STATUS_STYLE
+  return (
+    <Badge
+      variant="outline"
+      className={cn('self-start text-xs font-medium uppercase tracking-wide', meta.className)}
+    >
+      {meta.label}
+    </Badge>
+  )
+}
+
+interface PaginationControlsProps {
+  pathname: string
+  pageInfo: PageInfo
+  paginationParam: string
+  searchParams: Record<string, string>
+  tabValue: TabValue
+}
+
+function PaginationControls({
+  pathname,
+  pageInfo,
+  paginationParam,
+  searchParams,
+  tabValue,
+}: PaginationControlsProps) {
+  if (pageInfo.total <= pageInfo.pageSize && pageInfo.page === 1 && !pageInfo.hasMore) {
+    return null
+  }
+
+  const totalPages = Math.max(1, Math.ceil(pageInfo.total / pageInfo.pageSize))
+  const prevPage = pageInfo.page > 1 ? pageInfo.page - 1 : null
+  const nextPage = pageInfo.hasMore ? pageInfo.page + 1 : null
+
+  const buildHref = (page: number | null) => {
+    if (!page) {
+      return null
+    }
+
+    const params = new URLSearchParams(searchParams)
+
+    if (page <= 1) {
+      params.delete(paginationParam)
+    } else {
+      params.set(paginationParam, String(page))
+    }
+
+    if (tabValue === 'household') {
+      params.set('tab', 'household')
+    } else {
+      params.delete('tab')
+    }
+
+    const query = params.toString()
+    return query ? `${pathname}?${query}` : pathname
+  }
+
+  const prevHref = buildHref(prevPage)
+  const nextHref = buildHref(nextPage)
+
+  const startItem = pageInfo.total === 0 ? 0 : (pageInfo.page - 1) * pageInfo.pageSize + 1
+  const endItem = Math.min(pageInfo.total, pageInfo.page * pageInfo.pageSize)
+
+  return (
+    <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-xs text-muted-foreground">
+        Showing {startItem}-{endItem} of {pageInfo.total}
+      </p>
+      <div className="flex items-center gap-2">
+        {prevHref ? (
+          <Button variant="outline" size="sm" asChild>
+            <Link href={prevHref}>Previous</Link>
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" disabled>
+            Previous
+          </Button>
+        )}
+
+        <span className="text-xs text-muted-foreground">
+          Page {pageInfo.page} of {totalPages}
+        </span>
+
+        {nextHref ? (
+          <Button variant="outline" size="sm" asChild>
+            <Link href={nextHref}>Next</Link>
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" disabled>
+            Next
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function getInitials(name: string) {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+}

--- a/src/app/(tenant)/chores/data.ts
+++ b/src/app/(tenant)/chores/data.ts
@@ -1,0 +1,170 @@
+import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+
+import { getMockChoreAssignments, getMockCurrentMember } from './mock-data'
+import type {
+  ChoreAssignmentsResponse,
+  ChoreAssignment,
+  GetChoreAssignmentsOptions,
+  MemberProfile,
+} from './types'
+
+const DEFAULT_PAGE_SIZE = 6
+
+function normalizePage(input?: number) {
+  if (!input || Number.isNaN(input) || input <= 0) {
+    return 1
+  }
+
+  return input
+}
+
+function resolvePageSize(input?: number) {
+  if (!input || Number.isNaN(input) || input <= 0) {
+    return DEFAULT_PAGE_SIZE
+  }
+
+  return Math.min(input, 25)
+}
+
+function environmentsReady() {
+  return Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  )
+}
+
+export async function getCurrentMemberProfile(): Promise<MemberProfile> {
+  if (!environmentsReady()) {
+    return getMockCurrentMember()
+  }
+
+  try {
+    const supabase = await createSupbaseServerClientReadOnly()
+    const { data: authData } = await supabase.auth.getUser()
+
+    const user = authData?.user
+    if (!user) {
+      return getMockCurrentMember()
+    }
+
+    const { data: profileData } = await supabase
+      .from('profiles')
+      .select('full_name, avatar_url, household_id')
+      .eq('id', user.id)
+      .single()
+
+    return {
+      id: user.id,
+      fullName: profileData?.full_name ?? user.email ?? 'Household member',
+      householdId: profileData?.household_id ?? undefined,
+      avatarUrl: profileData?.avatar_url ?? undefined,
+    }
+  } catch (error) {
+    console.error('Failed to load member profile from Supabase', error)
+    return getMockCurrentMember()
+  }
+}
+
+export async function getChoreAssignments(
+  options: GetChoreAssignmentsOptions,
+): Promise<ChoreAssignmentsResponse> {
+  const page = normalizePage(options.page)
+  const pageSize = resolvePageSize(options.pageSize)
+
+  const fallback = () =>
+    getMockChoreAssignments({
+      ...options,
+      page,
+      pageSize,
+    })
+
+  if (!environmentsReady()) {
+    return fallback()
+  }
+
+  try {
+    const supabase = await createSupbaseServerClientReadOnly()
+    const from = (page - 1) * pageSize
+    const to = from + pageSize - 1
+
+    let query = supabase
+      .from('chore_assignments_view')
+      .select(
+        `
+        id,
+        title,
+        description,
+        due_date,
+        status,
+        frequency,
+        last_completed_at,
+        points,
+        attachments_count,
+        household_id,
+        assigned_member:assigned_member_id (
+          id,
+          full_name,
+          avatar_url
+        )
+      `,
+        { count: 'exact' },
+      )
+      .order('due_date', { ascending: true })
+      .range(from, to)
+
+    if (options.householdId) {
+      query = query.eq('household_id', options.householdId)
+    }
+
+    if (options.scope === 'member' && options.memberId) {
+      query = query.eq('assigned_member_id', options.memberId)
+    }
+
+    const { data, count, error } = await query
+
+    if (error) {
+      console.error('Failed to load chore assignments from Supabase', error)
+      return fallback()
+    }
+
+    const assignments: ChoreAssignment[] = (data ?? []).map((item) => ({
+      id: item.id,
+      title: item.title,
+      description: item.description,
+      dueDate: item.due_date ?? new Date().toISOString(),
+      status: (item.status as ChoreAssignment['status']) ?? 'pending',
+      frequency: item.frequency,
+      lastCompletedAt: item.last_completed_at ?? undefined,
+      points: item.points ?? undefined,
+      attachmentsCount: item.attachments_count ?? undefined,
+      householdId: item.household_id ?? undefined,
+      assignedMember: item.assigned_member
+        ? {
+            id: item.assigned_member.id,
+            fullName: item.assigned_member.full_name ?? 'Household member',
+            avatarUrl: item.assigned_member.avatar_url ?? undefined,
+          }
+        : undefined,
+    }))
+
+    const hasMore = typeof count === 'number' ? to + 1 < count : (assignments.length ?? 0) === pageSize
+    const total =
+      typeof count === 'number'
+        ? count
+        : (page - 1) * pageSize + assignments.length + (hasMore ? 1 : 0)
+
+    return {
+      assignments,
+      pageInfo: {
+        page,
+        pageSize,
+        total,
+        hasMore,
+      },
+    }
+  } catch (error) {
+    console.error('Unexpected error loading chore assignments', error)
+    return fallback()
+  }
+}
+
+export { DEFAULT_PAGE_SIZE }

--- a/src/app/(tenant)/chores/mock-data.ts
+++ b/src/app/(tenant)/chores/mock-data.ts
@@ -1,0 +1,229 @@
+import { addDays, subDays } from 'date-fns'
+
+import type {
+  ChoreAssignment,
+  ChoreAssignmentsResponse,
+  GetChoreAssignmentsOptions,
+  MemberProfile,
+} from './types'
+
+const MOCK_HOUSEHOLD_ID = 'household-lincoln-ave'
+
+const mockHouseholdMembers: MemberProfile[] = [
+  {
+    id: 'member-alex-johnson',
+    fullName: 'Alex Johnson',
+    avatarUrl: 'https://api.dicebear.com/7.x/personas/svg?seed=Alex',
+    householdId: MOCK_HOUSEHOLD_ID,
+  },
+  {
+    id: 'member-samantha-lee',
+    fullName: 'Samantha Lee',
+    avatarUrl: 'https://api.dicebear.com/7.x/personas/svg?seed=Samantha',
+    householdId: MOCK_HOUSEHOLD_ID,
+  },
+  {
+    id: 'member-jordan-park',
+    fullName: 'Jordan Park',
+    avatarUrl: 'https://api.dicebear.com/7.x/personas/svg?seed=Jordan',
+    householdId: MOCK_HOUSEHOLD_ID,
+  },
+  {
+    id: 'member-taylor-evans',
+    fullName: 'Taylor Evans',
+    avatarUrl: 'https://api.dicebear.com/7.x/personas/svg?seed=Taylor',
+    householdId: MOCK_HOUSEHOLD_ID,
+  },
+]
+
+const choreBlueprints = [
+  {
+    id: 'chore-kitchen-deep-clean',
+    title: 'Deep clean the kitchen',
+    description: 'Wipe counters, scrub the sink, and refresh the stovetop.',
+    dueInDays: 0,
+    status: 'due_today' as const,
+    frequency: 'Weekly · Sundays',
+    lastCompletedOffset: 6,
+    points: 15,
+    attachmentsCount: 2,
+    memberId: 'member-alex-johnson',
+  },
+  {
+    id: 'chore-bathroom-refresh',
+    title: 'Bathroom refresh',
+    description: 'Sanitize sinks, mirrors, and stock fresh towels.',
+    dueInDays: 2,
+    status: 'upcoming' as const,
+    frequency: 'Biweekly · Tuesdays',
+    lastCompletedOffset: 12,
+    points: 10,
+    attachmentsCount: 0,
+    memberId: 'member-samantha-lee',
+  },
+  {
+    id: 'chore-trash-rotation',
+    title: 'Take out trash & recycling',
+    description: 'Empty all bins, replace liners, and wheel cans to the curb.',
+    dueInDays: -1,
+    status: 'overdue' as const,
+    frequency: 'Twice weekly',
+    lastCompletedOffset: 5,
+    points: 5,
+    attachmentsCount: 0,
+    memberId: 'member-alex-johnson',
+  },
+  {
+    id: 'chore-living-room-reset',
+    title: 'Living room reset',
+    description: 'Vacuum rugs, fold blankets, and tidy remote controls.',
+    dueInDays: 4,
+    status: 'pending' as const,
+    frequency: 'Weekly · Fridays',
+    lastCompletedOffset: 3,
+    points: 8,
+    attachmentsCount: 1,
+    memberId: 'member-jordan-park',
+  },
+  {
+    id: 'chore-fridge-inventory',
+    title: 'Fridge inventory & wipe down',
+    description: 'Toss expired food and clean shelves and drawers.',
+    dueInDays: 7,
+    status: 'upcoming' as const,
+    frequency: 'Monthly · First Monday',
+    lastCompletedOffset: 27,
+    points: 12,
+    attachmentsCount: 0,
+    memberId: 'member-taylor-evans',
+  },
+  {
+    id: 'chore-plants-water',
+    title: 'Water shared plants',
+    description: 'Check soil moisture and water all common-area plants.',
+    dueInDays: 1,
+    status: 'in_progress' as const,
+    frequency: 'Weekly · Mondays',
+    lastCompletedOffset: 7,
+    points: 4,
+    attachmentsCount: 0,
+    memberId: 'member-samantha-lee',
+  },
+  {
+    id: 'chore-counters-disinfect',
+    title: 'Disinfect high-touch surfaces',
+    description: 'Door handles, fridge handles, and shared keyboards.',
+    dueInDays: 3,
+    status: 'pending' as const,
+    frequency: 'Weekly · Wednesdays',
+    lastCompletedOffset: 9,
+    points: 6,
+    attachmentsCount: 1,
+    memberId: 'member-jordan-park',
+  },
+  {
+    id: 'chore-laundry-rotation',
+    title: 'Shared linens laundry',
+    description: 'Wash dish towels and shared bathroom mats.',
+    dueInDays: -3,
+    status: 'overdue' as const,
+    frequency: 'Biweekly · Saturdays',
+    lastCompletedOffset: 15,
+    points: 9,
+    attachmentsCount: 0,
+    memberId: 'member-taylor-evans',
+  },
+  {
+    id: 'chore-mail-sorting',
+    title: 'Sort delivered mail',
+    description: 'Open shared mail and place individual items in the cubbies.',
+    dueInDays: 0,
+    status: 'due_today' as const,
+    frequency: 'Daily',
+    lastCompletedOffset: 1,
+    points: 3,
+    attachmentsCount: 0,
+    memberId: 'member-alex-johnson',
+  },
+  {
+    id: 'chore-appliance-check',
+    title: 'Appliance maintenance check',
+    description: 'Run dishwasher clean cycle and wipe laundry machine seals.',
+    dueInDays: 5,
+    status: 'pending' as const,
+    frequency: 'Monthly · Mid-month',
+    lastCompletedOffset: 29,
+    points: 14,
+    attachmentsCount: 1,
+    memberId: 'member-samantha-lee',
+  },
+]
+
+function buildMockAssignments(): ChoreAssignment[] {
+  const today = new Date()
+
+  return choreBlueprints.map((blueprint) => {
+    const member = mockHouseholdMembers.find((item) => item.id === blueprint.memberId) ?? mockHouseholdMembers[0]
+    const dueDate = addDays(today, blueprint.dueInDays)
+
+    return {
+      id: blueprint.id,
+      title: blueprint.title,
+      description: blueprint.description,
+      dueDate: dueDate.toISOString(),
+      status: blueprint.status,
+      frequency: blueprint.frequency,
+      lastCompletedAt: blueprint.lastCompletedOffset != null
+        ? subDays(today, blueprint.lastCompletedOffset).toISOString()
+        : null,
+      points: blueprint.points,
+      attachmentsCount: blueprint.attachmentsCount,
+      householdId: MOCK_HOUSEHOLD_ID,
+      assignedMember: {
+        id: member.id,
+        fullName: member.fullName,
+        avatarUrl: member.avatarUrl,
+      },
+    }
+  })
+}
+
+export function getMockCurrentMember(): MemberProfile {
+  return mockHouseholdMembers[0]
+}
+
+export function getMockChoreAssignments(
+  options: GetChoreAssignmentsOptions & { page: number; pageSize: number }
+): ChoreAssignmentsResponse {
+  const assignments = buildMockAssignments()
+  const memberId = options.memberId ?? getMockCurrentMember().id
+
+  const filtered = assignments.filter((assignment) => {
+    if (options.scope === 'member') {
+      return assignment.assignedMember?.id === memberId
+    }
+
+    if (options.householdId) {
+      return assignment.householdId === options.householdId
+    }
+
+    return true
+  })
+
+  const total = filtered.length
+  const start = (options.page - 1) * options.pageSize
+  const end = start + options.pageSize
+  const paginated = filtered.slice(start, end)
+
+  return {
+    assignments: paginated,
+    pageInfo: {
+      page: options.page,
+      pageSize: options.pageSize,
+      total,
+      hasMore: end < total,
+    },
+  }
+}
+
+export { MOCK_HOUSEHOLD_ID, mockHouseholdMembers }

--- a/src/app/(tenant)/chores/page.tsx
+++ b/src/app/(tenant)/chores/page.tsx
@@ -1,0 +1,225 @@
+import type { ReactNode } from 'react'
+
+import { differenceInCalendarDays } from 'date-fns'
+import { AlertTriangle, CheckCircle2, ClipboardList, Clock10 } from 'lucide-react'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+import { ChoreList } from './components/chore-list'
+import { DEFAULT_PAGE_SIZE, getChoreAssignments, getCurrentMemberProfile } from './data'
+import type { ChoreAssignment } from './types'
+
+interface PageProps {
+  searchParams?: Record<string, string | string[] | undefined>
+}
+
+function parsePageParam(value?: string | string[]): number {
+  if (!value) {
+    return 1
+  }
+
+  const raw = Array.isArray(value) ? value[0] : value
+  const parsed = Number.parseInt(raw ?? '', 10)
+
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return 1
+  }
+
+  return parsed
+}
+
+function normalizeSearchParams(params?: Record<string, string | string[] | undefined>) {
+  const normalized: Record<string, string> = {}
+
+  if (!params) {
+    return normalized
+  }
+
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      if (value[0]) {
+        normalized[key] = value[0]
+      }
+    } else if (typeof value === 'string' && value.length > 0) {
+      normalized[key] = value
+    }
+  }
+
+  return normalized
+}
+
+function getSummaryMetrics(assignments: ChoreAssignment[]) {
+  const now = new Date()
+  const upcoming = assignments.filter((item) => {
+    const due = new Date(item.dueDate)
+    const days = differenceInCalendarDays(due, now)
+    return days >= 0 && days <= 3
+  }).length
+
+  const overdue = assignments.filter((item) => item.status === 'overdue').length
+  const completed = assignments.filter((item) => item.status === 'completed').length
+
+  return { upcoming, overdue, completed }
+}
+
+export default async function ChoresPage({ searchParams }: PageProps) {
+  const currentTab = searchParams?.tab === 'household' ? 'household' : 'mine'
+  const memberPage = parsePageParam(searchParams?.memberPage)
+  const householdPage = parsePageParam(searchParams?.householdPage)
+
+  const normalizedSearchParams = normalizeSearchParams(searchParams)
+
+  const memberProfile = await getCurrentMemberProfile()
+
+  const [memberAssignments, householdAssignments] = await Promise.all([
+    getChoreAssignments({
+      scope: 'member',
+      memberId: memberProfile.id,
+      householdId: memberProfile.householdId ?? undefined,
+      page: memberPage,
+      pageSize: DEFAULT_PAGE_SIZE,
+    }),
+    getChoreAssignments({
+      scope: 'household',
+      householdId: memberProfile.householdId ?? undefined,
+      page: householdPage,
+      pageSize: DEFAULT_PAGE_SIZE,
+    }),
+  ])
+
+  const summary = getSummaryMetrics([
+    ...memberAssignments.assignments,
+    ...householdAssignments.assignments,
+  ])
+
+  return (
+    <div className="container max-w-6xl space-y-8 py-8">
+      <header className="space-y-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Chore assignments</h1>
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+              Stay aligned on rotating responsibilities, track due dates, and keep your household running smoothly.
+            </p>
+          </div>
+          <Card className="max-w-sm">
+            <CardHeader className="flex flex-row items-center gap-3 space-y-0">
+              <Avatar className="size-12">
+                <AvatarImage src={memberProfile.avatarUrl ?? undefined} alt={memberProfile.fullName} />
+                <AvatarFallback>{getInitials(memberProfile.fullName)}</AvatarFallback>
+              </Avatar>
+              <div>
+                <CardTitle className="text-base">{memberProfile.fullName}</CardTitle>
+                <CardDescription className="text-xs">
+                  Viewing assignments {memberProfile.householdId ? `for household ${memberProfile.householdId}` : 'across your household'}
+                </CardDescription>
+              </div>
+            </CardHeader>
+          </Card>
+        </div>
+        <Separator />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <SummaryCard
+            title="Assigned to you"
+            value={memberAssignments.pageInfo.total}
+            description="Active chores currently on your list"
+            icon={<ClipboardList className="size-5 text-primary" />}
+          />
+          <SummaryCard
+            title="Due soon"
+            value={summary.upcoming}
+            description="Tasks due within the next three days"
+            icon={<Clock10 className="size-5 text-primary" />}
+          />
+          <SummaryCard
+            title="Overdue"
+            value={summary.overdue}
+            description="Chores needing immediate attention"
+            icon={<AlertTriangle className="size-5 text-primary" />}
+          />
+          <SummaryCard
+            title="Completed"
+            value={summary.completed}
+            description="Recently wrapped up household tasks"
+            icon={<CheckCircle2 className="size-5 text-primary" />}
+          />
+        </div>
+      </header>
+
+      <Tabs defaultValue={currentTab} className="space-y-6">
+        <TabsList className="grid w-full max-w-md grid-cols-2">
+          <TabsTrigger value="mine">My assignments</TabsTrigger>
+          <TabsTrigger value="household">Household view</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="mine">
+          <ChoreList
+            scope="member"
+            tabValue="mine"
+            assignments={memberAssignments.assignments}
+            pageInfo={memberAssignments.pageInfo}
+            paginationParam="memberPage"
+            searchParams={normalizedSearchParams}
+            emptyState={{
+              title: 'No chores assigned to you right now',
+              description: 'You are all caught up. Take a breather and check back for new rotations.',
+            }}
+          />
+        </TabsContent>
+
+        <TabsContent value="household">
+          <ChoreList
+            scope="household"
+            tabValue="household"
+            assignments={householdAssignments.assignments}
+            pageInfo={householdAssignments.pageInfo}
+            paginationParam="householdPage"
+            searchParams={normalizedSearchParams}
+            emptyState={{
+              title: 'No active household chores',
+              description: 'There are no shared tasks scheduled. Create a rotation to keep things balanced.',
+            }}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function SummaryCard({
+  title,
+  value,
+  description,
+  icon,
+}: {
+  title: string
+  value: number
+  description: string
+  icon: ReactNode
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold">{value}</div>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function getInitials(name: string) {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+}

--- a/src/app/(tenant)/chores/types.ts
+++ b/src/app/(tenant)/chores/types.ts
@@ -1,0 +1,55 @@
+export type ChoreStatus =
+  | 'upcoming'
+  | 'due_today'
+  | 'pending'
+  | 'in_progress'
+  | 'overdue'
+  | 'completed'
+  | 'skipped'
+
+export interface HouseholdMemberSummary {
+  id: string
+  fullName: string
+  avatarUrl?: string | null
+}
+
+export interface ChoreAssignment {
+  id: string
+  title: string
+  description?: string | null
+  dueDate: string
+  status: ChoreStatus
+  frequency?: string | null
+  lastCompletedAt?: string | null
+  points?: number | null
+  attachmentsCount?: number | null
+  householdId?: string | null
+  assignedMember?: HouseholdMemberSummary | null
+}
+
+export interface MemberProfile {
+  id: string
+  fullName: string
+  householdId?: string | null
+  avatarUrl?: string | null
+}
+
+export interface PageInfo {
+  page: number
+  pageSize: number
+  total: number
+  hasMore: boolean
+}
+
+export interface ChoreAssignmentsResponse {
+  assignments: ChoreAssignment[]
+  pageInfo: PageInfo
+}
+
+export interface GetChoreAssignmentsOptions {
+  scope: 'member' | 'household'
+  memberId?: string
+  householdId?: string
+  page?: number
+  pageSize?: number
+}


### PR DESCRIPTION
## Summary
- move the /chores route to a grouped tenant path and point the existing page to the new implementation
- implement a server-driven chores dashboard with member and household tabs, summary tiles, and pagination-aware list components
- add supabase-aware data helpers with mock fallbacks so chores can render when Supabase is unavailable

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d16c15a48328a8651dbe1e3a7e5c