### PR TITLE
Add regional uptime monitoring automation

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,39 @@
+name: Edge uptime checks
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+jobs:
+  run-uptime-probe:
+    name: Run regional uptime probes
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      UPTIME_BASE_URL_AMERICAS: ${{ secrets.UPTIME_BASE_URL_AMERICAS }}
+      UPTIME_BASE_URL_EMEA: ${{ secrets.UPTIME_BASE_URL_EMEA }}
+      UPTIME_BASE_URL_APAC: ${{ secrets.UPTIME_BASE_URL_APAC }}
+      UPTIME_ALERT_WEBHOOK: ${{ secrets.UPTIME_ALERT_WEBHOOK }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Execute uptime probes
+        run: pnpm run uptime:check

--- a/config/uptime.json
+++ b/config/uptime.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "requestTimeoutMs": 8000,
+  "responseExcerptLength": 256,
+  "consecutiveFailureThreshold": 3,
+  "failWorkflowOnAlert": true,
+  "endpoints": [
+    { "path": "/health", "method": "GET" },
+    { "path": "/dashboard", "method": "GET" },
+    { "path": "/bookings", "method": "GET" }
+  ],
+  "regions": [
+    {
+      "id": "americas",
+      "label": "Americas Edge",
+      "baseUrlEnv": "UPTIME_BASE_URL_AMERICAS"
+    },
+    {
+      "id": "emea",
+      "label": "EMEA Edge",
+      "baseUrlEnv": "UPTIME_BASE_URL_EMEA"
+    },
+    {
+      "id": "apac",
+      "label": "APAC Edge",
+      "baseUrlEnv": "UPTIME_BASE_URL_APAC"
+    }
+  ]
+}

--- a/docs/perf/uptime.md
+++ b/docs/perf/uptime.md
@@ -1,0 +1,85 @@
+# Uptime Monitoring Playbook
+
+The portal now performs scheduled uptime probes from the Americas, EMEA, and APAC edges to ensure `/health`, `/dashboard`, and `/bookings` remain reachable. This document explains how the probes run, how results are stored, and how to interpret the metrics.
+
+## Execution Flow
+
+| Component | Purpose |
+| --- | --- |
+| `.github/workflows/uptime.yml` | Runs every 30 minutes (and on demand) to execute the uptime probes. |
+| `scripts/uptime-check.mjs` | Reads `config/uptime.json`, calls each endpoint per region, and records latency + status. |
+| `config/uptime.json` | Declarative definition of regions, endpoints, failure thresholds, and runtime defaults. |
+| `supabase/migrations/20250107_uptime_monitoring.sql` | Creates the `uptime_checks` table for storing historical results. |
+
+Each workflow run resolves region-specific base URLs from environment variables, executes the probes sequentially, and records a row per `(region, endpoint)` combination. Latency is measured client-side using Node's high-resolution timer.
+
+## Configuration Summary
+
+`config/uptime.json` centralises every knob used by the monitoring job. The defaults are:
+
+- **Request timeout:** 8 000 ms
+- **Excerpt length:** 256 characters (response bodies are truncated before storage)
+- **Consecutive failure threshold:** 3 strikes before an alert is emitted
+- **Workflow failure on alert:** enabled (the GitHub Action exits non-zero once the threshold is crossed)
+
+Region base URLs are supplied through secrets to keep production hosts out of the repository:
+
+| Region | Label | Expected secret |
+| --- | --- | --- |
+| Americas | `Americas Edge` | `UPTIME_BASE_URL_AMERICAS` |
+| EMEA | `EMEA Edge` | `UPTIME_BASE_URL_EMEA` |
+| APAC | `APAC Edge` | `UPTIME_BASE_URL_APAC` |
+
+You can override defaults or add endpoints by editing the JSON file and committing the changes. Local dry-runs are available via `pnpm run uptime:check` once the same environment variables are exported.
+
+## Data Model
+
+All observations land in the `public.uptime_checks` table. Key columns include:
+
+| Column | Description |
+| --- | --- |
+| `checked_at` | UTC timestamp of the probe execution. |
+| `region` / `region_label` | Machine and human readable identifiers for the edge location. |
+| `endpoint` / `http_method` | Path and verb that were tested. |
+| `status_code` & `success` | HTTP response metadata determining pass/fail. |
+| `latency_ms` | Round-trip time recorded from the runner. |
+| `consecutive_failures` | Rolling failure streak used to trigger alerts. |
+| `response_excerpt` & `error_message` | Troubleshooting context captured on failure. |
+
+Supabase exposes two helpful indexes for querying recent results:
+
+```sql
+-- last 24 hours of probes with failure streaks
+delimiter $$
+select
+  region,
+  endpoint,
+  max(checked_at) as last_check,
+  min(latency_ms) filter (where success) as best_latency_ms,
+  avg(latency_ms) as avg_latency_ms,
+  max(consecutive_failures) as highest_failure_streak,
+  sum(case when success then 1 else 0 end)::decimal / count(*) as success_ratio
+from public.uptime_checks
+where checked_at >= now() - interval '1 day'
+group by region, endpoint
+order by region, endpoint;
+$$;
+```
+
+## Alerting
+
+When a probe fails, the script increments the stored `consecutive_failures` counter. Once the threshold is reached, two things happen:
+
+1. The GitHub Action step logs the alert and, if `config.failWorkflowOnAlert` is `true`, exits with a non-zero status so failures surface in the Actions UI.
+2. If `UPTIME_ALERT_WEBHOOK` is configured, a JSON payload containing the region, endpoint, status, latency, and failure reason is delivered to the webhook (compatible with Slack/Teams generic incoming webhooks).
+
+Missing webhook secrets do not block data collection—the script logs a warning instead. Historical alerts can therefore be reconstructed by filtering for rows where `consecutive_failures` ≥ threshold.
+
+## Operations Checklist
+
+- **Rotate secrets** whenever endpoints move or credentials change (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, regional base URLs, webhook URL).
+- **Update config** if new surfaces need monitoring or thresholds change; commit to keep automation reproducible.
+- **Inspect results** in Supabase or any BI tool using the `uptime_checks` table. The sample SQL above provides a rolling success ratio.
+- **Triaging alerts:** reconcile the webhook notification with entries in `uptime_checks` to differentiate transient blips from sustained downtime.
+
+With this workflow in place, the team has end-to-end visibility from probe execution through to alert delivery for critical tenant-facing endpoints.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -187,6 +187,23 @@ export type Database = {
         created_at: string | null
         updated_at: string | null
       }>
