### PR TITLE
Add shared skeleton primitives and update loading fallbacks

### DIFF
--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -15,6 +15,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { CardSkeleton } from "@/components/ui/skeletons"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
@@ -85,15 +86,8 @@ export default function BookingsPage() {
       <Suspense
         fallback={
           <div className="grid gap-4 md:grid-cols-4">
-            {[...Array(4)].map((_, i) => (
-              <Card key={i} className="animate-pulse">
-                <CardHeader className="pb-2">
-                  <div className="h-4 w-3/4 rounded bg-muted"></div>
-                </CardHeader>
-                <CardContent>
-                  <div className="h-8 w-1/2 rounded bg-muted"></div>
-                </CardContent>
-              </Card>
+            {Array.from({ length: 4 }).map((_, index) => (
+              <CardSkeleton key={index} variant="metric" />
             ))}
           </div>
         }

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ListSkeleton } from "@/components/ui/skeletons";
 import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
 import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
@@ -78,32 +79,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   };
 
   if (loading) {
-    return (
-      <div className="space-y-4">
-        {[...Array(3)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <div className="space-y-2">
-                  <div className="h-5 w-48 rounded bg-muted"></div>
-                  <div className="h-4 w-32 rounded bg-muted"></div>
-                </div>
-                <div className="h-6 w-20 rounded bg-muted"></div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center justify-between">
-                <div className="h-4 w-24 rounded bg-muted"></div>
-                <div className="flex space-x-2">
-                  <div className="h-8 w-16 rounded bg-muted"></div>
-                  <div className="h-8 w-16 rounded bg-muted"></div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    );
+    return <ListSkeleton count={3} />;
   }
 
   if (error) {

--- a/app/documents/components/documents-stats.tsx
+++ b/app/documents/components/documents-stats.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardSkeleton } from "@/components/ui/skeletons";
 import { FileText, Clock, CheckCircle, AlertCircle } from 'lucide-react';
 import { getDocumentStatsAction } from '../actions';
 import { DocumentStats } from '@/types/documents';
@@ -30,15 +31,8 @@ export function DocumentsStats() {
   if (loading) {
     return (
       <div className="grid gap-4 md:grid-cols-4">
-        {[...Array(4)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader className="pb-2">
-              <div className="h-4 w-3/4 rounded bg-muted"></div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-8 w-1/2 rounded bg-muted"></div>
-            </CardContent>
-          </Card>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <CardSkeleton key={index} variant="metric" />
         ))}
       </div>
     );

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Separator } from "@/components/ui/separator";
 import { FileText, Users, Clock, Upload } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CardSkeleton, ListSkeleton } from "@/components/ui/skeletons";
 import { UploadDocumentDialog } from "./components/upload-document-dialog";
 import { DocumentsStats } from "./components/documents-stats";
 import { DocumentsList } from "./components/documents-list";
@@ -26,18 +27,15 @@ export default function DocumentsPage() {
       </header>
 
       {/* Stats Overview */}
-      <Suspense fallback={<div className="grid gap-4 md:grid-cols-4">
-        {[...Array(4)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader className="pb-2">
-              <div className="h-4 w-3/4 rounded bg-muted"></div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-8 w-1/2 rounded bg-muted"></div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>}>
+      <Suspense
+        fallback={
+          <div className="grid gap-4 md:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <CardSkeleton key={index} variant="metric" />
+            ))}
+          </div>
+        }
+      >
         <DocumentsStats />
       </Suspense>
 
@@ -54,25 +52,25 @@ export default function DocumentsPage() {
         </div>
 
         <TabsContent value="all" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
+          <Suspense fallback={<ListSkeleton count={5} />}>
             <DocumentsList filter={{}} />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="leases" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
+          <Suspense fallback={<ListSkeleton count={5} />}>
             <DocumentsList filter={{ type: ['lease'] }} />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="pending" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
+          <Suspense fallback={<ListSkeleton count={5} />}>
             <DocumentsList filter={{ status: ['pending_signature'] }} />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="signed" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
+          <Suspense fallback={<ListSkeleton count={5} />}>
             <DocumentsList filter={{ status: ['signed'] }} />
           </Suspense>
         </TabsContent>
@@ -140,31 +138,3 @@ export default function DocumentsPage() {
   );
 }
 
-function DocumentsListSkeleton() {
-  return (
-    <div className="space-y-4">
-      {[...Array(5)].map((_, i) => (
-        <Card key={i} className="animate-pulse">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <div className="space-y-2">
-                <div className="h-5 w-48 rounded bg-muted"></div>
-                <div className="h-4 w-32 rounded bg-muted"></div>
-              </div>
-              <div className="h-6 w-20 rounded bg-muted"></div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between">
-              <div className="h-4 w-24 rounded bg-muted"></div>
-              <div className="flex space-x-2">
-                <div className="h-8 w-16 rounded bg-muted"></div>
-                <div className="h-8 w-16 rounded bg-muted"></div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
-}

--- a/components/ui/skeletons/card.tsx
+++ b/components/ui/skeletons/card.tsx
@@ -1,0 +1,85 @@
+import * as React from "react"
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+
+import { Skeleton } from "./skeleton"
+
+export type CardSkeletonVariant = "generic" | "metric" | "list"
+
+export interface CardSkeletonProps extends React.ComponentProps<typeof Card> {
+  variant?: CardSkeletonVariant
+  /** Number of placeholder lines for the generic variant. */
+  lines?: number
+}
+
+export function CardSkeleton({
+  variant = "generic",
+  lines = 3,
+  className,
+  ...props
+}: CardSkeletonProps) {
+  if (variant === "metric") {
+    return (
+      <Card
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+        className={cn("overflow-hidden", className)}
+        {...props}
+      >
+        <CardHeader className="pb-2">
+          <Skeleton className="h-4 w-3/4" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-1/2" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (variant === "list") {
+    return (
+      <Card
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+        className={cn("overflow-hidden", className)}
+        {...props}
+      >
+        <CardHeader className="pb-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-48" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+            <Skeleton className="h-6 w-20" />
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <Skeleton className="h-4 w-24" />
+            <div className="flex gap-2">
+              <Skeleton className="h-8 w-16" />
+              <Skeleton className="h-8 w-16" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className={cn("space-y-4 p-6", className)}
+      {...props}
+    >
+      {Array.from({ length: Math.max(lines, 1) }).map((_, index) => (
+        <Skeleton key={index} className="h-4 w-full" />
+      ))}
+    </Card>
+  )
+}

--- a/components/ui/skeletons/index.ts
+++ b/components/ui/skeletons/index.ts
@@ -1,0 +1,4 @@
+export { Skeleton } from "./skeleton"
+export { CardSkeleton, type CardSkeletonProps, type CardSkeletonVariant } from "./card"
+export { ListSkeleton, type ListSkeletonProps } from "./list"
+export { TableSkeleton, type TableSkeletonProps } from "./table"

--- a/components/ui/skeletons/list.tsx
+++ b/components/ui/skeletons/list.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+import { CardSkeleton, CardSkeletonProps } from "./card"
+
+export interface ListSkeletonProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  count?: number
+  variant?: CardSkeletonProps["variant"]
+  cardProps?: Omit<CardSkeletonProps, "variant"> & { key?: never }
+}
+
+export function ListSkeleton({
+  count = 3,
+  variant = "list",
+  cardProps,
+  className,
+  ...props
+}: ListSkeletonProps) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className={cn("space-y-4", className)}
+      {...props}
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <CardSkeleton key={index} variant={variant} {...cardProps} />
+      ))}
+    </div>
+  )
+}

--- a/components/ui/skeletons/skeleton.tsx
+++ b/components/ui/skeletons/skeleton.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Skeleton = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    aria-hidden="true"
+    className={cn("animate-pulse rounded-md bg-muted/70", className)}
+    {...props}
+  />
+))
+Skeleton.displayName = "Skeleton"
+
+export { Skeleton }

--- a/components/ui/skeletons/table.tsx
+++ b/components/ui/skeletons/table.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+import { Skeleton } from "./skeleton"
+
+export interface TableSkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  columns?: number
+  rows?: number
+  showHeader?: boolean
+}
+
+export function TableSkeleton({
+  columns = 4,
+  rows = 5,
+  showHeader = true,
+  className,
+  ...props
+}: TableSkeletonProps) {
+  const columnArray = React.useMemo(() => Array.from({ length: Math.max(columns, 1) }), [columns])
+  const rowArray = React.useMemo(() => Array.from({ length: Math.max(rows, 1) }), [rows])
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className={cn("overflow-hidden rounded-xl border", className)}
+      {...props}
+    >
+      <table className="w-full border-collapse text-left text-sm">
+        {showHeader && (
+          <thead className="bg-muted/30">
+            <tr>
+              {columnArray.map((_, index) => (
+                <th key={index} className="px-4 py-3">
+                  <Skeleton className="h-3 w-3/4" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+        )}
+        <tbody>
+          {rowArray.map((_, rowIndex) => (
+            <tr key={rowIndex} className="border-t">
+              {columnArray.map((_, columnIndex) => (
+                <td key={columnIndex} className="px-4 py-3">
+                  <Skeleton className="h-4 w-full" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/docs/design/skeletons.mdx
+++ b/docs/design/skeletons.mdx
@@ -1,0 +1,53 @@
+# Skeleton primitives
+
+Consistent loading placeholders help residents understand when content is still being fetched. The shared skeleton primitives live in `components/ui/skeletons` and expose opinionated variants for the most common layouts in the portal.
+
+## CardSkeleton
+
+`CardSkeleton` mirrors our card spacing and typography rhythm. Use the `variant` prop to switch between presets:
+
+- `"metric"` — a compact stat card with a label line and a large value block. Perfect for dashboard counters.
+- `"list"` — matches the document row layout with primary/secondary text and trailing actions.
+- `"generic"` — renders `lines` full-width blocks for quick one-off placeholders.
+
+```tsx
+import { CardSkeleton } from "@/components/ui/skeletons"
+
+function StatsFallback() {
+  return (
+    <div className="grid gap-4 md:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <CardSkeleton key={index} variant="metric" />
+      ))}
+    </div>
+  )
+}
+```
+
+## ListSkeleton
+
+`ListSkeleton` handles vertical stacks of card rows and defaults to the `"list"` variant. Adjust `count` for the number of rows and pass `cardProps` to tweak spacing when necessary.
+
+```tsx
+import { ListSkeleton } from "@/components/ui/skeletons"
+
+function DocumentsFallback() {
+  return <ListSkeleton count={5} />
+}
+```
+
+## TableSkeleton
+
+`TableSkeleton` provides a responsive table wrapper with configurable headers and row counts. Use it whenever tabular data is loading so column widths remain stable.
+
+```tsx
+import { TableSkeleton } from "@/components/ui/skeletons"
+
+function PaymentsTableFallback() {
+  return <TableSkeleton columns={5} rows={6} />
+}
+```
+
+## Accessibility
+
+The skeleton primitives apply `role="status"` and `aria-busy="true"` so assistive technologies announce that content is in a loading state. Individual skeleton blocks are marked with `aria-hidden` to avoid noise. Always pair skeletons with an adjacent heading that describes the content being loaded (e.g. "Documents" or "Amenity Stats").

--- a/tests/skeletons.test.tsx
+++ b/tests/skeletons.test.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import {
+  CardSkeleton,
+  ListSkeleton,
+  TableSkeleton,
+  Skeleton,
+} from "@/components/ui/skeletons"
+
+describe("skeleton primitives", () => {
+  it("renders metric card skeleton with accessible state", () => {
+    const markup = renderToStaticMarkup(<CardSkeleton variant="metric" />)
+
+    expect(markup).toContain("aria-busy=\"true\"")
+    expect(markup).toContain("aria-live=\"polite\"")
+    expect((markup.match(/h-8 w-1\/2/g) || []).length).toBe(1)
+  })
+
+  it("renders the requested number of list skeleton rows", () => {
+    const count = 2
+    const markup = renderToStaticMarkup(<ListSkeleton count={count} />)
+
+    expect((markup.match(/h-6 w-20/g) || []).length).toBe(count)
+  })
+
+  it("renders a table skeleton with the expected grid", () => {
+    const columns = 3
+    const rows = 2
+    const markup = renderToStaticMarkup(
+      <TableSkeleton columns={columns} rows={rows} />
+    )
+
+    expect((markup.match(/<th\b/g) || []).length).toBe(columns)
+    expect((markup.match(/<tr/g) || []).length).toBe(rows + 1) // include header row
+  })
+
+  it("hides individual skeleton blocks from assistive tech", () => {
+    const markup = renderToStaticMarkup(<Skeleton className="h-4" />)
+
+    expect(markup).toContain("aria-hidden=\"true\"")
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add reusable skeleton primitives for cards, lists, and tables
- refactor bookings and documents fallbacks to consume the shared skeleton components
- document skeleton variants and add coverage for skeleton rendering states
- enable tsx tests in vitest configuration

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d15d6ebed883289e6a18ae2546d358