### PR TITLE
Add Next.js bundle analyzer workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+artifacts/
 
 # debug
 npm-debug.log*

--- a/docs/perf/bundle-analyzer.md
+++ b/docs/perf/bundle-analyzer.md
@@ -1,0 +1,29 @@
+# Bundle Analyzer Workflow
+
+## Running the analyzer
+
+1. From the repository root, run `pnpm analyze:bundle`.
+   - The script sets `ANALYZE=true` for `next build`, enabling `@next/bundle-analyzer`.
+   - After the build completes, `scripts/analyze-bundle.js` parses `.next/analyze/client-stats.json`, creates `artifacts/bundle/top-modules.txt`, and enforces the module budget.
+2. Open the generated bundle reports in `.next/analyze/*.html` for an interactive treemap if you want to drill deeper into chunk composition.
+
+> **Tip:** If you only need to rebuild the text summary after a previous analyze run, execute `node scripts/analyze-bundle.js`. It will reuse the existing stats JSON.
+
+## Inspecting results
+
+- `artifacts/bundle/top-modules.txt` lists the 20 heaviest modules by gzipped size with their paths and sizes in kilobytes. The report regenerates on every run.
+- `.next/analyze/client.html`, `.next/analyze/nodejs.html`, and `.next/analyze/edge.html` contain the visual reports emitted by `webpack-bundle-analyzer` for each runtime target. Serve them locally (e.g. `pnpm dlx serve .next/analyze`) to browse the treemaps.
+
+## Enforcing gzipped budgets
+
+- Each module is checked against the `BUNDLE_MODULE_GZIP_BUDGET_KB` environment variable (default: `150`).
+- If any module exceeds the budget the script:
+  - writes an over-budget section to `artifacts/bundle/top-modules.txt`, and
+  - exits with status `1` so CI fails.
+- Adjust the budget per run with `BUNDLE_MODULE_GZIP_BUDGET_KB=120 pnpm analyze:bundle`.
+
+## Troubleshooting
+
+- **Missing stats file:** Ensure `ANALYZE=true pnpm exec next build` runs successfully before invoking the analysis script directly.
+- **Stale data:** Delete `.next/analyze` or rerun `pnpm analyze:bundle` to regenerate reports after dependency changes.
+- **CI noise:** The script removes the previous `artifacts/bundle` directory on every run, keeping the report deterministic.

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,11 @@
 /** @type {import('next').NextConfig} */
 
-const withPlugins = require("next-compose-plugins")
 const withMDX = require('@next/mdx')()
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+  openAnalyzer: false,
+  analyzerMode: 'static',
+})
 // Temporarily disable PWA to fix build issue
 // const withPWA = require("@ducanh2912/next-pwa").default({
 //   dest: "public",
