### PR TITLE
Add promise coalescing helper and instrument fetchers

### DIFF
--- a/docs/perf/fetching.md
+++ b/docs/perf/fetching.md
@@ -1,0 +1,80 @@
+# Fetch Performance Playbook
+
+## Coalescing in-flight work
+
+We now expose `withCoalescing` in `@/lib/fetcher/with-coalescing` to prevent repeated
+requests from stampeding downstream APIs. The helper caches the active promise for a
+`resource` + `params` pair and hands the same promise back to every concurrent caller.
+Once the promise settles it is removed from the cache so subsequent requests trigger
+fresh network calls.
+
+Use the helper for *idempotent* read paths that are susceptible to thundering herds:
+Documenso reads, Cal.com lookups, Supabase loaders that power frequently rendered
+layouts, etc. Avoid wrapping mutations or anything that must run every time a caller
+invokes it.
+
+## API
+
+```ts
+withCoalescing<TResult, TParams>(
+  resource: string,
+  params: TParams,
+  loader: () => Promise<TResult>,
+  options?: {
+    logger?: (event: CoalescingLogEvent<TParams>) => void;
+  }
+): Promise<TResult>
+```
+
+- `resource`: A stable name for the upstream system + operation. Keep it human
+  readable so metrics dashboards make sense.
+- `params`: Serializable inputs that influence the upstream call. Use plain objects
+  with primitive values so we can reliably derive a cache key.
+- `loader`: The actual fetcher. It should return a promise and remain side-effect free
+  beyond the network request.
+- `options.logger`: Optional hook to emit custom telemetry. The default logger writes
+  to `console.info` with hit/miss counts, hit rate and a hashed params fingerprint.
+
+The module also exports:
+
+- `getCoalescingMetrics(resource?: string)` – snapshot of hit/miss counters for all
+  resources or a specific resource. Handy when piping counts into unit tests or
+  dashboards.
+- `resetCoalescingState()` – clears the in-flight cache and metrics. Useful in tests
+  or when hot reloading modules in development.
+
+## Example
+
+```ts
+const document = await withCoalescing(
+  'documenso:getDocument',
+  { documentId },
+  () => fetchDocumensoDocument(documentId)
+);
+```
+
+The helper ensures that multiple concurrent requests for the same document reuse the
+same promise, drastically cutting Documenso traffic when pages render on the server.
+
+## Observability
+
+`withCoalescing` automatically logs hit/miss events through the default logger so we can
+watch hit rates inside the Vercel or Datadog log streams. Custom loggers can push the
+`CoalescingLogEvent` payload into StatsD, OpenTelemetry, or any other aggregation layer.
+When building those integrations prefer recording the `paramsFingerprint` instead of raw
+params to avoid logging PII.
+
+Review logs after shipping new fetchers. Low hit rates usually mean either the params
+object is unstable between calls or the fetcher is not receiving the coalescing helper.
+
+## Best practices
+
+- Wrap only deterministic fetches. If a call performs writes, queueing or other
+  side-effects it should not be coalesced.
+- Pass the minimal set of parameters required to uniquely identify the upstream
+  request. Extra data reduces the likelihood of hits.
+- Normalize parameter ordering before calling the helper (e.g. sort filter arrays) so
+  equivalent requests share the same cache key.
+- Reset the state between tests to avoid cross-test bleed.
+- Keep an eye on the default logs in lower environments; they are intentionally noisy to
+  make it obvious when coalescing is working.

