### PR TITLE
Configure responsive image defaults

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next"
-import Image from "next/image"
 import Link from "next/link"
+
+import { ResponsiveImage } from "@/components/media/ResponsiveImage"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
@@ -16,14 +17,14 @@ export default function OnboardingPage() {
   return (
     <>
       <div className="hidden">
-        <Image
+        <ResponsiveImage
           src="/images/house-portal-1.jpg"
           width={1280}
           height={843}
           alt="Roomsily household workspace"
           className="block dark:hidden"
         />
-        <Image
+        <ResponsiveImage
           src="/images/house-portal-2.jpg"
           width={1280}
           height={843}
@@ -43,14 +44,15 @@ export default function OnboardingPage() {
         </Link>
         <div className="relative hidden h-full flex-col bg-muted p-10 text-white md:flex dark:border-r">
           <div className="absolute inset-0 bg-gradient-to-r from-gray-700 via-gray-900 to-black">
-          <Image
-          src="/images/house-portal-2.jpg"
-          width={2048}
-          height={2048}
-          alt="Roommate Collaboration"
-          style={{objectFit: "contain"}}
-          
-        />
+          <ResponsiveImage
+            src="/images/house-portal-2.jpg"
+            width={2048}
+            height={2048}
+            alt="Roommate Collaboration"
+            className="size-full"
+            priority
+            style={{ objectFit: "contain" }}
+          />
           </div>
           <div className="relative z-20 flex items-center text-lg font-medium">
             <svg

--- a/components/media/ResponsiveImage.tsx
+++ b/components/media/ResponsiveImage.tsx
@@ -1,0 +1,33 @@
+import Image, { type ImageProps } from "next/image"
+
+import { cn } from "@/lib/utils"
+
+const DEFAULT_SIZES = "(min-width: 1536px) 1280px, (min-width: 1280px) 1024px, (min-width: 768px) 768px, 100vw"
+
+export type ResponsiveImageProps = Omit<ImageProps, "className" | "loading" | "sizes"> & {
+  className?: string
+  loading?: ImageProps["loading"]
+  sizes?: ImageProps["sizes"]
+}
+
+export function ResponsiveImage({
+  className,
+  priority,
+  loading,
+  sizes = DEFAULT_SIZES,
+  alt,
+  ...props
+}: ResponsiveImageProps) {
+  const resolvedLoading = priority ? "eager" : loading ?? "lazy"
+
+  return (
+    <Image
+      {...props}
+      alt={alt}
+      priority={priority}
+      sizes={sizes}
+      loading={resolvedLoading}
+      className={cn("w-full", className)}
+    />
+  )
+}

--- a/docs/design/images.md
+++ b/docs/design/images.md
@@ -1,0 +1,33 @@
+# Image Delivery Guidelines
+
+## Next.js image configuration
+- We pin responsive breakpoints through `next.config.js` using:
+  - `images.deviceSizes`: 360, 414, 640, 768, 1024, 1280, 1536
+  - `images.imageSizes`: 16, 32, 48, 64, 96, 128, 256, 384, 640
+- These values mirror our mobile-first breakpoints and allow the Image Optimization API to serve the closest asset size per device.
+
+## Priority loading
+- Reserve the `priority` flag for the single above-the-fold hero or marketing image on a page.
+- Supporting or deferred imagery should rely on the default lazy-loading behaviour to conserve bandwidth.
+- Hidden preloads (for dark/light swaps) should remain non-priority to avoid competing with the main hero request.
+
+## `ResponsiveImage` component
+- Use `components/media/ResponsiveImage` instead of importing `next/image` directly for marketing surfaces.
+- The component ships shared defaults:
+  - Sets a balanced `sizes` attribute for common layout widths.
+  - Forces lazy loading unless `priority` is explicitly supplied.
+  - Applies a sensible `w-full` baseline class while still allowing overrides.
+- Example usage:
+
+  ```tsx
+  <ResponsiveImage
+    src="/images/hero.jpg"
+    alt="Roommates collaborating"
+    width={2048}
+    height={1365}
+    priority
+    className="size-full object-cover"
+  />
+  ```
+
+Following these conventions keeps page weight low and ensures the highest-impact media renders immediately for tenants.

--- a/next.config.js
+++ b/next.config.js
@@ -70,8 +70,10 @@ const nextConfig = {
   experimental: {
     mdxRs: true,
   },
-    images : {
-      remotePatterns: [
+  images: {
+    deviceSizes: [360, 414, 640, 768, 1024, 1280, 1536],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384, 640],
+    remotePatterns: [
       {
         protocol: 'https',
         hostname: 'quantumone.b-cdn.net',
@@ -96,7 +98,6 @@ const nextConfig = {
         port: '',
         pathname: '/embed/HR6a2aHhY_c?si=L2O3Cf7pQ-0HHhsP',
       },
-
       {
         protocol: 'https',
         hostname: 'quantumone.b-cdn.net',
@@ -109,13 +110,10 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
-
       {
-
         protocol: 'https',
         hostname: 'api.web3modal.com',
         port: '',
-      
       },
     ],
   },


### PR DESCRIPTION
## Summary
- define mobile-first breakpoints for the Next.js image optimizer via `images.deviceSizes` and `images.imageSizes`
- introduce a reusable `ResponsiveImage` helper with shared loading and sizing defaults and update the onboarding hero to use it with a single priority asset
- document the shared image policy, including priority rules and usage guidance, in `docs/design/images.md`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68d15d608dbc8328b1e6c7ad8846d65b