### PR TITLE
Add ETag support for documents API and client fetcher

### DIFF
--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server"
+
+import { generateETag, isIfNoneMatchFresh } from "@/lib/api/etag"
+import { fetchDocumentsForApi } from "@/lib/server/documents-snapshot"
+import type { DocumentWithLease } from "@/types/documents"
+
+const CACHE_CONTROL_HEADER = "private, max-age=0, must-revalidate"
+
+const buildResponseHeaders = (etag: string, lastModified: string | null) => {
+  const headers: Record<string, string> = {
+    ETag: etag,
+    "Cache-Control": CACHE_CONTROL_HEADER,
+  }
+
+  if (lastModified) {
+    headers["Last-Modified"] = new Date(lastModified).toUTCString()
+  }
+
+  return headers
+}
+
+const getLatestTimestamp = (documents: DocumentWithLease[]) => {
+  let latest: string | null = null
+
+  for (const document of documents) {
+    const candidate = document.updated_at ?? document.created_at
+    if (!latest || new Date(candidate) > new Date(latest)) {
+      latest = candidate
+    }
+  }
+
+  return latest
+}
+
+const createFingerprint = (documents: DocumentWithLease[]) => {
+  if (!documents.length) {
+    return "empty"
+  }
+
+  return [...documents]
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((document) => `${document.id}:${document.updated_at}:${document.version}`)
+    .join("|")
+}
+
+export const GET = async (request: Request) => {
+  try {
+    const documents = await fetchDocumentsForApi()
+    const lastModified = getLatestTimestamp(documents)
+    const fingerprint = createFingerprint(documents)
+    const etag = generateETag(fingerprint)
+
+    if (isIfNoneMatchFresh(request.headers.get("if-none-match"), etag)) {
+      return new NextResponse(null, {
+        status: 304,
+        headers: buildResponseHeaders(etag, lastModified),
+      })
+    }
+
+    return NextResponse.json(
+      { documents, lastModified },
+      {
+        headers: buildResponseHeaders(etag, lastModified),
+      }
+    )
+  } catch (error) {
+    console.error("Documents API error:", error)
+    return NextResponse.json(
+      { error: "Failed to load documents." },
+      { status: 500 }
+    )
+  }
+}

