### PR TITLE
Instrument Supabase tracing and add observability docs

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -7,8 +7,12 @@ import {
 } from "@/lib/notifications"
 import { getStripe } from "@/lib/stripe"
 import type { Database, TablesInsert } from "@/lib/supabase"
+import { createSupabaseClientLoggingConfig } from "@/utils/supabase/logging"
+import { TRACE_HEADER_NAME } from "@/utils/trace/constants"
 
-function createSupabaseAdminClient(): SupabaseClient<Database> | null {
+function createSupabaseAdminClient(
+  traceId?: string,
+): SupabaseClient<Database> | null {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
@@ -17,24 +21,32 @@ function createSupabaseAdminClient(): SupabaseClient<Database> | null {
     return null
   }
 
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId,
+    source: "stripe-webhook",
+  })
+
   return createClient<Database>(supabaseUrl, serviceRoleKey, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,
     },
+    ...loggingConfig,
   })
 }
 
 export async function POST(req: Request) {
   const stripe = getStripe()
-  const signature = (await headers()).get("stripe-signature")
+  const requestHeaders = headers()
+  const signature = requestHeaders.get("stripe-signature")
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
 
   if (!webhookSecret) {
     return new Response("Webhook not configured", { status: 500 })
   }
 
-  const supabase = createSupabaseAdminClient()
+  const traceId = requestHeaders.get(TRACE_HEADER_NAME) ?? undefined
+  const supabase = createSupabaseAdminClient(traceId)
   if (!supabase) {
     return new Response("Supabase client not configured", { status: 500 })
   }

--- a/docs/perf/logging.md
+++ b/docs/perf/logging.md
@@ -1,0 +1,48 @@
+# Supabase Query Logging & Tracing
+
+The Supabase client wrappers now emit structured console logs for every PostgREST query, RPC call, or storage request. Each log line captures the HTTP method, path, duration, row count (when available), emitted SQL text (when Supabase returns it), and a trace identifier that follows the request through middleware, API handlers, and database calls.
+
+## Quick start
+
+1. **Run any server code path** (API route, server action, or server component) and inspect the terminal running `pnpm dev`/`pnpm start`. Look for log lines that begin with `[Supabase]`.
+2. **Provide your own trace id when testing** with `curl` or Postman by setting the `x-trace-id` header. If none is provided the middleware generates one automatically.
+3. **Opt in to exact row counts** where needed by using Supabase's count hint: `supabase.from('profiles').select('*', { count: 'exact' })`. The logging wrapper will include the returned count alongside the observed data length.
+
+Example output:
+
+```
+[Supabase] source=server-action trace=7d98fe92-8d0a-4b6f-9095-e9578e8cb07a GET /rest/v1/profiles status=200 durationMs=34 rows=3
+```
+
+Failures are logged via `console.error` with the same trace id to simplify cross-service debugging.
+
+## Enabling verbose tracing
+
+Verbose tracing is on by default—every Supabase request is wrapped by the logging middleware. Use the steps below to surface the most context:
+
+1. **Local development**: run `NODE_ENV=development pnpm dev` so that JSON parse issues (for example, a 204 response) emit `console.debug` hints during logging.
+2. **Custom trace identifiers**: send a header such as `x-trace-id: onboarding-flow` from tests or external clients. The middleware forwards this value to every downstream Supabase call so you can correlate HTTP, application, and database logs.
+3. **Vercel / production visibility**: forward the application logs to your log drain (Datadog, New Relic, etc.). Filter for `[Supabase]` or the shared trace id to follow a request across services.
+4. **API route correlation**: API handlers can access the active trace id via `headers().get('x-trace-id')`. Reuse it in any additional logging or outbound calls.
+
+## Database observability views
+
+The Supabase migration `20250214090000_observability_views.sql` creates an `observability` schema with two helper views backed by `pg_stat_statements`:
+
+- `observability.top_slow_queries` — top 100 statements ordered by mean execution time, including min/max durations and rows per call.
+- `observability.n_plus_one_candidates` — highlights statements executed frequently (`calls > 25`) that return roughly one row per call, a common N+1 signal.
+
+Query them from the SQL editor or Supabase CLI:
+
+```sql
+select * from observability.top_slow_queries limit 20;
+select * from observability.n_plus_one_candidates limit 20;
+```
+
+Both views are granted to the `authenticated` and `service_role` roles so they can power admin dashboards or scheduled reports without additional grants.
+
+## Operational checklist
+
+- Deploy the migration with `supabase db push` (or via CI) to enable the observability schema.
+- Confirm your monitoring stack stores the `[Supabase]` logs with trace ids.
+- When investigating performance issues, start with the new SQL views, then correlate the slow query back to the originating API call using the shared `x-trace-id`.

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,11 +3,24 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
+import { createSupabaseClientLoggingConfig } from '@/utils/supabase/logging'
+import { TRACE_HEADER_NAME } from '@/utils/trace/constants'
+
 export async function middleware(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers)
+  const traceId = requestHeaders.get(TRACE_HEADER_NAME) ?? crypto.randomUUID()
+  requestHeaders.set(TRACE_HEADER_NAME, traceId)
+
   let response = NextResponse.next({
     request: {
-      headers: request.headers,
+      headers: requestHeaders,
     },
+  })
+  response.headers.set(TRACE_HEADER_NAME, traceId)
+
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId,
+    source: 'middleware',
   })
 
   const supabase = createServerClient(
@@ -26,9 +39,10 @@ export async function middleware(request: NextRequest) {
           })
           response = NextResponse.next({
             request: {
-              headers: request.headers,
+              headers: requestHeaders,
             },
           })
