### PR TITLE
Add Supabase performance instrumentation and alerting

### DIFF
--- a/app/api/_middleware.ts
+++ b/app/api/_middleware.ts
@@ -1,0 +1,82 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+import { recordPerformanceSample } from '@/lib/supabase'
+
+const SKIP_HEADER = 'x-share-house-skip-api-middleware'
+
+function shouldIncludeBody(method: string) {
+  const upper = method.toUpperCase()
+  return upper !== 'GET' && upper !== 'HEAD'
+}
+
+export async function middleware(request: NextRequest) {
+  if (request.headers.get(SKIP_HEADER) === '1') {
+    return NextResponse.next()
+  }
+
+  const start =
+    typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now()
+
+  const headers = new Headers(request.headers)
+  headers.set(SKIP_HEADER, '1')
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: 'manual',
+    cache: 'no-store',
+  }
+
+  if (shouldIncludeBody(request.method) && request.body) {
+    init.body = request.body
+  }
+
+  const targetRequest = new Request(request.nextUrl, init)
+
+  let response: Response | undefined
+  let error: unknown
+
+  try {
+    response = await fetch(targetRequest)
+    return response
+  } catch (err) {
+    error = err
+    throw err
+  } finally {
+    const end =
+      typeof performance !== 'undefined' && typeof performance.now === 'function'
+        ? performance.now()
+        : Date.now()
+
+    const durationMs = end - start
+
+    const metadata: Record<string, unknown> = {
+      method: request.method.toUpperCase(),
+      route: request.nextUrl.pathname,
+      status: response?.status ?? null,
+      requestId: request.headers.get('x-request-id') ?? undefined,
+    }
+
+    if (error instanceof Error) {
+      metadata.error = error.message
+    } else if (error) {
+      metadata.error = String(error)
+    }
+
+    recordPerformanceSample({
+      key: `api:${request.nextUrl.pathname}:${request.method.toUpperCase()}`,
+      durationMs,
+      source: 'api-middleware',
+      environment: 'edge',
+      helper: 'app/api/_middleware',
+      statusCode: response?.status,
+      metadata,
+    })
+  }
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -6,7 +6,11 @@ import {
   sendInAppNotification,
 } from "@/lib/notifications"
 import { getStripe } from "@/lib/stripe"
-import type { Database, TablesInsert } from "@/lib/supabase"
+import {
+  createSupabaseInstrumentationConfig,
+  type Database,
+  type TablesInsert,
+} from "@/lib/supabase"
 
 function createSupabaseAdminClient(): SupabaseClient<Database> | null {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -22,6 +26,11 @@ function createSupabaseAdminClient(): SupabaseClient<Database> | null {
       autoRefreshToken: false,
       persistSession: false,
     },
+    ...createSupabaseInstrumentationConfig({
+      helper: 'api/stripe/webhook',
+      environment: 'server',
+      context: { route: '/api/stripe/webhook' },
+    }),
   })
 }
 

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -6,6 +6,8 @@ import { ScheduleForm } from '@/components/schedule-form';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Toaster } from "@/components/ui/toaster"
 
+import { createSupabaseInstrumentationConfig } from '@/lib/supabase';
+
 export default async function SchedulePage() {
     const cookieStore = cookies();
     const supabase = createServerClient(
@@ -17,6 +19,11 @@ export default async function SchedulePage() {
                     return cookieStore.get(name)?.value;
                 },
             },
+            ...createSupabaseInstrumentationConfig({
+                helper: 'app/schedule/page',
+                environment: 'server',
+                context: { route: '/schedule' },
+            }),
         }
     );
 

