### PR TITLE
feat: add caching layer for core server loaders

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '@/utils/supa-server-actions';
+import { createClient as createServerClient } from '@/utils/supa-server-actions';
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { z } from 'zod';
@@ -13,6 +13,7 @@ import {
   DocumentSigningRequest,
   DocumentStats
 } from '@/types/documents';
+import { createCachedLoader, CACHE_TAGS, createSupabaseClientWithToken, invalidateCacheTag } from '@/lib/cache';
 
 // Validation schemas
 const documentUploadSchema = z.object({
@@ -50,29 +51,28 @@ interface ActionResult<T = any> {
   message?: string;
 }
 
-// Get documents with optional filters
-export async function getDocumentsAction(
-  filters?: DocumentListFilters
-): Promise<ActionResult<DocumentWithLease[]>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+type DocumentQueryContext = {
+  accessToken: string;
+  userId: string;
+  role: string | null;
+  filters: DocumentListFilters;
+};
 
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to view documents.' };
-    }
+type DocumentStatsContext = {
+  accessToken: string;
+  userId: string;
+  role: string | null;
+};
 
-    // Validate filters
-    const validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
+const normaliseDocumentFilters = (filters: DocumentListFilters = {}): DocumentListFilters => ({
+  ...filters,
+  status: filters.status ? [...filters.status].sort() : undefined,
+  type: filters.type ? [...filters.type].sort() : undefined,
+});
 
-    // Determine role for scoping
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .single();
+const fetchDocumentsCached = createCachedLoader<DocumentQueryContext, DocumentWithLease[]>(
+  async ({ accessToken, userId, role, filters }) => {
+    const supabase = createSupabaseClientWithToken(accessToken);
 
     let query = (supabase as any)
       .from('documents')
@@ -84,42 +84,127 @@ export async function getDocumentsAction(
       `)
       .order('created_at', { ascending: false });
 
-    // Scope non-admin/property_manager users to their own documents or ones they need to sign
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
+    if (role !== 'property_manager' && role !== 'admin') {
       query = query.or(
-        `tenant_id.eq.${user.id},signatures.signer_id.eq.${user.id}`
+        `tenant_id.eq.${userId},signatures.signer_id.eq.${userId}`
       );
     }
 
-    // Apply filters
-    if (validatedFilters.status?.length) {
-      query = query.in('status', validatedFilters.status);
+    if (filters.status?.length) {
+      query = query.in('status', filters.status);
     }
-    if (validatedFilters.type?.length) {
-      query = query.in('document_type', validatedFilters.type);
+    if (filters.type?.length) {
+      query = query.in('document_type', filters.type);
     }
-    if (validatedFilters.tenant_id) {
-      query = query.eq('tenant_id', validatedFilters.tenant_id);
+    if (filters.tenant_id) {
+      query = query.eq('tenant_id', filters.tenant_id);
     }
-    if (validatedFilters.unit_id) {
-      query = query.eq('unit_id', validatedFilters.unit_id);
+    if (filters.unit_id) {
+      query = query.eq('unit_id', filters.unit_id);
     }
-    if (validatedFilters.date_from) {
-      query = query.gte('created_at', validatedFilters.date_from);
+    if (filters.date_from) {
+      query = query.gte('created_at', filters.date_from);
     }
-    if (validatedFilters.date_to) {
-      query = query.lte('created_at', validatedFilters.date_to);
+    if (filters.date_to) {
+      query = query.lte('created_at', filters.date_to);
     }
 
-    const { data: documents, error } = await query;
+    const { data, error } = await query;
 
     if (error) {
-      console.error('Error fetching documents:', error);
-      return { success: false, error: 'Failed to fetch documents.' };
+      throw new Error(error.message);
     }
 
-    // Log access
-    for (const doc of documents || []) {
+    return data || [];
+  },
+  {
+    keyParts: ['documents', 'list'],
+    tags: [CACHE_TAGS.documents],
+    ttl: 120,
+    getCacheKey: ({ userId, role, filters }) =>
+      JSON.stringify({ userId, role, filters: normaliseDocumentFilters(filters) }),
+  }
+);
+
+const fetchDocumentStatsCached = createCachedLoader<DocumentStatsContext, DocumentStats>(
+  async ({ accessToken, userId, role }) => {
+    const supabase = createSupabaseClientWithToken(accessToken);
+
+    let query = supabase.from('documents').select('status');
+
+    if (role !== 'property_manager' && role !== 'admin') {
+      query = query.eq('tenant_id', userId);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const documents = data || [];
+
+    return {
+      total_documents: documents.length,
+      pending_signatures: documents.filter(d => d.status === 'pending_signature').length,
+      signed_documents: documents.filter(d => d.status === 'signed').length,
+      expired_documents: documents.filter(d => d.status === 'expired').length,
+      draft_documents: documents.filter(d => d.status === 'draft').length,
+    };
+  },
+  {
+    keyParts: ['documents', 'stats'],
+    tags: [CACHE_TAGS.documentStats],
+    ttl: 60,
+    getCacheKey: ({ userId, role }) => JSON.stringify({ userId, role }),
+  }
+);
+
+const revalidateDocumentCaches = async (reason: string) => {
+  await Promise.all([
+    invalidateCacheTag(CACHE_TAGS.documents, reason),
+    invalidateCacheTag(CACHE_TAGS.documentStats, reason),
+  ]);
+};
+
+// Get documents with optional filters
+export async function getDocumentsAction(
+  filters?: DocumentListFilters
+): Promise<ActionResult<DocumentWithLease[]>> {
+  const cookieStore = cookies();
+  const supabase = createServerClient(cookieStore);
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to view documents.' };
+    }
+
+    const validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
+    const normalisedFilters = normaliseDocumentFilters(validatedFilters);
+
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+
+    const { data: session, error: sessionError } = await supabase.auth.getSession();
+    const accessToken = session?.session?.access_token;
+
+    if (sessionError || !accessToken) {
+      console.error('Error retrieving access token for documents:', sessionError);
+      return { success: false, error: 'Unable to authenticate documents request.' };
+    }
+
+    const documents = await fetchDocumentsCached({
+      accessToken,
+      userId: user.id,
+      role: profile?.role ?? null,
+      filters: normalisedFilters,
+    });
+
+    for (const doc of documents) {
       await (supabase as any).rpc('log_document_access', {
         p_document_id: doc.id,
         p_action: 'view',
@@ -127,7 +212,7 @@ export async function getDocumentsAction(
       });
     }
 
-    return { success: true, data: documents || [] };
+    return { success: true, data: documents };
   } catch (error) {
     console.error('Unexpected error in getDocumentsAction:', error);
     return {
@@ -142,7 +227,7 @@ export async function uploadDocumentAction(
   formData: FormData
 ): Promise<ActionResult<Document>> {
   const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createServerClient(cookieStore);
 
   try {
     // Check authentication
@@ -229,6 +314,7 @@ export async function uploadDocumentAction(
       p_metadata: { file_name: file.name, file_size: file.size }
     });
 
+      await revalidateDocumentCaches('upload-document');
     revalidatePath('/documents');
     return { success: true, data: document, message: 'Document uploaded successfully.' };
   } catch (error) {
@@ -245,7 +331,7 @@ export async function createSigningRequestAction(
   formData: FormData
 ): Promise<ActionResult<{ signing_url?: string; envelope_id?: string }>> {
   const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createServerClient(cookieStore);
 
   try {
     // Check authentication
@@ -403,6 +489,7 @@ export async function createSigningRequestAction(
       p_metadata: { envelope_id: signingResult.id, recipients: tenantEmails }
     });
 
+    await revalidateDocumentCaches('create-signing-request');
     revalidatePath('/documents');
     return {
       success: true,
@@ -424,7 +511,7 @@ export async function signDocumentAction(
   signatureData?: Record<string, any>
 ): Promise<ActionResult> {
   const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createServerClient(cookieStore);
 
   try {
     // Check authentication
@@ -481,6 +568,7 @@ export async function signDocumentAction(
       p_metadata: signatureData
     });
 
+    await revalidateDocumentCaches('sign-document');
     revalidatePath('/documents');
     return { success: true, message: 'Document signed successfully.' };
   } catch (error) {
@@ -497,7 +585,7 @@ export async function getSigningUrlAction(
   documentId: string
 ): Promise<ActionResult<{ signing_url: string }>> {
   const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createServerClient(cookieStore);
 
   try {
     const { data: { user }, error: authError } = await supabase.auth.getUser();
@@ -547,43 +635,33 @@ export async function getSigningUrlAction(
 // Get document statistics
 export async function getDocumentStatsAction(): Promise<ActionResult<DocumentStats>> {
   const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createServerClient(cookieStore);
 
   try {
-    // Check authentication
     const { data: { user }, error: authError } = await supabase.auth.getUser();
     if (authError || !user) {
       return { success: false, error: 'You must be logged in to view document statistics.' };
     }
 
-    // Get stats based on user role
     const { data: profile } = await supabase
       .from('profiles')
       .select('role')
       .eq('id', user.id)
       .single();
 
-    let query = supabase.from('documents').select('status');
+    const { data: session, error: sessionError } = await supabase.auth.getSession();
+    const accessToken = session?.session?.access_token;
 
-    // If not admin/property manager, filter by tenant_id
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
-      query = query.eq('tenant_id', user.id);
+    if (sessionError || !accessToken) {
+      console.error('Error retrieving access token for document stats:', sessionError);
+      return { success: false, error: 'Unable to authenticate document statistics request.' };
     }
 
-    const { data: documents, error } = await query;
-
-    if (error) {
-      console.error('Error fetching document stats:', error);
-      return { success: false, error: 'Failed to fetch document statistics.' };
-    }
-
-    const stats: DocumentStats = {
-      total_documents: documents?.length || 0,
-      pending_signatures: documents?.filter(d => d.status === 'pending_signature').length || 0,
-      signed_documents: documents?.filter(d => d.status === 'signed').length || 0,
-      expired_documents: documents?.filter(d => d.status === 'expired').length || 0,
-      draft_documents: documents?.filter(d => d.status === 'draft').length || 0,
-    };
+    const stats = await fetchDocumentStatsCached({
+      accessToken,
+      userId: user.id,
+      role: profile?.role ?? null,
+    });
 
     return { success: true, data: stats };
   } catch (error) {

--- a/docs/perf/caching.md
+++ b/docs/perf/caching.md
@@ -1,0 +1,43 @@
+# Caching strategy
+
+The Roomsily portal now layers deterministic caching around document, booking, and notification loaders to reduce redundant calls to Supabase and Cal.com while keeping responses fresh.
+
+## Core primitives
+
+- `lib/cache.ts` wraps `unstable_cache` as `createCachedLoader`. Loaders opt into caching by providing `keyParts`, `tags`, and (optionally) a TTL and custom cache key generator.
+- Cached responses are tagged via `CACHE_TAGS` so downstream mutations can call `invalidateCacheTag(tag, reason)` to bust the Next.js data cache and any Upstash entries.
+- When `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are configured a lightweight Upstash Redis client is initialised. Cache entries are stored under the `roomsily:cache` namespace and each tag keeps a set of member keys for targeted invalidation. Without these env vars the system transparently falls back to in-region caching only.
+- `createSupabaseClientWithToken` builds a short-lived Supabase client using the caller's JWT so cached queries still respect RLS.
+- Invalidation events are appended to an in-memory log (`getCacheInvalidationLog`) and also emitted via `console.info([cache] …)` to aid monitoring.
+
+## Loader coverage
+
+| Domain        | Loader                                          | Tags applied                    | TTL |
+|---------------|--------------------------------------------------|---------------------------------|-----|
+| Documents     | `fetchDocumentsCached`, `fetchDocumentStatsCached` | `documents`, `document-stats`    | 120s / 60s |
+| Bookings      | Cal.com event types, booking detail/list loaders | `bookings`                       | 300s / 120s |
+| Notifications | `fetchNotificationsCached`                       | `notifications`                  | 60s |
+
+Each loader normalises its cache key (e.g. sorted filter arrays, explicit booleans) so equivalent queries hit the same entry regardless of argument order.
+
+## Invalidation matrix
+
+| Triggering action                                    | Tags revalidated                  | Notes |
+|------------------------------------------------------|----------------------------------|-------|
+| Document upload / signing request / signature update | `documents`, `document-stats`    | Invoked through `revalidateDocumentCaches` in the respective server actions. |
+| Cal.com booking creation                             | `bookings`                        | Fired when `createBooking` returns successfully. |
+| Cal.com booking cancellation                         | `bookings`                        | Fired after a successful cancellation response. |
+| In-app notification creation                         | `notifications`                   | Fired inside `sendInAppNotification` after Supabase insert. |
+
+If additional workflows mutate these resources they should call `invalidateCacheTag` (or reuse `revalidateDocumentCaches`) so the above guarantees remain intact.
+
+## Operational guidance
+
+- **Enabling Upstash:** configure `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in your environment. Entries are automatically evicted on tag invalidation and respect loader TTLs. Without these variables caching still functions inside the regional Next.js data cache.
+- **Monitoring:**
+  - Watch application logs for `[cache] revalidating tag …` messages. The in-memory history from `getCacheInvalidationLog()` can be surfaced via health endpoints if deeper introspection is needed.
+  - Upstash provides per-key metrics; the cache uses the prefixes `roomsily:cache:*` (entries) and `roomsily:cache-tag:*` (tag member sets).
+  - Consider alerting on Upstash error logs—`createCachedLoader` already reports degraded states via `console.warn`.
+- **Manual purges:** use `invalidateCacheTag(tag, reason)` when running administrative scripts or reacting to upstream fixes. The helper clears both Next.js caches and any mirrored Redis entries in a single call.
+
+By consolidating all server loaders behind `createCachedLoader` the portal benefits from deterministic caching semantics today while leaving room for future resource-specific tuning (different TTLs, multi-tag entries, etc.).

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,176 @@
+import { unstable_cache as nextCache, revalidateTag as nextRevalidateTag } from 'next/cache';
+import { createHash } from 'crypto';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/lib/supabase';
+
+const CACHE_NAMESPACE = 'roomsily:cache';
+const TAG_NAMESPACE = 'roomsily:cache-tag';
+const INVALIDATION_HISTORY_LIMIT = 50;
+
+export const CACHE_TAGS = {
+  documents: 'documents',
+  documentStats: 'document-stats',
+  bookings: 'bookings',
+  notifications: 'notifications',
+} as const;
+
+type CacheInvalidationRecord = {
+  tag: string;
+  reason?: string;
+  timestamp: number;
+};
+
+const invalidationHistory: CacheInvalidationRecord[] = [];
+
+const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
+const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+type RedisClient = {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T, options?: { ex?: number }): Promise<'OK' | null>;
+  del(...keys: string[]): Promise<number>;
+  sadd(key: string, member: string): Promise<number>;
+  smembers<T = string>(key: string): Promise<T[]>;
+};
+
+let redisClientPromise: Promise<RedisClient | null> | null = null;
+
+async function getRedisClient(): Promise<RedisClient | null> {
+  if (!redisUrl || !redisToken) {
+    return null;
+  }
+
+  if (!redisClientPromise) {
+    redisClientPromise = import('@upstash/redis')
+      .then(({ Redis }) => new Redis({ url: redisUrl, token: redisToken }) as unknown as RedisClient)
+      .catch((error) => {
+        console.warn('[cache] Failed to initialise Upstash Redis client:', error);
+        return null;
+      });
+  }
+
+  return redisClientPromise;
+}
+
+type CachedEntry<T> = {
+  value: T;
+  expiresAt?: number;
+  tags: string[];
+};
+
+type CacheOptions<TArgs extends any[]> = {
+  keyParts: string[];
+  tags: string[];
+  ttl?: number;
+  getCacheKey?: (...args: TArgs) => string;
+};
+
+const buildCacheKey = (key: string) => `${CACHE_NAMESPACE}:${key}`;
+const buildTagKey = (tag: string) => `${TAG_NAMESPACE}:${tag}`;
+
+const hashArgs = (args: unknown[]): string => {
+  return createHash('sha1').update(JSON.stringify(args)).digest('hex');
+};
+
+export function createCachedLoader<TArgs extends any[], TResult>(
+  loader: (...args: TArgs) => Promise<TResult>,
+  options: CacheOptions<TArgs>
+) {
+  return nextCache(
+    async (...args: TArgs) => {
+      const cacheKeyInput = options.getCacheKey
+        ? options.getCacheKey(...args)
+        : hashArgs(args);
+      const redisKey = buildCacheKey(`${options.keyParts.join(':')}:${cacheKeyInput}`);
+      const redis = await getRedisClient();
+
+      if (redis) {
+        try {
+          const cached = await redis.get<CachedEntry<TResult>>(redisKey);
+          if (cached && (!cached.expiresAt || cached.expiresAt > Date.now())) {
+            return cached.value;
+          }
+        } catch (error) {
+          console.warn('[cache] Unable to read cached value from Upstash:', error);
+        }
+      }
+
+      const value = await loader(...args);
+
+      if (redis) {
+        try {
+          const entry: CachedEntry<TResult> = {
+            value,
+            tags: options.tags,
+            expiresAt: options.ttl ? Date.now() + options.ttl * 1000 : undefined,
+          };
+          const ttlOptions = options.ttl ? { ex: options.ttl } : undefined;
+          await redis.set(redisKey, entry, ttlOptions);
+          await Promise.all(
+            options.tags.map((tag) => redis.sadd(buildTagKey(tag), redisKey))
+          );
+        } catch (error) {
+          console.warn('[cache] Unable to persist cached value to Upstash:', error);
+        }
+      }
+
+      return value;
+    },
+    options.keyParts,
+    { tags: options.tags }
+  );
+}
+
+export async function invalidateCacheTag(tag: string, reason?: string) {
+  const timestamp = Date.now();
+  invalidationHistory.unshift({ tag, reason, timestamp });
+  if (invalidationHistory.length > INVALIDATION_HISTORY_LIMIT) {
+    invalidationHistory.length = INVALIDATION_HISTORY_LIMIT;
+  }
+
+  if (reason || process.env.NODE_ENV !== 'production') {
+    console.info(`[cache] revalidating tag "${tag}"${reason ? ` due to ${reason}` : ''}`);
+  }
+
+  await nextRevalidateTag(tag);
+
+  const redis = await getRedisClient();
+  if (redis) {
+    const tagKey = buildTagKey(tag);
+    try {
+      const keys = await redis.smembers<string>(tagKey);
+      if (keys && keys.length > 0) {
+        await redis.del(...keys);
+      }
+      await redis.del(tagKey);
+    } catch (error) {
+      console.warn('[cache] Unable to clear Upstash cache for tag', tag, error);
+    }
+  }
+}
+
+export function getCacheInvalidationLog(): CacheInvalidationRecord[] {
+  return [...invalidationHistory];
+}
+
+export function createSupabaseClientWithToken(accessToken: string) {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error('Supabase environment variables are not configured.');
+  }
+
+  return createSupabaseClient<Database>(url, anonKey, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+

--- a/lib/calcom-service.ts
+++ b/lib/calcom-service.ts
@@ -1,3 +1,5 @@
+import { CACHE_TAGS, createCachedLoader, invalidateCacheTag } from '@/lib/cache';
+
 interface CalComCreateBookingRequest {
   start: string;
   end: string;
@@ -26,6 +28,109 @@ interface CalComEventType {
   hidden: boolean;
 }
 
+type EventTypesLoaderParams = {
+  baseUrl: string;
+  apiKey: string;
+  userSlug?: string;
+};
+
+type BookingListParams = {
+  baseUrl: string;
+  apiKey: string;
+  userEmail: string;
+  startDate?: string;
+  endDate?: string;
+};
+
+type BookingDetailParams = {
+  baseUrl: string;
+  apiKey: string;
+  bookingId: string;
+};
+
+const fetchEventTypesCached = createCachedLoader<[EventTypesLoaderParams], CalComEventType[]>(
+  async ({ baseUrl, apiKey, userSlug }) => {
+    const endpoint = userSlug
+      ? `${baseUrl}/api/v1/event-types/${userSlug}`
+      : `${baseUrl}/api/v1/event-types`;
+
+    const response = await fetch(endpoint, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch event types: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data.eventTypes || [];
+  },
+  {
+    keyParts: ['calcom', 'event-types'],
+    tags: [CACHE_TAGS.bookings],
+    ttl: 300,
+    getCacheKey: ({ userSlug }) => userSlug ?? 'all',
+  }
+);
+
+const fetchUserBookingsCached = createCachedLoader<[BookingListParams], any[]>(
+  async ({ baseUrl, apiKey, userEmail: _userEmail, startDate, endDate }) => {
+    const params = new URLSearchParams();
+    if (startDate) params.append('startDate', startDate);
+    if (endDate) params.append('endDate', endDate);
+
+    const response = await fetch(
+      `${baseUrl}/api/v1/bookings?${params.toString()}`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch user bookings: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data.bookings || [];
+  },
+  {
+    keyParts: ['calcom', 'bookings'],
+    tags: [CACHE_TAGS.bookings],
+    ttl: 120,
+    getCacheKey: ({ userEmail, startDate, endDate }) =>
+      JSON.stringify({ userEmail, startDate, endDate }),
+  }
+);
+
+const fetchBookingCached = createCachedLoader<[BookingDetailParams], any>(
+  async ({ baseUrl, apiKey, bookingId }) => {
+    const response = await fetch(`${baseUrl}/api/v1/bookings/${bookingId}`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch booking: ${response.statusText}`);
+    }
+
+    return response.json();
+  },
+  {
+    keyParts: ['calcom', 'booking-detail'],
+    tags: [CACHE_TAGS.bookings],
+    ttl: 120,
+    getCacheKey: ({ bookingId }) => bookingId,
+  }
+);
+
 class CalComService {
   private baseUrl: string;
   private apiKey: string;
@@ -39,24 +144,12 @@ class CalComService {
    * Get event types for a specific user or team
    */
   async getEventTypes(userSlug?: string): Promise<CalComEventType[]> {
-    const endpoint = userSlug
-      ? `${this.baseUrl}/api/v1/event-types/${userSlug}`
-      : `${this.baseUrl}/api/v1/event-types`;
-
     try {
-      const response = await fetch(endpoint, {
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
+      return await fetchEventTypesCached({
+        baseUrl: this.baseUrl,
+        apiKey: this.apiKey,
+        userSlug,
       });
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch event types: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-      return data.eventTypes || [];
     } catch (error) {
       console.error('Error fetching Cal.com event types:', error);
       return [];
@@ -100,6 +193,8 @@ class CalComService {
 
       const data = await response.json();
 
+      await invalidateCacheTag(CACHE_TAGS.bookings, 'booking-created');
+
       return {
         success: true,
         bookingId: data.booking?.id?.toString(),
@@ -130,7 +225,13 @@ class CalComService {
         }
       );
 
-      return response.ok;
+      const ok = response.ok;
+
+      if (ok) {
+        await invalidateCacheTag(CACHE_TAGS.bookings, 'booking-cancelled');
+      }
+
+      return ok;
     } catch (error) {
       console.error('Error canceling Cal.com booking:', error);
       return false;
@@ -142,21 +243,11 @@ class CalComService {
    */
   async getBooking(bookingId: string): Promise<any> {
     try {
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings/${bookingId}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch booking: ${response.statusText}`);
-      }
-
-      return await response.json();
+      return await fetchBookingCached({
+        baseUrl: this.baseUrl,
+        apiKey: this.apiKey,
+        bookingId,
+      });
     } catch (error) {
       console.error('Error fetching Cal.com booking:', error);
       return null;
@@ -172,26 +263,13 @@ class CalComService {
     endDate?: string
   ): Promise<any[]> {
     try {
-      const params = new URLSearchParams();
-      if (startDate) params.append('startDate', startDate);
-      if (endDate) params.append('endDate', endDate);
-
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings?${params.toString()}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch user bookings: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-      return data.bookings || [];
+      return await fetchUserBookingsCached({
+        baseUrl: this.baseUrl,
+        apiKey: this.apiKey,
+        userEmail,
+        startDate,
+        endDate,
+      });
     } catch (error) {
       console.error('Error fetching Cal.com user bookings:', error);
       return [];

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { createSupbaseServerClient } from "@/utils/supaone"
+import { CACHE_TAGS, createCachedLoader, createSupabaseClientWithToken, invalidateCacheTag } from "@/lib/cache"
 import { Resend } from "resend"
 
 export interface NotificationData {
@@ -19,6 +20,51 @@ export interface InAppNotification {
   actionUrl?: string
   metadata?: Record<string, any>
 }
+
+type NotificationLoaderParams = {
+  accessToken: string
+  userId: string
+  limit?: number
+  unreadOnly?: boolean
+}
+
+const fetchNotificationsCached = createCachedLoader<
+  [NotificationLoaderParams],
+  any[]
+>(
+  async ({ accessToken, userId, limit, unreadOnly }) => {
+    const supabase = createSupabaseClientWithToken(accessToken)
+
+    let query = supabase
+      .from('notifications')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+
+    if (typeof limit === 'number') {
+      query = query.limit(limit)
+    }
+
+    if (unreadOnly) {
+      query = query.eq('read', false)
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    return data || []
+  },
+  {
+    keyParts: ['notifications', 'list'],
+    tags: [CACHE_TAGS.notifications],
+    ttl: 60,
+    getCacheKey: ({ userId, limit, unreadOnly }) =>
+      JSON.stringify({ userId, limit: limit ?? null, unreadOnly: !!unreadOnly }),
+  }
+)
 
 class NotificationService {
   private resend: Resend | null = null
@@ -107,6 +153,8 @@ class NotificationService {
         console.error("Failed to create in-app notification:", error)
         return { success: false, error: error.message }
       }
+
+      await invalidateCacheTag(CACHE_TAGS.notifications, "notification-created")
 
       return { success: true, data }
     } catch (error) {
@@ -261,4 +309,13 @@ export async function sendBulkNotifications(
   notifications: (NotificationData | InAppNotification)[]
 ) {
   return notificationService.sendBulkNotification(notifications)
+}
+
+export async function getNotificationsForUser(params: NotificationLoaderParams) {
+  try {
+    return await fetchNotificationsCached(params)
+  } catch (error) {
+    console.error('Failed to load notifications:', error)
+    return []
+  }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@supabase/supabase-js": "^2.39.3",
     "@tanstack/react-query": "^5.51.9",
     "@types/mdx": "^2.0.13",
+    "@upstash/redis": "^1.35.4",
     "@vercel/analytics": "^1.3.1",
     "@vercel/speed-insights": "^1.0.12",
     "bech32": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
+      '@upstash/redis':
+        specifier: ^1.35.4
+        version: 1.35.4
       '@vercel/analytics':
         specifier: ^1.3.1
         version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
@@ -1793,6 +1796,9 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  '@upstash/redis@1.35.4':
+    resolution: {integrity: sha512-WE1ZnhFyBiIjTDW13GbO6JjkiMVVjw5VsvS8ENmvvJsze/caMQ5paxVD44+U68IUVmkXcbsLSoE+VIYsHtbQEw==}
 
   '@use-gesture/core@10.3.1':
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
@@ -4449,6 +4455,9 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -6382,6 +6391,10 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
+
+  '@upstash/redis@1.35.4':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@use-gesture/core@10.3.1': {}
 
@@ -9595,6 +9608,8 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary
- wrap document, booking, and notification server loaders in a shared caching helper with tagging support
- introduce optional Upstash Redis integration plus cache invalidation utilities and Supabase client helper
- document caching strategy and invalidation/monitoring approach in docs/perf/caching.md

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d6c91c88328bbe10d565cc2be81