### PR TITLE
Add paginated document and messaging feeds

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -8,11 +8,17 @@ import { documensoService } from '@/lib/documenso';
 import {
   Document,
   DocumentWithLease,
-  DocumentListFilters,
+  DocumentListParams,
   DocumentUploadRequest,
   DocumentSigningRequest,
-  DocumentStats
+  DocumentStats,
+  PaginatedDocumentsResponse,
 } from '@/types/documents';
+import {
+  buildPaginationMetadata,
+  normalizePaginationParams,
+  paginationParamsSchema,
+} from '@/utils/pagination';
 
 // Validation schemas
 const documentUploadSchema = z.object({
@@ -42,6 +48,13 @@ const documentListFiltersSchema = z.object({
   date_to: z.string().datetime().optional(),
 });
 
+const documentsQuerySchema = z.object({
+  filters: documentListFiltersSchema.optional(),
+  pagination: paginationParamsSchema.optional(),
+});
+
+const DEFAULT_DOCUMENT_PAGE_SIZE = 10;
+
 // Action result interface
 interface ActionResult<T = any> {
   success: boolean;
@@ -52,8 +65,8 @@ interface ActionResult<T = any> {
 
 // Get documents with optional filters
 export async function getDocumentsAction(
-  filters?: DocumentListFilters
-): Promise<ActionResult<DocumentWithLease[]>> {
+  params?: DocumentListParams
+): Promise<ActionResult<PaginatedDocumentsResponse>> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
 
@@ -64,8 +77,21 @@ export async function getDocumentsAction(
       return { success: false, error: 'You must be logged in to view documents.' };
     }
 
-    // Validate filters
-    const validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
+    const parsedParams = documentsQuerySchema.parse(params ?? {});
+    const validatedFilters = parsedParams.filters ?? {};
+    const paginationInput = parsedParams.pagination;
+
+    let paginationConfig;
+    try {
+      const fallbackLimit = paginationInput?.limit ?? DEFAULT_DOCUMENT_PAGE_SIZE;
+      paginationConfig = normalizePaginationParams(paginationInput, fallbackLimit);
+    } catch (error) {
+      console.error('Invalid pagination cursor for documents:', error);
+      return { success: false, error: 'Invalid pagination cursor provided.' };
+    }
+
+    const { limit, offset, pageOverride } = paginationConfig;
+    const rangeEnd = Math.max(offset + limit - 1, offset);
 
     // Determine role for scoping
     const { data: profile } = await supabase
@@ -81,7 +107,7 @@ export async function getDocumentsAction(
         lease:leases(*),
         signatures:document_signatures(*),
         access_logs:document_access_logs(*, profiles:signer_id(username, full_name))
-      `)
+      `, { count: 'exact' })
       .order('created_at', { ascending: false });
 
     // Scope non-admin/property_manager users to their own documents or ones they need to sign
@@ -111,7 +137,7 @@ export async function getDocumentsAction(
       query = query.lte('created_at', validatedFilters.date_to);
     }
 
-    const { data: documents, error } = await query;
+    const { data: documents, error, count } = await query.range(offset, rangeEnd);
 
     if (error) {
       console.error('Error fetching documents:', error);
@@ -127,7 +153,22 @@ export async function getDocumentsAction(
       });
     }
 
-    return { success: true, data: documents || [] };
+    const pagination = buildPaginationMetadata({
+      total: count ?? 0,
+      limit,
+      offset,
+      itemCount: documents?.length ?? 0,
+      pageOverride,
+    });
+
+    return {
+      success: true,
+      data: {
+        items: documents || [],
+        pagination,
+        filters: validatedFilters,
+      },
+    };
   } catch (error) {
     console.error('Unexpected error in getDocumentsAction:', error);
     return {

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,36 +9,86 @@ import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
 import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import type { PaginationMetadata } from '@/types/pagination';
+import { PaginationControls } from '@/components/pagination-controls';
 
 interface DocumentsListProps {
   filter: DocumentListFilters;
 }
 
+const PAGE_SIZE = 10;
+
 export function DocumentsList({ filter }: DocumentsListProps) {
   const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState<PaginationMetadata | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [cursorMap, setCursorMap] = useState<Record<number, string | null>>({ 1: null });
+
+  const filterKey = useMemo(() => JSON.stringify(filter ?? {}), [filter]);
+  const filtersForRequest = useMemo<DocumentListFilters>(() => {
+    return JSON.parse(filterKey) as DocumentListFilters;
+  }, [filterKey]);
+  const cursorForPage = cursorMap[currentPage] ?? null;
+
+  useEffect(() => {
+    setCurrentPage(1);
+    setCursorMap({ 1: null });
+  }, [filterKey]);
 
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
         setLoading(true);
-        const result = await getDocumentsAction(filter);
+        setError(null);
+
+        const result = await getDocumentsAction({
+          filters: filtersForRequest,
+          pagination: {
+            limit: PAGE_SIZE,
+            page: currentPage,
+            cursor: cursorForPage ?? undefined,
+          },
+        });
+
         if (result.success && result.data) {
-          setDocuments(result.data);
+          setDocuments(result.data.items);
+          setPagination(result.data.pagination);
+          setCursorMap(prev => {
+            const next = { ...prev };
+
+            if (result.data.pagination.nextCursor) {
+              next[currentPage + 1] = result.data.pagination.nextCursor;
+            } else {
+              delete next[currentPage + 1];
+            }
+
+            if (currentPage > 1) {
+              next[currentPage - 1] = result.data.pagination.prevCursor ?? null;
+            }
+
+            next[currentPage] = cursorForPage ?? null;
+
+            return next;
+          });
         } else {
           setError(result.error || 'Failed to fetch documents');
+          setDocuments([]);
+          setPagination(null);
         }
       } catch (err) {
         console.error('Error fetching documents:', err);
         setError('An unexpected error occurred');
+        setDocuments([]);
+        setPagination(null);
       } finally {
         setLoading(false);
       }
     };
 
     fetchDocuments();
-  }, [filter]);
+  }, [filterKey, currentPage, cursorForPage, filtersForRequest]);
 
   const getStatusBadge = (status: string) => {
     const variants = {
@@ -77,7 +127,16 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     }
   };
 
