### PR TITLE
feat: add SmartLink wrapper with contextual prefetch

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -4,7 +4,7 @@ import { readUserSession } from "@/utils/actions";
 import { redirect } from "next/navigation";
 import { Icons } from '@/components/icons'
 import { cn } from "@/lib/utils"
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 import { siteConfig } from "@/config/site"
 import { buttonVariants } from "@/components/ui/button"
 
@@ -18,10 +18,10 @@ export default async function page() {
         <div className="mt-10 px-2 lg:p-8">
           <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
             <div className="flex flex-col items-center space-y-2 text-center">
-      <Link href="/" className="mb-8 flex items-center space-x-2">
+      <SmartLink href="/" className="mb-8 flex items-center space-x-2">
         <Icons.logo className="size-8" />
         <span className="inline-block font-bold">{siteConfig.name}</span>
-      </Link>
+      </SmartLink>
               <h1 className="text-2xl font-semibold tracking-tight">
                 Welcome back!
               </h1>
@@ -32,19 +32,19 @@ export default async function page() {
             <AuthForm />
             <p className="px-8 text-center text-sm text-muted-foreground">
               By clicking continue, you agree to our{" "}
-              <Link
+              <SmartLink
                 href="/terms"
                 className="underline underline-offset-4 hover:text-primary"
               >
                 Terms of Service
-              </Link>{" "}
+              </SmartLink>{" "}
               and{" "}
-              <Link
+              <SmartLink
                 href="/privacy"
                 className="underline underline-offset-4 hover:text-primary"
               >
                 Privacy Policy
-              </Link>
+              </SmartLink>
               .
             </p>
           </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Link from 'next/link'
+import SmartLink from "@/components/navigation/SmartLink"
 import { siteConfig } from '@/config/site'
 import { Icons } from '@/components/icons'
 import { cookies } from 'next/headers'
@@ -24,10 +24,10 @@ export default async function ContactPage() {
                         <div className="mt-10 px-2 lg:p-8">
           <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
             <div className="flex flex-col items-center space-y-2 text-center">
-      <Link href="/" className="mb-8 flex items-center space-x-2">
+      <SmartLink href="/" className="mb-8 flex items-center space-x-2">
         <Icons.logo className="size-6" />
         <span className="inline-block font-bold">{siteConfig.name}</span>
-      </Link>
+      </SmartLink>
               <h1 className="text-2xl font-semibold tracking-tight">
                 Contact Us
               </h1>

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 
 export default function DashboardPage() {
   return (
@@ -8,9 +8,9 @@ export default function DashboardPage() {
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h2 className="text-2xl font-bold tracking-tight">Welcome back</h2>
         <div className="flex gap-2">
-          <Link href="/payments">
+          <SmartLink href="/payments">
             <Button size="sm">Pay rent</Button>
-          </Link>
+          </SmartLink>
         </div>
       </div>
 
@@ -23,9 +23,9 @@ export default function DashboardPage() {
             <div className="text-sm text-muted-foreground">Amount</div>
             <div className="text-2xl font-semibold">$1,260.00</div>
             <div className="mt-1 text-sm text-muted-foreground">Due on the 1st</div>
-            <Link href="/payments" className="mt-4 inline-block">
+            <SmartLink href="/payments" className="mt-4 inline-block">
               <Button size="sm">View details</Button>
-            </Link>
+            </SmartLink>
           </CardContent>
         </Card>
 
@@ -38,9 +38,9 @@ export default function DashboardPage() {
               <li>Lease agreement v2.pdf</li>
               <li>House rules.pdf</li>
             </ul>
-            <Link href="/documents" className="mt-4 inline-block">
+            <SmartLink href="/documents" className="mt-4 inline-block">
               <Button variant="outline" size="sm">Open</Button>
-            </Link>
+            </SmartLink>
           </CardContent>
         </Card>
       </div>
@@ -54,9 +54,9 @@ export default function DashboardPage() {
             <li>Jordan: Wi-Fi is down, rebooted router.</li>
             <li>Avery: Parking spot swap this weekend?</li>
           </ul>
-          <Link href="/messaging" className="mt-4 inline-block">
+          <SmartLink href="/messaging" className="mt-4 inline-block">
             <Button variant="outline" size="sm">Go to messages</Button>
-          </Link>
+          </SmartLink>
         </CardContent>
       </Card>
     </div>

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
-import Link from "next/link";
+import SmartLink from "@/components/navigation/SmartLink";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
 import { createClient } from "@/utils/supabase-browser";
@@ -54,23 +54,24 @@ export default function NavLinks() {
 			{links.map((link, index) => {
 				const Icon = link.Icon;
 				return (
-					<Link
-						onClick={() =>
-							document.getElementById("sidebar-close")?.click()
-						}
-						href={link.href}
-						key={index}
-						className={cn(
-							"flex items-center gap-2 rounded-sm p-2",
-							{
-								" bg-gray-500 dark:bg-gray-700 text-white ":
-									pathname === link.href,
-							}
-						)}
-					>
-						<Icon />
-						{link.text}
-					</Link>
+                                        <SmartLink
+                                                onClick={() =>
+                                                        document.getElementById("sidebar-close")?.click()
+                                                }
+                                                href={link.href}
+                                                key={index}
+                                                className={cn(
+                                                        "flex items-center gap-2 rounded-sm p-2",
+                                                        {
+                                                                " bg-gray-500 dark:bg-gray-700 text-white ":
+                                                                        pathname === link.href,
+                                                        }
+                                                )}
+                                                intent="navigation"
+                                        >
+                                                <Icon />
+                                                {link.text}
+                                        </SmartLink>
 				);
 			})}
 		</div>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
 import Image from "next/image"
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
@@ -32,7 +32,7 @@ export default function OnboardingPage() {
         />
       </div>
       <div className="container relative mx-auto grid h-[640px] grid-cols-1 flex-col items-center justify-center md:grid-cols-2 lg:max-w-none lg:px-0">
-        <Link
+        <SmartLink
           href="/auth"
           className={cn(
             buttonVariants({ variant: "ghost" }),
@@ -40,7 +40,7 @@ export default function OnboardingPage() {
           )}
         >
           Login
-        </Link>
+        </SmartLink>
         <div className="relative hidden h-full flex-col bg-muted p-10 text-white md:flex dark:border-r">
           <div className="absolute inset-0 bg-gradient-to-r from-gray-700 via-gray-900 to-black">
           <Image
@@ -90,19 +90,19 @@ export default function OnboardingPage() {
             <AuthFormLegacy />
             <p className="px-8 text-center text-sm text-muted-foreground">
               By clicking continue, you agree to our{" "}
-              <Link
+              <SmartLink
                 href="#"
                 className="underline underline-offset-4 hover:text-primary"
               >
                 Terms of Service
-              </Link>{" "}
+              </SmartLink>{" "}
               and{" "}
-              <Link
+              <SmartLink
                 href="#"
                 className="underline underline-offset-4 hover:text-primary"
               >
                 Privacy Policy
-              </Link>
+              </SmartLink>
               .
             </p>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 import { redirect } from "next/navigation"
 import {
   CalendarRange,
@@ -145,24 +145,26 @@ export default async function IndexPage() {
               Roomsily centralizes rent, amenities, documents, and roommate communication into one elegant portal so shared homes stay calm, coordinated, and connected.
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
-              <Link
+              <SmartLink
                 href={siteConfig.links.login}
                 className={cn(
                   buttonVariants({ size: "lg" }),
                   "bg-primary px-8 text-base font-semibold shadow-lg shadow-primary/30 transition hover:bg-primary/90"
                 )}
+                intent="critical"
               >
                 Sign in
-              </Link>
-              <Link
+              </SmartLink>
+              <SmartLink
                 href={siteConfig.links.signup}
                 className={cn(
                   buttonVariants({ variant: "outline", size: "lg" }),
                   "border-primary/40 bg-background/80 px-8 text-base font-semibold backdrop-blur transition hover:border-primary hover:bg-primary/10"
                 )}
+                intent="critical"
               >
                 Create your household
-              </Link>
+              </SmartLink>
             </div>
             <div className="grid gap-4 pt-8 sm:grid-cols-3">
               {heroMetrics.map((metric) => (
@@ -199,9 +201,13 @@ export default async function IndexPage() {
                 <CardDescription>{feature.description}</CardDescription>
               </CardHeader>
               <CardContent>
-                <Link href={feature.href} className="text-sm font-medium text-primary hover:underline">
+                <SmartLink
+                  href={feature.href}
+                  className="text-sm font-medium text-primary hover:underline"
+                  intent="passive"
+                >
                   Learn more
-                </Link>
+                </SmartLink>
               </CardContent>
             </Card>
           ))}
@@ -228,15 +234,16 @@ export default async function IndexPage() {
                       </li>
                     ))}
                   </ul>
-                  <Link
+                  <SmartLink
                     href={highlight.cta.href}
                     className={cn(
                       buttonVariants({ variant: "ghost", size: "sm" }),
                       "justify-start px-0 text-primary hover:text-primary"
                     )}
+                    intent="passive"
                   >
                     {highlight.cta.label} →
-                  </Link>
+                  </SmartLink>
                 </CardContent>
               </Card>
             ))}
@@ -281,16 +288,17 @@ export default async function IndexPage() {
                 </p>
               </div>
               <div className="flex flex-col gap-4 sm:flex-row">
-                <Link
+                <SmartLink
                   href={siteConfig.links.signup}
                   className={cn(
                     buttonVariants({ size: "lg" }),
                     "bg-primary px-8 text-base font-semibold text-primary-foreground shadow-lg shadow-primary/30 transition hover:bg-primary/90"
                   )}
+                  intent="critical"
                 >
                   Get started
-                </Link>
-                <Link
+                </SmartLink>
+                <SmartLink
                   href={siteConfig.links.contact}
                   className={cn(
                     buttonVariants({ variant: "outline", size: "lg" }),
@@ -298,7 +306,7 @@ export default async function IndexPage() {
                   )}
                 >
                   Talk with us
-                </Link>
+                </SmartLink>
               </div>
             </CardContent>
           </Card>

--- a/components/cookie-button.tsx
+++ b/components/cookie-button.tsx
@@ -1,7 +1,6 @@
 import { siteConfig } from '@/config/site'
 import { Icons } from '@/components/icons'
 import { buttonVariants } from '@/components/ui/button'
-import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
 

--- a/components/forms/hreflink.tsx
+++ b/components/forms/hreflink.tsx
@@ -1,11 +1,11 @@
 import type { Route } from 'next'
-import Link from 'next/link'
+import SmartLink from "@/components/navigation/SmartLink"
 import React from 'react'
  
 function Card<T extends string>({ href }: { href: Route<T> | URL }) {
   return (
-    <Link href={href}>
+    <SmartLink href={href}>
       <div>My Card</div>
-    </Link>
+    </SmartLink>
   )
 }

--- a/components/forms/profile-form.tsx
+++ b/components/forms/profile-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useFieldArray, useForm } from "react-hook-form"
 import { z } from "zod"
@@ -125,7 +125,10 @@ export function ProfileForm() {
               </Select>
               <FormDescription>
                 You can manage verified email addresses in your{" "}
-                <Link href="#">email settings</Link>.
+                <SmartLink href="#" intent="passive">
+                  email settings
+                </SmartLink>
+                .
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/components/forms/reacthookformstep.tsx
+++ b/components/forms/reacthookformstep.tsx
@@ -3,7 +3,7 @@
 import useAppFormContext from '@/lib/hooks/useAppFormContext';
 import clsx from 'clsx';
 // Components
-import Link from 'next/link';
+import SmartLink from "@/components/navigation/SmartLink";
 import { useRouter } from 'next/navigation';
 
 export default function Step({ step, segment }: StepProps) {
@@ -19,7 +19,7 @@ export default function Step({ step, segment }: StepProps) {
   // };
 
   return (
-    <Link href={`/${step.segment}`}>
+    <SmartLink href={`/${step.segment}`} intent="navigation">
       {/* <button type="button" onClick={() => validateStep(`/${step}`)}> */}
       <div className="flex items-center gap-4">
         <button
@@ -48,7 +48,7 @@ export default function Step({ step, segment }: StepProps) {
         </div>
       </div>
       {/* </button> */}
-    </Link>
+    </SmartLink>
   );
 }
 

--- a/components/forms/updateProfile.tsx
+++ b/components/forms/updateProfile.tsx
@@ -1,6 +1,6 @@
  "use client"
 
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useFieldArray, useForm } from "react-hook-form"
 import * as z from "zod"
@@ -125,7 +125,10 @@ export function ProfileForm() {
               </Select>
               <FormDescription>
                 You can manage verified email addresses in your{" "}
-                <Link href="/account">email settings</Link>.
+                <SmartLink href="/account" intent="passive">
+                  email settings
+                </SmartLink>
+                .
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 
 import { NavItem } from "@/types/nav"
 import { siteConfig } from "@/config/site"
@@ -13,28 +13,29 @@ interface MainNavProps {
 export function MainNav({ items }: MainNavProps) {
   return (
         <div className="mr-2 hidden gap-4 md:flex md:gap-8">
-      <Link href="/" className="flex items-center gap-2">
+      <SmartLink href="/" className="flex items-center gap-2" intent="navigation">
         <Icons.logo className="size-6 text-primary" />
         <div className="flex flex-col leading-tight">
           <span className="font-semibold">{siteConfig.name}</span>
           <span className="text-xs font-medium text-muted-foreground">www.roomsily</span>
         </div>
-      </Link>
+      </SmartLink>
       {items?.length ? (
         <nav className="flex gap-6">
           {items?.map(
             (item, index) =>
               item.href && (
-                <Link
+                <SmartLink
                   key={index}
                   href={item.href}
                   className={cn(
                     "flex items-center text-sm font-medium text-muted-foreground",
                     item.disabled && "cursor-not-allowed opacity-80"
                   )}
+                  intent="navigation"
                 >
                   {item.title}
-                </Link>
+                </SmartLink>
               )
           )}
         </nav>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import Link, { LinkProps } from "next/link"
+import SmartLink, { SmartLinkProps } from "@/components/navigation/SmartLink"
 import { useRouter } from "next/navigation"
 
 import { docsConfig } from "@/config/docs"
@@ -32,10 +32,10 @@ export function MobileNav({ isAuthenticated }: MobileNavProps) {
         </Button>
       </SheetTrigger>
       <div className="xs:items-center ml-1 gap-4 md:hidden">
-        <Link href="/" className="flex items-center space-x-2">
+        <SmartLink href="/" className="flex items-center space-x-2" intent="navigation">
           <Icons.logo className="size-6" />
           <span className="font-bold">{siteConfig.name}</span>
-        </Link>
+        </SmartLink>
       </div>
 
       <SheetContent side="left" className="pr-0">
@@ -139,7 +139,7 @@ export function MobileNav({ isAuthenticated }: MobileNavProps) {
   )
 }
 
-interface MobileLinkProps extends LinkProps {
+interface MobileLinkProps extends SmartLinkProps {
   onOpenChange?: (open: boolean) => void
   children: React.ReactNode
   className?: string
@@ -154,16 +154,17 @@ function MobileLink({
 }: MobileLinkProps) {
   const router = useRouter()
   return (
-    <Link
+    <SmartLink
       href={href}
       onClick={() => {
         router.push(href.toString())
         onOpenChange?.(false)
       }}
       className={cn(className)}
+      intent="navigation"
       {...props}
     >
       {children}
-    </Link>
+    </SmartLink>
   )
 }

--- a/components/navigation/SmartLink.tsx
+++ b/components/navigation/SmartLink.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import * as React from "react"
+import NextLink from "next/link"
+import { useRouter } from "next/navigation"
+
+export type SmartLinkIntent = "standard" | "critical" | "passive" | "navigation"
+
+export interface SmartLinkProps
+  extends React.ComponentPropsWithoutRef<typeof NextLink> {
+  /**
+   * Hint the prefetch heuristics about how aggressively we should warm up the route.
+   * - `standard`: prefetch when the link nears the viewport (default).
+   * - `critical`: prefetch immediately on mount.
+   * - `passive`: wait for user intent such as hover/focus before prefetching.
+   * - `navigation`: treat as part of a dense nav/table cluster and only prefetch on intent.
+   */
+  intent?: SmartLinkIntent
+  /**
+   * Custom root margin applied to the IntersectionObserver used for viewport based prefetching.
+   */
+  viewportMargin?: string
+}
+
+type PrefetchHint = "never" | "hover" | "viewport" | "immediate"
+
+type AnchorRef = HTMLAnchorElement | null
+
+export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
+  (props, forwardedRef) => {
+    const {
+      intent = "standard",
+      viewportMargin = "200px",
+      prefetch: prefetchProp,
+      onPointerEnter,
+      onFocus,
+      href,
+      ...rest
+    } = props
+
+    const router = useRouter()
+    const innerRef = React.useRef<HTMLAnchorElement | null>(null)
+    const combinedRef = React.useCallback(
+      (node: AnchorRef) => {
+        innerRef.current = node
+        if (typeof forwardedRef === "function") {
+          forwardedRef(node)
+        } else if (forwardedRef) {
+          forwardedRef.current = node
+        }
+      },
+      [forwardedRef]
+    )
+
+    const isInternalHref = React.useMemo(() => {
+      if (typeof href === "string") {
+        return href.startsWith("/") && !href.startsWith("//")
+      }
+      if (typeof href === "object") {
+        return true
+      }
+      return false
+    }, [href])
+
+    const [isVisible, setIsVisible] = React.useState(false)
+    const hasPrefetchedRef = React.useRef(false)
+
+    const prefetchHint = React.useMemo<PrefetchHint>(() => {
+      if (!isInternalHref) {
+        return "never"
+      }
+
+      if (typeof prefetchProp === "boolean") {
+        return prefetchProp ? "viewport" : "never"
+      }
+
+      switch (intent) {
+        case "critical":
+          return "immediate"
+        case "passive":
+        case "navigation":
+          return "hover"
+        case "standard":
+        default:
+          return "viewport"
+      }
+    }, [intent, isInternalHref, prefetchProp])
+
+    const prefetchHref = React.useMemo(() => {
+      if (!isInternalHref) {
+        return undefined
+      }
+
+      if (typeof href === "string") {
+        if (href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) {
+          return undefined
+        }
+        return href
+      }
+
+      return undefined
+    }, [href, isInternalHref])
+
+    React.useEffect(() => {
+      if (prefetchHint !== "viewport") {
+        return
+      }
+
+      const node = innerRef.current
+      if (!node || typeof IntersectionObserver === "undefined") {
+        return
+      }
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          const entry = entries[0]
+          if (entry?.isIntersecting) {
+            setIsVisible(true)
+            observer.disconnect()
+          }
+        },
+        { rootMargin: viewportMargin }
+      )
+
+      observer.observe(node)
+
+      return () => {
+        observer.disconnect()
+      }
+    }, [prefetchHint, viewportMargin])
+
+    const triggerPrefetch = React.useCallback(() => {
+      if (hasPrefetchedRef.current) {
+        return
+      }
+
+      if (!prefetchHref) {
+        return
+      }
+
+      router.prefetch(prefetchHref)
+      hasPrefetchedRef.current = true
+    }, [prefetchHref, router])
+
+    React.useEffect(() => {
+      if (prefetchHint === "immediate") {
+        triggerPrefetch()
+      }
+    }, [prefetchHint, triggerPrefetch])
+
+    React.useEffect(() => {
+      if (prefetchHint === "viewport" && isVisible && prefetchHref) {
+        hasPrefetchedRef.current = true
+      }
+    }, [isVisible, prefetchHint, prefetchHref])
+
+    const handlePointerEnter = React.useCallback(
+      (event: React.PointerEvent<HTMLAnchorElement>) => {
+        onPointerEnter?.(event)
+        if (event.defaultPrevented) {
+          return
+        }
+
+        if (prefetchHint === "never" || prefetchHint === "immediate") {
+          return
+        }
+
+        triggerPrefetch()
+      },
+      [onPointerEnter, prefetchHint, triggerPrefetch]
+    )
+
+    const handleFocus = React.useCallback(
+      (event: React.FocusEvent<HTMLAnchorElement>) => {
+        onFocus?.(event)
+        if (event.defaultPrevented) {
+          return
+        }
+
+        if (prefetchHint === "never" || prefetchHint === "immediate") {
+          return
+        }
+
+        triggerPrefetch()
+      },
+      [onFocus, prefetchHint, triggerPrefetch]
+    )
+
+    const shouldPrefetch = React.useMemo(() => {
+      if (!isInternalHref) {
+        return false
+      }
+
+      switch (prefetchHint) {
+        case "immediate":
+          return true
+        case "viewport":
+          return isVisible
+        case "hover":
+        case "never":
+        default:
+          return false
+      }
+    }, [isInternalHref, isVisible, prefetchHint])
+
+    return (
+      <NextLink
+        ref={combinedRef}
+        href={href}
+        prefetch={shouldPrefetch}
+        onPointerEnter={handlePointerEnter}
+        onFocus={handleFocus}
+        {...rest}
+      />
+    )
+  }
+)
+
+SmartLink.displayName = "SmartLink"
+
+export default SmartLink

--- a/components/onboarding-progress.tsx
+++ b/components/onboarding-progress.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import SmartLink from "@/components/navigation/SmartLink"
 
 export default function OnboardingProgress({ step = 1 }: { step?: number }) {
   return (
@@ -8,16 +8,40 @@ export default function OnboardingProgress({ step = 1 }: { step?: number }) {
           <div className="absolute left-0 top-1/2 -mt-px h-0.5 w-full bg-slate-200 dark:bg-slate-700" aria-hidden="true"></div>
           <ul className="relative flex w-full justify-between">
             <li>
-              <Link className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${step >= 1 ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'}`} href="/signup?=page1">1</Link>
+              <SmartLink
+                className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${step >= 1 ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'}`}
+                href="/signup?=page1"
+                intent="navigation"
+              >
+                1
+              </SmartLink>
             </li>
             <li>
-              <Link className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${step >= 2 ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'}`} href="/signup?=page2">2</Link>
+              <SmartLink
+                className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${step >= 2 ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'}`}
+                href="/signup?=page2"
+                intent="navigation"
+              >
+                2
+              </SmartLink>
             </li>
             <li>
-              <Link className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${step >= 3 ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'}`} href="/signup?=page3">3</Link>
+              <SmartLink
+                className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${step >= 3 ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'}`}
+                href="/signup?=page3"
+                intent="navigation"
+              >
+                3
+              </SmartLink>
             </li>
             <li>
-              <Link className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${step >= 4 ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'}`} href="/signup?=page4">4</Link>
+              <SmartLink
+                className={`flex size-6 items-center justify-center rounded-full text-xs font-semibold ${step >= 4 ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'}`}
+                href="/signup?=page4"
+                intent="navigation"
+              >
+                4
+              </SmartLink>
             </li>
           </ul>
         </div>

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 import { usePathname } from "next/navigation"
 import { SidebarNavItem } from "types/nav"
 
@@ -42,7 +42,7 @@ export function DocsSidebarNavItems({
     <div className="grid grid-flow-row auto-rows-max text-sm">
       {items.map((item, index) =>
         item.href && !item.disabled ? (
-          <Link
+          <SmartLink
             key={index}
             href={item.href}
             className={cn(
@@ -54,6 +54,7 @@ export function DocsSidebarNavItems({
             )}
             target={item.external ? "_blank" : ""}
             rel={item.external ? "noreferrer" : ""}
+            intent="navigation"
           >
             {item.title}
             {item.label && (
@@ -61,7 +62,7 @@ export function DocsSidebarNavItems({
                 {item.label}
               </span>
             )}
-          </Link>
+          </SmartLink>
         ) : (
           <span
             key={index}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 import { siteConfig } from "@/config/site"
 import { buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/icons"
@@ -8,13 +8,13 @@ export function SiteFooter() {
     <footer className="z-40 border-t">
       <div className="container flex flex-col gap-8 py-8 md:flex-row md:py-12">
         <div className="flex-1 space-y-4">
-         <Link className="ml-0 flex items-center gap-2" href="/">
+         <SmartLink className="ml-0 flex items-center gap-2" href="/" intent="navigation">
           <Icons.logo className="size-6" />
           <div className="flex flex-col leading-tight">
             <span className="inline-block font-semibold">{siteConfig.name}</span>
             <span className="text-xs font-medium text-muted-foreground">www.roomsily</span>
           </div>
-        </Link>
+        </SmartLink>
           <p className="text-sm text-muted-foreground">
             Manage rent, roommates, and shared amenities from a single, secure Roomsily HQ.
           </p>
@@ -24,19 +24,31 @@ export function SiteFooter() {
             <h3 className="text-sm font-medium">Solutions</h3>
             <ul className="space-y-3 text-sm">
               <li>
-                <Link href="/payments" className="text-muted-foreground transition-colors hover:text-primary">
+                <SmartLink
+                  href="/payments"
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                  intent="navigation"
+                >
                   Rent payments
-                </Link>
+                </SmartLink>
               </li>
               <li>
-                <Link href="/documents" className="text-muted-foreground transition-colors hover:text-primary">
+                <SmartLink
+                  href="/documents"
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                  intent="navigation"
+                >
                   Document vault
-                </Link>
+                </SmartLink>
               </li>
               <li>
-                <Link href="/messaging" className="text-muted-foreground transition-colors hover:text-primary">
+                <SmartLink
+                  href="/messaging"
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                  intent="navigation"
+                >
                   Roommate messaging
-                </Link>
+                </SmartLink>
               </li>
             </ul>
           </div>
@@ -44,24 +56,40 @@ export function SiteFooter() {
             <h3 className="text-sm font-medium">Company</h3>
             <ul className="space-y-3 text-sm">
               <li>
-                <Link href="/about" className="text-muted-foreground transition-colors hover:text-primary">
+                <SmartLink
+                  href="/about"
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                  intent="navigation"
+                >
                   About Us
-                </Link>
+                </SmartLink>
               </li>
               <li>
-                <Link href="/contact" className="text-muted-foreground transition-colors hover:text-primary">
+                <SmartLink
+                  href="/contact"
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                  intent="navigation"
+                >
                   Contact
-                </Link>
+                </SmartLink>
               </li>
               <li>
-                <Link href="/privacy" className="text-muted-foreground transition-colors hover:text-primary">
+                <SmartLink
+                  href="/privacy"
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                  intent="navigation"
+                >
                   Privacy Policy
-                </Link>
+                </SmartLink>
               </li>
               <li>
-                <Link href="/terms" className="text-muted-foreground transition-colors hover:text-primary">
+                <SmartLink
+                  href="/terms"
+                  className="text-muted-foreground transition-colors hover:text-primary"
+                  intent="navigation"
+                >
                   Terms of Service
-                </Link>
+                </SmartLink>
               </li>
             </ul>
           </div>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link"
+import SmartLink from "@/components/navigation/SmartLink"
 import { readUserSession } from "@/utils/actions"
 
 import { siteConfig } from "@/config/site"
@@ -26,15 +26,16 @@ export async function SiteHeader() {
           <div className="hidden items-center gap-2 md:flex">
             {isAuthenticated ? (
               <>
-                <Link
+                <SmartLink
                   href="/dashboard"
                   className={cn(
                     buttonVariants({ variant: "ghost", size: "sm" }),
                     "justify-center"
                   )}
+                  intent="navigation"
                 >
                   Dashboard
-                </Link>
+                </SmartLink>
                 <SignOutButton
                   variant="outline"
                   size="sm"
@@ -43,24 +44,26 @@ export async function SiteHeader() {
               </>
             ) : (
               <>
-                <Link
+                <SmartLink
                   href="/auth"
                   className={cn(
                     buttonVariants({ variant: "ghost", size: "sm" }),
                     "justify-center"
                   )}
+                  intent="navigation"
                 >
                   Log in
-                </Link>
-                <Link
+                </SmartLink>
+                <SmartLink
                   href="/onboarding"
                   className={cn(
                     buttonVariants({ size: "sm" }),
                     "justify-center"
                   )}
+                  intent="navigation"
                 >
                   Sign up
-                </Link>
+                </SmartLink>
               </>
             )}
           </div>

--- a/docs/perf/prefetching.md
+++ b/docs/perf/prefetching.md
@@ -1,0 +1,54 @@
+# Navigation Prefetching Guidelines
+
+Roomsily ships a custom [`SmartLink`](../../components/navigation/SmartLink.tsx) wrapper around Next.js `Link` to keep navigation responsive without wasting bandwidth. The component exposes lightweight heuristics so that we only prefetch routes when a tenant is likely to visit them soon.
+
+## Heuristics at a glance
+
+- **Visibility aware:** Links marked with the default `intent="standard"` will begin prefetching once they near the viewport (200px root margin). Hovering or focusing the link will also trigger a warm up.
+- **High intent CTAs:** Set `intent="critical"` for the primary actions on a surface (e.g. hero CTAs). These routes prefetch immediately on mount and on interaction.
+- **Dense navigation clusters:** Use `intent="navigation"` for elements inside menus, tabular data, footers, or anywhere we render many links at once. This disables automatic viewport prefetching so we only prefetch when someone hovers or focuses the link.
+- **Passive or low intent links:** `intent="passive"` skips the intersection observer and waits for hover/focus before prefetching. Handy for tertiary links, legal copy, or long lists of resources.
+
+All intents can still be overridden by passing the native `prefetch` prop directly when a component needs bespoke behaviour.
+
+## Usage examples
+
+```tsx
+import SmartLink from "@/components/navigation/SmartLink"
+
+function HeroCtas() {
+  return (
+    <div className="flex gap-4">
+      <SmartLink href="/auth" intent="critical" className="btn-primary">
+        Sign in
+      </SmartLink>
+      <SmartLink href="/onboarding" intent="critical" className="btn-secondary">
+        Create your household
+      </SmartLink>
+    </div>
+  )
+}
+
+function FooterNav() {
+  return (
+    <nav className="grid gap-2 text-sm">
+      <SmartLink href="/payments" intent="navigation">
+        Rent payments
+      </SmartLink>
+      <SmartLink href="/documents" intent="navigation">
+        Document vault
+      </SmartLink>
+    </nav>
+  )
+}
+```
+
+## Migration checklist
+
+1. **Use `SmartLink` instead of `next/link`** for any internal navigation within the portal.
+2. **Tag dense link zones** (`nav`, `table`, multi-column lists) with `intent="navigation"` so we do not prefetch every entry on initial paint.
+3. **Promote the primary action** with `intent="critical"` when immediate navigation is desirable.
+4. **Fallback to `intent="passive"`** for legal or tertiary references that the tenant is unlikely to click.
+5. **Leave external URLs as `<a>` elements.** `SmartLink` automatically skips prefetching for external, hash, mailto, and tel targets.
+
+Following these rules keeps the dashboard fast for roommates on slower networks while still providing instant transitions for the actions that matter most.


### PR DESCRIPTION
## Summary
- add a SmartLink navigation wrapper that tunes prefetching based on visibility, interaction, and declared intent
- swap existing Link usage across navigation, CTA, and helper components to adopt SmartLink with navigation/critical/passive intents
- document prefetching guidelines for engineers in docs/perf/prefetching.md

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d6f8d84832896e8344e4d0b95e2