### PR TITLE
Add shared feedback primitives and route skeleton fallbacks

### DIFF
--- a/app/dashboard/error.tsx
+++ b/app/dashboard/error.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { ErrorFallback } from "@/components/feedback/ErrorBoundary"
+
+type ErrorProps = {
+  error: Error
+  reset: () => void
+}
+
+export default function DashboardError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(error)
+    }
+  }, [error])
+
+  return <ErrorFallback error={error} onRetry={reset} />
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,9 +1,13 @@
-import React, { ReactNode } from "react";
-import SideNav from "./components/SideNav";
-import ToggleSidebar from "./components/ToggleSidebar";
-import MobileSideNav from "./components/MobileSideNav";
-import { readUserSession } from "@/utils/actions";
-import { redirect } from "next/navigation";
+import { Suspense, type ReactNode } from "react"
+
+import { redirect } from "next/navigation"
+
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+import { readUserSession } from "@/utils/actions"
+import MobileSideNav from "./components/MobileSideNav"
+import SideNav from "./components/SideNav"
+import ToggleSidebar from "./components/ToggleSidebar"
 
 export default async function Layout({ children }: { children: ReactNode }) {
 	const { data: userSession } = await readUserSession();
@@ -18,10 +22,14 @@ export default async function Layout({ children }: { children: ReactNode }) {
 				<MobileSideNav />
 			</div>
 
-			<div className="w-full space-y-5 bg-gray-100 p-5 sm:flex-1 sm:p-10 dark:bg-inherit">
-				<ToggleSidebar />
-				{children}
-			</div>
-		</div>
-	);
+                        <div className="w-full space-y-5 bg-gray-100 p-5 sm:flex-1 sm:p-10 dark:bg-inherit">
+                                <ToggleSidebar />
+                                <ErrorBoundary>
+                                        <Suspense fallback={<RouteSkeleton />}>
+                                                {children}
+                                        </Suspense>
+                                </ErrorBoundary>
+                        </div>
+                </div>
+        );
 }

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function Loading() {
+  return <RouteSkeleton />
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { ErrorFallback } from "@/components/feedback/ErrorBoundary"
+
+type ErrorProps = {
+  error: Error
+  reset: () => void
+}
+
+export default function GlobalError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(error)
+    }
+  }, [error])
+
+  return <ErrorFallback error={error} onRetry={reset} />
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,24 @@
- import type { Metadata, Viewport } from 'next'
-import { Inter } from 'next/font/google'
-import { Analytics } from '@vercel/analytics/react';
+import type { Metadata, Viewport } from "next"
+import { Inter } from "next/font/google"
+import { Suspense } from "react"
+
+import { Analytics } from "@vercel/analytics/react"
 import { SpeedInsights } from "@vercel/speed-insights/next"
-import './globals.css'
-import { ThemeProvider } from "@/components/theme-provider"
+
+import "./globals.css"
+
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
 import { CookieButton } from "@/components/cookie-button"
-import { fontSans } from "@/lib/font"
-import { siteConfig } from '@/config/site'
-import { ReactQueryClientProvider } from '@/components/react-query-client-provider'
-import { Toaster } from "@/components/ui/toaster"
-import { SiteHeader } from "@/components/site-header"
 import { SiteFooter } from "@/components/site-footer"
+import { SiteHeader } from "@/components/site-header"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
+import { ThemeProvider } from "@/components/theme-provider"
+import { Toaster } from "@/components/ui/toaster"
+import { fontSans } from "@/lib/font"
 import { cn } from "@/lib/utils"
+import { siteConfig } from "@/config/site"
+import { ReactQueryClientProvider } from "@/components/react-query-client-provider"
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
@@ -126,9 +132,18 @@ export default function RootLayout({ children }: RootLayoutProps) {
           >
              <div className="relative flex min-h-screen flex-col">
               <SiteHeader />
-              <div className="flex-1">{children}<Toaster/><Analytics/><SpeedInsights/></div>
-              
-   </div>           
+              <div className="flex-1">
+                <ErrorBoundary>
+                  <Suspense fallback={<RouteSkeleton />}>
+                    {children}
+                  </Suspense>
+                </ErrorBoundary>
+                <Toaster />
+                <Analytics />
+                <SpeedInsights />
+              </div>
+
+   </div>
 <SiteFooter/>
 
 
@@ -138,10 +153,11 @@ enter your api info from termly.io or a provider of your choice
   type="text/javascript"
   src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
 
-*/}
-   <CookieButton />    
+ */}
+   <CookieButton />
+   <TailwindIndicator />
           </ThemeProvider>
