### PR TITLE
Prevent overallocating catch-up payments

### DIFF
--- a/lib/payments/catch-up.ts
+++ b/lib/payments/catch-up.ts
@@ -56,13 +56,6 @@ export function allocatePaymentToCharges(
     }
   }
 
-  if (remainingCents > 0 && allocations.length > 0) {
-    const adjustment = remainingCents / 100
-    const lastAllocation = allocations[allocations.length - 1]
-    lastAllocation.amount = roundToCurrency(lastAllocation.amount + adjustment)
-    remainingCents = 0
-  }
-
   if (remainingCents > 0) {
     throw new Error("Catch-up amount exceeds outstanding charges.")
   }

--- a/tests/catch-up.test.ts
+++ b/tests/catch-up.test.ts
@@ -56,6 +56,12 @@ describe("catch-up helpers", () => {
     ])
   })
 
+  it("prevents allocating more than the outstanding balance", () => {
+    expect(() => allocatePaymentToCharges(sampleCharges, 600)).toThrow(
+      "Catch-up amount exceeds outstanding charges.",
+    )
+  })
+
   it("reduces outstanding amounts after applying allocations", () => {
     const allocations = [
       { chargeId: "charge_rent", amount: 450.25 },


### PR DESCRIPTION
## Summary
- stop catch-up allocation from absorbing extra funds into the final charge so overpayments are rejected
- add a regression test covering the overpayment scenario for catch-up allocations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d129cfd7e4832899d36974b46c4721