--- a/docs/perf/logging.md
+++ b/docs/perf/logging.md
@@ -1,0 +1,158 @@
+# Performance Logging & Alerting
+
+This document describes how Share House Portal records high latency samples for Supabase activity and API route handlers, how the data is aggregated, and how to configure downstream alerts.
+
+## Instrumentation Overview
+
+The Supabase helper factory in [`lib/supabase.ts`](../../lib/supabase.ts) wraps every client with a fetch interceptor. For each Supabase REST request the wrapper measures the elapsed time, maintains a sliding window of recent durations, and writes samples that fall above the calculated p95 or p99 percentile into `performance_logs`. The helper also exposes `recordPerformanceSample`, which is used by `app/api/_middleware.ts` to proxy API route handlers and capture request latency at the edge before handing the request back to Next.js.
+
+Key properties of the instrumentation:
+
+- Percentile calculations are performed per logical key (for example, `supabase:profiles:GET` or `api:/api/documents:POST`) with a bounded in-memory window of the 200 most recent durations.
+- A minimum of 20 observations is required before the module begins sampling outliers. This avoids noisy alerts while a process is warming up.
+- Outlier samples are written asynchronously using the Supabase service role key (never on the client). Failures to persist are logged in development but do not disrupt request flow.
+- Metadata for each sample includes the helper that executed the operation, HTTP method, response status code, and any optional context added by the caller (for example the originating route).
+
+## API Middleware Proxy
+
+`app/api/_middleware.ts` runs on the edge for `/api/*` requests. When a request enters the middleware:
+
+1. It injects a guard header (`x-share-house-skip-api-middleware`) to prevent infinite recursion.
+2. The middleware proxies the request to the intended API route and waits for the response.
+3. Once the response resolves (or throws), the middleware pushes the recorded duration to `recordPerformanceSample` with a key in the form `api:{pathname}:{METHOD}`.
+
+This design allows us to measure full handler latency—including middleware, route handler logic, and any downstream I/O—without modifying each API route individually.
+
+## Database Schema
+
+The Supabase migration `20250109_performance_monitoring.sql` provisions three tables that back the monitoring pipeline:
+
+### `performance_logs`
+
+Stores raw high-latency samples captured from the wrappers.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key. |
+| `created_at` | `timestamptz` | Insertion timestamp. |
+| `source` | `text` | Either `supabase-client` or `api-middleware`. |
+| `key` | `text` | Logical identifier, e.g. `supabase:profiles:GET`. |
+| `helper` | `text` | Helper/module that executed the operation. |
+| `environment` | `text` | Execution environment (`server`, `browser`, `edge`, or `worker`). |
+| `duration_ms` | `numeric` | Duration of the sampled request. |
+| `threshold` | `text` | Which percentile the sample crossed (`p95` or `p99`). |
+| `calculated_p95_ms` | `numeric` | Snapshot of the current p95 for the window. |
+| `calculated_p99_ms` | `numeric` | Snapshot of the current p99 for the window. |
+| `sample_size` | `integer` | Number of observations used to calculate the percentiles. |
+| `status_code` | `integer` | HTTP status code when available. |
+| `metadata` | `jsonb` | Additional context (route, query parameters, request ID, error message, etc.). |
+
+### `performance_thresholds`
+
+Defines alerting windows and channel configuration.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `target` | `text` | Matches `performance_logs.key`. Unique per record. |
+| `window_interval` | `interval` | Analysis window (defaults to 15 minutes). |
+| `max_p95_ms` / `max_p99_ms` | `numeric` | Optional absolute thresholds. |
+| `max_p95_count` / `max_p99_count` | `integer` | Optional breach counters for the window. |
+| `slack_webhook_secret` | `text` | Name of the Vault secret that stores the Slack webhook URL. |
+| `email_webhook_secret` | `text` | Name of the Vault secret containing an email provider webhook URL. |
+| `email_recipients` | `text[]` | Recipients to notify for email alerts. |
+| `metadata` | `jsonb` | Arbitrary configuration metadata (for example, custom email subjects). |
+| `last_triggered_at` | `timestamptz` | Timestamp of the most recent alert. |
+| `active` | `boolean` | Enables/disables the threshold definition. |
+
+### `performance_alerts`
+
+Persists alert executions for auditing.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `target` | `text` | Threshold key that triggered the alert. |
+| `window_start` / `window_end` | `timestamptz` | Time window evaluated. |
+| `p95_duration_ms` / `p99_duration_ms` | `numeric` | Worst observed percentiles within the window. |
+| `p95_breach_count` / `p99_breach_count` | `integer` | Count of sampled breaches. |
+| `sample_size` | `integer` | Number of samples considered. |
+| `notification_status` | `text` | `sent`, `failed`, or `skipped`. |
+| `metadata` | `jsonb` | Copy of the payload sent to downstream channels. |
+
+## Scheduled Aggregation & Alerts
+
+`process_performance_metrics()` runs every five minutes via `pg_cron`. For each active row in `performance_thresholds` it:
+
+1. Aggregates the outlier samples from `performance_logs` that fall within the configured window.
+2. Compares the aggregated metrics to the defined limits (absolute percentile values and/or breach counts).
+3. Sends Slack and/or email notifications when limits are exceeded.
+4. Records the outcome in `performance_alerts` and updates `last_triggered_at`.
+
+Slack and email integrations rely on Supabase Vault secrets so sensitive URLs are not stored in plaintext. Before enabling alerts set the secrets referenced by `slack_webhook_secret` and `email_webhook_secret` using the Supabase CLI, for example:
+
+```sh
+supabase secrets set SLACK_PERF_ALERT_WEBHOOK="https://hooks.slack.com/services/..."
+supabase secrets set RESEND_PERF_ALERT_WEBHOOK="https://api.resend.com/emails"
+```
+
+Then create a threshold record pointing to those secret names:
+
+```sql
+insert into public.performance_thresholds (
+  target,
+  description,
+  window_interval,
+  max_p99_ms,
+  max_p99_count,
+  slack_webhook_secret,
+  email_webhook_secret,
+  email_recipients,
+  metadata
+) values (
+  'api:/api/documents:POST',
+  'Document upload API should respond within 1.5 seconds',
+  interval '10 minutes',
+  1500,
+  5,
+  'SLACK_PERF_ALERT_WEBHOOK',
+  'RESEND_PERF_ALERT_WEBHOOK',
+  array['ops@sharehouse.example'],
+  jsonb_build_object('email_subject', 'Document upload latency alert')
+);
+```
+
+## Querying the Data
+
+Use the logs table to inspect recent outliers:
+
+```sql
+select created_at,
+       key,
+       duration_ms,
+       threshold,
+       metadata->>'status' as status,
+       metadata->>'error' as error
+from public.performance_logs
+where created_at > now() - interval '1 hour'
+order by created_at desc
+limit 50;
+```
+
+To review recent alerts:
+
+```sql
+select created_at,
+       target,
+       notification_status,
+       p99_duration_ms,
+       metadata->'metrics'->>'p99_count' as p99_breaches
+from public.performance_alerts
+order by created_at desc
+limit 20;
+```
+
+## Operational Notes
+
+- The logging helpers only persist samples when running server-side with `SUPABASE_SERVICE_ROLE_KEY` available. Client-side instrumentation still maintains percentiles but skips persistence to avoid exposing elevated credentials.
+- Ensure `pg_cron`, `pg_net`, and `vault` extensions remain enabled in every environment where alerts should run.
+- Because only outlier samples are stored, percentile statistics inside `performance_logs` reflect the state at the time of sampling. Use the aggregated metrics to understand whether percentile limits are consistently breached.
+- Adjust `MIN_SAMPLE_SIZE_FOR_ALERT` or `SAMPLE_WINDOW_SIZE` in `lib/supabase.ts` if you need a larger baseline before sampling begins.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,3 +1,9 @@
+import {
+  createClient as createSupabaseAdminClient,
+  type SupabaseClient,
+  type SupabaseClientOptions,
+} from '@supabase/supabase-js'
+
 export type Json =
   | string
   | number
