### PR TITLE
Add Playwright smoke suite and preview workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,69 @@
+name: Playwright smoke tests
+
+on:
+  deployment_status:
+    types: [success]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    if: >-
+      ${{ github.event.deployment_status.state == 'success' &&
+          (github.event.deployment.environment == 'Preview' || github.event.deployment.environment == 'preview') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve preview URL
+        id: preview
+        run: |
+          url="${{ github.event.deployment_status.environment_url }}"
+          if [ -z "$url" ]; then
+            url="${{ github.event.deployment_status.target_url }}"
+          fi
+          if [ -z "$url" ]; then
+            echo "Preview URL is not available from deployment event." >&2
+            exit 1
+          fi
+          echo "Using preview URL: $url"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright smoke suite
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.preview.outputs.url }}
+          PLAYWRIGHT_SUPABASE_URL: ${{ secrets.PLAYWRIGHT_SUPABASE_URL }}
+          PLAYWRIGHT_SUPABASE_ANON_KEY: ${{ secrets.PLAYWRIGHT_SUPABASE_ANON_KEY }}
+          PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY }}
+          PLAYWRIGHT_SEEDED_EMAIL: ${{ secrets.PLAYWRIGHT_SEEDED_EMAIL }}
+          PLAYWRIGHT_SEEDED_PASSWORD: ${{ secrets.PLAYWRIGHT_SEEDED_PASSWORD }}
+          PLAYWRIGHT_SEEDED_NAME: ${{ secrets.PLAYWRIGHT_SEEDED_NAME }}
+          PLAYWRIGHT_SEEDED_UNIT_ID: ${{ secrets.PLAYWRIGHT_SEEDED_UNIT_ID }}
+          PLAYWRIGHT_SEEDED_DOCUMENT_TITLE: ${{ secrets.PLAYWRIGHT_SEEDED_DOCUMENT_TITLE }}
+        run: npx playwright test --config tests/e2e/playwright.config.ts
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-artifacts
+          path: |
+            tests/e2e/playwright-report
+            tests/e2e/test-results
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 
 # testing
 /coverage
+playwright-report
+test-results
+tests/e2e/.auth
+tests/e2e/playwright-report
+tests/e2e/test-results
 
 # next.js
 /.next/

