### PR TITLE
Optimize document and payment renders with memoization

### DIFF
--- a/app/documents/components/document-actions.tsx
+++ b/app/documents/components/document-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -21,20 +21,19 @@ interface DocumentActionsProps {
   document: DocumentWithLease;
 }
 
-export function DocumentActions({ document }: DocumentActionsProps) {
+function DocumentActionsComponent({ document }: DocumentActionsProps) {
   const [showViewer, setShowViewer] = useState(false);
   const [showSignatureDialog, setShowSignatureDialog] = useState(false);
   const [loading, setLoading] = useState<string | null>(null);
   const permissions = useDocumentPermissions();
 
-  const handleView = () => {
+  const handleView = useCallback(() => {
     setShowViewer(true);
-  };
+  }, []);
 
-  const handleSign = async () => {
+  const handleSign = useCallback(async () => {
     setLoading('signing');
     try {
-      // If we have an external signing flow via Documenso, open it
       const urlResult = await getSigningUrlAction(document.id);
       if (urlResult.success && urlResult.data?.signing_url) {
         window.open(urlResult.data.signing_url, '_blank');
@@ -42,7 +41,6 @@ export function DocumentActions({ document }: DocumentActionsProps) {
         return;
       }
 
-      // Fallback: mark as signed locally (only if URL not available)
       const result = await signDocumentAction(document.id);
       if (result.success) {
         toast.success('Document signed successfully');
@@ -56,38 +54,37 @@ export function DocumentActions({ document }: DocumentActionsProps) {
     } finally {
       setLoading(null);
     }
-  };
+  }, [document.id]);
 
-  const handleCreateSigningRequest = () => {
+  const handleCreateSigningRequest = useCallback(() => {
     setShowSignatureDialog(true);
-  };
+  }, []);
 
-  const handleDownload = () => {
+  const handleDownload = useCallback(() => {
     if (document.file_url) {
       window.open(document.file_url, '_blank');
     }
-  };
+  }, [document.file_url]);
 
-  const handleShare = () => {
+  const handleShare = useCallback(() => {
     if (navigator.share && document.file_url) {
       navigator.share({
         title: document.title,
         url: document.file_url,
       });
     } else {
-      // Fallback: copy URL to clipboard
       navigator.clipboard.writeText(document.file_url || '');
       toast.success('Document URL copied to clipboard');
     }
-  };
+  }, [document.file_url, document.title]);
 
-  // Permission checks
-  const canView = permissions.canViewDocument(document);
-  const canSign = permissions.canSignDocument(document);
-  const canCreateSignature = permissions.canCreateSigningRequests &&
-    document.status === 'draft' &&
-    document.requires_signature;
-  const canEdit = permissions.canEditDocument(document);
+  const canView = useMemo(() => permissions.canViewDocument(document), [permissions, document]);
+  const canSign = useMemo(() => permissions.canSignDocument(document), [permissions, document]);
+  const canCreateSignature = useMemo(
+    () => permissions.canCreateSigningRequests && document.status === 'draft' && document.requires_signature,
+    [document.requires_signature, document.status, permissions],
+  );
+  const canEdit = useMemo(() => permissions.canEditDocument(document), [permissions, document]);
 
   // Don't render anything if user can't view this document
   if (!canView) {
@@ -152,3 +149,8 @@ export function DocumentActions({ document }: DocumentActionsProps) {
     </>
   );
 }
+
+export const DocumentActions = memo(
+  DocumentActionsComponent,
+  (prev, next) => prev.document.id === next.document.id && prev.document.updated_at === next.document.updated_at,
+);

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,20 +10,187 @@ import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
 import { FileText, Users, Calendar, Eye } from 'lucide-react';
 
+const STATUS_VARIANTS = {
+  draft: 'secondary',
+  pending_signature: 'outline',
+  signed: 'default',
+  expired: 'destructive',
+  cancelled: 'secondary',
+} as const;
+
+const STATUS_LABELS = {
+  draft: 'Draft',
+  pending_signature: 'Pending Signature',
+  signed: 'Signed',
+  expired: 'Expired',
+  cancelled: 'Cancelled',
+} as const;
+
+type NormalizedFilter = DocumentListFilters | Record<string, never>;
+
+function normalizeFilter(filter: DocumentListFilters | undefined): NormalizedFilter {
+  if (!filter) {
+    return {};
+  }
+
+  const normalized: DocumentListFilters = {};
+
+  if (filter.status?.length) {
+    normalized.status = [...filter.status].sort();
+  }
+
+  if (filter.type?.length) {
+    normalized.type = [...filter.type].sort();
+  }
+
+  if (filter.tenant_id) {
+    normalized.tenant_id = filter.tenant_id;
+  }
+
+  if (filter.unit_id) {
+    normalized.unit_id = filter.unit_id;
+  }
+
+  if (filter.date_from) {
+    normalized.date_from = filter.date_from;
+  }
+
+  if (filter.date_to) {
+    normalized.date_to = filter.date_to;
+  }
+
+  return normalized;
+}
+
+function createFilterKey(filter: NormalizedFilter) {
+  return JSON.stringify(filter ?? {});
+}
+
+function areFiltersEqual(prev: DocumentsListProps, next: DocumentsListProps) {
+  const prevNormalized = normalizeFilter(prev.filter);
+  const nextNormalized = normalizeFilter(next.filter);
+  return createFilterKey(prevNormalized) === createFilterKey(nextNormalized);
+}
+
+interface DocumentCardProps {
+  document: DocumentWithLease;
+}
+
+const DocumentCard = memo(({ document }: DocumentCardProps) => {
+  const createdLabel = useMemo(
+    () => formatDistanceToNow(new Date(document.created_at), { addSuffix: true }),
+    [document.created_at],
+  );
+
+  const statusVariant = STATUS_VARIANTS[document.status as keyof typeof STATUS_VARIANTS] ?? 'secondary';
+  const statusLabel = STATUS_LABELS[document.status as keyof typeof STATUS_LABELS] ?? document.status;
+
+  const typeIcon = useMemo(() => {
+    switch (document.document_type) {
+      case 'lease':
+      case 'addendum':
+        return <FileText className="size-4" />;
+      case 'insurance':
+        return <Users className="size-4" />;
+      default:
+        return <FileText className="size-4" />;
+    }
+  }, [document.document_type]);
+
+  const signedCount = useMemo(
+    () => document.signatures?.filter((signature) => signature.status === 'signed').length ?? 0,
+    [document.signatures],
+  );
+
+  const totalSignatures = document.signatures?.length ?? 0;
+
+  const visibleSignatures = useMemo(
+    () => document.signatures?.slice(0, 3) ?? [],
+    [document.signatures],
+  );
+
+  return (
+    <Card className="transition-shadow hover:shadow-md">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between">
+          <div className="flex items-start space-x-3">
+            <div className="mt-1">{typeIcon}</div>
+            <div className="space-y-1">
+              <h3 className="font-medium leading-none">{document.title}</h3>
+              {document.description ? (
+                <p className="text-sm text-muted-foreground">{document.description}</p>
+              ) : null}
+              <div className="flex items-center space-x-4 text-xs text-muted-foreground">
+                <div className="flex items-center space-x-1">
+                  <Calendar className="size-3" />
+                  <span>{createdLabel}</span>
+                </div>
+                {document.lease ? (
+                  <div className="flex items-center space-x-1">
+                    <Users className="size-3" />
+                    <span>Lease • {document.lease.tenant_ids?.length ?? 0} tenants</span>
+                  </div>
+                ) : null}
+                {totalSignatures > 0 ? (
+                  <div className="flex items-center space-x-1">
+                    <Eye className="size-3" />
+                    <span>
+                      {signedCount}/{totalSignatures} signed
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Badge variant={statusVariant}>{statusLabel}</Badge>
+            <DocumentActions document={document} />
+          </div>
+        </div>
+      </CardHeader>
+      {totalSignatures > 0 ? (
+        <CardContent className="pt-0">
+          <div className="flex items-center space-x-2">
+            <span className="text-xs text-muted-foreground">Signers:</span>
+            {visibleSignatures.map((signature) => (
+              <Badge
+                key={signature.id}
+                variant={signature.status === 'signed' ? 'default' : 'outline'}
+                className="text-xs"
+              >
+                {signature.signer_name || signature.signer_email.split('@')[0]}
+              </Badge>
+            ))}
+            {totalSignatures > visibleSignatures.length ? (
+              <Badge variant="secondary" className="text-xs">
+                +{totalSignatures - visibleSignatures.length} more
+              </Badge>
+            ) : null}
+          </div>
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}, (prev, next) => prev.document.id === next.document.id && prev.document.updated_at === next.document.updated_at);
+
+DocumentCard.displayName = 'DocumentCard';
+
 interface DocumentsListProps {
   filter: DocumentListFilters;
 }
 
-export function DocumentsList({ filter }: DocumentsListProps) {
+export const DocumentsList = memo(function DocumentsList({ filter }: DocumentsListProps) {
   const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const normalizedFilter = useMemo(() => normalizeFilter(filter), [filter]);
+  const filterKey = useMemo(() => createFilterKey(normalizedFilter), [normalizedFilter]);
 
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
         setLoading(true);
-        const result = await getDocumentsAction(filter);
+        const result = await getDocumentsAction(normalizedFilter as DocumentListFilters);
         if (result.success && result.data) {
           setDocuments(result.data);
         } else {
@@ -38,44 +205,12 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     };
 
     fetchDocuments();
-  }, [filter]);
+  }, [filterKey, normalizedFilter]);
 
-  const getStatusBadge = (status: string) => {
-    const variants = {
-      draft: 'secondary',
-      pending_signature: 'outline',
-      signed: 'default',
-      expired: 'destructive',
-      cancelled: 'secondary',
-    } as const;
-
-    const labels = {
-      draft: 'Draft',
-      pending_signature: 'Pending Signature',
-      signed: 'Signed',
-      expired: 'Expired',
-      cancelled: 'Cancelled',
-    };
-
-    return (
-      <Badge variant={variants[status as keyof typeof variants] || 'secondary'}>
-        {labels[status as keyof typeof labels] || status}
-      </Badge>
-    );
-  };
-
-  const getTypeIcon = (type: string) => {
-    switch (type) {
-      case 'lease':
-        return <FileText className="size-4" />;
-      case 'addendum':
-        return <FileText className="size-4" />;
-      case 'insurance':
-        return <Users className="size-4" />;
-      default:
-        return <FileText className="size-4" />;
-    }
-  };
+  const documentCards = useMemo(
+    () => documents.map((doc) => <DocumentCard key={doc.id} document={doc} />),
+    [documents],
+  );
 
   if (loading) {
     return (
@@ -140,77 +275,5 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     );
   }
 
-  return (
-    <div className="space-y-4">
-      {documents.map((doc) => (
-        <Card key={doc.id} className="transition-shadow hover:shadow-md">
-          <CardHeader className="pb-3">
-            <div className="flex items-start justify-between">
-              <div className="flex items-start space-x-3">
-                <div className="mt-1">
-                  {getTypeIcon(doc.document_type)}
-                </div>
-                <div className="space-y-1">
-                  <h3 className="font-medium leading-none">{doc.title}</h3>
-                  {doc.description && (
-                    <p className="text-sm text-muted-foreground">
-                      {doc.description}
-                    </p>
-                  )}
-                  <div className="flex items-center space-x-4 text-xs text-muted-foreground">
-                    <div className="flex items-center space-x-1">
-                      <Calendar className="size-3" />
-                      <span>
-                        {formatDistanceToNow(new Date(doc.created_at), { addSuffix: true })}
-                      </span>
-                    </div>
-                    {doc.lease && (
-                      <div className="flex items-center space-x-1">
-                        <Users className="size-3" />
-                        <span>Lease • {doc.lease.tenant_ids?.length || 0} tenants</span>
-                      </div>
-                    )}
-                    {doc.signatures && doc.signatures.length > 0 && (
-                      <div className="flex items-center space-x-1">
-                        <Eye className="size-3" />
-                        <span>
-                          {doc.signatures.filter(s => s.status === 'signed').length}/
-                          {doc.signatures.length} signed
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                {getStatusBadge(doc.status)}
-                <DocumentActions document={doc} />
-              </div>
-            </div>
-          </CardHeader>
-          {doc.signatures && doc.signatures.length > 0 && (
-            <CardContent className="pt-0">
-              <div className="flex items-center space-x-2">
-                <span className="text-xs text-muted-foreground">Signers:</span>
-                {doc.signatures.slice(0, 3).map((signature) => (
-                  <Badge
-                    key={signature.id}
-                    variant={signature.status === 'signed' ? 'default' : 'outline'}
-                    className="text-xs"
-                  >
-                    {signature.signer_name || signature.signer_email.split('@')[0]}
-                  </Badge>
-                ))}
-                {doc.signatures.length > 3 && (
-                  <Badge variant="secondary" className="text-xs">
-                    +{doc.signatures.length - 3} more
-                  </Badge>
-                )}
-              </div>
-            </CardContent>
-          )}
-        </Card>
-      ))}
-    </div>
-  );
-}
+  return <div className="space-y-4">{documentCards}</div>;
+}, areFiltersEqual);

--- a/app/payments/_components/catch-up-payment-card.tsx
+++ b/app/payments/_components/catch-up-payment-card.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState, useTransition } from "react"
+import React, { useCallback, useEffect, useMemo, useState, useTransition } from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { format, parseISO } from "date-fns"
 import { useForm } from "react-hook-form"
@@ -69,7 +69,8 @@ type QuickAmount = {
   value: number
 }
 
-export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
+export const CatchUpPaymentCard = React.memo(
+  function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
   const schema = useMemo(() => createCatchUpFormSchema(balances), [balances])
   const form = useForm<CatchUpPaymentFormValues>({
     resolver: zodResolver(schema),
@@ -188,14 +189,17 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
     )
   }, [nextCharge, outstandingBalance, selectedBalance])
 
-  const handleQuickAmount = (value: number) => {
-    form.setValue("amount", value.toFixed(2), {
-      shouldDirty: true,
-      shouldValidate: true,
-    })
-  }
+  const handleQuickAmount = useCallback(
+    (value: number) => {
+      form.setValue("amount", value.toFixed(2), {
+        shouldDirty: true,
+        shouldValidate: true,
+      })
+    },
+    [form],
+  )
 
-  const onSubmit = async (values: CatchUpPaymentFormValues) => {
+  const onSubmit = useCallback(async (values: CatchUpPaymentFormValues) => {
     const parsed = parseCurrencyInput(values.amount)
     if (!Number.isFinite(parsed) || parsed <= 0) {
       toast({
@@ -242,7 +246,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
         })
       }
     })
-  }
+  }, [form])
 
   const disableSubmit =
     !selectedBalance || outstandingBalance <= 0 || normalizedAmount <= 0 || isPending
@@ -535,4 +539,6 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
       ) : null}
     </Card>
   )
-}
+  },
+  (prev, next) => prev.balances === next.balances,
+)