@@ -244,6 +250,52 @@ export type Database = {
         updated_at: string | null
         metadata: Json | null
       }>
+      performance_logs: SupabaseTable<{
+        id: string
+        created_at: string | null
+        source: 'supabase-client' | 'api-middleware'
+        key: string
+        helper: string | null
+        environment: 'server' | 'browser' | 'edge' | 'worker' | null
+        duration_ms: number
+        threshold: 'p95' | 'p99'
+        calculated_p95_ms: number | null
+        calculated_p99_ms: number | null
+        sample_size: number | null
+        status_code: number | null
+        metadata: Json | null
+      }>
+      performance_thresholds: SupabaseTable<{
+        id: string
+        created_at: string | null
+        target: string
+        description: string | null
+        window_interval: string | null
+        max_p95_ms: number | null
+        max_p99_ms: number | null
+        max_p95_count: number | null
+        max_p99_count: number | null
+        slack_webhook_secret: string | null
+        email_webhook_secret: string | null
+        email_recipients: string[] | null
+        active: boolean | null
+        metadata: Json | null
+        last_triggered_at: string | null
+      }>
+      performance_alerts: SupabaseTable<{
+        id: string
+        created_at: string | null
+        target: string
+        window_start: string
+        window_end: string
+        p95_duration_ms: number | null
+        p99_duration_ms: number | null
+        p95_breach_count: number | null
+        p99_breach_count: number | null
+        sample_size: number | null
+        notification_status: 'sent' | 'failed' | 'skipped'
+        metadata: Json | null
+      }>
     }
     Views: Record<string, never>
     Functions: {
@@ -310,3 +362,343 @@ export type TablesInsert<T extends keyof PublicSchema['Tables']> =
   PublicSchema['Tables'][T]['Insert']
 export type TablesUpdate<T extends keyof PublicSchema['Tables']> =
   PublicSchema['Tables'][T]['Update']
+
+type PerformanceSource = 'supabase-client' | 'api-middleware'
+export type PerformanceEnvironment = 'server' | 'browser' | 'edge' | 'worker'
+
+type PerformanceLogInsert = TablesInsert<'performance_logs'>
+
+type PerformanceSample = {
+  key: string
+  durationMs: number
+  source: PerformanceSource
+  environment: PerformanceEnvironment
+  helper?: string | null
+  statusCode?: number
+  metadata?: Record<string, unknown>
+}
+
+export type SupabaseInstrumentationConfig = {
+  helper: string
+  environment: PerformanceEnvironment
+  context?: Record<string, unknown>
+}
+
+const SAMPLE_WINDOW_SIZE = 200
+const MIN_SAMPLE_SIZE_FOR_ALERT = 20
+
+const performanceWindows = new Map<string, number[]>()
+let performanceLogClient: SupabaseClient<Database> | null = null
+const globalFetch: typeof fetch | undefined =
+  typeof fetch === 'function' ? fetch.bind(globalThis) : undefined
+
+function schedule(task: () => void | Promise<void>) {
+  if (typeof queueMicrotask === 'function') {
+    queueMicrotask(() => {
+      void task()
+    })
+  } else {
+    void Promise.resolve().then(() => {
+      void task()
+    })
+  }
+}
+
+function getTimestamp(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now()
+  }
+
+  return Date.now()
+}
+
+function calculatePercentile(sortedValues: number[], percentile: number): number {
+  if (!sortedValues.length) {
+    return 0
+  }
+
+  if (sortedValues.length === 1) {
+    return sortedValues[0]
+  }
+
+  const index = (sortedValues.length - 1) * percentile
+  const lowerIndex = Math.floor(index)
+  const upperIndex = Math.ceil(index)
+
+  if (lowerIndex === upperIndex) {
+    return sortedValues[lowerIndex]
+  }
+
+  const lowerValue = sortedValues[lowerIndex]
+  const upperValue = sortedValues[upperIndex]
+  const weight = index - lowerIndex
+
+  return lowerValue * (1 - weight) + upperValue * weight
+}
+
+function sanitizeJsonValue(value: unknown): Json | undefined {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    const sanitizedArray: Json[] = []
+
+    for (const item of value) {
+      const sanitizedItem = sanitizeJsonValue(item)
+
+      if (sanitizedItem !== undefined) {
+        sanitizedArray.push(sanitizedItem)
+      }
+    }
+
+    return sanitizedArray
+  }
+
+  if (typeof value === 'object' && value) {
+    const sanitizedObject: Record<string, Json> = {}
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      const sanitizedValue = sanitizeJsonValue(nestedValue)
+
+      if (sanitizedValue !== undefined) {
+        sanitizedObject[key] = sanitizedValue
+      }
+    }
+
+    return sanitizedObject
+  }
+
+  if (value === undefined) {
+    return undefined
+  }
+
+  return String(value)
+}
+
+function buildMetadata(metadata?: Record<string, unknown>): Json | null {
+  if (!metadata) {
+    return null
+  }
+
+  const sanitizedEntries: Record<string, Json> = {}
+
+  for (const [key, value] of Object.entries(metadata)) {
+    const sanitizedValue = sanitizeJsonValue(value)
+
+    if (sanitizedValue !== undefined) {
+      sanitizedEntries[key] = sanitizedValue
+    }
+  }
+
+  return Object.keys(sanitizedEntries).length > 0 ? sanitizedEntries : null
+}
+
+function getPerformanceLogClient(): SupabaseClient<Database> | null {
+  if (typeof window !== 'undefined') {
+    return null
+  }
+
+  if (performanceLogClient) {
+    return performanceLogClient
+  }
+
+  const supabaseUrl =
+    typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_SUPABASE_URL : undefined
+  const serviceRoleKey =
+    typeof process !== 'undefined' ? process.env.SUPABASE_SERVICE_ROLE_KEY : undefined
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return null
+  }
+
+  performanceLogClient = createSupabaseAdminClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+
+  return performanceLogClient
+}
+
+async function persistPerformanceLog(entry: PerformanceLogInsert) {
+  const client = getPerformanceLogClient()
+
+  if (!client) {
+    return
+  }
+
+  try {
+    const { error } = await client.from('performance_logs').insert(entry)
+
+    if (error && typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+      console.warn('Failed to persist performance log', error)
+    }
+  } catch (error) {
+    if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+      console.warn('Unexpected error while persisting performance log', error)
+    }
+  }
+}
+
+export function recordPerformanceSample(sample: PerformanceSample) {
+  const bucket = performanceWindows.get(sample.key) ?? []
+
+  bucket.push(sample.durationMs)
+
+  if (bucket.length > SAMPLE_WINDOW_SIZE) {
+    bucket.shift()
+  }
+
+  performanceWindows.set(sample.key, bucket)
+
+  if (bucket.length < MIN_SAMPLE_SIZE_FOR_ALERT) {
+    return
+  }
+
+  const sorted = [...bucket].sort((a, b) => a - b)
+  const p95 = calculatePercentile(sorted, 0.95)
+  const p99 = calculatePercentile(sorted, 0.99)
+
+  let threshold: PerformanceLogInsert['threshold'] | null = null
+
+  if (sample.durationMs >= p99) {
+    threshold = 'p99'
+  } else if (sample.durationMs >= p95) {
+    threshold = 'p95'
+  }
+
+  if (!threshold) {
+    return
+  }
+
+  const logEntry: PerformanceLogInsert = {
+    source: sample.source,
+    key: sample.key,
+    helper: sample.helper ?? null,
+    environment: sample.environment,
+    duration_ms: sample.durationMs,
+    threshold,
+    calculated_p95_ms: p95,
+    calculated_p99_ms: p99,
+    sample_size: bucket.length,
+    status_code: sample.statusCode ?? null,
+    metadata: buildMetadata(sample.metadata),
+  }
+
+  schedule(() => persistPerformanceLog(logEntry))
+}
+
+function extractUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input
+  }
+
+  if (input instanceof URL) {
+    return input.toString()
+  }
+
+  return input.url
+}
+
+function extractMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method) {
+    return init.method.toUpperCase()
+  }
+
+  if (typeof input === 'string' || input instanceof URL) {
+    return 'GET'
+  }
+
+  return input.method?.toUpperCase() ?? 'GET'
+}
+
+function normalizeSupabaseOperation(url: URL): {
+  operationKey: string
+  path: string
+  search: string | null
+} {
+  const path = url.pathname.startsWith('/') ? url.pathname.slice(1) : url.pathname
+  const sanitizedPath = path.replace(/^rest\/v1\//, '').replace(/^storage\/v1\//, '')
+  const operationKey = sanitizedPath || path
+
+  return {
+    operationKey,
+    path: `/${path}`,
+    search: url.search ? url.search : null,
+  }
+}
+
+export function createSupabaseInstrumentationConfig(
+  config: SupabaseInstrumentationConfig
+): Pick<SupabaseClientOptions<'public'>, 'global'> {
+  if (!globalFetch) {
+    return {}
+  }
+
+  const supabaseUrl =
+    typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_SUPABASE_URL : undefined
+
+  if (!supabaseUrl) {
+    return {}
+  }
+
+  const normalizedBase = new URL(supabaseUrl)
+  const baseOrigin = normalizedBase.origin
+
+  const instrumentedFetch: typeof fetch = async (input, init) => {
+    const requestUrl = extractUrl(input)
+
+    const shouldTrack = requestUrl.startsWith(baseOrigin)
+
+    const start = getTimestamp()
+    let response: Response | undefined
+    let fetchError: unknown
+
+    try {
+      response = await globalFetch(input as any, init)
+      return response
+    } catch (error) {
+      fetchError = error
+      throw error
+    } finally {
+      if (!shouldTrack) {
+        return
+      }
+
+      const end = getTimestamp()
+      const durationMs = end - start
+
+      try {
+        const parsedUrl = new URL(requestUrl)
+        const operation = normalizeSupabaseOperation(parsedUrl)
+
+        recordPerformanceSample({
+          key: `supabase:${operation.operationKey}:${extractMethod(input, init)}`,
+          durationMs,
+          source: 'supabase-client',
+          environment: config.environment,
+          helper: config.helper,
+          statusCode: response?.status ?? null,
+          metadata: {
+            ...config.context,
+            method: extractMethod(input, init),
+            path: operation.path,
+            search: operation.search,
+            status: response?.status ?? null,
+            error: fetchError instanceof Error ? fetchError.message : undefined,
+          },
+        })
+      } catch (error) {
+        if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+          console.warn('Failed to record Supabase performance sample', error)
+        }
+      }
+    }
+  }
+
+  return { global: { fetch: instrumentedFetch } }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,8 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
+import { createSupabaseInstrumentationConfig } from '@/lib/supabase'
+
 export async function middleware(request: NextRequest) {
   let response = NextResponse.next({
     request: {
@@ -53,6 +55,11 @@ export async function middleware(request: NextRequest) {
           })
         },
       },
+      ...createSupabaseInstrumentationConfig({
+        helper: 'middleware',
+        environment: 'edge',
+        context: { scope: 'middleware', matcher: 'app-wide' },
+      }),
     }
   )
 

