### PR TITLE
Add circuit breaker and fallbacks for external services

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -48,6 +48,7 @@ interface ActionResult<T = any> {
   data?: T;
   error?: string;
   message?: string;
+  fallbackNotice?: string;
 }
 
 // Get documents with optional filters
@@ -307,6 +308,15 @@ export async function createSigningRequestAction(
 
     // Upload file to Documenso to obtain documentDataId
     const uploadResult = await documensoService.uploadDocument(file);
+    const uploadResponse = uploadResult.data;
+
+    if (!uploadResponse) {
+      return {
+        success: false,
+        error: 'Failed to upload document to Documenso.',
+        fallbackNotice: uploadResult.error,
+      };
+    }
 
     // Get tenant emails for lease documents
     let tenantEmails = [validatedData.signer_email];
@@ -335,7 +345,7 @@ export async function createSigningRequestAction(
     // Create signing request via Documenso
     const signingResult = await documensoService.createDocumentSigningEnvelope({
       title: document.title,
-      documentDataId: uploadResult.documentDataId,
+      documentDataId: uploadResponse.documentDataId,
       recipients: tenantEmails.map((email, index) => ({
         email,
         name: tenantNames[index] || email.split('@')[0],
@@ -348,7 +358,9 @@ export async function createSigningRequestAction(
         : undefined,
     });
 
-    if (!signingResult) {
+    const envelope = signingResult.data;
+
+    if (!envelope) {
       return { success: false, error: 'Failed to create signing request.' };
     }
 
@@ -356,7 +368,7 @@ export async function createSigningRequestAction(
     await (supabase as any)
       .from('documents')
       .update({
-        documenso_envelope_id: signingResult.id,
+        documenso_envelope_id: envelope.id,
         status: 'pending_signature'
       })
       .eq('id', document.id);
@@ -379,7 +391,7 @@ export async function createSigningRequestAction(
       }
     }
 
-    for (const recipient of signingResult.recipients) {
+    for (const recipient of envelope.recipients) {
       const signerId = emailToProfileId.get(recipient.email);
       if (!signerId) {
         continue; // skip recipients we cannot map to a user
@@ -400,14 +412,32 @@ export async function createSigningRequestAction(
     await supabase.rpc('log_document_access', {
       p_document_id: document.id,
       p_action: 'signing_request_created',
-      p_metadata: { envelope_id: signingResult.id, recipients: tenantEmails }
+      p_metadata: { envelope_id: envelope.id, recipients: tenantEmails }
     });
+
+    const fallbackMessages: string[] = [];
+
+    const signingUrlResult = await documensoService.getSigningUrl(
+      envelope.id,
+      envelope.recipients[0].id
+    );
+
+    if (signingUrlResult.fromCache) {
+      fallbackMessages.push(
+        'Documenso service is degraded. Showing cached signing link which may be stale.'
+      );
+    }
+
+    if (signingUrlResult.error) {
+      fallbackMessages.push(signingUrlResult.error);
+    }
 
     revalidatePath('/documents');
     return {
       success: true,
-      data: { envelope_id: signingResult.id },
-      message: 'Signing request created successfully.'
+      data: { envelope_id: envelope.id, signing_url: signingUrlResult.data || undefined },
+      message: 'Signing request created successfully.',
+      fallbackNotice: fallbackMessages.join(' ') || undefined,
     };
   } catch (error) {
     console.error('Unexpected error in createSigningRequestAction:', error);
@@ -529,12 +559,26 @@ export async function getSigningUrlAction(
     }
 
     // Get signing URL from Documenso
-    const url = await documensoService.getSigningUrl(
+    const signingUrlResult = await documensoService.getSigningUrl(
       document.documenso_envelope_id,
       signature.documenso_signature_id
     );
 
-    return { success: true, data: { signing_url: url } };
+    const fallbackMessages: string[] = [];
+    if (signingUrlResult.fromCache) {
+      fallbackMessages.push(
+        'Documenso is currently unavailable. Serving a cached signing link.'
+      );
+    }
+    if (signingUrlResult.error) {
+      fallbackMessages.push(signingUrlResult.error);
+    }
+
+    return {
+      success: true,
+      data: { signing_url: signingUrlResult.data },
+      fallbackNotice: fallbackMessages.join(' ') || undefined,
+    };
   } catch (error) {
     console.error('Unexpected error in getSigningUrlAction:', error);
     return {

--- a/app/documents/components/create-signature-dialog.tsx
+++ b/app/documents/components/create-signature-dialog.tsx
@@ -76,6 +76,9 @@ export function CreateSignatureDialog({
 
       if (result.success) {
         toast.success('Signing request created successfully');
+        if (result.fallbackNotice) {
+          toast.warning(result.fallbackNotice);
+        }
         onOpenChange(false);
         setFormData({
           signer_email: '',

--- a/app/documents/components/document-actions.tsx
+++ b/app/documents/components/document-actions.tsx
@@ -37,6 +37,9 @@ export function DocumentActions({ document }: DocumentActionsProps) {
       // If we have an external signing flow via Documenso, open it
       const urlResult = await getSigningUrlAction(document.id);
       if (urlResult.success && urlResult.data?.signing_url) {
+        if (urlResult.fallbackNotice) {
+          toast.warning(urlResult.fallbackNotice);
+        }
         window.open(urlResult.data.signing_url, '_blank');
         setLoading(null);
         return;

--- a/app/schedule/actions/index.tsx
+++ b/app/schedule/actions/index.tsx
@@ -55,7 +55,7 @@ export async function scheduleMeetingAction(
   const { data: { user }, error: authError } = await supabase.auth.getUser();
   if (authError || !user) {
     console.error('Authentication error in server action:', authError);
-    return { success: false, message: null, error: 'You must be logged in to schedule a meeting.', googleEventLink: null };
+    return { success: false, message: null, error: 'You must be logged in to schedule a meeting.', googleEventLink: null, fallbackNotice: null };
   }
 
    // 2. Validate Form Data (using the updated schema with coerce)
@@ -79,7 +79,7 @@ export async function scheduleMeetingAction(
            .map(errors => errors?.join('. '))
            .filter(Boolean)
            .join(' ');
-       return { success: false, message: null, error: errorMessages || 'Invalid form data provided.', googleEventLink: null };
+       return { success: false, message: null, error: errorMessages || 'Invalid form data provided.', googleEventLink: null, fallbackNotice: null };
    }
 
    // --- IMPORTANT: validationResult.data now contains actual Date objects ---
@@ -88,7 +88,7 @@ export async function scheduleMeetingAction(
    // 3. Basic check: User email from form should match logged-in user
    if (validatedData.userEmail !== user.email) {
        console.error(`Security Alert: Form email (${validatedData.userEmail}) does not match authenticated user (${user.email})`);
-       return { success: false, message: null, error: 'User email mismatch.', googleEventLink: null };
+       return { success: false, message: null, error: 'User email mismatch.', googleEventLink: null, fallbackNotice: null };
    }
 
 
@@ -104,14 +104,27 @@ export async function scheduleMeetingAction(
       description: validatedData.description || `Scheduled by ${validatedData.userEmail}`,
     });
 
-    if (!calendarResult.success || !calendarResult.eventId) {
-      console.error("Failed to create Google Calendar event:", calendarResult.error);
-      // Pass specific Google error back if available
-      const errorMessage = calendarResult.error || 'Failed to create Google Calendar event.';
-      return { success: false, message: null, error: errorMessage, googleEventLink: null };
+    const eventData = calendarResult.data;
+    const fallbackNotice =
+      calendarResult.fromCache
+        ? calendarResult.error ||
+          'Google Calendar is unavailable. We are using cached data for reference.'
+        : undefined;
+
+    if (!eventData || !eventData.success || !eventData.eventId) {
+      console.error('Failed to create Google Calendar event:', eventData?.error || calendarResult.error);
+      const errorMessage =
+        eventData?.error || calendarResult.error || 'Failed to create Google Calendar event.';
+      return {
+        success: false,
+        message: null,
+        error: errorMessage,
+        googleEventLink: eventData?.link || null,
+        fallbackNotice,
+      };
     }
 
-    console.log(`Google Event created: ${calendarResult.eventId}, Link: ${calendarResult.link}`);
+    console.log(`Google Event created: ${eventData.eventId}, Link: ${eventData.link}`);
 
     // 5. Store meeting info in Supabase DB
     //    Pass the validated Date objects directly to the Supabase client.
@@ -122,7 +135,7 @@ export async function scheduleMeetingAction(
         user_id: user.id,
         start_time: validatedData.startTime, // Pass Date object
         end_time: validatedData.endTime,     // Pass Date object
-        google_event_id: calendarResult.eventId,
+        google_event_id: eventData.eventId,
         summary: validatedData.summary,
       });
 
@@ -140,10 +153,11 @@ export async function scheduleMeetingAction(
 
     // 7. Return success state
     return {
-        success: true,
-        message: 'Meeting scheduled successfully! Check your email for the invite.',
-        error: null,
-        googleEventLink: calendarResult.link,
+      success: true,
+      message: 'Meeting scheduled successfully! Check your email for the invite.',
+      error: null,
+      googleEventLink: eventData.link,
+      fallbackNotice,
     };
 
   } catch (error) {
@@ -152,6 +166,6 @@ export async function scheduleMeetingAction(
      if (error instanceof Error) {
          errorMessage = error.message;
      }
-    return { success: false, message: null, error: errorMessage, googleEventLink: null };
+    return { success: false, message: null, error: errorMessage, googleEventLink: null, fallbackNotice: null };
   }
 }

--- a/components/schedule-form.tsx
+++ b/components/schedule-form.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button'
 import { scheduleMeetingAction } from '@/app/schedule/actions';
 import { useFormState, useFormStatus } from 'react-dom';
 import { DayPicker } from 'react-day-picker';
 import * as z from 'zod'; // Import Zod
+import { toast } from 'sonner';
 import {
     format,
     formatISO,
@@ -51,11 +52,18 @@ interface ScheduleFormProps {
   userName: string;
 }
 
-const initialState: { message: string | null; error: string | null; success: boolean; googleEventLink?: string | null } = {
+const initialState: {
+  message: string | null;
+  error: string | null;
+  success: boolean;
+  googleEventLink?: string | null;
+  fallbackNotice?: string | null;
+} = {
   message: null,
   error: null,
   success: false,
   googleEventLink: null,
+  fallbackNotice: null,
 };
 
 const MEETING_DURATION_MINUTES = 60;
@@ -90,6 +98,12 @@ export function ScheduleForm({ userEmail, userName }: ScheduleFormProps) {
   const [selectedTimeSlot, setSelectedTimeSlot] = useState<string | undefined>(undefined);
   // Client-side validation state
   const [clientErrors, setClientErrors] = useState<ClientValidationErrors | null>(null);
+
+  useEffect(() => {
+    if (serverState?.fallbackNotice) {
+      toast.warning(serverState.fallbackNotice);
+    }
+  }, [serverState?.fallbackNotice]);
 
 
   const availableTimeSlots = useMemo(() => {
@@ -203,9 +217,14 @@ export function ScheduleForm({ userEmail, userName }: ScheduleFormProps) {
           )}
         </p>
       )}
-       {serverState?.error && (
+      {serverState?.error && (
         <p className="rounded bg-red-100 p-3 text-sm text-red-800">
           Server Error: {serverState.error}
+        </p>
+      )}
+      {serverState?.fallbackNotice && (
+        <p className="rounded bg-yellow-100 p-3 text-sm text-yellow-800">
+          {serverState.fallbackNotice}
         </p>
       )}
 

--- a/config/external-apis.ts
+++ b/config/external-apis.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+
+const numberSchema = z
+  .string()
+  .transform((value) => Number(value))
+  .pipe(z.number().min(0))
+  .optional();
+
+function parseNumberEnv(key: string, fallback: number): number {
+  const value = process.env[key];
+  if (!value) {
+    return fallback;
+  }
+
+  const result = numberSchema.safeParse(value.trim());
+  if (!result.success) {
+    console.warn(`Invalid value provided for ${key}. Using fallback ${fallback}.`);
+    return fallback;
+  }
+
+  return result.data;
+}
+
+export interface ExternalApiBaseConfig {
+  timeoutMs: number;
+  maxRetries: number;
+  failureThreshold: number;
+  cooldownMs: number;
+  cacheTtlMs: number;
+  halfOpenSuccesses: number;
+}
+
+const defaults: ExternalApiBaseConfig = {
+  timeoutMs: parseNumberEnv('EXTERNAL_API_TIMEOUT_MS', 10000),
+  maxRetries: parseNumberEnv('EXTERNAL_API_MAX_RETRIES', 2),
+  failureThreshold: parseNumberEnv('EXTERNAL_API_CIRCUIT_BREAKER_FAILURE_THRESHOLD', 3),
+  cooldownMs: parseNumberEnv('EXTERNAL_API_CIRCUIT_BREAKER_COOLDOWN_MS', 60000),
+  cacheTtlMs: parseNumberEnv('EXTERNAL_API_CACHE_TTL_MS', 5 * 60 * 1000),
+  halfOpenSuccesses: parseNumberEnv('EXTERNAL_API_HALF_OPEN_SUCCESS_THRESHOLD', 1),
+};
+
+type ProviderKeys = keyof ExternalApiBaseConfig;
+
+const providerOverrides: Record<ProviderKeys, string> = {
+  timeoutMs: 'API_TIMEOUT_MS',
+  maxRetries: 'API_MAX_RETRIES',
+  failureThreshold: 'API_FAILURE_THRESHOLD',
+  cooldownMs: 'API_COOLDOWN_MS',
+  cacheTtlMs: 'API_CACHE_TTL_MS',
+  halfOpenSuccesses: 'API_HALF_OPEN_SUCCESS_THRESHOLD',
+};
+
+function toEnvPrefix(provider: string): string {
+  return provider
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_');
+}
+
+export function getExternalApiConfig(provider: string): ExternalApiBaseConfig {
+  const prefix = toEnvPrefix(provider);
+
+  const resolved: Partial<Record<ProviderKeys, number>> = {};
+
+  (Object.keys(providerOverrides) as ProviderKeys[]).forEach((key) => {
+    const envKey = `${prefix}_${providerOverrides[key]}`;
+    const value = process.env[envKey];
+    if (value) {
+      const parsed = numberSchema.safeParse(value.trim());
+      if (parsed.success) {
+        resolved[key] = parsed.data;
+      } else {
+        console.warn(`Invalid value provided for ${envKey}. Using fallback ${defaults[key]}.`);
+      }
+    }
+  });
+
+  return {
+    timeoutMs: resolved.timeoutMs ?? defaults.timeoutMs,
+    maxRetries: resolved.maxRetries ?? defaults.maxRetries,
+    failureThreshold: resolved.failureThreshold ?? defaults.failureThreshold,
+    cooldownMs: resolved.cooldownMs ?? defaults.cooldownMs,
+    cacheTtlMs: resolved.cacheTtlMs ?? defaults.cacheTtlMs,
+    halfOpenSuccesses: resolved.halfOpenSuccesses ?? defaults.halfOpenSuccesses,
+  };
+}
+
+export const externalApiDefaults = defaults;

--- a/docs/ops/external-apis.md
+++ b/docs/ops/external-apis.md
@@ -1,0 +1,47 @@
+# External API Resilience Configuration
+
+The portal wraps integrations with Cal.com, Documenso, and Google Calendar with common retry, timeout, and circuit-breaker logic. This page documents the configuration knobs that control that behaviour.
+
+## Global settings
+
+The following environment variables apply to all providers unless a provider-specific override is supplied. Values are read at process start and expressed in milliseconds unless noted otherwise.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `EXTERNAL_API_TIMEOUT_MS` | Maximum duration for a single outbound request before it is aborted. | `10000` (10 seconds) |
+| `EXTERNAL_API_MAX_RETRIES` | Number of retry attempts performed via `p-retry` after a transient failure or timeout. | `2` |
+| `EXTERNAL_API_CIRCUIT_BREAKER_FAILURE_THRESHOLD` | Consecutive failures before a circuit transitions to the open state. | `3` |
+| `EXTERNAL_API_CIRCUIT_BREAKER_COOLDOWN_MS` | How long an open circuit waits before allowing a half-open probe. | `60000` (60 seconds) |
+| `EXTERNAL_API_CACHE_TTL_MS` | Time-to-live for cached successful responses that are used when a provider is unavailable. | `300000` (5 minutes) |
+| `EXTERNAL_API_HALF_OPEN_SUCCESS_THRESHOLD` | Number of consecutive half-open successes required before closing the circuit. | `1` |
+
+## Provider overrides
+
+Each provider can override the global defaults by exporting environment variables that follow the pattern `<PROVIDER>_API_<SETTING>`. Provider prefixes are:
+
+- `CALCOM`
+- `DOCUMENSO`
+- `GOOGLE_CALENDAR`
+
+Available suffixes mirror the global settings: `API_TIMEOUT_MS`, `API_MAX_RETRIES`, `API_FAILURE_THRESHOLD`, `API_COOLDOWN_MS`, `API_CACHE_TTL_MS`, and `API_HALF_OPEN_SUCCESS_THRESHOLD`.
+
+For example, to increase the Cal.com timeout to 15 seconds while leaving other services untouched:
+
+```bash
+CALCOM_API_TIMEOUT_MS=15000
+```
+
+## Behaviour summary
+
+- Calls are retried with `p-retry` and aborted when the configured timeout is exceeded.
+- When a circuit is open, read operations return cached responses (if available) or the configured fallback value instead of making upstream calls.
+- Circuit state and cache metadata are exposed to the UI so we can surface degraded mode notices.
+
+## User-facing fallbacks
+
+When cached data is served or a provider is unavailable:
+
+- Document signing flows display a toast warning and inline banner explaining that Documenso data may be stale.
+- Scheduling events through Google Calendar raises a warning toast and inline callout whenever the service falls back to cached metadata or cannot create a new event.
+
+These cues help operators understand when external systems are degraded and decide whether to retry or escalate.

--- a/lib/calcom-service.ts
+++ b/lib/calcom-service.ts
@@ -1,3 +1,6 @@
+import { ExternalApiResult } from '@/lib/circuit-breaker';
+import { calComCircuitBreaker } from '@/lib/external-integrations';
+
 interface CalComCreateBookingRequest {
   start: string;
   end: string;
@@ -38,29 +41,39 @@ class CalComService {
   /**
    * Get event types for a specific user or team
    */
-  async getEventTypes(userSlug?: string): Promise<CalComEventType[]> {
+  async getEventTypes(userSlug?: string): Promise<ExternalApiResult<CalComEventType[]>> {
     const endpoint = userSlug
       ? `${this.baseUrl}/api/v1/event-types/${userSlug}`
       : `${this.baseUrl}/api/v1/event-types`;
 
-    try {
-      const response = await fetch(endpoint, {
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
+    return calComCircuitBreaker.execute(
+      userSlug ? `event-types:${userSlug}` : 'event-types',
+      async () => {
+        const response = await fetch(endpoint, {
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => response.statusText);
+          throw new Error(
+            `Failed to fetch event types: ${response.status} ${response.statusText} ${errorText}`.trim()
+          );
+        }
+
+        const data = await response.json();
+        return data.eventTypes || [];
+      },
+      {
+        fallbackValue: [],
+        context: {
+          operation: 'getEventTypes',
+          endpoint,
         },
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch event types: ${response.statusText}`);
       }
-
-      const data = await response.json();
-      return data.eventTypes || [];
-    } catch (error) {
-      console.error('Error fetching Cal.com event types:', error);
-      return [];
-    }
+    );
   }
 
   /**
@@ -69,98 +82,127 @@ class CalComService {
   async createBooking(
     eventTypeId: number,
     bookingData: CalComCreateBookingRequest
-  ): Promise<CalComBookingResponse> {
-    try {
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings`,
-        {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            eventTypeId,
-            start: bookingData.start,
-            end: bookingData.end,
-            title: bookingData.title,
-            description: bookingData.description,
-            attendees: bookingData.attendees,
-            location: bookingData.location,
-          }),
-        }
-      );
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(
-          errorData.message || `Failed to create booking: ${response.statusText}`
+  ): Promise<ExternalApiResult<CalComBookingResponse>> {
+    return calComCircuitBreaker.execute(
+      `bookings:create:${eventTypeId}`,
+      async () => {
+        const response = await fetch(
+          `${this.baseUrl}/api/v1/bookings`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${this.apiKey}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              eventTypeId,
+              start: bookingData.start,
+              end: bookingData.end,
+              title: bookingData.title,
+              description: bookingData.description,
+              attendees: bookingData.attendees,
+              location: bookingData.location,
+            }),
+          }
         );
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(
+            errorData.message || `Failed to create booking: ${response.status} ${response.statusText}`
+          );
+        }
+
+        const data = await response.json();
+
+        return {
+          success: true,
+          bookingId: data.booking?.id?.toString(),
+          bookingUrl: data.booking?.url,
+        } satisfies CalComBookingResponse;
+      },
+      {
+        cacheResult: false,
+        fallbackValue: {
+          success: false,
+          error: 'Cal.com booking service is currently unavailable. Your request was not processed.',
+        },
+        context: {
+          operation: 'createBooking',
+          eventTypeId,
+        },
       }
-
-      const data = await response.json();
-
-      return {
-        success: true,
-        bookingId: data.booking?.id?.toString(),
-        bookingUrl: data.booking?.url,
-      };
-    } catch (error) {
-      console.error('Error creating Cal.com booking:', error);
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to create booking',
-      };
-    }
+    );
   }
 
   /**
    * Cancel a booking
    */
-  async cancelBooking(bookingId: string): Promise<boolean> {
-    try {
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings/${bookingId}/cancel`,
-        {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
+  async cancelBooking(bookingId: string): Promise<ExternalApiResult<boolean>> {
+    return calComCircuitBreaker.execute(
+      `bookings:cancel:${bookingId}`,
+      async () => {
+        const response = await fetch(
+          `${this.baseUrl}/api/v1/bookings/${bookingId}/cancel`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${this.apiKey}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        );
 
-      return response.ok;
-    } catch (error) {
-      console.error('Error canceling Cal.com booking:', error);
-      return false;
-    }
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => response.statusText);
+          throw new Error(`Failed to cancel booking: ${response.status} ${errorText}`.trim());
+        }
+
+        return true;
+      },
+      {
+        cacheResult: false,
+        fallbackValue: false,
+        context: {
+          operation: 'cancelBooking',
+          bookingId,
+        },
+      }
+    );
   }
 
   /**
    * Get booking details
    */
-  async getBooking(bookingId: string): Promise<any> {
-    try {
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings/${bookingId}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
+  async getBooking(bookingId: string): Promise<ExternalApiResult<any>> {
+    return calComCircuitBreaker.execute(
+      `bookings:get:${bookingId}`,
+      async () => {
+        const response = await fetch(
+          `${this.baseUrl}/api/v1/bookings/${bookingId}`,
+          {
+            headers: {
+              Authorization: `Bearer ${this.apiKey}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => response.statusText);
+          throw new Error(`Failed to fetch booking: ${response.status} ${errorText}`.trim());
         }
-      );
 
-      if (!response.ok) {
-        throw new Error(`Failed to fetch booking: ${response.statusText}`);
+        return await response.json();
+      },
+      {
+        fallbackValue: null,
+        context: {
+          operation: 'getBooking',
+          bookingId,
+        },
       }
-
-      return await response.json();
-    } catch (error) {
-      console.error('Error fetching Cal.com booking:', error);
-      return null;
-    }
+    );
   }
 
   /**
@@ -170,32 +212,42 @@ class CalComService {
     userEmail: string,
     startDate?: string,
     endDate?: string
-  ): Promise<any[]> {
-    try {
-      const params = new URLSearchParams();
-      if (startDate) params.append('startDate', startDate);
-      if (endDate) params.append('endDate', endDate);
+  ): Promise<ExternalApiResult<any[]>> {
+    return calComCircuitBreaker.execute(
+      `bookings:list:${userEmail}`,
+      async () => {
+        const params = new URLSearchParams();
+        if (startDate) params.append('startDate', startDate);
+        if (endDate) params.append('endDate', endDate);
 
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings?${params.toString()}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
+        const response = await fetch(
+          `${this.baseUrl}/api/v1/bookings?${params.toString()}`,
+          {
+            headers: {
+              Authorization: `Bearer ${this.apiKey}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => response.statusText);
+          throw new Error(`Failed to fetch user bookings: ${response.status} ${errorText}`.trim());
         }
-      );
 
-      if (!response.ok) {
-        throw new Error(`Failed to fetch user bookings: ${response.statusText}`);
+        const data = await response.json();
+        return data.bookings || [];
+      },
+      {
+        fallbackValue: [],
+        context: {
+          operation: 'getUserBookings',
+          userEmail,
+          startDate,
+          endDate,
+        },
       }
-
-      const data = await response.json();
-      return data.bookings || [];
-    } catch (error) {
-      console.error('Error fetching Cal.com user bookings:', error);
-      return [];
-    }
+    );
   }
 }
 
@@ -224,23 +276,32 @@ export async function createAmenityBooking({
   userEmail: string;
   userName: string;
   description?: string;
-}): Promise<CalComBookingResponse> {
-  // Get available event types for amenities
-  const eventTypes = await calComService.getEventTypes();
+}): Promise<ExternalApiResult<CalComBookingResponse>> {
+  const eventTypesResult = await calComService.getEventTypes();
+  const eventTypes = eventTypesResult.data;
 
-  // Find the appropriate event type for the amenity
   const amenityEventType = eventTypes.find(
     (et) => et.title.toLowerCase().includes(amenityType.toLowerCase()) && !et.hidden
   );
 
   if (!amenityEventType) {
     return {
-      success: false,
-      error: `No booking slot available for ${amenityType}. Please try a different time or contact support.`,
+      data: {
+        success: false,
+        error: `No booking slot available for ${amenityType}. Please try a different time or contact support.`,
+      },
+      fromCache: eventTypesResult.fromCache,
+      breakerState: eventTypesResult.breakerState,
+      error:
+        eventTypesResult.error ||
+        `Unable to determine event type for ${amenityType}.`,
+      metadata: {
+        eventTypes: eventTypesResult.metadata,
+      },
     };
   }
 
-  return await calComService.createBooking(amenityEventType.id, {
+  const bookingResult = await calComService.createBooking(amenityEventType.id, {
     start: startTime,
     end: endTime,
     title: `${amenityType} - ${userName}`,
@@ -253,9 +314,20 @@ export async function createAmenityBooking({
     ],
     location: 'Property Amenity',
   });
+
+  return {
+    data: bookingResult.data,
+    fromCache: bookingResult.fromCache || eventTypesResult.fromCache,
+    breakerState: bookingResult.breakerState,
+    error: bookingResult.error ?? eventTypesResult.error,
+    metadata: {
+      ...(bookingResult.metadata ?? {}),
+      eventTypes: eventTypesResult.metadata,
+    },
+  };
 }
 
-export async function cancelAmenityBooking(bookingId: string): Promise<boolean> {
+export async function cancelAmenityBooking(bookingId: string): Promise<ExternalApiResult<boolean>> {
   return await calComService.cancelBooking(bookingId);
 }
 
@@ -263,6 +335,6 @@ export async function getAmenityBookings(
   userEmail: string,
   startDate?: string,
   endDate?: string
-): Promise<any[]> {
+): Promise<ExternalApiResult<any[]>> {
   return await calComService.getUserBookings(userEmail, startDate, endDate);
 }

--- a/lib/calendar-service.ts
+++ b/lib/calendar-service.ts
@@ -1,5 +1,8 @@
 import { google } from 'googleapis';
-import { GaxiosError } from 'gaxios'; // Part of googleapis
+import { GaxiosError } from 'gaxios';
+
+import { ExternalApiResult } from '@/lib/circuit-breaker';
+import { googleCalendarCircuitBreaker } from '@/lib/external-integrations';
 
 // Configure the Google OAuth2 client
 const oauth2Client = new google.auth.OAuth2(
@@ -24,7 +27,7 @@ interface CreateEventOptions {
   summary: string;
   description: string;
   startTime: string; // ISO 8601 format (e.g., '2025-05-20T10:00:00-04:00')
-  endTime: string;   // ISO 8601 format
+  endTime: string; // ISO 8601 format
   attendeeEmail: string; // Email of the user scheduling the meeting
   attendeeName?: string; // Optional name of the user
 }
@@ -39,72 +42,104 @@ export async function createGoogleCalendarEvent({
   endTime,
   attendeeEmail,
   attendeeName,
-}: CreateEventOptions) {
+}: CreateEventOptions): Promise<ExternalApiResult<{ success: boolean; eventId?: string; link?: string; error?: string }>> {
   console.log(`Attempting to create event for ${attendeeEmail} from ${startTime} to ${endTime}`);
 
-  try {
-    const event = {
-      summary: summary,
-      description: description,
-      start: {
-        dateTime: startTime,
-        // Optional: Specify the time zone, otherwise it uses calendar's default
-        // timeZone: 'America/New_York',
+  const result = await googleCalendarCircuitBreaker.execute(
+    'create-event',
+    async () => {
+      const event = {
+        summary,
+        description,
+        start: {
+          dateTime: startTime,
+        },
+        end: {
+          dateTime: endTime,
+        },
+        attendees: [
+          { email: attendeeEmail, displayName: attendeeName },
+        ],
+        sendNotifications: true,
+      };
+
+      try {
+        const response = await calendar.events.insert({
+          calendarId: OWNER_CALENDAR_ID,
+          requestBody: event,
+        });
+
+        console.log('Google Calendar Event created: %s', response.data.htmlLink);
+        return {
+          success: true,
+          eventId: response.data.id,
+          link: response.data.htmlLink,
+        };
+      } catch (error) {
+        const message = mapGoogleCalendarError(error);
+        throw new Error(message);
+      }
+    },
+    {
+      fallbackValue: {
+        success: false,
+        error: 'Google Calendar event could not be created. Service unavailable.',
       },
-      end: {
-        dateTime: endTime,
-        // timeZone: 'America/New_York',
+      context: {
+        operation: 'createGoogleCalendarEvent',
+        summary,
+        attendeeEmail,
       },
-      // Add the user who scheduled the meeting as an attendee
-      attendees: [
-        { email: attendeeEmail, displayName: attendeeName },
-        // Optionally add the owner explicitly if needed, though they are the organizer
-        // { email: OWNER_CALENDAR_ID } // Only if OWNER_CALENDAR_ID is an email
-      ],
-      // Send notifications to attendees
-      sendNotifications: true,
-      // Optional: Add conference data (e.g., Google Meet link)
-      // conferenceData: {
-      //   createRequest: {
-      //     requestId: `meet-${Date.now()}`, // Unique request ID
-      //     conferenceSolutionKey: { type: 'hangoutsMeet' },
-      //   },
-      // },
+    }
+  );
+
+  if (result.fromCache) {
+    const fallbackMessage =
+      result.error ||
+      'Google Calendar service unavailable. Returning cached event details for reference.';
+    return {
+      ...result,
+      data: {
+        success: false,
+        eventId: result.data?.eventId,
+        link: result.data?.link,
+        error: fallbackMessage,
+      },
+      error: fallbackMessage,
     };
-
-    const response = await calendar.events.insert({
-      calendarId: OWNER_CALENDAR_ID,
-      requestBody: event,
-      // conferenceDataVersion: 1, // Required if adding conferenceData
-    });
-
-    console.log('Google Calendar Event created: %s', response.data.htmlLink);
-    return { success: true, eventId: response.data.id, link: response.data.htmlLink };
-
-  } catch (error: unknown) {
-    console.error('Error creating Google Calendar event:');
-    if (error instanceof GaxiosError) {
-        console.error('Gaxios Error:', error.response?.status, error.response?.data);
-    } else if (error instanceof Error) {
-         console.error(error.message);
-    } else {
-        console.error('An unknown error occurred', error);
-    }
-
-    // More specific error handling
-    if (error instanceof GaxiosError && error.response?.status === 401) {
-       console.error('Authentication error: Check Google credentials (Refresh Token might be expired or invalid).');
-       return { success: false, error: 'Authentication error with Google Calendar.' };
-    }
-     if (error instanceof GaxiosError && error.response?.status === 403) {
-        console.error('Permission error: Ensure the Calendar API is enabled and the refresh token has the correct scope (calendar.events).');
-       return { success: false, error: 'Permission error with Google Calendar.' };
-    }
-    if (error instanceof GaxiosError && error.response?.status === 400) {
-        console.error('Bad Request: Check event data format (dates, emails etc).', error.response?.data?.error?.errors);
-       return { success: false, error: `Invalid meeting data: ${error.response?.data?.error?.message || 'Check input format.'}` };
-    }
-
-    return { success: false, error: 'Failed to create Google Calendar event.' };
   }
+
+  return result;
+}
+
+function mapGoogleCalendarError(error: unknown): string {
+  console.error('Error creating Google Calendar event:');
+  if (error instanceof GaxiosError) {
+    const status = error.response?.status;
+    console.error('Gaxios Error:', status, error.response?.data);
+
+    if (status === 401) {
+      return 'Authentication error with Google Calendar.';
+    }
+
+    if (status === 403) {
+      return 'Permission error with Google Calendar.';
+    }
+
+    if (status === 400) {
+      const message = error.response?.data?.error?.message;
+      return `Invalid meeting data: ${message || 'Check input format.'}`;
+    }
+
+    const message = error.response?.data?.error?.message;
+    return message ? `Google Calendar error: ${message}` : 'Failed to create Google Calendar event.';
+  }
+
+  if (error instanceof Error) {
+    console.error(error.message);
+    return error.message;
+  }
+
+  console.error('An unknown error occurred', error);
+  return 'Failed to create Google Calendar event.';
 }

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -1,0 +1,295 @@
+import pRetry, { FailedAttemptError } from 'p-retry';
+
+export type CircuitBreakerState = 'closed' | 'open' | 'half-open';
+export type FallbackReason = 'open' | 'error';
+
+interface CircuitBreakerOptions {
+  name: string;
+  failureThreshold: number;
+  cooldownPeriod: number;
+  halfOpenSuccessThreshold?: number;
+  cacheTtlMs: number;
+  maxRetries: number;
+  timeoutMs: number;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+  cachedAt: number;
+}
+
+export interface ExternalApiResult<T> {
+  data: T;
+  fromCache: boolean;
+  breakerState: CircuitBreakerState;
+  error?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ExecuteOptions<T> {
+  cacheKey?: string;
+  cacheResult?: boolean;
+  cacheTtlMs?: number;
+  allowFallback?: boolean;
+  fallbackValue?: T;
+  retries?: number;
+  timeoutMs?: number;
+  context?: Record<string, unknown>;
+  onRetry?: (error: FailedAttemptError) => void;
+}
+
+export class CircuitOpenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TimeoutError';
+  }
+}
+
+export class CircuitBreaker {
+  private readonly name: string;
+  private readonly failureThreshold: number;
+  private readonly cooldownPeriod: number;
+  private readonly halfOpenSuccessThreshold: number;
+  private readonly cacheTtlMs: number;
+  private readonly maxRetries: number;
+  private readonly timeoutMs: number;
+
+  private state: CircuitBreakerState = 'closed';
+  private failureCount = 0;
+  private successCount = 0;
+  private nextAttempt = 0;
+  private lastError?: unknown;
+  private readonly cache = new Map<string, CacheEntry<unknown>>();
+
+  constructor(options: CircuitBreakerOptions) {
+    this.name = options.name;
+    this.failureThreshold = Math.max(options.failureThreshold, 1);
+    this.cooldownPeriod = options.cooldownPeriod;
+    this.halfOpenSuccessThreshold = Math.max(options.halfOpenSuccessThreshold ?? 1, 1);
+    this.cacheTtlMs = options.cacheTtlMs;
+    this.maxRetries = options.maxRetries;
+    this.timeoutMs = options.timeoutMs;
+  }
+
+  getStatus() {
+    return {
+      name: this.name,
+      state: this.state,
+      failureCount: this.failureCount,
+      nextAttempt: this.nextAttempt,
+      lastError: this.lastError,
+    };
+  }
+
+  clearCache(key?: string) {
+    if (key) {
+      this.cache.delete(key);
+    } else {
+      this.cache.clear();
+    }
+  }
+
+  async execute<T>(
+    key: string,
+    action: (attemptNumber: number) => Promise<T>,
+    options: ExecuteOptions<T> = {}
+  ): Promise<ExternalApiResult<T>> {
+    const cacheKey = options.cacheKey ?? key;
+    const allowFallback = options.allowFallback !== false;
+    const retries = options.retries ?? this.maxRetries;
+    const timeoutMs = options.timeoutMs ?? this.timeoutMs;
+
+    const now = Date.now();
+    if (this.state === 'open') {
+      if (now >= this.nextAttempt) {
+        this.state = 'half-open';
+        this.successCount = 0;
+      } else {
+        const cached = allowFallback ? this.getCacheEntry<T>(cacheKey) : undefined;
+        if (cached) {
+          return {
+            data: cached.value,
+            fromCache: true,
+            breakerState: this.state,
+            error: `${this.name} circuit open`,
+            metadata: this.buildMetadata(cacheKey, cached.cachedAt, 'open', options.context),
+          };
+        }
+
+        if (allowFallback && options.fallbackValue !== undefined) {
+          return {
+            data: options.fallbackValue,
+            fromCache: true,
+            breakerState: this.state,
+            error: `${this.name} circuit open`,
+            metadata: this.buildMetadata(cacheKey, Date.now(), 'open', options.context),
+          };
+        }
+
+        throw new CircuitOpenError(`${this.name} circuit is open. Skipping call for ${cacheKey}.`);
+      }
+    }
+
+    try {
+      const result = await pRetry(
+        (attemptNumber) =>
+          runWithTimeout(() => action(attemptNumber), timeoutMs, `${this.name}:${cacheKey}`),
+        {
+          retries,
+          onFailedAttempt: (error) => {
+            this.lastError = error;
+            options.onRetry?.(error);
+          },
+        }
+      );
+
+      this.recordSuccess();
+
+      if (options.cacheResult !== false) {
+        this.setCacheEntry(cacheKey, result, options.cacheTtlMs);
+      }
+
+      return {
+        data: result,
+        fromCache: false,
+        breakerState: this.state,
+        metadata: this.buildMetadata(cacheKey, Date.now(), undefined, options.context),
+      };
+    } catch (error) {
+      this.recordFailure();
+
+      if (allowFallback) {
+        const cached = this.getCacheEntry<T>(cacheKey);
+        if (cached) {
+          return {
+            data: cached.value,
+            fromCache: true,
+            breakerState: this.state,
+            error: error instanceof Error ? error.message : 'Unknown error',
+            metadata: this.buildMetadata(cacheKey, cached.cachedAt, 'error', options.context),
+          };
+        }
+
+        if (options.fallbackValue !== undefined) {
+          return {
+            data: options.fallbackValue,
+            fromCache: true,
+            breakerState: this.state,
+            error: error instanceof Error ? error.message : 'Unknown error',
+            metadata: this.buildMetadata(cacheKey, Date.now(), 'error', options.context),
+          };
+        }
+      }
+
+      throw error;
+    }
+  }
+
+  private recordSuccess() {
+    this.failureCount = 0;
+    this.lastError = undefined;
+
+    if (this.state === 'half-open') {
+      this.successCount += 1;
+      if (this.successCount >= this.halfOpenSuccessThreshold) {
+        this.state = 'closed';
+        this.successCount = 0;
+      }
+    } else {
+      this.state = 'closed';
+    }
+  }
+
+  private recordFailure() {
+    this.failureCount += 1;
+
+    if (this.state === 'half-open') {
+      this.tripCircuit();
+      return;
+    }
+
+    if (this.failureCount >= this.failureThreshold) {
+      this.tripCircuit();
+    }
+  }
+
+  private tripCircuit() {
+    this.state = 'open';
+    this.nextAttempt = Date.now() + this.cooldownPeriod;
+    this.successCount = 0;
+  }
+
+  private setCacheEntry<T>(key: string, value: T, cacheTtl?: number) {
+    const ttl = cacheTtl ?? this.cacheTtlMs;
+    if (ttl <= 0) {
+      return;
+    }
+
+    const entry: CacheEntry<T> = {
+      value,
+      cachedAt: Date.now(),
+      expiresAt: Date.now() + ttl,
+    };
+
+    this.cache.set(key, entry);
+  }
+
+  private getCacheEntry<T>(key: string): CacheEntry<T> | undefined {
+    const entry = this.cache.get(key) as CacheEntry<T> | undefined;
+    if (!entry) {
+      return undefined;
+    }
+
+    if (entry.expiresAt < Date.now()) {
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    return entry;
+  }
+
+  private buildMetadata(
+    cacheKey: string,
+    cachedAt: number,
+    fallbackReason?: FallbackReason,
+    context?: Record<string, unknown>
+  ) {
+    return {
+      provider: this.name,
+      cacheKey,
+      cachedAt,
+      fallbackReason,
+      ...(context ?? {}),
+    };
+  }
+}
+
+async function runWithTimeout<T>(
+  fn: () => Promise<T>,
+  timeoutMs: number,
+  descriptor: string
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new TimeoutError(`${descriptor} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    fn()
+      .then((result) => {
+        clearTimeout(timer);
+        resolve(result);
+      })
+      .catch((error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}

--- a/lib/documenso.ts
+++ b/lib/documenso.ts
@@ -1,3 +1,5 @@
+import { ExternalApiResult } from '@/lib/circuit-breaker';
+import { documensoCircuitBreaker } from '@/lib/external-integrations';
 import { DocumentSigningRequest, DocumentSigningResponse } from '@/types/documents';
 
 const DOCUMENSO_BASE_URL = process.env.DOCUMENSO_BASE_URL || 'https://app.documenso.com';
@@ -70,24 +72,36 @@ class DocumensoService {
   /**
    * Upload a document to Documenso
    */
-  async uploadDocument(file: File): Promise<DocumensoUploadResponse> {
-    const formData = new FormData();
-    formData.append('file', file);
+  async uploadDocument(file: File): Promise<ExternalApiResult<DocumensoUploadResponse>> {
+    return documensoCircuitBreaker.execute(
+      'upload-document',
+      async () => {
+        const formData = new FormData();
+        formData.append('file', file);
 
-    const response = await fetch(`${this.baseUrl}/api/v1/documents/upload`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
+        const response = await fetch(`${this.baseUrl}/api/v1/documents/upload`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+          body: formData,
+        });
+
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso upload failed: ${error}`);
+        }
+
+        return response.json();
       },
-      body: formData,
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso upload failed: ${error}`);
-    }
-
-    return response.json();
+      {
+        cacheResult: false,
+        allowFallback: false,
+        context: {
+          operation: 'uploadDocument',
+        },
+      }
+    );
   }
 
   /**
@@ -95,90 +109,160 @@ class DocumensoService {
    */
   async createDocumentSigningEnvelope(
     request: DocumensoCreateDocumentRequest
-  ): Promise<DocumensoCreateDocumentResponse> {
-    const response = await fetch(`${this.baseUrl}/api/v1/documents`, {
-      method: 'POST',
-      headers: getAuthHeaders(),
-      body: JSON.stringify(request),
-    });
+  ): Promise<ExternalApiResult<DocumensoCreateDocumentResponse>> {
+    return documensoCircuitBreaker.execute(
+      'create-envelope',
+      async () => {
+        const response = await fetch(`${this.baseUrl}/api/v1/documents`, {
+          method: 'POST',
+          headers: getAuthHeaders(),
+          body: JSON.stringify(request),
+        });
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso create document failed: ${error}`);
-    }
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso create document failed: ${error}`);
+        }
 
-    return response.json();
+        return response.json();
+      },
+      {
+        cacheResult: false,
+        allowFallback: false,
+        context: {
+          operation: 'createDocumentSigningEnvelope',
+        },
+      }
+    );
   }
 
   /**
    * Get document details
    */
-  async getDocument(documentId: string): Promise<DocumensoDocument> {
-    const response = await fetch(`${this.baseUrl}/api/v1/documents/${documentId}`, {
-      method: 'GET',
-      headers: getAuthHeaders(),
-    });
+  async getDocument(documentId: string): Promise<ExternalApiResult<DocumensoDocument>> {
+    return documensoCircuitBreaker.execute(
+      `document:${documentId}`,
+      async () => {
+        const response = await fetch(`${this.baseUrl}/api/v1/documents/${documentId}`, {
+          method: 'GET',
+          headers: getAuthHeaders(),
+        });
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso get document failed: ${error}`);
-    }
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso get document failed: ${error}`);
+        }
 
-    return response.json();
+        return response.json();
+      },
+      {
+        fallbackValue: undefined,
+        context: {
+          operation: 'getDocument',
+          documentId,
+        },
+      }
+    );
   }
 
   /**
    * Get signing URL for a recipient
    */
-  async getSigningUrl(documentId: string, recipientId: string): Promise<string> {
-    const response = await fetch(
-      `${this.baseUrl}/api/v1/documents/${documentId}/recipients/${recipientId}/signing-url`,
+  async getSigningUrl(
+    documentId: string,
+    recipientId: string
+  ): Promise<ExternalApiResult<string>> {
+    return documensoCircuitBreaker.execute(
+      `signing-url:${documentId}:${recipientId}`,
+      async () => {
+        const response = await fetch(
+          `${this.baseUrl}/api/v1/documents/${documentId}/recipients/${recipientId}/signing-url`,
+          {
+            method: 'GET',
+            headers: getAuthHeaders(),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso get signing URL failed: ${error}`);
+        }
+
+        const data = await response.json();
+        return data.signingUrl as string;
+      },
       {
-        method: 'GET',
-        headers: getAuthHeaders(),
+        fallbackValue: '',
+        context: {
+          operation: 'getSigningUrl',
+          documentId,
+          recipientId,
+        },
       }
     );
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso get signing URL failed: ${error}`);
-    }
-
-    const data = await response.json();
-    return data.signingUrl;
   }
 
   /**
    * Send signing reminder
    */
-  async sendSigningReminder(documentId: string, recipientId: string): Promise<void> {
-    const response = await fetch(
-      `${this.baseUrl}/api/v1/documents/${documentId}/recipients/${recipientId}/remind`,
+  async sendSigningReminder(
+    documentId: string,
+    recipientId: string
+  ): Promise<ExternalApiResult<void>> {
+    return documensoCircuitBreaker.execute(
+      `remind:${documentId}:${recipientId}`,
+      async () => {
+        const response = await fetch(
+          `${this.baseUrl}/api/v1/documents/${documentId}/recipients/${recipientId}/remind`,
+          {
+            method: 'POST',
+            headers: getAuthHeaders(),
+          }
+        );
+
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso send reminder failed: ${error}`);
+        }
+      },
       {
-        method: 'POST',
-        headers: getAuthHeaders(),
+        cacheResult: false,
+        allowFallback: false,
+        context: {
+          operation: 'sendSigningReminder',
+          documentId,
+          recipientId,
+        },
       }
     );
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso send reminder failed: ${error}`);
-    }
   }
 
   /**
    * Cancel a document
    */
-  async cancelDocument(documentId: string): Promise<void> {
-    const response = await fetch(`${this.baseUrl}/api/v1/documents/${documentId}/cancel`, {
-      method: 'POST',
-      headers: getAuthHeaders(),
-    });
+  async cancelDocument(documentId: string): Promise<ExternalApiResult<void>> {
+    return documensoCircuitBreaker.execute(
+      `cancel:${documentId}`,
+      async () => {
+        const response = await fetch(`${this.baseUrl}/api/v1/documents/${documentId}/cancel`, {
+          method: 'POST',
+          headers: getAuthHeaders(),
+        });
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso cancel document failed: ${error}`);
-    }
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso cancel document failed: ${error}`);
+        }
+      },
+      {
+        cacheResult: false,
+        allowFallback: false,
+        context: {
+          operation: 'cancelDocument',
+          documentId,
+        },
+      }
+    );
   }
 
   /**
@@ -188,22 +272,35 @@ class DocumensoService {
     templateId: string,
     title: string,
     recipients: DocumensoCreateDocumentRequest['recipients']
-  ): Promise<DocumensoCreateDocumentResponse> {
-    const response = await fetch(`${this.baseUrl}/api/v1/templates/${templateId}/use`, {
-      method: 'POST',
-      headers: getAuthHeaders(),
-      body: JSON.stringify({
-        title,
-        recipients,
-      }),
-    });
+  ): Promise<ExternalApiResult<DocumensoCreateDocumentResponse>> {
+    return documensoCircuitBreaker.execute(
+      `template:${templateId}`,
+      async () => {
+        const response = await fetch(`${this.baseUrl}/api/v1/templates/${templateId}/use`, {
+          method: 'POST',
+          headers: getAuthHeaders(),
+          body: JSON.stringify({
+            title,
+            recipients,
+          }),
+        });
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso create from template failed: ${error}`);
-    }
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Documenso create from template failed: ${error}`);
+        }
 
-    return response.json();
+        return response.json();
+      },
+      {
+        cacheResult: false,
+        allowFallback: false,
+        context: {
+          operation: 'createFromTemplate',
+          templateId,
+        },
+      }
+    );
   }
 }
 
@@ -225,7 +322,16 @@ export async function createLeaseSigningRequest(
 ): Promise<DocumentSigningResponse> {
   try {
     // Upload the document first
-    const uploadResponse = await documensoService.uploadDocument(request.file);
+    const uploadResult = await documensoService.uploadDocument(request.file);
+    const uploadResponse = uploadResult.data;
+
+    if (!uploadResponse) {
+      return {
+        success: false,
+        error: 'Failed to upload document to Documenso.',
+        fallbackNotice: uploadResult.error,
+      };
+    }
 
     // Create recipients from tenant emails
     const recipients = request.tenantEmails.map((email, index) => ({
@@ -239,7 +345,7 @@ export async function createLeaseSigningRequest(
     // TODO: Add property manager email from profile
 
     // Create the document envelope
-    const docResponse = await documensoService.createDocumentSigningEnvelope({
+    const envelopeResult = await documensoService.createDocumentSigningEnvelope({
       title: request.document_id, // Using document_id as title for now
       documentDataId: uploadResponse.documentDataId,
       recipients,
@@ -248,17 +354,38 @@ export async function createLeaseSigningRequest(
         ? new Date(Date.now() + request.expires_in_days * 24 * 60 * 60 * 1000).toISOString()
         : undefined,
     });
+    const docResponse = envelopeResult.data;
 
     // Get signing URL for the first recipient
-    const signingUrl = await documensoService.getSigningUrl(
+    const signingUrlResult = await documensoService.getSigningUrl(
       docResponse.id,
       docResponse.recipients[0].id
     );
+
+    const fallbackMessages: string[] = [];
+    if (signingUrlResult.fromCache) {
+      fallbackMessages.push(
+        'Documenso is responding slowly. Showing the most recent signing link we have on file.'
+      );
+    }
+    if (signingUrlResult.error) {
+      fallbackMessages.push(signingUrlResult.error);
+    }
+
+    const signingUrl = signingUrlResult.data;
+    if (!signingUrl) {
+      return {
+        success: false,
+        error: 'A signing URL is not currently available. Please try again shortly.',
+        fallbackNotice: fallbackMessages.join(' ') || undefined,
+      };
+    }
 
     return {
       success: true,
       envelope_id: docResponse.id,
       signing_url: signingUrl,
+      fallbackNotice: fallbackMessages.join(' ') || undefined,
     };
   } catch (error) {
     console.error('Error creating lease signing request:', error);

--- a/lib/external-integrations.ts
+++ b/lib/external-integrations.ts
@@ -1,0 +1,36 @@
+import { getExternalApiConfig } from '@/config/external-apis';
+import { CircuitBreaker } from '@/lib/circuit-breaker';
+
+const calComConfig = getExternalApiConfig('CALCOM');
+const documensoConfig = getExternalApiConfig('DOCUMENSO');
+const googleCalendarConfig = getExternalApiConfig('GOOGLE_CALENDAR');
+
+export const calComCircuitBreaker = new CircuitBreaker({
+  name: 'cal.com',
+  failureThreshold: calComConfig.failureThreshold,
+  cooldownPeriod: calComConfig.cooldownMs,
+  halfOpenSuccessThreshold: calComConfig.halfOpenSuccesses,
+  cacheTtlMs: calComConfig.cacheTtlMs,
+  maxRetries: calComConfig.maxRetries,
+  timeoutMs: calComConfig.timeoutMs,
+});
+
+export const documensoCircuitBreaker = new CircuitBreaker({
+  name: 'documenso',
+  failureThreshold: documensoConfig.failureThreshold,
+  cooldownPeriod: documensoConfig.cooldownMs,
+  halfOpenSuccessThreshold: documensoConfig.halfOpenSuccesses,
+  cacheTtlMs: documensoConfig.cacheTtlMs,
+  maxRetries: documensoConfig.maxRetries,
+  timeoutMs: documensoConfig.timeoutMs,
+});
+
+export const googleCalendarCircuitBreaker = new CircuitBreaker({
+  name: 'google-calendar',
+  failureThreshold: googleCalendarConfig.failureThreshold,
+  cooldownPeriod: googleCalendarConfig.cooldownMs,
+  halfOpenSuccessThreshold: googleCalendarConfig.halfOpenSuccesses,
+  cacheTtlMs: googleCalendarConfig.cacheTtlMs,
+  maxRetries: googleCalendarConfig.maxRetries,
+  timeoutMs: googleCalendarConfig.timeoutMs,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -54,6 +54,7 @@
         "next": "14.2.4",
         "next-compose-plugins": "^2.2.1",
         "next-themes": "^0.2.1",
+        "p-retry": "^7.0.0",
         "prettier": "^2.8.8",
         "react": "^18.2.0",
         "react-day-picker": "^8.10.0",
@@ -8007,6 +8008,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
+      "integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9872,6 +9885,21 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.0.0.tgz",
+      "integrity": "sha512-3BgO9rjULJYyr0Y0pcsG7FZ+7JB/hfOODO8kx9ppumiO5jprUF92WK/Y7Q0xppZtq4VhTcPiVq7qWLQfIV5aKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "next": "14.2.4",
     "next-compose-plugins": "^2.2.1",
     "next-themes": "^0.2.1",
+    "p-retry": "^7.0.0",
     "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-day-picker": "^8.10.0",

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -96,6 +96,7 @@ export interface DocumentSigningResponse {
   envelope_id?: string;
   signing_url?: string;
   error?: string;
+  fallbackNotice?: string;
 }
 
 export interface DocumentUploadRequest {


### PR DESCRIPTION
## Summary
- introduce shared retry, timeout, and circuit breaker utilities for Cal.com, Documenso, and Google Calendar helpers
- surface fallback warnings in document signing and scheduling flows when cached data is served
- document external API resilience configuration knobs for operators

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d63676883288dfb76f746ec3611