### PR TITLE
Implement autosave drafts for tenant forms

### DIFF
--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
+import { formatDistanceToNow } from "date-fns";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useNotifications } from "@/hooks/use-notifications";
+import { useAutosaveDraft } from "@/hooks/use-autosave-draft";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -59,6 +60,75 @@ export function MaintenanceRequestForm() {
       location: "",
     },
   });
+
+  const watchedValues = form.watch();
+
+  const {
+    status: autosaveStatus,
+    lastSavedAt,
+    lastError,
+    hasDraft,
+    isLoadingDraft,
+    resolvedStorage,
+    clearDraft,
+    resumeDraft,
+  } = useAutosaveDraft<MaintenanceRequestFormData>("maintenance-request", watchedValues, {
+    storage: "supabase",
+    throttleMs: 2000,
+    isDirty: form.formState.isDirty,
+  });
+
+  const autosaveMessage = useMemo(() => {
+    if (autosaveStatus === "saving") {
+      return "Saving draft...";
+    }
+
+    if (autosaveStatus === "saved" && lastSavedAt) {
+      return `Draft saved ${formatDistanceToNow(lastSavedAt, { addSuffix: true })}`;
+    }
+
+    if (autosaveStatus === "error") {
+      return lastError ? `Autosave failed: ${lastError}` : "Autosave failed";
+    }
+
+    if (!form.formState.isDirty) {
+      return "Autosave ready. Start typing to save your draft.";
+    }
+
+    return "Autosave idle";
+  }, [autosaveStatus, lastError, lastSavedAt, form.formState.isDirty]);
+
+  const storageMessage = resolvedStorage === "supabase" ? "Synced to Supabase" : "Stored on this device";
+
+  const handleResumeDraft = useCallback(async () => {
+    const draft = await resumeDraft();
+
+    if (!draft) {
+      toast({
+        title: "No draft found",
+        description: "There is no saved draft to restore.",
+      });
+      return;
+    }
+
+    form.reset({
+      ...form.getValues(),
+      ...draft,
+    });
+
+    toast({
+      title: "Draft restored",
+      description: "Your in-progress maintenance request has been loaded.",
+    });
+  }, [form, resumeDraft, toast]);
+
+  const handleDiscardDraft = useCallback(async () => {
+    await clearDraft();
+    toast({
+      title: "Draft discarded",
+      description: "Autosaved progress has been cleared.",
+    });
+  }, [clearDraft, toast]);
 
   const onSubmit = async (data: MaintenanceRequestFormData) => {
     setIsSubmitting(true);
@@ -130,6 +200,7 @@ export function MaintenanceRequestForm() {
       });
 
       form.reset();