--- a/supabase/migrations/20250109_performance_monitoring.sql
+++ b/supabase/migrations/20250109_performance_monitoring.sql
@@ -1,0 +1,258 @@
+-- Performance monitoring schema and scheduled alerting
+
+-- Ensure required extensions are available
+CREATE EXTENSION IF NOT EXISTS pg_net;
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS vault;
+
+-- Raw performance log storage (outlier samples)
+CREATE TABLE IF NOT EXISTS public.performance_logs (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  source TEXT NOT NULL CHECK (source IN ('supabase-client', 'api-middleware')),
+  key TEXT NOT NULL,
+  helper TEXT,
+  environment TEXT NOT NULL CHECK (environment IN ('server', 'browser', 'edge', 'worker')),
+  duration_ms NUMERIC NOT NULL,
+  threshold TEXT NOT NULL CHECK (threshold IN ('p95', 'p99')),
+  calculated_p95_ms NUMERIC,
+  calculated_p99_ms NUMERIC,
+  sample_size INTEGER,
+  status_code INTEGER,
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_performance_logs_created_at
+  ON public.performance_logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_performance_logs_key
+  ON public.performance_logs (key);
+CREATE INDEX IF NOT EXISTS idx_performance_logs_source
+  ON public.performance_logs (source);
+
+-- Threshold configuration describing alert windows and channels
+CREATE TABLE IF NOT EXISTS public.performance_thresholds (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  target TEXT NOT NULL UNIQUE,
+  description TEXT,
+  window_interval INTERVAL NOT NULL DEFAULT INTERVAL '15 minutes',
+  max_p95_ms NUMERIC,
+  max_p99_ms NUMERIC,
+  max_p95_count INTEGER,
+  max_p99_count INTEGER,
+  slack_webhook_secret TEXT,
+  email_webhook_secret TEXT,
+  email_recipients TEXT[],
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  last_triggered_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX IF NOT EXISTS idx_performance_thresholds_active
+  ON public.performance_thresholds (active)
+  WHERE active IS TRUE;
+
+-- Historical alert records for auditing notifications
+CREATE TABLE IF NOT EXISTS public.performance_alerts (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  target TEXT NOT NULL,
+  window_start TIMESTAMP WITH TIME ZONE NOT NULL,
+  window_end TIMESTAMP WITH TIME ZONE NOT NULL,
+  p95_duration_ms NUMERIC,
+  p99_duration_ms NUMERIC,
+  p95_breach_count INTEGER DEFAULT 0,
+  p99_breach_count INTEGER DEFAULT 0,
+  sample_size INTEGER DEFAULT 0,
+  notification_status TEXT NOT NULL CHECK (notification_status IN ('sent', 'failed', 'skipped')),
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_performance_alerts_target
+  ON public.performance_alerts (target);
+CREATE INDEX IF NOT EXISTS idx_performance_alerts_created_at
+  ON public.performance_alerts (created_at DESC);
+
+ALTER TABLE public.performance_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.performance_thresholds ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.performance_alerts ENABLE ROW LEVEL SECURITY;
+
+-- Aggregation and notification routine
+CREATE OR REPLACE FUNCTION public.process_performance_metrics()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_threshold RECORD;
+  v_now TIMESTAMP WITH TIME ZONE := NOW();
+  v_window_start TIMESTAMP WITH TIME ZONE;
+  v_metrics RECORD;
+  v_slack_url TEXT;
+  v_email_url TEXT;
+  v_payload JSONB;
+  v_status TEXT;
+BEGIN
+  FOR v_threshold IN
+    SELECT *
+    FROM public.performance_thresholds
+    WHERE active IS TRUE
+  LOOP
+    v_window_start := v_now - COALESCE(v_threshold.window_interval, INTERVAL '15 minutes');
+
+    SELECT
+      COUNT(*)::INTEGER AS sample_size,
+      COUNT(*) FILTER (WHERE threshold = 'p95')::INTEGER AS p95_breach_count,
+      COUNT(*) FILTER (WHERE threshold = 'p99')::INTEGER AS p99_breach_count,
+      MAX(calculated_p95_ms)::NUMERIC AS observed_p95_ms,
+      MAX(calculated_p99_ms)::NUMERIC AS observed_p99_ms,
+      MAX(duration_ms) FILTER (WHERE threshold = 'p95')::NUMERIC AS max_p95_duration_ms,
+      MAX(duration_ms) FILTER (WHERE threshold = 'p99')::NUMERIC AS max_p99_duration_ms
+    INTO v_metrics
+    FROM public.performance_logs
+    WHERE key = v_threshold.target
+      AND created_at >= v_window_start
+      AND created_at <= v_now;
+
+    IF COALESCE(v_metrics.sample_size, 0) = 0 THEN
+      CONTINUE;
+    END IF;
+
+    IF (v_threshold.max_p95_ms IS NOT NULL AND COALESCE(v_metrics.observed_p95_ms, 0) > v_threshold.max_p95_ms)
+       OR (v_threshold.max_p99_ms IS NOT NULL AND COALESCE(v_metrics.observed_p99_ms, 0) > v_threshold.max_p99_ms)
+       OR (v_threshold.max_p95_count IS NOT NULL AND v_metrics.p95_breach_count > v_threshold.max_p95_count)
+       OR (v_threshold.max_p99_count IS NOT NULL AND v_metrics.p99_breach_count > v_threshold.max_p99_count)
+    THEN
+      v_payload := jsonb_build_object(
+        'target', v_threshold.target,
+        'window', jsonb_build_object('start', v_window_start, 'end', v_now),
+        'metrics', jsonb_build_object(
+          'sample_size', v_metrics.sample_size,
+          'p95_count', v_metrics.p95_breach_count,
+          'p99_count', v_metrics.p99_breach_count,
+          'observed_p95_ms', v_metrics.observed_p95_ms,
+          'observed_p99_ms', v_metrics.observed_p99_ms,
+          'max_p95_duration_ms', v_metrics.max_p95_duration_ms,
+          'max_p99_duration_ms', v_metrics.max_p99_duration_ms
+        ),
+        'thresholds', jsonb_build_object(
+          'max_p95_ms', v_threshold.max_p95_ms,
+          'max_p99_ms', v_threshold.max_p99_ms,
+          'max_p95_count', v_threshold.max_p95_count,
+          'max_p99_count', v_threshold.max_p99_count
+        ),
+        'metadata', COALESCE(v_threshold.metadata, '{}'::jsonb)
+      );
+
+      v_status := 'sent';
+
+      IF v_threshold.slack_webhook_secret IS NOT NULL THEN
+        BEGIN
+          v_slack_url := vault.get_secret(v_threshold.slack_webhook_secret)::TEXT;
+        EXCEPTION
+          WHEN OTHERS THEN
+            v_slack_url := NULL;
+        END;
+
+        IF v_slack_url IS NOT NULL THEN
+          BEGIN
+            PERFORM net.http_post(
+              url := v_slack_url,
+              headers := jsonb_build_object('Content-Type', 'application/json'),
+              body := jsonb_build_object(
+                'text',
+                format(
+                  ':rotating_light: Performance alert for %s\nWindow: %s → %s\nObserved p95: %s ms (limit %s)\nObserved p99: %s ms (limit %s)\nBreaches — p95: %s, p99: %s',
+                  v_threshold.target,
+                  v_window_start,
+                  v_now,
+                  COALESCE(v_metrics.observed_p95_ms, 0),
+                  COALESCE(v_threshold.max_p95_ms, 0),
+                  COALESCE(v_metrics.observed_p99_ms, 0),
+                  COALESCE(v_threshold.max_p99_ms, 0),
+                  COALESCE(v_metrics.p95_breach_count, 0),
+                  COALESCE(v_metrics.p99_breach_count, 0)
+                )
+              )::TEXT
+            );
+          EXCEPTION
+            WHEN OTHERS THEN
+              v_status := 'failed';
+          END;
+        END IF;
+      END IF;
+
+      IF v_threshold.email_webhook_secret IS NOT NULL AND v_threshold.email_recipients IS NOT NULL THEN
+        BEGIN
+          v_email_url := vault.get_secret(v_threshold.email_webhook_secret)::TEXT;
+        EXCEPTION
+          WHEN OTHERS THEN
+            v_email_url := NULL;
+        END;
+
+        IF v_email_url IS NOT NULL THEN
+          BEGIN
+            PERFORM net.http_post(
+              url := v_email_url,
+              headers := jsonb_build_object('Content-Type', 'application/json'),
+              body := jsonb_build_object(
+                'subject', COALESCE(v_threshold.metadata->>'email_subject', format('Performance alert for %s', v_threshold.target)),
+                'recipients', v_threshold.email_recipients,
+                'payload', v_payload
+              )::TEXT
+            );
+          EXCEPTION
+            WHEN OTHERS THEN
+              v_status := 'failed';
+          END;
+        END IF;
+      END IF;
+
+      INSERT INTO public.performance_alerts (
+        target,
+        window_start,
+        window_end,
+        p95_duration_ms,
+        p99_duration_ms,
+        p95_breach_count,
+        p99_breach_count,
+        sample_size,
+        notification_status,
+        metadata
+      )
+      VALUES (
+        v_threshold.target,
+        v_window_start,
+        v_now,
+        v_metrics.observed_p95_ms,
+        v_metrics.observed_p99_ms,
+        COALESCE(v_metrics.p95_breach_count, 0),
+        COALESCE(v_metrics.p99_breach_count, 0),
+        COALESCE(v_metrics.sample_size, 0),
+        v_status,
+        v_payload
+      );
+
+      UPDATE public.performance_thresholds
+      SET last_triggered_at = v_now
+      WHERE id = v_threshold.id;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+-- Schedule aggregation to run every five minutes
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'performance-metrics-aggregation'
+  ) THEN
+    PERFORM cron.schedule(
+      'performance-metrics-aggregation',
+      '*/5 * * * *',
+      $$SELECT public.process_performance_metrics();$$
+    );
+  END IF;
+END;
+$$;

--- a/utils/supa-auth-admin.tsx
+++ b/utils/supa-auth-admin.tsx
@@ -1,13 +1,23 @@
 import { createClient } from '@supabase/supabase-js'
+
+import { createSupabaseInstrumentationConfig } from '@/lib/supabase'
 import type { Database } from '@/lib/supabase'
 
-const supabase = createClient<Database>(process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-  auth: {
-    autoRefreshToken: false,
-    persistSession: false
+const supabase = createClient<Database>(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+    ...createSupabaseInstrumentationConfig({
+      helper: 'utils/supa-auth-admin',
+      environment: 'server',
+      context: { helper: 'utils/supa-auth-admin' },
+    }),
   }
-})
+)
 
 // Access auth admin api
 export const adminAuthClient = supabase.auth.admin

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,6 +1,8 @@
 import { type CookieOptions, createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import { createSupabaseInstrumentationConfig } from '@/lib/supabase'
+
 export function createClient(cookieStore: ReturnType<typeof cookies>) {
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL || '',
@@ -17,6 +19,11 @@ export function createClient(cookieStore: ReturnType<typeof cookies>) {
           cookieStore.set({ name, value: '', ...options })
         },
       },
+      ...createSupabaseInstrumentationConfig({
+        helper: 'supa-server-actions',
+        environment: 'server',
+        context: { helper: 'utils/supa-server-actions' },
+      }),
     }
   )
 }

