### PR TITLE
Fix Supabase typing and tailwind lint issues

### DIFF
--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server"
+
+import {
+  sendBulkNotifications,
+  sendEmailNotification,
+  sendInAppNotification,
+  type InAppNotification,
+  type NotificationData,
+} from "@/lib/notifications"
+
+type NotificationRequest =
+  | { type: "email"; notification: NotificationData }
+  | { type: "in-app"; notification: InAppNotification }
+  | {
+      type: "bulk"
+      notifications: (NotificationData | InAppNotification)[]
+    }
+
+export async function POST(request: Request) {
+  try {
+    const payload = (await request.json()) as NotificationRequest
+
+    switch (payload.type) {
+      case "email": {
+        const result = await sendEmailNotification(payload.notification)
+        const status = result.success ? 200 : 400
+        return NextResponse.json(result, { status })
+      }
+      case "in-app": {
+        const result = await sendInAppNotification(payload.notification)
+        const status = result.success ? 200 : 400
+        return NextResponse.json(result, { status })
+      }
+      case "bulk": {
+        const results = await sendBulkNotifications(payload.notifications)
+        const success = results.every((entry) => entry.success)
+        return NextResponse.json(
+          { success, results },
+          { status: success ? 200 : 400 }
+        )
+      }
+      default: {
+        return NextResponse.json(
+          { success: false, error: "Invalid notification request" },
+          { status: 400 }
+        )
+      }
+    }
+  } catch (error) {
+    console.error("Notification API error:", error)
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Unexpected error sending notification"
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,19 +1,29 @@
 import { headers } from "next/headers"
-import { getStripe } from "@/lib/stripe"
-import { createClient } from "@supabase/supabase-js"
-import type { Database } from "@/lib/supabase"
-import { notificationService } from "@/lib/notifications"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 
-const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  {
+import {
+  sendEmailNotification,
+  sendInAppNotification,
+} from "@/lib/notifications"
+import { getStripe } from "@/lib/stripe"
+import type { Database } from "@/lib/supabase"
+
+function createSupabaseAdminClient(): SupabaseClient<Database> | null {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error("Supabase admin credentials are not configured")
+    return null
+  }
+
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
     auth: {
       autoRefreshToken: false,
-      persistSession: false
-    }
-  }
-)
+      persistSession: false,
+    },
+  })
+}
 
 export async function POST(req: Request) {
   const stripe = getStripe()
@@ -24,26 +34,35 @@ export async function POST(req: Request) {
     return new Response("Webhook not configured", { status: 500 })
   }
 
+  const supabase = createSupabaseAdminClient()
+  if (!supabase) {
+    return new Response("Supabase client not configured", { status: 500 })
+  }
+
   const rawBody = await req.text()
 
   try {
-    const event = stripe.webhooks.constructEvent(rawBody, signature ?? "", webhookSecret)
+    const event = stripe.webhooks.constructEvent(
+      rawBody,
+      signature ?? "",
+      webhookSecret
+    )
 
     switch (event.type) {
       case "checkout.session.completed":
-        await handleCheckoutSessionCompleted(event.data.object)
+        await handleCheckoutSessionCompleted(supabase, event.data.object)
         break
       case "invoice.payment_succeeded":
-        await handleInvoicePaymentSucceeded(event.data.object)
+        await handleInvoicePaymentSucceeded(supabase, event.data.object)
         break
       case "customer.subscription.created":
-        await handleSubscriptionCreated(event.data.object)
+        await handleSubscriptionCreated(supabase, event.data.object)
         break
       case "customer.subscription.updated":
-        await handleSubscriptionUpdated(event.data.object)
+        await handleSubscriptionUpdated(supabase, event.data.object)
         break
       case "customer.subscription.deleted":
-        await handleSubscriptionDeleted(event.data.object)
+        await handleSubscriptionDeleted(supabase, event.data.object)
         break
       default:
         console.log(`Unhandled event type: ${event.type}`)
@@ -58,16 +77,19 @@ export async function POST(req: Request) {
   }
 }
 
-async function handleCheckoutSessionCompleted(session: any) {
+async function handleCheckoutSessionCompleted(
+  supabase: SupabaseClient<Database>,
+  session: any
+) {
   try {
     // Retrieve the full session with line items
     const stripe = getStripe()
     const fullSession = await stripe.checkout.sessions.retrieve(session.id, {
-      expand: ['line_items', 'customer']
+      expand: ["line_items", "customer"],
     })
 
     // For one-time payments, create a rent payment record
-    if (fullSession.mode === 'payment') {
+    if (fullSession.mode === "payment") {
       const lineItem = fullSession.line_items?.data[0]
       if (lineItem) {
         // Extract tenant and unit info from metadata if available
@@ -75,43 +97,45 @@ async function handleCheckoutSessionCompleted(session: any) {
         const unitId = fullSession.metadata?.unit_id
 
         const paymentData = {
-          user_id: tenantId || '00000000-0000-0000-0000-000000000000', // Use tenant_id as user_id, or a default UUID
+          user_id: tenantId || "00000000-0000-0000-0000-000000000000", // Use tenant_id as user_id, or a default UUID
           stripe_payment_intent_id: session.payment_intent as string,
           stripe_charge_id: session.payment_intent as string, // Will be updated when charge is available
           stripe_customer_id: session.customer as string,
           amount: lineItem.amount_total / 100, // Convert from cents
           currency: lineItem.currency.toUpperCase(),
-          description: lineItem.description || `Payment for ${lineItem.price?.nickname || 'rent'}`,
-          status: 'completed',
+          description:
+            lineItem.description ||
+            `Payment for ${lineItem.price?.nickname || "rent"}`,
+          status: "completed",
           processed_at: new Date().toISOString(),
           receipt_url: session.receipt_url,
           tenant_id: tenantId,
           unit_id: unitId,
-          payment_method_type: 'card', // Default assumption
+          payment_method_type: "card", // Default assumption
           metadata: {
             session_id: session.id,
             payment_status: session.payment_status,
-            ...fullSession.metadata
-          }
-        };
+            ...fullSession.metadata,
+          },
+        }
 
-        await supabase.from('rent_payments').insert(paymentData);
+        await supabase.from("rent_payments").insert(paymentData)
 
         // Send payment receipt notification if we have tenant info
         if (tenantId) {
           try {
             // Get tenant profile
             const { data: tenantProfile } = await supabase
-              .from('profiles')
-              .select('full_name, email')
-              .eq('id', tenantId)
-              .single();
+              .from("profiles")
+              .select("full_name, email")
+              .eq("id", tenantId)
+              .single()
 
             if (tenantProfile?.email) {
-              await notificationService.sendEmail({
+              await sendEmailNotification({
                 to: tenantProfile.email,
                 subject: `Payment Receipt - $${paymentData.amount}`,
-                template: 'payment-receipt',
+                template: "payment-receipt",
                 data: {
                   tenantName: tenantProfile.full_name || tenantProfile.email,
                   amount: `$${paymentData.amount}`,
@@ -119,19 +143,22 @@ async function handleCheckoutSessionCompleted(session: any) {
                   date: new Date(paymentData.processed_at).toLocaleDateString(),
                 },
                 userId: tenantId,
-              });
+              })
 
               // Also send in-app notification
-              await notificationService.sendInAppNotification({
+              await sendInAppNotification({
                 userId: tenantId,
                 title: "Payment Successful",
                 message: `Your payment of $${paymentData.amount} has been processed successfully.`,
-                type: 'success',
-                actionUrl: '/payments',
-              });
+                type: "success",
+                actionUrl: "/payments",
+              })
             }
           } catch (notificationError) {
-            console.error('Failed to send payment notification:', notificationError);
+            console.error(
+              "Failed to send payment notification:",
+              notificationError
+            )
             // Don't fail the webhook for notification errors
           }
         }
@@ -140,20 +167,22 @@ async function handleCheckoutSessionCompleted(session: any) {
 
     // For subscriptions, the subscription will be created separately
     // We might want to link the checkout session to the subscription here
-
   } catch (error) {
-    console.error('Error handling checkout session completed:', error)
+    console.error("Error handling checkout session completed:", error)
     throw error
   }
 }
 
-async function handleInvoicePaymentSucceeded(invoice: any) {
+async function handleInvoicePaymentSucceeded(
+  supabase: SupabaseClient<Database>,
+  invoice: any
+) {
   try {
     const stripe = getStripe()
 
     // Get the full invoice with subscription details
     const fullInvoice = await stripe.invoices.retrieve(invoice.id, {
-      expand: ['subscription', 'customer']
+      expand: ["subscription", "customer"],
     })
 
     const subscription = fullInvoice.subscription as any
@@ -162,100 +191,138 @@ async function handleInvoicePaymentSucceeded(invoice: any) {
       // This is a subscription payment
       const amount = invoice.amount_paid / 100 // Convert from cents
 
-      await supabase.from('rent_payments').insert({
-        user_id: subscription.metadata?.tenant_id || '00000000-0000-0000-0000-000000000000', // Use tenant_id as user_id, or a default UUID
+      await supabase.from("rent_payments").insert({
+        user_id:
+          subscription.metadata?.tenant_id ||
+          "00000000-0000-0000-0000-000000000000", // Use tenant_id as user_id, or a default UUID
         stripe_customer_id: invoice.customer as string,
         stripe_subscription_id: subscription.id,
         amount: amount,
         currency: invoice.currency.toUpperCase(),
-        description: `Subscription payment - ${subscription.metadata?.unit_label || 'Rent'}`,
-        status: 'completed',
+        description: `Subscription payment - ${
+          subscription.metadata?.unit_label || "Rent"
+        }`,
+        status: "completed",
         processed_at: new Date().toISOString(),
         receipt_url: invoice.hosted_invoice_url,
         tenant_id: subscription.metadata?.tenant_id,
         unit_id: subscription.metadata?.unit_id,
-        payment_method_type: 'card', // Default assumption
-        billing_period_start: subscription.current_period_start ? new Date(subscription.current_period_start * 1000).toISOString().split('T')[0] : undefined,
-        billing_period_end: subscription.current_period_end ? new Date(subscription.current_period_end * 1000).toISOString().split('T')[0] : undefined,
+        payment_method_type: "card", // Default assumption
+        billing_period_start: subscription.current_period_start
+          ? new Date(subscription.current_period_start * 1000)
+              .toISOString()
+              .split("T")[0]
+          : undefined,
+        billing_period_end: subscription.current_period_end
+          ? new Date(subscription.current_period_end * 1000)
+              .toISOString()
+              .split("T")[0]
+          : undefined,
         metadata: {
           invoice_id: invoice.id,
           subscription_id: subscription.id,
-          billing_reason: invoice.billing_reason
-        }
+          billing_reason: invoice.billing_reason,
+        },
       })
 
       // Update subscription status if needed
-      await supabase.from('subscriptions').update({
-        status: subscription.status,
-        current_period_start: new Date(subscription.current_period_start * 1000).toISOString(),
-        current_period_end: new Date(subscription.current_period_end * 1000).toISOString(),
-      }).eq('stripe_subscription_id', subscription.id)
+      await supabase
+        .from("subscriptions")
+        .update({
+          status: subscription.status,
+          current_period_start: new Date(
+            subscription.current_period_start * 1000
+          ).toISOString(),
+          current_period_end: new Date(
+            subscription.current_period_end * 1000
+          ).toISOString(),
+        })
+        .eq("stripe_subscription_id", subscription.id)
     }
-
   } catch (error) {
-    console.error('Error handling invoice payment succeeded:', error)
+    console.error("Error handling invoice payment succeeded:", error)
     throw error
   }
 }
 
-async function handleSubscriptionCreated(subscription: any) {
+async function handleSubscriptionCreated(
+  supabase: SupabaseClient<Database>,
+  subscription: any
+) {
   try {
     // This handles when a subscription is first created
     const price = subscription.items.data[0]?.price
 
-    await supabase.from('subscriptions').insert({
-      user_id: subscription.metadata?.tenant_id || '00000000-0000-0000-0000-000000000000',
+    await supabase.from("subscriptions").insert({
+      user_id:
+        subscription.metadata?.tenant_id ||
+        "00000000-0000-0000-0000-000000000000",
       stripe_subscription_id: subscription.id,
       stripe_customer_id: subscription.customer,
       status: subscription.status,
-      current_period_start: new Date(subscription.current_period_start * 1000).toISOString(),
-      current_period_end: new Date(subscription.current_period_end * 1000).toISOString(),
+      current_period_start: new Date(
+        subscription.current_period_start * 1000
+      ).toISOString(),
+      current_period_end: new Date(
+        subscription.current_period_end * 1000
+      ).toISOString(),
       amount: price?.unit_amount || 0, // Convert from cents
-      currency: price?.currency?.toUpperCase() || 'USD',
-      interval: 'month', // Default, could be determined from price
+      currency: price?.currency?.toUpperCase() || "USD",
+      interval: "month", // Default, could be determined from price
       metadata: {
         ...subscription.metadata,
-        price_id: price?.id
-      }
+        price_id: price?.id,
+      },
     })
-
   } catch (error) {
-    console.error('Error handling subscription created:', error)
+    console.error("Error handling subscription created:", error)
     throw error
   }
 }
 
-async function handleSubscriptionUpdated(subscription: any) {
+async function handleSubscriptionUpdated(
+  supabase: SupabaseClient<Database>,
+  subscription: any
+) {
   try {
-    await supabase.from('subscriptions').update({
-      status: subscription.status,
-      current_period_start: new Date(subscription.current_period_start * 1000).toISOString(),
-      current_period_end: new Date(subscription.current_period_end * 1000).toISOString(),
-      updated_at: new Date().toISOString()
-    }).eq('stripe_subscription_id', subscription.id)
-
+    await supabase
+      .from("subscriptions")
+      .update({
+        status: subscription.status,
+        current_period_start: new Date(
+          subscription.current_period_start * 1000
+        ).toISOString(),
+        current_period_end: new Date(
+          subscription.current_period_end * 1000
+        ).toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("stripe_subscription_id", subscription.id)
   } catch (error) {
-    console.error('Error handling subscription updated:', error)
+    console.error("Error handling subscription updated:", error)
     throw error
   }
 }
 
-async function handleSubscriptionDeleted(subscription: any) {
+async function handleSubscriptionDeleted(
+  supabase: SupabaseClient<Database>,
+  subscription: any
+) {
   try {
-    await supabase.from('subscriptions').update({
-      status: 'canceled',
-      ended_at: new Date().toISOString(),
-      canceled_at: new Date().toISOString(),
-      updated_at: new Date().toISOString()
-    }).eq('stripe_subscription_id', subscription.id)
-
+    await supabase
+      .from("subscriptions")
+      .update({
+        status: "canceled",
+        ended_at: new Date().toISOString(),
+        canceled_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("stripe_subscription_id", subscription.id)
   } catch (error) {
-    console.error('Error handling subscription deleted:', error)
+    console.error("Error handling subscription deleted:", error)
     throw error
   }
 }
 
 // Export runtime config for edge runtime
-export const runtime = 'edge';
-
-
+export const runtime = "edge"

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -1,82 +1,103 @@
-import { Suspense } from "react";
+import { Suspense } from "react"
+import {
+  Calendar,
+  Car,
+  Gamepad2,
+  Monitor,
+  Tv,
+  UtensilsCrossed,
+} from "lucide-react"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { AmenityBookingForm } from './components/amenity-booking-form';
-import { BookingHistory } from './components/booking-history';
-import { BookingStats } from './components/booking-stats';
-import { UtensilsCrossed, Tv, Gamepad2, Car, Monitor, Calendar } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+import { AmenityBookingForm } from "./components/amenity-booking-form"
+import { BookingHistory } from "./components/booking-history"
+import { BookingStats } from "./components/booking-stats"
 
 const amenities = [
   {
-    id: 'kitchen',
-    name: 'Kitchen',
-    description: 'Book the kitchen for cooking or meal prep',
+    id: "kitchen",
+    name: "Kitchen",
+    description: "Book the kitchen for cooking or meal prep",
     icon: UtensilsCrossed,
-    duration: '2 hours',
-    maxAdvance: '7 days',
+    duration: "2 hours",
+    maxAdvance: "7 days",
   },
   {
-    id: 'tv-room',
-    name: 'TV Room',
-    description: 'Reserve the living room TV for movies or gaming',
+    id: "tv-room",
+    name: "TV Room",
+    description: "Reserve the living room TV for movies or gaming",
     icon: Tv,
-    duration: '3 hours',
-    maxAdvance: '7 days',
+    duration: "3 hours",
+    maxAdvance: "7 days",
   },
   {
-    id: 'playstation',
-    name: 'PlayStation Nook',
-    description: 'Book the gaming area for console gaming',
+    id: "playstation",
+    name: "PlayStation Nook",
+    description: "Book the gaming area for console gaming",
     icon: Gamepad2,
-    duration: '2 hours',
-    maxAdvance: '7 days',
+    duration: "2 hours",
+    maxAdvance: "7 days",
   },
   {
-    id: 'parking',
-    name: 'Parking Spot',
-    description: 'Reserve a visitor parking spot',
+    id: "parking",
+    name: "Parking Spot",
+    description: "Reserve a visitor parking spot",
     icon: Car,
-    duration: '24 hours',
-    maxAdvance: '14 days',
+    duration: "24 hours",
+    maxAdvance: "14 days",
   },
   {
-    id: 'computer',
-    name: 'Shared Computer',
-    description: 'Use the shared computer workstation',
+    id: "computer",
+    name: "Shared Computer",
+    description: "Use the shared computer workstation",
     icon: Monitor,
-    duration: '1 hour',
-    maxAdvance: '3 days',
+    duration: "1 hour",
+    maxAdvance: "3 days",
   },
-];
+]
 
 export default function BookingsPage() {
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
         <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Amenity Bookings</h1>
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            Amenity Bookings
+          </h1>
           <p className="text-base text-muted-foreground sm:text-lg">
-            Reserve shared amenities like the kitchen, TV room, parking, and more. Bookings are managed through our Cal.com integration.
+            Reserve shared amenities like the kitchen, TV room, parking, and
+            more. Bookings are managed through our Cal.com integration.
           </p>
         </div>
         <Separator />
       </header>
 
       {/* Stats Overview */}
-      <Suspense fallback={<div className="grid gap-4 md:grid-cols-4">
-        {[...Array(4)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader className="pb-2">
-              <div className="h-4 w-3/4 rounded bg-muted"></div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-8 w-1/2 rounded bg-muted"></div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>}>
+      <Suspense
+        fallback={
+          <div className="grid gap-4 md:grid-cols-4">
+            {[...Array(4)].map((_, i) => (
+              <Card key={i} className="animate-pulse">
+                <CardHeader className="pb-2">
+                  <div className="h-4 w-3/4 rounded bg-muted"></div>
+                </CardHeader>
+                <CardContent>
+                  <div className="h-8 w-1/2 rounded bg-muted"></div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        }
+      >
         <BookingStats />
       </Suspense>
 
@@ -89,11 +110,14 @@ export default function BookingsPage() {
 
         <TabsContent value="book" className="space-y-6">
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {amenities.map((amenity) => (
-              <Card key={amenity.id} className="transition-shadow hover:shadow-md">
+            {amenities.map(({ icon: Icon, ...amenity }) => (
+              <Card
+                key={amenity.id}
+                className="transition-shadow hover:shadow-md"
+              >
                 <CardHeader>
                   <div className="flex items-center space-x-3">
-                    <amenity.icon className="size-6 text-primary" />
+                    <Icon className="size-6 text-primary" />
                     <div>
                       <CardTitle className="text-lg">{amenity.name}</CardTitle>
                       <CardDescription>{amenity.description}</CardDescription>
@@ -123,7 +147,9 @@ export default function BookingsPage() {
           <CardHeader className="pb-3">
             <div className="flex items-center space-x-2">
               <Calendar className="size-5 text-primary" />
-              <CardTitle className="text-sm font-medium">Smart Scheduling</CardTitle>
+              <CardTitle className="text-sm font-medium">
+                Smart Scheduling
+              </CardTitle>
             </div>
           </CardHeader>
           <CardContent>
@@ -137,7 +163,9 @@ export default function BookingsPage() {
           <CardHeader className="pb-3">
             <div className="flex items-center space-x-2">
               <Tv className="size-5 text-primary" />
-              <CardTitle className="text-sm font-medium">Real-time Availability</CardTitle>
+              <CardTitle className="text-sm font-medium">
+                Real-time Availability
+              </CardTitle>
             </div>
           </CardHeader>
           <CardContent>
@@ -156,7 +184,8 @@ export default function BookingsPage() {
           </CardHeader>
           <CardContent>
             <CardDescription className="text-xs">
-              Booking limits prevent overuse while ensuring everyone gets access.
+              Booking limits prevent overuse while ensuring everyone gets
+              access.
             </CardDescription>
           </CardContent>
         </Card>
@@ -165,7 +194,9 @@ export default function BookingsPage() {
           <CardHeader className="pb-3">
             <div className="flex items-center space-x-2">
               <Car className="size-5 text-primary" />
-              <CardTitle className="text-sm font-medium">Mobile Friendly</CardTitle>
+              <CardTitle className="text-sm font-medium">
+                Mobile Friendly
+              </CardTitle>
             </div>
           </CardHeader>
           <CardContent>
@@ -176,5 +207,5 @@ export default function BookingsPage() {
         </Card>
       </div>
     </div>
-  );
+  )
 }

--- a/app/contact/actions/index.tsx
+++ b/app/contact/actions/index.tsx
@@ -1,34 +1,37 @@
-"use server";
+"use server"
 
-import { createClient } from "@/utils/supa-server-actions";
-import { revalidatePath } from "next/cache";
-import { cookies } from 'next/headers';
+import { revalidatePath } from "next/cache"
+import { cookies } from "next/headers"
+import { createClient } from "@/utils/supa-server-actions"
 
 type formData = {
-    name: string;
-    email: string;
-    message: string;
+  name: string
+  email: string
+  message: string
 }
 
 export async function submitInquiry(data: formData) {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
 
   try {
-    const { error } = await supabase
-      .from('inquiries')
-      .insert({
+    const { error } = await supabase.from("inquiries").insert([
+      {
         name: data.name,
         email: data.email,
-        message: data.message
-      } as any);
+        message: data.message,
+      },
+    ])
 
-    if (error) throw error;
+    if (error) throw error
 
-    revalidatePath('/contact');
-    return { success: true, message: 'Message sent successfully!' };
+    revalidatePath("/contact")
+    return { success: true, message: "Message sent successfully!" }
   } catch (error) {
-    console.error('Error submitting inquiry:', error);
-    return { success: false, message: 'Error sending message. Please try again.' };
+    console.error("Error submitting inquiry:", error)
+    return {
+      success: false,
+      message: "Error sending message. Please try again.",
+    }
   }
 }

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -1,137 +1,192 @@
-"use client";
+"use client"
 
-import { useToast } from "@/components/ui/use-toast";
-import { notificationService, NotificationData, InAppNotification } from "@/lib/notifications";
+import type { InAppNotification, NotificationData } from "@/lib/notifications"
+import { useToast } from "@/components/ui/use-toast"
+
+type NotificationResult = { success: boolean; error?: string }
+type BulkNotificationResult = {
+  success: boolean
+  results: Array<{ index: number; success: boolean; error: unknown }>
+}
+
+async function postNotification<T>(payload: unknown): Promise<T> {
+  const response = await fetch("/api/notifications", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  })
+
+  const data = (await response.json().catch(() => null)) as
+    | T
+    | { error?: string }
+    | null
+
+  if (!response.ok || !data) {
+    const message =
+      data &&
+      typeof data === "object" &&
+      "error" in data &&
+      typeof data.error === "string"
+        ? data.error
+        : "Failed to send notification"
+
+    throw new Error(message)
+  }
+
+  return data as T
+}
 
 export function useNotifications() {
-  const { toast } = useToast();
+  const { toast } = useToast()
 
   const sendEmail = async (notification: NotificationData) => {
     try {
-      const result = await notificationService.sendEmail(notification);
+      const result = await postNotification<NotificationResult>({
+        type: "email",
+        notification,
+      })
       if (result.success) {
         toast({
           title: "Email sent",
           description: "Notification email has been sent successfully.",
-        });
+        })
       } else {
         toast({
           title: "Email failed",
           description: result.error || "Failed to send email notification.",
           variant: "destructive",
-        });
+        })
       }
-      return result;
+      return result
     } catch (error) {
       toast({
         title: "Error",
         description: "An unexpected error occurred while sending email.",
         variant: "destructive",
-      });
-      return { success: false, error: "Unexpected error" };
+      })
+      return { success: false, error: "Unexpected error" }
     }
-  };
+  }
 
   const sendInAppNotification = async (notification: InAppNotification) => {
     try {
-      const result = await notificationService.sendInAppNotification(notification);
+      const result = await postNotification<NotificationResult>({
+        type: "in-app",
+        notification,
+      })
       if (result.success) {
         // Show toast for immediate feedback
         toast({
           title: notification.title,
           description: notification.message,
-          variant: notification.type === 'error' ? 'destructive' :
-                  notification.type === 'warning' ? 'default' : 'default',
-        });
+          variant:
+            notification.type === "error"
+              ? "destructive"
+              : notification.type === "warning"
+              ? "default"
+              : "default",
+        })
       }
-      return result;
+      return result
     } catch (error) {
       toast({
         title: "Notification failed",
         description: "Failed to send in-app notification.",
         variant: "destructive",
-      });
-      return { success: false, error: "Unexpected error" };
+      })
+      return { success: false, error: "Unexpected error" }
     }
-  };
+  }
 
-  const sendBulkNotifications = async (notifications: (NotificationData | InAppNotification)[]) => {
+  const sendBulkNotifications = async (
+    notifications: (NotificationData | InAppNotification)[]
+  ) => {
     try {
-      const results = await notificationService.sendBulkNotification(notifications);
-      const successCount = results.filter(r => r.success).length;
-      const failureCount = results.length - successCount;
+      const response = await postNotification<BulkNotificationResult>({
+        type: "bulk",
+        notifications,
+      })
+      const successCount = response.results.filter((r) => r.success).length
+      const failureCount = response.results.length - successCount
 
       if (successCount > 0) {
         toast({
           title: "Notifications sent",
-          description: `${successCount} notification${successCount > 1 ? 's' : ''} sent successfully${failureCount > 0 ? `, ${failureCount} failed` : ''}.`,
-        });
+          description: `${successCount} notification${
+            successCount > 1 ? "s" : ""
+          } sent successfully${
+            failureCount > 0 ? `, ${failureCount} failed` : ""
+          }.`,
+        })
       }
 
       if (failureCount > 0) {
         toast({
           title: "Some notifications failed",
-          description: `${failureCount} notification${failureCount > 1 ? 's' : ''} could not be sent.`,
+          description: `${failureCount} notification${
+            failureCount > 1 ? "s" : ""
+          } could not be sent.`,
           variant: "destructive",
-        });
+        })
       }
 
-      return results;
+      return response.results
     } catch (error) {
       toast({
         title: "Error",
-        description: "An unexpected error occurred while sending notifications.",
+        description:
+          "An unexpected error occurred while sending notifications.",
         variant: "destructive",
-      });
-      return [];
+      })
+      return []
     }
-  };
+  }
 
   // Convenience methods for common notification types
   const notifyVisitorBooking = async (data: {
-    guestName: string;
-    hostName: string;
-    checkInDate: string;
-    checkOutDate: string;
-    purpose: string;
-    roommates: Array<{ id: string; email: string; name: string }>;
-    propertyManager: { id: string; email: string; name: string };
+    guestName: string
+    hostName: string
+    checkInDate: string
+    checkOutDate: string
+    purpose: string
+    roommates: Array<{ id: string; email: string; name: string }>
+    propertyManager: { id: string; email: string; name: string }
   }) => {
     const notifications: (NotificationData | InAppNotification)[] = [
       // Email to property manager
       {
         to: data.propertyManager.email,
         subject: `New Visitor Booking: ${data.guestName}`,
-        template: 'visitor-booking',
+        template: "visitor-booking",
         data,
         userId: data.propertyManager.id,
       },
       // In-app notifications to all roommates
-      ...data.roommates.map(roommate => ({
+      ...data.roommates.map((roommate) => ({
         userId: roommate.id,
         title: "New Visitor Booking",
         message: `${data.guestName} is visiting from ${data.checkInDate} to ${data.checkOutDate}`,
-        type: 'info' as const,
-        actionUrl: '/dashboard',
+        type: "info" as const,
+        actionUrl: "/dashboard",
       })),
-    ];
+    ]
 
-    return sendBulkNotifications(notifications);
-  };
+    return sendBulkNotifications(notifications)
+  }
 
   const notifyMaintenanceRequest = async (data: {
-    requesterName: string;
-    title: string;
-    description: string;
-    priority: string;
-    propertyManager: { id: string; email: string; name: string };
+    requesterName: string
+    title: string
+    description: string
+    priority: string
+    propertyManager: { id: string; email: string; name: string }
   }) => {
     const notifications: (NotificationData | InAppNotification)[] = [
       // Email to property manager
       {
         to: data.propertyManager.email,
         subject: `New Maintenance Request: ${data.title}`,
-        template: 'maintenance-request',
+        template: "maintenance-request",
         data,
         userId: data.propertyManager.id,
       },
@@ -140,28 +195,28 @@ export function useNotifications() {
         userId: data.propertyManager.id,
         title: "New Maintenance Request",
         message: `${data.requesterName} reported: ${data.title}`,
-        type: 'warning' as const,
-        actionUrl: '/dashboard',
+        type: "warning" as const,
+        actionUrl: "/dashboard",
       },
-    ];
+    ]
 
-    return sendBulkNotifications(notifications);
-  };
+    return sendBulkNotifications(notifications)
+  }
 
   const notifyPaymentReceipt = async (data: {
-    tenantName: string;
-    amount: string;
-    description: string;
-    date: string;
-    tenantEmail: string;
-    tenantId: string;
+    tenantName: string
+    amount: string
+    description: string
+    date: string
+    tenantEmail: string
+    tenantId: string
   }) => {
     const notifications: (NotificationData | InAppNotification)[] = [
       // Email receipt to tenant
       {
         to: data.tenantEmail,
         subject: `Payment Receipt - $${data.amount}`,
-        template: 'payment-receipt',
+        template: "payment-receipt",
         data,
         userId: data.tenantId,
       },
@@ -170,27 +225,27 @@ export function useNotifications() {
         userId: data.tenantId,
         title: "Payment Successful",
         message: `Your payment of $${data.amount} has been processed.`,
-        type: 'success' as const,
-        actionUrl: '/payments',
+        type: "success" as const,
+        actionUrl: "/payments",
       },
-    ];
+    ]
 
-    return sendBulkNotifications(notifications);
-  };
+    return sendBulkNotifications(notifications)
+  }
 
   const notifyDocumentSigned = async (data: {
-    documentTitle: string;
-    signerName: string;
-    signedAt: string;
-    signerEmail: string;
-    signerId: string;
+    documentTitle: string
+    signerName: string
+    signedAt: string
+    signerEmail: string
+    signerId: string
   }) => {
     const notifications: (NotificationData | InAppNotification)[] = [
       // Email confirmation to signer
       {
         to: data.signerEmail,
         subject: `Document Signed: ${data.documentTitle}`,
-        template: 'document-signed',
+        template: "document-signed",
         data,
         userId: data.signerId,
       },
@@ -199,13 +254,13 @@ export function useNotifications() {
         userId: data.signerId,
         title: "Document Signed",
         message: `You have successfully signed "${data.documentTitle}"`,
-        type: 'success' as const,
-        actionUrl: '/documents',
+        type: "success" as const,
+        actionUrl: "/documents",
       },
-    ];
+    ]
 
-    return sendBulkNotifications(notifications);
-  };
+    return sendBulkNotifications(notifications)
+  }
 
   return {
     sendEmail,
@@ -215,5 +270,5 @@ export function useNotifications() {
     notifyMaintenanceRequest,
     notifyPaymentReceipt,
     notifyDocumentSigned,
-  };
+  }
 }

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,87 +1,97 @@
-"use server";
+"use server"
 
-import { Resend } from 'resend';
-import { createSupbaseServerClient } from "@/utils/supaone";
+import { createSupbaseServerClient } from "@/utils/supaone"
+import { Resend } from "resend"
 
 export interface NotificationData {
-  to: string | string[];
-  subject: string;
-  template: string;
-  data?: Record<string, any>;
-  userId?: string;
+  to: string | string[]
+  subject: string
+  template: string
+  data?: Record<string, any>
+  userId?: string
 }
 
 export interface InAppNotification {
-  userId: string;
-  title: string;
-  message: string;
-  type: 'info' | 'success' | 'warning' | 'error';
-  actionUrl?: string;
-  metadata?: Record<string, any>;
+  userId: string
+  title: string
+  message: string
+  type: "info" | "success" | "warning" | "error"
+  actionUrl?: string
+  metadata?: Record<string, any>
 }
 
 class NotificationService {
-  private resend: Resend | null = null;
+  private resend: Resend | null = null
 
   constructor() {
-    const apiKey = process.env.RESEND_API_KEY;
-    if (apiKey && apiKey !== 're_your_resend_api_key_here') {
-      this.resend = new Resend(apiKey);
+    const apiKey = process.env.RESEND_API_KEY
+    if (apiKey && apiKey !== "re_your_resend_api_key_here") {
+      this.resend = new Resend(apiKey)
     }
   }
 
   async sendEmail(notification: NotificationData) {
     if (!this.resend) {
-      console.warn('Resend API key not configured. Skipping email notification.');
-      return { success: false, error: 'Email service not configured' };
+      console.warn(
+        "Resend API key not configured. Skipping email notification."
+      )
+      return { success: false, error: "Email service not configured" }
     }
 
     try {
-      const recipients = Array.isArray(notification.to) ? notification.to : [notification.to];
+      const recipients = Array.isArray(notification.to)
+        ? notification.to
+        : [notification.to]
 
       const emailTemplates = {
-        'visitor-booking': this.getVisitorBookingTemplate(notification.data),
-        'maintenance-request': this.getMaintenanceRequestTemplate(notification.data),
-        'payment-receipt': this.getPaymentReceiptTemplate(notification.data),
-        'document-signed': this.getDocumentSignedTemplate(notification.data),
-        'welcome': this.getWelcomeTemplate(notification.data),
-      };
+        "visitor-booking": this.getVisitorBookingTemplate(notification.data),
+        "maintenance-request": this.getMaintenanceRequestTemplate(
+          notification.data
+        ),
+        "payment-receipt": this.getPaymentReceiptTemplate(notification.data),
+        "document-signed": this.getDocumentSignedTemplate(notification.data),
+        welcome: this.getWelcomeTemplate(notification.data),
+      }
 
-      const emailContent = emailTemplates[notification.template as keyof typeof emailTemplates];
+      const emailContent =
+        emailTemplates[notification.template as keyof typeof emailTemplates]
       if (!emailContent) {
-        throw new Error(`Email template '${notification.template}' not found`);
+        throw new Error(`Email template '${notification.template}' not found`)
       }
 
       const { data, error } = await this.resend.emails.send({
-        from: 'Shared House Portal <notifications@sharedhouseportal.com>',
+        from: "Shared House Portal <notifications@sharedhouseportal.com>",
         to: recipients,
         subject: notification.subject,
         html: emailContent,
-      });
+      })
 
       if (error) {
-        console.error('Failed to send email:', error);
-        return { success: false, error: error.message };
+        console.error("Failed to send email:", error)
+        return { success: false, error: error.message }
       }
 
       // Store email notification in database for tracking
       if (notification.userId) {
-        await this.storeEmailNotification(notification);
+        await this.storeEmailNotification(notification)
       }
 
-      return { success: true, data };
+      return { success: true, data }
     } catch (error) {
-      console.error('Email sending error:', error);
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+      console.error("Email sending error:", error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      }
     }
   }
 
   async sendInAppNotification(notification: InAppNotification) {
     try {
-      const supabase = await createSupbaseServerClient();
+      const supabase = await createSupbaseServerClient()
 
       const { data, error } = await (supabase as any)
-        .from('notifications')
+        .from("notifications")
         .insert({
           user_id: notification.userId,
           title: notification.title,
@@ -91,54 +101,59 @@ class NotificationService {
           metadata: notification.metadata,
           read: false,
           created_at: new Date().toISOString(),
-        });
+        })
 
       if (error) {
-        console.error('Failed to create in-app notification:', error);
-        return { success: false, error: error.message };
+        console.error("Failed to create in-app notification:", error)
+        return { success: false, error: error.message }
       }
 
-      return { success: true, data };
+      return { success: true, data }
     } catch (error) {
-      console.error('In-app notification error:', error);
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+      console.error("In-app notification error:", error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      }
     }
   }
 
-  async sendBulkNotification(notifications: (NotificationData | InAppNotification)[]) {
+  async sendBulkNotification(
+    notifications: (NotificationData | InAppNotification)[]
+  ) {
     const results = await Promise.allSettled(
-      notifications.map(notification => {
-        if ('to' in notification) {
-          return this.sendEmail(notification);
+      notifications.map((notification) => {
+        if ("to" in notification) {
+          return this.sendEmail(notification)
         } else {
-          return this.sendInAppNotification(notification);
+          return this.sendInAppNotification(notification)
         }
       })
-    );
+    )
 
     return results.map((result, index) => ({
       index,
-      success: result.status === 'fulfilled' ? result.value.success : false,
-      error: result.status === 'rejected' ? result.reason : result.value.error,
-    }));
+      success: result.status === "fulfilled" ? result.value.success : false,
+      error: result.status === "rejected" ? result.reason : result.value.error,
+    }))
   }
 
   private async storeEmailNotification(notification: NotificationData) {
     try {
-      const supabase = await createSupbaseServerClient();
+      const supabase = await createSupbaseServerClient()
 
-      await (supabase as any)
-        .from('email_notifications')
-        .insert({
-          user_id: notification.userId,
-          recipient: Array.isArray(notification.to) ? notification.to.join(', ') : notification.to,
-          subject: notification.subject,
-          template: notification.template,
-          status: 'sent',
-          sent_at: new Date().toISOString(),
-        });
+      await (supabase as any).from("email_notifications").insert({
+        user_id: notification.userId,
+        recipient: Array.isArray(notification.to)
+          ? notification.to.join(", ")
+          : notification.to,
+        subject: notification.subject,
+        template: notification.template,
+        status: "sent",
+        sent_at: new Date().toISOString(),
+      })
     } catch (error) {
-      console.error('Failed to store email notification:', error);
+      console.error("Failed to store email notification:", error)
     }
   }
 
@@ -146,59 +161,77 @@ class NotificationService {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>New Overnight Visitor Booking</h2>
-        <p><strong>Guest:</strong> ${data?.guestName || 'Unknown'}</p>
-        <p><strong>Host:</strong> ${data?.hostName || 'Unknown'}</p>
-        <p><strong>Dates:</strong> ${data?.checkInDate || 'Unknown'} to ${data?.checkOutDate || 'Unknown'}</p>
-        <p><strong>Purpose:</strong> ${data?.purpose || 'Not specified'}</p>
+        <p><strong>Guest:</strong> ${data?.guestName || "Unknown"}</p>
+        <p><strong>Host:</strong> ${data?.hostName || "Unknown"}</p>
+        <p><strong>Dates:</strong> ${data?.checkInDate || "Unknown"} to ${
+      data?.checkOutDate || "Unknown"
+    }</p>
+        <p><strong>Purpose:</strong> ${data?.purpose || "Not specified"}</p>
         <p>Please review this booking request in the dashboard.</p>
-        <a href="${process.env.NEXT_PUBLIC_APP_URL}/dashboard" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View in Dashboard</a>
+        <a href="${
+          process.env.NEXT_PUBLIC_APP_URL
+        }/dashboard" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View in Dashboard</a>
       </div>
-    `;
+    `
   }
 
   private getMaintenanceRequestTemplate(data?: any) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>New Maintenance Request</h2>
-        <p><strong>Requested by:</strong> ${data?.requesterName || 'Unknown'}</p>
-        <p><strong>Issue:</strong> ${data?.title || 'Unknown'}</p>
-        <p><strong>Description:</strong> ${data?.description || 'No description provided'}</p>
-        <p><strong>Priority:</strong> ${data?.priority || 'Normal'}</p>
-        <a href="${process.env.NEXT_PUBLIC_APP_URL}/dashboard" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View Request</a>
+        <p><strong>Requested by:</strong> ${
+          data?.requesterName || "Unknown"
+        }</p>
+        <p><strong>Issue:</strong> ${data?.title || "Unknown"}</p>
+        <p><strong>Description:</strong> ${
+          data?.description || "No description provided"
+        }</p>
+        <p><strong>Priority:</strong> ${data?.priority || "Normal"}</p>
+        <a href="${
+          process.env.NEXT_PUBLIC_APP_URL
+        }/dashboard" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View Request</a>
       </div>
-    `;
+    `
   }
 
   private getPaymentReceiptTemplate(data?: any) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>Payment Receipt</h2>
-        <p><strong>Tenant:</strong> ${data?.tenantName || 'Unknown'}</p>
-        <p><strong>Amount:</strong> $${data?.amount || '0.00'}</p>
-        <p><strong>Description:</strong> ${data?.description || 'Rent payment'}</p>
-        <p><strong>Date:</strong> ${data?.date || new Date().toLocaleDateString()}</p>
+        <p><strong>Tenant:</strong> ${data?.tenantName || "Unknown"}</p>
+        <p><strong>Amount:</strong> $${data?.amount || "0.00"}</p>
+        <p><strong>Description:</strong> ${
+          data?.description || "Rent payment"
+        }</p>
+        <p><strong>Date:</strong> ${
+          data?.date || new Date().toLocaleDateString()
+        }</p>
         <p>Thank you for your payment!</p>
       </div>
-    `;
+    `
   }
 
   private getDocumentSignedTemplate(data?: any) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>Document Signed</h2>
-        <p><strong>Document:</strong> ${data?.documentTitle || 'Unknown'}</p>
-        <p><strong>Signed by:</strong> ${data?.signerName || 'Unknown'}</p>
-        <p><strong>Date:</strong> ${data?.signedAt || new Date().toLocaleDateString()}</p>
-        <a href="${process.env.NEXT_PUBLIC_APP_URL}/documents" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View Document</a>
+        <p><strong>Document:</strong> ${data?.documentTitle || "Unknown"}</p>
+        <p><strong>Signed by:</strong> ${data?.signerName || "Unknown"}</p>
+        <p><strong>Date:</strong> ${
+          data?.signedAt || new Date().toLocaleDateString()
+        }</p>
+        <a href="${
+          process.env.NEXT_PUBLIC_APP_URL
+        }/documents" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View Document</a>
       </div>
-    `;
+    `
   }
 
   private getWelcomeTemplate(data?: any) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>Welcome to Shared House Portal!</h2>
