### PR TITLE
Add RUM web vitals pipeline and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ DOCUMENSO_BASE_URL="your_documenso_instance_url"
 # Calendar (Optional)
 CALCOM_API_KEY="your_calcom_api_key"
 CALCOM_BASE_URL="your_calcom_instance_url"
+
+# Real User Monitoring
+NEXT_PUBLIC_RUM_ENDPOINT="/api/perf-metrics"
+NEXT_PUBLIC_RUM_WRITE_TOKEN="$SUPABASE_SERVICE_ROLE_KEY"
 ```
 
 ### Database Setup
@@ -114,6 +118,19 @@ Deploy to Vercel with the following environment variables configured in your Ver
 - All Supabase environment variables
 - Stripe keys (use live keys for production)
 - Document and calendar service URLs/keys
+- Real User Monitoring variables (`NEXT_PUBLIC_RUM_ENDPOINT`, `NEXT_PUBLIC_RUM_WRITE_TOKEN`)
+
+### Real User Monitoring
+
+The project ships with real user monitoring (RUM) for Web Vitals. When `NEXT_PUBLIC_RUM_WRITE_TOKEN` is defined the browser will
+send metrics to `/api/perf-metrics`, which persists them in Supabase using the service-role key. To enable it:
+
+- **Local**: add the variables from the `.env.local` template above and run `npm run dev`. Check Supabase Studio for rows in
+  `public.perf_metrics`.
+- **Vercel**: configure the same variables for each environment (Preview/Staging/Production) and redeploy so the bundle receives
+  the token.
+
+Dashboards, alerts, and additional context are documented in [`docs/perf/rum.md`](docs/perf/rum.md).
 
 ## Project Structure
 

--- a/app/api/perf-metrics/route.ts
+++ b/app/api/perf-metrics/route.ts
@@ -1,0 +1,197 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import type { Database, TablesInsert } from "@/lib/supabase"
+
+type MetricName = "LCP" | "TTFB" | "INP" | "CLS"
+
+type BudgetViolation = {
+  name: MetricName
+  value: number
+  limit: number
+  rating: "good" | "needs-improvement" | "poor"
+}
+
+const METRIC_BUDGETS: Record<MetricName, number> = {
+  LCP: 2500,
+  TTFB: 800,
+  INP: 200,
+  CLS: 0.1,
+}
+
+const metricSchema = z.object({
+  id: z.string().min(1),
+  name: z.enum(["LCP", "TTFB", "INP", "CLS"]),
+  value: z.number().nonnegative(),
+  rating: z.enum(["good", "needs-improvement", "poor"]),
+  delta: z.number(),
+})
+
+const payloadSchema = z.object({
+  eventId: z.string().uuid().optional(),
+  sessionId: z.string().min(1),
+  userId: z.string().uuid().optional().nullable(),
+  pathname: z.string().min(1),
+  href: z.string().url().optional(),
+  referrer: z.string().optional(),
+  userAgent: z.string().optional(),
+  locale: z.string().optional(),
+  timezone: z.string().optional(),
+  navigationType: z.string().optional(),
+  viewport: z
+    .object({
+      width: z.number().int().nonnegative(),
+      height: z.number().int().nonnegative(),
+    })
+    .optional(),
+  connection: z
+    .object({
+      effectiveType: z.string().optional(),
+      downlink: z.number().nonnegative().optional(),
+      rtt: z.number().nonnegative().optional(),
+      saveData: z.boolean().optional(),
+    })
+    .optional(),
+  metrics: z.array(metricSchema),
+})
+
+function createSupabaseAdminClient(
+  supabaseUrl: string,
+  serviceRoleKey: string
+): SupabaseClient<Database> {
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}
+
+function evaluateBudgets(metrics: z.infer<typeof metricSchema>[]) {
+  const violations: BudgetViolation[] = []
+  const seen = new Set<MetricName>()
+
+  for (const metric of metrics) {
+    const limit = METRIC_BUDGETS[metric.name]
+    seen.add(metric.name)
+    if (limit !== undefined && metric.value > limit) {
+      violations.push({
+        name: metric.name,
+        value: metric.value,
+        limit,
+        rating: metric.rating,
+      })
+    }
+  }
+
+  const missing = (Object.keys(METRIC_BUDGETS) as MetricName[]).filter(
+    (metricName) => !seen.has(metricName)
+  )
+
+  return {
+    ok: violations.length === 0,
+    violations,
+    missing,
+  }
+}
+
+export async function POST(request: Request) {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+
+  if (!serviceRoleKey || !supabaseUrl) {
+    console.error("Supabase credentials missing for perf metrics ingest")
+    return NextResponse.json(
+      { success: false, error: "Supabase not configured" },
+      { status: 500 }
+    )
+  }
+
+  const authHeader = request.headers.get("authorization")
+  if (authHeader !== `Bearer ${serviceRoleKey}`) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    )
+  }
+
+  let payload: z.infer<typeof payloadSchema>
+  try {
+    const json = await request.json()
+    payload = payloadSchema.parse(json)
+  } catch (error) {
+    console.warn("Invalid perf metrics payload", error)
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { success: false, error: "Invalid payload", details: error.flatten() },
+        { status: 422 }
+      )
+    }
+
+    return NextResponse.json(
+      { success: false, error: "Malformed payload" },
+      { status: 400 }
+    )
+  }
+
+  if (payload.metrics.length === 0) {
+    return NextResponse.json(
+      { success: false, error: "No metrics received" },
+      { status: 400 }
+    )
+  }
+
+  const budgetResult = evaluateBudgets(payload.metrics)
+
+  const supabase = createSupabaseAdminClient(supabaseUrl, serviceRoleKey)
+
+  const record: TablesInsert<"perf_metrics"> = {
+    session_id: payload.sessionId,
+    user_id: payload.userId ?? null,
+    url: payload.href ?? payload.pathname,
+    pathname: payload.pathname,
+    referrer: payload.referrer ?? null,
+    user_agent: payload.userAgent ?? null,
+    locale: payload.locale ?? null,
+    timezone: payload.timezone ?? null,
+    navigation_type: payload.navigationType ?? null,
+    viewport: payload.viewport ?? null,
+    connection: payload.connection ?? null,
+    metrics: payload.metrics,
+    budget_status: {
+      ok: budgetResult.ok,
+      violations: budgetResult.violations,
+      missing: budgetResult.missing,
+    },
+    metadata: {
+      event_id: payload.eventId ?? null,
+    },
+  }
+
+  const { error } = await supabase.from("perf_metrics").insert(record)
+  if (error) {
+    console.error("Failed to persist perf metrics sample", error)
+    return NextResponse.json(
+      { success: false, error: "Database error" },
+      { status: 500 }
+    )
+  }
+
+  if (!budgetResult.ok) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Performance budget(s) exceeded",
+        violations: budgetResult.violations,
+        missing: budgetResult.missing,
+      },
+      { status: 422 }
+    )
+  }
+
+  return NextResponse.json(
+    { success: true, missing: budgetResult.missing },
+    { status: 201 }
+  )
+}

--- a/app/reportWebVitals.ts
+++ b/app/reportWebVitals.ts
@@ -1,0 +1,7 @@
+import type { NextWebVitalsMetric } from "next/app"
+
+import { reportWebVitals as captureWebVital } from "@/utils/metrics/web-vitals"
+
+export function reportWebVitals(metric: NextWebVitalsMetric) {
+  void captureWebVital(metric)
+}

--- a/docs/perf/rum.md
+++ b/docs/perf/rum.md
@@ -1,0 +1,98 @@
+# Real User Monitoring (RUM)
+
+This document describes how we capture, store, and visualize real-user performance metrics for the Roomsily portal.
+
+## Data flow overview
+
+1. The browser collects Web Vitals (LCP, TTFB, INP, CLS) via `utils/metrics/web-vitals.ts`, which is automatically wired into Next.js through `app/reportWebVitals.ts`.
+2. Samples are POSTed to `/api/perf-metrics` with a `Bearer` token that must match the Supabase service-role key.
+3. The API validates the payload, enforces the performance budgets, and stores the record in `public.perf_metrics`.
+4. Dashboards and alerts use the aggregated data to track regressions.
+
+### Performance budgets
+
+| Metric | Budget | Notes |
+| --- | --- | --- |
+| LCP | ≤ 2500 ms | Largest Contentful Paint should stay in the "good" band |
+| TTFB | ≤ 800 ms | First byte target keeps the server responsive |
+| INP | ≤ 200 ms | Interaction to Next Paint should feel instant |
+| CLS | ≤ 0.1 | Cumulative Layout Shift must remain minimal |
+
+Samples that exceed any budget are still stored but the API responds with `422` to surface the violation. The `budget_status` JSONB column contains `ok` and a `violations` array for downstream analytics.
+
+### Table schema
+
+`public.perf_metrics` keeps one row per flush from the client script. Important columns:
+
+- `session_id` – browser session identifier persisted in `sessionStorage`
+- `user_id` – Supabase user (if available)
+- `metrics` – JSONB payload containing the tracked metrics
+- `budget_status` – JSONB with `ok` flag and the list of budget violations
+- `navigation_type`, `connection`, `viewport`, `locale`, `timezone` – context for segmenting samples
+
+Use the migration in `supabase/migrations/20250103_perf_metrics_schema.sql` when provisioning databases.
+
+## Dashboards
+
+Create a Supabase Dashboard card (or use any BI tool pointed at the replica) with queries such as:
+
+```sql
+-- 75th percentile web-vitals grouped by route (last 7 days)
+with samples as (
+  select
+    pathname,
+    (jsonb_path_query_first(metrics, '$[*] ? (@.name == "LCP").value'))::numeric as lcp,
+    (jsonb_path_query_first(metrics, '$[*] ? (@.name == "TTFB").value'))::numeric as ttfb,
+    (jsonb_path_query_first(metrics, '$[*] ? (@.name == "INP").value'))::numeric as inp,
+    (jsonb_path_query_first(metrics, '$[*] ? (@.name == "CLS").value'))::numeric as cls
+  from public.perf_metrics
+  where created_at >= now() - interval '7 days'
+)
+select
+  pathname,
+  percentile_disc(0.75) within group (order by lcp) as p75_lcp,
+  percentile_disc(0.75) within group (order by ttfb) as p75_ttfb,
+  percentile_disc(0.75) within group (order by inp) as p75_inp,
+  percentile_disc(0.75) within group (order by cls) as p75_cls
+from samples
+group by pathname;
+```
+
+For quick status views, chart the share of rows where `budget_status ->> 'ok' = 'true'` grouped by environment or route.
+
+## Alerts
+
+Set up one of the following strategies:
+
+- **Supabase Scheduled Function**: A nightly cron can run a SQL check for `budget_status ->> 'ok' = 'false'` above a threshold and send an email/slack notification using existing notification infrastructure.
+- **Vercel Cron Job**: Hit an internal route that aggregates recent metrics and triggers Resend emails when budgets regress.
+- **BI Tool Thresholds**: If using Metabase/Looker, create a pulse on the 75th percentile metrics crossing the budget.
+
+Be sure to rotate the service-role key if alerts are sent externally.
+
+## Enabling the client script
+
+### Local development
+
+1. Ensure `.env.local` contains the following values:
+   ```env
+   NEXT_PUBLIC_SUPABASE_URL="…"
+   NEXT_PUBLIC_SUPABASE_ANON_KEY="…"
+   SUPABASE_SERVICE_ROLE_KEY="…"
+   NEXT_PUBLIC_RUM_ENDPOINT="/api/perf-metrics"
+   NEXT_PUBLIC_RUM_WRITE_TOKEN="$SUPABASE_SERVICE_ROLE_KEY"
+   ```
+2. Run `npm run dev`; the script loads automatically on every page. Inspect network traffic for `/api/perf-metrics` to confirm ingestion.
+3. Use Supabase Studio to verify rows in `public.perf_metrics` and that `budget_status.ok` stays `true` during development.
+
+### Vercel deployments
+
+1. In each environment (Preview, Staging, Production) add:
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `NEXT_PUBLIC_RUM_ENDPOINT` (defaults to `/api/perf-metrics` if omitted)
+   - `NEXT_PUBLIC_RUM_WRITE_TOKEN` set to the same service-role key or a dedicated ingest key.
+2. Redeploy the project so the client bundle receives the token.
+3. Configure dashboards/alerts in the corresponding Supabase project; the admin RLS policy allows property managers and admins to query the data.
+4. Monitor the Vercel logs for `Performance budget(s) exceeded` responses to catch regressions early.
+
+> **Security note:** If you prefer to avoid exposing the full service-role key to the client, create a proxy or edge function that injects the header server-side and use a short-lived token in `NEXT_PUBLIC_RUM_WRITE_TOKEN`.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -199,6 +199,24 @@ export type Database = {
         created_at: string | null
         updated_at: string | null
       }>
+      perf_metrics: SupabaseTable<{
+        id: string
+        created_at: string | null
+        session_id: string
+        user_id: string | null
+        url: string
+        pathname: string
+        referrer: string | null
+        user_agent: string | null
+        locale: string | null
+        timezone: string | null
+        navigation_type: string | null
+        connection: Json | null
+        viewport: Json | null
+        metrics: Json
+        budget_status: Json
+        metadata: Json | null
+      }>
       email_notifications: SupabaseTable<{
         id: string
         user_id: string | null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -67,6 +67,7 @@
         "tailwind-merge": "^2.2.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "0.160.0",
+        "web-vitals": "^5.1.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -13136,6 +13137,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webgl-constants": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "0.160.0",
+    "web-vitals": "^5.1.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/supabase/migrations/20250103_perf_metrics_schema.sql
+++ b/supabase/migrations/20250103_perf_metrics_schema.sql
@@ -1,0 +1,41 @@
+-- Create table for Real User Monitoring samples
+CREATE TABLE public.perf_metrics (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  session_id TEXT NOT NULL,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  url TEXT NOT NULL,
+  pathname TEXT NOT NULL,
+  referrer TEXT,
+  user_agent TEXT,
+  locale TEXT,
+  timezone TEXT,
+  navigation_type TEXT,
+  connection JSONB,
+  viewport JSONB,
+  metrics JSONB NOT NULL,
+  budget_status JSONB NOT NULL,
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX idx_perf_metrics_created_at ON public.perf_metrics(created_at DESC);
+CREATE INDEX idx_perf_metrics_session_id ON public.perf_metrics(session_id);
+CREATE INDEX idx_perf_metrics_user_id ON public.perf_metrics(user_id);
+
+ALTER TABLE public.perf_metrics ENABLE ROW LEVEL SECURITY;
+
+-- Only service role should be able to insert/update/delete samples.
+CREATE POLICY "Service role manage perf metrics" ON public.perf_metrics
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Allow admins and property managers to query samples for dashboards.
+CREATE POLICY "Admin access to perf metrics" ON public.perf_metrics
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+  );

--- a/utils/metrics/web-vitals.ts
+++ b/utils/metrics/web-vitals.ts
@@ -1,0 +1,271 @@
+"use client"
+
+import { createBrowserClient } from "@supabase/ssr"
+import type { NextWebVitalsMetric } from "next/app"
+
+type MetricName = "LCP" | "TTFB" | "INP" | "CLS"
+
+type MetricSnapshot = {
+  id: string
+  name: MetricName
+  value: number
+  rating: "good" | "needs-improvement" | "poor"
+  delta: number
+  navigationType?: NextWebVitalsMetric["navigationType"]
+}
+
+type ConnectionInformation = {
+  effectiveType?: string
+  downlink?: number
+  rtt?: number
+  saveData?: boolean
+}
+
+type ViewportInformation = {
+  width: number
+  height: number
+}
+
+const TRACKED_METRICS: ReadonlyArray<MetricName> = [
+  "LCP",
+  "TTFB",
+  "INP",
+  "CLS",
+] as const
+
+const INGEST_ENDPOINT =
+  process.env.NEXT_PUBLIC_RUM_ENDPOINT || "/api/perf-metrics"
+const AUTH_TOKEN = process.env.NEXT_PUBLIC_RUM_WRITE_TOKEN
+
+const SESSION_STORAGE_KEY = "shp::rum-session-id"
+
+let pendingMetrics: Partial<Record<MetricName, MetricSnapshot>> = {}
+let flushTimer: ReturnType<typeof setTimeout> | undefined
+let unloadListenersRegistered = false
+let cachedUserId: string | null | undefined
+let cachedSupabaseClient: ReturnType<typeof createBrowserClient<any>> | null = null
+
+function isTrackedMetric(metric: NextWebVitalsMetric): metric is NextWebVitalsMetric & {
+  name: MetricName
+} {
+  return (TRACKED_METRICS as readonly string[]).includes(metric.name)
+}
+
+function clearFlushTimer() {
+  if (!flushTimer) {
+    return
+  }
+
+  clearTimeout(flushTimer)
+  flushTimer = undefined
+}
+
+function scheduleFlush() {
+  if (flushTimer) {
+    return
+  }
+
+  flushTimer = setTimeout(() => {
+    flushTimer = undefined
+    void flushMetrics()
+  }, 5000)
+}
+
+function registerUnloadListeners() {
+  if (typeof window === "undefined" || unloadListenersRegistered) {
+    return
+  }
+
+  unloadListenersRegistered = true
+
+  const flush = () => {
+    clearFlushTimer()
+    void flushMetrics()
+  }
+
+  window.addEventListener("pagehide", flush)
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      flush()
+    }
+  })
+}
+
+function hasAllMetrics() {
+  return (TRACKED_METRICS as readonly MetricName[]).every(
+    (metricName) => pendingMetrics[metricName]
+  )
+}
+
+function getSessionId(): string {
+  if (typeof window === "undefined") {
+    return "server"
+  }
+
+  try {
+    const existing = window.sessionStorage.getItem(SESSION_STORAGE_KEY)
+    if (existing) {
+      return existing
+    }
+
+    const sessionId =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, sessionId)
+    return sessionId
+  } catch (error) {
+    console.warn("Unable to persist RUM session identifier", error)
+    return "unknown"
+  }
+}
+
+function getViewport(): ViewportInformation | undefined {
+  if (typeof window === "undefined") {
+    return undefined
+  }
+
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }
+}
+
+function getConnection(): ConnectionInformation | undefined {
+  if (typeof navigator === "undefined") {
+    return undefined
+  }
+
+  const connection = (navigator as any).connection
+  if (!connection) {
+    return undefined
+  }
+
+  const { effectiveType, downlink, rtt, saveData } = connection
+  return {
+    effectiveType,
+    downlink,
+    rtt,
+    saveData,
+  }
+}
+
+async function resolveUserId(): Promise<string | null> {
+  if (cachedUserId !== undefined) {
+    return cachedUserId
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !anonKey) {
+    cachedUserId = null
+    return cachedUserId
+  }
+
+  try {
+    if (!cachedSupabaseClient) {
+      cachedSupabaseClient = createBrowserClient<any>(supabaseUrl, anonKey)
+    }
+
+    const { data } = await cachedSupabaseClient.auth.getUser()
+    cachedUserId = data.user?.id ?? null
+  } catch (error) {
+    console.warn("Failed to resolve Supabase user for RUM payload", error)
+    cachedUserId = null
+  }
+
+  return cachedUserId
+}
+
+async function flushMetrics() {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  clearFlushTimer()
+
+  const metrics = Object.values(pendingMetrics) as MetricSnapshot[]
+  if (metrics.length === 0) {
+    return
+  }
+
+  pendingMetrics = {}
+
+  const payload = {
+    eventId:
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    sessionId: getSessionId(),
+    metrics: metrics.map((metric) => ({
+      id: metric.id,
+      name: metric.name,
+      value: metric.value,
+      rating: metric.rating,
+      delta: metric.delta,
+    })),
+    navigationType: metrics[0]?.navigationType,
+    pathname: window.location.pathname,
+    href: window.location.href,
+    referrer: document.referrer || undefined,
+    userAgent: navigator.userAgent,
+    locale: navigator.language,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    viewport: getViewport(),
+    connection: getConnection(),
+    userId: await resolveUserId(),
+  }
+
+  try {
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+    }
+
+    if (AUTH_TOKEN) {
+      headers.Authorization = `Bearer ${AUTH_TOKEN}`
+    }
+
+    const response = await fetch(INGEST_ENDPOINT, {
+      method: "POST",
+      keepalive: true,
+      headers,
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      console.warn("Failed to persist RUM web-vitals sample", await response.text())
+    }
+  } catch (error) {
+    console.warn("Error reporting RUM web-vitals sample", error)
+  }
+}
+
+export async function reportWebVitals(metric: NextWebVitalsMetric) {
+  if (!isTrackedMetric(metric)) {
+    return
+  }
+
+  registerUnloadListeners()
+
+  pendingMetrics = {
+    ...pendingMetrics,
+    [metric.name]: {
+      id: metric.id,
+      name: metric.name,
+      value: metric.value,
+      rating: metric.rating,
+      delta: metric.delta,
+      navigationType: metric.navigationType,
+    },
+  }
+
+  if (hasAllMetrics()) {
+    clearFlushTimer()
+    void flushMetrics()
+    return
+  }
+
+  scheduleFlush()
+}


### PR DESCRIPTION
## Summary
- add a client-side web vitals reporter that enriches payloads with session/user metadata and posts to the new perf metrics API
- add `/api/perf-metrics` ingestion, Supabase schema, and typing updates to persist samples and enforce the Web Vitals budgets
- document the RUM pipeline plus configuration steps for local and Vercel environments

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d178ac13008328a90f8c3b253cabff