-  if (loading) {
+  const handlePageChange = (page: number) => {
+    if (!pagination) return;
+    if (page < 1) return;
+    if (pagination.pageCount > 0 && page > pagination.pageCount) return;
+    if (page !== currentPage) {
+      setCurrentPage(page);
+    }
+  };
+
+  if (loading && documents.length === 0) {
     return (
       <div className="space-y-4">
         {[...Array(3)].map((_, i) => (
@@ -211,6 +270,16 @@ export function DocumentsList({ filter }: DocumentsListProps) {
           )}
         </Card>
       ))}
+      {pagination && (
+        <PaginationControls
+          page={pagination.page}
+          pageCount={pagination.pageCount}
+          total={pagination.total}
+          limit={pagination.limit}
+          onPageChange={handlePageChange}
+          isLoading={loading}
+        />
+      )}
     </div>
   );
 }

--- a/app/messaging/actions/index.ts
+++ b/app/messaging/actions/index.ts
@@ -1,0 +1,156 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+
+import { createClient } from '@/utils/supa-server-actions';
+import {
+  buildPaginationMetadata,
+  normalizePaginationParams,
+  paginationParamsSchema,
+} from '@/utils/pagination';
+import type {
+  MessageListParams,
+  PaginatedMessagesResponse,
+} from '@/types/messages';
+
+interface ActionResult<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+const messageFiltersSchema = z.object({
+  type: z.array(z.enum(['info', 'success', 'warning', 'error'])).optional(),
+  read: z.boolean().optional(),
+  userId: z.string().uuid().optional(),
+  search: z.string().max(200).optional(),
+});
+
+const messagesQuerySchema = z.object({
+  filters: messageFiltersSchema.optional(),
+  pagination: paginationParamsSchema.optional(),
+});
+
+const DEFAULT_MESSAGE_PAGE_SIZE = 10;
+
+const escapeIlike = (value: string) =>
+  value.replace(/[\\%_]/g, match => `\\${match}`);
+
+export async function getMessagesAction(
+  params?: MessageListParams
+): Promise<ActionResult<PaginatedMessagesResponse>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+
+  try {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to view messages.' };
+    }
+
+    const parsedParams = messagesQuerySchema.parse(params ?? {});
+    const filters = parsedParams.filters ?? {};
+    const paginationInput = parsedParams.pagination;
+
+    let paginationConfig;
+    try {
+      const fallbackLimit = paginationInput?.limit ?? DEFAULT_MESSAGE_PAGE_SIZE;
+      paginationConfig = normalizePaginationParams(paginationInput, fallbackLimit);
+    } catch (error) {
+      console.error('Invalid pagination cursor for messages:', error);
+      return { success: false, error: 'Invalid pagination cursor provided.' };
+    }
+
+    const { limit, offset, pageOverride } = paginationConfig;
+    const rangeEnd = Math.max(offset + limit - 1, offset);
+
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+
+    let query = (supabase as any)
+      .from('notifications')
+      .select(
+        `id, user_id, title, message, type, action_url, metadata, read, created_at, updated_at`,
+        { count: 'exact' }
+      )
+      .order('created_at', { ascending: false });
+
+    const isManager = profile?.role === 'property_manager' || profile?.role === 'admin';
+
+    if (!isManager) {
+      query = query.eq('user_id', user.id);
+    } else if (filters.userId) {
+      query = query.eq('user_id', filters.userId);
+    }
+
+    if (filters.type?.length) {
+      query = query.in('type', filters.type);
+    }
+
+    if (filters.read !== undefined) {
+      query = query.eq('read', filters.read);
+    }
+
+    if (filters.search) {
+      const sanitized = escapeIlike(filters.search.trim());
+      if (sanitized.length > 0) {
+        const pattern = `%${sanitized}%`;
+        query = query.or(
+          `title.ilike.${pattern},message.ilike.${pattern}`
+        );
+      }
+    }
+
+    const { data: rows, error, count } = await query.range(offset, rangeEnd);
+
+    if (error) {
+      console.error('Error fetching messages:', error);
+      return { success: false, error: 'Failed to fetch messages.' };
+    }
+
+    const items = (rows || []).map(row => ({
+      id: row.id,
+      user_id: row.user_id,
+      title: row.title,
+      body: row.message,
+      type: row.type,
+      action_url: row.action_url,
+      metadata: row.metadata ?? {},
+      read: row.read,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    }));
+
+    const pagination = buildPaginationMetadata({
+      total: count ?? 0,
+      limit,
+      offset,
+      itemCount: items.length,
+      pageOverride,
+    });
+
+    return {
+      success: true,
+      data: {
+        items,
+        pagination,
+        filters,
+      },
+    };
+  } catch (error) {
+    console.error('Unexpected error in getMessagesAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
+    };
+  }
+}