--- a/lib/calcom-service.ts
+++ b/lib/calcom-service.ts
@@ -1,3 +1,5 @@
+import { withCoalescing } from '@/lib/fetcher/with-coalescing';
+
 interface CalComCreateBookingRequest {
   start: string;
   end: string;
@@ -44,19 +46,25 @@ class CalComService {
       : `${this.baseUrl}/api/v1/event-types`;
 
     try {
-      const response = await fetch(endpoint, {
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      });
+      return await withCoalescing(
+        'calcom:getEventTypes',
+        { endpoint },
+        async () => {
+          const response = await fetch(endpoint, {
+            headers: {
+              'Authorization': `Bearer ${this.apiKey}`,
+              'Content-Type': 'application/json',
+            },
+          });
 
-      if (!response.ok) {
-        throw new Error(`Failed to fetch event types: ${response.statusText}`);
-      }
+          if (!response.ok) {
+            throw new Error(`Failed to fetch event types: ${response.statusText}`);
+          }
 
-      const data = await response.json();
-      return data.eventTypes || [];
+          const data = await response.json();
+          return data.eventTypes || [];
+        }
+      );
     } catch (error) {
       console.error('Error fetching Cal.com event types:', error);
       return [];
@@ -142,21 +150,27 @@ class CalComService {
    */
   async getBooking(bookingId: string): Promise<any> {
     try {
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings/${bookingId}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
+      return await withCoalescing(
+        'calcom:getBooking',
+        { bookingId },
+        async () => {
+          const response = await fetch(
+            `${this.baseUrl}/api/v1/bookings/${bookingId}`,
+            {
+              headers: {
+                'Authorization': `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json',
+              },
+            }
+          );
+
+          if (!response.ok) {
+            throw new Error(`Failed to fetch booking: ${response.statusText}`);
+          }
+
+          return response.json();
         }
       );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch booking: ${response.statusText}`);
-      }
-
-      return await response.json();
     } catch (error) {
       console.error('Error fetching Cal.com booking:', error);
       return null;
@@ -172,26 +186,32 @@ class CalComService {
     endDate?: string
   ): Promise<any[]> {
     try {
-      const params = new URLSearchParams();
-      if (startDate) params.append('startDate', startDate);
-      if (endDate) params.append('endDate', endDate);
+      return await withCoalescing(
+        'calcom:getUserBookings',
+        { userEmail, startDate, endDate },
+        async () => {
+          const params = new URLSearchParams();
+          if (startDate) params.append('startDate', startDate);
+          if (endDate) params.append('endDate', endDate);
 
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings?${params.toString()}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
+          const response = await fetch(
+            `${this.baseUrl}/api/v1/bookings?${params.toString()}`,
+            {
+              headers: {
+                'Authorization': `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json',
+              },
+            }
+          );
+
+          if (!response.ok) {
+            throw new Error(`Failed to fetch user bookings: ${response.statusText}`);
+          }
+
+          const data = await response.json();
+          return data.bookings || [];
         }
       );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch user bookings: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-      return data.bookings || [];
     } catch (error) {
       console.error('Error fetching Cal.com user bookings:', error);
       return [];

--- a/lib/documenso.ts
+++ b/lib/documenso.ts
@@ -1,4 +1,5 @@
 import { DocumentSigningRequest, DocumentSigningResponse } from '@/types/documents';
+import { withCoalescing } from '@/lib/fetcher/with-coalescing';
 
 const DOCUMENSO_BASE_URL = process.env.DOCUMENSO_BASE_URL || 'https://app.documenso.com';
 const DOCUMENSO_API_KEY = process.env.DOCUMENSO_API_KEY;
@@ -114,38 +115,50 @@ class DocumensoService {
    * Get document details
    */
   async getDocument(documentId: string): Promise<DocumensoDocument> {
-    const response = await fetch(`${this.baseUrl}/api/v1/documents/${documentId}`, {
-      method: 'GET',
-      headers: getAuthHeaders(),
-    });
+    return withCoalescing(
+      'documenso:getDocument',
+      { documentId },
+      async () => {
+        const response = await fetch(`${this.baseUrl}/api/v1/documents/${documentId}`, {
+          method: 'GET',
+          headers: getAuthHeaders(),
+        });
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso get document failed: ${error}`);
-    }
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso get document failed: ${error}`);
+        }
 
-    return response.json();
+        return response.json();
+      }
+    );
   }
 
   /**
    * Get signing URL for a recipient
    */
   async getSigningUrl(documentId: string, recipientId: string): Promise<string> {
-    const response = await fetch(
-      `${this.baseUrl}/api/v1/documents/${documentId}/recipients/${recipientId}/signing-url`,
-      {
-        method: 'GET',
-        headers: getAuthHeaders(),
+    return withCoalescing(
+      'documenso:getSigningUrl',
+      { documentId, recipientId },
+      async () => {
+        const response = await fetch(
+          `${this.baseUrl}/api/v1/documents/${documentId}/recipients/${recipientId}/signing-url`,
+          {
+            method: 'GET',
+            headers: getAuthHeaders(),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso get signing URL failed: ${error}`);
+        }
+
+        const data = await response.json();
+        return data.signingUrl;
       }
     );
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso get signing URL failed: ${error}`);
-    }
-
-    const data = await response.json();
-    return data.signingUrl;
   }
 
   /**

--- a/lib/fetcher/with-coalescing.ts
+++ b/lib/fetcher/with-coalescing.ts
@@ -1,0 +1,199 @@
+const inFlightRequests = new Map<string, Promise<unknown>>();
+const metricsByResource = new Map<string, { hits: number; misses: number }>();
+
+export type CoalescingStatus = 'hit' | 'miss';
+
+export interface CoalescingLogEvent<TParams = unknown> {
+  resource: string;
+  params: TParams;
+  paramsFingerprint: string;
+  status: CoalescingStatus;
+  hits: number;
+  misses: number;
+  hitRate: number;
+  inFlight: number;
+}
+
+export interface CoalescingOptions<TParams = unknown> {
+  /**
+   * Custom logger for instrumentation. Defaults to a console.info statement.
+   */
+  logger?: (event: CoalescingLogEvent<TParams>) => void;
+}
+
+const defaultLogger = (event: CoalescingLogEvent) => {
+  const rate = Number.isFinite(event.hitRate) ? event.hitRate.toFixed(2) : '0.00';
+  console.info(
+    `[fetcher:coalesce] resource=${event.resource} status=${event.status} hitRate=${rate} hits=${event.hits} misses=${event.misses} inFlight=${event.inFlight} fingerprint=${event.paramsFingerprint}`
+  );
+};
+
+const PARAMS_PLACEHOLDER = '::no-params::';
+const KEY_SEPARATOR = '::';
+
+function stableSerialize(value: unknown): string {
+  if (value === undefined) {
+    return PARAMS_PLACEHOLDER;
+  }
+
+  if (value === null) {
+    return 'null';
+  }
+
+  const type = typeof value;
+
+  if (type === 'string' || type === 'number' || type === 'boolean' || type === 'bigint') {
+    return String(value);
+  }
+
+  if (value instanceof URLSearchParams) {
+    return value.toString();
+  }
+
+  try {
+    return JSON.stringify(value, (_key, nestedValue) => {
+      if (typeof nestedValue === 'bigint') {
+        return nestedValue.toString();
+      }
+
+      if (nestedValue instanceof URLSearchParams) {
+        return nestedValue.toString();
+      }
+
+      return nestedValue;
+    });
+  } catch {
+    return String(value);
+  }
+}
+
+function fingerprint(serialized: string): string {
+  let hash = 0;
+
+  for (let index = 0; index < serialized.length; index += 1) {
+    hash = Math.imul(31, hash) + serialized.charCodeAt(index);
+    hash |= 0; // Convert to 32bit integer
+  }
+
+  return (hash >>> 0).toString(16);
+}
+
+function createMetrics(resource: string) {
+  if (!metricsByResource.has(resource)) {
+    metricsByResource.set(resource, { hits: 0, misses: 0 });
+  }
+
+  return metricsByResource.get(resource)!;
+}
+
+function countInFlight(resource: string) {
+  let count = 0;
+
+  for (const key of inFlightRequests.keys()) {
+    if (key.startsWith(`${resource}${KEY_SEPARATOR}`)) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+function createCacheKey(resource: string, paramsKey: string) {
+  return `${resource}${KEY_SEPARATOR}${paramsKey}`;
+}
+
+function emitLog<TParams>(
+  resource: string,
+  paramsKey: string,
+  params: TParams,
+  status: CoalescingStatus,
+  options?: CoalescingOptions<TParams>
+) {
+  const metrics = metricsByResource.get(resource)!;
+  const total = metrics.hits + metrics.misses;
+  const hitRate = total === 0 ? 0 : metrics.hits / total;
+  const logger = options?.logger ?? defaultLogger;
+
+  const event: CoalescingLogEvent<TParams> = {
+    resource,
+    params,
+    paramsFingerprint: fingerprint(paramsKey),
+    status,
+    hits: metrics.hits,
+    misses: metrics.misses,
+    hitRate,
+    inFlight: countInFlight(resource),
+  };
+
+  logger(event);
+}
+
+/**
+ * Coalesce concurrent fetches for a shared resource to avoid thundering herds.
+ *
+ * Subsequent calls with the same resource + params while a request is in-flight
+ * receive the same promise. Once the promise settles it is removed from the cache.
+ */
+export async function withCoalescing<TResult, TParams = unknown>(
+  resource: string,
+  params: TParams,
+  loader: () => Promise<TResult>,
+  options?: CoalescingOptions<TParams>
+): Promise<TResult> {
+  const paramsKey = stableSerialize(params);
+  const cacheKey = createCacheKey(resource, paramsKey);
+  const metrics = createMetrics(resource);
+  const inFlightPromise = inFlightRequests.get(cacheKey) as Promise<TResult> | undefined;
+
+  if (inFlightPromise) {
+    metrics.hits += 1;
+    emitLog(resource, paramsKey, params, 'hit', options);
+    return inFlightPromise;
+  }
+
+  metrics.misses += 1;
+
+  let loaderPromise: Promise<TResult>;
+  try {
+    loaderPromise = Promise.resolve(loader());
+  } catch (error) {
+    // Ensure metrics stay consistent when the loader throws synchronously.
+    emitLog(resource, paramsKey, params, 'miss', options);
+    throw error;
+  }
+
+  const trackedPromise = loaderPromise.finally(() => {
+    inFlightRequests.delete(cacheKey);
+  });
+
+  inFlightRequests.set(cacheKey, trackedPromise);
+  emitLog(resource, paramsKey, params, 'miss', options);
+
+  return trackedPromise;
+}
+
+/**
+ * Expose metrics for observability dashboards and testing.
+ */
+export function getCoalescingMetrics(resource?: string) {
+  if (resource) {
+    return metricsByResource.get(resource) ?? { hits: 0, misses: 0 };
+  }
+
+  return Array.from(metricsByResource.entries()).reduce<Record<string, { hits: number; misses: number }>>(
+    (acc, [key, value]) => {
+      acc[key] = { ...value };
+      return acc;
+    },
+    {}
+  );
+}
+
+/**
+ * Clears tracked in-flight requests and metrics.
+ * Useful for testing or when reloading modules in development.
+ */
+export function resetCoalescingState() {
+  inFlightRequests.clear();
+  metricsByResource.clear();
+}


### PR DESCRIPTION
## Summary
- add a shared `withCoalescing` helper to dedupe in-flight fetches and expose metrics hooks
- wrap Documenso and Cal.com read operations with the coalescing helper to curb thundering herds
- document the fetching playbook so teams know when and how to apply the helper

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d6612e88328bf96d4cc732739a3