### PR TITLE
Define ISR defaults and enforce marketing caching

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -8,6 +8,10 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { ChevronRight, Star, Zap, Shield } from "lucide-react"
 import { Contact } from '@/components/forms/contact'
+import { POLICY_PAGE_REVALIDATE_SECONDS } from '@/config/isr'
+
+export const dynamic = 'error'
+export const revalidate = POLICY_PAGE_REVALIDATE_SECONDS
 
 export default function AboutPage() {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
- import type { Metadata, Viewport } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/next"
@@ -13,7 +13,11 @@ import { SiteHeader } from "@/components/site-header"
 import { SiteFooter } from "@/components/site-footer"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { cn } from "@/lib/utils"
+import { DEFAULT_DYNAMIC, DEFAULT_REVALIDATE } from '@/config/isr'
 const inter = Inter({ subsets: ['latin'] })
+
+export const dynamic = DEFAULT_DYNAMIC
+export const revalidate = DEFAULT_REVALIDATE
 
 export const metadata: Metadata = {
   title: {

--- a/app/maintenance/page.tsx
+++ b/app/maintenance/page.tsx
@@ -1,5 +1,9 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MaintenanceRequestForm } from "@/components/maintenance/maintenance-request-form";
+import { PRODUCT_MARKETING_REVALIDATE_SECONDS } from '@/config/isr'
+
+export const dynamic = 'force-static'
+export const revalidate = PRODUCT_MARKETING_REVALIDATE_SECONDS
 
 const maintenanceHighlights = [
   {

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,5 +1,9 @@
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { PRODUCT_MARKETING_REVALIDATE_SECONDS } from '@/config/isr'
+
+export const dynamic = 'force-static'
+export const revalidate = PRODUCT_MARKETING_REVALIDATE_SECONDS
 
 const messagingHighlights = [
   {

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -19,6 +19,10 @@ import {
 import { formatCurrency } from "@/lib/payments/currency"
 import { catchUpBalances } from "@/lib/payments/mock-data"
 import type { CatchUpBalance } from "@/types/payments"
+import { PRODUCT_MARKETING_REVALIDATE_SECONDS } from '@/config/isr'
+
+export const dynamic = 'force-static'
+export const revalidate = PRODUCT_MARKETING_REVALIDATE_SECONDS
 
 const paymentHighlights = [
   {

--- a/app/privacy/page.mdx
+++ b/app/privacy/page.mdx
@@ -1,3 +1,8 @@
+import { POLICY_PAGE_REVALIDATE_SECONDS } from '@/config/isr'
+
+export const dynamic = 'error'
+export const revalidate = POLICY_PAGE_REVALIDATE_SECONDS
+
 # Privacy Policy
 
 *Last Updated: [Current Date]*

--- a/app/terms/page.mdx
+++ b/app/terms/page.mdx
@@ -1,3 +1,8 @@
+import { POLICY_PAGE_REVALIDATE_SECONDS } from '@/config/isr'
+
+export const dynamic = 'error'
+export const revalidate = POLICY_PAGE_REVALIDATE_SECONDS
+
 # Terms of Service
 
 *Last Updated: [Current Date]*

--- a/app/visitors/page.tsx
+++ b/app/visitors/page.tsx
@@ -1,5 +1,9 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { VisitorBookingForm } from "@/components/visitors/visitor-booking-form";
+import { PRODUCT_MARKETING_REVALIDATE_SECONDS } from '@/config/isr'
+
+export const dynamic = 'force-static'
+export const revalidate = PRODUCT_MARKETING_REVALIDATE_SECONDS
 
 const visitorHighlights = [
   {

--- a/config/isr.ts
+++ b/config/isr.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_DYNAMIC = 'force-dynamic' as const
+export const DEFAULT_REVALIDATE = 0 as const
+
+export const POLICY_PAGE_REVALIDATE_SECONDS = 60 * 60 * 24 // 24 hours
+export const PRODUCT_MARKETING_REVALIDATE_SECONDS = 60 * 60 // 1 hour
+
+export const ISR_TAGS = {
+  marketingPolicies: 'marketing:policies',
+  productMarketing: 'marketing:product-experience',
+} as const
+
+export const STATIC_ROUTES = ['/about', '/privacy', '/terms'] as const
+export const SEMI_STATIC_ROUTES = ['/payments', '/messaging', '/maintenance', '/visitors'] as const
+
+export type CacheTag = typeof ISR_TAGS[keyof typeof ISR_TAGS]

--- a/docs/perf/isr.md
+++ b/docs/perf/isr.md
@@ -1,0 +1,58 @@
+# Incremental Static Regeneration Policies
+
+## Overview
+
+Roomsily mixes authenticated dashboards with marketing content. To keep the
+platform responsive we standardize cache behavior via the shared definitions in
+[`config/isr.ts`](../../config/isr.ts). The root layout exports the application
+defaults so every route inherits a consistent baseline before applying
+route-specific overrides.
+
+- `DEFAULT_DYNAMIC = 'force-dynamic'`
+- `DEFAULT_REVALIDATE = 0`
+
+Any route that should opt into static generation **must** override the layout
+defaults explicitly.
+
+## Static policy surfaces
+
+The policies at `/about`, `/privacy`, and `/terms` are fully static. Each route
+exports `dynamic = 'error'` so accidental use of dynamic server APIs fails fast
+at build time. The pages revalidate every 24 hours to allow content updates
+without requiring a deploy.
+
+```ts
+export const dynamic = 'error'
+export const revalidate = POLICY_PAGE_REVALIDATE_SECONDS // 24 hours
+```
+
+Mutations that touch policy copy should revalidate the `marketing:policies` tag
+(from `ISR_TAGS.marketingPolicies`).
+
+## Semi-static product marketing
+
+The product explainer routes at `/payments`, `/messaging`, `/maintenance`, and
+`/visitors` render static shells with interactive client components. They export
+`dynamic = 'force-static'` plus an hourly `revalidate` window so edits flow to
+production without a deploy flood.
+
+```ts
+export const dynamic = 'force-static'
+export const revalidate = PRODUCT_MARKETING_REVALIDATE_SECONDS // 1 hour
+```
+
+When these pages begin to fetch CMS driven content, wrap the data loaders in
+`fetch(..., { next: { tags: [ISR_TAGS.productMarketing] } })` (or
+`unstable_cache`) and call `revalidateTag(ISR_TAGS.productMarketing)` from the
+relevant server actions.
+
+## Test coverage
+
+`tests/isr-config.test.ts` enforces that:
+
+- layout exports the global defaults
+- policy routes continue to guard static rendering
+- semi-static pages keep the hourly ISR contract
+
+Run `pnpm test` before shipping caching changes so the configuration stays in
+sync.

--- a/tests/isr-config.test.ts
+++ b/tests/isr-config.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_DYNAMIC,
+  DEFAULT_REVALIDATE,
+  POLICY_PAGE_REVALIDATE_SECONDS,
+  PRODUCT_MARKETING_REVALIDATE_SECONDS,
+  STATIC_ROUTES,
+  SEMI_STATIC_ROUTES,
+  ISR_TAGS,
+} from '@/config/isr'
+
+const PROJECT_ROOT = process.cwd()
+
+function readSource(relativePath: string) {
+  return readFileSync(path.join(PROJECT_ROOT, relativePath), 'utf8')
+}
+
+function expectConstExport(source: string, name: string, valueExpression: string) {
+  const pattern = new RegExp(`export const ${name}\\s*=\\s*${valueExpression}`)
+  expect(source).toMatch(pattern)
+}
+
+describe('ISR defaults', () => {
+  it('defines global defaults in config', () => {
+    expect(DEFAULT_DYNAMIC).toBe('force-dynamic')
+    expect(DEFAULT_REVALIDATE).toBe(0)
+    expect(POLICY_PAGE_REVALIDATE_SECONDS).toBe(60 * 60 * 24)
+    expect(PRODUCT_MARKETING_REVALIDATE_SECONDS).toBe(60 * 60)
+    expect(STATIC_ROUTES).toEqual(['/about', '/privacy', '/terms'])
+    expect(SEMI_STATIC_ROUTES).toEqual(['/payments', '/messaging', '/maintenance', '/visitors'])
+    expect(ISR_TAGS).toMatchObject({
+      marketingPolicies: 'marketing:policies',
+      productMarketing: 'marketing:product-experience',
+    })
+  })
+
+  it('applies defaults at the root layout', () => {
+    const layoutSource = readSource('app/layout.tsx')
+    expectConstExport(layoutSource, 'dynamic', 'DEFAULT_DYNAMIC')
+    expectConstExport(layoutSource, 'revalidate', 'DEFAULT_REVALIDATE')
+  })
+})
+
+describe('static marketing policy routes', () => {
+  const staticRoutes = [
+    { path: 'app/about/page.tsx', dynamic: 'error', revalidateExpr: 'POLICY_PAGE_REVALIDATE_SECONDS' },
+    { path: 'app/privacy/page.mdx', dynamic: 'error', revalidateExpr: 'POLICY_PAGE_REVALIDATE_SECONDS' },
+    { path: 'app/terms/page.mdx', dynamic: 'error', revalidateExpr: 'POLICY_PAGE_REVALIDATE_SECONDS' },
+  ] as const
+
+  for (const route of staticRoutes) {
+    it(`enforces static rendering for ${route.path}`, () => {
+      const source = readSource(route.path)
+      expectConstExport(source, 'dynamic', `["']${route.dynamic}["']`)
+      expectConstExport(source, 'revalidate', route.revalidateExpr)
+    })
+  }
+})
+
+describe('semi-static product marketing routes', () => {
+  const semiStaticRoutes = [
+    { path: 'app/payments/page.tsx', revalidateExpr: 'PRODUCT_MARKETING_REVALIDATE_SECONDS' },
+    { path: 'app/messaging/page.tsx', revalidateExpr: 'PRODUCT_MARKETING_REVALIDATE_SECONDS' },
+    { path: 'app/maintenance/page.tsx', revalidateExpr: 'PRODUCT_MARKETING_REVALIDATE_SECONDS' },
+    { path: 'app/visitors/page.tsx', revalidateExpr: 'PRODUCT_MARKETING_REVALIDATE_SECONDS' },
+  ] as const
+
+  for (const route of semiStaticRoutes) {
+    it(`uses ISR for ${route.path}`, () => {
+      const source = readSource(route.path)
+      expectConstExport(source, 'dynamic', `["']force-static["']`)
+      expectConstExport(source, 'revalidate', route.revalidateExpr)
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- centralize ISR constants and apply them through the root layout
- lock down policy pages and add hourly ISR to product marketing routes
- document the caching plan and cover it with configuration tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d15d777fac8328b224b34b163e6a03