### PR TITLE
Refactor Supabase data fetching helpers

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
 import { createClient } from "@/utils/supabase-browser";
+import { fetchMemberRole } from "@/lib/data/members";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
 export default function NavLinks() {
 	const pathname = usePathname();
@@ -14,20 +16,22 @@ export default function NavLinks() {
 		const load = async () => {
 			try {
 				const supabase = createClient();
-				const { data: { user } } = await supabase.auth.getUser();
-				if (!user) {
-					setRole(null);
-					return;
-				}
-				const { data: profile } = await supabase
-					.from('profiles')
-					.select('role')
-					.eq('id', user.id)
-					.single();
-				setRole(profile?.role || null);
-			} catch (e) {
-				setRole(null);
-			}
+                                const { data: { user } } = await supabase.auth.getUser();
+                                if (!user) {
+                                        setRole(null);
+                                        return;
+                                }
+                                const typedSupabase = supabase as unknown as TypedSupabaseClient;
+                                try {
+                                        const resolvedRole = await fetchMemberRole(typedSupabase, user.id);
+                                        setRole(resolvedRole || null);
+                                } catch (memberError) {
+                                        console.error("Error loading member role", memberError);
+                                        setRole(null);
+                                }
+                        } catch (e) {
+                                setRole(null);
+                        }
 		};
 		load();
 	}, []);

