### PR TITLE
Add chores table and demo seed data

### DIFF
--- a/supabase/demo/seed.sql
+++ b/supabase/demo/seed.sql
@@ -1,0 +1,54 @@
+-- Demo seed script for validating household chore relationships
+-- Inserts sample households and related chores for local development/testing
+
+-- Ensure demo households exist
+INSERT INTO public.households (id, name)
+VALUES
+  ('11111111-2222-3333-4444-555555555501', 'Demo Household Alpha'),
+  ('11111111-2222-3333-4444-555555555502', 'Demo Household Beta')
+ON CONFLICT DO NOTHING;
+
+-- Starter chores for Demo Household Alpha
+WITH target_household AS (
+  SELECT id
+  FROM public.households
+  WHERE id = '11111111-2222-3333-4444-555555555501'
+)
+INSERT INTO public.chores (household_id, title, cadence, points, active)
+SELECT target_household.id, chore.title, chore.cadence, chore.points, chore.active
+FROM target_household
+CROSS JOIN (
+  VALUES
+    ('Take out trash', 'weekly', 5, TRUE),
+    ('Kitchen wipe-down', 'daily', 2, TRUE),
+    ('Laundry rotation', 'biweekly', 4, TRUE),
+    ('Deep clean fridge', 'monthly', 8, FALSE)
+) AS chore(title, cadence, points, active)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.chores existing
+  WHERE existing.household_id = target_household.id
+    AND existing.title = chore.title
+);
+
+-- Starter chores for Demo Household Beta
+WITH target_household AS (
+  SELECT id
+  FROM public.households
+  WHERE id = '11111111-2222-3333-4444-555555555502'
+)
+INSERT INTO public.chores (household_id, title, cadence, points, active)
+SELECT target_household.id, chore.title, chore.cadence, chore.points, chore.active
+FROM target_household
+CROSS JOIN (
+  VALUES
+    ('Water indoor plants', 'weekly', 3, TRUE),
+    ('Vacuum hallways', 'weekly', 4, TRUE),
+    ('Inspect smoke detectors', 'one_time', 6, TRUE)
+) AS chore(title, cadence, points, active)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.chores existing
+  WHERE existing.household_id = target_household.id
+    AND existing.title = chore.title
+);

--- a/supabase/migrations/20250103_notifications_schema.sql
+++ b/supabase/migrations/20250103_notifications_schema.sql
@@ -37,6 +37,16 @@ CREATE TABLE public.visitor_logs (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Create chores table for household chore tracking
+CREATE TABLE public.chores (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  household_id UUID NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  cadence TEXT NOT NULL DEFAULT 'weekly' CHECK (cadence IN ('daily', 'weekly', 'biweekly', 'monthly', 'one_time')),
+  points INTEGER NOT NULL DEFAULT 1 CHECK (points >= 0),
+  active BOOLEAN NOT NULL DEFAULT TRUE
+);
+
 -- Create notifications table for in-app notifications
 CREATE TABLE public.notifications (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
@@ -76,6 +86,10 @@ CREATE INDEX idx_visitor_logs_host_id ON public.visitor_logs(host_id);
 CREATE INDEX idx_visitor_logs_status ON public.visitor_logs(status);
 CREATE INDEX idx_visitor_logs_check_in_date ON public.visitor_logs(check_in_date);
 CREATE INDEX idx_visitor_logs_created_at ON public.visitor_logs(created_at DESC);
+
+CREATE INDEX idx_chores_household_id ON public.chores(household_id);
+CREATE INDEX idx_chores_active ON public.chores(active);
+CREATE INDEX idx_chores_cadence ON public.chores(cadence);
 
 CREATE INDEX idx_notifications_user_id ON public.notifications(user_id);
 CREATE INDEX idx_notifications_read ON public.notifications(read);


### PR DESCRIPTION
## Summary
- create the `chores` table with defaults, constraints, and a foreign key to `households`
- add supporting indexes for chore lookups
- seed demo households and chores to validate the new relationship

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0d16fe00c832897d5a3d984e4f6e7