+          response.headers.set(TRACE_HEADER_NAME, traceId)
           response.cookies.set({
             name,
             value,
@@ -43,9 +57,10 @@ export async function middleware(request: NextRequest) {
           })
           response = NextResponse.next({
             request: {
-              headers: request.headers,
+              headers: requestHeaders,
             },
           })
+          response.headers.set(TRACE_HEADER_NAME, traceId)
           response.cookies.set({
             name,
             value: '',
@@ -53,6 +68,7 @@ export async function middleware(request: NextRequest) {
           })
         },
       },
+      ...loggingConfig,
     }
   )
 

--- a/supabase/migrations/20250214090000_observability_views.sql
+++ b/supabase/migrations/20250214090000_observability_views.sql
@@ -1,0 +1,50 @@
+-- Enable pg_stat_statements to gather execution metrics if it is not already active
+create extension if not exists pg_stat_statements;
+
+-- Dedicated schema to hold observability helpers that surface performance insights
+create schema if not exists observability;
+
+comment on schema observability is 'Helper views for performance diagnostics (slow queries, N+1 detection, Supabase telemetry).';
+
+create or replace view observability.top_slow_queries as
+select
+  query,
+  calls,
+  total_exec_time as total_time_ms,
+  mean_exec_time as mean_time_ms,
+  min_exec_time as min_time_ms,
+  max_exec_time as max_time_ms,
+  stddev_exec_time as stddev_time_ms,
+  rows,
+  (case when calls > 0 then rows::numeric / calls else null end) as rows_per_call,
+  (case when calls > 0 then total_exec_time / calls else null end) as avg_time_per_call_ms
+from pg_stat_statements
+where query is not null
+order by mean_exec_time desc
+limit 100;
+
+comment on view observability.top_slow_queries is 'Top 100 queries by mean execution time sourced from pg_stat_statements.';
+
+create or replace view observability.n_plus_one_candidates as
+select
+  query,
+  calls,
+  rows,
+  total_exec_time as total_time_ms,
+  mean_exec_time as mean_time_ms,
+  (case when calls > 0 then rows::numeric / calls else null end) as rows_per_call,
+  (case when calls > 0 then total_exec_time / calls else null end) as avg_time_per_call_ms
+from pg_stat_statements
+where query is not null
+  and calls > 25
+  and (case when calls > 0 then rows::numeric / calls else null end) <= 1
+order by calls desc
+limit 100;
+
+comment on view observability.n_plus_one_candidates is 'High call-count, low row-per-call queries highlighting potential N+1 issues.';
+
+grant usage on schema observability to authenticated, service_role;
+grant select on all tables in schema observability to authenticated, service_role;
+
+alter default privileges in schema observability
+  grant select on tables to authenticated, service_role;

--- a/utils/supa-auth-admin.tsx
+++ b/utils/supa-auth-admin.tsx
@@ -1,13 +1,24 @@
 import { createClient } from '@supabase/supabase-js'