--- a/app/messaging/components/message-feed.tsx
+++ b/app/messaging/components/message-feed.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { AlertCircle, Bell, CheckCircle2, Info, MessagesSquare } from 'lucide-react';
+
+import { PaginationControls } from '@/components/pagination-controls';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import type { MessageRecord } from '@/types/messages';
+import type { PaginationMetadata } from '@/types/pagination';
+
+import { getMessagesAction } from '../actions';
+
+const PAGE_SIZE = 10;
+
+type MessageTypeFilter = 'all' | 'info' | 'success' | 'warning' | 'error';
+
+type CursorMap = Record<number, string | null>;
+
+const typeLabels: Record<MessageTypeFilter, string> = {
+  all: 'All types',
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  error: 'Error',
+};
+
+const typeIconMap = {
+  info: Info,
+  success: CheckCircle2,
+  warning: AlertCircle,
+  error: Bell,
+} satisfies Record<'info' | 'success' | 'warning' | 'error', typeof Info>;
+
+export function MessageFeed() {
+  const [messages, setMessages] = useState<MessageRecord[]>([]);
+  const [pagination, setPagination] = useState<PaginationMetadata | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [cursorMap, setCursorMap] = useState<CursorMap>({ 1: null });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [typeFilter, setTypeFilter] = useState<MessageTypeFilter>('all');
+  const [showUnreadOnly, setShowUnreadOnly] = useState(false);
+
+  const messageFilters = useMemo(() => {
+    return {
+      type: typeFilter === 'all' ? undefined : [typeFilter],
+      read: showUnreadOnly ? false : undefined,
+    };
+  }, [typeFilter, showUnreadOnly]);
+
+  const filterKey = useMemo(() => JSON.stringify(messageFilters), [messageFilters]);
+  const cursorForPage = cursorMap[currentPage] ?? null;
+
+  useEffect(() => {
+    setCurrentPage(1);
+    setCursorMap({ 1: null });
+  }, [filterKey]);
+
+  useEffect(() => {
+    const fetchMessages = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const result = await getMessagesAction({
+          filters: messageFilters,
+          pagination: {
+            limit: PAGE_SIZE,
+            page: currentPage,
+            cursor: cursorForPage ?? undefined,
+          },
+        });
+
+        if (result.success && result.data) {
+          setMessages(result.data.items);
+          setPagination(result.data.pagination);
+          setCursorMap(prev => {
+            const next = { ...prev };
+
+            if (result.data.pagination.nextCursor) {
+              next[currentPage + 1] = result.data.pagination.nextCursor;
+            } else {
+              delete next[currentPage + 1];
+            }
+
+            if (currentPage > 1) {
+              next[currentPage - 1] = result.data.pagination.prevCursor ?? null;
+            }
+
+            next[currentPage] = cursorForPage ?? null;
+            return next;
+          });
+        } else {
+          setError(result.error || 'Failed to fetch messages');
+          setMessages([]);
+          setPagination(null);
+        }
+      } catch (error) {
+        console.error('Error fetching messages:', error);
+        setError('An unexpected error occurred while loading messages.');
+        setMessages([]);
+        setPagination(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMessages();
+  }, [currentPage, cursorForPage, filterKey, messageFilters]);
+
+  const handlePageChange = (page: number) => {
+    if (!pagination) return;
+    if (page < 1) return;
+    if (pagination.pageCount > 0 && page > pagination.pageCount) return;
+    if (page !== currentPage) {
+      setCurrentPage(page);
+    }
+  };
+
+  const renderMessageCard = (message: MessageRecord) => {
+    const Icon = typeIconMap[message.type];
+    const timestamp = formatDistanceToNow(new Date(message.created_at), {
+      addSuffix: true,
+    });
+
+    return (
+      <Card key={message.id} className="border-muted-foreground/20 transition-shadow hover:shadow-sm">
+        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+          <div className="flex items-center gap-3">
+            <div className="flex size-9 items-center justify-center rounded-full bg-muted">
+              <Icon className="size-5 text-primary" />
+            </div>
+            <div>
+              <CardTitle className="text-base font-semibold leading-tight">
+                {message.title}
+              </CardTitle>
+              <div className="text-xs text-muted-foreground">{timestamp}</div>
+            </div>
+          </div>
+          <Badge variant={message.read ? 'outline' : 'default'} className="text-xs">
+            {message.read ? 'Read' : 'Unread'}
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>{message.body}</p>
+          {message.action_url && (
+            <a
+              href={message.action_url}
+              className="inline-flex items-center text-xs font-medium text-primary hover:underline"
+            >
+              View details
+            </a>
+          )}
+        </CardContent>
+      </Card>
+    );
+  };
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Select value={typeFilter} onValueChange={value => setTypeFilter(value as MessageTypeFilter)}>
+            <SelectTrigger className="w-44">
+              <SelectValue placeholder="Filter type" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(typeLabels).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Switch
+              id="unread-only"
+              checked={showUnreadOnly}
+              onCheckedChange={setShowUnreadOnly}
+            />
+            <label htmlFor="unread-only">Unread only</label>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <MessagesSquare className="size-4" />
+          <span>
+            {pagination ? `${pagination.total.toLocaleString()} messages` : '—'}
+          </span>
+        </div>
+      </div>
+
+      {loading && messages.length === 0 ? (
+        <div className="space-y-3">
+          {[...Array(4)].map((_, index) => (
+            <Card key={index} className="animate-pulse">
+              <CardHeader>
+                <div className="h-5 w-1/3 rounded bg-muted" />
+                <div className="mt-2 h-4 w-24 rounded bg-muted" />
+              </CardHeader>
+              <CardContent>
+                <div className="h-4 w-full rounded bg-muted" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : error ? (
+        <Card className="border-destructive/40 bg-destructive/5 p-6">
+          <div className="space-y-3 text-center">
+            <p className="text-sm text-destructive">{error}</p>
+            <Button variant="outline" size="sm" onClick={() => setCurrentPage(1)}>
+              Try again
+            </Button>
+          </div>
+        </Card>
+      ) : messages.length === 0 ? (
+        <Card className="p-10 text-center">
+          <h3 className="text-lg font-medium">No messages yet</h3>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {showUnreadOnly
+              ? 'You have no unread messages with the current filters.'
+              : 'System notifications and roommate updates will appear here.'}
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {messages.map(renderMessageCard)}
+        </div>
+      )}
+
+      {pagination && messages.length > 0 && (
+        <PaginationControls
+          page={pagination.page}
+          pageCount={pagination.pageCount}
+          total={pagination.total}
+          limit={pagination.limit}
+          onPageChange={handlePageChange}
+          isLoading={loading}
+        />
+      )}
+    </section>
+  );
+}

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,6 +1,8 @@
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 
+import { MessageFeed } from './components/message-feed'
+
 const messagingHighlights = [
   {
     title: "Threaded conversations",
@@ -26,7 +28,7 @@ const messagingHighlights = [
 
 export default function MessagingPage() {
   return (
-    <div className="container max-w-5xl space-y-10 py-12">
+    <div className="container max-w-6xl space-y-12 py-12">
       <header className="space-y-4">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Messaging</h1>
@@ -36,16 +38,30 @@ export default function MessagingPage() {
         </div>
         <Separator />
       </header>
-      <div className="grid gap-6 md:grid-cols-2">
-        {messagingHighlights.map((item) => (
-          <Card key={item.title}>
-            <CardHeader>
-              <CardTitle>{item.title}</CardTitle>
-              <CardDescription>{item.description}</CardDescription>
-            </CardHeader>
-          </Card>
-        ))}
-      </div>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold tracking-tight">Latest activity</h2>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            Review announcements, rent reminders, and roommate updates in a single, paginated inbox.
+          </p>
+        </div>
+        <MessageFeed />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Why roommates love the feed</h2>
+        <div className="grid gap-6 md:grid-cols-2">
+          {messagingHighlights.map((item) => (
+            <Card key={item.title}>
+              <CardHeader>
+                <CardTitle>{item.title}</CardTitle>
+                <CardDescription>{item.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </section>
     </div>
   )
 }

--- a/components/pagination-controls.tsx
+++ b/components/pagination-controls.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationControlsProps {
+  page: number;
+  pageCount: number;
+  total: number;
+  limit: number;
+  onPageChange: (page: number) => void;
+  isLoading?: boolean;
+}
+
+export function PaginationControls({
+  page,
+  pageCount,
+  total,
+  limit,
+  onPageChange,
+  isLoading = false,
+}: PaginationControlsProps) {
+  const safePageCount = pageCount > 0 ? pageCount : 0;
+  const safePage = safePageCount === 0 ? 0 : Math.min(Math.max(page, 1), safePageCount);
+
+  const hasPrevious = safePageCount > 0 && safePage > 1;
+  const hasNext = safePageCount > 0 && safePage < safePageCount;
+
+  const startItem = total === 0 || safePageCount === 0 ? 0 : (safePage - 1) * limit + 1;
+  const endItem = total === 0 || safePageCount === 0 ? 0 : Math.min(startItem + limit - 1, total);
+
+  return (
+    <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="text-sm text-muted-foreground">
+        {total === 0
+          ? 'Showing 0 to 0 of 0 entries'
+          : `Showing ${startItem.toLocaleString()} to ${endItem.toLocaleString()} of ${total.toLocaleString()} entries`}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!hasPrevious || isLoading}
+          onClick={() => hasPrevious && onPageChange(safePage - 1)}
+        >
+          <ChevronLeft className="mr-1 size-4" />
+          Previous
+        </Button>
+        <div className="text-sm font-medium">
+          Page {safePageCount === 0 ? 0 : safePage} of {safePageCount === 0 ? 0 : safePageCount}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!hasNext || isLoading}
+          onClick={() => hasNext && onPageChange(safePage + 1)}
+        >
+          Next
+          <ChevronRight className="ml-1 size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/docs/perf/pagination.md
+++ b/docs/perf/pagination.md
@@ -1,0 +1,48 @@
+# Pagination Guidelines
+
+Efficient pagination keeps heavy lists responsive while ensuring filters and role-based access rules stay intact. This guide captures the approach used for documents and messaging so new endpoints can follow the same pattern.
+
+## Server-side patterns
+
+1. **Validate inputs with Zod**
+   - Compose a `filters` schema that mirrors the shape of accepted query parameters.
+   - Reuse the shared [`paginationParamsSchema`](../../utils/pagination.ts) to coerce `limit`, `page`, and `cursor` values.
+   - Return early with a 400-style error when cursors fail validation instead of falling back to unbounded queries.
+
+2. **Normalize offset + cursor**
+   - Call `normalizePaginationParams` to translate either a cursor or explicit page into an offset.
+   - Always supply a deterministic fallback limit (e.g. 10) so the API has predictable defaults.
+
+3. **Select with counts**
+   - Request Supabase rows via `select(..., { count: 'exact' })` and append `.range(offset, offset + limit - 1)`.
+   - Scope data using role checks *before* pagination so totals reflect the caller’s permissions.
+
+4. **Return metadata**
+   - Use `buildPaginationMetadata` with the `count`, `limit`, `offset`, and returned row count.
+   - Send `{ total, page, pageCount, nextCursor, prevCursor }` so the client can render both classic pagination and “load more” experiences.
+
+5. **Include applied filters**
+   - Echo validated filter values in the payload to help clients sync UI state after a refetch.
+
+## Client-side patterns
+
+1. **Track cursors per page**
+   - Maintain a `Record<number, string | null>` that stores the cursor that produced each page. This enables quick jumps back to previous pages without recomputing offsets.
+
+2. **Reset state on filter change**
+   - Memoise filters (`JSON.stringify` is a pragmatic helper) and reset `currentPage` + cursors when filters change.
+
+3. **Optimistic rendering**
+   - Only show skeleton loaders when the current page is empty; otherwise keep the previous page visible and disable controls while loading.
+
+4. **Shared controls**
+   - Reuse `<PaginationControls>` to keep Prev/Next, total counts, and range messaging consistent across surfaces.
+
+## Quick checklist
+
+- [x] Inputs validated with Zod, including pagination parameters.
+- [x] Supabase queries scoped with `.range` and `count: 'exact'`.
+- [x] Responses include `items`, `pagination`, and applied `filters`.
+- [x] UI components request specific pages and surface pagination controls.
+
+Following this template prevents accidental full-table scans and keeps navigation predictable as data grows.

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -1,3 +1,5 @@
+import type { PaginationMetadata, PaginationParams } from './pagination';
+
 export type DocumentType = 'lease' | 'addendum' | 'insurance' | 'maintenance' | 'other';
 
 export type DocumentStatus = 'draft' | 'pending_signature' | 'signed' | 'expired' | 'cancelled';
@@ -124,4 +126,15 @@ export interface DocumentStats {
   signed_documents: number;
   expired_documents: number;
   draft_documents: number;
+}
+
+export interface DocumentListParams {
+  filters?: DocumentListFilters;
+  pagination?: PaginationParams;
+}
+
+export interface PaginatedDocumentsResponse {
+  items: DocumentWithLease[];
+  pagination: PaginationMetadata;
+  filters?: DocumentListFilters;
 }

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -1,0 +1,34 @@
+import type { PaginationMetadata, PaginationParams } from './pagination';
+
+export type MessageCategory = 'info' | 'success' | 'warning' | 'error';
+
+export interface MessageRecord {
+  id: string;
+  user_id: string;
+  title: string;
+  body: string;
+  type: MessageCategory;
+  action_url?: string | null;
+  metadata?: Record<string, any>;
+  read?: boolean | null;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface MessageListFilters {
+  type?: MessageCategory[];
+  read?: boolean;
+  userId?: string;
+  search?: string;
+}
+
+export interface MessageListParams {
+  filters?: MessageListFilters;
+  pagination?: PaginationParams;
+}
+
+export interface PaginatedMessagesResponse {
+  items: MessageRecord[];
+  pagination: PaginationMetadata;
+  filters?: MessageListFilters;
+}

--- a/types/pagination.ts
+++ b/types/pagination.ts
@@ -1,0 +1,14 @@
+export interface PaginationMetadata {
+  total: number;
+  page: number;
+  limit: number;
+  pageCount: number;
+  nextCursor: string | null;
+  prevCursor: string | null;
+}
+
+export interface PaginationParams {
+  limit?: number;
+  page?: number;
+  cursor?: string | null;
+}

--- a/utils/pagination.ts
+++ b/utils/pagination.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod'
+
+import type { PaginationMetadata, PaginationParams } from '@/types/pagination'
+
+export const paginationParamsSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+  page: z.coerce.number().int().min(1).optional(),
+  cursor: z.string().min(1).optional(),
+})
+
+function base64UrlEncode(input: string) {
+  return Buffer.from(input, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function base64UrlDecode(input: string) {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/')
+  const padding = normalized.length % 4
+  const padded = normalized + (padding ? '='.repeat(4 - padding) : '')
+  return Buffer.from(padded, 'base64').toString('utf-8')
+}
+
+export function encodeCursor(offset: number) {
+  if (!Number.isFinite(offset) || offset < 0) {
+    throw new Error('Invalid offset for cursor encoding')
+  }
+
+  return base64UrlEncode(JSON.stringify({ offset }))
+}
+
+export function decodeCursor(cursor: string) {
+  try {
+    const parsed = JSON.parse(base64UrlDecode(cursor))
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof parsed.offset !== 'number' ||
+      !Number.isFinite(parsed.offset) ||
+      parsed.offset < 0
+    ) {
+      throw new Error('Invalid cursor payload')
+    }
+
+    return parsed.offset
+  } catch (error) {
+    throw new Error('Invalid cursor')
+  }
+}
+
+export function normalizePaginationParams(
+  pagination: PaginationParams | undefined,
+  fallbackLimit = 10
+) {
+  const limit = pagination?.limit ?? fallbackLimit
+  let offset = 0
+
+  if (pagination?.cursor) {
+    offset = decodeCursor(pagination.cursor)
+  } else if (pagination?.page) {
+    offset = (pagination.page - 1) * limit
+  }
+
+  return { limit, offset, pageOverride: pagination?.page }
+}
+
+export function buildPaginationMetadata({
+  total,
+  limit,
+  offset,
+  itemCount,
+  pageOverride,
+}: {
+  total: number
+  limit: number
+  offset: number
+  itemCount: number
+  pageOverride?: number
+}): PaginationMetadata {
+  const safeTotal = Math.max(total, 0)
+  const pageCount = safeTotal === 0 ? 0 : Math.ceil(safeTotal / limit)
+  const computedPage = safeTotal === 0 ? 0 : Math.floor(offset / limit) + 1
+
+  let page = computedPage
+  if (pageOverride !== undefined) {
+    if (pageCount === 0) {
+      page = 0
+    } else {
+      page = Math.min(Math.max(pageOverride, 1), pageCount)
+    }
+  }
+
+  const hasNext = offset + itemCount < safeTotal
+  const nextCursor = hasNext ? encodeCursor(offset + itemCount) : null
+  const prevCursor = offset > 0 && safeTotal > 0 ? encodeCursor(Math.max(offset - limit, 0)) : null
+
+  return {
+    total: safeTotal,
+    page,
+    limit,
+    pageCount,
+    nextCursor,
+    prevCursor,
+  }
+}


### PR DESCRIPTION
## Summary
- add cursor-aware pagination utilities and types for reuse across endpoints
- update document server actions and client list to validate params, return metadata, and render pagination controls
- introduce messaging feed server action and UI with filters, paging controls, and supporting documentation for pagination patterns

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d15d6adbcc83289260cbf231093bbe