### PR TITLE
Add Lighthouse CI workflow and documentation

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,92 @@
+name: Lighthouse CI
+
+on:
+  deployment_status:
+    types: [success]
+  workflow_dispatch:
+    inputs:
+      preview-url:
+        description: 'Fully-qualified preview base URL (for example, https://preview.vercel.app)'
+        required: true
+
+jobs:
+  audit:
+    name: Run Lighthouse checks
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'deployment_status' && !github.event.deployment.production_environment) }}
+    env:
+      PREVIEW_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.preview-url || github.event.deployment_status.target_url || '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: pnpm
+
+      - name: Validate preview URL
+        run: |
+          if [ -z "${PREVIEW_URL}" ]; then
+            echo "A preview URL is required to run Lighthouse CI." >&2
+            exit 1
+          fi
+        env:
+          PREVIEW_URL: ${{ env.PREVIEW_URL }}
+
+      - name: Run Lighthouse CI
+        env:
+          LHCI_PREVIEW_BASE_URL: ${{ env.PREVIEW_URL }}
+        run: pnpm dlx @lhci/cli@0.13.x autorun
+
+      - name: Summarize Lighthouse scores
+        if: always()
+        run: |
+          if [ -f artifacts/lighthouse/manifest.json ]; then
+            node <<'SUMMARY'
+const fs = require('fs');
+const path = require('path');
+
+const manifestPath = path.join(process.cwd(), 'artifacts', 'lighthouse', 'manifest.json');
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+if (!fs.existsSync(manifestPath) || !summaryPath) {
+  process.exit(0);
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const toPercent = (value) =>
+  typeof value === 'number' ? `${Math.round(value * 100)}%` : '—';
+
+const lines = [];
+lines.push('# Lighthouse results');
+lines.push('');
+lines.push('| URL | Performance | Accessibility | Best Practices | SEO |');
+lines.push('| --- | --- | --- | --- | --- |');
+
+for (const entry of manifest) {
+  const summary = entry.summary || {};
+  lines.push(
+    `| ${entry.url} | ${toPercent(summary.performance)} | ${toPercent(summary.accessibility)} | ${toPercent(summary['best-practices'])} | ${toPercent(summary.seo)} |`,
+  );
+}
+
+lines.push('');
+lines.push('Detailed HTML reports are uploaded to the `artifacts/lighthouse/` directory.');
+
+fs.appendFileSync(summaryPath, `${lines.join('\n')}\n`);
+SUMMARY
+          else
+            echo "Lighthouse reports were not generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload Lighthouse reports
+        if: always() && hashFiles('artifacts/lighthouse/*.html') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-reports
+          path: artifacts/lighthouse
+          if-no-files-found: warn

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,0 +1,67 @@
+const coreRoutes = [
+  '/',
+  '/dashboard',
+  '/payments',
+  '/documents',
+  '/messaging',
+  '/visitors',
+  '/maintenance',
+  '/account',
+  '/contact',
+  '/auth',
+  '/onboarding',
+];
+
+const buildUrl = (baseUrl, route) => {
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  return `${normalizedBase}${route}`;
+};
+
+const previewBaseUrl =
+  process.env.LHCI_PREVIEW_BASE_URL || process.env.URL || 'http://localhost:3000';
+
+module.exports = {
+  coreRoutes,
+  ci: {
+    collect: {
+      url: coreRoutes.map((route) => buildUrl(previewBaseUrl, route)),
+      numberOfRuns: 3,
+      settings: {
+        extraHeaders: JSON.stringify({
+          'x-lhci-env': 'ci',
+        }),
+      },
+      budgets: [
+        {
+          path: '/*',
+          timings: [
+            { metric: 'first-contentful-paint', threshold: 1800 },
+            { metric: 'largest-contentful-paint', threshold: 2500 },
+            { metric: 'speed-index', threshold: 3400 },
+            { metric: 'total-blocking-time', threshold: 200 },
+            { metric: 'cumulative-layout-shift', threshold: 0.1 },
+          ],
+        },
+      ],
+    },
+    assert: {
+      preset: 'lighthouse:recommended',
+      assertions: {
+        'categories:performance': ['error', { minScore: 0.9 }],
+        'categories:accessibility': ['error', { minScore: 0.9 }],
+        'categories:best-practices': ['error', { minScore: 0.9 }],
+        'categories:seo': ['error', { minScore: 0.9 }],
+        'first-contentful-paint': ['error', { maxNumericValue: 1800, aggregationMethod: 'median' }],
+        'largest-contentful-paint': ['error', { maxNumericValue: 2500, aggregationMethod: 'median' }],
+        'speed-index': ['error', { maxNumericValue: 3400, aggregationMethod: 'median' }],
+        'total-blocking-time': ['error', { maxNumericValue: 200, aggregationMethod: 'median' }],
+        'cumulative-layout-shift': ['error', { maxNumericValue: 0.1, aggregationMethod: 'median' }],
+      },
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: 'artifacts/lighthouse',
+      reportFilenamePattern: 'report-<%= urlHash %>.html',
+    },
+  },
+};

--- a/docs/perf/ci.md
+++ b/docs/perf/ci.md
@@ -1,0 +1,36 @@
+# Lighthouse CI in Roomsily
+
+## Overview
+The Lighthouse CI workflow validates core preview routes against the Web Vitals
+budgets defined in [`.lighthouserc.js`](../../.lighthouserc.js). Each run audits
+shared tenant flows (dashboard, payments, messaging, visitors, maintenance, and
+more) and fails when any category score drops below 90 or when LCP, FCP, TBT,
+Speed Index, or CLS regress beyond our budgets.
+
+## When it runs
+- **Preview deployments** &mdash; Every successful non-production deployment
+  automatically triggers the `Lighthouse CI` workflow once the hosting provider
+  posts an updated preview URL.
+- **Manual checks** &mdash; Platform or feature teams can trigger ad-hoc runs from the
+  Actions tab when debugging a regression, testing a hotfix, or validating
+  marketing experiments.
+
+## Rerunning the workflow
+Use the approach that best matches your situation:
+
+### Re-run a failed or outdated job
+1. Navigate to **Actions → Lighthouse CI**.
+2. Open the run you want to replay.
+3. Click **Re-run jobs → Re-run failed jobs** (or **Re-run all jobs** if you want
+   a clean comparison).
+
+### Trigger a fresh audit with a preview URL
+1. Navigate to **Actions → Lighthouse CI → Run workflow**.
+2. Paste the full preview base URL (for example, the Vercel preview link shared
+   in the pull request comment or Deployments pane).
+3. Select the target branch (defaults to the current branch) and click
+   **Run workflow**.
+
+The workflow exports the URL to `LHCI_PREVIEW_BASE_URL`, collects reports for the
+core routes listed in `.lighthouserc.js`, and uploads HTML output to
+`artifacts/lighthouse/` together with a markdown score table in the job summary.


### PR DESCRIPTION
## Summary
- add a Lighthouse CI configuration that covers the core tenant routes and enforces Web Vitals-aligned budgets
- add a GitHub Actions workflow that runs Lighthouse against preview deployments and uploads HTML reports
- document how to rerun the Lighthouse workflow when debugging regressions

## Testing
- not run (workflow and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d178a43e5883288946d0ff1b75cbd0