### PR TITLE
Persist Stripe events and add monitoring jobs

### DIFF
--- a/app/api/jobs/stripe/monitor/route.ts
+++ b/app/api/jobs/stripe/monitor/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server"
+
+import { sendStripeWebhookFailureAlert } from "@/lib/payments/stripe-webhooks"
+import type { Tables } from "@/lib/supabase"
+import { createSupabaseAdminClient } from "@/lib/supabase-admin"
+
+const DEFAULT_STALE_MINUTES = 10
+const DEFAULT_COOLDOWN_MINUTES = 30
+
+export const runtime = "nodejs"
+
+export async function POST(req: Request) {
+  let supabase
+  try {
+    supabase = createSupabaseAdminClient()
+  } catch (error) {
+    console.error("Unable to create Supabase admin client", error)
+    return NextResponse.json(
+      { error: "Supabase client not configured" },
+      { status: 500 }
+    )
+  }
+
+  const url = new URL(req.url)
+  const staleParam = url.searchParams.get("staleMinutes")
+  const cooldownParam = url.searchParams.get("cooldownMinutes")
+
+  let staleMinutes = Number.parseInt(staleParam ?? "", 10)
+  if (!Number.isFinite(staleMinutes) || staleMinutes <= 0) {
+    staleMinutes = DEFAULT_STALE_MINUTES
+  }
+
+  let cooldownMinutes = Number.parseInt(cooldownParam ?? "", 10)
+  if (!Number.isFinite(cooldownMinutes) || cooldownMinutes <= 0) {
+    cooldownMinutes = DEFAULT_COOLDOWN_MINUTES
+  }
+
+  const now = Date.now()
+  const staleCutoffIso = new Date(now - staleMinutes * 60 * 1000).toISOString()
+  const cooldownCutoffIso = new Date(now - cooldownMinutes * 60 * 1000).toISOString()
+
+  const results = {
+    flagged: 0,
+    alertsSent: 0,
+    alertedEventIds: [] as string[],
+  }
+
+  try {
+    const { data: failedEvents, error: failedError } = await supabase
+      .from("stripe_webhook_events")
+      .select("*")
+      .eq("status", "failed")
+      .or(`last_alert_at.is.null,last_alert_at.lte.${cooldownCutoffIso}`)
+
+    if (failedError) {
+      throw failedError
+    }
+
+    const { data: staleEvents, error: staleError } = await supabase
+      .from("stripe_webhook_events")
+      .select("*")
+      .eq("status", "received")
+      .lte("created_at", staleCutoffIso)
+      .or(`last_alert_at.is.null,last_alert_at.lte.${cooldownCutoffIso}`)
+
+    if (staleError) {
+      throw staleError
+    }
+
+    const eventsById = new Map<string, Tables<'stripe_webhook_events'>>()
+
+    for (const event of failedEvents ?? []) {
+      eventsById.set(event.event_id, event as Tables<'stripe_webhook_events'>)
+    }
+
+    for (const event of staleEvents ?? []) {
+      if (!eventsById.has(event.event_id)) {
+        eventsById.set(event.event_id, event as Tables<'stripe_webhook_events'>)
+      }
+    }
+
+    results.flagged = eventsById.size
+
+    for (const event of eventsById.values()) {
+      const createdAt = event.created_at ? Date.parse(event.created_at) : now
+      const minutesOpen = Math.max(0, Math.round((now - createdAt) / 60000))
+      const message =
+        event.status === "failed"
+          ? `Stripe webhook event ${event.event_id} failed: ${event.last_error ?? "unknown error"}.`
+          : `Stripe webhook event ${event.event_id} has been pending for ${minutesOpen} minutes without processing.`
+
+      try {
+        await sendStripeWebhookFailureAlert(supabase, {
+          event: {
+            event_id: event.event_id,
+            event_type: event.event_type,
+            status: event.status,
+            alert_count: event.alert_count ?? 0,
+          },
+          message,
+        })
+        results.alertsSent += 1
+        results.alertedEventIds.push(event.event_id)
+      } catch (alertError) {
+        console.error("Failed to send webhook monitor alert", alertError)
+      }
+    }
+
+    return NextResponse.json({
+      ...results,
+      staleMinutes,
+      cooldownMinutes,
+    })
+  } catch (error) {
+    console.error("Stripe webhook monitor job failed", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/jobs/stripe/reconcile/route.ts
+++ b/app/api/jobs/stripe/reconcile/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server"
+
+import {
+  ensureStripeEventRecord,
+  processStripeEvent,
+  sendStripeWebhookFailureAlert,
+  updateStripeEventStatus,
+} from "@/lib/payments/stripe-webhooks"
+import { getStripe } from "@/lib/stripe"
+import { createSupabaseAdminClient } from "@/lib/supabase-admin"
+
+const DEFAULT_LOOKBACK_SECONDS = 60 * 60 * 24
+const MAX_EVENTS = 500
+
+export const runtime = "nodejs"
+
+export async function POST(req: Request) {
+  const stripe = getStripe()
+
+  let supabase
+  try {
+    supabase = createSupabaseAdminClient()
+  } catch (error) {
+    console.error("Unable to create Supabase admin client", error)
+    return NextResponse.json(
+      { error: "Supabase client not configured" },
+      { status: 500 }
+    )
+  }
+
+  const url = new URL(req.url)
+  const sinceParam = url.searchParams.get("since")
+  const lookbackParam = url.searchParams.get("lookback")
+
+  let lookbackSeconds = Number.parseInt(lookbackParam ?? "", 10)
+  if (!Number.isFinite(lookbackSeconds) || lookbackSeconds <= 0) {
+    lookbackSeconds = DEFAULT_LOOKBACK_SECONDS
+  }
+
+  let sinceEpoch = Number.parseInt(sinceParam ?? "", 10)
+  if (!Number.isFinite(sinceEpoch) || sinceEpoch <= 0) {
+    sinceEpoch = Math.floor(Date.now() / 1000) - lookbackSeconds
+  }
+
+  const results = {
+    since: sinceEpoch,
+    lookbackSeconds,
+    totalConsidered: 0,
+    processed: 0,
+    retried: 0,
+    skipped: 0,
+    failures: [] as { eventId: string; message: string }[],
+  }
+
+  try {
+    const events = stripe.events.list({
+      limit: 100,
+      created: { gte: sinceEpoch },
+    })
+
+    for await (const event of events) {
+      results.totalConsidered += 1
+      if (results.totalConsidered > MAX_EVENTS) {
+        break
+      }
+
+      const existingRecord = await ensureStripeEventRecord(supabase, event)
+
+      if (existingRecord?.status === "processed") {
+        results.skipped += 1
+        continue
+      }
+
+      await updateStripeEventStatus(supabase, event, "received", {
+        resetAlerts: true,
+      })
+
+      try {
+        await processStripeEvent({ supabase, stripe, event })
+        await updateStripeEventStatus(supabase, event, "processed")
+        results.processed += 1
+
+        if (existingRecord && existingRecord.status && existingRecord.status !== "received") {
+          results.retried += 1
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown processing error"
+        console.error(`Failed to reconcile Stripe event ${event.id}:`, error)
+
+        results.failures.push({ eventId: event.id, message })
+
+        await updateStripeEventStatus(supabase, event, "failed", {
+          error: message,
+        })
+
+        try {
+          await sendStripeWebhookFailureAlert(supabase, {
+            event: {
+              event_id: event.id,
+              event_type: event.type,
+              status: "failed",
+              alert_count: existingRecord?.alert_count ?? 0,
+            },
+            message: `Reconciliation failed for event ${event.id}: ${message}`,
+          })
+        } catch (alertError) {
+          console.error("Failed to send reconciliation alert", alertError)
+        }
+      }
+    }
+
+    return NextResponse.json(results)
+  } catch (error) {
+    console.error("Stripe reconciliation job failed", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,29 +1,8 @@
 import { headers } from "next/headers"
-import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 
-import {
-  sendEmailNotification,
-  sendInAppNotification,
-} from "@/lib/notifications"
+import { processStripeEvent, ensureStripeEventRecord, updateStripeEventStatus, sendStripeWebhookFailureAlert } from "@/lib/payments/stripe-webhooks"
 import { getStripe } from "@/lib/stripe"
-import type { Database, TablesInsert } from "@/lib/supabase"
-
-function createSupabaseAdminClient(): SupabaseClient<Database> | null {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-
-  if (!supabaseUrl || !serviceRoleKey) {
-    console.error("Supabase admin credentials are not configured")
-    return null
-  }
-
-  return createClient<Database>(supabaseUrl, serviceRoleKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  })
-}
+import { createSupabaseAdminClient } from "@/lib/supabase-admin"
 
 export async function POST(req: Request) {
   const stripe = getStripe()
@@ -34,8 +13,12 @@ export async function POST(req: Request) {
     return new Response("Webhook not configured", { status: 500 })
   }
 
-  const supabase = createSupabaseAdminClient()
-  if (!supabase) {
+  let supabase
+
+  try {
+    supabase = createSupabaseAdminClient()
+  } catch (error) {
+    console.error("Unable to create Supabase admin client", error)
     return new Response("Supabase client not configured", { status: 500 })
   }
 
@@ -48,284 +31,58 @@ export async function POST(req: Request) {
       webhookSecret
     )
 
-    switch (event.type) {
-      case "checkout.session.completed":
-        await handleCheckoutSessionCompleted(supabase, event.data.object)
-        break
-      case "invoice.payment_succeeded":
-        await handleInvoicePaymentSucceeded(supabase, event.data.object)
-        break
-      case "customer.subscription.created":
-        await handleSubscriptionCreated(supabase, event.data.object)
-        break
-      case "customer.subscription.updated":
-        await handleSubscriptionUpdated(supabase, event.data.object)
-        break
-      case "customer.subscription.deleted":
-        await handleSubscriptionDeleted(supabase, event.data.object)
-        break
-      default:
-        console.log(`Unhandled event type: ${event.type}`)
-        break
-    }
+    const eventRecord = await ensureStripeEventRecord(supabase, event)
+    await updateStripeEventStatus(supabase, event, "received", {
+      resetAlerts: true,
+    })
 
-    return new Response("ok", { status: 200 })
+    try {
+      await processStripeEvent({
+        supabase,
+        stripe,
+        event,
+      })
+
+      await updateStripeEventStatus(supabase, event, "processed")
+      return new Response("ok", { status: 200 })
+    } catch (processingError) {
+      const message =
+        processingError instanceof Error
+          ? processingError.message
+          : "Unknown processing error"
+
+      console.error(
+        `Stripe webhook event ${event.id} failed to process:`,
+        processingError
+      )
+
+      await updateStripeEventStatus(supabase, event, "failed", {
+        error: message,
+      })
+
+      try {
+        await sendStripeWebhookFailureAlert(supabase, {
+          event: {
+            event_id: event.id,
+            event_type: event.type,
+            status: "failed",
+            alert_count: eventRecord?.alert_count ?? 0,
+          },
+          message: `Stripe webhook event ${event.id} failed: ${message}`,
+        })
+      } catch (alertError) {
+        console.error("Failed to dispatch webhook failure alert", alertError)
+      }
+
+      return new Response(`Webhook processing error: ${message}`, {
+        status: 500,
+      })
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : "Invalid payload"
-    console.error("Webhook error:", message)
+    console.error("Webhook error:", err)
     return new Response(`Webhook error: ${message}`, { status: 400 })
   }
 }
 
-async function handleCheckoutSessionCompleted(
-  supabase: SupabaseClient<Database>,
-  session: any
-) {
-  try {
-    // Retrieve the full session with line items
-    const stripe = getStripe()
-    const fullSession = await stripe.checkout.sessions.retrieve(session.id, {
-      expand: ["line_items", "customer"],
-    })
-
-    // For one-time payments, create a rent payment record
-    if (fullSession.mode === "payment") {
-      const lineItem = fullSession.line_items?.data[0]
-      if (lineItem) {
-        // Extract tenant and unit info from metadata if available
-        const tenantId = fullSession.metadata?.tenant_id
-        const unitId = fullSession.metadata?.unit_id
-
-        const paymentData: TablesInsert<'rent_payments'> = {
-          user_id: tenantId || "00000000-0000-0000-0000-000000000000", // Use tenant_id as user_id, or a default UUID
-          stripe_payment_intent_id: session.payment_intent as string,
-          stripe_charge_id: session.payment_intent as string, // Will be updated when charge is available
-          stripe_customer_id: session.customer as string,
-          amount: lineItem.amount_total / 100, // Convert from cents
-          currency: lineItem.currency.toUpperCase(),
-          description:
-            lineItem.description ||
-            `Payment for ${lineItem.price?.nickname || "rent"}`,
-          status: "completed",
-          processed_at: new Date().toISOString(),
-          receipt_url: session.receipt_url,
-          tenant_id: tenantId,
-          unit_id: unitId,
-          payment_method_type: "card", // Default assumption
-          metadata: {
-            session_id: session.id,
-            payment_status: session.payment_status,
-            ...fullSession.metadata,
-          },
-        }
-
-        await supabase.from("rent_payments").insert(paymentData)
-
-        // Send payment receipt notification if we have tenant info
-        if (tenantId) {
-          try {
-            // Get tenant profile
-            const { data: tenantProfile } = await supabase
-              .from("profiles")
-              .select("full_name, email")
-              .eq("id", tenantId)
-              .single()
-
-            if (tenantProfile?.email) {
-              await sendEmailNotification({
-                to: tenantProfile.email,
-                subject: `Payment Receipt - $${paymentData.amount}`,
-                template: "payment-receipt",
-                data: {
-                  tenantName: tenantProfile.full_name || tenantProfile.email,
-                  amount: `$${paymentData.amount}`,
-                  description: paymentData.description,
-                  date: new Date(
-                    paymentData.processed_at ?? new Date().toISOString()
-                  ).toLocaleDateString(),
-                },
-                userId: tenantId,
-              })
-
-              // Also send in-app notification
-              await sendInAppNotification({
-                userId: tenantId,
-                title: "Payment Successful",
-                message: `Your payment of $${paymentData.amount} has been processed successfully.`,
-                type: "success",
-                actionUrl: "/payments",
-              })
-            }
-          } catch (notificationError) {
-            console.error(
-              "Failed to send payment notification:",
-              notificationError
-            )
-            // Don't fail the webhook for notification errors
-          }
-        }
-      }
-    }
-
-    // For subscriptions, the subscription will be created separately
-    // We might want to link the checkout session to the subscription here
-  } catch (error) {
-    console.error("Error handling checkout session completed:", error)
-    throw error
-  }
-}
-
-async function handleInvoicePaymentSucceeded(
-  supabase: SupabaseClient<Database>,
-  invoice: any
-) {
-  try {
-    const stripe = getStripe()
-
-    // Get the full invoice with subscription details
-    const fullInvoice = await stripe.invoices.retrieve(invoice.id, {
-      expand: ["subscription", "customer"],
-    })
-
-    const subscription = fullInvoice.subscription as any
-
-    if (subscription) {
-      // This is a subscription payment
-      const amount = invoice.amount_paid / 100 // Convert from cents
-
-      const subscriptionPayment: TablesInsert<'rent_payments'> = {
-        user_id:
-          subscription.metadata?.tenant_id ||
-          "00000000-0000-0000-0000-000000000000", // Use tenant_id as user_id, or a default UUID
-        stripe_customer_id: invoice.customer as string,
-        stripe_subscription_id: subscription.id,
-        amount,
-        currency: invoice.currency.toUpperCase(),
-        description: `Subscription payment - ${
-          subscription.metadata?.unit_label || "Rent"
-        }`,
-        status: "completed",
-        processed_at: new Date().toISOString(),
-        receipt_url: invoice.hosted_invoice_url,
-        tenant_id: subscription.metadata?.tenant_id,
-        unit_id: subscription.metadata?.unit_id,
-        payment_method_type: "card", // Default assumption
-        billing_period_start: subscription.current_period_start
-          ? new Date(subscription.current_period_start * 1000)
-              .toISOString()
-              .split("T")[0]
-          : undefined,
-        billing_period_end: subscription.current_period_end
-          ? new Date(subscription.current_period_end * 1000)
-              .toISOString()
-              .split("T")[0]
-          : undefined,
-        metadata: {
-          invoice_id: invoice.id,
-          subscription_id: subscription.id,
-          billing_reason: invoice.billing_reason,
-        },
-      }
-      await supabase.from("rent_payments").insert(subscriptionPayment)
-
-      // Update subscription status if needed
-      await supabase
-        .from("subscriptions")
-        .update({
-          status: subscription.status,
-          current_period_start: new Date(
-            subscription.current_period_start * 1000
-          ).toISOString(),
-          current_period_end: new Date(
-            subscription.current_period_end * 1000
-          ).toISOString(),
-        })
-        .eq("stripe_subscription_id", subscription.id)
-    }
-  } catch (error) {
-    console.error("Error handling invoice payment succeeded:", error)
-    throw error
-  }
-}
-
-async function handleSubscriptionCreated(
-  supabase: SupabaseClient<Database>,
-  subscription: any
-) {
-  try {
-    // This handles when a subscription is first created
-    const price = subscription.items.data[0]?.price
-
-    await supabase.from("subscriptions").insert({
-      user_id:
-        subscription.metadata?.tenant_id ||
-        "00000000-0000-0000-0000-000000000000",
-      stripe_subscription_id: subscription.id,
-      stripe_customer_id: subscription.customer,
-      status: subscription.status,
-      current_period_start: new Date(
-        subscription.current_period_start * 1000
-      ).toISOString(),
-      current_period_end: new Date(
-        subscription.current_period_end * 1000
-      ).toISOString(),
-      amount: price?.unit_amount || 0, // Convert from cents
-      currency: price?.currency?.toUpperCase() || "USD",
-      interval: "month", // Default, could be determined from price
-      metadata: {
-        ...subscription.metadata,
-        price_id: price?.id,
-      },
-    })
-  } catch (error) {
-    console.error("Error handling subscription created:", error)
-    throw error
-  }
-}
-
-async function handleSubscriptionUpdated(
-  supabase: SupabaseClient<Database>,
-  subscription: any
-) {
-  try {
-    await supabase
-      .from("subscriptions")
-      .update({
-        status: subscription.status,
-        current_period_start: new Date(
-          subscription.current_period_start * 1000
-        ).toISOString(),
-        current_period_end: new Date(
-          subscription.current_period_end * 1000
-        ).toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq("stripe_subscription_id", subscription.id)
-  } catch (error) {
-    console.error("Error handling subscription updated:", error)
-    throw error
-  }
-}
-
-async function handleSubscriptionDeleted(
-  supabase: SupabaseClient<Database>,
-  subscription: any
-) {
-  try {
-    await supabase
-      .from("subscriptions")
-      .update({
-        status: "canceled",
-        ended_at: new Date().toISOString(),
-        canceled_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq("stripe_subscription_id", subscription.id)
-  } catch (error) {
-    console.error("Error handling subscription deleted:", error)
-    throw error
-  }
-}
-
-// Export runtime config for edge runtime
 export const runtime = "edge"

--- a/app/payments/_components/payment-status-overview.tsx
+++ b/app/payments/_components/payment-status-overview.tsx
@@ -1,0 +1,193 @@
+import type { ComponentProps } from "react"
+
+import { cookies } from "next/headers"
+import { format } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { formatCurrency } from "@/lib/payments/currency"
+import { Tables } from "@/lib/supabase"
+import { createClient } from "@/utils/supa-server-actions"
+
+const paymentStatusConfig: Record<
+  Tables<'rent_payments'>['status'],
+  { label: string; variant: ComponentProps<typeof Badge>['variant'] }
+> = {
+  succeeded: { label: "Succeeded", variant: "complete" },
+  pending: { label: "Pending", variant: "secondary" },
+  failed: { label: "Failed", variant: "destructive" },
+  cancelled: { label: "Cancelled", variant: "outline" },
+}
+
+const subscriptionStatusConfig: Record<
+  Tables<'subscriptions'>['status'],
+  { label: string; variant: ComponentProps<typeof Badge>['variant'] }
+> = {
+  active: { label: "Active", variant: "complete" },
+  past_due: { label: "Past due", variant: "destructive" },
+  unpaid: { label: "Unpaid", variant: "destructive" },
+  canceled: { label: "Canceled", variant: "outline" },
+}
+
+function formatDateLabel(value: string | null) {
+  if (!value) {
+    return "—"
+  }
+
+  try {
+    return format(new Date(value), "MMM d, yyyy")
+  } catch (error) {
+    console.error("Unable to format date", error)
+    return "—"
+  }
+}
+
+export async function PaymentStatusOverview() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Payment activity</CardTitle>
+          <CardDescription>Sign in to review your latest rent payments and autopay subscriptions.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Rent payments and subscription statuses are stored securely in Supabase once Stripe confirms each event. Sign in to
+            access your payment history.
+          </p>
+          <Button asChild className="mt-4" variant="outline">
+            <a href="/auth">Go to sign in</a>
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const [paymentsResponse, subscriptionsResponse] = await Promise.all([
+    supabase
+      .from("rent_payments")
+      .select("id, amount, currency, status, description, processed_at, created_at, receipt_url, metadata")
+      .eq("user_id", user.id)
+      .order("processed_at", { ascending: false })
+      .limit(5),
+    supabase
+      .from("subscriptions")
+      .select(
+        "id, stripe_subscription_id, status, amount, currency, interval, current_period_end, cancel_at_period_end, metadata"
+      )
+      .eq("user_id", user.id)
+      .order("current_period_end", { ascending: false })
+      .limit(5),
+  ])
+
+  if (paymentsResponse.error) {
+    console.error("Failed to load rent payments", paymentsResponse.error)
+  }
+  if (subscriptionsResponse.error) {
+    console.error("Failed to load subscriptions", subscriptionsResponse.error)
+  }
+
+  const rentPayments = paymentsResponse.data ?? []
+  const subscriptions = subscriptionsResponse.data ?? []
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent rent payments</CardTitle>
+          <CardDescription>Statuses are synced from Stripe webhooks and stored in Supabase.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {rentPayments.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No rent payments recorded yet.</p>
+          ) : (
+            <div className="space-y-4">
+              {rentPayments.map((payment) => {
+                const statusConfig = paymentStatusConfig[payment.status]
+                const amountDisplay = formatCurrency(payment.amount ?? 0, payment.currency ?? "USD")
+                const processedAt = payment.processed_at ?? payment.created_at ?? null
+                const receiptUrl = payment.receipt_url
+
+                return (
+                  <div
+                    key={payment.id}
+                    className="flex flex-col gap-2 rounded-lg border bg-muted/30 p-4 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-semibold">{amountDisplay}</p>
+                        <Badge variant={statusConfig.variant}>{statusConfig.label}</Badge>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {payment.description ?? "Rent payment"}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Processed {formatDateLabel(processedAt)}
+                      </p>
+                    </div>
+                    {receiptUrl ? (
+                      <Button asChild size="sm" variant="outline" className="self-start sm:self-auto">
+                        <a href={receiptUrl} target="_blank" rel="noreferrer">
+                          View receipt
+                        </a>
+                      </Button>
+                    ) : null}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Autopay subscriptions</CardTitle>
+          <CardDescription>Stripe subscription states are normalized before persisting to Supabase.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {subscriptions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No active subscriptions on file.</p>
+          ) : (
+            <div className="space-y-4">
+              {subscriptions.map((subscription) => {
+                const statusConfig = subscriptionStatusConfig[subscription.status]
+                const amountDisplay = formatCurrency(subscription.amount ?? 0, subscription.currency ?? "USD")
+                const renewsOn = formatDateLabel(subscription.current_period_end)
+                const planInterval = subscription.interval === "year" ? "yearly" : "monthly"
+                const cancelCopy = subscription.cancel_at_period_end
+                  ? "Cancellation scheduled at period end"
+                  : undefined
+
+                return (
+                  <div key={subscription.id} className="space-y-2 rounded-lg border bg-muted/30 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-semibold">{amountDisplay} · {planInterval}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Subscription ID: {subscription.stripe_subscription_id ?? "—"}
+                        </p>
+                      </div>
+                      <Badge variant={statusConfig.variant}>{statusConfig.label}</Badge>
+                    </div>
+                    <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                      <span>Renews {renewsOn}</span>
+                      {cancelCopy ? <span>{cancelCopy}</span> : null}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -11,6 +11,7 @@ import { Separator } from "@/components/ui/separator"
 import { Button } from "@/components/ui/button"
 import { StripeActions } from "./_components/stripe-actions"
 import { CatchUpPaymentCard } from "./_components/catch-up-payment-card"
+import { PaymentStatusOverview } from "./_components/payment-status-overview"
 import {
   calculateOutstanding,
   formatAutopayDay,
@@ -215,6 +216,9 @@ export default function PaymentsPage() {
           </Card>
         </div>
         <CatchUpPaymentCard balances={catchUpBalances} />
+      </section>
+      <section>
+        <PaymentStatusOverview />
       </section>
     </div>
   )

--- a/docs/payments/stripe.md
+++ b/docs/payments/stripe.md
@@ -1,0 +1,95 @@
+# Stripe Payments Integration
+
+Roomsily relies on Stripe Checkout and Billing Portal for collecting rent while Supabase stores the system of record. This guide
+covers how webhook events are normalized, persisted, and monitored.
+
+## Database setup
+
+1. Apply the payments schema migrations (rent payments, subscriptions, and webhook audit log):
+   ```bash
+   supabase db push --file supabase/migrations/20250103_payments_schema.sql
+   supabase db push --file supabase/migrations/20250105_stripe_webhook_events.sql
+   ```
+2. Confirm the following environment variables are set for the Next.js app:
+   - `STRIPE_SECRET_KEY`
+   - `STRIPE_WEBHOOK_SECRET`
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+3. Create a Stripe webhook endpoint that points to `/api/stripe/webhook` and subscribe to these events:
+   - `checkout.session.completed`
+   - `invoice.payment_succeeded`
+   - `invoice.payment_failed`
+   - `payment_intent.payment_failed`
+   - `customer.subscription.created`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+
+## Normalized statuses
+
+Stripe responses are mapped to canonical enums before persisting to Supabase:
+
+| Context              | Stripe status                                            | Stored status |
+| -------------------- | -------------------------------------------------------- | ------------- |
+| Rent payments        | `paid`, `succeeded`, `completed`, `captured`              | `succeeded`   |
+|                      | `processing`, `pending`, `requires_*`, `open`, `draft`   | `pending`     |
+|                      | `failed`, `declined`, `unpaid`, `uncollectible`          | `failed`      |
+|                      | `void`, `canceled`, `cancelled`, `incomplete_expired`    | `cancelled`   |
+| Subscriptions        | `trialing`, `active`                                     | `active`      |
+|                      | `past_due`, `paused`, `incomplete`                       | `past_due`    |
+|                      | `unpaid`                                                 | `unpaid`      |
+|                      | `canceled`, `cancelled`, `incomplete_expired`            | `canceled`    |
+
+Webhook payloads are stored in the `stripe_webhook_events` table with a processing status (`received`, `processed`, `failed`,
+`ignored`) plus alert metadata for monitoring.
+
+## Reconciliation job
+
+Stripe occasionally retries or drops events, so a scheduled reconciliation job replays missing deliveries by calling:
+
+```
+POST /api/jobs/stripe/reconcile?lookback=86400
+```
+
+- `lookback` is optional (seconds, default 86,400 / 24 hours).
+- The job fetches recent Stripe events, inserts any missing `stripe_webhook_events` rows, and re-runs the same processors used by
+the webhook handler.
+- Failures are marked in `stripe_webhook_events` and alert recipients are notified.
+
+Configure a Vercel Cron entry similar to:
+
+```json
+{
+  "path": "/api/jobs/stripe/reconcile",
+  "schedule": "0 * * * *",
+  "method": "POST",
+  "body": "{\"lookback\": 86400}"
+}
+```
+
+## Webhook monitoring
+
+Use the monitor endpoint to raise alerts when an event is stuck in `received` or marked as `failed`:
+
+```
+POST /api/jobs/stripe/monitor?staleMinutes=10&cooldownMinutes=30
+```
+
+- `staleMinutes` controls how long a `received` event can sit without being processed (default 10 minutes).
+- `cooldownMinutes` throttles repeat notifications (default 30 minutes).
+- Alerts are written to the `notifications` table for every admin/property-manager profile.
+
+Schedule the monitor to run frequently (e.g. every five minutes) via Vercel Cron or your job runner.
+
+## Frontend status widgets
+
+The `/payments` page now renders the `PaymentStatusOverview` server component, which queries Supabase for the latest
+`rent_payments` and `subscriptions` records and surfaces the normalized statuses instead of calling Stripe directly. This ensures
+rent status indicators always reflect the persisted system of record.
+
+## Testing tips
+
+- Use the Stripe CLI or Dashboard to trigger test events and confirm they appear in `stripe_webhook_events` with status
+  `processed`.
+- Manually set a row to `failed` and run `POST /api/jobs/stripe/monitor` to verify alerts are generated.
+- Delete a `stripe_webhook_events` row and run the reconciliation job to confirm it re-creates the record and associated
+  `rent_payments` / `subscriptions` entries.

--- a/lib/payments/stripe-webhooks.ts
+++ b/lib/payments/stripe-webhooks.ts
@@ -1,0 +1,924 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type Stripe from "stripe"
+
+import { sendEmailNotification, sendInAppNotification } from "@/lib/notifications"
+import type {
+  Database,
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from "@/lib/supabase"
+
+export type RentPaymentStatus = Tables<'rent_payments'>['status']
+export type SubscriptionStatus = Tables<'subscriptions'>['status']
+export type StripeWebhookEventRow = Tables<'stripe_webhook_events'>
+export type StripeWebhookEventStatus = StripeWebhookEventRow['status']
+
+const PAYMENT_STATUS_MAP: Record<string, RentPaymentStatus> = {
+  succeeded: "succeeded",
+  paid: "succeeded",
+  completed: "succeeded",
+  captured: "succeeded",
+  processing: "pending",
+  pending: "pending",
+  requires_action: "pending",
+  requires_capture: "pending",
+  requires_confirmation: "pending",
+  requires_payment_method: "pending",
+  open: "pending",
+  draft: "pending",
+  past_due: "pending",
+  unpaid: "failed",
+  failed: "failed",
+  declined: "failed",
+  uncollectible: "failed",
+  void: "cancelled",
+  canceled: "cancelled",
+  cancelled: "cancelled",
+  no_payment_required: "succeeded",
+  incomplete: "pending",
+  incomplete_expired: "cancelled",
+}
+
+const SUBSCRIPTION_STATUS_MAP: Record<string, SubscriptionStatus> = {
+  trialing: "active",
+  active: "active",
+  past_due: "past_due",
+  unpaid: "unpaid",
+  paused: "past_due",
+  canceled: "canceled",
+  cancelled: "canceled",
+  incomplete: "past_due",
+  incomplete_expired: "canceled",
+}
+
+function toIsoTimestamp(timestamp: number | null | undefined): string | null {
+  if (!timestamp) {
+    return null
+  }
+
+  return new Date(timestamp * 1000).toISOString()
+}
+
+function buildMetadata(
+  existing: Record<string, unknown> | null | undefined,
+  updates: Record<string, unknown>
+) {
+  return { ...(existing ?? {}), ...updates }
+}
+
+export function normalizeRentPaymentStatus(
+  status?: string | null
+): RentPaymentStatus {
+  if (!status) {
+    return "pending"
+  }
+
+  const normalized = PAYMENT_STATUS_MAP[status.toLowerCase()]
+  return normalized ?? "pending"
+}
+
+export function normalizeSubscriptionStatus(
+  status?: string | null
+): SubscriptionStatus {
+  if (!status) {
+    return "active"
+  }
+
+  const normalized = SUBSCRIPTION_STATUS_MAP[status.toLowerCase()]
+  if (normalized) {
+    return normalized
+  }
+
+  // Treat unknown states as past_due so we surface them for manual review.
+  return "past_due"
+}
+
+export async function ensureStripeEventRecord(
+  supabase: SupabaseClient<Database>,
+  event: Stripe.Event
+): Promise<StripeWebhookEventRow | null> {
+  const { data: existing, error } = await supabase
+    .from("stripe_webhook_events")
+    .select("*")
+    .eq("event_id", event.id)
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to load webhook event record", error)
+    throw error
+  }
+
+  if (existing) {
+    return existing
+  }
+
+  const insert: TablesInsert<'stripe_webhook_events'> = {
+    event_id: event.id,
+    event_type: event.type,
+    status: "received",
+    stripe_created_at: toIsoTimestamp(event.created ?? null),
+    payload: event as unknown as TablesInsert<'stripe_webhook_events'>['payload'],
+    processed_at: null,
+    last_error: null,
+    alert_count: 0,
+    last_alert_at: null,
+  }
+
+  const { data: created, error: insertError } = await supabase
+    .from("stripe_webhook_events")
+    .insert(insert)
+    .select()
+    .single()
+
+  if (insertError) {
+    console.error("Failed to persist webhook event", insertError)
+    throw insertError
+  }
+
+  return created
+}
+
+export async function updateStripeEventStatus(
+  supabase: SupabaseClient<Database>,
+  event: Stripe.Event,
+  status: StripeWebhookEventStatus,
+  options?: {
+    error?: string | null
+    resetAlerts?: boolean
+  }
+) {
+  const update: TablesUpdate<'stripe_webhook_events'> = {
+    status,
+    event_type: event.type,
+    payload: event as unknown as TablesUpdate<'stripe_webhook_events'>['payload'],
+  }
+
+  if (status === "processed" || status === "failed") {
+    update.processed_at = new Date().toISOString()
+  } else if (status === "received") {
+    update.processed_at = null
+  }
+
+  if (options?.error !== undefined) {
+    update.last_error = options.error
+  } else if (status !== "failed") {
+    update.last_error = null
+  }
+
+  if (options?.resetAlerts) {
+    update.alert_count = 0
+    update.last_alert_at = null
+  }
+
+  const { error } = await supabase
+    .from("stripe_webhook_events")
+    .update(update)
+    .eq("event_id", event.id)
+
+  if (error) {
+    console.error("Failed to update webhook event status", error)
+    throw error
+  }
+}
+
+export async function sendStripeWebhookFailureAlert(
+  supabase: SupabaseClient<Database>,
+  params: {
+    event: Pick<StripeWebhookEventRow, "event_id" | "event_type" | "status" | "alert_count">
+    message: string
+  }
+) {
+  const { data: admins, error: adminError } = await supabase
+    .from("profiles")
+    .select("id")
+    .in("role", ["property_manager", "admin"])
+
+  if (adminError) {
+    console.error("Unable to load admin recipients for webhook alert", adminError)
+    return
+  }
+
+  if (!admins || admins.length === 0) {
+    console.warn("No admin recipients available for webhook failure alert")
+    return
+  }
+
+  const nowIso = new Date().toISOString()
+  const notificationRows = admins.map((admin) => ({
+    user_id: admin.id,
+    title: "Stripe webhook issue detected",
+    message: params.message,
+    type: "error" as const,
+    action_url: "/payments",
+    metadata: {
+      eventId: params.event.event_id,
+      eventType: params.event.event_type,
+      status: params.event.status,
+      source: "stripe-webhook-monitor",
+    },
+    read: false,
+    created_at: nowIso,
+  }))
+
+  const { error: notifyError } = await supabase
+    .from("notifications")
+    .insert(notificationRows as TablesInsert<'notifications'>[])
+
+  if (notifyError) {
+    console.error("Failed to persist webhook failure notification", notifyError)
+  }
+
+  const { error: updateError } = await supabase
+    .from("stripe_webhook_events")
+    .update({
+      alert_count: (params.event.alert_count ?? 0) + 1,
+      last_alert_at: nowIso,
+    })
+    .eq("event_id", params.event.event_id)
+
+  if (updateError) {
+    console.error("Failed to update webhook alert metadata", updateError)
+  }
+}
+
+interface ProcessStripeEventArgs {
+  supabase: SupabaseClient<Database>
+  stripe: Stripe
+  event: Stripe.Event
+}
+
+export async function processStripeEvent({
+  supabase,
+  stripe,
+  event,
+}: ProcessStripeEventArgs): Promise<void> {
+  switch (event.type) {
+    case "checkout.session.completed":
+      await handleCheckoutSessionCompleted(
+        supabase,
+        stripe,
+        event.data.object as Stripe.Checkout.Session,
+        event.id
+      )
+      break
+    case "invoice.payment_succeeded":
+      await handleInvoicePaymentSucceeded(
+        supabase,
+        stripe,
+        event.data.object as Stripe.Invoice,
+        event.id
+      )
+      break
+    case "invoice.payment_failed":
+      await handleInvoicePaymentFailed(
+        supabase,
+        stripe,
+        event.data.object as Stripe.Invoice,
+        event.id
+      )
+      break
+    case "customer.subscription.created":
+      await handleSubscriptionCreated(
+        supabase,
+        event.data.object as Stripe.Subscription,
+        event.id
+      )
+      break
+    case "customer.subscription.updated":
+      await handleSubscriptionUpdated(
+        supabase,
+        event.data.object as Stripe.Subscription,
+        event.id
+      )
+      break
+    case "customer.subscription.deleted":
+      await handleSubscriptionDeleted(
+        supabase,
+        event.data.object as Stripe.Subscription,
+        event.id
+      )
+      break
+    case "payment_intent.payment_failed":
+      await handlePaymentIntentFailed(
+        supabase,
+        event.data.object as Stripe.PaymentIntent,
+        event.id
+      )
+      break
+    default:
+      console.log(`Unhandled Stripe event type: ${event.type}`)
+  }
+}
+
+async function handleCheckoutSessionCompleted(
+  supabase: SupabaseClient<Database>,
+  stripe: Stripe,
+  session: Stripe.Checkout.Session,
+  eventId: string
+) {
+  const fullSession = await stripe.checkout.sessions.retrieve(session.id, {
+    expand: [
+      "line_items",
+      "customer",
+      "payment_intent",
+      "payment_intent.latest_charge",
+    ],
+  })
+
+  const lineItem = fullSession.line_items?.data?.[0]
+  const tenantId = fullSession.metadata?.tenant_id ?? undefined
+  const unitId = fullSession.metadata?.unit_id ?? undefined
+
+  const paymentIntentId =
+    typeof fullSession.payment_intent === "string"
+      ? fullSession.payment_intent
+      : fullSession.payment_intent?.id
+
+  const paymentIntent = paymentIntentId
+    ? await stripe.paymentIntents.retrieve(paymentIntentId, {
+        expand: ["latest_charge", "payment_method"],
+      })
+    : null
+
+  let paymentStatus = normalizeRentPaymentStatus(fullSession.payment_status)
+  let chargeId: string | null = null
+  let paymentMethodType: string | null = null
+  let paymentMethod: string | null = null
+  let receiptUrl: string | null = null
+
+  if (paymentIntent) {
+    paymentStatus = normalizeRentPaymentStatus(paymentIntent.status)
+    paymentMethodType = paymentIntent.payment_method_types?.[0] ?? null
+    if (typeof paymentIntent.payment_method === "string") {
+      paymentMethod = paymentIntent.payment_method
+    } else if (paymentIntent.payment_method) {
+      paymentMethod = paymentIntent.payment_method.id
+    }
+
+    const latestCharge = paymentIntent.latest_charge
+    if (typeof latestCharge === "string") {
+      chargeId = latestCharge
+    } else if (latestCharge && typeof latestCharge === "object") {
+      const charge = latestCharge as Stripe.Charge
+      chargeId = charge.id
+      paymentStatus = normalizeRentPaymentStatus(charge.status)
+      receiptUrl = charge.receipt_url ?? null
+      if (charge.payment_method_details?.type) {
+        paymentMethodType = charge.payment_method_details.type
+      }
+    }
+  }
+
+  const amountTotal = lineItem?.amount_total ?? fullSession.amount_total ?? 0
+  const currency =
+    lineItem?.currency?.toUpperCase() ?? fullSession.currency?.toUpperCase() ?? "USD"
+
+  const rentPaymentData: TablesInsert<'rent_payments'> = {
+    user_id:
+      (tenantId as string | undefined) ||
+      "00000000-0000-0000-0000-000000000000",
+    stripe_payment_intent_id: paymentIntentId ?? session.id,
+    stripe_charge_id: chargeId,
+    stripe_customer_id:
+      typeof fullSession.customer === "string"
+        ? fullSession.customer
+        : fullSession.customer?.id ?? null,
+    amount: amountTotal / 100,
+    currency,
+    status: paymentStatus,
+    payment_method: paymentMethod,
+    payment_method_type: paymentMethodType,
+    description:
+      lineItem?.description ??
+      `Payment for ${lineItem?.price?.nickname ?? "rent"}`,
+    receipt_url: receiptUrl,
+    metadata: buildMetadata(fullSession.metadata, {
+      session_id: session.id,
+      event_id: eventId,
+      payment_status: fullSession.payment_status,
+    }),
+    tenant_id: tenantId,
+    unit_id: unitId,
+    processed_at: new Date().toISOString(),
+  }
+
+  const existingPayment = await findExistingRentPayment(
+    supabase,
+    paymentIntentId,
+    session.id
+  )
+
+  if (existingPayment) {
+    const update: TablesUpdate<'rent_payments'> = {
+      stripe_charge_id: chargeId,
+      stripe_customer_id: rentPaymentData.stripe_customer_id,
+      amount: rentPaymentData.amount,
+      currency: rentPaymentData.currency,
+      status: rentPaymentData.status,
+      payment_method: rentPaymentData.payment_method,
+      payment_method_type: rentPaymentData.payment_method_type,
+      description: rentPaymentData.description,
+      receipt_url: rentPaymentData.receipt_url,
+      metadata: buildMetadata(existingPayment.metadata as Record<string, unknown> | null, {
+        session_id: session.id,
+        event_id: eventId,
+        payment_status: fullSession.payment_status,
+      }),
+      tenant_id: tenantId,
+      unit_id: unitId,
+      processed_at: rentPaymentData.processed_at,
+    }
+
+    await supabase
+      .from("rent_payments")
+      .update(update)
+      .eq("id", existingPayment.id)
+  } else {
+    await supabase.from("rent_payments").insert(rentPaymentData)
+  }
+
+  if (tenantId) {
+    await notifyTenantOfPaymentSuccess(
+      supabase,
+      tenantId,
+      rentPaymentData.amount,
+      rentPaymentData.description
+    )
+  }
+}
+
+async function handleInvoicePaymentSucceeded(
+  supabase: SupabaseClient<Database>,
+  stripe: Stripe,
+  invoice: Stripe.Invoice,
+  eventId: string
+) {
+  const fullInvoice = await stripe.invoices.retrieve(invoice.id, {
+    expand: ["subscription", "customer", "payment_intent"],
+  })
+
+  const subscription = fullInvoice.subscription as Stripe.Subscription | null
+  const paymentIntentId =
+    typeof fullInvoice.payment_intent === "string"
+      ? fullInvoice.payment_intent
+      : fullInvoice.payment_intent?.id
+
+  const paymentIntent = paymentIntentId
+    ? await stripe.paymentIntents.retrieve(paymentIntentId, {
+        expand: ["latest_charge", "payment_method"],
+      })
+    : null
+
+  let paymentStatus = normalizeRentPaymentStatus(fullInvoice.status)
+  let paymentMethodType: string | null = null
+  let paymentMethod: string | null = null
+  let chargeId: string | null = null
+  let receiptUrl: string | null = null
+
+  if (paymentIntent) {
+    paymentStatus = normalizeRentPaymentStatus(paymentIntent.status)
+    paymentMethodType = paymentIntent.payment_method_types?.[0] ?? null
+    if (typeof paymentIntent.payment_method === "string") {
+      paymentMethod = paymentIntent.payment_method
+    } else if (paymentIntent.payment_method) {
+      paymentMethod = paymentIntent.payment_method.id
+    }
+
+    const latestCharge = paymentIntent.latest_charge
+    if (typeof latestCharge === "string") {
+      chargeId = latestCharge
+    } else if (latestCharge && typeof latestCharge === "object") {
+      const charge = latestCharge as Stripe.Charge
+      chargeId = charge.id
+      receiptUrl = charge.receipt_url ?? null
+      paymentStatus = normalizeRentPaymentStatus(charge.status)
+      if (charge.payment_method_details?.type) {
+        paymentMethodType = charge.payment_method_details.type
+      }
+    }
+  }
+
+  const tenantId = subscription?.metadata?.tenant_id
+  const unitId = subscription?.metadata?.unit_id
+
+  const amountPaid = (fullInvoice.amount_paid ?? 0) / 100
+  const currency = fullInvoice.currency?.toUpperCase() ?? "USD"
+
+  const rentPaymentData: TablesInsert<'rent_payments'> = {
+    user_id:
+      (tenantId as string | undefined) ||
+      "00000000-0000-0000-0000-000000000000",
+    stripe_payment_intent_id: paymentIntentId ?? invoice.id,
+    stripe_charge_id: chargeId,
+    stripe_customer_id:
+      typeof fullInvoice.customer === "string"
+        ? fullInvoice.customer
+        : fullInvoice.customer?.id ?? null,
+    stripe_subscription_id: subscription?.id ?? null,
+    amount: amountPaid,
+    currency,
+    status: paymentStatus,
+    payment_method: paymentMethod,
+    payment_method_type: paymentMethodType,
+    description: `Subscription payment - ${
+      subscription?.metadata?.unit_label ?? "Rent"
+    }`,
+    receipt_url: receiptUrl ?? fullInvoice.hosted_invoice_url ?? null,
+    metadata: buildMetadata(subscription?.metadata, {
+      invoice_id: invoice.id,
+      subscription_id: subscription?.id,
+      billing_reason: fullInvoice.billing_reason,
+      event_id: eventId,
+    }),
+    tenant_id: tenantId,
+    unit_id: unitId,
+    processed_at: new Date().toISOString(),
+    billing_period_start: toIsoTimestamp(subscription?.current_period_start),
+    billing_period_end: toIsoTimestamp(subscription?.current_period_end),
+  }
+
+  const existingPayment = await findExistingRentPayment(
+    supabase,
+    paymentIntentId,
+    undefined,
+    invoice.id
+  )
+
+  if (existingPayment) {
+    const update: TablesUpdate<'rent_payments'> = {
+      stripe_charge_id: chargeId,
+      stripe_customer_id: rentPaymentData.stripe_customer_id,
+      stripe_subscription_id: rentPaymentData.stripe_subscription_id,
+      amount: rentPaymentData.amount,
+      currency: rentPaymentData.currency,
+      status: rentPaymentData.status,
+      payment_method: rentPaymentData.payment_method,
+      payment_method_type: rentPaymentData.payment_method_type,
+      description: rentPaymentData.description,
+      receipt_url: rentPaymentData.receipt_url,
+      metadata: buildMetadata(existingPayment.metadata as Record<string, unknown> | null, {
+        invoice_id: invoice.id,
+        subscription_id: subscription?.id,
+        billing_reason: fullInvoice.billing_reason,
+        event_id: eventId,
+      }),
+      tenant_id: tenantId,
+      unit_id: unitId,
+      processed_at: rentPaymentData.processed_at,
+      billing_period_start: rentPaymentData.billing_period_start,
+      billing_period_end: rentPaymentData.billing_period_end,
+    }
+
+    await supabase
+      .from("rent_payments")
+      .update(update)
+      .eq("id", existingPayment.id)
+  } else {
+    await supabase.from("rent_payments").insert(rentPaymentData)
+  }
+
+  if (subscription) {
+    await upsertSubscriptionRecord(supabase, subscription, eventId)
+  }
+
+  if (tenantId) {
+    await notifyTenantOfPaymentSuccess(
+      supabase,
+      tenantId,
+      rentPaymentData.amount,
+      rentPaymentData.description
+    )
+  }
+}
+
+async function handleInvoicePaymentFailed(
+  supabase: SupabaseClient<Database>,
+  stripe: Stripe,
+  invoice: Stripe.Invoice,
+  eventId: string
+) {
+  const fullInvoice = await stripe.invoices.retrieve(invoice.id, {
+    expand: ["subscription", "payment_intent"],
+  })
+
+  const subscription = fullInvoice.subscription as Stripe.Subscription | null
+  const paymentIntentId =
+    typeof fullInvoice.payment_intent === "string"
+      ? fullInvoice.payment_intent
+      : fullInvoice.payment_intent?.id
+
+  const tenantId = subscription?.metadata?.tenant_id
+  const unitId = subscription?.metadata?.unit_id
+
+  const amountDue = (fullInvoice.amount_due ?? 0) / 100
+  const currency = fullInvoice.currency?.toUpperCase() ?? "USD"
+
+  const paymentStatus = "failed" satisfies RentPaymentStatus
+
+  const existingPayment = await findExistingRentPayment(
+    supabase,
+    paymentIntentId,
+    undefined,
+    invoice.id
+  )
+
+  const metadataUpdates = {
+    invoice_id: invoice.id,
+    subscription_id: subscription?.id,
+    billing_reason: fullInvoice.billing_reason,
+    event_id: eventId,
+  }
+
+  if (existingPayment) {
+    const update: TablesUpdate<'rent_payments'> = {
+      status: paymentStatus,
+      amount: amountDue,
+      currency,
+      tenant_id: tenantId,
+      unit_id: unitId,
+      metadata: buildMetadata(existingPayment.metadata as Record<string, unknown> | null, metadataUpdates),
+      processed_at: new Date().toISOString(),
+    }
+
+    await supabase
+      .from("rent_payments")
+      .update(update)
+      .eq("id", existingPayment.id)
+  } else {
+    const rentPaymentData: TablesInsert<'rent_payments'> = {
+      user_id:
+        (tenantId as string | undefined) ||
+        "00000000-0000-0000-0000-000000000000",
+      stripe_payment_intent_id: paymentIntentId ?? invoice.id,
+      stripe_customer_id:
+        typeof fullInvoice.customer === "string"
+          ? fullInvoice.customer
+          : fullInvoice.customer?.id ?? null,
+      stripe_subscription_id: subscription?.id ?? null,
+      amount: amountDue,
+      currency,
+      status: paymentStatus,
+      description: `Subscription payment - ${
+        subscription?.metadata?.unit_label ?? "Rent"
+      }`,
+      metadata: buildMetadata(subscription?.metadata, metadataUpdates),
+      tenant_id: tenantId,
+      unit_id: unitId,
+      processed_at: new Date().toISOString(),
+    }
+
+    await supabase.from("rent_payments").insert(rentPaymentData)
+  }
+
+  if (subscription) {
+    await supabase
+      .from("subscriptions")
+      .update({
+        status: "past_due",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("stripe_subscription_id", subscription.id)
+  }
+}
+
+async function handleSubscriptionCreated(
+  supabase: SupabaseClient<Database>,
+  subscription: Stripe.Subscription,
+  eventId: string
+) {
+  await upsertSubscriptionRecord(supabase, subscription, eventId)
+}
+
+async function handleSubscriptionUpdated(
+  supabase: SupabaseClient<Database>,
+  subscription: Stripe.Subscription,
+  eventId: string
+) {
+  await upsertSubscriptionRecord(supabase, subscription, eventId)
+}
+
+async function handleSubscriptionDeleted(
+  supabase: SupabaseClient<Database>,
+  subscription: Stripe.Subscription,
+  eventId: string
+) {
+  const { error } = await supabase
+    .from("subscriptions")
+    .update({
+      status: "canceled",
+      cancel_at_period_end: true,
+      updated_at: new Date().toISOString(),
+      metadata: buildMetadata(subscription.metadata as Record<string, unknown> | null, {
+        event_id: eventId,
+      }),
+    })
+    .eq("stripe_subscription_id", subscription.id)
+
+  if (error) {
+    console.error("Failed to mark subscription as canceled", error)
+    throw error
+  }
+}
+
+async function handlePaymentIntentFailed(
+  supabase: SupabaseClient<Database>,
+  paymentIntent: Stripe.PaymentIntent,
+  eventId: string
+) {
+  const paymentIntentId = paymentIntent.id
+  const paymentStatus = normalizeRentPaymentStatus(paymentIntent.status)
+  const tenantId = paymentIntent.metadata?.tenant_id
+  const unitId = paymentIntent.metadata?.unit_id
+
+  const existingPayment = await findExistingRentPayment(
+    supabase,
+    paymentIntentId,
+    paymentIntent.metadata?.session_id ?? undefined
+  )
+
+  const metadataUpdates = buildMetadata(
+    (existingPayment?.metadata as Record<string, unknown> | null) ??
+      (paymentIntent.metadata as Record<string, unknown> | undefined),
+    {
+      event_id: eventId,
+      payment_intent_status: paymentIntent.status,
+    }
+  )
+
+  if (existingPayment) {
+    const update: TablesUpdate<'rent_payments'> = {
+      status: paymentStatus,
+      tenant_id: tenantId,
+      unit_id: unitId,
+      metadata: metadataUpdates,
+      processed_at: new Date().toISOString(),
+    }
+
+    await supabase
+      .from("rent_payments")
+      .update(update)
+      .eq("id", existingPayment.id)
+  } else {
+    const rentPaymentData: TablesInsert<'rent_payments'> = {
+      user_id:
+        (tenantId as string | undefined) ||
+        "00000000-0000-0000-0000-000000000000",
+      stripe_payment_intent_id: paymentIntentId,
+      stripe_customer_id: paymentIntent.customer
+        ? typeof paymentIntent.customer === "string"
+          ? paymentIntent.customer
+          : paymentIntent.customer.id
+        : null,
+      amount: (paymentIntent.amount ?? 0) / 100,
+      currency: paymentIntent.currency?.toUpperCase() ?? "USD",
+      status: paymentStatus,
+      payment_method: typeof paymentIntent.payment_method === "string"
+        ? paymentIntent.payment_method
+        : paymentIntent.payment_method?.id ?? null,
+      payment_method_type: paymentIntent.payment_method_types?.[0] ?? null,
+      metadata: metadataUpdates,
+      tenant_id: tenantId,
+      unit_id: unitId,
+      processed_at: new Date().toISOString(),
+    }
+
+    await supabase.from("rent_payments").insert(rentPaymentData)
+  }
+}
+
+async function findExistingRentPayment(
+  supabase: SupabaseClient<Database>,
+  paymentIntentId?: string | null,
+  sessionId?: string,
+  invoiceId?: string
+) {
+  if (paymentIntentId) {
+    const { data, error } = await supabase
+      .from("rent_payments")
+      .select("id, metadata")
+      .eq("stripe_payment_intent_id", paymentIntentId)
+      .maybeSingle()
+
+    if (error) {
+      console.error("Failed to lookup rent payment by payment_intent", error)
+    } else if (data) {
+      return data
+    }
+  }
+
+  if (invoiceId) {
+    const { data, error } = await supabase
+      .from("rent_payments")
+      .select("id, metadata")
+      .contains("metadata", { invoice_id: invoiceId })
+      .maybeSingle()
+
+    if (error) {
+      console.error("Failed to lookup rent payment by invoice", error)
+    } else if (data) {
+      return data
+    }
+  }
+
+  if (sessionId) {
+    const { data, error } = await supabase
+      .from("rent_payments")
+      .select("id, metadata")
+      .contains("metadata", { session_id: sessionId })
+      .maybeSingle()
+
+    if (error) {
+      console.error("Failed to lookup rent payment by session", error)
+    } else if (data) {
+      return data
+    }
+  }
+
+  return null
+}
+
+async function upsertSubscriptionRecord(
+  supabase: SupabaseClient<Database>,
+  subscription: Stripe.Subscription,
+  eventId: string
+) {
+  const normalizedStatus = normalizeSubscriptionStatus(subscription.status)
+  const price = subscription.items.data[0]?.price
+
+  const subscriptionData: TablesInsert<'subscriptions'> = {
+    user_id:
+      (subscription.metadata?.tenant_id as string | undefined) ||
+      "00000000-0000-0000-0000-000000000000",
+    stripe_subscription_id: subscription.id,
+    stripe_customer_id: subscription.customer
+      ? typeof subscription.customer === "string"
+        ? subscription.customer
+        : subscription.customer.id
+      : null,
+    status: normalizedStatus,
+    current_period_start: toIsoTimestamp(subscription.current_period_start),
+    current_period_end: toIsoTimestamp(subscription.current_period_end),
+    cancel_at_period_end: subscription.cancel_at_period_end ?? null,
+    amount: (price?.unit_amount ?? 0) / 100,
+    currency: price?.currency?.toUpperCase() ?? "USD",
+    interval: price?.recurring?.interval === "year" ? "year" : "month",
+    metadata: buildMetadata(subscription.metadata, {
+      event_id: eventId,
+      price_id: price?.id,
+    }),
+  }
+
+  const { error } = await supabase
+    .from("subscriptions")
+    .upsert(subscriptionData, { onConflict: "stripe_subscription_id" })
+
+  if (error) {
+    console.error("Failed to upsert subscription record", error)
+    throw error
+  }
+}
+
+async function notifyTenantOfPaymentSuccess(
+  supabase: SupabaseClient<Database>,
+  tenantId: string,
+  amount: number,
+  description: string | null
+) {
+  const { data: tenantProfile } = await supabase
+    .from("profiles")
+    .select("full_name, email")
+    .eq("id", tenantId)
+    .maybeSingle()
+
+  if (!tenantProfile?.email) {
+    return
+  }
+
+  const amountDisplay = `$${amount.toFixed(2)}`
+
+  try {
+    await sendEmailNotification({
+      to: tenantProfile.email,
+      subject: `Payment Receipt - ${amountDisplay}`,
+      template: "payment-receipt",
+      data: {
+        tenantName: tenantProfile.full_name || tenantProfile.email,
+        amount: amountDisplay,
+        description: description ?? "Rent payment",
+        date: new Date().toLocaleDateString(),
+      },
+      userId: tenantId,
+    })
+
+    await sendInAppNotification({
+      userId: tenantId,
+      title: "Payment Successful",
+      message: `Your payment of ${amountDisplay} has been processed successfully.`,
+      type: "success",
+      actionUrl: "/payments",
+    })
+  } catch (notificationError) {
+    console.error("Failed to send tenant payment notification", notificationError)
+  }
+}

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,0 +1,19 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+export function createSupabaseAdminClient(): SupabaseClient<Database> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Supabase admin credentials are not configured")
+  }
+
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -112,7 +112,7 @@ export type Database = {
         stripe_subscription_id: string | null
         amount: number
         currency: string
-        status: 'pending' | 'succeeded' | 'failed' | 'cancelled' | 'completed'
+        status: 'pending' | 'succeeded' | 'failed' | 'cancelled'
         payment_method: string | null
         payment_method_type: string | null
         description: string | null
@@ -123,6 +123,20 @@ export type Database = {
         processed_at: string | null
         billing_period_start: string | null
         billing_period_end: string | null
+        created_at: string | null
+        updated_at: string | null
+      }>
+      stripe_webhook_events: SupabaseTable<{
+        id: string
+        event_id: string
+        event_type: string
+        status: 'received' | 'processed' | 'failed' | 'ignored'
+        stripe_created_at: string | null
+        processed_at: string | null
+        last_error: string | null
+        payload: Json
+        alert_count: number
+        last_alert_at: string | null
         created_at: string | null
         updated_at: string | null
       }>

--- a/supabase/migrations/20250105_stripe_webhook_events.sql
+++ b/supabase/migrations/20250105_stripe_webhook_events.sql
@@ -1,0 +1,25 @@
+-- Persist Stripe webhook delivery attempts and outcomes
+CREATE TABLE public.stripe_webhook_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id TEXT NOT NULL UNIQUE,
+  event_type TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('received', 'processed', 'failed', 'ignored')),
+  stripe_created_at TIMESTAMP WITH TIME ZONE,
+  processed_at TIMESTAMP WITH TIME ZONE,
+  last_error TEXT,
+  payload JSONB NOT NULL,
+  alert_count INTEGER NOT NULL DEFAULT 0,
+  last_alert_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_stripe_webhook_events_status ON public.stripe_webhook_events(status);
+CREATE INDEX idx_stripe_webhook_events_event_id ON public.stripe_webhook_events(event_id);
+CREATE INDEX idx_stripe_webhook_events_created_at ON public.stripe_webhook_events(created_at DESC);
+
+ALTER TABLE public.stripe_webhook_events ENABLE ROW LEVEL SECURITY;
+
+CREATE TRIGGER update_stripe_webhook_events_updated_at
+  BEFORE UPDATE ON public.stripe_webhook_events
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- normalize Stripe rent payment and subscription statuses before persisting them and store raw webhook payloads in Supabase
- add reconciliation and monitoring API jobs that replay missed Stripe events and alert admins about webhook failures
- expose payment and subscription statuses from Supabase on the Payments page and document the full setup in docs/payments/stripe.md

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d64e5c883288e24fe8c5757ffb6