### PR TITLE
Virtualize document and message lists

### DIFF
--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -2,7 +2,14 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Link from "next/link"
 
+import { RoommateBoardList } from "../components/roommate-board-list"
+
 export default function DashboardPage() {
+  const roommateBoardMessages = [
+    { id: "jordan-wifi", content: "Jordan: Wi-Fi is down, rebooted router." },
+    { id: "avery-parking", content: "Avery: Parking spot swap this weekend?" },
+  ]
+
   return (
     <div className="w-full space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -50,10 +57,7 @@ export default function DashboardPage() {
           <CardTitle>Roommate board</CardTitle>
         </CardHeader>
         <CardContent>
-          <ul className="space-y-2 text-sm">
-            <li>Jordan: Wi-Fi is down, rebooted router.</li>
-            <li>Avery: Parking spot swap this weekend?</li>
-          </ul>
+          <RoommateBoardList messages={roommateBoardMessages} />
           <Link href="/messaging" className="mt-4 inline-block">
             <Button variant="outline" size="sm">Go to messages</Button>
           </Link>

--- a/app/dashboard/components/roommate-board-list.tsx
+++ b/app/dashboard/components/roommate-board-list.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { VirtualizedList } from '@/components/ui/virtualized-list';
+
+type RoommateMessage = {
+  id: string;
+  content: string;
+};
+
+interface RoommateBoardListProps {
+  messages: RoommateMessage[];
+}
+
+export function RoommateBoardList({ messages }: RoommateBoardListProps) {
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <VirtualizedList
+      items={messages}
+      estimateSize={(item) => (item.content.length > 120 ? 72 : 56)}
+      getKey={(item) => item.id}
+      overscan={4}
+      itemClassName="py-2 text-sm"
+      role="list"
+      itemRole="listitem"
+      parentProps={{ className: 'relative text-sm' }}
+      fallbackParentProps={{ className: 'text-sm' }}
+      useWindowScroll
+    >
+      {({ item }) => (
+        <p className="leading-snug">{item.content}</p>
+      )}
+    </VirtualizedList>
+  );
+}

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -9,6 +9,7 @@ import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
 import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import { VirtualizedList } from '@/components/ui/virtualized-list';
 
 interface DocumentsListProps {
   filter: DocumentListFilters;
@@ -141,9 +142,19 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   }
 
   return (
-    <div className="space-y-4">
-      {documents.map((doc) => (
-        <Card key={doc.id} className="transition-shadow hover:shadow-md">
+    <VirtualizedList
+      items={documents}
+      estimateSize={(item) => (item.signatures && item.signatures.length > 0 ? 228 : 188)}
+      getKey={(item) => item.id}
+      overscan={6}
+      itemClassName="pb-4"
+      role="list"
+      itemRole="listitem"
+      parentProps={{ className: 'relative' }}
+      useWindowScroll
+    >
+      {({ item: doc }) => (
+        <Card className="transition-shadow hover:shadow-md">
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between">
               <div className="flex items-start space-x-3">
@@ -210,7 +221,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
             </CardContent>
           )}
         </Card>
-      ))}
-    </div>
+      )}
+    </VirtualizedList>
   );
 }