--- a/lib/api/etag.ts
+++ b/lib/api/etag.ts
@@ -1,0 +1,40 @@
+import { createHash } from "crypto"
+
+const DEFAULT_ENCODING = "base64url"
+
+const stripWeakPrefix = (value: string) => value.replace(/^W\//i, "")
+
+const stripQuotes = (value: string) =>
+  value.startsWith("\"") && value.endsWith("\"")
+    ? value.slice(1, value.length - 1)
+    : value
+
+const normaliseTag = (value: string) => stripQuotes(stripWeakPrefix(value.trim()))
+
+export const generateETag = (payload: unknown, opts?: { weak?: boolean }) => {
+  const serialised =
+    typeof payload === "string" ? payload : JSON.stringify(payload ?? null)
+
+  const hash = createHash("sha256").update(serialised).digest(DEFAULT_ENCODING)
+  const tag = `"${hash}"`
+  return opts?.weak ? `W/${tag}` : tag
+}
+
+export const isIfNoneMatchFresh = (
+  headerValue: string | null,
+  currentTag: string
+) => {
+  if (!headerValue) {
+    return false
+  }
+
+  if (headerValue.trim() === "*") {
+    return true
+  }
+
+  const expected = normaliseTag(currentTag)
+  return headerValue
+    .split(",")
+    .map((candidate) => normaliseTag(candidate))
+    .some((candidate) => candidate === expected)
+}

--- a/lib/server/documents-snapshot.ts
+++ b/lib/server/documents-snapshot.ts
@@ -1,0 +1,29 @@
+"use server"
+
+import { cookies } from "next/headers"
+
+import { createClient } from "@/utils/supa-server-actions"
+import type { DocumentWithLease } from "@/types/documents"
+
+export const fetchDocumentsForApi = async (): Promise<DocumentWithLease[]> => {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const { data, error } = await (supabase as any)
+    .from("documents")
+    .select(
+      `
+        *,
+        lease:leases(*),
+        signatures:document_signatures(*),
+        access_logs:document_access_logs(*)
+      `
+    )
+    .order("updated_at", { ascending: false })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return (data as DocumentWithLease[] | null) ?? []
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,26 +8,89 @@ export function cn(...inputs: ClassValue[]) {
 
 
 
+type FetchCacheEntry = {
+  etag: string
+  payload: unknown
+}
+
+const etagCache = new Map<string, FetchCacheEntry>()
+
+const createCacheKey = (input: RequestInfo, init?: RequestInit) => {
+  const method =
+    (init?.method || (input instanceof Request ? input.method : "GET"))?.toUpperCase() ??
+    "GET"
+
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url
+
+  return `${method}:${url}`
+}
+
+const ensureHeaders = (init?: RequestInit) => {
+  const headers = new Headers(init?.headers)
+  return { ...init, headers }
+}
+
 export async function fetcher<JSON = any>(
   input: RequestInfo,
   init?: RequestInit
 ): Promise<JSON> {
-  const res = await fetch(input, init)
+  const cacheKey = createCacheKey(input, init)
+  const cached = etagCache.get(cacheKey)
+
+  const requestInit = ensureHeaders(init)
+
+  if (cached) {
+    requestInit.headers.set("If-None-Match", cached.etag)
+  }
+
+  const res = await fetch(input, requestInit)
+
+  if (res.status === 304) {
+    if (cached) {
+      return cached.payload as JSON
+    }
+
+    throw new Error("Cached response unavailable for 304 Not Modified.")
+  }
 
   if (!res.ok) {
-    const json = await res.json()
-    if (json.error) {
+    let json: any = null
+    try {
+      json = await res.json()
+    } catch (error) {
+      // Ignore JSON parsing issues for error responses without bodies
+    }
+
+    if (json?.error) {
       const error = new Error(json.error) as Error & {
         status: number
       }
       error.status = res.status
       throw error
-    } else {
-      throw new Error('An unexpected error occurred')
     }
+
+    throw new Error("An unexpected error occurred")
   }
 
-  return res.json()
+  const data = (await res.json()) as JSON
+  const etag = res.headers.get("ETag")
+
+  if (etag) {
+    etagCache.set(cacheKey, { etag, payload: data })
+  } else if (etagCache.has(cacheKey)) {
+    etagCache.delete(cacheKey)
+  }
+
+  return data
+}
+
+export const clearFetcherCache = () => {
+  etagCache.clear()
 }
 
 export function formatDate(input: string | number | Date): string {

--- a/tests/api-documents-etag.test.ts
+++ b/tests/api-documents-etag.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { DocumentWithLease } from "@/types/documents"
+
+vi.mock("@/lib/server/documents-snapshot", () => ({
+  fetchDocumentsForApi: vi.fn(),
+}))
+
+import { GET } from "@/app/api/documents/route"
+import { fetchDocumentsForApi } from "@/lib/server/documents-snapshot"
+
+const mockedFetchDocuments = vi.mocked(fetchDocumentsForApi)
+
+const createDocument = (overrides: Partial<DocumentWithLease> = {}) => ({
+  id: "document-id",
+  created_at: "2024-01-01T00:00:00.000Z",
+  updated_at: "2024-01-02T00:00:00.000Z",
+  title: "Lease agreement",
+  document_type: "lease",
+  status: "signed",
+  metadata: {},
+  requires_signature: false,
+  version: 1,
+  ...overrides,
+}) satisfies DocumentWithLease
+
+describe("GET /api/documents", () => {
+  beforeEach(() => {
+    mockedFetchDocuments.mockReset()
+  })
+
+  it("returns a 200 response with an ETag header", async () => {
+    const documents = [createDocument({ id: "doc-1" })]
+    mockedFetchDocuments.mockResolvedValue(documents)
+
+    const response = await GET(new Request("http://localhost/api/documents"))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("ETag")).toBeTruthy()
+    expect(body.documents).toEqual(documents)
+  })
+
+  it("returns 304 when the If-None-Match header matches", async () => {
+    const documents = [createDocument({ id: "doc-2" })]
+    mockedFetchDocuments.mockResolvedValue(documents)
+
+    const initialResponse = await GET(new Request("http://localhost/api/documents"))
+    const etag = initialResponse.headers.get("ETag")
+    expect(etag).toBeTruthy()
+
+    mockedFetchDocuments.mockResolvedValue(documents)
+
+    const conditionalResponse = await GET(
+      new Request("http://localhost/api/documents", {
+        headers: {
+          "If-None-Match": etag ?? "",
+        },
+      })
+    )
+
+    expect(conditionalResponse.status).toBe(304)
+    expect(await conditionalResponse.text()).toBe("")
+  })
+
+  it("returns a new ETag when document metadata changes", async () => {
+    mockedFetchDocuments
+      .mockResolvedValueOnce([createDocument({ id: "doc-3", updated_at: "2024-01-02T00:00:00.000Z" })])
+      .mockResolvedValueOnce([createDocument({ id: "doc-3", updated_at: "2024-02-15T12:00:00.000Z" })])
+
+    const firstResponse = await GET(new Request("http://localhost/api/documents"))
+    const firstTag = firstResponse.headers.get("ETag")
+    expect(firstTag).toBeTruthy()
+
+    const secondResponse = await GET(new Request("http://localhost/api/documents"))
+    const secondTag = secondResponse.headers.get("ETag")
+
+    expect(secondTag).toBeTruthy()
+    expect(secondTag).not.toBe(firstTag)
+  })
+})

--- a/tests/fetcher-etag.test.ts
+++ b/tests/fetcher-etag.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { clearFetcherCache, fetcher } from "@/lib/utils"
+
+describe("fetcher ETag support", () => {
+  beforeEach(() => {
+    clearFetcherCache()
+  })
+
+  afterEach(() => {
+    clearFetcherCache()
+    vi.unstubAllGlobals()
+  })
+
+  it("stores the ETag from a successful response and reuses it", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "hello" }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          ETag: '"etag-1"',
+        },
+      })
+    )
+
+    const first = await fetcher<{ message: string }>("/api/documents")
+    expect(first).toEqual({ message: "hello" })
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 304,
+        headers: {
+          ETag: '"etag-1"',
+        },
+      })
+    )
+
+    const second = await fetcher<{ message: string }>("/api/documents")
+
+    const headersArg = fetchMock.mock.calls[1]?.[1]?.headers
+    const headers = headersArg instanceof Headers ? headersArg : new Headers(headersArg)
+    expect(headers.get("If-None-Match")).toBe('"etag-1"')
+    expect(second).toEqual({ message: "hello" })
+  })
+
+  it("updates the cached payload when a new ETag is returned", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ version: 1 }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          ETag: '"etag-1"',
+        },
+      })
+    )
+
+    await fetcher("/api/documents")
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ version: 2 }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          ETag: '"etag-2"',
+        },
+      })
+    )
+
+    const result = await fetcher<{ version: number }>("/api/documents")
+
+    const headersArg = fetchMock.mock.calls[1]?.[1]?.headers
+    const headers = headersArg instanceof Headers ? headersArg : new Headers(headersArg)
+    expect(headers.get("If-None-Match")).toBe('"etag-1"')
+    expect(result).toEqual({ version: 2 })
+  })
+})


### PR DESCRIPTION
## Summary
- add a documents API route that fingerprints document metadata, emits ETags, and returns 304 when the If-None-Match header matches
- factor ETag utilities and a Supabase-backed document snapshot helper for reuse across routes
- teach the shared fetcher helper to cache responses using ETags and cover the behaviour with Vitest specs

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d15d6595088328b421798d1f18f081