### PR TITLE
feat: add optimistic todo and notification updates

### DIFF
--- a/app/dashboard/todo/components/ListOfTodo.tsx
+++ b/app/dashboard/todo/components/ListOfTodo.tsx
@@ -1,87 +1,89 @@
-import React from "react";
-import { TrashIcon } from "@radix-ui/react-icons";
-import { Button } from "@/components/ui/button";
-import EditTodo from "./EditTodo";
+"use client";
+
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useTodos } from "@/hooks/use-todos";
 import { cn } from "@/lib/utils";
 
-export default function ListOfTodo() {
-	const todos = [
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Garfield",
-		},
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Trender",
-		},
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Some string",
-		},
-	];
-	return (
-		<div className="mx-2 rounded-sm bg-white dark:bg-inherit">
-			{todos.map((todo, index) => {
-				return (
-					<div
-						className=" grid grid-cols-5  rounded-sm  p-3 align-middle font-normal "
-						key={index}
-					>
-						{Object.keys(todo).map((key, index) => {
-							if (key === "status") {
-								return (
-									<div
-										key={index}
-										className="flex items-center"
-									>
-										<div>
-											<span
-												className={cn(
-													"  rounded-full border-[.5px] px-2 py-1 text-sm capitalize  shadow dark:bg-zinc-800",
-													{
-														"border-green-500 bg-green-400 dark:text-green-400":
-															todo.status ===
-															"completed",
-													}
-												)}
-											>
-												{todo.status}
-											</span>
-										</div>
-									</div>
-								);
-							} else {
-								return (
-									<h1
-										className="flex items-center text-lg dark:text-white"
-										key={index}
-									>
-										{todo[key as keyof typeof todo]}
-									</h1>
-								);
-							}
-						})}
+function formatDate(value: string | null) {
+  if (!value) {
+    return "—";
+  }
 
-						<div className="flex items-center gap-2">
-							<Button
-								variant="outline"
-								className="bg-dark dark:bg-inherit"
-							>
-								<TrashIcon />
-								delete
-							</Button>
-							<EditTodo />
-						</div>
-					</div>
-				);
-			})}
-		</div>
-	);
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString();
+}
+
+export default function ListOfTodo() {
+  const { todos, isLoading, toggleTodo, togglingId } = useTodos();
+
+  if (isLoading) {
+    return (
+      <div className="px-5 py-4 text-sm text-muted-foreground">
+        Loading todos...
+      </div>
+    );
+  }
+
+  if (todos.length === 0) {
+    return (
+      <div className="px-5 py-4 text-sm text-muted-foreground">
+        No todos yet.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {todos.map((todo) => {
+        const isToggling = togglingId === todo.id;
+
+        return (
+          <div
+            className="grid grid-cols-5 items-center rounded-sm px-5 py-3 text-sm"
+            key={todo.id}
+          >
+            <span className="font-medium dark:text-white">{todo.title}</span>
+            <div>
+              <Badge
+                variant="outline"
+                className={cn(
+                  "w-fit capitalize",
+                  todo.completed
+                    ? "border-green-200 bg-green-100 text-green-700"
+                    : "border-amber-200 bg-amber-100 text-amber-700",
+                )}
+              >
+                {todo.completed ? "completed" : "pending"}
+              </Badge>
+            </div>
+            <span className="text-muted-foreground">
+              {formatDate(todo.created_at)}
+            </span>
+            <span className="text-muted-foreground">
+              {todo.created_by || "—"}
+            </span>
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                variant={todo.completed ? "outline" : "default"}
+                onClick={() => toggleTodo(todo.id)}
+                disabled={isToggling}
+              >
+                {isToggling
+                  ? "Saving..."
+                  : todo.completed
+                  ? "Mark pending"
+                  : "Mark done"}
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
 }

--- a/app/dashboard/todo/page.tsx
+++ b/app/dashboard/todo/page.tsx
@@ -1,42 +1,16 @@
 
 import React from "react";
+
 import CreateForm from "./components/CreateForm";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import TodoTable from "./components/TodoTable";
 
 export default function Todo() {
-	const todos = [
-		{
-			title: "Subscribe",
-			created_by: "091832901830",
-			id: "101981908",
-			completed: false,
-		},
-	];
-
-	return (
-		<div className="flex h-screen items-center justify-center">
-			<div className="w-96 space-y-5">
-
-				<CreateForm />
-
-				{todos?.map((todo, index) => {
-					return (
-						<div key={index} className="flex items-center gap-6">
-							<h1
-								className={cn({
-									"line-through": todo.completed,
-								})}
-							>
-								{todo.title}
-							</h1>
-
-							<Button>delete</Button>
-							<Button>Update</Button>
-						</div>
-					);
-				})}
-			</div>
-		</div>
-	);
+  return (
+    <div className="flex h-full min-h-screen items-start justify-center py-10">
+      <div className="w-full max-w-4xl space-y-6 px-4">
+        <CreateForm />
+        <TodoTable />
+      </div>
+    </div>
+  );
 }

--- a/components/notifications/notification-center.tsx
+++ b/components/notifications/notification-center.tsx
@@ -21,6 +21,16 @@ interface Notification {
   created_at: string;
 }
 
+const normalizeNotification = (notification: any): Notification => ({
+  id: notification.id,
+  title: notification.title,
+  message: notification.message,
+  type: notification.type,
+  action_url: notification.action_url ?? undefined,
+  read: Boolean(notification.read),
+  created_at: notification.created_at,
+});
+
 export function NotificationCenter() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
@@ -40,8 +50,9 @@ export function NotificationCenter() {
 
       if (error) throw error;
 
-      setNotifications(data || []);
-      setUnreadCount(data?.filter((n: any) => !n.read).length || 0);
+      const normalized = (data || []).map(normalizeNotification);
+      setNotifications(normalized);
+      setUnreadCount(normalized.filter((n) => !n.read).length);
     } catch (error) {
       console.error('Failed to fetch notifications:', error);
     } finally {
@@ -63,9 +74,9 @@ export function NotificationCenter() {
           table: 'notifications',
         },
         (payload) => {
-          const newNotification = payload.new as Notification;
+          const newNotification = normalizeNotification(payload.new);
           setNotifications(prev => [newNotification, ...prev]);
-          setUnreadCount(prev => prev + 1);
+          setUnreadCount(prev => prev + (newNotification.read ? 0 : 1));
 
           // Show toast for new notification
           toast({
@@ -84,31 +95,83 @@ export function NotificationCenter() {
   }, [fetchNotifications, supabase, toast]);
 
   const markAsRead = async (notificationId: string) => {
+    const targetNotification = notifications.find(
+      (notification) => notification.id === notificationId,
+    );
+
+    if (!targetNotification || targetNotification.read) {
+      return;
+    }
+
+    const previousNotifications = notifications.map((notification) => ({
+      ...notification,
+    }));
+    const previousUnreadCount = unreadCount;
+
+    setNotifications((prev) =>
+      prev.map((notification) =>
+        notification.id === notificationId
+          ? { ...notification, read: true }
+          : notification,
+      ),
+    );
+    setUnreadCount((prev) => Math.max(0, prev - 1));
+
     try {
-      const { error } = await (supabase as any)
+      const { data, error } = await (supabase as any)
         .from('notifications')
         .update({ read: true })
-        .eq('id', notificationId);
+        .eq('id', notificationId)
+        .select('*')
+        .single();
 
       if (error) throw error;
 
-      setNotifications(prev =>
-        prev.map(n =>
-          n.id === notificationId ? { ...n, read: true } : n
-        )
-      );
-      setUnreadCount(prev => Math.max(0, prev - 1));
+      if (data) {
+        const normalized = normalizeNotification(data);
+        setNotifications((prev) =>
+          prev.map((notification) =>
+            notification.id === notificationId ? normalized : notification,
+          ),
+        );
+      }
+
+      toast({
+        title: 'Notification read',
+        description: targetNotification.title
+          ? `Marked "${targetNotification.title}" as read.`
+          : 'Notification marked as read.',
+      });
     } catch (error) {
       console.error('Failed to mark notification as read:', error);
+      setNotifications(previousNotifications);
+      setUnreadCount(previousUnreadCount);
+      toast({
+        title: 'Failed to mark notification as read',
+        description:
+          error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
+      });
     }
   };
 
   const markAllAsRead = async () => {
+    const unreadIds = notifications.filter((n) => !n.read).map((n) => n.id);
+
+    if (unreadIds.length === 0) return;
+
+    const previousNotifications = notifications.map((notification) => ({
+      ...notification,
+    }));
+    const previousUnreadCount = unreadCount;
+
+    setNotifications((prev) => prev.map((notification) => ({
+      ...notification,
+      read: true,
+    })));
+    setUnreadCount(0);
+
     try {
-      const unreadIds = notifications.filter(n => !n.read).map(n => n.id);
-
-      if (unreadIds.length === 0) return;
-
       const { error } = await (supabase as any)
         .from('notifications')
         .update({ read: true })
@@ -116,20 +179,42 @@ export function NotificationCenter() {
 
       if (error) throw error;
 
-      setNotifications(prev =>
-        prev.map(n => ({ ...n, read: true }))
-      );
-      setUnreadCount(0);
-
       toast({
-        title: "All notifications marked as read",
+        title: 'All notifications marked as read',
+        description: `Cleared ${unreadIds.length} notification${
+          unreadIds.length > 1 ? 's' : ''
+        }.`,
       });
     } catch (error) {
       console.error('Failed to mark all notifications as read:', error);
+      setNotifications(previousNotifications);
+      setUnreadCount(previousUnreadCount);
+      toast({
+        title: 'Failed to mark all as read',
+        description:
+          error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
+      });
     }
   };
 
   const deleteNotification = async (notificationId: string) => {
+    const previousNotifications = notifications.map((notification) => ({
+      ...notification,
+    }));
+    const previousUnreadCount = unreadCount;
+    const deletedNotification = notifications.find(
+      (notification) => notification.id === notificationId,
+    );
+
+    setNotifications((prev) =>
+      prev.filter((notification) => notification.id !== notificationId),
+    );
+
+    if (deletedNotification && !deletedNotification.read) {
+      setUnreadCount((prev) => Math.max(0, prev - 1));
+    }
+
     try {
       const { error } = await (supabase as any)
         .from('notifications')
@@ -138,14 +223,22 @@ export function NotificationCenter() {
 
       if (error) throw error;
 
-      const deletedNotification = notifications.find(n => n.id === notificationId);
-      setNotifications(prev => prev.filter(n => n.id !== notificationId));
-
-      if (deletedNotification && !deletedNotification.read) {
-        setUnreadCount(prev => Math.max(0, prev - 1));
-      }
+      toast({
+        title: 'Notification deleted',
+        description: deletedNotification?.title
+          ? `Removed "${deletedNotification.title}".`
+          : 'Notification removed.',
+      });
     } catch (error) {
       console.error('Failed to delete notification:', error);
+      setNotifications(previousNotifications);
+      setUnreadCount(previousUnreadCount);
+      toast({
+        title: 'Failed to delete notification',
+        description:
+          error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
+      });
     }
   };
 

--- a/docs/perf/optimistic-ui.md
+++ b/docs/perf/optimistic-ui.md
@@ -1,0 +1,131 @@
+# Optimistic UI Patterns
+
+Optimistic updates keep the interface responsive even when we're waiting on Supabase writes. Two common flows now use the pattern:
+
+- Todo toggles (`useTodos`)
+- Notification actions (`NotificationCenter`)
+
+The following guidelines cover how to adopt the same approach elsewhere.
+
+## Core Loop
+
+1. **Snapshot current state** – grab the query cache or component state before mutating it.
+2. **Apply the optimistic change** – immediately update the UI so it reflects the desired end state.
+3. **Execute the mutation** – call Supabase (or any async mutation) with the intended change.
+4. **Handle results**
+   - On success, reconcile with the server response (in case of extra fields like `updated_at`).
+   - On failure, roll back to the saved snapshot and surface an error toast.
+5. **Invalidate queries** (React Query) to let background refetches keep the cache fresh.
+
+## React Query Example – Toggling Todos
+
+`hooks/use-todos.ts` uses `useMutation` with `onMutate`, `onError`, `onSuccess`, and `onSettled`:
+
+```ts
+const toggleMutation = useMutation({
+  mutationFn: async ({ id, completed }) => {
+    const { data } = await supabase
+      .from("todos")
+      .update({ completed })
+      .eq("id", id)
+      .select("*")
+      .single()
+    return data
+  },
+  onMutate: async ({ id, completed }) => {
+    await queryClient.cancelQueries({ queryKey: ["todos"] })
+    const previous = queryClient.getQueryData<Todo[]>(["todos"])
+    queryClient.setQueryData(["todos"], (old) =>
+      old?.map((todo) =>
+        todo.id === id ? { ...todo, completed } : todo,
+      ),
+    )
+    return { previous }
+  },
+  onError: (_err, _vars, context) => {
+    queryClient.setQueryData(["todos"], context?.previous)
+    toast({ variant: "destructive", title: "Unable to update todo" })
+  },
+  onSuccess: (updatedTodo) => {
+    queryClient.setQueryData(["todos"], (old) =>
+      old?.map((todo) =>
+        todo.id === updatedTodo.id ? updatedTodo : todo,
+      ),
+    )
+    toast({ title: updatedTodo.completed ? "Todo completed" : "Todo reopened" })
+  },
+  onSettled: () => queryClient.invalidateQueries({ queryKey: ["todos"] }),
+})
+```
+
+Key takeaways:
+
+- Always cancel in-flight queries before mutating the cache.
+- Return the snapshot from `onMutate` so you can restore it in `onError`.
+- Use the Supabase response to reconcile the cache in `onSuccess`.
+- Fire a toast for both success and failure so tenants know what happened.
+
+## Local State Example – Notifications
+
+`components/notifications/notification-center.tsx` relies on local state because it also handles realtime inserts. The same principles apply:
+
+```ts
+const previousNotifications = notifications.map((n) => ({ ...n }))
+const previousUnread = unreadCount
+
+setNotifications((prev) =>
+  prev.map((notification) =>
+    notification.id === notificationId
+      ? { ...notification, read: true }
+      : notification,
+  ),
+)
+setUnreadCount((prev) => Math.max(0, prev - 1))
+
+try {
+  const { data } = await supabase
+    .from("notifications")
+    .update({ read: true })
+    .eq("id", notificationId)
+    .select("*")
+    .single()
+
+  setNotifications((prev) =>
+    prev.map((notification) =>
+      notification.id === notificationId ? normalise(data) : notification,
+    ),
+  )
+  toast({ title: "Notification read" })
+} catch (error) {
+  setNotifications(previousNotifications)
+  setUnreadCount(previousUnread)
+  toast({ variant: "destructive", title: "Failed to mark notification as read" })
+}
+```
+
+### Normalising Data
+
+Supabase can return `null` for booleans like `read`. Always normalise to a plain boolean before writing to state so optimistic updates behave predictably.
+
+### Toasts Are Required
+
+Every optimistic path now fires a toast on success and failure. Use them to communicate what changed and how to recover if something goes wrong.
+
+## When to Use Optimistic Updates
+
+- Mutations that toggle booleans or update small payloads (e.g., mark-as-read, favourite/like toggles).
+- Actions where conflicts are rare and the failure path can be handled with a simple rollback.
+- Interfaces that benefit from instant feedback, especially when we expect repeated quick interactions.
+
+Avoid optimistic updates for destructive actions that can't be undone or when you need authoritative conflict resolution (e.g., multi-step workflows, payments).
+
+## Checklist
+
+- [ ] Snapshot previous state.
+- [ ] Apply the optimistic update.
+- [ ] Perform the mutation.
+- [ ] Roll back on error and toast the failure.
+- [ ] Reconcile the cache/state on success.
+- [ ] Invalidate the query (if using React Query) so background refetches keep things honest.
+
+Follow this template and we maintain the snappy UX without sacrificing correctness.

--- a/hooks/use-todos.ts
+++ b/hooks/use-todos.ts
@@ -1,0 +1,142 @@
+"use client"
+
+import { useCallback, useMemo } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useToast } from "@/components/ui/use-toast"
+import type { Database } from "@/lib/supabase"
+import { createClient } from "@/utils/supabase-browser"
+
+type Todo = Database["public"]["Tables"]["todos"]["Row"]
+
+function mapTodo(todo: Todo): Todo {
+  return {
+    ...todo,
+    completed: Boolean(todo.completed),
+  }
+}
+
+export function useTodos() {
+  const supabase = useMemo(() => createClient(), [])
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+
+  const todosQuery = useQuery({
+    queryKey: ["todos"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("todos")
+        .select("*")
+        .order("created_at", { ascending: false })
+
+      if (error) {
+        throw error
+      }
+
+      return (data ?? []).map(mapTodo) as Todo[]
+    },
+    staleTime: 30_000,
+    onError: (error) => {
+      const message =
+        error instanceof Error ? error.message : "Unable to load todos."
+      toast({
+        title: "Failed to load todos",
+        description: message,
+        variant: "destructive",
+      })
+    },
+  })
+
+  const toggleMutation = useMutation({
+    mutationFn: async ({ id, completed }: { id: string; completed: boolean }) => {
+      const { data, error } = await (supabase as any)
+        .from("todos")
+        .update({ completed })
+        .eq("id", id)
+        .select("*")
+        .single()
+
+      if (error) {
+        throw error
+      }
+
+      return mapTodo(data as Todo)
+    },
+    onMutate: async ({ id, completed }) => {
+      await queryClient.cancelQueries({ queryKey: ["todos"] })
+
+      const previousTodos = queryClient.getQueryData<Todo[]>(["todos"])
+
+      queryClient.setQueryData<Todo[]>(["todos"], (old) =>
+        (old ?? []).map((todo) =>
+          todo.id === id
+            ? {
+                ...todo,
+                completed,
+              }
+            : todo,
+        ),
+      )
+
+      return { previousTodos }
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousTodos) {
+        queryClient.setQueryData(["todos"], context.previousTodos)
+      }
+
+      toast({
+        title: "Unable to update todo",
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+        variant: "destructive",
+      })
+    },
+    onSuccess: (updatedTodo) => {
+      queryClient.setQueryData<Todo[]>(["todos"], (old) =>
+        (old ?? []).map((todo) =>
+          todo.id === updatedTodo.id
+            ? {
+                ...todo,
+                ...updatedTodo,
+              }
+            : todo,
+        ),
+      )
+
+      toast({
+        title: updatedTodo.completed ? "Todo completed" : "Todo reopened",
+        description: updatedTodo.title,
+      })
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] })
+    },
+  })
+
+  const toggleTodo = useCallback(
+    (id: string) => {
+      const existingTodos = queryClient.getQueryData<Todo[]>(["todos"]) ?? []
+      const target = existingTodos.find((todo) => todo.id === id)
+
+      if (!target) {
+        toast({
+          title: "Todo not found",
+          description: "The requested todo could not be located.",
+          variant: "destructive",
+        })
+        return
+      }
+
+      toggleMutation.mutate({ id, completed: !target.completed })
+    },
+    [queryClient, toast, toggleMutation],
+  )
+
+  return {
+    todos: todosQuery.data ?? [],
+    isLoading: todosQuery.isLoading,
+    toggleTodo,
+    togglingId: toggleMutation.variables?.id ?? null,
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -83,6 +83,14 @@ export type Database = {
         user_agent: string | null
         metadata: Json | null
       }>
+      todos: SupabaseTable<{
+        id: string
+        title: string
+        completed: boolean
+        created_at: string | null
+        updated_at: string | null
+        created_by: string | null
+      }>
       leases: SupabaseTable<{
         id: string
         document_id: string


### PR DESCRIPTION
## Summary
- add a React Query powered `useTodos` hook with optimistic toggles and toasts
- refactor dashboard todo table to use the new hook and Supabase todo types
- make notification center actions optimistic with rollback + toast feedback and document the pattern

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d5b1ab08328a4b2e7d174da7b9d