-import type { Database } from '@/lib/supabase'
 
-const supabase = createClient<Database>(process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-  auth: {
-    autoRefreshToken: false,
-    persistSession: false
-  }
+import type { Database } from '@/lib/supabase'
+import { createSupabaseClientLoggingConfig } from '@/utils/supabase/logging'
+
+const loggingConfig = createSupabaseClientLoggingConfig({
+  traceId: typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : undefined,
+  source: 'service-role',
 })
+
+const supabase = createClient<Database>(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+    ...loggingConfig,
+  },
+)
 
 // Access auth admin api
 export const adminAuthClient = supabase.auth.admin

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,7 +1,15 @@
 import { type CookieOptions, createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import { createSupabaseClientLoggingConfig } from '@/utils/supabase/logging'
+import { getCurrentTraceId } from '@/utils/trace/server'
+
 export function createClient(cookieStore: ReturnType<typeof cookies>) {
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId: getCurrentTraceId(),
+    source: 'server-action',
+  })
+
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL || '',
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
@@ -17,6 +25,7 @@ export function createClient(cookieStore: ReturnType<typeof cookies>) {
           cookieStore.set({ name, value: '', ...options })
         },
       },
-    }
+      ...loggingConfig,
+    },
   )
 }

--- a/utils/supabase-browser.ts
+++ b/utils/supabase-browser.ts
@@ -4,7 +4,26 @@ import { createBrowserClient } from "@supabase/ssr"
 import { useMemo } from "react"
 
 import type { Database } from "@/lib/supabase"
+import { createSupabaseClientLoggingConfig } from "@/utils/supabase/logging"
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+declare global {
+  interface Window {
+    __SUPABASE_TRACE_ID__?: string
+  }
+}
+
+function getBrowserTraceId() {
+  if (typeof window === "undefined") {
+    return undefined
+  }
+
+  if (!window.__SUPABASE_TRACE_ID__ && typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    window.__SUPABASE_TRACE_ID__ = crypto.randomUUID()
+  }
+
+  return window.__SUPABASE_TRACE_ID__
+}
 
 let client: TypedSupabaseClient
 
@@ -13,9 +32,18 @@ function getSupabaseBrowserClient() {
     return client
   }
 
-  client = createBrowserClient<any>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId: getBrowserTraceId(),
+    source: "browser",
+  })
+
+  client = createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "",
+    {
+      ...loggingConfig,
+      isSingleton: true,
+    },
   )
 
   return client

--- a/utils/supabase-server.ts
+++ b/utils/supabase-server.ts
@@ -1,10 +1,18 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+
 import type { Database } from '@/lib/supabase'
+import { createSupabaseClientLoggingConfig } from '@/utils/supabase/logging'
+import { getCurrentTraceId } from '@/utils/trace/server'
 
 export default function createSupabaseServer(
-  cookieStore: ReturnType<typeof cookies>
+  cookieStore: ReturnType<typeof cookies>,
 ) {
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId: getCurrentTraceId(),
+    source: 'server',
+  })
+
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -14,6 +22,7 @@ export default function createSupabaseServer(
           return cookieStore.get(name)?.value
         },
       },
-    }
+      ...loggingConfig,
+    },
   )
 }

--- a/utils/supabase/actions.ts
+++ b/utils/supabase/actions.ts
@@ -2,10 +2,17 @@
 
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { cookies } from 'next/headers';
+
 import type { Database } from '@/lib/supabase';
+import { createSupabaseClientLoggingConfig } from '@/utils/supabase/logging';
+import { getCurrentTraceId } from '@/utils/trace/server';
 
 export async function createActionClient() {
   const cookieStore = cookies();
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId: getCurrentTraceId(),
+    source: 'server-action',
+  });
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -22,6 +29,7 @@ export async function createActionClient() {
           cookieStore.set({ name, value: '', ...options });
         },
       },
+      ...loggingConfig,
     }
   );
 }