--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -1,0 +1,79 @@
+# End-to-End Smoke Tests
+
+This project exercises critical tenant journeys with [Playwright](https://playwright.dev/).
+The suite is designed to validate the onboarding, payments, bookings, documents, and messaging
+surfaces against a live Roomsily deployment.
+
+## Running the suite locally
+
+1. Ensure the target app and Supabase project are available. When testing against a deployed
+   preview, export the preview URL and Supabase credentials; for local runs start `npm run dev`.
+2. Install dependencies and Playwright browsers if you have not already:
+
+   ```bash
+   npm install
+   npx playwright install --with-deps
+   ```
+
+3. Provide the required environment variables (see below) and run the smoke suite:
+
+   ```bash
+   PLAYWRIGHT_BASE_URL="https://preview.roomsily.app" \
+   PLAYWRIGHT_SUPABASE_URL="https://<project>.supabase.co" \
+   PLAYWRIGHT_SUPABASE_ANON_KEY="anon-key" \
+   PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY="service-role-key" \
+   PLAYWRIGHT_SEEDED_EMAIL="tenant.e2e@roomsily.dev" \
+   PLAYWRIGHT_SEEDED_PASSWORD="Roomsily!123" \
+   npm run test:e2e
+   ```
+
+The Playwright configuration lives in `tests/e2e/playwright.config.ts`. Base URLs and Supabase
+credentials default to the seeded demo values when no overrides are supplied.
+
+## Supabase fixture maintenance
+
+`tests/e2e/global-setup.ts` seeds Supabase via the service-role key before each run. The script:
+
+- Ensures the smoke-test tenant user exists (defaults: `tenant.e2e@roomsily.dev` / `Roomsily!123`).
+- Upserts the matching `profiles` row with role `tenant` and unit `unit-e2e-1`.
+- Inserts deterministic records for rent payments, an active lease, and two documents
+  (`E2E Lease Agreement` pending signature and `E2E House Rules` already signed).
+- Creates a pending `document_signatures` entry so the UI renders “Sign Document”.
+
+When Supabase schemas change, update these fixtures to keep the smoke suite green:
+
+1. Adjust any new required columns within the upsert payloads—keep IDs stable so stats remain
+   deterministic.
+2. If new relations are introduced, seed companion rows (e.g., a new `units` table) inside the
+   same script using the shared `SEED_TAG` metadata for discoverability.
+3. Use `npm run test:e2e -- --debug` to iterate on fixture changes; the setup runs once per suite.
+
+All seeded records include `metadata.seed = "playwright-smoke"` to make cleanup or manual
+inspection simple within the Supabase dashboard.
+
+## Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `PLAYWRIGHT_BASE_URL` | Base URL for the app under test (preview deployment or local dev). |
+| `PLAYWRIGHT_SUPABASE_URL` | Supabase project URL used for seeding and browser auth. |
+| `PLAYWRIGHT_SUPABASE_ANON_KEY` | Anon key required by the client during tests. |
+| `PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY` | Service role key used in `global-setup` to provision fixtures. |
+| `PLAYWRIGHT_SEEDED_EMAIL` / `PLAYWRIGHT_SEEDED_PASSWORD` | Credentials for the seeded tenant user. |
+| `PLAYWRIGHT_SEEDED_NAME`, `PLAYWRIGHT_SEEDED_UNIT_ID`, `PLAYWRIGHT_SEEDED_DOCUMENT_TITLE`, `PLAYWRIGHT_SEEDED_SIGNED_DOCUMENT_TITLE` | Optional overrides for seeded profile metadata and document titles. |
+
+## Retries, traces, and videos
+
+- CI retries are configured in `tests/e2e/playwright.config.ts` (`retries: 2` on CI, none locally).
+  Increase cautiously only after reviewing flaky behaviour and ensuring fixtures are deterministic.
+- The config retains traces, screenshots, and videos for failed tests (`retain-on-failure`).
+  Artifacts are written to `tests/e2e/test-results` and `tests/e2e/playwright-report`.
+- `.github/workflows/playwright.yml` runs on successful Vercel preview deployments and uploads the
+  Playwright artifacts via `actions/upload-artifact`. Inspect these when debugging failures.
+
+## Troubleshooting
+
+- If onboarding fails locally, confirm Supabase env vars match your seeded tenant and that the
+  `global-setup` script is using the same service-role key as your preview deployment.
+- To wipe smoke data manually, delete rows tagged with `metadata->>seed = 'playwright-smoke'` in
+  Supabase and rerun the suite to repopulate fixtures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -71,6 +71,7 @@
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+        "@playwright/test": "^1.45.2",
         "@types/eslint": "^8.56.2",
         "@types/node": "^20.19.0",
         "@types/react": "^18.3.3",
@@ -1472,6 +1473,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -10042,6 +10059,53 @@
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test --config tests/e2e/playwright.config.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -73,6 +74,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@playwright/test": "^1.45.2",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,227 @@
+import type { FullConfig } from "@playwright/test"
+import { createClient, type PostgrestError } from "@supabase/supabase-js"
+
+import type { Database } from "../../lib/supabase"
+
+const SEED_TAG = "playwright-smoke"
+
+function assertNoError(label: string, error: PostgrestError | null) {
+  if (error) {
+    throw new Error(`${label}: ${error.message}`)
+  }
+}
+
+export default async function globalSetup(_config: FullConfig) {
+  const supabaseUrl =
+    process.env.PLAYWRIGHT_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey =
+    process.env.PLAYWRIGHT_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const supabaseServiceRoleKey =
+    process.env.PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (supabaseUrl && !process.env.NEXT_PUBLIC_SUPABASE_URL) {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = supabaseUrl
+  }
+
+  if (supabaseAnonKey && !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = supabaseAnonKey
+  }
+
+  if (supabaseServiceRoleKey && !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = supabaseServiceRoleKey
+  }
+
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    console.warn(
+      "[playwright] Missing Supabase credentials; skipping smoke fixture provisioning.",
+    )
+    return
+  }
+
+  const supabase = createClient<Database>(supabaseUrl, supabaseServiceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+
+  const seededEmail = process.env.PLAYWRIGHT_SEEDED_EMAIL || "tenant.e2e@roomsily.dev"
+  const seededPassword = process.env.PLAYWRIGHT_SEEDED_PASSWORD || "Roomsily!123"
+  const seededName = process.env.PLAYWRIGHT_SEEDED_NAME || "E2E Tenant"
+  const seededUnitId = process.env.PLAYWRIGHT_SEEDED_UNIT_ID || "unit-e2e-1"
+
+  const listUsersResult = await supabase.auth.admin.listUsers({ perPage: 1000 })
+
+  if ('error' in listUsersResult && listUsersResult.error) {
+    throw new Error(`Failed to read Supabase users: ${listUsersResult.error.message}`)
+  }
+
+  const existingUser = listUsersResult.data.users.find(
+    (user) => user.email?.toLowerCase() === seededEmail.toLowerCase(),
+  )
+
+  let userId = existingUser?.id
+
+  if (!userId) {
+    const { data, error } = await supabase.auth.admin.createUser({
+      email: seededEmail,
+      password: seededPassword,
+      email_confirm: true,
+    })
+
+    if (error || !data?.user) {
+      throw new Error(
+        `Unable to create seeded tenant ${seededEmail}: ${error?.message ?? "unknown error"}`,
+      )
+    }
+
+    userId = data.user.id
+  } else {
+    const { error } = await supabase.auth.admin.updateUserById(userId, {
+      password: seededPassword,
+      email_confirm: true,
+    })
+
+    if (error) {
+      throw new Error(`Unable to update seeded tenant credentials: ${error.message}`)
+    }
+  }
+
+  const now = new Date()
+  const isoNow = now.toISOString()
+  const isoYesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString()
+
+  const { error: profileError } = await supabase.from("profiles").upsert(
+    {
+      id: userId,
+      email: seededEmail,
+      full_name: seededName,
+      role: "tenant",
+      unit_id: seededUnitId,
+      rent_share: 1260,
+      metadata: { seed: SEED_TAG, onboarding_completed: true } as Database["public"]["Tables"]["profiles"]["Row"]["metadata"],
+      updated_at: isoNow,
+    },
+    { onConflict: "id" },
+  )
+  assertNoError("profile upsert", profileError)
+
+  const pendingDocumentId =
+    process.env.PLAYWRIGHT_SEEDED_DOCUMENT_ID || "11111111-1111-1111-1111-111111111111"
+  const signedDocumentId =
+    process.env.PLAYWRIGHT_SEEDED_SIGNED_DOCUMENT_ID || "22222222-2222-2222-2222-222222222222"
+  const signatureId =
+    process.env.PLAYWRIGHT_SEEDED_SIGNATURE_ID || "33333333-3333-3333-3333-333333333333"
+  const leaseId = process.env.PLAYWRIGHT_SEEDED_LEASE_ID || "44444444-4444-4444-4444-444444444444"
+
+  const pendingDocumentTitle =
+    process.env.PLAYWRIGHT_SEEDED_DOCUMENT_TITLE || "E2E Lease Agreement"
+  const signedDocumentTitle =
+    process.env.PLAYWRIGHT_SEEDED_SIGNED_DOCUMENT_TITLE || "E2E House Rules"
+
+  const { error: documentsError } = await supabase.from("documents").upsert(
+    [
+      {
+        id: pendingDocumentId,
+        title: pendingDocumentTitle,
+        description: "Automated smoke-test lease for Roomsily E2E coverage.",
+        document_type: "lease",
+        status: "pending_signature",
+        requires_signature: true,
+        tenant_id: userId,
+        unit_id: seededUnitId,
+        created_by: userId,
+        metadata: { seed: SEED_TAG, scenario: "smoke" } as Database["public"]["Tables"]["documents"]["Row"]["metadata"],
+        created_at: isoNow,
+        updated_at: isoNow,
+        version: 1,
+      },
+      {
+        id: signedDocumentId,
+        title: signedDocumentTitle,
+        description: "Reference policies for the seeded household.",
+        document_type: "other",
+        status: "signed",
+        requires_signature: false,
+        tenant_id: userId,
+        unit_id: seededUnitId,
+        created_by: userId,
+        signed_at: isoYesterday,
+        metadata: { seed: SEED_TAG, scenario: "smoke" } as Database["public"]["Tables"]["documents"]["Row"]["metadata"],
+        created_at: isoYesterday,
+        updated_at: isoYesterday,
+        version: 1,
+      },
+    ],
+    { onConflict: "id" },
+  )
+  assertNoError("documents upsert", documentsError)
+
+  const { error: leaseError } = await supabase.from("leases").upsert(
+    {
+      id: leaseId,
+      document_id: pendingDocumentId,
+      start_date: "2024-01-01",
+      end_date: "2024-12-31",
+      rent_amount: 126000,
+      rent_frequency: "monthly",
+      security_deposit: 126000,
+      tenant_ids: [userId],
+      property_address: "123 Roomsily Ave, Unit 3B",
+      unit_number: "3B",
+      landlord_name: "Roomsily Property Management",
+      landlord_email: "pm@roomsily.dev",
+      auto_renew: true,
+      renewal_notice_days: 45,
+      status: "active",
+      created_at: isoNow,
+      updated_at: isoNow,
+    },
+    { onConflict: "id" },
+  )
+  assertNoError("lease upsert", leaseError)
+
+  const { error: signatureError } = await supabase.from("document_signatures").upsert(
+    {
+      id: signatureId,
+      document_id: pendingDocumentId,
+      signer_id: userId,
+      signer_email: seededEmail,
+      signer_name: seededName,
+      status: "pending",
+      signature_data: { seed: SEED_TAG },
+      created_at: isoNow,
+      updated_at: isoNow,
+    },
+    { onConflict: "id" },
+  )
+  assertNoError("document signature upsert", signatureError)
+
+  const paymentId =
+    process.env.PLAYWRIGHT_SEEDED_PAYMENT_ID || "55555555-5555-5555-5555-555555555555"
+
+  const { error: paymentError } = await supabase.from("rent_payments").upsert(
+    {
+      id: paymentId,
+      user_id: userId,
+      tenant_id: userId,
+      unit_id: seededUnitId,
+      amount: 126000,
+      currency: "usd",
+      status: "succeeded",
+      payment_method: "card",
+      payment_method_type: "card",
+      description: "Roomsily smoke test rent payment",
+      metadata: { seed: SEED_TAG },
+      processed_at: isoYesterday,
+      billing_period_start: "2024-06-01T00:00:00.000Z",
+      billing_period_end: "2024-06-30T23:59:59.000Z",
+      created_at: isoYesterday,
+      updated_at: isoNow,
+    },
+    { onConflict: "id" },
+  )
+  assertNoError("rent payment upsert", paymentError)
+
+  console.log("[playwright] Seeded Supabase smoke fixtures for", seededEmail)
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,107 @@
+import { defineConfig, devices } from "@playwright/test"
+import type { ReporterDescription } from "@playwright/test"
+import path from "path"
+
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ||
+  process.env.PLAYWRIGHT_APP_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  "http://127.0.0.1:3000"
+
+const supabaseUrl =
+  process.env.PLAYWRIGHT_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  ""
+
+const supabaseAnonKey =
+  process.env.PLAYWRIGHT_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  ""
+
+const supabaseServiceRoleKey =
+  process.env.PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  ""
+
+if (supabaseUrl && !process.env.NEXT_PUBLIC_SUPABASE_URL) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = supabaseUrl
+}
+
+if (supabaseAnonKey && !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = supabaseAnonKey
+}
+
+if (supabaseServiceRoleKey && !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  process.env.SUPABASE_SERVICE_ROLE_KEY = supabaseServiceRoleKey
+}
+
+if (!process.env.NEXT_PUBLIC_APP_URL) {
+  process.env.NEXT_PUBLIC_APP_URL = baseURL
+}
+
+if (!process.env.NEXT_PUBLIC_SITE_URL) {
+  process.env.NEXT_PUBLIC_SITE_URL = baseURL
+}
+
+if (!process.env.PLAYWRIGHT_SEEDED_EMAIL) {
+  process.env.PLAYWRIGHT_SEEDED_EMAIL = "tenant.e2e@roomsily.dev"
+}
+
+if (!process.env.PLAYWRIGHT_SEEDED_PASSWORD) {
+  process.env.PLAYWRIGHT_SEEDED_PASSWORD = "Roomsily!123"
+}
+
+if (!process.env.PLAYWRIGHT_SEEDED_NAME) {
+  process.env.PLAYWRIGHT_SEEDED_NAME = "E2E Tenant"
+}
+
+if (!process.env.PLAYWRIGHT_SEEDED_UNIT_ID) {
+  process.env.PLAYWRIGHT_SEEDED_UNIT_ID = "unit-e2e-1"
+}
+
+if (!process.env.PLAYWRIGHT_SEEDED_DOCUMENT_TITLE) {
+  process.env.PLAYWRIGHT_SEEDED_DOCUMENT_TITLE = "E2E Lease Agreement"
+}
+
+if (!process.env.PLAYWRIGHT_SEEDED_SIGNED_DOCUMENT_TITLE) {
+  process.env.PLAYWRIGHT_SEEDED_SIGNED_DOCUMENT_TITLE = "E2E House Rules"
+}
+
+const reporterConfig: ReporterDescription[] = process.env.CI
+  ? [
+      ["github"],
+      ["html", { outputFolder: path.join(__dirname, "playwright-report"), open: "never" }],
+    ]
+  : [
+      ["list"],
+      ["html", { outputFolder: path.join(__dirname, "playwright-report"), open: "never" }],
+    ]
+
+export default defineConfig({
+  testDir: "./",
+  timeout: 120_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 4 : undefined,
+  reporter: reporterConfig,
+  globalSetup: require.resolve("./global-setup"),
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+  outputDir: path.join(__dirname, "test-results"),
+})

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test"
+import fs from "fs"
+import path from "path"
+
+const seededEmail = process.env.PLAYWRIGHT_SEEDED_EMAIL || "tenant.e2e@roomsily.dev"
+const seededPassword = process.env.PLAYWRIGHT_SEEDED_PASSWORD || "Roomsily!123"
+const pendingDocumentTitle =
+  process.env.PLAYWRIGHT_SEEDED_DOCUMENT_TITLE || "E2E Lease Agreement"
+
+const hasSupabaseConfig = Boolean(
+  (process.env.PLAYWRIGHT_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL) &&
+    seededEmail &&
+    seededPassword,
+)
+
+const describeSmoke = hasSupabaseConfig ? test.describe : test.describe.skip
+const authStoragePath = path.join(__dirname, ".auth", "tenant.json")
+
+describeSmoke("Roomsily tenant smoke flows", () => {
+  test.describe.configure({ mode: "serial" })
+
+  test("onboarding: seeded tenant signs in from the onboarding flow", async ({ page }) => {
+    fs.mkdirSync(path.dirname(authStoragePath), { recursive: true })
+
+    await page.goto("/onboarding")
+    await expect(page.getByRole("heading", { name: "Create an account" })).toBeVisible()
+    await page.getByRole("tab", { name: /signin/i }).click()
+    await page.getByLabel("Email").fill(seededEmail)
+    await page.getByLabel("Password").fill(seededPassword)
+    await page.getByRole("button", { name: /sign in/i }).click()
+
+    await expect(page.getByText(/Successful login/)).toBeVisible({ timeout: 15_000 })
+
+    await page.goto("/dashboard")
+    await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible()
+
+    await page.context().storageState({ path: authStoragePath })
+  })
+
+  test.describe("authenticated experience", () => {
+    test.use({ storageState: authStoragePath })
+
+    test("rent payments: surfaces autopay status and outstanding balances", async ({ page }) => {
+      await page.goto("/payments")
+
+      await expect(page.getByRole("heading", { name: "Payments" })).toBeVisible()
+      await expect(page.getByText("Catch-up snapshot")).toBeVisible()
+      await expect(page.getByText("Roommate balances")).toBeVisible()
+      await expect(page.getByText("Avery Chen")).toBeVisible()
+    })
+
+    test("amenity bookings: allows a roommate to launch the booking flow", async ({ page }) => {
+      await page.goto("/bookings")
+
+      await expect(page.getByRole("heading", { name: "Amenity Bookings" })).toBeVisible()
+      const bookKitchen = page.getByRole("button", { name: "Book now" }).first()
+      await bookKitchen.click()
+      await expect(page.getByText("Opening booking flow for Kitchen")).toBeVisible()
+    })
+
+    test("documents: shows pending signatures and relevant actions", async ({ page }) => {
+      await page.goto("/documents")
+
+      await expect(page.getByRole("heading", { name: "Documents" })).toBeVisible()
+      await expect(page.getByText(pendingDocumentTitle)).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByText("Pending Signatures")).toBeVisible()
+
+      const pendingCard = page
+        .locator("div")
+        .filter({ has: page.getByRole("heading", { name: pendingDocumentTitle }) })
+        .first()
+
+      const menuButton = pendingCard.getByRole("button", { name: "Open menu" })
+      await expect(menuButton).toBeVisible()
+      await menuButton.click()
+      await expect(page.getByRole("menuitem", { name: "Sign Document" })).toBeVisible()
+    })
+
+    test("messaging: highlights realtime roommate collaboration", async ({ page }) => {
+      await page.goto("/messaging")
+
+      await expect(page.getByRole("heading", { name: "Messaging" })).toBeVisible()
+      await expect(page.getByText("Threaded conversations")).toBeVisible()
+      await expect(page.getByText("Realtime presence")).toBeVisible()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a Playwright configuration and Supabase-backed smoke spec that covers onboarding, payments, bookings, documents, and messaging
- seed deterministic Supabase fixtures during global setup and document how to maintain them
- run the smoke suite on Vercel preview deployments and retain traces/videos for debugging

## Testing
- npm run test
- npx tsc --noEmit *(fails: existing type errors in app/countries/[id]/page.tsx and app/ssrcountries/[id]/country.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d15d7ccfe88328b3d19c28d49fceb5