--- a/docs/perf/flamegraphs/documents-after.json
+++ b/docs/perf/flamegraphs/documents-after.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "DocumentsList",
+    "phase": "mount",
+    "actualDuration": 16.411143000003904,
+    "baseDuration": 8.919639000001098,
+    "startTime": 2507.619032,
+    "commitTime": 2525.40623
+  },
+  {
+    "id": "DocumentsList",
+    "phase": "update",
+    "actualDuration": 11.889624999999796,
+    "baseDuration": 5.361589000000549,
+    "startTime": 2530.280841,
+    "commitTime": 2542.37583
+  }
+]

--- a/docs/perf/flamegraphs/documents-before.json
+++ b/docs/perf/flamegraphs/documents-before.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "DocumentsList",
+    "phase": "mount",
+    "actualDuration": 18.14072900000292,
+    "baseDuration": 10.362381000000823,
+    "startTime": 2491.590402,
+    "commitTime": 2511.196338
+  },
+  {
+    "id": "DocumentsList",
+    "phase": "update",
+    "actualDuration": 12.838325999997778,
+    "baseDuration": 5.817711999997755,
+    "startTime": 2516.633317,
+    "commitTime": 2529.735458
+  }
+]

--- a/docs/perf/flamegraphs/payments-after.json
+++ b/docs/perf/flamegraphs/payments-after.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "mount",
+    "actualDuration": 70.7293399999985,
+    "baseDuration": 39.504838000003474,
+    "startTime": 2561.164867,
+    "commitTime": 2632.282057
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 10.763597000000573,
+    "baseDuration": 9.337174000005234,
+    "startTime": 2637.712744,
+    "commitTime": 2648.967578
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 11.448451000001114,
+    "baseDuration": 11.791153000004215,
+    "startTime": 2650.432411,
+    "commitTime": 2662.72215
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 7.348979000001236,
+    "baseDuration": 10.975577000006979,
+    "startTime": 2663.957982,
+    "commitTime": 2671.605514
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 0.6227359999975306,
+    "baseDuration": 10.84306600000491,
+    "startTime": 2672.537964,
+    "commitTime": 2673.885729
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "update",
+    "actualDuration": 8.42620300000408,
+    "baseDuration": 7.267908000003445,
+    "startTime": 2674.280215,
+    "commitTime": 2683.101584
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 0.047909000002618995,
+    "baseDuration": 7.267908000003445,
+    "startTime": 2683.678046,
+    "commitTime": 2684.589486
+  }
+]

