### PR TITLE
Convert documents overview components to server components

### DIFF
--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,44 +1,36 @@
-'use client';
-
-import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
+import { DocumentListFilters } from '@/types/documents';
 import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
 import { FileText, Users, Calendar, Eye } from 'lucide-react';
 
 interface DocumentsListProps {
-  filter: DocumentListFilters;
+  filter?: DocumentListFilters;
 }
 
-export function DocumentsList({ filter }: DocumentsListProps) {
-  const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+export async function DocumentsList({ filter = {} }: DocumentsListProps) {
+  const result = await getDocumentsAction(filter);
 
-  useEffect(() => {
-    const fetchDocuments = async () => {
-      try {
-        setLoading(true);
-        const result = await getDocumentsAction(filter);
-        if (result.success && result.data) {
-          setDocuments(result.data);
-        } else {
-          setError(result.error || 'Failed to fetch documents');
-        }
-      } catch (err) {
-        console.error('Error fetching documents:', err);
-        setError('An unexpected error occurred');
-      } finally {
-        setLoading(false);
-      }
-    };
+  if (!result.success) {
+    return (
+      <Card className="p-6">
+        <div className="text-center">
+          <p className="mb-2 text-destructive">Error loading documents</p>
+          <p className="text-sm text-muted-foreground">
+            {result.error || 'An unexpected error occurred.'}
+          </p>
+          <Button asChild variant="outline" className="mt-4">
+            <a href="/documents">Try again</a>
+          </Button>
+        </div>
+      </Card>
+    );
+  }
 
-    fetchDocuments();
-  }, [filter]);
+  const documents = result.data ?? [];
 
   const getStatusBadge = (status: string) => {
     const variants = {
@@ -76,53 +68,6 @@ export function DocumentsList({ filter }: DocumentsListProps) {
         return <FileText className="size-4" />;
     }
   };
-
-  if (loading) {
-    return (
-      <div className="space-y-4">
-        {[...Array(3)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <div className="space-y-2">
-                  <div className="h-5 w-48 rounded bg-muted"></div>
-                  <div className="h-4 w-32 rounded bg-muted"></div>
-                </div>
-                <div className="h-6 w-20 rounded bg-muted"></div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center justify-between">
-                <div className="h-4 w-24 rounded bg-muted"></div>
-                <div className="flex space-x-2">
-                  <div className="h-8 w-16 rounded bg-muted"></div>
-                  <div className="h-8 w-16 rounded bg-muted"></div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <Card className="p-6">
-        <div className="text-center">
-          <p className="mb-2 text-destructive">Error loading documents</p>
-          <p className="text-sm text-muted-foreground">{error}</p>
-          <Button
-            variant="outline"
-            className="mt-4"
-            onClick={() => window.location.reload()}
-          >
-            Try Again
-          </Button>
-        </div>
-      </Card>
-    );
-  }
 
   if (documents.length === 0) {
     return (

--- a/app/documents/components/documents-stats.tsx
+++ b/app/documents/components/documents-stats.tsx
@@ -1,42 +1,24 @@
-'use client';
-
-import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FileText, Clock, CheckCircle, AlertCircle } from 'lucide-react';
 import { getDocumentStatsAction } from '../actions';
-import { DocumentStats } from '@/types/documents';
 
-export function DocumentsStats() {
-  const [stats, setStats] = useState<DocumentStats | null>(null);
-  const [loading, setLoading] = useState(true);
+export async function DocumentsStats() {
+  const result = await getDocumentStatsAction();
 
-  useEffect(() => {
-    const fetchStats = async () => {
-      try {
-        const result = await getDocumentStatsAction();
-        if (result.success && result.data) {
-          setStats(result.data);
-        }
-      } catch (error) {
-        console.error('Error fetching document stats:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchStats();
-  }, []);
-
-  if (loading) {
+  if (!result.success || !result.data) {
     return (
       <div className="grid gap-4 md:grid-cols-4">
         {[...Array(4)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
+          <Card key={i} className="border-dashed">
             <CardHeader className="pb-2">
-              <div className="h-4 w-3/4 rounded bg-muted"></div>
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Documents unavailable
+              </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="h-8 w-1/2 rounded bg-muted"></div>
+              <p className="text-xs text-muted-foreground">
+                {result.error || 'Unable to load document statistics.'}
+              </p>
             </CardContent>
           </Card>
         ))}
@@ -44,9 +26,7 @@ export function DocumentsStats() {
     );
   }
 
-  if (!stats) {
-    return null;
-  }
+  const stats = result.data;
 
   const statItems = [
     {
@@ -54,26 +34,30 @@ export function DocumentsStats() {
       value: stats.total_documents,
       icon: FileText,
       color: "text-blue-600",
+      description: "All document types",
     },
     {
       title: "Pending Signatures",
       value: stats.pending_signatures,
       icon: Clock,
       color: "text-yellow-600",
+      description: "Awaiting signatures",
     },
     {
       title: "Signed Documents",
       value: stats.signed_documents,
       icon: CheckCircle,
       color: "text-green-600",
+      description: "Fully executed",
     },
     {
       title: "Expired Documents",
       value: stats.expired_documents,
       icon: AlertCircle,
       color: "text-red-600",
+      description: "Past expiry date",
     },
-  ];
+  ] as const;
 
   return (
     <div className="grid gap-4 md:grid-cols-4">
@@ -87,12 +71,7 @@ export function DocumentsStats() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{item.value}</div>
-            <p className="text-xs text-muted-foreground">
-              {item.title === "Total Documents" && "All document types"}
-              {item.title === "Pending Signatures" && "Awaiting signatures"}
-              {item.title === "Signed Documents" && "Fully executed"}
-              {item.title === "Expired Documents" && "Past expiry date"}
-            </p>
+            <p className="text-xs text-muted-foreground">{item.description}</p>
           </CardContent>
         </Card>
       ))}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "pnpm run guard:client-directives && next lint",
+    "guard:client-directives": "node ./scripts/check-client-directives.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/scripts/check-client-directives.mjs
+++ b/scripts/check-client-directives.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const allowList = [
+  'app/about/page.tsx',
+  'app/account/account-form.tsx',
+  'app/account/avatar.tsx',
+  'app/account/supa-account-form.tsx',
+  'app/auth-server-action/components/AuthFormLegacy.tsx',
+  'app/auth/components/AuthForm.tsx',
+  'app/auth/components/user-auth-form.tsx',
+  'app/bookings/components/amenity-booking-form.tsx',
+  'app/confirmation/page.tsx',
+  'app/countries/[id]/page.tsx',
+  'app/dashboard/components/MobileSideNav.tsx',
+  'app/dashboard/components/NavLinks.tsx',
+  'app/dashboard/components/SignOut.tsx',
+  'app/dashboard/components/ToggleSidebar.tsx',
+  'app/dashboard/members/components/create/CreateForm.tsx',
+  'app/dashboard/members/components/edit/AccountForm.tsx',
+  'app/dashboard/members/components/edit/AdvanceForm.tsx',
+  'app/dashboard/members/components/edit/BasicForm.tsx',
+  'app/dashboard/todo/components/CreateForm.tsx',
+  'app/dashboard/todo/components/TodoForm.tsx',
+  'app/dashboard/todo/components/ToggleDarkMode.tsx',
+  'app/documents/components/create-signature-dialog.tsx',
+  'app/documents/components/document-actions.tsx',
+  'app/documents/components/document-viewer-dialog.tsx',
+  'app/documents/components/documents-filters.tsx',
+  'app/documents/components/upload-document-dialog.tsx',
+  'app/payments/_components/catch-up-payment-card.tsx',
+  'app/payments/_components/stripe-actions.tsx',
+  'app/ssrcountries/[id]/country.tsx',
+  'components/feature-prism.tsx',
+  'components/forms/contact.tsx',
+  'components/forms/profile-form.tsx',
+  'components/forms/reacthookformstep.tsx',
+  'components/forms/updateProfile.tsx',
+  'components/google-auth-button.tsx',
+  'components/maintenance/maintenance-request-form.tsx',
+  'components/mobile-nav.tsx',
+  'components/notifications/notification-center.tsx',
+  'components/react-query-client-provider.tsx',
+  'components/schedule-form.tsx',
+  'components/sidebar-nav.tsx',
+  'components/sign-out-button.tsx',
+  'components/sign-out.tsx',
+  'components/theme-provider.tsx',
+  'components/theme-toggle.tsx',
+  'components/ui/3d-cards.tsx',
+  'components/ui/alert-dialog.tsx',
+  'components/ui/avatar.tsx',
+  'components/ui/calendar.tsx',
+  'components/ui/checkbox.tsx',
+  'components/ui/command.tsx',
+  'components/ui/context-menu.tsx',
+  'components/ui/dialog.tsx',
+  'components/ui/dropdown-menu.tsx',
+  'components/ui/hover-card.tsx',
+  'components/ui/infinite-moving-cards.tsx',
+  'components/ui/label.tsx',
+  'components/ui/menubar.tsx',
+  'components/ui/popover.tsx',
+  'components/ui/progress.tsx',
+  'components/ui/scroll-area.tsx',
+  'components/ui/select.tsx',
+  'components/ui/separator.tsx',
+  'components/ui/sheet.tsx',
+  'components/ui/slider.tsx',
+  'components/ui/switch.tsx',
+  'components/ui/tabs.tsx',
+  'components/ui/time-picker.tsx',
+  'components/ui/toaster.tsx',
+  'components/visitors/visitor-booking-form.tsx',
+  'hooks/use-auth.ts',
+  'hooks/use-document-permissions.ts',
+  'hooks/use-notifications.ts',
+  'lib/hooks/use-copy-to-clipboard.tsx',
+  'lib/hooks/use-sidebar.tsx',
+  'utils/supabase-browser.ts',
+].map((filePath) => filePath.replace(/\\/g, '/'))
+
+const allowedFiles = new Set(allowList)
+const disallowed = []
+
+const IGNORED_DIRECTORIES = new Set([
+  '.git',
+  '.next',
+  'node_modules',
+  '.turbo',
+])
+
+const FILE_PATTERN = /\.(?:[tj]sx?|mdx)$/
+
+async function walk(directory) {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+  for (const entry of entries) {
+    if (IGNORED_DIRECTORIES.has(entry.name)) continue
+
+    const fullPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      await walk(fullPath)
+      continue
+    }
+
+    if (!FILE_PATTERN.test(entry.name)) continue
+
+    const contents = await fs.readFile(fullPath, 'utf8')
+    if (!contents.includes("'use client'") && !contents.includes('"use client"')) {
+      continue
+    }
+
+    const relativePath = path
+      .relative(repoRoot, fullPath)
+      .split(path.sep)
+      .join('/')
+
+    if (!allowedFiles.has(relativePath)) {
+      disallowed.push(relativePath)
+    }
+  }
+}
+
+await walk(repoRoot)
+
+if (disallowed.length > 0) {
+  console.error('\nThe following files contain a "use client" directive but are not in the allow list:')
+  disallowed.forEach((file) => console.error(`  - ${file}`))
+  console.error('\nIf these files must be client components, explicitly add them to the allow list in scripts/check-client-directives.mjs.')
+  process.exit(1)
+}
+
+const missing = []
+for (const filePath of allowedFiles) {
+  const absolute = path.join(repoRoot, filePath)
+  try {
+    const contents = await fs.readFile(absolute, 'utf8')
+    if (!contents.includes("'use client'") && !contents.includes('"use client"')) {
+      missing.push(filePath)
+    }
+  } catch {
+    missing.push(filePath)
+  }
+}
+
+if (missing.length > 0) {
+  console.error('\nThe allow list references files without a "use client" directive:')
+  missing.forEach((file) => console.error(`  - ${file}`))
+  console.error('\nUpdate the allow list in scripts/check-client-directives.mjs to keep it in sync.')
+  process.exit(1)
+}
+


### PR DESCRIPTION
## Summary
- convert the documents list and stats components to async server components that fetch data on the server
- preserve client interactivity within child components while updating error states to avoid direct browser APIs
- add a guard script to enforce an allowlist of client components and run it as part of `pnpm lint`

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d772eb0832890ef5adaf2a57c91