+      await clearDraft().catch(() => undefined);
     } catch (error) {
       console.error('Error submitting maintenance request:', error);
       toast({
@@ -145,6 +216,30 @@ export function MaintenanceRequestForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {!isLoadingDraft && hasDraft && (
+          <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-4">
+            <div className="flex flex-col gap-2 text-sm">
+              <div>
+                <p className="font-medium text-primary">Saved draft available</p>
+                <p className="text-muted-foreground">
+                  {lastSavedAt
+                    ? `Last saved ${formatDistanceToNow(lastSavedAt, { addSuffix: true })}.`
+                    : "Resume your in-progress request."}{" "}
+                  {storageMessage}.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button type="button" size="sm" onClick={handleResumeDraft}>
+                  Resume draft
+                </Button>
+                <Button type="button" size="sm" variant="ghost" onClick={handleDiscardDraft}>
+                  Discard draft
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
         <FormField
           control={form.control}
           name="title"
@@ -242,6 +337,15 @@ export function MaintenanceRequestForm() {
             </FormItem>
           )}
         />
+
+        <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className={autosaveStatus === "error" ? "text-destructive" : "text-muted-foreground"}>
+              {autosaveMessage}
+            </span>
+            <span className="font-medium text-muted-foreground">{storageMessage}</span>
+          </div>
+        </div>
 
         <Button type="submit" disabled={isSubmitting} className="w-full">
           {isSubmitting ? "Submitting..." : "Submit Maintenance Request"}

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
-import { format } from "date-fns";
+import { format, formatDistanceToNow } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -16,6 +15,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { useNotifications } from "@/hooks/use-notifications";
+import { useAutosaveDraft } from "@/hooks/use-autosave-draft";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -36,6 +36,11 @@ const visitorBookingSchema = z.object({
 
 type VisitorBookingFormData = z.infer<typeof visitorBookingSchema>;
 
+type VisitorBookingDraftPayload = Omit<VisitorBookingFormData, "checkInDate" | "checkOutDate"> & {
+  checkInDate?: string | null;
+  checkOutDate?: string | null;
+};
+
 export function VisitorBookingForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { notifyVisitorBooking } = useNotifications();
@@ -53,6 +58,108 @@ export function VisitorBookingForm() {
       specialNotes: "",
     },
   });
+
+  const watchedValues = form.watch();
+
+  const serializeDraft = useCallback(
+    (values: VisitorBookingFormData): VisitorBookingDraftPayload => ({
+      guestName: values.guestName,
+      guestEmail: values.guestEmail,
+      guestPhone: values.guestPhone,
+      purpose: values.purpose,
+      emergencyContact: values.emergencyContact,
+      specialNotes: values.specialNotes,
+      checkInDate: values.checkInDate ? values.checkInDate.toISOString() : null,
+      checkOutDate: values.checkOutDate ? values.checkOutDate.toISOString() : null,
+    }),
+    [],
+  );
+
+  const deserializeDraft = useCallback(
+    (payload: VisitorBookingDraftPayload): Partial<VisitorBookingFormData> => {
+      const { checkInDate, checkOutDate, ...rest } = payload;
+
+      return {
+        ...rest,
+        checkInDate: checkInDate ? new Date(checkInDate) : undefined,
+        checkOutDate: checkOutDate ? new Date(checkOutDate) : undefined,
+      };
+    },
+    [],
+  );
+
+  const {
+    status: autosaveStatus,
+    lastSavedAt,
+    lastError,
+    hasDraft,
+    isLoadingDraft,
+    resolvedStorage,
+    clearDraft,
+    resumeDraft,
+  } = useAutosaveDraft<VisitorBookingFormData, VisitorBookingDraftPayload>(
+    "visitor-booking",
+    watchedValues,
+    {
+      storage: "supabase",
+      throttleMs: 2000,
+      isDirty: form.formState.isDirty,
+      serialize: serializeDraft,
+      deserialize: deserializeDraft,
+    },
+  );
+
+  const autosaveMessage = useMemo(() => {
+    if (autosaveStatus === "saving") {
+      return "Saving draft...";
+    }
+
+    if (autosaveStatus === "saved" && lastSavedAt) {
+      return `Draft saved ${formatDistanceToNow(lastSavedAt, { addSuffix: true })}`;
+    }
+
+    if (autosaveStatus === "error") {
+      return lastError ? `Autosave failed: ${lastError}` : "Autosave failed";
+    }
+
+    if (!form.formState.isDirty) {
+      return "Autosave ready. Start typing to save your draft.";
+    }
+
+    return "Autosave idle";
+  }, [autosaveStatus, lastError, lastSavedAt, form.formState.isDirty]);
+
+  const storageMessage = resolvedStorage === "supabase" ? "Synced to Supabase" : "Stored on this device";
+
+  const handleResumeDraft = useCallback(async () => {
+    const draft = await resumeDraft();
+
+    if (!draft) {
+      toast({
+        title: "No draft found",
+        description: "There is no saved draft to restore.",
+      });
+      return;
+    }
+
+    form.reset({
+      ...form.getValues(),
+      ...draft,
+    });
+
+    toast({
+      title: "Draft restored",
+      description: "Your visitor booking draft has been loaded.",
+    });
+  }, [form, resumeDraft, toast]);
+
+  const handleDiscardDraft = useCallback(async () => {
+    await clearDraft();
+    toast({
+      title: "Draft discarded",
+      description: "Autosaved progress has been cleared.",
+    });
+  }, [clearDraft, toast]);
 
   const onSubmit = async (data: VisitorBookingFormData) => {
     setIsSubmitting(true);
@@ -131,6 +238,7 @@ export function VisitorBookingForm() {
       });
 
       form.reset();
+      await clearDraft().catch(() => undefined);
     } catch (error) {
       console.error('Error submitting visitor booking:', error);
       toast({
@@ -146,6 +254,30 @@ export function VisitorBookingForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {!isLoadingDraft && hasDraft && (
+          <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-4">
+            <div className="flex flex-col gap-2 text-sm">
+              <div>
+                <p className="font-medium text-primary">Saved draft available</p>
+                <p className="text-muted-foreground">
+                  {lastSavedAt
+                    ? `Last saved ${formatDistanceToNow(lastSavedAt, { addSuffix: true })}.`
+                    : "Resume your in-progress booking."}{" "}
+                  {storageMessage}.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button type="button" size="sm" onClick={handleResumeDraft}>
+                  Resume draft
+                </Button>
+                <Button type="button" size="sm" variant="ghost" onClick={handleDiscardDraft}>
+                  Discard draft
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
         <div className="grid gap-4 md:grid-cols-2">
           <FormField
             control={form.control}
@@ -325,6 +457,15 @@ export function VisitorBookingForm() {
             </FormItem>
           )}
         />
+
+        <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className={autosaveStatus === "error" ? "text-destructive" : "text-muted-foreground"}>
+              {autosaveMessage}
+            </span>
+            <span className="font-medium text-muted-foreground">{storageMessage}</span>
+          </div>
+        </div>
 
         <Button type="submit" disabled={isSubmitting} className="w-full">
           {isSubmitting ? "Submitting..." : "Submit Visitor Booking"}

--- a/docs/product/forms.md
+++ b/docs/product/forms.md
@@ -1,0 +1,43 @@
+# Long-form Autosave Strategy
+
+## Overview
+Longer forms such as maintenance requests and visitor bookings now persist in-progress drafts automatically. The `useAutosaveDraft` hook throttles change detection and saves form state every ~2 seconds while the user is actively editing. Drafts are written to Supabase when an authenticated user is available and fall back to IndexedDB on the device when Supabase cannot be reached.
+
+## Hook contract
+- **Hook**: `useAutosaveDraft(formKey, data, options)`
+  - `formKey`: stable identifier per form.
+  - `data`: the watched form values (typically `form.watch()`).
+  - `options`:
+    - `storage`: prefer `"supabase"` (default) or `"indexeddb"`.
+    - `throttleMs`: debounce window before persisting (defaults to 1.5s, forms use 2s).
+    - `isDirty`: optional flag (e.g. `form.formState.isDirty`) to suppress saving pristine defaults.
+    - `serialize` / `deserialize`: optional transforms for non-JSON-friendly values (dates, Maps, etc.).
+    - `expireMs`: retention window before a draft is considered stale (defaults to 30 days).
+- **Returns** status metadata (`status`, `lastSavedAt`, `lastError`), booleans (`hasDraft`, `isLoadingDraft`), resolved storage target, and control helpers (`resumeDraft`, `clearDraft`).
+- Autosave pauses while the initial draft is loading to avoid overwriting prior progress and resumes once the user changes any field.
+
+## Storage flows
+- **Supabase**
+  - Drafts land in `public.form_drafts` keyed by `(user_id, form_key)` with an `expires_at` column.
+  - Upserts ensure a single draft per user/form combination. `expires_at` is refreshed on every save.
+  - RLS policy restricts access to the owning user only.
+- **IndexedDB**
+  - Local fallback (DB: `share-house-portal`, store: `form_drafts`).
+  - Records mirror Supabase payload shape and carry the same `updatedAt` / `expiresAt` metadata for consistent cleanup semantics.
+  - Reads/writes are guarded to run only in the browser, protecting SSR paths.
+
+## UI affordances
+- Maintenance and visitor booking forms display a banner when a draft exists with **Resume** and **Discard** controls.
+- A status pill summarises autosave progress (`Saving…`, `Draft saved 2 minutes ago`, or error messaging) alongside the active storage target (“Synced to Supabase” vs “Stored on this device”).
+- On successful submission the draft is cleared to prevent stale data from resurfacing.
+
+## Draft lifecycle & cleanup
+- Drafts default to a 30 day TTL. Components may override via `expireMs` if a shorter retention window is desired.
+- A nightly cron job (`cleanup_form_drafts`, 03:00 UTC) removes rows where `expires_at` has passed or the draft has been idle for 30+ days, keeping storage tidy.
+- Local drafts honour `expiresAt` during load; expired entries are purged the next time a form mounts.
+
+## Adoption checklist for new forms
+1. Choose a unique `formKey` and wire `useAutosaveDraft(formKey, form.watch(), { isDirty: form.formState.isDirty })`.
+2. Provide serializers when form data includes non-JSON primitives (e.g. convert `Date` values to ISO strings).
+3. Surface the standard status banner and storage indicator to give tenants visibility and control over their drafts.
+4. Clear the draft via `clearDraft()` after successful submission.

--- a/hooks/use-autosave-draft.ts
+++ b/hooks/use-autosave-draft.ts
@@ -1,0 +1,445 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import {
+  deleteDraftFromIndexedDb,
+  readDraftFromIndexedDb,
+  writeDraftToIndexedDb,
+  type IndexedDraftRecord,
+} from "@/utils/indexeddb"
+
+export type AutosaveStorageProvider = "supabase" | "indexeddb"
+export type AutosaveStatus = "idle" | "saving" | "saved" | "error"
+
+const DEFAULT_THROTTLE_MS = 1500
+const DEFAULT_EXPIRY_MS = 1000 * 60 * 60 * 24 * 30 // 30 days
+
+type SerializeFn<T, TSerialized> = ((data: T) => TSerialized) | undefined
+type DeserializeFn<T, TSerialized> = ((data: TSerialized) => Partial<T>) | undefined
+
+export interface UseAutosaveDraftOptions<T, TSerialized = T> {
+  storage?: AutosaveStorageProvider
+  throttleMs?: number
+  enabled?: boolean
+  expireMs?: number
+  isDirty?: boolean
+  serialize?: (data: T) => TSerialized
+  deserialize?: (data: TSerialized) => Partial<T>
+}
+
+export interface UseAutosaveDraftResult<T> {
+  status: AutosaveStatus
+  lastSavedAt: Date | null
+  lastError: string | null
+  hasDraft: boolean
+  isLoadingDraft: boolean
+  resolvedStorage: AutosaveStorageProvider
+  clearDraft: () => Promise<void>
+  resumeDraft: () => Promise<Partial<T> | null>
+}
+
+export function useAutosaveDraft<T, TSerialized = T>(
+  formKey: string,
+  data: T,
+  options: UseAutosaveDraftOptions<T, TSerialized> = {},
+): UseAutosaveDraftResult<T> {
+  const supabase = useSupabaseBrowser()
+  const preferredStorage = options.storage ?? "supabase"
+  const throttleMs = options.throttleMs ?? DEFAULT_THROTTLE_MS
+  const expireMs = options.expireMs ?? DEFAULT_EXPIRY_MS
+  const enabled = options.enabled ?? true
+  const canSave = enabled && (options.isDirty ?? true)
+
+  const serializeRef = useRef<SerializeFn<T, TSerialized>>(options.serialize)
+  const deserializeRef = useRef<DeserializeFn<T, TSerialized>>(options.deserialize)
+
+  useEffect(() => {
+    serializeRef.current = options.serialize
+  }, [options.serialize])
+
+  useEffect(() => {
+    deserializeRef.current = options.deserialize
+  }, [options.deserialize])
+
+  const [userId, setUserId] = useState<string | null>(null)
+  const [authChecked, setAuthChecked] = useState(preferredStorage !== "supabase")
+  const [status, setStatus] = useState<AutosaveStatus>("idle")
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null)
+  const [lastError, setLastError] = useState<string | null>(null)
+  const [hasDraft, setHasDraft] = useState(false)
+  const [isLoadingDraft, setIsLoadingDraft] = useState(true)
+
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastSavedSnapshotRef = useRef<string>("")
+  const draftRef = useRef<Partial<T> | null>(null)
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (preferredStorage !== "supabase") {
+      return
+    }
+
+    let isActive = true
+
+    supabase.auth
+      .getUser()
+      .then(({ data }) => {
+        if (!isActive || !isMountedRef.current) {
+          return
+        }
+        setUserId(data.user?.id ?? null)
+        setAuthChecked(true)
+      })
+      .catch(() => {
+        if (!isActive || !isMountedRef.current) {
+          return
+        }
+        setUserId(null)
+        setAuthChecked(true)
+      })
+
+    return () => {
+      isActive = false
+    }
+  }, [preferredStorage, supabase])
+
+  const resolvedStorage: AutosaveStorageProvider = useMemo(() => {
+    if (preferredStorage === "supabase") {
+      if (userId) {
+        return "supabase"
+      }
+      if (authChecked) {
+        return "indexeddb"
+      }
+    }
+
+    return preferredStorage === "indexeddb" ? "indexeddb" : "supabase"
+  }, [authChecked, preferredStorage, userId])
+
+  const resetDraftState = useCallback(() => {
+    draftRef.current = null
+    lastSavedSnapshotRef.current = ""
+    if (!isMountedRef.current) {
+      return
+    }
+    setHasDraft(false)
+    setLastSavedAt(null)
+  }, [])
+
+  const loadDraft = useCallback(async (): Promise<Partial<T> | null> => {
+    if (!enabled) {
+      if (isMountedRef.current) {
+        setIsLoadingDraft(false)
+      }
+      return null
+    }
+
+    if (resolvedStorage === "supabase" && !userId) {
+      return null
+    }
+
+    if (isMountedRef.current) {
+      setIsLoadingDraft(true)
+    }
+
+    try {
+      if (resolvedStorage === "supabase") {
+        const { data: draft, error } = await supabase
+          .from("form_drafts")
+          .select("payload, updated_at, expires_at")
+          .eq("user_id", userId as string)
+          .eq("form_key", formKey)
+          .maybeSingle()
+
+        if (error) {
+          throw error
+        }
+
+        if (!draft) {
+          resetDraftState()
+          return null
+        }
+
+        const isExpired = Boolean(
+          draft.expires_at && new Date(draft.expires_at).getTime() < Date.now(),
+        )
+
+        if (isExpired) {
+          await supabase
+            .from("form_drafts")
+            .delete()
+            .eq("user_id", userId as string)
+            .eq("form_key", formKey)
+          resetDraftState()
+          return null
+        }
+
+        const serializedString = JSON.stringify(draft.payload ?? {})
+        lastSavedSnapshotRef.current = serializedString
+
+        const parsed = deserializeRef.current
+          ? deserializeRef.current(draft.payload as TSerialized)
+          : ((draft.payload as unknown) as Partial<T>)
+
+        draftRef.current = parsed
+        if (isMountedRef.current) {
+          setHasDraft(true)
+          setLastSavedAt(draft.updated_at ? new Date(draft.updated_at) : new Date())
+        }
+        return parsed
+      }
+
+      const record = await readDraftFromIndexedDb<TSerialized>(formKey)
+
+      if (!record) {
+        resetDraftState()
+        return null
+      }
+
+      const isExpired = Boolean(
+        record.expiresAt && new Date(record.expiresAt).getTime() < Date.now(),
+      )
+
+      if (isExpired) {
+        await deleteDraftFromIndexedDb(formKey)
+        resetDraftState()
+        return null
+      }
+
+      const serializedString = JSON.stringify(record.payload ?? {})
+      lastSavedSnapshotRef.current = serializedString
+
+      const parsed = deserializeRef.current
+        ? deserializeRef.current(record.payload as TSerialized)
+        : ((record.payload as unknown) as Partial<T>)
+
+      draftRef.current = parsed
+      if (isMountedRef.current) {
+        setHasDraft(true)
+        setLastSavedAt(record.updatedAt ? new Date(record.updatedAt) : new Date())
+      }
+      return parsed
+    } catch (error) {
+      console.error("Failed to load form draft", error)
+      if (isMountedRef.current) {
+        setLastError(error instanceof Error ? error.message : "Unable to load draft")
+      }
+      return null
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoadingDraft(false)
+      }
+    }
+  }, [enabled, formKey, resolvedStorage, resetDraftState, supabase, userId])
+
+  useEffect(() => {
+    if (!enabled) {
+      if (isMountedRef.current) {
+        setIsLoadingDraft(false)
+      }
+      return
+    }
+
+    if (resolvedStorage === "supabase" && !userId) {
+      return
+    }
+
+    void loadDraft()
+  }, [enabled, loadDraft, resolvedStorage, userId])
+
+  useEffect(() => {
+    if (!canSave) {
+      if (status !== "idle" && isMountedRef.current) {
+        setStatus("idle")
+      }
+      return
+    }
+
+    if (resolvedStorage === "supabase" && !userId) {
+      return
+    }
+
+    if (isLoadingDraft) {
+      return
+    }
+
+    const serializeFn = serializeRef.current
+    const serializedPayload = serializeFn ? serializeFn(data) : ((data as unknown) as TSerialized)
+
+    let serializedSnapshot: string
+    try {
+      serializedSnapshot = JSON.stringify(serializedPayload ?? {})
+    } catch (error) {
+      console.error("Failed to serialise form draft", error)
+      if (isMountedRef.current) {
+        setStatus("error")
+        setLastError(error instanceof Error ? error.message : "Unable to serialise form data")
+      }
+      return
+    }
+
+    if (serializedSnapshot === lastSavedSnapshotRef.current) {
+      return
+    }
+
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+    }
+
+    if (isMountedRef.current) {
+      setStatus("saving")
+      setLastError(null)
+    }
+
+    saveTimeoutRef.current = setTimeout(() => {
+      saveTimeoutRef.current = null
+
+      const persistDraft = async () => {
+        if (!isMountedRef.current) {
+          return
+        }
+
+        if (resolvedStorage === "supabase") {
+          if (!userId) {
+            return
+          }
+
+          try {
+            const expiresAtIso = new Date(Date.now() + expireMs).toISOString()
+            const { error } = await supabase
+              .from("form_drafts")
+              .upsert(
+                {
+                  user_id: userId,
+                  form_key: formKey,
+                  payload: serializedPayload,
+                  expires_at: expiresAtIso,
+                },
+                { onConflict: "user_id,form_key" },
+              )
+
+            if (error) {
+              throw error
+            }
+
+            const parsed = deserializeRef.current
+              ? deserializeRef.current(serializedPayload)
+              : ((serializedPayload as unknown) as Partial<T>)
+
+            draftRef.current = parsed
+            lastSavedSnapshotRef.current = serializedSnapshot
+            setHasDraft(true)
+            setLastSavedAt(new Date())
+            setStatus("saved")
+            setLastError(null)
+          } catch (error) {
+            console.error("Failed to save draft to Supabase", error)
+            setStatus("error")
+            setLastError(error instanceof Error ? error.message : "Failed to autosave draft")
+          }
+
+          return
+        }
+
+        try {
+          const record: IndexedDraftRecord<TSerialized> = {
+            key: formKey,
+            payload: serializedPayload,
+            updatedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + expireMs).toISOString(),
+          }
+
+          await writeDraftToIndexedDb(record)
+
+          const parsed = deserializeRef.current
+            ? deserializeRef.current(serializedPayload)
+            : ((serializedPayload as unknown) as Partial<T>)
+
+          draftRef.current = parsed
+          lastSavedSnapshotRef.current = serializedSnapshot
+          setHasDraft(true)
+          setLastSavedAt(new Date(record.updatedAt))
+          setStatus("saved")
+          setLastError(null)
+        } catch (error) {
+          console.error("Failed to save draft locally", error)
+          setStatus("error")
+          setLastError(error instanceof Error ? error.message : "Failed to autosave draft")
+        }
+      }
+
+      void persistDraft()
+    }, throttleMs)
+
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+        saveTimeoutRef.current = null
+      }
+    }
+  }, [canSave, data, expireMs, formKey, isLoadingDraft, resolvedStorage, status, supabase, throttleMs, userId])
+
+  const clearDraft = useCallback(async () => {
+    if (!enabled) {
+      return
+    }
+
+    try {
+      if (resolvedStorage === "supabase") {
+        if (!userId) {
+          return
+        }
+        await supabase
+          .from("form_drafts")
+          .delete()
+          .eq("user_id", userId)
+          .eq("form_key", formKey)
+      } else {
+        await deleteDraftFromIndexedDb(formKey)
+      }
+    } catch (error) {
+      console.error("Failed to clear draft", error)
+      if (isMountedRef.current) {
+        setStatus("error")
+        setLastError(error instanceof Error ? error.message : "Unable to clear draft")
+      }
+      return
+    }
+
+    resetDraftState()
+    if (isMountedRef.current) {
+      setStatus("idle")
+      setLastError(null)
+    }
+  }, [enabled, formKey, resetDraftState, resolvedStorage, supabase, userId])
+
+  const resumeDraft = useCallback(async () => {
+    if (draftRef.current) {
+      return draftRef.current
+    }
+
+    return loadDraft()
+  }, [loadDraft])
+
+  return {
+    status,
+    lastSavedAt,
+    lastError,
+    hasDraft,
+    isLoadingDraft,
+    resolvedStorage,
+    clearDraft,
+    resumeDraft,
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -199,6 +199,15 @@ export type Database = {
         created_at: string | null
         updated_at: string | null
       }>
+      form_drafts: SupabaseTable<{
+        id: string
+        user_id: string
+        form_key: string
+        payload: Json
+        created_at: string | null
+        updated_at: string | null
+        expires_at: string | null
+      }>
       email_notifications: SupabaseTable<{
         id: string
         user_id: string | null

--- a/supabase/migrations/20250104_form_drafts.sql
+++ b/supabase/migrations/20250104_form_drafts.sql
@@ -1,0 +1,41 @@
+-- Form drafts autosave storage
+CREATE TABLE public.form_drafts (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  form_key TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  expires_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE UNIQUE INDEX idx_form_drafts_user_form_key ON public.form_drafts(user_id, form_key);
+CREATE INDEX idx_form_drafts_expires_at ON public.form_drafts(expires_at);
+
+ALTER TABLE public.form_drafts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage their own form drafts" ON public.form_drafts
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER update_form_drafts_updated_at
+  BEFORE UPDATE ON public.form_drafts
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Schedule cleanup of stale drafts every day at 3 AM UTC
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'cleanup_form_drafts';
+
+SELECT
+  cron.schedule(
+    'cleanup_form_drafts',
+    '0 3 * * *',
+    $$
+      DELETE FROM public.form_drafts
+      WHERE (expires_at IS NOT NULL AND expires_at < NOW())
+         OR updated_at < NOW() - INTERVAL '30 days';
+    $$
+  );

--- a/utils/indexeddb.ts
+++ b/utils/indexeddb.ts
@@ -1,0 +1,140 @@
+const DB_NAME = "share-house-portal"
+const STORE_NAME = "form_drafts"
+const DB_VERSION = 1
+
+export type IndexedDraftRecord<T> = {
+  key: string
+  payload: T
+  updatedAt: string
+  expiresAt?: string | null
+}
+
+function isBrowser() {
+  return typeof window !== "undefined" && typeof window.indexedDB !== "undefined"
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  if (!isBrowser()) {
+    return Promise.reject(new Error("IndexedDB is not available in this environment"))
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION)
+
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: "key" })
+        store.createIndex("updatedAt", "updatedAt")
+        store.createIndex("expiresAt", "expiresAt")
+      }
+    }
+
+    request.onsuccess = () => {
+      resolve(request.result)
+    }
+
+    request.onerror = () => {
+      reject(request.error ?? new Error("Failed to open IndexedDB"))
+    }
+  })
+}
+
+export async function readDraftFromIndexedDb<T>(key: string): Promise<IndexedDraftRecord<T> | null> {
+  if (!isBrowser()) {
+    return null
+  }
+
+  const db = await openDatabase()
+
+  try {
+    return await new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, "readonly")
+      const store = transaction.objectStore(STORE_NAME)
+      const request = store.get(key)
+
+      request.onsuccess = () => {
+        resolve((request.result as IndexedDraftRecord<T> | undefined) ?? null)
+      }
+
+      request.onerror = () => {
+        reject(request.error ?? new Error("Failed to read draft from IndexedDB"))
+      }
+
+      transaction.oncomplete = () => {
+        db.close()
+      }
+
+      transaction.onabort = () => {
+        reject(transaction.error ?? new Error("IndexedDB transaction aborted"))
+      }
+    })
+  } catch (error) {
+    db.close()
+    throw error
+  }
+}
+
+export async function writeDraftToIndexedDb<T>(record: IndexedDraftRecord<T>): Promise<void> {
+  if (!isBrowser()) {
+    return
+  }
+
+  const db = await openDatabase()
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, "readwrite")
+      const store = transaction.objectStore(STORE_NAME)
+      const request = store.put(record)
+
+      request.onerror = () => {
+        reject(request.error ?? new Error("Failed to write draft to IndexedDB"))
+      }
+
+      transaction.oncomplete = () => {
+        resolve()
+        db.close()
+      }
+
+      transaction.onabort = () => {
+        reject(transaction.error ?? new Error("IndexedDB transaction aborted"))
+      }
+    })
+  } catch (error) {
+    db.close()
+    throw error
+  }
+}
+
+export async function deleteDraftFromIndexedDb(key: string): Promise<void> {
+  if (!isBrowser()) {
+    return
+  }
+
+  const db = await openDatabase()
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, "readwrite")
+      const store = transaction.objectStore(STORE_NAME)
+      const request = store.delete(key)
+
+      request.onerror = () => {
+        reject(request.error ?? new Error("Failed to delete draft from IndexedDB"))
+      }
+
+      transaction.oncomplete = () => {
+        resolve()
+        db.close()
+      }
+
+      transaction.onabort = () => {
+        reject(transaction.error ?? new Error("IndexedDB transaction aborted"))
+      }
+    })
+  } catch (error) {
+    db.close()
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `useAutosaveDraft` hook that throttles saves and targets Supabase or IndexedDB for draft persistence
- surface autosave banners, resume/discard controls, and status indicators on maintenance request and visitor booking forms while clearing drafts on submit
- provision a `form_drafts` Supabase table with nightly cleanup and document the autosave workflow for future forms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d5a8f4c83288f4ac89ae5c8c390