-        <p>Hello ${data?.firstName || 'there'}!</p>
+        <p>Hello ${data?.firstName || "there"}!</p>
         <p>Welcome to your shared house management portal. You can now:</p>
         <ul>
           <li>Manage your rent payments</li>
@@ -206,10 +239,26 @@ class NotificationService {
           <li>Access important documents</li>
           <li>Communicate with roommates</li>
         </ul>
-        <a href="${process.env.NEXT_PUBLIC_APP_URL}/dashboard" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">Get Started</a>
+        <a href="${
+          process.env.NEXT_PUBLIC_APP_URL
+        }/dashboard" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">Get Started</a>
       </div>
-    `;
+    `
   }
 }
 
-export const notificationService = new NotificationService();
+const notificationService = new NotificationService()
+
+export async function sendEmailNotification(notification: NotificationData) {
+  return notificationService.sendEmail(notification)
+}
+
+export async function sendInAppNotification(notification: InAppNotification) {
+  return notificationService.sendInAppNotification(notification)
+}
+
+export async function sendBulkNotifications(
+  notifications: (NotificationData | InAppNotification)[]
+) {
+  return notificationService.sendBulkNotification(notifications)
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1702,6 +1702,39 @@ export type Database = {
           },
         ]
       }
+      inquiries: {
+        Row: {
+          id: string
+          name: string
+          email: string
+          message: string
+          status: string
+          created_at: string
+          updated_at: string
+          metadata: Json | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          email: string
+          message: string
+          status?: string
+          created_at?: string
+          updated_at?: string
+          metadata?: Json | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          email?: string
+          message?: string
+          status?: string
+          created_at?: string
+          updated_at?: string
+          metadata?: Json | null
+        }
+        Relationships: []
+      }
       leases: {
         Row: {
           id: string
@@ -2120,177 +2153,6 @@ export type Database = {
           },
         ]
       }