--- a/utils/supabase-browser.ts
+++ b/utils/supabase-browser.ts
@@ -3,6 +3,7 @@
 import { createBrowserClient } from "@supabase/ssr"
 import { useMemo } from "react"
 
+import { createSupabaseInstrumentationConfig } from "@/lib/supabase"
 import type { Database } from "@/lib/supabase"
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
 
@@ -13,9 +14,14 @@ function getSupabaseBrowserClient() {
     return client
   }
 
-  client = createBrowserClient<any>(
+  client = createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL || '',
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+    createSupabaseInstrumentationConfig({
+      helper: 'utils/supabase-browser',
+      environment: 'browser',
+      context: { helper: 'utils/supabase-browser' },
+    })
   )
 
   return client

--- a/utils/supabase-server.ts
+++ b/utils/supabase-server.ts
@@ -2,6 +2,8 @@ import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import type { Database } from '@/lib/supabase'
 
+import { createSupabaseInstrumentationConfig } from '@/lib/supabase'
+
 export default function createSupabaseServer(
   cookieStore: ReturnType<typeof cookies>
 ) {
@@ -14,6 +16,11 @@ export default function createSupabaseServer(
           return cookieStore.get(name)?.value
         },
       },
+      ...createSupabaseInstrumentationConfig({
+        helper: 'utils/supabase-server',
+        environment: 'server',
+        context: { helper: 'utils/supabase-server' },
+      }),
     }
   )
 }