--- a/components/ui/virtualized-list.tsx
+++ b/components/ui/virtualized-list.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import {
+  type AriaRole,
+  type HTMLAttributes,
+  type Key,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+import { cn } from '@/lib/utils';
+
+export interface VirtualizedListProps<T> {
+  items: T[];
+  children: (context: { item: T; index: number }) => ReactNode;
+  estimateSize: (item: T, index: number) => number;
+  getKey?: (item: T, index: number) => Key;
+  overscan?: number;
+  virtualizationThreshold?: number;
+  role?: AriaRole;
+  itemRole?: AriaRole;
+  parentProps?: HTMLAttributes<HTMLDivElement>;
+  fallbackParentProps?: HTMLAttributes<HTMLDivElement>;
+  itemClassName?: string;
+  useWindowScroll?: boolean;
+}
+
+const DEFAULT_THRESHOLD = 1;
+
+export function VirtualizedList<T>({
+  items,
+  children,
+  estimateSize,
+  getKey,
+  overscan = 8,
+  virtualizationThreshold = DEFAULT_THRESHOLD,
+  role = 'list',
+  itemRole = 'listitem',
+  parentProps,
+  fallbackParentProps,
+  itemClassName,
+  useWindowScroll = false,
+}: VirtualizedListProps<T>) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const windowContainerRef = useRef<HTMLDivElement>(null);
+  const [isClient, setIsClient] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isClient) {
+      return;
+    }
+
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    handleChange(motionQuery);
+
+    const listener = (event: MediaQueryListEvent) => handleChange(event);
+    if ('addEventListener' in motionQuery) {
+      motionQuery.addEventListener('change', listener);
+    } else {
+      // Safari < 14 fallback
+      motionQuery.addListener(listener);
+    }
+
+    return () => {
+      if ('removeEventListener' in motionQuery) {
+        motionQuery.removeEventListener('change', listener);
+      } else {
+        motionQuery.removeListener(listener);
+      }
+    };
+  }, [isClient]);
+
+  useLayoutEffect(() => {
+    if (!isClient || !useWindowScroll) {
+      return;
+    }
+
+    const updateScrollMargin = () => {
+      if (!windowContainerRef.current) {
+        return;
+      }
+
+      const rect = windowContainerRef.current.getBoundingClientRect();
+      setScrollMargin(rect.top + window.scrollY);
+    };
+
+    updateScrollMargin();
+    window.addEventListener('resize', updateScrollMargin);
+
+    return () => {
+      window.removeEventListener('resize', updateScrollMargin);
+    };
+  }, [isClient, useWindowScroll, items.length]);
+
+  const shouldVirtualize = isClient && !prefersReducedMotion && items.length >= virtualizationThreshold;
+
+  const { className: parentClassName, ...restParentProps } = parentProps ?? {};
+  const { className: fallbackClassName, ...restFallbackProps } = fallbackParentProps ?? {};
+
+  const getScrollElement = useCallback(
+    () => (useWindowScroll ? window : parentRef.current),
+    [useWindowScroll],
+  );
+
+  const virtualizer = useVirtualizer({
+    count: shouldVirtualize ? items.length : 0,
+    getScrollElement,
+    estimateSize: index => {
+      const item = items[index];
+      return item ? estimateSize(item, index) : 0;
+    },
+    overscan,
+    scrollMargin: useWindowScroll ? scrollMargin : undefined,
+    getItemKey: getKey
+      ? index => {
+          const item = items[index];
+          return item ? getKey(item, index) : index;
+        }
+      : undefined,
+  });
+
+  if (!shouldVirtualize) {
+    return (
+      <div
+        {...restFallbackProps}
+        role={role}
+        className={cn(parentClassName, fallbackClassName)}
+      >
+        {items.map((item, index) => (
+          <div
+            key={getKey ? getKey(item, index) : index}
+            role={itemRole}
+            className={itemClassName}
+          >
+            {children({ item, index })}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      {...restParentProps}
+      ref={useWindowScroll ? windowContainerRef : parentRef}
+      role={role}
+      className={cn('relative w-full', parentClassName)}
+      aria-live="off"
+    >
+      <div
+        style={{
+          height: virtualizer.getTotalSize(),
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {virtualizer.getVirtualItems().map(virtualItem => {
+          const item = items[virtualItem.index];
+          if (!item) {
+            return null;
+          }
+
+          return (
+            <div
+              key={getKey ? getKey(item, virtualItem.index) : virtualItem.key}
+              data-index={virtualItem.index}
+              role={itemRole}
+              className={cn('absolute left-0 w-full', itemClassName)}
+              style={{
+                transform: `translateY(${virtualItem.start}px)`,
+                top: 0,
+              }}
+              ref={node => {
+                if (node) {
+                  virtualizer.measureElement(node);
+                }
+              }}
+            >
+              {children({ item, index: virtualItem.index })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/docs/perf/virtualization.md
+++ b/docs/perf/virtualization.md
@@ -1,0 +1,83 @@
+# List Virtualization
+
+Large UI surfaces such as the documents library and roommate message board now rely on the shared `VirtualizedList` wrapper to stream content efficiently. The wrapper is built on top of [`@tanstack/react-virtual`](https://tanstack.com/virtual) and centralises common accessibility fallbacks so individual screens can stay declarative.
+
+## Component overview
+
+`components/ui/virtualized-list.tsx` exposes a render-prop API:
+
+```tsx
+<VirtualizedList
+  items={items}
+  estimateSize={(item) => /* return approximate pixel height */}
+  getKey={(item) => item.id}
+  overscan={6}
+  itemClassName="py-2"
+  parentProps={{ className: 'relative' }}
+  useWindowScroll
+>
+  {({ item, index }) => (
+    /* render row */
+  )}
+</VirtualizedList>
+```
+
+### Props
+
+| Prop | Description |
+| --- | --- |
+| `items` | Array of row data to render. |
+| `children` | Render function that returns JSX for each row. |
+| `estimateSize` | Returns the estimated pixel height for a row; it is refined automatically via measurements. |
+| `getKey` | Optional stable key generator for deterministic rendering. |
+| `overscan` | Number of extra items to render before/after the viewport (defaults to `8`). |
+| `virtualizationThreshold` | Minimum item count before virtualization is applied (defaults to `1`). |
+| `role` / `itemRole` | Accessibility roles (defaults to `list` / `listitem`). |
+| `parentProps` | DOM props applied to the virtualised container. |
+| `fallbackParentProps` | DOM props applied when virtualization is disabled. |
+| `itemClassName` | Shared class name applied to each virtual row wrapper. |
+| `useWindowScroll` | When `true`, virtualization tracks the window scroll position instead of a dedicated scroll container. |
+
+### Accessibility fallbacks
+
+- If the user has `prefers-reduced-motion` enabled, virtualization is skipped and the full list is rendered so screen readers have complete access to the content.
+- The fallback branch reuses the same render function, so no additional markup is needed for SSR skeletons or Suspense boundaries.
+
+## Usage examples
+
+### Documents list
+
+```tsx
+<VirtualizedList
+  items={documents}
+  estimateSize={(doc) => (doc.signatures?.length ? 228 : 188)}
+  getKey={(doc) => doc.id}
+  overscan={6}
+  itemClassName="pb-4"
+  parentProps={{ className: 'relative' }}
+  useWindowScroll
+>
+  {({ item }) => <DocumentCard document={item} />}
+</VirtualizedList>
+```
+
+### Roommate board
+
+```tsx
+<VirtualizedList
+  items={messages}
+  estimateSize={(message) => (message.content.length > 120 ? 72 : 56)}
+  getKey={(message) => message.id}
+  itemClassName="py-2 text-sm"
+  parentProps={{ className: 'relative text-sm' }}
+  useWindowScroll
+>
+  {({ item }) => <p className="leading-snug">{item.content}</p>}
+</VirtualizedList>
+```
+
+## Implementation notes
+
+- Skeleton states remain server-rendered. The virtualized list only mounts once data is available, preserving loading placeholders for Suspense boundaries.
+- Always keep `estimateSize` reasonably close to the real height; the virtualizer refines the measurement using `measureElement`, but a sensible starting point reduces layout shifts.
+- When a list should scroll within its own container instead of the window, pass `useWindowScroll={false}` and provide a scrollable wrapper via `parentProps`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -38,6 +38,7 @@
         "@supabase/ssr": "^0.0.10",
         "@supabase/supabase-js": "^2.39.3",
         "@tanstack/react-query": "^5.51.9",
+        "@tanstack/react-virtual": "^3.13.12",
         "@types/mdx": "^2.0.13",
         "@vercel/analytics": "^1.3.1",
         "@vercel/speed-insights": "^1.0.12",
@@ -3191,6 +3192,33 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tweenjs/tween.js": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@supabase/ssr": "^0.0.10",
     "@supabase/supabase-js": "^2.39.3",
     "@tanstack/react-query": "^5.51.9",
+    "@tanstack/react-virtual": "^3.13.12",
     "@types/mdx": "^2.0.13",
     "@vercel/analytics": "^1.3.1",
     "@vercel/speed-insights": "^1.0.12",


### PR DESCRIPTION
## Summary
- add a shared `VirtualizedList` wrapper powered by `@tanstack/react-virtual` with accessibility-aware fallbacks
- apply the virtualized list to the documents page and dashboard roommate board to limit DOM nodes for large collections
- document usage and add the new dependency for future list surfaces

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d739de08328bfde60e844864f0e