-        
+
 
 
 </body>

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function Loading() {
+  return <RouteSkeleton />
+}

--- a/app/mdx/error.tsx
+++ b/app/mdx/error.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { ErrorFallback } from "@/components/feedback/ErrorBoundary"
+
+type ErrorProps = {
+  error: Error
+  reset: () => void
+}
+
+export default function MdxError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(error)
+    }
+  }, [error])
+
+  return <ErrorFallback error={error} onRetry={reset} />
+}

--- a/app/mdx/layout.tsx
+++ b/app/mdx/layout.tsx
@@ -1,8 +1,17 @@
-export default function MdxLayout({ children }: { children: React.ReactNode }) {
-    // Create any shared layout or styles here
-    return (
-      <div className="prose prose-headings:mt-8 prose-headings:font-semibold prose-headings:text-black prose-h1:text-5xl prose-h2:text-4xl prose-h3:text-3xl prose-h4:text-2xl prose-h5:text-xl prose-h6:text-lg dark:prose-headings:text-white container mx-auto px-4 py-8 text-justify">
-        {children}
-      </div>
-    )
-  }
+import { Suspense, type ReactNode } from "react"
+
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function MdxLayout({ children }: { children: ReactNode }) {
+  // Create any shared layout or styles here
+  return (
+    <div className="prose prose-headings:mt-8 prose-headings:font-semibold prose-headings:text-black prose-h1:text-5xl prose-h2:text-4xl prose-h3:text-3xl prose-h4:text-2xl prose-h5:text-xl prose-h6:text-lg dark:prose-headings:text-white container mx-auto px-4 py-8 text-justify">
+      <ErrorBoundary>
+        <Suspense fallback={<RouteSkeleton />}>
+          {children}
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  )
+}

--- a/app/mdx/loading.tsx
+++ b/app/mdx/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function Loading() {
+  return <RouteSkeleton />
+}

--- a/app/privacy/error.tsx
+++ b/app/privacy/error.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { ErrorFallback } from "@/components/feedback/ErrorBoundary"
+
+type ErrorProps = {
+  error: Error
+  reset: () => void
+}
+
+export default function PrivacyError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(error)
+    }
+  }, [error])
+
+  return <ErrorFallback error={error} onRetry={reset} />
+}

--- a/app/privacy/layout.tsx
+++ b/app/privacy/layout.tsx
@@ -1,8 +1,17 @@
-export default function MdxLayout({ children }: { children: React.ReactNode }) {
+import { Suspense, type ReactNode } from "react"
+
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function MdxLayout({ children }: { children: ReactNode }) {
   // Create any shared layout or styles here
   return (
     <div className="prose prose-headings:mt-8 prose-headings:font-semibold prose-headings:text-black prose-h1:text-5xl prose-h2:text-4xl prose-h3:text-3xl prose-h4:text-2xl prose-h5:text-xl prose-h6:text-lg dark:prose-headings:text-white container mx-auto px-4 py-8 text-justify">
-      {children}
+      <ErrorBoundary>
+        <Suspense fallback={<RouteSkeleton />}>
+          {children}
+        </Suspense>
+      </ErrorBoundary>
     </div>
   )
 }

--- a/app/privacy/loading.tsx
+++ b/app/privacy/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function Loading() {
+  return <RouteSkeleton />
+}

--- a/app/terms/error.tsx
+++ b/app/terms/error.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { ErrorFallback } from "@/components/feedback/ErrorBoundary"
+
+type ErrorProps = {
+  error: Error
+  reset: () => void
+}
+
+export default function TermsError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error(error)
+    }
+  }, [error])
+
+  return <ErrorFallback error={error} onRetry={reset} />
+}