--- a/utils/supabase/logging.ts
+++ b/utils/supabase/logging.ts
@@ -1,0 +1,171 @@
+import { TRACE_HEADER_NAME } from '@/utils/trace/constants'
+
+type Logger = Pick<typeof console, 'info' | 'error'>
+
+export type SupabaseLoggingOptions = {
+  traceId?: string
+  source?: string
+  logger?: Logger
+}
+
+export type SupabaseClientLoggingConfig = {
+  global: {
+    fetch: typeof fetch
+    headers?: Record<string, string>
+  }
+}
+
+function parseRowCountFromContentRange(contentRange: string | null): number | undefined {
+  if (!contentRange) {
+    return undefined
+  }
+
+  const [, totalPart] = contentRange.split('/')
+  if (!totalPart || totalPart === '*') {
+    return undefined
+  }
+
+  const total = Number(totalPart)
+  return Number.isFinite(total) ? total : undefined
+}
+
+async function safelyExtractJson(response: Response) {
+  try {
+    return await response.json()
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('[Supabase] Unable to parse JSON body for logging', error)
+    }
+    return undefined
+  }
+}
+
+function deriveRowCount(data: unknown): number | undefined {
+  if (!data) {
+    return undefined
+  }
+
+  if (Array.isArray(data)) {
+    return data.length
+  }
+
+  if (typeof data === 'object') {
+    const casted = data as Record<string, unknown>
+    if (Array.isArray(casted.data)) {
+      return casted.data.length
+    }
+
+    if (typeof casted.count === 'number') {
+      return casted.count
+    }
+  }
+
+  return undefined
+}
+
+function buildLogPrefix(meta: SupabaseLogMeta) {
+  const parts = [
+    '[Supabase]',
+    meta.source ? `source=${meta.source}` : undefined,
+    meta.traceId ? `trace=${meta.traceId}` : undefined,
+    `${meta.method} ${meta.path}`,
+    `status=${meta.status}`,
+    `durationMs=${meta.durationMs}`,
+    meta.rows !== undefined ? `rows=${meta.rows}` : undefined,
+  ].filter(Boolean)
+
+  return parts.join(' ')
+}
+
+type SupabaseLogMeta = {
+  traceId?: string
+  source?: string
+  method: string
+  path: string
+  status: number
+  durationMs: number
+  rows?: number
+  sql?: string | null
+  requestId?: string | null
+}
+
+export function createSupabaseFetchWithLogging(
+  options: SupabaseLoggingOptions = {},
+): typeof fetch {
+  const { traceId, source, logger = console } = options
+
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init)
+    const effectiveTraceId = traceId ?? request.headers.get(TRACE_HEADER_NAME) ?? undefined
+    if (effectiveTraceId && !request.headers.has(TRACE_HEADER_NAME)) {
+      request.headers.set(TRACE_HEADER_NAME, effectiveTraceId)
+    }
+
+    const requestUrl = new URL(request.url)
+    const startedAt = Date.now()
+
+    try {
+      const response = await fetch(request)
+      const durationMs = Date.now() - startedAt
+
+      const clone = response.clone()
+      const [body, contentRange] = await Promise.all([
+        safelyExtractJson(clone),
+        Promise.resolve(response.headers.get('content-range')),
+      ])
+
+      const rowsFromBody = deriveRowCount(body)
+      const rows = rowsFromBody ?? parseRowCountFromContentRange(contentRange)
+
+      const meta: SupabaseLogMeta = {
+        traceId: effectiveTraceId,
+        source,
+        method: request.method.toUpperCase(),
+        path: `${requestUrl.pathname}${requestUrl.search}`,
+        status: response.status,
+        durationMs,
+        rows,
+        sql: response.headers.get('x-supabase-sql'),
+        requestId:
+          response.headers.get('x-request-id') ??
+          response.headers.get('request-id') ??
+          response.headers.get('x-correlation-id'),
+      }
+
+      logger.info(buildLogPrefix(meta), {
+        ...meta,
+      })
+
+      return response
+    } catch (error) {
+      const durationMs = Date.now() - startedAt
+      logger.error('[Supabase] Request failed', {
+        traceId: effectiveTraceId,
+        source,
+        method: request.method.toUpperCase(),
+        url: request.url,
+        durationMs,
+        error,
+      })
+      throw error
+    }
+  }
+}
+
+export function createSupabaseClientLoggingConfig(
+  options: SupabaseLoggingOptions = {},
+): SupabaseClientLoggingConfig {
+  const fetch = createSupabaseFetchWithLogging(options)
+  const headers: Record<string, string> | undefined = options.traceId
+    ? { [TRACE_HEADER_NAME]: options.traceId }
+    : undefined
+
+  return {
+    global: headers
+      ? {
+          fetch,
+          headers,
+        }
+      : { fetch },
+  }
+}

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,8 +1,15 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import { createSupabaseClientLoggingConfig } from '@/utils/supabase/logging'
+import { getCurrentTraceId } from '@/utils/trace/server'
+
 export function createClient() {
   const cookieStore = cookies()
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId: getCurrentTraceId(),
+    source: 'server',
+  })
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -31,6 +38,7 @@ export function createClient() {
           }
         },
       },