--- a/utils/supabase/actions.ts
+++ b/utils/supabase/actions.ts
@@ -4,6 +4,8 @@ import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import type { Database } from '@/lib/supabase';
 
+import { createSupabaseInstrumentationConfig } from '@/lib/supabase';
+
 export async function createActionClient() {
   const cookieStore = cookies();
 
@@ -22,6 +24,11 @@ export async function createActionClient() {
           cookieStore.set({ name, value: '', ...options });
         },
       },
+      ...createSupabaseInstrumentationConfig({
+        helper: 'utils/supabase/actions',
+        environment: 'server',
+        context: { helper: 'utils/supabase/actions' },
+      }),
     }
   );
 }

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,6 +1,8 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import { createSupabaseInstrumentationConfig } from '@/lib/supabase'
+
 export function createClient() {
   const cookieStore = cookies()
 
@@ -31,6 +33,11 @@ export function createClient() {
           }
         },
       },
+      ...createSupabaseInstrumentationConfig({
+        helper: 'utils/supabase/server',
+        environment: 'server',
+        context: { helper: 'utils/supabase/server' },
+      }),
     }
   )
 }

--- a/utils/supaone.tsx
+++ b/utils/supaone.tsx
@@ -3,40 +3,52 @@ import { cookies } from "next/headers";
 import type { Database } from '@/lib/supabase'
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
 
