### PR TITLE
Fix Supabase typing and notification infrastructure

### DIFF
--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from 'next/server';
+
+import {
+  type InAppNotification,
+  type NotificationData,
+  sendBulkNotifications,
+  sendEmailNotification,
+  sendInAppNotification,
+} from '@/lib/notifications';
+
+type VisitorBookingPayload = {
+  guestName: string;
+  hostName: string;
+  checkInDate: string;
+  checkOutDate: string;
+  purpose: string;
+  roommates: Array<{ id: string; email: string; name: string }>;
+  propertyManager: { id: string; email: string; name: string };
+};
+
+type MaintenanceRequestPayload = {
+  requesterName: string;
+  title: string;
+  description: string;
+  priority: string;
+  propertyManager: { id: string; email: string; name: string };
+};
+
+type PaymentReceiptPayload = {
+  tenantName: string;
+  amount: string;
+  description: string;
+  date: string;
+  tenantEmail: string;
+  tenantId: string;
+};
+
+type DocumentSignedPayload = {
+  documentTitle: string;
+  signerName: string;
+  signedAt: string;
+  signerEmail: string;
+  signerId: string;
+};
+
+type NotificationRequest =
+  | { type: 'sendEmail'; payload: NotificationData }
+  | { type: 'sendInApp'; payload: InAppNotification }
+  | { type: 'sendBulk'; payload: (NotificationData | InAppNotification)[] }
+  | { type: 'visitorBooking'; payload: VisitorBookingPayload }
+  | { type: 'maintenanceRequest'; payload: MaintenanceRequestPayload }
+  | { type: 'paymentReceipt'; payload: PaymentReceiptPayload }
+  | { type: 'documentSigned'; payload: DocumentSignedPayload };
+
+function createErrorResponse(error: string, status = 400) {
+  return NextResponse.json({ success: false, error }, { status });
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as NotificationRequest;
+
+    switch (body.type) {
+      case 'sendEmail': {
+        const result = await sendEmailNotification(body.payload);
+        return NextResponse.json(result, { status: result.success ? 200 : 500 });
+      }
+      case 'sendInApp': {
+        const result = await sendInAppNotification(body.payload);
+        return NextResponse.json(result, { status: result.success ? 200 : 500 });
+      }
+      case 'sendBulk': {
+        const results = await sendBulkNotifications(body.payload);
+        return NextResponse.json({ success: true, results });
+      }
+      case 'visitorBooking': {
+        const { payload } = body;
+        const notifications: (NotificationData | InAppNotification)[] = [
+          {
+            to: payload.propertyManager.email,
+            subject: `New Visitor Booking: ${payload.guestName}`,
+            template: 'visitor-booking',
+            data: payload,
+            userId: payload.propertyManager.id,
+          },
+          ...payload.roommates.map<InAppNotification>((roommate) => ({
+            userId: roommate.id,
+            title: 'New Visitor Booking',
+            message: `${payload.guestName} is visiting from ${payload.checkInDate} to ${payload.checkOutDate}`,
+            type: 'info',
+            actionUrl: '/dashboard',
+          })),
+        ];
+        const results = await sendBulkNotifications(notifications);
+        return NextResponse.json({ success: true, results });
+      }
+      case 'maintenanceRequest': {
+        const { payload } = body;
+        const notifications: (NotificationData | InAppNotification)[] = [
+          {
+            to: payload.propertyManager.email,
+            subject: `New Maintenance Request: ${payload.title}`,
+            template: 'maintenance-request',
+            data: payload,
+            userId: payload.propertyManager.id,
+          },
+          {
+            userId: payload.propertyManager.id,
+            title: 'New Maintenance Request',
+            message: `${payload.requesterName} reported: ${payload.title}`,
+            type: 'warning',
+            actionUrl: '/dashboard',
+          },
+        ];
+        const results = await sendBulkNotifications(notifications);
+        return NextResponse.json({ success: true, results });
+      }
+      case 'paymentReceipt': {
+        const { payload } = body;
+        const notifications: (NotificationData | InAppNotification)[] = [
+          {
+            to: payload.tenantEmail,
+            subject: `Payment Receipt - $${payload.amount}`,
+            template: 'payment-receipt',
+            data: payload,
+            userId: payload.tenantId,
+          },
+          {
+            userId: payload.tenantId,
+            title: 'Payment Successful',
+            message: `Your payment of $${payload.amount} has been processed.`,
+            type: 'success',
+            actionUrl: '/payments',
+          },
+        ];
+        const results = await sendBulkNotifications(notifications);
+        return NextResponse.json({ success: true, results });
+      }
+      case 'documentSigned': {
+        const { payload } = body;
+        const notifications: (NotificationData | InAppNotification)[] = [
+          {
+            to: payload.signerEmail,
+            subject: `Document Signed: ${payload.documentTitle}`,
+            template: 'document-signed',
+            data: payload,
+            userId: payload.signerId,
+          },
+          {
+            userId: payload.signerId,
+            title: 'Document Signed',
+            message: `${payload.documentTitle} has been signed.`,
+            type: 'success',
+            actionUrl: '/documents',
+          },
+        ];
+        const results = await sendBulkNotifications(notifications);
+        return NextResponse.json({ success: true, results });
+      }
+      default:
+        return createErrorResponse('Unsupported notification type');
+    }
+  } catch (error) {
+    console.error('Notification API error', error);
+    return createErrorResponse('Failed to process notification request', 500);
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -2,18 +2,24 @@ import { headers } from "next/headers"
 import { getStripe } from "@/lib/stripe"
 import { createClient } from "@supabase/supabase-js"
 import type { Database } from "@/lib/supabase"
-import { notificationService } from "@/lib/notifications"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { sendEmailNotification, sendInAppNotification } from "@/lib/notifications"
 
-const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  {
+function createSupabaseAdminClient(): SupabaseClient<Database> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceKey) {
+    throw new Error('Supabase admin credentials are not configured')
+  }
+
+  return createClient<Database>(url, serviceKey, {
     auth: {
       autoRefreshToken: false,
-      persistSession: false
-    }
-  }
-)
+      persistSession: false,
+    },
+  })
+}
 
 export async function POST(req: Request) {
   const stripe = getStripe()
@@ -26,24 +32,32 @@ export async function POST(req: Request) {
 
   const rawBody = await req.text()
 
+  let supabase: SupabaseClient<Database>
+  try {
+    supabase = createSupabaseAdminClient()
+  } catch (error) {
+    console.error('Supabase configuration error:', error)
+    return new Response('Server configuration error', { status: 500 })
+  }
+
   try {
     const event = stripe.webhooks.constructEvent(rawBody, signature ?? "", webhookSecret)
 
     switch (event.type) {
       case "checkout.session.completed":
-        await handleCheckoutSessionCompleted(event.data.object)
+        await handleCheckoutSessionCompleted(event.data.object, supabase)
         break
       case "invoice.payment_succeeded":
-        await handleInvoicePaymentSucceeded(event.data.object)
+        await handleInvoicePaymentSucceeded(event.data.object, supabase)
         break
       case "customer.subscription.created":
-        await handleSubscriptionCreated(event.data.object)
+        await handleSubscriptionCreated(event.data.object, supabase)
         break
       case "customer.subscription.updated":
-        await handleSubscriptionUpdated(event.data.object)
+        await handleSubscriptionUpdated(event.data.object, supabase)
         break
       case "customer.subscription.deleted":
-        await handleSubscriptionDeleted(event.data.object)
+        await handleSubscriptionDeleted(event.data.object, supabase)
         break
       default:
         console.log(`Unhandled event type: ${event.type}`)
@@ -58,7 +72,7 @@ export async function POST(req: Request) {
   }
 }
 
-async function handleCheckoutSessionCompleted(session: any) {
+async function handleCheckoutSessionCompleted(session: any, supabase: SupabaseClient<Database>) {
   try {
     // Retrieve the full session with line items
     const stripe = getStripe()
@@ -108,7 +122,7 @@ async function handleCheckoutSessionCompleted(session: any) {
               .single();
 
             if (tenantProfile?.email) {
-              await notificationService.sendEmail({
+              await sendEmailNotification({
                 to: tenantProfile.email,
                 subject: `Payment Receipt - $${paymentData.amount}`,
                 template: 'payment-receipt',
@@ -122,7 +136,7 @@ async function handleCheckoutSessionCompleted(session: any) {
               });
 
               // Also send in-app notification
-              await notificationService.sendInAppNotification({
+              await sendInAppNotification({
                 userId: tenantId,
                 title: "Payment Successful",
                 message: `Your payment of $${paymentData.amount} has been processed successfully.`,
@@ -147,7 +161,7 @@ async function handleCheckoutSessionCompleted(session: any) {
   }
 }
 
-async function handleInvoicePaymentSucceeded(invoice: any) {
+async function handleInvoicePaymentSucceeded(invoice: any, supabase: SupabaseClient<Database>) {
   try {
     const stripe = getStripe()
 
@@ -198,7 +212,7 @@ async function handleInvoicePaymentSucceeded(invoice: any) {
   }
 }
 
-async function handleSubscriptionCreated(subscription: any) {
+async function handleSubscriptionCreated(subscription: any, supabase: SupabaseClient<Database>) {
   try {
     // This handles when a subscription is first created
     const price = subscription.items.data[0]?.price
@@ -225,7 +239,7 @@ async function handleSubscriptionCreated(subscription: any) {
   }
 }
 
-async function handleSubscriptionUpdated(subscription: any) {
+async function handleSubscriptionUpdated(subscription: any, supabase: SupabaseClient<Database>) {
   try {
     await supabase.from('subscriptions').update({
       status: subscription.status,
@@ -240,7 +254,7 @@ async function handleSubscriptionUpdated(subscription: any) {
   }
 }
 
-async function handleSubscriptionDeleted(subscription: any) {
+async function handleSubscriptionDeleted(subscription: any, supabase: SupabaseClient<Database>) {
   try {
     await supabase.from('subscriptions').update({
       status: 'canceled',
@@ -254,8 +268,4 @@ async function handleSubscriptionDeleted(subscription: any) {
     throw error
   }
 }
-
-// Export runtime config for edge runtime
-export const runtime = 'edge';
-
 

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -104,7 +104,15 @@ export default function BookingsPage() {
                     <span>Duration: {amenity.duration}</span>
                     <span>Max advance: {amenity.maxAdvance}</span>
                   </div>
-                  <AmenityBookingForm amenity={amenity} />
+                  <AmenityBookingForm
+                    amenity={{
+                      id: amenity.id,
+                      name: amenity.name,
+                      description: amenity.description,
+                      duration: amenity.duration,
+                      maxAdvance: amenity.maxAdvance,
+                    }}
+                  />
                 </CardContent>
               </Card>
             ))}

--- a/app/contact/actions/index.tsx
+++ b/app/contact/actions/index.tsx
@@ -2,7 +2,7 @@
 
 import { createClient } from "@/utils/supa-server-actions";
 import { revalidatePath } from "next/cache";
-import { cookies } from 'next/headers';
+import { cookies } from "next/headers";
 
 type formData = {
     name: string;
@@ -20,8 +20,8 @@ export async function submitInquiry(data: formData) {
       .insert({
         name: data.name,
         email: data.email,
-        message: data.message
-      } as any);
+        message: data.message,
+      });
 
     if (error) throw error;
 

--- a/app/schedule/actions/index.tsx
+++ b/app/schedule/actions/index.tsx
@@ -3,7 +3,6 @@
 import { createClient } from '@/utils/supa-server-actions';
 import { createGoogleCalendarEvent } from '@/lib/calendar-service';
 import { revalidatePath } from 'next/cache';
-import { Database } from '@/lib/supabase';
 import { z } from 'zod';
 import { cookies } from 'next/headers';
 import { formatISO, isPast } from 'date-fns'; // Import formatISO here
@@ -95,9 +94,11 @@ export async function scheduleMeetingAction(
   try {
     // 4. Create Google Calendar Event
     //    Format the validated Date objects back into ISO strings for the Google API call
+    const startTimeIso = formatISO(validatedData.startTime);
+    const endTimeIso = formatISO(validatedData.endTime);
     const calendarResult = await createGoogleCalendarEvent({
-      startTime: formatISO(validatedData.startTime), // Format Date -> ISO String
-      endTime: formatISO(validatedData.endTime),     // Format Date -> ISO String
+      startTime: startTimeIso, // Format Date -> ISO String
+      endTime: endTimeIso,     // Format Date -> ISO String
       attendeeEmail: validatedData.userEmail,
       attendeeName: validatedData.userName,
       summary: validatedData.summary,
@@ -120,10 +121,11 @@ export async function scheduleMeetingAction(
       .from('meetings')
       .insert({
         user_id: user.id,
-        start_time: validatedData.startTime, // Pass Date object
-        end_time: validatedData.endTime,     // Pass Date object
-        google_event_id: calendarResult.eventId,
+        start_time: startTimeIso,
+        end_time: endTimeIso,
+        meet_link: calendarResult.link ?? '',
         summary: validatedData.summary,
+        description: validatedData.description ?? null,
       });
 
     if (dbError) {

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -1,14 +1,111 @@
-"use client";
-
 import { useToast } from "@/components/ui/use-toast";
-import { notificationService, NotificationData, InAppNotification } from "@/lib/notifications";
+import type { InAppNotification, NotificationData } from "@/lib/notifications";
+
+type BulkNotificationResult = {
+  index: number;
+  success: boolean;
+  error?: unknown;
+};
+
+type VisitorBookingPayload = {
+  guestName: string;
+  hostName: string;
+  checkInDate: string;
+  checkOutDate: string;
+  purpose: string;
+  roommates: Array<{ id: string; email: string; name: string }>;
+  propertyManager: { id: string; email: string; name: string };
+};
+
+type MaintenanceRequestPayload = {
+  requesterName: string;
+  title: string;
+  description: string;
+  priority: string;
+  propertyManager: { id: string; email: string; name: string };
+};
+
+type PaymentReceiptPayload = {
+  tenantName: string;
+  amount: string;
+  description: string;
+  date: string;
+  tenantEmail: string;
+  tenantId: string;
+};
+
+type DocumentSignedPayload = {
+  documentTitle: string;
+  signerName: string;
+  signedAt: string;
+  signerEmail: string;
+  signerId: string;
+};
+
+type NotificationRequestBody =
+  | { type: "sendEmail"; payload: NotificationData }
+  | { type: "sendInApp"; payload: InAppNotification }
+  | { type: "sendBulk"; payload: (NotificationData | InAppNotification)[] }
+  | { type: "visitorBooking"; payload: VisitorBookingPayload }
+  | { type: "maintenanceRequest"; payload: MaintenanceRequestPayload }
+  | { type: "paymentReceipt"; payload: PaymentReceiptPayload }
+  | { type: "documentSigned"; payload: DocumentSignedPayload };
+
+type NotificationApiError = { error?: string };
+
+type BulkResponse = { success: true; results: BulkNotificationResult[] };
+
+type SingleResponse = { success: boolean; error?: string };
+
+async function postNotificationRequest<T>(body: NotificationRequestBody): Promise<T> {
+  const response = await fetch("/api/notifications", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as NotificationApiError | null;
+    throw new Error(errorBody?.error ?? "Notification request failed");
+  }
+
+  return (await response.json()) as T;
+}
 
 export function useNotifications() {
   const { toast } = useToast();
 
+  const handleBulkResults = (results: BulkNotificationResult[]) => {
+    const successCount = results.filter((result) => result.success).length;
+    const failureCount = results.length - successCount;
+
+    if (successCount > 0) {
+      toast({
+        title: "Notifications sent",
+        description: `${successCount} notification${successCount > 1 ? "s" : ""} sent successfully${
+          failureCount > 0 ? `, ${failureCount} failed` : ""
+        }.`,
+      });
+    }
+
+    if (failureCount > 0) {
+      toast({
+        title: "Some notifications failed",
+        description: `${failureCount} notification${failureCount > 1 ? "s" : ""} could not be sent.`,
+        variant: "destructive",
+      });
+    }
+  };
+
   const sendEmail = async (notification: NotificationData) => {
     try {
-      const result = await notificationService.sendEmail(notification);
+      const result = await postNotificationRequest<SingleResponse>({
+        type: "sendEmail",
+        payload: notification,
+      });
+
       if (result.success) {
         toast({
           title: "Email sent",
@@ -21,6 +118,7 @@ export function useNotifications() {
           variant: "destructive",
         });
       }
+
       return result;
     } catch (error) {
       toast({
@@ -28,22 +126,34 @@ export function useNotifications() {
         description: "An unexpected error occurred while sending email.",
         variant: "destructive",
       });
-      return { success: false, error: "Unexpected error" };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unexpected error",
+      };
     }
   };
 
   const sendInAppNotification = async (notification: InAppNotification) => {
     try {
-      const result = await notificationService.sendInAppNotification(notification);
+      const result = await postNotificationRequest<SingleResponse>({
+        type: "sendInApp",
+        payload: notification,
+      });
+
       if (result.success) {
-        // Show toast for immediate feedback
         toast({
           title: notification.title,
           description: notification.message,
-          variant: notification.type === 'error' ? 'destructive' :
-                  notification.type === 'warning' ? 'default' : 'default',
+          variant: notification.type === "error" ? "destructive" : "default",
+        });
+      } else {
+        toast({
+          title: "Notification failed",
+          description: result.error || "Failed to send in-app notification.",
+          variant: "destructive",
         });
       }
+
       return result;
     } catch (error) {
       toast({
@@ -51,32 +161,22 @@ export function useNotifications() {
         description: "Failed to send in-app notification.",
         variant: "destructive",
       });
-      return { success: false, error: "Unexpected error" };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unexpected error",
+      };
     }
   };
 
   const sendBulkNotifications = async (notifications: (NotificationData | InAppNotification)[]) => {
     try {
-      const results = await notificationService.sendBulkNotification(notifications);
-      const successCount = results.filter(r => r.success).length;
-      const failureCount = results.length - successCount;
+      const result = await postNotificationRequest<BulkResponse>({
+        type: "sendBulk",
+        payload: notifications,
+      });
 
-      if (successCount > 0) {
-        toast({
-          title: "Notifications sent",
-          description: `${successCount} notification${successCount > 1 ? 's' : ''} sent successfully${failureCount > 0 ? `, ${failureCount} failed` : ''}.`,
-        });
-      }
-
-      if (failureCount > 0) {
-        toast({
-          title: "Some notifications failed",
-          description: `${failureCount} notification${failureCount > 1 ? 's' : ''} could not be sent.`,
-          variant: "destructive",
-        });
-      }
-
-      return results;
+      handleBulkResults(result.results);
+      return result.results;
     } catch (error) {
       toast({
         title: "Error",
@@ -87,124 +187,80 @@ export function useNotifications() {
     }
   };
 
-  // Convenience methods for common notification types
-  const notifyVisitorBooking = async (data: {
-    guestName: string;
-    hostName: string;
-    checkInDate: string;
-    checkOutDate: string;
-    purpose: string;
-    roommates: Array<{ id: string; email: string; name: string }>;
-    propertyManager: { id: string; email: string; name: string };
-  }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
-      // Email to property manager
-      {
-        to: data.propertyManager.email,
-        subject: `New Visitor Booking: ${data.guestName}`,
-        template: 'visitor-booking',
-        data,
-        userId: data.propertyManager.id,
-      },
-      // In-app notifications to all roommates
-      ...data.roommates.map(roommate => ({
-        userId: roommate.id,
-        title: "New Visitor Booking",
-        message: `${data.guestName} is visiting from ${data.checkInDate} to ${data.checkOutDate}`,
-        type: 'info' as const,
-        actionUrl: '/dashboard',
-      })),
-    ];
+  const notifyVisitorBooking = async (data: VisitorBookingPayload) => {
+    try {
+      const result = await postNotificationRequest<BulkResponse>({
+        type: "visitorBooking",
+        payload: data,
+      });
 
-    return sendBulkNotifications(notifications);
+      handleBulkResults(result.results);
+      return result.results;
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to send visitor booking notifications.",
+        variant: "destructive",
+      });
+      return [];
+    }
   };
 
-  const notifyMaintenanceRequest = async (data: {
-    requesterName: string;
-    title: string;
-    description: string;
-    priority: string;
-    propertyManager: { id: string; email: string; name: string };
-  }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
-      // Email to property manager
-      {
-        to: data.propertyManager.email,
-        subject: `New Maintenance Request: ${data.title}`,
-        template: 'maintenance-request',
-        data,
-        userId: data.propertyManager.id,
-      },
-      // In-app notification to property manager
-      {
-        userId: data.propertyManager.id,
-        title: "New Maintenance Request",
-        message: `${data.requesterName} reported: ${data.title}`,
-        type: 'warning' as const,
-        actionUrl: '/dashboard',
-      },
-    ];
+  const notifyMaintenanceRequest = async (data: MaintenanceRequestPayload) => {
+    try {
+      const result = await postNotificationRequest<BulkResponse>({
+        type: "maintenanceRequest",
+        payload: data,
+      });
 
-    return sendBulkNotifications(notifications);
+      handleBulkResults(result.results);
+      return result.results;
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to send maintenance request notifications.",
+        variant: "destructive",
+      });
+      return [];
+    }
   };
 
-  const notifyPaymentReceipt = async (data: {
-    tenantName: string;
-    amount: string;
-    description: string;
-    date: string;
-    tenantEmail: string;
-    tenantId: string;
-  }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
-      // Email receipt to tenant
-      {
-        to: data.tenantEmail,
-        subject: `Payment Receipt - $${data.amount}`,
-        template: 'payment-receipt',
-        data,
-        userId: data.tenantId,
-      },
-      // In-app notification to tenant
-      {
-        userId: data.tenantId,
-        title: "Payment Successful",
-        message: `Your payment of $${data.amount} has been processed.`,
-        type: 'success' as const,
-        actionUrl: '/payments',
-      },
-    ];
+  const notifyPaymentReceipt = async (data: PaymentReceiptPayload) => {
+    try {
+      const result = await postNotificationRequest<BulkResponse>({
+        type: "paymentReceipt",
+        payload: data,
+      });
 
-    return sendBulkNotifications(notifications);
+      handleBulkResults(result.results);
+      return result.results;
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to send payment receipt notifications.",
+        variant: "destructive",
+      });
+      return [];
+    }
   };
 
-  const notifyDocumentSigned = async (data: {
-    documentTitle: string;
-    signerName: string;
-    signedAt: string;
-    signerEmail: string;
-    signerId: string;
-  }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
-      // Email confirmation to signer
-      {
-        to: data.signerEmail,
-        subject: `Document Signed: ${data.documentTitle}`,
-        template: 'document-signed',
-        data,
-        userId: data.signerId,
-      },
-      // In-app notification to signer
-      {
-        userId: data.signerId,
-        title: "Document Signed",
-        message: `You have successfully signed "${data.documentTitle}"`,
-        type: 'success' as const,
-        actionUrl: '/documents',
-      },
-    ];
+  const notifyDocumentSigned = async (data: DocumentSignedPayload) => {
+    try {
+      const result = await postNotificationRequest<BulkResponse>({
+        type: "documentSigned",
+        payload: data,
+      });
 
-    return sendBulkNotifications(notifications);
+      handleBulkResults(result.results);
+      return result.results;
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to send document signed notifications.",
+        variant: "destructive",
+      });
+      return [];
+    }
   };
 
   return {

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -212,4 +212,18 @@ class NotificationService {
   }
 }
 
-export const notificationService = new NotificationService();
+const notificationService = new NotificationService();
+
+export async function sendEmailNotification(notification: NotificationData) {
+  return notificationService.sendEmail(notification);
+}
+
+export async function sendInAppNotification(notification: InAppNotification) {
+  return notificationService.sendInAppNotification(notification);
+}
+
+export async function sendBulkNotifications(
+  notifications: (NotificationData | InAppNotification)[],
+) {
+  return notificationService.sendBulkNotification(notifications);
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -941,30 +941,36 @@ export type Database = {
         }
         Relationships: []
       }
-      inqueries: {
+      inquiries: {
         Row: {
-          created_at: string
-          email: string
-          id: number
-          message: string
+          id: string
           name: string
-          user_id: string
+          email: string
+          message: string
+          status: string
+          created_at: string
+          updated_at: string
+          metadata: Json | null
         }
         Insert: {
-          created_at?: string
-          email?: string
-          id?: number
+          id?: string
+          name: string
+          email: string
           message: string
-          name?: string
-          user_id?: string
+          status?: string
+          created_at?: string
+          updated_at?: string
+          metadata?: Json | null
         }
         Update: {
-          created_at?: string
-          email?: string
-          id?: number
-          message?: string
+          id?: string
           name?: string
-          user_id?: string
+          email?: string
+          message?: string
+          status?: string
+          created_at?: string
+          updated_at?: string
+          metadata?: Json | null
         }
         Relationships: []
       }
@@ -2120,177 +2126,6 @@ export type Database = {
           },
         ]
       }
-      // Removed duplicate document_signatures definition
-      // Removed duplicate document_access_logs definition
-      // Removed duplicate leases definition
-          signer_id: string
-          signer_email: string
-          signer_name: string | null
-          status: string
-          signed_at: string | null
-          declined_at: string | null
-          decline_reason: string | null
-          documenso_signature_id: string | null
-          ip_address: string | null
-          user_agent: string | null
-          signature_data: Json | null
-        }
-        Insert: {
-          id?: string
-          created_at?: string
-          updated_at?: string
-          document_id: string
-          signer_id: string
-          signer_email: string
-          signer_name?: string | null
-          status?: string
-          signed_at?: string | null
-          declined_at?: string | null
-          decline_reason?: string | null
-          documenso_signature_id?: string | null
-          ip_address?: string | null
-          user_agent?: string | null
-          signature_data?: Json | null
-        }
-        Update: {
-          id?: string
-          created_at?: string
-          updated_at?: string
-          document_id?: string
-          signer_id?: string
-          signer_email?: string
-          signer_name?: string | null
-          status?: string
-          signed_at?: string | null
-          declined_at?: string | null
-          decline_reason?: string | null
-          documenso_signature_id?: string | null
-          ip_address?: string | null
-          user_agent?: string | null
-          signature_data?: Json | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "document_signatures_document_id_fkey"
-            columns: ["document_id"]
-            isOneToOne: false
-            referencedRelation: "documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      document_access_logs: {
-        Row: {
-          id: string
-          created_at: string
-          document_id: string
-          user_id: string
-          action: string
-          ip_address: string | null
-          user_agent: string | null
-          metadata: Json | null
-        }
-        Insert: {
-          id?: string
-          created_at?: string
-          document_id: string
-          user_id: string
-          action: string
-          ip_address?: string | null
-          user_agent?: string | null
-          metadata?: Json | null
-        }
-        Update: {
-          id?: string
-          created_at?: string
-          document_id?: string
-          user_id?: string
-          action?: string
-          ip_address?: string | null
-          user_agent?: string | null
-          metadata?: Json | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "document_access_logs_document_id_fkey"
-            columns: ["document_id"]
-            isOneToOne: false
-            referencedRelation: "documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      leases: {
-        Row: {
-          id: string
-          document_id: string
-          created_at: string
-          updated_at: string
-          start_date: string
-          end_date: string | null
-          rent_amount: number | null
-          rent_frequency: string
-          security_deposit: number | null
-          tenant_ids: string[]
-          property_address: string | null
-          unit_number: string | null
-          landlord_name: string | null
-          landlord_email: string | null
-          auto_renew: boolean
-          renewal_notice_days: number
-          special_terms: string | null
-          status: string
-        }
-        Insert: {
-          id?: string
-          document_id: string
-          created_at?: string
-          updated_at?: string
-          start_date: string
-          end_date?: string | null
-          rent_amount?: number | null
-          rent_frequency?: string
-          security_deposit?: number | null
-          tenant_ids: string[]
-          property_address?: string | null
-          unit_number?: string | null
-          landlord_name?: string | null
-          landlord_email?: string | null
-          auto_renew?: boolean
-          renewal_notice_days?: number
-          special_terms?: string | null
-          status?: string
-        }
-        Update: {
-          id?: string
-          document_id?: string
-          created_at?: string
-          updated_at?: string
-          start_date?: string
-          end_date?: string | null
-          rent_amount?: number | null
-          rent_frequency?: string
-          security_deposit?: number | null
-          tenant_ids?: string[]
-          property_address?: string | null
-          unit_number?: string | null
-          landlord_name?: string | null
-          landlord_email?: string | null
-          auto_renew?: boolean
-          renewal_notice_days?: number
-          special_terms?: string | null
-          status?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "leases_document_id_fkey"
-            columns: ["document_id"]
-            isOneToOne: false
-            referencedRelation: "documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
     }
     Views: {
       package_utilization: {
@@ -2383,6 +2218,14 @@ export type Database = {
         Args: { user_id: string }
         Returns: boolean
       }
+      log_document_access: {
+        Args: {
+          p_document_id: string
+          p_action: string
+          p_metadata?: Json
+        }
+        Returns: string
+      }
       ivfflat_bit_support: {
         Args: { internal: unknown }
         Returns: unknown
@@ -2470,39 +2313,6 @@ export type Database = {
     CompositeTypes: {
       [_ in never]: never
     }
-  }
-  inquiries: {
-    Row: {
-      id: string
-      name: string
-      email: string
-      message: string
-      status: string
-      created_at: string
-      updated_at: string
-      metadata: Json | null
-    }
-    Insert: {
-      id?: string
-      name: string
-      email: string
-      message: string
-      status?: string
-      created_at?: string
-      updated_at?: string
-      metadata?: Json | null
-    }
-    Update: {
-      id?: string
-      name?: string
-      email?: string
-      message?: string
-      status?: string
-      created_at?: string
-      updated_at?: string
-      metadata?: Json | null
-    }
-    Relationships: []
   }
   storage: {
     Tables: {

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,8 +1,10 @@
 import { type CookieOptions, createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import type { Database } from '@/lib/supabase'
+
 export function createClient(cookieStore: ReturnType<typeof cookies>) {
-  return createServerClient(
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL || '',
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
     {


### PR DESCRIPTION
## Summary
- clean up Supabase generated types by deduplicating tables, typing the inquiries schema, and adding the log_document_access RPC signature
- ensure server actions and utilities create typed Supabase clients and write properly shaped records
- add an API route plus client hook changes for triggering notification emails/in-app alerts and update the Stripe webhook to use the new helpers
- avoid passing icon components to client booking forms while keeping stats and amenity cards intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1358a09ec8328a66845a977914771