--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -5,6 +5,9 @@ import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
+import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import { fetchMemberRole } from '@/lib/data/members';
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import {
   Document,
   DocumentWithLease,
@@ -56,6 +59,7 @@ export async function getDocumentsAction(
 ): Promise<ActionResult<DocumentWithLease[]>> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
   try {
     // Check authentication
@@ -66,60 +70,29 @@ export async function getDocumentsAction(
 
     // Validate filters
     const validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
-
-    // Determine role for scoping
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .single();
-
-    let query = (supabase as any)
-      .from('documents')
-      .select(`
-        *,
-        lease:leases(*),
-        signatures:document_signatures(*),
-        access_logs:document_access_logs(*, profiles:signer_id(username, full_name))
-      `)
-      .order('created_at', { ascending: false });
-
-    // Scope non-admin/property_manager users to their own documents or ones they need to sign
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
-      query = query.or(
-        `tenant_id.eq.${user.id},signatures.signer_id.eq.${user.id}`
-      );
+    let role: Awaited<ReturnType<typeof fetchMemberRole>>;
+    try {
+      role = await fetchMemberRole(typedSupabase, user.id);
+    } catch (roleError) {
+      console.error('Error resolving member role:', roleError);
+      return { success: false, error: 'Failed to fetch documents.' };
     }
 
-    // Apply filters
-    if (validatedFilters.status?.length) {
-      query = query.in('status', validatedFilters.status);
-    }
-    if (validatedFilters.type?.length) {
-      query = query.in('document_type', validatedFilters.type);
-    }
-    if (validatedFilters.tenant_id) {
-      query = query.eq('tenant_id', validatedFilters.tenant_id);
-    }
-    if (validatedFilters.unit_id) {
-      query = query.eq('unit_id', validatedFilters.unit_id);
-    }
-    if (validatedFilters.date_from) {
-      query = query.gte('created_at', validatedFilters.date_from);
-    }
-    if (validatedFilters.date_to) {
-      query = query.lte('created_at', validatedFilters.date_to);
-    }
-
-    const { data: documents, error } = await query;
-
-    if (error) {
-      console.error('Error fetching documents:', error);
+    let documents: DocumentWithLease[];
+    try {
+      documents = await fetchDocumentsList({
+        client: typedSupabase,
+        userId: user.id,
+        role,
+        filters: validatedFilters,
+      });
+    } catch (documentsError) {
+      console.error('Error fetching documents:', documentsError);
       return { success: false, error: 'Failed to fetch documents.' };
     }
 
     // Log access
-    for (const doc of documents || []) {
+    for (const doc of documents) {
       await (supabase as any).rpc('log_document_access', {
         p_document_id: doc.id,
         p_action: 'view',
@@ -127,7 +100,7 @@ export async function getDocumentsAction(
       });
     }
 
-    return { success: true, data: documents || [] };
+    return { success: true, data: documents };
   } catch (error) {
     console.error('Unexpected error in getDocumentsAction:', error);
     return {
@@ -246,6 +219,7 @@ export async function createSigningRequestAction(
 ): Promise<ActionResult<{ signing_url?: string; envelope_id?: string }>> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
   try {
     // Check authentication
@@ -286,13 +260,15 @@ export async function createSigningRequestAction(
     }
 
     // Check permissions (user must be property manager or admin, or document owner)
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .single();
+    let role: Awaited<ReturnType<typeof fetchMemberRole>>;
+    try {
+      role = await fetchMemberRole(typedSupabase, user.id);
+    } catch (roleError) {
+      console.error('Error resolving member role for signing request:', roleError);
+      return { success: false, error: 'You do not have permission to create signing requests for this document.' };
+    }
 
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin' && document.tenant_id !== user.id) {
+    if (role !== 'property_manager' && role !== 'admin' && document.tenant_id !== user.id) {
       return { success: false, error: 'You do not have permission to create signing requests for this document.' };
     }
 
@@ -548,6 +524,7 @@ export async function getSigningUrlAction(
 export async function getDocumentStatsAction(): Promise<ActionResult<DocumentStats>> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
   try {
     // Check authentication
@@ -556,34 +533,25 @@ export async function getDocumentStatsAction(): Promise<ActionResult<DocumentSta
       return { success: false, error: 'You must be logged in to view document statistics.' };
     }
 
-    // Get stats based on user role
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .single();
-
-    let query = supabase.from('documents').select('status');
-
-    // If not admin/property manager, filter by tenant_id
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
-      query = query.eq('tenant_id', user.id);
-    }
-
-    const { data: documents, error } = await query;
-
-    if (error) {
-      console.error('Error fetching document stats:', error);
+    let role: Awaited<ReturnType<typeof fetchMemberRole>>;
+    try {
+      role = await fetchMemberRole(typedSupabase, user.id);
+    } catch (roleError) {
+      console.error('Error resolving member role for stats:', roleError);
       return { success: false, error: 'Failed to fetch document statistics.' };
     }
 
-    const stats: DocumentStats = {
-      total_documents: documents?.length || 0,
-      pending_signatures: documents?.filter(d => d.status === 'pending_signature').length || 0,
-      signed_documents: documents?.filter(d => d.status === 'signed').length || 0,
-      expired_documents: documents?.filter(d => d.status === 'expired').length || 0,
-      draft_documents: documents?.filter(d => d.status === 'draft').length || 0,
-    };
+    let stats: DocumentStats;
+    try {
+      stats = await fetchDocumentStats({
+        client: typedSupabase,
+        userId: user.id,
+        role,
+      });
+    } catch (statsError) {
+      console.error('Error fetching document stats:', statsError);
+      return { success: false, error: 'Failed to fetch document statistics.' };
+    }
 
     return { success: true, data: stats };
   } catch (error) {

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -13,6 +13,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
+import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
 const maintenanceRequestSchema = z.object({
   title: z.string().min(5, "Title must be at least 5 characters"),
@@ -48,6 +50,7 @@ export function MaintenanceRequestForm() {
   const { notifyMaintenanceRequest } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
   const form = useForm<MaintenanceRequestFormData>({
     resolver: zodResolver(maintenanceRequestSchema),
@@ -69,11 +72,7 @@ export function MaintenanceRequestForm() {
       if (!user) throw new Error("Not authenticated");
 
       // Get user profile
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('full_name, unit_id')
-        .eq('id', user.id)
-        .single();
+      const profile = await fetchMemberProfile(typedSupabase, user.id);
 
       if (!profile) throw new Error("Profile not found");
 
@@ -81,13 +80,9 @@ export function MaintenanceRequestForm() {
         throw new Error("User is not assigned to a unit");
       }
 
-      // Get property manager for this unit
-      const { data: propertyManager } = await supabase
-        .from('profiles')
-        .select('id, full_name, email')
-        .eq('unit_id', profile.unit_id!)
-        .eq('role', 'property_manager')
-        .single();
+      const [propertyManager] = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
+        roles: ['property_manager'],
+      });
 
       if (!propertyManager) {
         throw new Error("Property manager not found for this unit");
@@ -103,7 +98,7 @@ export function MaintenanceRequestForm() {
           category: data.category || null,
           location: data.location || null,
           requested_by: user.id,
-          unit_id: (profile as any).unit_id,
+          unit_id: profile.unit_id,
           status: 'pending',
         })
         .select()
@@ -113,7 +108,7 @@ export function MaintenanceRequestForm() {
 
       // Send notifications
       await notifyMaintenanceRequest({
-        requesterName: (profile as any).full_name || user.email || 'Unknown',
+        requesterName: profile.full_name || user.email || 'Unknown',
         title: data.title,
         description: data.description,
         priority: data.priority,

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -18,6 +18,8 @@ import { cn } from "@/lib/utils";
 import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
+import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
 const visitorBookingSchema = z.object({
   guestName: z.string().min(2, "Guest name must be at least 2 characters"),
@@ -41,6 +43,7 @@ export function VisitorBookingForm() {
   const { notifyVisitorBooking } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
   const form = useForm<VisitorBookingFormData>({
     resolver: zodResolver(visitorBookingSchema),
@@ -63,24 +66,22 @@ export function VisitorBookingForm() {
       if (!user) throw new Error("Not authenticated");
 
       // Get user profile
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('full_name, email, unit_id')
-        .eq('id', user.id)
-        .single();
+      const profile = await fetchMemberProfile(typedSupabase, user.id);
 
       if (!profile) throw new Error("Profile not found");
 
-      // Get roommates and property manager
-      // This assumes there's a units table with tenant relationships
-      const { data: unitData } = await supabase
-        .from('profiles')
-        .select('id, full_name, email, role')
-        .eq('unit_id', profile.unit_id!)
-        .neq('id', user.id);
+      if (!profile.unit_id) {
+        throw new Error("User is not assigned to a unit");
+      }
 
-      const roommates = unitData?.filter(p => p.role === 'tenant' || p.role === 'roommate') || [];
-      const propertyManager = unitData?.find(p => p.role === 'property_manager');
+      const unitMembers = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
+        excludeUserId: user.id,
+      });
+
+      const roommates = unitMembers.filter(
+        member => member.role === 'tenant' || member.role === 'roommate'
+      );
+      const propertyManager = unitMembers.find(member => member.role === 'property_manager');
 
       if (!propertyManager) {
         throw new Error("Property manager not found for this unit");

--- a/docs/perf/data-fetching.md
+++ b/docs/perf/data-fetching.md
@@ -1,0 +1,39 @@
+# Data Fetching Utilities
+
+Roomsily consolidates common Supabase queries into shared helpers to minimize network chatter and keep client components lean. Use these modules whenever you need document or member data so filters and role-based scoping stay consistent across the app.
+
+## `lib/data/documents.ts`
+
+### `fetchDocumentsList`
+- **Purpose:** Returns the document list with leases, signatures, and access logs joined in a single round trip.
+- **Role-aware:** Automatically limits tenants/roommates to documents they own or must sign while allowing property managers and admins to view everything.
+- **Filters:** Supports status, type, tenant, unit, and created-at range filters.
+- **Usage:** Pass a Supabase client along with the requesting user id, their role (or `null`), and optional filters. The helper throws on Supabase errors so wrap calls in `try/catch` inside server actions or client hooks.
+
+### `fetchDocumentStats`
+- **Purpose:** Computes document counts (total, signed, pending signatures, expired, drafts).
+- **Role-aware:** Applies the same tenant scoping rules as the list helper before aggregating.
+- **Usage:** Provide the Supabase client, user id, and role. Handle thrown errors to surface friendly feedback.
+
+## `lib/data/members.ts`
+
+### `fetchMemberRole`
+- **Purpose:** Looks up a profile’s role from the `profiles` table and normalizes the result to `MemberRole | null`.
+- **Usage:** Ideal for navigation guards and permission hooks. Wrap in `try/catch` if you want to recover gracefully when the profile is missing.
+
+### `fetchMemberProfile`
+- **Purpose:** Fetches a condensed profile record (`id`, `email`, `full_name`, `role`, `unit_id`).
+- **Usage:** Use in forms and actions that need the current member’s unit/identity without repeating column lists.
+
+### `fetchMembersByUnit`
+- **Purpose:** Returns members attached to a unit with optional filters for roles and users to exclude.
+- **Usage:** Power roommate/property manager lookups for maintenance requests, visitor bookings, or any dashboard member table. Errors bubble as exceptions so caller code can present a single “failed to load members” message.
+
+## Testing Strategy
+
+Vitest unit tests (`tests/lib/data/*.test.ts`) mock the Supabase client chain to confirm that each helper:
+- Calls the expected tables/filters.
+- Applies tenant scoping correctly.
+- Throws when Supabase returns an error.
+
+Run `pnpm test` after modifying these utilities to ensure behavior stays locked in.

--- a/hooks/use-document-permissions.ts
+++ b/hooks/use-document-permissions.ts
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import { createClient } from '@/utils/supabase-browser';
 import { DocumentWithLease } from '@/types/documents';
+import { fetchMemberRole } from '@/lib/data/members';
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 
 export interface UserPermissions {
   isTenant: boolean;
@@ -34,6 +36,7 @@ export function useDocumentPermissions(): UserPermissions {
     const checkPermissions = async () => {
       try {
         const supabase = createClient();
+        const typedSupabase = supabase as unknown as TypedSupabaseClient;
         const { data: { user } } = await supabase.auth.getUser();
 
         if (!user) {
@@ -51,18 +54,18 @@ export function useDocumentPermissions(): UserPermissions {
           return;
         }
 
-        // Get user profile with role
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('role')
-          .eq('id', user.id)
-          .single();
+        let role: Awaited<ReturnType<typeof fetchMemberRole>> = null;
+        try {
+          role = await fetchMemberRole(typedSupabase, user.id);
+        } catch (roleError) {
+          console.error('Error loading member role:', roleError);
+        }
 
-        const role = profile?.role || 'user';
-        const isPropertyManager = role === 'property_manager';
-        const isAdmin = role === 'admin';
-        const isTenant = role === 'tenant';
-        const isRoommate = role === 'roommate';
+        const resolvedRole = role || 'user';
+        const isPropertyManager = resolvedRole === 'property_manager';
+        const isAdmin = resolvedRole === 'admin';
+        const isTenant = resolvedRole === 'tenant';
+        const isRoommate = resolvedRole === 'roommate';
 
         const userPermissions: UserPermissions = {
           isTenant,

--- a/lib/data/documents.ts
+++ b/lib/data/documents.ts
@@ -1,0 +1,103 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+import type { DocumentListFilters, DocumentStats, DocumentWithLease } from '@/types/documents';
+import type { Database } from '@/lib/supabase';
+
+type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
+
+type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
+
+type FetchDocumentsParams = {
+  client: SupabaseClientLike;
+  userId: string;
+  role: MemberRole | null | undefined;
+  filters?: DocumentListFilters;
+};
+
+type FetchDocumentStatsParams = {
+  client: SupabaseClientLike;
+  userId: string;
+  role: MemberRole | null | undefined;
+};
+
+const DOCUMENT_SELECT = `
+        *,
+        lease:leases(*),
+        signatures:document_signatures(*),
+        access_logs:document_access_logs(*, profiles:signer_id(username, full_name))
+      `;
+
+function handlePostgrestError(error: { message: string } | null, context: string) {
+  if (error) {
+    throw new Error(`${context}: ${error.message}`);
+  }
+}
+
+export async function fetchDocumentsList({
+  client,
+  userId,
+  role,
+  filters = {},
+}: FetchDocumentsParams): Promise<DocumentWithLease[]> {
+  let query = (client as any)
+    .from('documents')
+    .select(DOCUMENT_SELECT)
+    .order('created_at', { ascending: false });
+
+  if (role !== 'property_manager' && role !== 'admin') {
+    query = query.or(`tenant_id.eq.${userId},signatures.signer_id.eq.${userId}`);
+  }
+
+  if (filters.status?.length) {
+    query = query.in('status', filters.status);
+  }
+
+  if (filters.type?.length) {
+    query = query.in('document_type', filters.type);
+  }
+
+  if (filters.tenant_id) {
+    query = query.eq('tenant_id', filters.tenant_id);
+  }
+
+  if (filters.unit_id) {
+    query = query.eq('unit_id', filters.unit_id);
+  }
+
+  if (filters.date_from) {
+    query = query.gte('created_at', filters.date_from);
+  }
+
+  if (filters.date_to) {
+    query = query.lte('created_at', filters.date_to);
+  }
+
+  const { data, error } = await query;
+  handlePostgrestError(error, 'Failed to fetch documents');
+
+  return data ?? [];
+}
+
+export async function fetchDocumentStats({
+  client,
+  userId,
+  role,
+}: FetchDocumentStatsParams): Promise<DocumentStats> {
+  let query = client.from('documents').select('status');
+
+  if (role !== 'property_manager' && role !== 'admin') {
+    query = query.eq('tenant_id', userId);
+  }
+
+  const { data, error } = await query;
+  handlePostgrestError(error, 'Failed to fetch document statistics');
+
+  const documents = (data ?? []) as { status: string | null }[];
+
+  return {
+    total_documents: documents.length,
+    pending_signatures: documents.filter(d => d.status === 'pending_signature').length,
+    signed_documents: documents.filter(d => d.status === 'signed').length,
+    expired_documents: documents.filter(d => d.status === 'expired').length,
+    draft_documents: documents.filter(d => d.status === 'draft').length,
+  };
+}

--- a/lib/data/members.ts
+++ b/lib/data/members.ts
@@ -1,0 +1,81 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+import type { Database } from '@/lib/supabase';
+
+type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
+
+export type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
+
+export type MemberProfile = Pick<
+  Database['public']['Tables']['profiles']['Row'],
+  'id' | 'email' | 'full_name' | 'role' | 'unit_id'
+>;
+
+function handlePostgrestError(error: { message: string } | null, context: string) {
+  if (error) {
+    throw new Error(`${context}: ${error.message}`);
+  }
+}
+
+export async function fetchMemberRole(
+  client: SupabaseClientLike,
+  memberId: string
+): Promise<MemberRole | null> {
+  const { data, error } = await client
+    .from('profiles')
+    .select('role')
+    .eq('id', memberId)
+    .maybeSingle();
+
+  handlePostgrestError(error, 'Failed to load member role');
+
+  return (data?.role as MemberRole | null | undefined) ?? null;
+}
+
+export async function fetchMemberProfile(
+  client: SupabaseClientLike,
+  memberId: string
+): Promise<MemberProfile | null> {
+  const { data, error } = await client
+    .from('profiles')
+    .select('id, email, full_name, role, unit_id')
+    .eq('id', memberId)
+    .maybeSingle();
+
+  handlePostgrestError(error, 'Failed to load member profile');
+
+  if (!data) {
+    return null;
+  }
+
+  return data as MemberProfile;
+}
+
+interface FetchMembersByUnitOptions {
+  excludeUserId?: string;
+  roles?: MemberRole[];
+}
+
+export async function fetchMembersByUnit(
+  client: SupabaseClientLike,
+  unitId: string,
+  options: FetchMembersByUnitOptions = {}
+): Promise<MemberProfile[]> {
+  let query = client
+    .from('profiles')
+    .select('id, email, full_name, role, unit_id')
+    .eq('unit_id', unitId);
+
+  if (options.excludeUserId) {
+    query = query.neq('id', options.excludeUserId);
+  }
+
+  if (options.roles?.length) {
+    query = query.in('role', options.roles);
+  }
+
+  const { data, error } = await query;
+
+  handlePostgrestError(error, 'Failed to load members for unit');
+
+  return (data as MemberProfile[] | null | undefined) ?? [];
+}

--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import type { DocumentListFilters } from '@/types/documents';
+
+type QueryResult<T> = { data: T; error: { message: string } | null };
+
+type QueryBuilder<T> = {
+  select: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  or: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  gte: ReturnType<typeof vi.fn>;
+  lte: ReturnType<typeof vi.fn>;
+  then: (onFulfilled: (value: QueryResult<T>) => unknown) => Promise<unknown>;
+};
+
+function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
+  const builder: Partial<QueryBuilder<T>> & {
+    select: ReturnType<typeof vi.fn>;
+    order: ReturnType<typeof vi.fn>;
+    or: ReturnType<typeof vi.fn>;
+    in: ReturnType<typeof vi.fn>;
+    eq: ReturnType<typeof vi.fn>;
+    gte: ReturnType<typeof vi.fn>;
+    lte: ReturnType<typeof vi.fn>;
+  } = {
+    select: vi.fn().mockImplementation(() => builder),
+    order: vi.fn().mockImplementation(() => builder),
+    or: vi.fn().mockImplementation(() => builder),
+    in: vi.fn().mockImplementation(() => builder),
+    eq: vi.fn().mockImplementation(() => builder),
+    gte: vi.fn().mockImplementation(() => builder),
+    lte: vi.fn().mockImplementation(() => builder),
+  };
+
+  (builder as QueryBuilder<T>).then = (onFulfilled) =>
+    Promise.resolve(onFulfilled(result));
+
+  return builder as QueryBuilder<T>;
+}
+
+function createSupabaseStub<T extends unknown[]>(query: QueryBuilder<T>) {
+  return {
+    from: vi.fn((table: string) => {
+      expect(table).toBe('documents');
+      return query;
+    }),
+  };
+}
+
+describe('fetchDocumentsList', () => {
+  it('applies role scoping and filters for non privileged members', async () => {
+    const query = createDocumentsQuery({ data: [{ id: 'doc-1' }] as any, error: null });
+    const supabase = createSupabaseStub(query);
+
+    const filters: DocumentListFilters = {
+      status: ['draft', 'signed'],
+      type: ['lease'],
+      tenant_id: 'tenant-123',
+      unit_id: 'unit-456',
+      date_from: '2024-01-01',
+      date_to: '2024-12-31',
+    };
+
+    const documents = await fetchDocumentsList({
+      client: supabase,
+      userId: 'user-123',
+      role: 'tenant',
+      filters,
+    });
+
+    expect(documents).toEqual([{ id: 'doc-1' }]);
+    expect(query.or).toHaveBeenCalledWith('tenant_id.eq.user-123,signatures.signer_id.eq.user-123');
+    expect(query.in).toHaveBeenCalledWith('status', filters.status);
+    expect(query.in).toHaveBeenCalledWith('document_type', filters.type);
+    expect(query.eq).toHaveBeenCalledWith('tenant_id', filters.tenant_id);
+    expect(query.eq).toHaveBeenCalledWith('unit_id', filters.unit_id);
+    expect(query.gte).toHaveBeenCalledWith('created_at', filters.date_from);
+    expect(query.lte).toHaveBeenCalledWith('created_at', filters.date_to);
+  });
+
+  it('skips scoping for property managers and admins', async () => {
+    const query = createDocumentsQuery({ data: [], error: null });
+    const supabase = createSupabaseStub(query);
+
+    await fetchDocumentsList({
+      client: supabase,
+      userId: 'manager-1',
+      role: 'property_manager',
+    });
+
+    expect(query.or).not.toHaveBeenCalled();
+  });
+
+  it('throws when Supabase returns an error', async () => {
+    const query = createDocumentsQuery({ data: null as any, error: { message: 'boom' } });
+    const supabase = createSupabaseStub(query);
+
+    await expect(
+      fetchDocumentsList({ client: supabase, userId: 'user-1', role: 'tenant' })
+    ).rejects.toThrow(/Failed to fetch documents: boom/);
+  });
+});
+
+describe('fetchDocumentStats', () => {
+  it('computes stats for scoped users', async () => {
+    const query = createDocumentsQuery({
+      data: [
+        { status: 'draft' },
+        { status: 'signed' },
+        { status: 'pending_signature' },
+      ] as any,
+      error: null,
+    });
+    const supabase = createSupabaseStub(query);
+
+    const stats = await fetchDocumentStats({
+      client: supabase,
+      userId: 'tenant-1',
+      role: 'tenant',
+    });
+
+    expect(query.eq).toHaveBeenCalledWith('tenant_id', 'tenant-1');
+    expect(stats).toEqual({
+      total_documents: 3,
+      pending_signatures: 1,
+      signed_documents: 1,
+      expired_documents: 0,
+      draft_documents: 1,
+    });
+  });
+
+  it('omits tenant filter for admins', async () => {
+    const query = createDocumentsQuery({ data: [], error: null });
+    const supabase = createSupabaseStub(query);
+
+    await fetchDocumentStats({ client: supabase, userId: 'admin-1', role: 'admin' });
+
+    expect(query.eq).not.toHaveBeenCalled();
+  });
+
+  it('throws when Supabase returns an error', async () => {
+    const query = createDocumentsQuery({ data: null as any, error: { message: 'stats failed' } });
+    const supabase = createSupabaseStub(query);
+
+    await expect(
+      fetchDocumentStats({ client: supabase, userId: 'user-1', role: 'tenant' })
+    ).rejects.toThrow(/Failed to fetch document statistics: stats failed/);
+  });
+});

--- a/tests/lib/data/members.test.ts
+++ b/tests/lib/data/members.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchMemberProfile, fetchMemberRole, fetchMembersByUnit } from '@/lib/data/members';
+
+type SingleResult<T> = { data: T; error: { message: string } | null };
+
+type SingleBuilder<T> = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  maybeSingle: () => Promise<SingleResult<T>>;
+};
+
+function createSingleBuilder<T>(result: SingleResult<T>): SingleBuilder<T> {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  } as unknown as SingleBuilder<T>;
+}
+
+type MultiResult<T> = { data: T; error: { message: string } | null };
+
+type MultiBuilder<T> = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  neq: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  then: (onFulfilled: (value: MultiResult<T>) => unknown) => Promise<unknown>;
+};
+
+function createMultiBuilder<T>(result: MultiResult<T>): MultiBuilder<T> {
+  const builder: Partial<MultiBuilder<T>> & {
+    select: ReturnType<typeof vi.fn>;
+    eq: ReturnType<typeof vi.fn>;
+    neq: ReturnType<typeof vi.fn>;
+    in: ReturnType<typeof vi.fn>;
+  } = {
+    select: vi.fn().mockImplementation(() => builder),
+    eq: vi.fn().mockImplementation(() => builder),
+    neq: vi.fn().mockImplementation(() => builder),
+    in: vi.fn().mockImplementation(() => builder),
+  };
+
+  (builder as MultiBuilder<T>).then = (onFulfilled) =>
+    Promise.resolve(onFulfilled(result));
+
+  return builder as MultiBuilder<T>;
+}
+
+function createProfilesStub<T>(builder: unknown) {
+  return {
+    from: vi.fn((table: string) => {
+      expect(table).toBe('profiles');
+      return builder;
+    }),
+  };
+}
+
+describe('fetchMemberRole', () => {
+  it('returns the member role when available', async () => {
+    const builder = createSingleBuilder({ data: { role: 'tenant' }, error: null });
+    const supabase = createProfilesStub(builder);
+
+    const role = await fetchMemberRole(supabase as any, 'user-1');
+
+    expect(builder.select).toHaveBeenCalledWith('role');
+    expect(builder.eq).toHaveBeenCalledWith('id', 'user-1');
+    expect(role).toBe('tenant');
+  });
+
+  it('throws when supabase returns an error', async () => {
+    const builder = createSingleBuilder({ data: null, error: { message: 'role failed' } });
+    const supabase = createProfilesStub(builder);
+
+    await expect(fetchMemberRole(supabase as any, 'user-1')).rejects.toThrow(
+      /Failed to load member role: role failed/
+    );
+  });
+});
+
+describe('fetchMemberProfile', () => {
+  it('returns profile data when present', async () => {
+    const profile = {
+      id: 'user-1',
+      email: 'user@example.com',
+      full_name: 'User Example',
+      role: 'tenant',
+      unit_id: 'unit-1',
+    };
+    const builder = createSingleBuilder({ data: profile, error: null });
+    const supabase = createProfilesStub(builder);
+
+    const result = await fetchMemberProfile(supabase as any, 'user-1');
+
+    expect(builder.select).toHaveBeenCalledWith('id, email, full_name, role, unit_id');
+    expect(builder.eq).toHaveBeenCalledWith('id', 'user-1');
+    expect(result).toEqual(profile);
+  });
+
+  it('throws when supabase reports an error', async () => {
+    const builder = createSingleBuilder({ data: null, error: { message: 'profile boom' } });
+    const supabase = createProfilesStub(builder);
+
+    await expect(fetchMemberProfile(supabase as any, 'user-1')).rejects.toThrow(
+      /Failed to load member profile: profile boom/
+    );
+  });
+});
+
+describe('fetchMembersByUnit', () => {
+  it('applies filters and returns members', async () => {
+    const members = [
+      { id: 'user-1', email: '1@example.com', full_name: 'One', role: 'tenant', unit_id: 'unit-1' },
+      { id: 'user-2', email: '2@example.com', full_name: 'Two', role: 'roommate', unit_id: 'unit-1' },
+    ];
+    const builder = createMultiBuilder({ data: members, error: null });
+    const supabase = createProfilesStub(builder);
+
+    const result = await fetchMembersByUnit(supabase as any, 'unit-1', {
+      excludeUserId: 'user-2',
+      roles: ['tenant'],
+    });
+
+    expect(builder.select).toHaveBeenCalledWith('id, email, full_name, role, unit_id');
+    expect(builder.eq).toHaveBeenCalledWith('unit_id', 'unit-1');
+    expect(builder.neq).toHaveBeenCalledWith('id', 'user-2');
+    expect(builder.in).toHaveBeenCalledWith('role', ['tenant']);
+    expect(result).toEqual(members);
+  });
+
+  it('throws when supabase returns an error', async () => {
+    const builder = createMultiBuilder({ data: null as any, error: { message: 'unit failed' } });
+    const supabase = createProfilesStub(builder);
+
+    await expect(
+      fetchMembersByUnit(supabase as any, 'unit-1')
+    ).rejects.toThrow(/Failed to load members for unit: unit failed/);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared document and member query helpers under `lib/data`
- refactor document actions, dashboard nav, and client forms to consume the shared utilities
- cover the new helpers with Vitest unit tests and document their usage in `docs/perf/data-fetching.md`

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d15d63d90c8328be8186d7fc1e9deb