+import { createSupabaseInstrumentationConfig } from '@/lib/supabase'
+
 export async function createSupbaseServerClientReadOnly() {
 	const cookieStore = cookies();
 
-	return createServerClient(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				get(name: string) {
-					return cookieStore.get(name)?.value;
-				},
-			},
-		}
-	);
+        return createServerClient(
+                process.env.NEXT_PUBLIC_SUPABASE_URL!,
+                process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+                {
+                        cookies: {
+                                get(name: string) {
+                                        return cookieStore.get(name)?.value;
+                                },
+                        },
+                        ...createSupabaseInstrumentationConfig({
+                                helper: 'utils/supaone#read-only',
+                                environment: 'server',
+                                context: { helper: 'utils/supaone', mode: 'readonly' },
+                        }),
+                }
+        );
 }
 
 export async function createSupbaseServerClient() {
 	const cookieStore = cookies();
 
-	return createServerClient<Database>(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				get(name: string) {
-					return cookieStore.get(name)?.value;
-				},
-				set(name: string, value: string, options: CookieOptions) {
-					cookieStore.set({ name, value, ...options });
-				},
-				remove(name: string, options: CookieOptions) {
-					cookieStore.set({ name, value: "", ...options });
-				},
-			},
-		}
-	);
+        return createServerClient<Database>(
+                process.env.NEXT_PUBLIC_SUPABASE_URL!,
+                process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+                {
+                        cookies: {
+                                get(name: string) {
+                                        return cookieStore.get(name)?.value;
+                                },
+                                set(name: string, value: string, options: CookieOptions) {
+                                        cookieStore.set({ name, value, ...options });
+                                },
+                                remove(name: string, options: CookieOptions) {
+                                        cookieStore.set({ name, value: "", ...options });
+                                },
+                        },
+                        ...createSupabaseInstrumentationConfig({
+                                helper: 'utils/supaone',
+                                environment: 'server',
+                                context: { helper: 'utils/supaone', mode: 'mutating' },
+                        }),
+                }
+        );
 }


### PR DESCRIPTION
## Summary
- add percentile-based performance logging utilities and instrumentation helpers for Supabase clients
- wire instrumentation into existing server/browser helpers and add edge middleware to capture API handler latency
- create Supabase schema, cron job, and documentation for performance log aggregation and alerting

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d7a6c848328b32e6daf37e54074