-      // Removed duplicate document_signatures definition
-      // Removed duplicate document_access_logs definition
-      // Removed duplicate leases definition
-          signer_id: string
-          signer_email: string
-          signer_name: string | null
-          status: string
-          signed_at: string | null
-          declined_at: string | null
-          decline_reason: string | null
-          documenso_signature_id: string | null
-          ip_address: string | null
-          user_agent: string | null
-          signature_data: Json | null
-        }
-        Insert: {
-          id?: string
-          created_at?: string
-          updated_at?: string
-          document_id: string
-          signer_id: string
-          signer_email: string
-          signer_name?: string | null
-          status?: string
-          signed_at?: string | null
-          declined_at?: string | null
-          decline_reason?: string | null
-          documenso_signature_id?: string | null
-          ip_address?: string | null
-          user_agent?: string | null
-          signature_data?: Json | null
-        }
-        Update: {
-          id?: string
-          created_at?: string
-          updated_at?: string
-          document_id?: string
-          signer_id?: string
-          signer_email?: string
-          signer_name?: string | null
-          status?: string
-          signed_at?: string | null
-          declined_at?: string | null
-          decline_reason?: string | null
-          documenso_signature_id?: string | null
-          ip_address?: string | null
-          user_agent?: string | null
-          signature_data?: Json | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "document_signatures_document_id_fkey"
-            columns: ["document_id"]
-            isOneToOne: false
-            referencedRelation: "documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      document_access_logs: {
-        Row: {
-          id: string
-          created_at: string
-          document_id: string
-          user_id: string
-          action: string
-          ip_address: string | null
-          user_agent: string | null
-          metadata: Json | null
-        }
-        Insert: {
-          id?: string
-          created_at?: string
-          document_id: string
-          user_id: string
-          action: string
-          ip_address?: string | null
-          user_agent?: string | null
-          metadata?: Json | null
-        }
-        Update: {
-          id?: string
-          created_at?: string
-          document_id?: string
-          user_id?: string
-          action?: string
-          ip_address?: string | null
-          user_agent?: string | null
-          metadata?: Json | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "document_access_logs_document_id_fkey"
-            columns: ["document_id"]
-            isOneToOne: false
-            referencedRelation: "documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      leases: {
-        Row: {
-          id: string
-          document_id: string
-          created_at: string
-          updated_at: string
-          start_date: string
-          end_date: string | null
-          rent_amount: number | null
-          rent_frequency: string
-          security_deposit: number | null
-          tenant_ids: string[]
-          property_address: string | null
-          unit_number: string | null
-          landlord_name: string | null
-          landlord_email: string | null
-          auto_renew: boolean
-          renewal_notice_days: number
-          special_terms: string | null
-          status: string
-        }
-        Insert: {
-          id?: string
-          document_id: string
-          created_at?: string
-          updated_at?: string
-          start_date: string
-          end_date?: string | null
-          rent_amount?: number | null
-          rent_frequency?: string
-          security_deposit?: number | null
-          tenant_ids: string[]
-          property_address?: string | null
-          unit_number?: string | null
-          landlord_name?: string | null
-          landlord_email?: string | null
-          auto_renew?: boolean
-          renewal_notice_days?: number
-          special_terms?: string | null
-          status?: string
-        }
-        Update: {
-          id?: string
-          document_id?: string
-          created_at?: string
-          updated_at?: string
-          start_date?: string
-          end_date?: string | null
-          rent_amount?: number | null
-          rent_frequency?: string
-          security_deposit?: number | null
-          tenant_ids?: string[]
-          property_address?: string | null
-          unit_number?: string | null
-          landlord_name?: string | null
-          landlord_email?: string | null
-          auto_renew?: boolean
-          renewal_notice_days?: number
-          special_terms?: string | null
-          status?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "leases_document_id_fkey"
-            columns: ["document_id"]
-            isOneToOne: false
-            referencedRelation: "documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
     }
     Views: {
       package_utilization: {
@@ -2470,39 +2332,6 @@ export type Database = {
     CompositeTypes: {
       [_ in never]: never
     }
-  }
-  inquiries: {
-    Row: {
-      id: string
-      name: string
-      email: string
-      message: string
-      status: string
-      created_at: string
-      updated_at: string
-      metadata: Json | null
-    }
-    Insert: {
-      id?: string
-      name: string
-      email: string
-      message: string
-      status?: string
-      created_at?: string
-      updated_at?: string
-      metadata?: Json | null
-    }
-    Update: {
-      id?: string
-      name?: string
-      email?: string
-      message?: string
-      status?: string
-      created_at?: string
-      updated_at?: string
-      metadata?: Json | null
-    }
-    Relationships: []
   }
   storage: {
     Tables: {


### PR DESCRIPTION
## Summary
- ensure the contact inquiry server action uses a properly typed Supabase insert and revalidation path
- clean up the generated Supabase types by removing duplicate document tables and adding the inquiries table definition
- refactor notification handling by exposing async helpers, adding a `/api/notifications` endpoint, and updating the notifications hook and Stripe webhook to use them
- avoid passing non-serializable icon functions through amenity booking props

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d135da45a88328bbce16bef91fda6b