@@ -63,8 +67,20 @@ const securityHeaders = [
 ]
 
 const nextConfig = {
-  webpack: config => {
+  webpack: (config, options) => {
     config.externals.push('pino-pretty', 'lokijs', 'encoding')
+
+    if (process.env.ANALYZE === 'true' && !options.nextRuntime) {
+      const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+      config.plugins.push(
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'json',
+          reportFilename: './analyze/client-stats.json',
+          openAnalyzer: false,
+        })
+      )
+    }
+
     return config
   },
   experimental: {
@@ -132,6 +148,6 @@ const nextConfig = {
    pageExtensions: ['ts', 'tsx', 'mdx', 'js', 'jsx', 'rs'],
 }
 
-module.exports = withMDX(nextConfig)
+module.exports = withBundleAnalyzer(withMDX(nextConfig))
 // module.exports = withPlugins([withPWA, withMDX], nextConfig)
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "analyze:bundle": "ANALYZE=true pnpm exec next build && node scripts/analyze-bundle.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -73,6 +74,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@next/bundle-analyzer": "^15.5.3",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@next/bundle-analyzer':
+        specifier: ^15.5.3
+        version: 15.5.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -374,6 +377,10 @@ packages:
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
+  '@discoveryjs/json-ext@0.5.7':
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
 
   '@emotion/is-prop-valid@0.8.8':
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
@@ -664,6 +671,9 @@ packages:
   '@mediapipe/tasks-vision@0.10.8':
     resolution: {integrity: sha512-Rp7ll8BHrKB3wXaRFKhrltwZl1CiXGdibPxuWXvqGnKTnv8fqa/nvftYNuSbf+pbJWKYCXdBtYTITdAUTGGh0Q==}
 
+  '@next/bundle-analyzer@15.5.3':
+    resolution: {integrity: sha512-l2NxnWHP2gWHbomAlz/wFnN2jNCx/dpr7P/XWeOLhULiyKkXSac8O8SjxRO/8FNhr2l4JNtWVKk82Uya4cZYTw==}
+
   '@next/env@14.2.4':
     resolution: {integrity: sha512-3EtkY5VDkuV2+lNmKlbkibIJxcO4oIHEhBWne6PaAp+76J9KoSsGvNikp6ivzAT8dhhBMYrm6op2pS1ApG0Hzg==}
 
@@ -754,6 +764,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -1958,6 +1971,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
@@ -2324,6 +2341,10 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2363,6 +2384,9 @@ packages:
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
+
+  debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2474,6 +2498,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2936,6 +2963,10 @@ packages:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
 
+  gzip-size@6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
+
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
 
@@ -2982,6 +3013,9 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -3117,6 +3151,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
@@ -3515,6 +3553,10 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -3651,6 +3693,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -4101,6 +4147,10 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4369,6 +4419,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -4635,6 +4689,11 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webpack-bundle-analyzer@4.10.1:
+    resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
+
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
@@ -4686,6 +4745,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.16.0:
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
@@ -4901,6 +4972,8 @@ snapshots:
     optional: true
 
   '@dimforge/rapier3d-compat@0.12.0': {}
+
+  '@discoveryjs/json-ext@0.5.7': {}
 
   '@emotion/is-prop-valid@0.8.8':
     dependencies:
@@ -5164,6 +5237,13 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.8': {}
 
+  '@next/bundle-analyzer@15.5.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      webpack-bundle-analyzer: 4.10.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@next/env@14.2.4': {}
 
   '@next/eslint-plugin-next@14.2.4':
@@ -5221,6 +5301,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@radix-ui/number@1.0.1':
     dependencies:
@@ -6599,6 +6681,10 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+
   acorn@8.11.3: {}
 
   acorn@8.15.0: {}
@@ -6988,6 +7074,8 @@ snapshots:
 
   commander@4.1.1: {}
 
+  commander@7.2.0: {}
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -7019,6 +7107,8 @@ snapshots:
   damerau-levenshtein@1.0.8: {}
 
   date-fns@3.3.1: {}
+
+  debounce@1.2.1: {}
 
   debug@3.2.7:
     dependencies:
@@ -7115,6 +7205,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -7778,6 +7870,10 @@ snapshots:
       - encoding
       - supports-color
 
+  gzip-size@6.0.0:
+    dependencies:
+      duplexer: 0.1.2
+
   has-bigints@1.0.2: {}
 
   has-flag@3.0.0: {}
@@ -7850,6 +7946,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  html-escaper@2.0.2: {}
 
   html-to-text@9.0.5:
     dependencies:
@@ -7982,6 +8080,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-reference@3.0.2:
     dependencies:
@@ -8546,6 +8646,8 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mrmime@2.0.1: {}
+
   ms@2.1.2: {}
 
   ms@2.1.3: {}
@@ -8674,6 +8776,8 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  opener@1.5.2: {}
+
   optionator@0.9.3:
     dependencies:
       '@aashutoshrathi/word-wrap': 1.2.6
@@ -8786,7 +8890,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -9195,6 +9299,12 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
 
+  sirv@2.0.4:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   slash@3.0.0: {}
 
   sonner@1.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
@@ -9508,6 +9618,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  totalist@3.0.1: {}
+
   tr46@0.0.3: {}
 
   trim-lines@3.0.1: {}
@@ -9800,6 +9912,25 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webpack-bundle-analyzer@4.10.1(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      commander: 7.2.0
+      debounce: 1.2.1
+      escape-string-regexp: 4.0.0
+      gzip-size: 6.0.0
+      html-escaper: 2.0.2
+      is-plain-object: 5.0.0
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 2.0.4
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   webpack-sources@3.3.3: {}
 
   webpack@5.93.0:
@@ -9898,6 +10029,11 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  ws@7.5.10(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
 
   ws@8.16.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     optionalDependencies:

--- a/scripts/analyze-bundle.js
+++ b/scripts/analyze-bundle.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const projectRoot = path.resolve(__dirname, '..')
+const statsPath = path.join(projectRoot, '.next', 'analyze', 'client-stats.json')
+const artifactsDir = path.join(projectRoot, 'artifacts', 'bundle')
+const outputPath = path.join(artifactsDir, 'top-modules.txt')
+
+const DEFAULT_BUDGET_KB = 150
+
+function parseBudget() {
+  const raw = process.env.BUNDLE_MODULE_GZIP_BUDGET_KB
+  if (!raw) {
+    return DEFAULT_BUDGET_KB
+  }
+
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      `BUNDLE_MODULE_GZIP_BUDGET_KB must be a positive number. Received: "${raw}".`
+    )
+  }
+
+  return parsed
+}
+
+function collectModules(input) {
+  const modules = []
+  const stack = [input]
+
+  while (stack.length > 0) {
+    const value = stack.pop()
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        stack.push(item)
+      }
+      continue
+    }
+
+    if (!value || typeof value !== 'object') {
+      continue
+    }
+
+    const groups = Array.isArray(value.groups) ? value.groups : []
+    const hasChildren = groups.length > 0
+
+    if (typeof value.gzipSize === 'number' && !hasChildren) {
+      modules.push({
+        label: typeof value.label === 'string' ? value.label : undefined,
+        path: typeof value.path === 'string' ? value.path : undefined,
+        gzipSize: value.gzipSize,
+      })
+    }
+
+    for (const child of groups) {
+      stack.push(child)
+    }
+
+    for (const [key, child] of Object.entries(value)) {
+      if (key === 'groups') {
+        continue
+      }
+      stack.push(child)
+    }
+  }
+
+  return modules
+}
+
+function formatKilobytes(bytes) {
+  return bytes / 1024
+}
+
+function formatModuleLine(index, module) {
+  const position = String(index + 1).padStart(2, '0')
+  const displayPath = (module.path || module.label || 'unknown').replace(/^\.\//, '')
+  const sizeKB = formatKilobytes(module.gzipSize)
+  return `${position}. ${displayPath} - ${sizeKB.toFixed(2)} kB gzip`
+}
+
+function ensureArtifactsDir() {
+  if (fs.existsSync(artifactsDir)) {
+    fs.rmSync(artifactsDir, { recursive: true, force: true })
+  }
+  fs.mkdirSync(artifactsDir, { recursive: true })
+}
+
+function main() {
+  if (!fs.existsSync(statsPath)) {
+    throw new Error(
+      `Bundle stats not found at ${path.relative(projectRoot, statsPath)}. ` +
+        'Run the build with ANALYZE=true before running this script.'
+    )
+  }
+
+  const raw = fs.readFileSync(statsPath, 'utf8')
+  const report = JSON.parse(raw)
+  const modules = collectModules(report)
+
+  if (!modules.length) {
+    throw new Error('No modules were found in the bundle stats output.')
+  }
+
+  modules.sort((a, b) => b.gzipSize - a.gzipSize)
+
+  const budgetKB = parseBudget()
+  const offenders = modules.filter(module => formatKilobytes(module.gzipSize) > budgetKB)
+
+  const topModules = modules.slice(0, 20)
+
+  ensureArtifactsDir()
+
+  const lines = []
+  lines.push('Top 20 modules by gzipped size')
+  lines.push('================================')
+  lines.push('')
+  for (let i = 0; i < topModules.length; i += 1) {
+    lines.push(formatModuleLine(i, topModules[i]))
+  }
+
+  lines.push('')
+  lines.push(`Budget: ${budgetKB.toFixed(2)} kB gzip per module`)
+
+  if (offenders.length > 0) {
+    lines.push('Modules exceeding the budget:')
+    for (const offender of offenders) {
+      const sizeKB = formatKilobytes(offender.gzipSize)
+      const displayPath = (offender.path || offender.label || 'unknown').replace(/^\.\//, '')
+      lines.push(`- ${displayPath} (${sizeKB.toFixed(2)} kB gzip)`)
+    }
+  } else {
+    lines.push('All modules are within the configured budget.')
+  }
+
+  fs.writeFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8')
+
+  const relativeOutput = path.relative(projectRoot, outputPath)
+  console.log(`Wrote bundle report to ${relativeOutput}`)
+
+  if (offenders.length > 0) {
+    console.error(
+      `Found ${offenders.length} module(s) exceeding the ${budgetKB.toFixed(2)} kB gzip budget.`
+    )
+    process.exit(1)
+  }
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(error.message)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- enable @next/bundle-analyzer when ANALYZE=true and emit a JSON stats report for the client bundle
- add an analyze:bundle script that parses the stats, writes the top modules report, and enforces a gzipped size budget
- document the bundle investigation workflow and ignore generated artifacts

## Testing
- pnpm analyze:bundle
- node scripts/analyze-bundle.js

------
https://chatgpt.com/codex/tasks/task_e_68d15d7dc1888328af8984a9533cc96a