--- a/app/terms/layout.tsx
+++ b/app/terms/layout.tsx
@@ -1,8 +1,17 @@
-export default function MdxLayout({ children }: { children: React.ReactNode }) {
+import { Suspense, type ReactNode } from "react"
+
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function MdxLayout({ children }: { children: ReactNode }) {
   // Create any shared layout or styles here
   return (
     <div className="prose prose-headings:mt-8 prose-headings:font-semibold prose-headings:text-black prose-h1:text-5xl prose-h2:text-4xl prose-h3:text-3xl prose-h4:text-2xl prose-h5:text-xl prose-h6:text-lg dark:prose-headings:text-white container mx-auto px-4 py-8 text-justify">
-      {children}
+      <ErrorBoundary>
+        <Suspense fallback={<RouteSkeleton />}>
+          {children}
+        </Suspense>
+      </ErrorBoundary>
     </div>
   )
 }

--- a/app/terms/loading.tsx
+++ b/app/terms/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function Loading() {
+  return <RouteSkeleton />
+}

--- a/components/feedback/ErrorBoundary.tsx
+++ b/components/feedback/ErrorBoundary.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Component,
+  type ErrorInfo,
+  type ReactNode,
+} from "react"
+
+type FallbackRender = (props: {
+  error?: Error
+  reset: () => void
+}) => ReactNode
+
+type ErrorBoundaryProps = {
+  children: ReactNode
+  fallback?: ReactNode | FallbackRender
+  onReset?: () => void
+}
+
+type ErrorBoundaryState = {
+  hasError: boolean
+  error?: Error
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+    error: undefined,
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("ErrorBoundary captured an error", error, errorInfo)
+    }
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (this.state.hasError && prevProps.children !== this.props.children) {
+      this.reset()
+    }
+  }
+
+  private reset() {
+    this.setState({ hasError: false, error: undefined })
+    this.props.onReset?.()
+  }
+
+  private handleRetry = () => {
+    this.reset()
+  }
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      const { fallback } = this.props
+
+      if (typeof fallback === "function") {
+        return fallback({
+          error: this.state.error,
+          reset: this.handleRetry,
+        })
+      }
+
+      if (fallback) {
+        return fallback
+      }
+
+      return (
+        <ErrorFallback error={this.state.error} onRetry={this.handleRetry} />
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+type ErrorFallbackProps = {
+  error?: Error
+  onRetry?: () => void
+}
+
+export function ErrorFallback({ error, onRetry }: ErrorFallbackProps) {
+  const isDev = process.env.NODE_ENV !== "production"
+  const showDetails = Boolean(isDev && error?.message)
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[200px] flex-col items-center justify-center gap-4 rounded-lg border border-destructive/20 bg-destructive/5 p-6 text-center"
+    >
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Something went wrong</h2>
+        <p className="text-sm text-muted-foreground">
+          We couldn&apos;t load this section. Please try again in a moment.
+        </p>
+        {showDetails ? (
+          <p className="text-xs text-muted-foreground/80">
+            {error?.message}
+          </p>
+        ) : null}
+      </div>
+      {onRetry ? (
+        <Button type="button" onClick={onRetry} variant="secondary">
+          Try again
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/components/feedback/RouteSkeleton.tsx
+++ b/components/feedback/RouteSkeleton.tsx
@@ -1,0 +1,23 @@
+export function RouteSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="space-y-6 rounded-lg border border-border/40 bg-background/40 p-6"
+    >
+      <div className="space-y-3">
+        <div className="h-8 w-2/3 animate-pulse rounded-lg bg-muted" />
+        <div className="h-4 w-1/2 animate-pulse rounded-lg bg-muted/80" />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="h-32 animate-pulse rounded-xl border border-border/40 bg-muted/60"
+          />
+        ))}
+      </div>
+      <span className="sr-only">Loading content…</span>
+    </div>
+  )
+}

--- a/docs/design/skeletons.mdx
+++ b/docs/design/skeletons.mdx
@@ -1,0 +1,45 @@
+# Skeleton Patterns
+
+Skeletons provide progressive disclosure while route data loads. The shared `RouteSkeleton` component keeps route transitions consistent and accessible across the portal.
+
+## When to Use
+
+- Wrap every route segment in `<Suspense fallback={<RouteSkeleton />}>` to provide immediate visual feedback while server components stream.
+- Export a `loading.tsx` file from the segment that returns `<RouteSkeleton />` so client-side transitions reuse the same treatment.
+- Pair skeletons with the shared `<ErrorBoundary>` to guarantee an error fallback when the suspense boundary rejects.
+
+## Layout Example
+
+```tsx
+import { Suspense } from "react"
+
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+type LayoutProps = {
+  children: React.ReactNode
+}
+
+export default function ExampleLayout({ children }: LayoutProps) {
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<RouteSkeleton />}>
+        {children}
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+## Loading Exports
+
+```tsx
+// app/example/loading.tsx
+import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+
+export default function Loading() {
+  return <RouteSkeleton />
+}
+```
+
+Skeletons should hint at the final layout without mirroring every pixel. Keep shapes simple, rely on the neutral `muted` palette, and reserve motion for the `animate-pulse` utility to avoid distracting shimmer effects.


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary and RouteSkeleton primitives for consistent feedback
- wrap root, dashboard, mdx, privacy, and terms layouts with the shared boundary and suspense fallback
- expose segment-level loading and error routes alongside documentation for skeleton usage

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d7b64f88328b8e487d642f78d79