+      uptime_checks: SupabaseTable<{
+        id: string
+        checked_at: string
+        region: string
+        region_label: string
+        endpoint: string
+        http_method: string
+        full_url: string
+        status_code: number | null
+        success: boolean
+        latency_ms: number | null
+        error_message: string | null
+        response_excerpt: string | null
+        consecutive_failures: number
+        config_version: number
+        metadata: Json
+      }>
       notifications: SupabaseTable<{
         id: string
         user_id: string

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "uptime:check": "node scripts/uptime-check.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/scripts/uptime-check.mjs
+++ b/scripts/uptime-check.mjs
@@ -1,0 +1,388 @@
+import { readFile } from "fs/promises"
+import path from "path"
+import process from "process"
+import { fileURLToPath } from "url"
+import { performance } from "perf_hooks"
+import { randomUUID } from "crypto"
+import { createClient } from "@supabase/supabase-js"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+async function loadConfig() {
+  const configPath = path.resolve(__dirname, "../config/uptime.json")
+  const configRaw = await readFile(configPath, "utf-8")
+  const config = JSON.parse(configRaw)
+  if (!Array.isArray(config.regions) || config.regions.length === 0) {
+    throw new Error("Uptime configuration must define at least one region")
+  }
+  if (!Array.isArray(config.endpoints) || config.endpoints.length === 0) {
+    throw new Error("Uptime configuration must define at least one endpoint")
+  }
+  return config
+}
+
+function resolveBaseUrl(region) {
+  if (region.baseUrlEnv) {
+    const envValue = process.env[region.baseUrlEnv]
+    if (envValue && envValue.trim().length > 0) {
+      return envValue.trim()
+    }
+  }
+  if (region.baseUrl) {
+    return region.baseUrl
+  }
+  return null
+}
+
+function normalisePath(endpointPath) {
+  if (!endpointPath || typeof endpointPath !== "string") {
+    throw new Error("Endpoint path must be a non-empty string")
+  }
+  return endpointPath.startsWith("/") ? endpointPath : `/${endpointPath}`
+}
+
+function buildUrl(baseUrl, endpointPath) {
+  try {
+    const url = new URL(endpointPath, baseUrl)
+    return url.toString()
+  } catch (error) {
+    throw new Error(`Unable to build URL from base '${baseUrl}' and path '${endpointPath}': ${error.message}`)
+  }
+}
+
+function excerpt(body, length) {
+  if (!body || !length) return null
+  if (body.length <= length) {
+    return body
+  }
+  return `${body.slice(0, length)}…`
+}
+
+async function fetchPreviousFailures(supabase, regionId, endpointPath) {
+  const { data, error } = await supabase
+    .from("uptime_checks")
+    .select("consecutive_failures")
+    .eq("region", regionId)
+    .eq("endpoint", endpointPath)
+    .order("checked_at", { ascending: false })
+    .limit(1)
+
+  if (error) {
+    throw new Error(`Failed to read previous uptime check: ${error.message}`)
+  }
+
+  if (!data || data.length === 0) {
+    return 0
+  }
+
+  return data[0]?.consecutive_failures ?? 0
+}
+
+async function recordUptimeCheck({
+  supabase,
+  region,
+  regionLabel,
+  endpointPath,
+  method,
+  url,
+  config,
+  runId,
+  baseUrl,
+}) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), config.requestTimeoutMs)
+  const startedAt = performance.now()
+
+  let statusCode = null
+  let responseText = null
+  let success = false
+  let errorMessage = null
+
+  try {
+    const response = await fetch(url, {
+      method,
+      signal: controller.signal,
+      headers: {
+        "User-Agent": `roomsily-uptime-monitor/${config.version ?? "1"}`,
+      },
+    })
+    const latency = Math.round(performance.now() - startedAt)
+    statusCode = response.status
+    success = response.ok
+    try {
+      responseText = await response.text()
+    } catch (responseReadError) {
+      responseText = null
+      if (!success) {
+        errorMessage =
+          responseReadError instanceof Error
+            ? responseReadError.message
+            : String(responseReadError)
+      }
+    }
+    clearTimeout(timeout)
+
+    if (!success && !errorMessage) {
+      errorMessage = `Request completed with status ${statusCode} ${response.statusText ?? ""}`.trim()
+    }
+
+    const previousFailures = await fetchPreviousFailures(
+      supabase,
+      region,
+      endpointPath
+    )
+    const consecutiveFailures = success ? 0 : previousFailures + 1
+
+    const { error: insertError } = await supabase.from("uptime_checks").insert({
+      region,
+      region_label: regionLabel,
+      endpoint: endpointPath,
+      http_method: method,
+      full_url: url,
+      status_code: statusCode,
+      success,
+      latency_ms: latency,
+      error_message: errorMessage,
+      response_excerpt: excerpt(responseText, config.responseExcerptLength),
+      consecutive_failures: consecutiveFailures,
+      config_version: config.version ?? 1,
+      metadata: {
+        runId,
+        baseUrl,
+        requestTimeoutMs: config.requestTimeoutMs,
+        configVersion: config.version ?? 1,
+      },
+    })
+
+    if (insertError) {
+      throw new Error(`Failed to store uptime check: ${insertError.message}`)
+    }
+
+    return {
+      success,
+      statusCode,
+      latency,
+      errorMessage,
+      consecutiveFailures,
+    }
+  } catch (error) {
+    clearTimeout(timeout)
+    const latency = Math.round(performance.now() - startedAt)
+    const failureReason =
+      error instanceof Error
+        ? error.name === "AbortError"
+          ? `Request timed out after ${config.requestTimeoutMs}ms`
+          : error.message
+        : String(error)
+
+    const previousFailures = await fetchPreviousFailures(
+      supabase,
+      region,
+      endpointPath
+    ).catch((readError) => {
+      throw new Error(`Failed to read previous failures: ${readError.message}`)
+    })
+
+    const consecutiveFailures = previousFailures + 1
+
+    const { error: insertError } = await supabase.from("uptime_checks").insert({
+      region,
+      region_label: regionLabel,
+      endpoint: endpointPath,
+      http_method: method,
+      full_url: url,
+      status_code: statusCode,
+      success: false,
+      latency_ms: latency,
+      error_message: failureReason,
+      response_excerpt: excerpt(responseText, config.responseExcerptLength),
+      consecutive_failures: consecutiveFailures,
+      config_version: config.version ?? 1,
+      metadata: {
+        runId,
+        baseUrl,
+        requestTimeoutMs: config.requestTimeoutMs,
+        configVersion: config.version ?? 1,
+      },
+    })
+
+    if (insertError) {
+      throw new Error(`Failed to store uptime failure: ${insertError.message}`)
+    }
+
+    return {
+      success: false,
+      statusCode,
+      latency,
+      errorMessage: failureReason,
+      consecutiveFailures,
+    }
+  }
+}
+
+async function sendAlert({ regionLabel, endpointPath, statusCode, errorMessage, latency, consecutiveFailures, url }, config) {
+  const webhookUrl = process.env.UPTIME_ALERT_WEBHOOK
+  const summary = `Uptime degradation detected for ${regionLabel} ${endpointPath} (streak: ${consecutiveFailures}).`
+  const payload = {
+    text: `${summary}\nURL: ${url}\nStatus: ${statusCode ?? "no-response"}\nLatency: ${latency ?? "n/a"}ms\nError: ${errorMessage ?? "unknown"}`,
+  }
+
+  if (!webhookUrl) {
+    console.warn(
+      `${summary} No UPTIME_ALERT_WEBHOOK configured; recording alert without external notification.`
+    )
+    return { delivered: false }
+  }
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      const responseBody = await response.text().catch(() => "")
+      throw new Error(
+        `Webhook responded with ${response.status}: ${response.statusText}. ${responseBody}`.trim()
+      )
+    }
+
+    console.info(`Alert delivered for ${regionLabel} ${endpointPath}`)
+    return { delivered: true }
+  } catch (error) {
+    console.error(`Failed to deliver alert: ${error instanceof Error ? error.message : String(error)}`)
+    return { delivered: false, error }
+  }
+}
+
+async function main() {
+  const config = await loadConfig()
+  if (!config.requestTimeoutMs) {
+    config.requestTimeoutMs = 10000
+  }
+  if (!config.responseExcerptLength) {
+    config.responseExcerptLength = 256
+  }
+  if (!config.consecutiveFailureThreshold) {
+    config.consecutiveFailureThreshold = 3
+  }
+  if (typeof config.failWorkflowOnAlert !== "boolean") {
+    config.failWorkflowOnAlert = false
+  }
+  const supabaseUrl = process.env.SUPABASE_URL
+  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl) {
+    throw new Error("SUPABASE_URL must be provided for uptime checks")
+  }
+
+  if (!supabaseServiceRoleKey) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY must be provided for uptime checks")
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { persistSession: false },
+  })
+
+  const runId = randomUUID()
+  const summary = []
+  let workflowShouldFail = false
+
+  for (const region of config.regions) {
+    const baseUrl = resolveBaseUrl(region)
+    const regionLabel = region.label ?? region.id
+
+    if (!baseUrl) {
+      console.error(
+        `Skipping region '${region.id}' because no base URL was provided via configuration or environment variable.`
+      )
+      workflowShouldFail = true
+      continue
+    }
+
+    const endpoints = Array.isArray(region.endpoints) && region.endpoints.length
+      ? region.endpoints
+      : config.endpoints
+
+    for (const endpoint of endpoints) {
+      const endpointPath = normalisePath(endpoint.path)
+      const method = (endpoint.method ?? "GET").toUpperCase()
+      const url = buildUrl(baseUrl, endpointPath)
+
+      try {
+        const result = await recordUptimeCheck({
+          supabase,
+          region: region.id,
+          regionLabel,
+          endpointPath,
+          method,
+          url,
+          config,
+          runId,
+          baseUrl,
+        })
+
+        summary.push({
+          region: regionLabel,
+          endpoint: endpointPath,
+          success: result.success,
+          statusCode: result.statusCode,
+          latency: result.latency,
+          consecutiveFailures: result.consecutiveFailures,
+        })
+
+        if (
+          !result.success &&
+          result.consecutiveFailures >= config.consecutiveFailureThreshold
+        ) {
+          console.warn(
+            `Consecutive failure threshold reached for ${regionLabel} ${endpointPath} (streak: ${result.consecutiveFailures}).`
+          )
+          await sendAlert(
+            {
+              regionLabel,
+              endpointPath,
+              statusCode: result.statusCode,
+              errorMessage: result.errorMessage,
+              latency: result.latency,
+              consecutiveFailures: result.consecutiveFailures,
+              url,
+            },
+            config
+          )
+
+          if (config.failWorkflowOnAlert) {
+            workflowShouldFail = true
+          }
+        }
+      } catch (error) {
+        workflowShouldFail = true
+        console.error(
+          `Failed to record uptime check for ${regionLabel} ${endpointPath}: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+    }
+  }
+
+  console.table(
+    summary.map((entry) => ({
+      Region: entry.region,
+      Endpoint: entry.endpoint,
+      Status: entry.success ? "ok" : "failed",
+      "HTTP": entry.statusCode ?? "-",
+      "Latency (ms)": entry.latency ?? "-",
+      "Failure Streak": entry.consecutiveFailures,
+    }))
+  )
+
+  if (workflowShouldFail) {
+    process.exit(1)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/supabase/migrations/20250107_uptime_monitoring.sql
+++ b/supabase/migrations/20250107_uptime_monitoring.sql
@@ -1,0 +1,39 @@
+create table if not exists public.uptime_checks (
+  id uuid primary key default gen_random_uuid(),
+  checked_at timestamptz not null default timezone('utc'::text, now()),
+  region text not null,
+  region_label text not null,
+  endpoint text not null,
+  http_method text not null default 'GET',
+  full_url text not null,
+  status_code integer,
+  success boolean not null,
+  latency_ms integer,
+  error_message text,
+  response_excerpt text,
+  consecutive_failures integer not null default 0,
+  config_version integer not null default 1,
+  metadata jsonb not null default '{}'::jsonb
+);
+
+comment on table public.uptime_checks is 'Stores uptime probe results for regional health checks.';
+comment on column public.uptime_checks.checked_at is 'Timestamp when the probe executed.';
+comment on column public.uptime_checks.region is 'Machine-readable region identifier (e.g., americas, emea, apac).';
+comment on column public.uptime_checks.region_label is 'Human-readable region label to display in dashboards.';
+comment on column public.uptime_checks.endpoint is 'Path that was checked (e.g., /health).';
+comment on column public.uptime_checks.http_method is 'HTTP method used when probing the endpoint.';
+comment on column public.uptime_checks.full_url is 'Absolute URL that was probed.';
+comment on column public.uptime_checks.status_code is 'HTTP status code returned by the probe.';
+comment on column public.uptime_checks.success is 'Flag set to true when the probe response was 2xx/3xx.';
+comment on column public.uptime_checks.latency_ms is 'Total response time measured in milliseconds.';
+comment on column public.uptime_checks.error_message is 'Failure reason captured for unsuccessful probes.';
+comment on column public.uptime_checks.response_excerpt is 'Truncated body excerpt stored for debugging.';
+comment on column public.uptime_checks.consecutive_failures is 'Number of consecutive failures observed for this region+endpoint pair.';
+comment on column public.uptime_checks.config_version is 'Version of config/uptime.json used to run the probe.';
+comment on column public.uptime_checks.metadata is 'JSON metadata captured for the probe execution.';
+
+create index if not exists uptime_checks_region_endpoint_checked_at_idx
+  on public.uptime_checks (region, endpoint, checked_at desc);
+
+create index if not exists uptime_checks_checked_at_idx
+  on public.uptime_checks (checked_at desc);


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Action that runs regional uptime probes for key endpoints
- implement a reusable Node.js probe runner that records results in Supabase and emits webhook alerts after repeated failures
- document the uptime pipeline, ship configuration, and add the uptime_checks schema/types for reproducibility

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d798820832894ff5e5e0d18fc5e