--- a/docs/perf/flamegraphs/payments-before.json
+++ b/docs/perf/flamegraphs/payments-before.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "mount",
+    "actualDuration": 78.55534800000032,
+    "baseDuration": 44.95728800000143,
+    "startTime": 2548.286372,
+    "commitTime": 2627.260772
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 9.413850000004913,
+    "baseDuration": 7.934123000005911,
+    "startTime": 2633.156704,
+    "commitTime": 2643.073052
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 11.570406000001185,
+    "baseDuration": 10.242351000006238,
+    "startTime": 2644.832446,
+    "commitTime": 2657.116003
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 7.94847499999878,
+    "baseDuration": 9.39114000000609,
+    "startTime": 2658.300474,
+    "commitTime": 2666.573356
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 0.746042999999645,
+    "baseDuration": 9.337478000006286,
+    "startTime": 2667.716036,
+    "commitTime": 2669.346518
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "update",
+    "actualDuration": 7.642407000003914,
+    "baseDuration": 6.792679000000135,
+    "startTime": 2669.825653,
+    "commitTime": 2677.794649
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 0.073851000000559,
+    "baseDuration": 6.792679000000135,
+    "startTime": 2678.51958,
+    "commitTime": 2679.65779
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "update",
+    "actualDuration": 7.0035899999984395,
+    "baseDuration": 6.037460000001829,
+    "startTime": 2687.01825,
+    "commitTime": 2694.266682
+  },
+  {
+    "id": "CatchUpPaymentCard",
+    "phase": "nested-update",
+    "actualDuration": 0.04956500000162123,
+    "baseDuration": 6.037460000001829,
+    "startTime": 2694.922458,
+    "commitTime": 2695.717125
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -71,6 +71,8 @@
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+        "@testing-library/jest-dom": "^6.8.0",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.2",
         "@types/node": "^20.19.0",
         "@types/react": "^18.3.3",
@@ -82,11 +84,19 @@
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-tailwindcss": "^3.14.2",
+        "jsdom": "^27.0.0",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.5.4",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -98,6 +108,50 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.4.tgz",
+      "integrity": "sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.5.tgz",
+      "integrity": "sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -364,6 +418,144 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {
@@ -3193,6 +3385,93 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -3207,6 +3486,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -5477,6 +5764,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5486,6 +5794,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/csstype": {
@@ -5498,6 +5821,57 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -5574,6 +5948,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -5741,6 +6122,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -7587,6 +7976,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-to-text": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
@@ -7620,6 +8022,20 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7630,6 +8046,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -7683,6 +8112,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -8051,6 +8490,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8332,6 +8778,83 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -8592,6 +9115,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/maath": {
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
@@ -8780,6 +9314,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-anything": {
       "version": "5.1.7",
@@ -9437,6 +9978,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -9917,6 +10468,32 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseley": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
@@ -10239,6 +10816,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10646,6 +11261,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10827,6 +11456,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10918,6 +11554,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -11596,6 +12252,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -11768,6 +12437,13 @@
       "peerDependencies": {
         "react": ">=17.0"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
@@ -12154,6 +12830,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.15.tgz",
+      "integrity": "sha512-heYRCiGLhtI+U/D0V8YM3QRwPfsLJiP+HX+YwiHZTnWzjIKC+ZCxQRYlzvOoTEc6KIP62B1VeAN63diGCng2hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.15"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.15.tgz",
+      "integrity": "sha512-YBkp2VfS9VTRMPNL2PA6PMESmxV1JEVoAr5iBlZnB5JG3KUrWzNCB3yNNkRa2FZkqClaBgfNYCp8PgpYmpjkZw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12163,6 +12859,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -13123,6 +13832,19 @@
         "node": ">= 14.6"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -13233,6 +13955,29 @@
       "peer": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -13479,6 +14224,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xregexp": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
@@ -84,6 +86,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/tests/components/memoization-behavior.test.tsx
+++ b/tests/components/memoization-behavior.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import * as React from "react"
+import "@testing-library/jest-dom/vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { DocumentWithLease } from "@/types/documents"
+import type { CatchUpPaymentSubmissionResult } from "@/types/payments"
+import { catchUpBalances } from "@/lib/payments/mock-data"
+
+;(globalThis as unknown as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+const sampleDocument: DocumentWithLease = {
+  id: "doc_memo",
+  title: "Signed Lease",
+  description: "Updated lease agreement",
+  created_at: new Date("2024-03-01T10:00:00Z").toISOString(),
+  updated_at: new Date("2024-03-02T10:00:00Z").toISOString(),
+  document_type: "lease",
+  status: "signed",
+  tenant_id: "tenant_1",
+  unit_id: "unit_2",
+  file_url: "https://example.com/lease.pdf",
+  requires_signature: true,
+  expires_at: null,
+  lease: {
+    id: "lease_2",
+    unit_id: "unit_2",
+    start_date: "2024-03-01",
+    end_date: "2025-02-28",
+    tenant_ids: ["tenant_1"],
+    rent_amount: 2200,
+    status: "active",
+    created_at: new Date("2024-03-01T00:00:00Z").toISOString(),
+    updated_at: new Date("2024-03-01T00:00:00Z").toISOString(),
+  },
+  signatures: [
+    {
+      id: "sig_a",
+      document_id: "doc_memo",
+      signer_id: "tenant_1",
+      signer_email: "tenant1@example.com",
+      signer_name: "Casey Resident",
+      status: "signed",
+      signed_at: new Date("2024-03-02T10:00:00Z").toISOString(),
+      created_at: new Date("2024-03-01T10:00:00Z").toISOString(),
+      updated_at: new Date("2024-03-02T10:00:00Z").toISOString(),
+    },
+  ],
+  access_logs: [],
+}
+
+const memoBalances = catchUpBalances.slice(0, 2)
+
+describe("memoized component behaviour", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it("avoids refetching documents when filter values stay stable", async () => {
+    const mockGetDocumentsAction = vi.fn().mockResolvedValue({
+      success: true,
+      data: [sampleDocument],
+    })
+
+    vi.doMock("@/app/documents/actions", () => ({
+      getDocumentsAction: mockGetDocumentsAction,
+    }))
+
+    vi.doMock("@/app/documents/components/document-actions", () => ({
+      DocumentActions: () => <div data-testid="document-actions" />,
+    }))
+
+    vi.doMock("@/hooks/use-document-permissions", () => ({
+      useDocumentPermissions: () => ({
+        canViewDocument: () => true,
+        canSignDocument: () => true,
+        canCreateSigningRequests: true,
+        canEditDocument: () => true,
+      }),
+    }))
+
+    const { DocumentsList } = await import("@/app/documents/components/documents-list")
+
+    const { rerender } = render(<DocumentsList filter={{ status: ["signed"] }} />)
+
+    await waitFor(() => expect(mockGetDocumentsAction).toHaveBeenCalledTimes(1))
+    await screen.findByText("Signed Lease")
+
+    rerender(<DocumentsList filter={{ status: ["signed"] }} />)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockGetDocumentsAction).toHaveBeenCalledTimes(1)
+  })
+  it("does not recompute schemas when catch-up balances reference is unchanged", async () => {
+    const mockSubmit = vi.fn<
+      [parameters: { roommateId: string; amount: number; includePropertyManager: boolean; note?: string }],
+      Promise<CatchUpPaymentSubmissionResult>
+    >().mockResolvedValue({
+      paymentIntentId: "pi_memo",
+      roommateId: memoBalances[0]!.roommateId,
+      roommateName: memoBalances[0]!.roommateName,
+      amount: 100,
+      currency: memoBalances[0]!.currency,
+      projectedBalance: 0,
+      allocations: [],
+      recipients: [],
+      note: undefined,
+    })
+
+    let schemaSpy: ((balances: typeof memoBalances) => ReturnType<typeof import("@/lib/payments/schemas").createCatchUpFormSchema>) | undefined
+
+    vi.doMock("@/app/payments/actions", () => ({
+      submitCatchUpPayment: mockSubmit,
+    }))
+
+    vi.doMock("@/lib/payments/schemas", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/payments/schemas")>(
+        "@/lib/payments/schemas",
+      )
+
+      schemaSpy = vi.fn(actual.createCatchUpFormSchema)
+
+      return {
+        ...actual,
+        createCatchUpFormSchema: schemaSpy!,
+      }
+    })
+
+    const { CatchUpPaymentCard } = await import("@/app/payments/_components/catch-up-payment-card")
+
+    const { rerender } = render(<CatchUpPaymentCard balances={memoBalances} />)
+
+    await waitFor(() => expect(screen.getByText("One-time catch up")).toBeInTheDocument())
+    expect(schemaSpy).toHaveBeenCalledTimes(1)
+
+    rerender(<CatchUpPaymentCard balances={memoBalances} />)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(schemaSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/perf/profile-components.test.tsx
+++ b/tests/perf/profile-components.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+import * as React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom/vitest"
+import fs from "node:fs"
+import path from "node:path"
+
+(globalThis as unknown as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+import type { DocumentWithLease } from "@/types/documents"
+import type { CatchUpPaymentSubmissionResult } from "@/types/payments"
+import { catchUpBalances } from "@/lib/payments/mock-data"
+
+import { DocumentsList } from "@/app/documents/components/documents-list"
+import { CatchUpPaymentCard } from "@/app/payments/_components/catch-up-payment-card"
+
+vi.mock("@/app/documents/components/document-actions", () => ({
+  DocumentActions: () => <div data-testid="document-actions" />,
+}))
+
+vi.mock("@/hooks/use-document-permissions", () => ({
+  useDocumentPermissions: () => ({
+    canViewDocument: () => true,
+    canSignDocument: () => true,
+    canCreateSigningRequests: true,
+    canEditDocument: () => true,
+  }),
+}))
+
+const mockGetDocumentsAction = vi.fn()
+vi.mock("@/app/documents/actions", () => ({
+  getDocumentsAction: (...args: unknown[]) => mockGetDocumentsAction(...args),
+}))
+
+const mockSubmitCatchUpPayment = vi.fn<
+  [parameters: { roommateId: string; amount: number; includePropertyManager: boolean; note?: string }],
+  Promise<CatchUpPaymentSubmissionResult>
+>()
+
+vi.mock("@/app/payments/actions", () => ({
+  submitCatchUpPayment: (...args: Parameters<typeof mockSubmitCatchUpPayment>) =>
+    mockSubmitCatchUpPayment(...args),
+}))
+
+const documentsProfileEntries: Array<Record<string, unknown>> = []
+const paymentsProfileEntries: Array<Record<string, unknown>> = []
+
+const sampleDocuments: DocumentWithLease[] = [
+  {
+    id: "doc_1",
+    title: "Lease Agreement",
+    description: "Primary lease document",
+    created_at: new Date("2024-01-05T12:00:00Z").toISOString(),
+    updated_at: new Date("2024-02-01T12:00:00Z").toISOString(),
+    document_type: "lease",
+    status: "pending_signature",
+    tenant_id: "tenant_1",
+    unit_id: "unit_1",
+    file_url: "https://example.com/lease.pdf",
+    requires_signature: true,
+    expires_at: null,
+    lease: {
+      id: "lease_1",
+      unit_id: "unit_1",
+      start_date: "2024-01-01",
+      end_date: "2024-12-31",
+      tenant_ids: ["tenant_1", "tenant_2"],
+      rent_amount: 2400,
+      status: "active",
+      created_at: new Date("2024-01-01T00:00:00Z").toISOString(),
+      updated_at: new Date("2024-01-01T00:00:00Z").toISOString(),
+    },
+    signatures: [
+      {
+        id: "sig_1",
+        document_id: "doc_1",
+        signer_id: "tenant_1",
+        signer_email: "tenant1@example.com",
+        signer_name: "Alex Tenant",
+        status: "signed",
+        signed_at: new Date("2024-01-06T12:00:00Z").toISOString(),
+        created_at: new Date("2024-01-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2024-01-06T12:00:00Z").toISOString(),
+      },
+      {
+        id: "sig_2",
+        document_id: "doc_1",
+        signer_id: "tenant_2",
+        signer_email: "tenant2@example.com",
+        signer_name: "Jamie Roommate",
+        status: "pending",
+        signed_at: null,
+        created_at: new Date("2024-01-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2024-01-06T12:00:00Z").toISOString(),
+      },
+    ],
+    access_logs: [],
+  },
+]
+
+function recordEntry(store: Array<Record<string, unknown>>, data: Parameters<React.ProfilerOnRenderCallback>) {
+  const [id, phase, actualDuration, baseDuration, startTime, commitTime] = data
+  store.push({
+    id,
+    phase,
+    actualDuration,
+    baseDuration,
+    startTime,
+    commitTime,
+  })
+}
+
+function persistProfiles() {
+  const outputDir = process.env.PROFILE_OUTPUT_DIR
+  if (!outputDir) {
+    return
+  }
+
+  const tag = process.env.PROFILE_PHASE ?? "snapshot"
+  fs.mkdirSync(outputDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(outputDir, `documents-${tag}.json`),
+    JSON.stringify(documentsProfileEntries, null, 2),
+    "utf8",
+  )
+  fs.writeFileSync(
+    path.join(outputDir, `payments-${tag}.json`),
+    JSON.stringify(paymentsProfileEntries, null, 2),
+    "utf8",
+  )
+}
+
+beforeEach(() => {
+  mockGetDocumentsAction.mockReset()
+  mockSubmitCatchUpPayment.mockReset()
+})
+
+afterAll(() => {
+  persistProfiles()
+})
+
+describe("profile snapshots", () => {
+  it("captures document list render profile", async () => {
+    documentsProfileEntries.length = 0
+    mockGetDocumentsAction.mockResolvedValue({ success: true, data: sampleDocuments })
+
+    render(
+      <React.Profiler id="DocumentsList" onRender={(...args) => recordEntry(documentsProfileEntries, args)}>
+        <DocumentsList filter={{ status: ["pending_signature"] }} />
+      </React.Profiler>,
+    )
+
+    await waitFor(() => expect(mockGetDocumentsAction).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByText("Lease Agreement")).toBeInTheDocument())
+
+    expect(documentsProfileEntries.length).toBeGreaterThan(0)
+  })
+
+  it("captures payment form render profile", async () => {
+    paymentsProfileEntries.length = 0
+    const result: CatchUpPaymentSubmissionResult = {
+      paymentIntentId: "pi_test",
+      roommateId: catchUpBalances[0]!.roommateId,
+      roommateName: catchUpBalances[0]!.roommateName,
+      amount: 120,
+      currency: catchUpBalances[0]!.currency,
+      projectedBalance: 0,
+      allocations: [],
+      recipients: [],
+      note: undefined,
+    }
+
+    mockSubmitCatchUpPayment.mockResolvedValue(result)
+
+    render(
+      <React.Profiler id="CatchUpPaymentCard" onRender={(...args) => recordEntry(paymentsProfileEntries, args)}>
+        <CatchUpPaymentCard balances={catchUpBalances.slice(0, 2)} />
+      </React.Profiler>,
+    )
+
+    await waitFor(() => expect(screen.getByText("One-time catch up")).toBeInTheDocument())
+    expect(paymentsProfileEntries.length).toBeGreaterThan(0)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,11 +4,15 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   },
   resolve: {
     alias: {
       "@": path.resolve(__dirname),
     },
+  },
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "react",
   },
 })


### PR DESCRIPTION
## Summary
- memoize the documents list rendering path and reuse normalized filters to avoid redundant fetches
- wrap document actions and the catch-up payment form in memoized components with stable callbacks and dependencies
- add profiling snapshot tests plus regression coverage for memoized behavior and store before/after profiler outputs

## Testing
- npm test
- PROFILE_OUTPUT_DIR=docs/perf/flamegraphs PROFILE_PHASE=before npm test -- tests/perf/profile-components.test.tsx
- PROFILE_OUTPUT_DIR=docs/perf/flamegraphs PROFILE_PHASE=after npm test -- tests/perf/profile-components.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d15d7463488328be8812d5b2ba64fc