-    }
+      ...loggingConfig,
+    },
   )
 }

--- a/utils/supaone.tsx
+++ b/utils/supaone.tsx
@@ -1,42 +1,55 @@
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
-import { cookies } from "next/headers";
+import { createServerClient, type CookieOptions } from "@supabase/ssr"
+import { cookies } from "next/headers"
+
 import type { Database } from '@/lib/supabase'
+import { createSupabaseClientLoggingConfig } from '@/utils/supabase/logging'
+import { getCurrentTraceId } from '@/utils/trace/server'
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
 
-export async function createSupbaseServerClientReadOnly() {
-	const cookieStore = cookies();
+export async function createSupbaseServerClientReadOnly(): Promise<TypedSupabaseClient> {
+  const cookieStore = cookies()
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId: getCurrentTraceId(),
+    source: 'server-readonly',
+  })
 
-	return createServerClient(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				get(name: string) {
-					return cookieStore.get(name)?.value;
-				},
-			},
-		}
-	);
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+      },
+      ...loggingConfig,
+    },
+  )
 }
 
-export async function createSupbaseServerClient() {
-	const cookieStore = cookies();
+export async function createSupbaseServerClient(): Promise<TypedSupabaseClient> {
+  const cookieStore = cookies()
+  const loggingConfig = createSupabaseClientLoggingConfig({
+    traceId: getCurrentTraceId(),
+    source: 'server-readwrite',
+  })
 
-	return createServerClient<Database>(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				get(name: string) {
-					return cookieStore.get(name)?.value;
-				},
-				set(name: string, value: string, options: CookieOptions) {
-					cookieStore.set({ name, value, ...options });
-				},
-				remove(name: string, options: CookieOptions) {
-					cookieStore.set({ name, value: "", ...options });
-				},
-			},
-		}
-	);
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options: CookieOptions) {
+          cookieStore.set({ name, value: "", ...options })
+        },
+      },
+      ...loggingConfig,
+    },
+  )
 }

--- a/utils/trace/constants.ts
+++ b/utils/trace/constants.ts
@@ -1,0 +1,4 @@
+export const TRACE_HEADER_NAME = 'x-trace-id' as const
+
+export const TRACE_HEADER_DESCRIPTION =
+  'Unique identifier used to correlate requests across middleware, API handlers, and Supabase logging'

--- a/utils/trace/server.ts
+++ b/utils/trace/server.ts
@@ -1,0 +1,30 @@
+import { headers } from 'next/headers'
+
+import { TRACE_HEADER_NAME } from './constants'
+
+export function readTraceIdFromHeaders(
+  source?: Headers | HeadersInit | null,
+): string | undefined {
+  if (!source) {
+    return undefined
+  }
+
+  if (source instanceof Headers) {
+    return source.get(TRACE_HEADER_NAME) ?? undefined
+  }
+
+  const headersInstance = new Headers(source)
+  return headersInstance.get(TRACE_HEADER_NAME) ?? undefined
+}
+
+export function getCurrentTraceId(): string | undefined {
+  try {
+    return headers().get(TRACE_HEADER_NAME) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function ensureTraceId(existing?: string | null): string {
+  return existing && existing.length > 0 ? existing : crypto.randomUUID()
+}


### PR DESCRIPTION
## Summary
- add a shared Supabase logging wrapper that captures SQL metadata, durations, row counts, and trace ids
- propagate the `x-trace-id` header through middleware, API handlers, and each Supabase client factory
- document the tracing workflow and ship pg_stat_statements-backed views for slow query and N+1 analysis

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d6d1d188328bfb2b9d3ff1573cc