### PR TITLE
Add shared virtualized data table and migrate dashboard tables

### DIFF
--- a/app/dashboard/members/components/ListOfMembers.tsx
+++ b/app/dashboard/members/components/ListOfMembers.tsx
@@ -1,89 +1,193 @@
-import React from "react";
+"use client";
+
+import * as React from "react";
+import { ColumnDef, ColumnPinningState } from "@tanstack/react-table";
 import { TrashIcon } from "@radix-ui/react-icons";
-import { Button } from "@/components/ui/button";
-import EditMember from "./edit/EditMember";
+
 import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+        DataTable,
+        DataTableColumnHeader,
+} from "@/components/ui/data-table";
+
+import EditMember from "./edit/EditMember";
+
+type MemberRole = "admin" | "user" | "guest";
+type MemberStatus = "active" | "resigned" | "invited";
+
+interface MemberRow {
+        id: string;
+        name: string;
+        role: MemberRole;
+        joinedAt: string;
+        status: MemberStatus;
+}
+
+const MEMBER_DATA: MemberRow[] = [
+        {
+                id: "member-1",
+                name: "Admin Member",
+                role: "admin",
+                joinedAt: "2023-11-01T10:00:00.000Z",
+                status: "active",
+        },
+        {
+                id: "member-2",
+                name: "Non Admin User",
+                role: "user",
+                joinedAt: "2023-12-15T09:12:00.000Z",
+                status: "active",
+        },
+        {
+                id: "member-3",
+                name: "Administrator",
+                role: "admin",
+                joinedAt: "2024-01-22T18:05:00.000Z",
+                status: "resigned",
+        },
+        {
+                id: "member-4",
+                name: "Satoshi",
+                role: "user",
+                joinedAt: "2024-02-02T13:54:00.000Z",
+                status: "active",
+        },
+        {
+                id: "member-5",
+                name: "New Roommate",
+                role: "guest",
+                joinedAt: "2024-04-11T16:23:00.000Z",
+                status: "invited",
+        },
+        {
+                id: "member-6",
+                name: "Operations Lead",
+                role: "admin",
+                joinedAt: "2024-05-03T08:42:00.000Z",
+                status: "active",
+        },
+];
+
+const ROLE_BADGE: Record<MemberRole, { label: string; variant: "default" | "secondary" | "destructive" | "outline" | "complete"; className?: string }> = {
+        admin: { label: "Admin", variant: "secondary" },
+        user: { label: "User", variant: "outline" },
+        guest: { label: "Guest", variant: "default" },
+};
+
+const STATUS_BADGE: Record<MemberStatus, { label: string; variant: "default" | "secondary" | "destructive" | "outline" | "complete"; className?: string }> = {
+        active: { label: "Active", variant: "complete" },
+        resigned: { label: "Resigned", variant: "destructive" },
+        invited: { label: "Invited", variant: "secondary", className: "text-foreground" },
+};
+
+const columns: ColumnDef<MemberRow>[] = [
+        {
+                accessorKey: "name",
+                header: ({ column }) => (
+                        <DataTableColumnHeader column={column} title="Name" />
+                ),
+                cell: ({ row }) => <span className="font-medium text-foreground">{row.original.name}</span>,
+                size: 260,
+                minSize: 220,
+        },
+        {
+                accessorKey: "role",
+                header: ({ column }) => (
+                        <DataTableColumnHeader column={column} title="Role" />
+                ),
+                cell: ({ row }) => {
+                        const role = ROLE_BADGE[row.original.role];
+                        return (
+                                <Badge
+                                        variant={role.variant}
+                                        className={role.className}
+                                        aria-label={`Role ${role.label}`}
+                                >
+                                        {role.label}
+                                </Badge>
+                        );
+                },
+                size: 160,
+                minSize: 140,
+        },
+        {
+                accessorKey: "joinedAt",
+                header: ({ column }) => (
+                        <DataTableColumnHeader column={column} title="Joined" />
+                ),
+                cell: ({ row }) => (
+                        <time dateTime={row.original.joinedAt} className="text-muted-foreground">
+                                {new Date(row.original.joinedAt).toLocaleDateString(undefined, {
+                                        month: "short",
+                                        day: "numeric",
+                                        year: "numeric",
+                                })}
+                        </time>
+                ),
+                size: 180,
+                minSize: 160,
+        },
+        {
+                accessorKey: "status",
+                header: ({ column }) => (
+                        <DataTableColumnHeader column={column} title="Status" />
+                ),
+                cell: ({ row }) => {
+                        const status = STATUS_BADGE[row.original.status];
+                        return (
+                                <Badge
+                                        variant={status.variant}
+                                        className={status.className}
+                                        aria-label={`Status ${status.label}`}
+                                >
+                                        {status.label}
+                                </Badge>
+                        );
+                },
+                size: 160,
+                minSize: 140,
+        },
+        {
+                id: "actions",
+                header: ({ column }) => (
+                        <DataTableColumnHeader
+                                column={column}
+                                title="Actions"
+                                className="justify-end"
+                        />
+                ),
+                cell: () => (
+                        <div className="flex items-center justify-end gap-2">
+                                <Button variant="outline" size="sm" aria-label="Remove member">
+                                        <TrashIcon aria-hidden="true" />
+                                </Button>
+                                <EditMember />
+                        </div>
+                ),
+                enableSorting: false,
+                size: 160,
+                minSize: 140,
+                enablePinning: true,
+        },
+];
 
 export default function ListOfMembers() {
-	const members = [
-		{
-			name: "Admin Member",
-			role: "admin",
-			created_at: new Date().toDateString(),
-			status: "active",
-		},
-		{
-			name: "Non Admin User",
-			role: "user",
-			created_at: new Date().toDateString(),
-			status: "active",
-		},
-		{
-			name: "Administrator",
-			role: "admin",
-			created_at: new Date().toDateString(),
-			status: "resigned",
-		},
-		{
-			name: "Satoshi",
-			role: "user",
-			created_at: new Date().toDateString(),
-			status: "active",
-		},
-	];
-	return (
-		<div className="mx-2 rounded-sm bg-white dark:bg-inherit">
-			{members.map((member, index) => {
-				return (
-					<div
-						className=" grid grid-cols-5  rounded-sm  p-3 align-middle font-normal"
-						key={index}
-					>
-						<h1>{member.name}</h1>
+        const [columnPinning, setColumnPinning] = React.useState<ColumnPinningState>({
+                left: ["name"],
+                right: ["actions"],
+        });
 
-						<div>
-							<span
-								className={cn(
-									" rounded-full border-[.5px] px-2 py-1 text-sm capitalize  shadow dark:bg-zinc-800",
-									{
-										"border-green-500 text-green-600 bg-green-200":
-											member.role === "admin",
-										"border-zinc-300 dark:text-yellow-300 dark:border-yellow-700 px-4 bg-yellow-50":
-											member.role === "user",
-									}
-								)}
-							>
-								{member.role}
-							</span>
-						</div>
-						<h1>{member.created_at}</h1>
-						<div>
-							<span
-								className={cn(
-									" rounded-full border border-zinc-300 px-2  py-1 text-sm capitalize  dark:bg-zinc-800",
-									{
-										"text-green-600 px-4 dark:border-green-400 bg-green-200":
-											member.status === "active",
-										"text-red-500 bg-red-100 dark:text-red-300 dark:border-red-400":
-											member.status === "resigned",
-									}
-								)}
-							>
-								{member.status}
-							</span>
-						</div>
-
-						<div className="flex items-center gap-2">
-							<Button variant="outline">
-								<TrashIcon />
-								Delete
-							</Button>
-							<EditMember />
-						</div>
-					</div>
-				);
-			})}
-		</div>
-	);
+        return (
+                <DataTable
+                        columns={columns}
+                        data={MEMBER_DATA}
+                        state={{ columnPinning }}
+                        onColumnPinningChange={setColumnPinning}
+                        pageSizeOptions={[5, 10, 20]}
+                        bodyHeight={"24rem"}
+                        caption="Workspace members"
+                        getRowId={(row) => row.id}
+                />
+        );
 }

--- a/app/dashboard/members/components/MemberTable.tsx
+++ b/app/dashboard/members/components/MemberTable.tsx
@@ -1,15 +1,5 @@
-import { Button } from "@/components/ui/button";
-import React from "react";
-import { TrashIcon, Pencil1Icon } from "@radix-ui/react-icons";
 import ListOfMembers from "./ListOfMembers";
-import Table from "@/components/ui/Table";
 
 export default function MemberTable() {
-	const tableHeader = ["Name", "Role", "Joined", "Status"];
-
-	return (
-		<Table headers={tableHeader}>
-			<ListOfMembers />
-		</Table>
-	);
+        return <ListOfMembers />;
 }

--- a/app/dashboard/todo/components/ListOfTodo.tsx
+++ b/app/dashboard/todo/components/ListOfTodo.tsx
@@ -1,87 +1,214 @@
-import React from "react";
+"use client";
+
+import * as React from "react";
+import { ColumnDef, ColumnPinningState } from "@tanstack/react-table";
 import { TrashIcon } from "@radix-ui/react-icons";
-import { Button } from "@/components/ui/button";
-import EditTodo from "./EditTodo";
+
 import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+        DataTable,
+        DataTableColumnHeader,
+} from "@/components/ui/data-table";
+
+import EditTodo from "./EditTodo";
+
+type TodoStatus = "completed" | "in-progress" | "pending" | "blocked";
+
+interface TodoRow {
+        id: string;
+        title: string;
+        status: TodoStatus;
+        createdAt: string;
+        createdBy: string;
+}
+
+const TODO_DATA: TodoRow[] = [
+        {
+                id: "todo-1",
+                title: "Collect roommate rent splits",
+                status: "completed",
+                createdAt: "2024-06-01T08:10:00.000Z",
+                createdBy: "Garfield",
+        },
+        {
+                id: "todo-2",
+                title: "Schedule monthly chore review",
+                status: "in-progress",
+                createdAt: "2024-06-05T12:30:00.000Z",
+                createdBy: "Trender",
+        },
+        {
+                id: "todo-3",
+                title: "Confirm overnight guest approvals",
+                status: "pending",
+                createdAt: "2024-06-07T15:42:00.000Z",
+                createdBy: "Some string",
+        },
+        {
+                id: "todo-4",
+                title: "Sync utility bill receipts",
+                status: "blocked",
+                createdAt: "2024-06-10T09:00:00.000Z",
+                createdBy: "Jess",
+        },
+        {
+                id: "todo-5",
+                title: "Update parking rotation schedule",
+                status: "in-progress",
+                createdAt: "2024-06-12T18:24:00.000Z",
+                createdBy: "Garfield",
+        },
+        {
+                id: "todo-6",
+                title: "Send rent reminder push notification",
+                status: "pending",
+                createdAt: "2024-06-14T07:45:00.000Z",
+                createdBy: "Trender",
+        },
+        {
+                id: "todo-7",
+                title: "Archive expired lease addendums",
+                status: "completed",
+                createdAt: "2024-06-16T13:18:00.000Z",
+                createdBy: "Jess",
+        },
+        {
+                id: "todo-8",
+                title: "Review maintenance backlog",
+                status: "pending",
+                createdAt: "2024-06-18T11:05:00.000Z",
+                createdBy: "Garfield",
+        },
+        {
+                id: "todo-9",
+                title: "Audit Cal.com amenity sync",
+                status: "in-progress",
+                createdAt: "2024-06-20T10:11:00.000Z",
+                createdBy: "Trender",
+        },
+        {
+                id: "todo-10",
+                title: "Draft welcome kit updates",
+                status: "completed",
+                createdAt: "2024-06-22T19:22:00.000Z",
+                createdBy: "Jess",
+        },
+];
+
+const STATUS_LABELS: Record<TodoStatus, string> = {
+        completed: "Completed",
+        "in-progress": "In progress",
+        pending: "Pending",
+        blocked: "Blocked",
+};
+
+const STATUS_BADGE: Record<TodoStatus, { variant: "default" | "secondary" | "destructive" | "outline" | "complete"; className?: string }> = {
+        completed: { variant: "complete" },
+        "in-progress": { variant: "secondary", className: "text-foreground" },
+        pending: { variant: "outline" },
+        blocked: { variant: "destructive" },
+};
+
+const columns: ColumnDef<TodoRow>[] = [
+        {
+                accessorKey: "title",
+                header: ({ column }) => (
+                        <DataTableColumnHeader column={column} title="Title" />
+                ),
+                cell: ({ row }) => (
+                        <span className="font-medium text-foreground">{row.original.title}</span>
+                ),
+                size: 280,
+                minSize: 220,
+        },
+        {
+                accessorKey: "status",
+                header: ({ column }) => (
+                        <DataTableColumnHeader column={column} title="Status" />
+                ),
+                cell: ({ row }) => {
+                        const status = row.original.status;
+                        const badge = STATUS_BADGE[status];
+                        return (
+                                <Badge
+                                        variant={badge.variant}
+                                        className={badge.className}
+                                        aria-label={`Status ${STATUS_LABELS[status]}`}
+                                >
+                                        {STATUS_LABELS[status]}
+                                </Badge>
+                        );
+                },
+                size: 160,
+                minSize: 140,
+        },
+        {
+                accessorKey: "createdAt",
+                header: ({ column }) => (
+                        <DataTableColumnHeader column={column} title="Created" />
+                ),
+                cell: ({ row }) => (
+                        <time dateTime={row.original.createdAt} className="text-muted-foreground">
+                                {new Date(row.original.createdAt).toLocaleDateString(undefined, {
+                                        month: "short",
+                                        day: "numeric",
+                                        year: "numeric",
+                                })}
+                        </time>
+                ),
+                size: 180,
+                minSize: 160,
+        },
+        {
+                accessorKey: "createdBy",
+                header: ({ column }) => (
+                        <DataTableColumnHeader column={column} title="Created by" />
+                ),
+                cell: ({ row }) => <span>{row.original.createdBy}</span>,
+                size: 200,
+                minSize: 160,
+        },
+        {
+                id: "actions",
+                header: ({ column }) => (
+                        <DataTableColumnHeader
+                                column={column}
+                                title="Actions"
+                                className="justify-end"
+                        />
+                ),
+                cell: () => (
+                        <div className="flex items-center justify-end gap-2">
+                                <Button variant="outline" size="sm" aria-label="Delete todo">
+                                        <TrashIcon aria-hidden="true" />
+                                </Button>
+                                <EditTodo />
+                        </div>
+                ),
+                enableSorting: false,
+                size: 160,
+                minSize: 140,
+                enablePinning: true,
+        },
+];
 
 export default function ListOfTodo() {
-	const todos = [
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Garfield",
-		},
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Trender",
-		},
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Some string",
-		},
-	];
-	return (
-		<div className="mx-2 rounded-sm bg-white dark:bg-inherit">
-			{todos.map((todo, index) => {
-				return (
-					<div
-						className=" grid grid-cols-5  rounded-sm  p-3 align-middle font-normal "
-						key={index}
-					>
-						{Object.keys(todo).map((key, index) => {
-							if (key === "status") {
-								return (
-									<div
-										key={index}
-										className="flex items-center"
-									>
-										<div>
-											<span
-												className={cn(
-													"  rounded-full border-[.5px] px-2 py-1 text-sm capitalize  shadow dark:bg-zinc-800",
-													{
-														"border-green-500 bg-green-400 dark:text-green-400":
-															todo.status ===
-															"completed",
-													}
-												)}
-											>
-												{todo.status}
-											</span>
-										</div>
-									</div>
-								);
-							} else {
-								return (
-									<h1
-										className="flex items-center text-lg dark:text-white"
-										key={index}
-									>
-										{todo[key as keyof typeof todo]}
-									</h1>
-								);
-							}
-						})}
+        const [columnPinning, setColumnPinning] = React.useState<ColumnPinningState>({
+                left: ["title"],
+                right: ["actions"],
+        });
 
-						<div className="flex items-center gap-2">
-							<Button
-								variant="outline"
-								className="bg-dark dark:bg-inherit"
-							>
-								<TrashIcon />
-								delete
-							</Button>
-							<EditTodo />
-						</div>
-					</div>
-				);
-			})}
-		</div>
-	);
+        return (
+                <DataTable
+                        columns={columns}
+                        data={TODO_DATA}
+                        state={{ columnPinning }}
+                        onColumnPinningChange={setColumnPinning}
+                        pageSizeOptions={[5, 10, 20]}
+                        bodyHeight={"26rem"}
+                        caption="Outstanding todo items"
+                        getRowId={(row) => row.id}
+                />
+        );
 }

--- a/app/dashboard/todo/components/TodoTable.tsx
+++ b/app/dashboard/todo/components/TodoTable.tsx
@@ -1,13 +1,5 @@
-import React from "react";
 import ListOfTodo from "./ListOfTodo";
-import Table from "@/components/ui/Table";
 
 export default function TodoTable() {
-	const tableHeader = ["Title", "Status", "Created at", "Created by"];
-
-	return (
-		<Table headers={tableHeader}>
-			<ListOfTodo />
-		</Table>
-	);
+        return <ListOfTodo />;
 }

--- a/components/ui/data-table/data-table-column-header.tsx
+++ b/components/ui/data-table/data-table-column-header.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import * as React from "react";
+import { Column } from "@tanstack/react-table";
+import {
+        ArrowDownIcon,
+        ArrowUpIcon,
+        CaretSortIcon,
+        DotsHorizontalIcon,
+        PinLeftIcon,
+        PinRightIcon,
+} from "@radix-ui/react-icons";
+
+import { Button } from "@/components/ui/button";
+import {
+        DropdownMenu,
+        DropdownMenuContent,
+        DropdownMenuItem,
+        DropdownMenuSeparator,
+        DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface DataTableColumnHeaderProps<TData, TValue> {
+        column: Column<TData, TValue>;
+        title: React.ReactNode;
+        className?: string;
+        enablePinning?: boolean;
+}
+
+export function DataTableColumnHeader<TData, TValue>({
+        column,
+        title,
+        className,
+        enablePinning = true,
+}: DataTableColumnHeaderProps<TData, TValue>) {
+        const canSort = column.getCanSort();
+        const canPin = enablePinning && column.getCanPin();
+        const sorted = column.getIsSorted();
+        const isPinned = column.getIsPinned();
+        const titleText =
+                typeof title === "string"
+                        ? title
+                        : React.isValidElement(title) && typeof title.props.children === "string"
+                        ? title.props.children
+                        : "column";
+
+        const renderSortIcon = () => {
+                if (!canSort) {
+                        return null;
+                }
+                if (sorted === "asc") {
+                        return <ArrowUpIcon aria-hidden="true" className="size-3.5" />;
+                }
+                if (sorted === "desc") {
+                        return <ArrowDownIcon aria-hidden="true" className="size-3.5" />;
+                }
+                return <CaretSortIcon aria-hidden="true" className="size-3.5" />;
+        };
+
+        return (
+                <div className={cn("flex w-full items-center justify-between gap-2", className)}>
+                        {canSort ? (
+                                <button
+                                        type="button"
+                                        className="group inline-flex items-center gap-1 text-left font-medium text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        onClick={column.getToggleSortingHandler()}
+                                        aria-label={`Sort ${titleText}`}
+                                        aria-live="polite"
+                                >
+                                        <span>{title}</span>
+                                        {renderSortIcon()}
+                                </button>
+                        ) : (
+                                <span className="font-medium text-foreground">{title}</span>
+                        )}
+
+                        {(canSort || canPin) && (
+                                <DropdownMenu>
+                                        <DropdownMenuTrigger asChild>
+                                                <Button
+                                                        size="icon"
+                                                        variant="ghost"
+                                                        className="size-7"
+                                                        aria-label={`Column options for ${titleText}`}
+                                                >
+                                                        <DotsHorizontalIcon aria-hidden="true" className="size-4" />
+                                                </Button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent align="end" className="w-44">
+                                                {canSort ? (
+                                                        <>
+                                                                <DropdownMenuItem
+                                                                        onSelect={() => column.toggleSorting(false)}
+                                                                        aria-label="Sort ascending"
+                                                                >
+                                                                        <ArrowUpIcon className="mr-2 size-4" aria-hidden="true" />
+                                                                        Sort ascending
+                                                                </DropdownMenuItem>
+                                                                <DropdownMenuItem
+                                                                        onSelect={() => column.toggleSorting(true)}
+                                                                        aria-label="Sort descending"
+                                                                >
+                                                                        <ArrowDownIcon className="mr-2 size-4" aria-hidden="true" />
+                                                                        Sort descending
+                                                                </DropdownMenuItem>
+                                                                <DropdownMenuItem
+                                                                        disabled={!sorted}
+                                                                        onSelect={() => column.clearSorting()}
+                                                                        aria-label="Clear sorting"
+                                                                >
+                                                                        <CaretSortIcon className="mr-2 size-4" aria-hidden="true" />
+                                                                        Clear sorting
+                                                                </DropdownMenuItem>
+                                                        </>
+                                                ) : null}
+                                                {canPin ? <DropdownMenuSeparator /> : null}
+                                                {canPin ? (
+                                                        <>
+                                                                <DropdownMenuItem
+                                                                        disabled={isPinned === "left"}
+                                                                        onSelect={() => column.pin("left")}
+                                                                        aria-label="Pin column to the left"
+                                                                >
+                                                                        <PinLeftIcon className="mr-2 size-4" aria-hidden="true" />
+                                                                        Pin to left
+                                                                </DropdownMenuItem>
+                                                                <DropdownMenuItem
+                                                                        disabled={isPinned === "right"}
+                                                                        onSelect={() => column.pin("right")}
+                                                                        aria-label="Pin column to the right"
+                                                                >
+                                                                        <PinRightIcon className="mr-2 size-4" aria-hidden="true" />
+                                                                        Pin to right
+                                                                </DropdownMenuItem>
+                                                                <DropdownMenuItem
+                                                                        disabled={!isPinned}
+                                                                        onSelect={() => column.pin(false)}
+                                                                        aria-label="Unpin column"
+                                                                >
+                                                                        <DotsHorizontalIcon
+                                                                                className="mr-2 size-4 rotate-90"
+                                                                                aria-hidden="true"
+                                                                        />
+                                                                        Unpin
+                                                                </DropdownMenuItem>
+                                                        </>
+                                                ) : null}
+                                        </DropdownMenuContent>
+                                </DropdownMenu>
+                        )}
+                </div>
+        );
+}

--- a/components/ui/data-table/data-table-pagination.tsx
+++ b/components/ui/data-table/data-table-pagination.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import { Table } from "@tanstack/react-table";
+import {
+        ChevronLeftIcon,
+        ChevronRightIcon,
+        DoubleArrowLeftIcon,
+        DoubleArrowRightIcon,
+} from "@radix-ui/react-icons";
+
+import { Button } from "@/components/ui/button";
+import {
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+interface DataTablePaginationProps<TData> {
+        table: Table<TData>;
+        pageSizeOptions?: number[];
+        ariaLabel?: string;
+        ariaControls?: string;
+        className?: string;
+}
+
+export function DataTablePagination<TData>({
+        table,
+        pageSizeOptions = [10, 20, 50, 100],
+        ariaLabel = "Table pagination",
+        ariaControls,
+        className,
+}: DataTablePaginationProps<TData>) {
+        const pagination = table.getState().pagination;
+        const pageIndex = pagination?.pageIndex ?? 0;
+        const pageSize = pagination?.pageSize ?? table.getRowModel().rows.length || pageSizeOptions[0];
+        const resolvedPageSizeOptions = React.useMemo(() => {
+                const merged = new Set<number>(pageSizeOptions);
+                merged.add(pageSize);
+                return Array.from(merged).sort((a, b) => a - b);
+        }, [pageSize, pageSizeOptions]);
+        const pageCount = table.getPageCount() || 1;
+        const canPreviousPage = table.getCanPreviousPage();
+        const canNextPage = table.getCanNextPage();
+        const currentRows = table.getRowModel().rows.length;
+        const totalRows =
+                typeof table.options.rowCount === "number"
+                        ? table.options.rowCount
+                        : table.getPrePaginationRowModel().rows.length;
+        const firstRow = totalRows === 0 ? 0 : pageIndex * pageSize + 1;
+        const lastRow = totalRows === 0 ? 0 : firstRow + currentRows - 1;
+
+        return (
+                <div
+                        className={cn(
+                                "flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between",
+                                className
+                        )}
+                        role="navigation"
+                        aria-label={ariaLabel}
+                >
+                        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                                <span className="hidden sm:inline">Rows per page</span>
+                                <Select
+                                        value={String(pageSize)}
+                                        onValueChange={(value) => table.setPageSize(Number(value))}
+                                >
+                                        <SelectTrigger className="h-8 w-[5.5rem]">
+                                                <SelectValue aria-label={`Show ${pageSize} rows`}>
+                                                        {pageSize}
+                                                </SelectValue>
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                                {resolvedPageSizeOptions.map((option) => (
+                                                        <SelectItem key={option} value={String(option)}>
+                                                                {option}
+                                                        </SelectItem>
+                                                ))}
+                                        </SelectContent>
+                                </Select>
+                                <span className="whitespace-nowrap">
+                                        Showing {firstRow === 0 ? 0 : firstRow}–{lastRow} of {totalRows}
+                                </span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                                <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => table.setPageIndex(0)}
+                                        disabled={!canPreviousPage}
+                                        aria-label="Go to first page"
+                                        aria-controls={ariaControls}
+                                >
+                                        <DoubleArrowLeftIcon aria-hidden="true" className="size-4" />
+                                </Button>
+                                <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => table.previousPage()}
+                                        disabled={!canPreviousPage}
+                                        aria-label="Go to previous page"
+                                        aria-controls={ariaControls}
+                                >
+                                        <ChevronLeftIcon aria-hidden="true" className="size-4" />
+                                </Button>
+                                <span className="px-2 text-sm font-medium text-foreground">
+                                        Page {pageIndex + 1} of {pageCount}
+                                </span>
+                                <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => table.nextPage()}
+                                        disabled={!canNextPage}
+                                        aria-label="Go to next page"
+                                        aria-controls={ariaControls}
+                                >
+                                        <ChevronRightIcon aria-hidden="true" className="size-4" />
+                                </Button>
+                                <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => table.setPageIndex(pageCount - 1)}
+                                        disabled={!canNextPage}
+                                        aria-label="Go to last page"
+                                        aria-controls={ariaControls}
+                                >
+                                        <DoubleArrowRightIcon aria-hidden="true" className="size-4" />
+                                </Button>
+                        </div>
+                </div>
+        );
+}

--- a/components/ui/data-table/data-table.tsx
+++ b/components/ui/data-table/data-table.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import * as React from "react";
+import {
+        ColumnDef,
+        ColumnPinningState,
+        OnChangeFn,
+        PaginationState,
+        SortingState,
+        Table as TableInstance,
+        flexRender,
+        getCoreRowModel,
+        getPaginationRowModel,
+        getSortedRowModel,
+        useReactTable,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+import { cn } from "@/lib/utils";
+
+import { DataTablePagination } from "./data-table-pagination";
+
+export type DataTableState = Partial<{
+        sorting: SortingState;
+        pagination: PaginationState;
+        columnPinning: ColumnPinningState;
+}>;
+
+export interface DataTableProps<TData, TValue> {
+        columns: ColumnDef<TData, TValue>[];
+        data: TData[];
+        pageCount?: number;
+        rowCount?: number;
+        state?: DataTableState;
+        onSortingChange?: OnChangeFn<SortingState>;
+        onPaginationChange?: OnChangeFn<PaginationState>;
+        onColumnPinningChange?: OnChangeFn<ColumnPinningState>;
+        manualSorting?: boolean;
+        manualPagination?: boolean;
+        enableColumnPinning?: boolean;
+        estimateRowHeight?: number;
+        overscan?: number;
+        pageSizeOptions?: number[];
+        isLoading?: boolean;
+        emptyState?: React.ReactNode;
+        caption?: React.ReactNode;
+        className?: string;
+        tableClassName?: string;
+        bodyClassName?: string;
+        bodyHeight?: number | string;
+        renderPagination?: (table: TableInstance<TData>) => React.ReactNode;
+        getRowId?: (originalRow: TData, index: number) => string;
+}
+
+function getManualState<T>(value: T | undefined, fallback: T | undefined) {
+        return value === undefined ? fallback : value;
+}
+
+export function DataTable<TData, TValue>({
+        columns,
+        data,
+        pageCount,
+        rowCount,
+        state,
+        onSortingChange,
+        onPaginationChange,
+        onColumnPinningChange,
+        manualSorting,
+        manualPagination,
+        enableColumnPinning = true,
+        estimateRowHeight = 48,
+        overscan = 5,
+        pageSizeOptions,
+        isLoading = false,
+        emptyState,
+        caption,
+        className,
+        tableClassName,
+        bodyClassName,
+        bodyHeight = "60vh",
+        renderPagination,
+        getRowId,
+}: DataTableProps<TData, TValue>) {
+        const tableId = React.useId();
+
+        const resolvedManualSorting = getManualState(manualSorting, Boolean(onSortingChange));
+        const resolvedManualPagination = getManualState(
+                manualPagination,
+                Boolean(onPaginationChange)
+        );
+
+        const tableState = React.useMemo(() => {
+                if (!state) return undefined;
+                const nextState: DataTableState = {};
+                if (state.sorting !== undefined) {
+                        nextState.sorting = state.sorting;
+                }
+                if (state.pagination !== undefined) {
+                        nextState.pagination = state.pagination;
+                }
+                if (state.columnPinning !== undefined) {
+                        nextState.columnPinning = state.columnPinning;
+                }
+                return nextState;
+        }, [state]);
+
+        const table = useReactTable({
+                data,
+                columns,
+                state: tableState,
+                onSortingChange,
+                onPaginationChange,
+                onColumnPinningChange,
+                enableColumnPinning,
+                manualSorting: resolvedManualSorting,
+                manualPagination: resolvedManualPagination,
+                pageCount,
+                rowCount,
+                getCoreRowModel: getCoreRowModel(),
+                getSortedRowModel: resolvedManualSorting ? undefined : getSortedRowModel(),
+                getPaginationRowModel: resolvedManualPagination ? undefined : getPaginationRowModel(),
+                getRowId,
+        });
+
+        const containerRef = React.useRef<HTMLDivElement>(null);
+        const rows = table.getRowModel().rows;
+        const rowVirtualizer = useVirtualizer({
+                count: rows.length,
+                getScrollElement: () => containerRef.current,
+                estimateSize: () => estimateRowHeight,
+                overscan,
+        });
+
+        const virtualRows = rowVirtualizer.getVirtualItems();
+        const totalSize = rowVirtualizer.getTotalSize();
+        const paddingTop = virtualRows.length > 0 ? virtualRows[0]?.start ?? 0 : 0;
+        const paddingBottom = virtualRows.length > 0 ? totalSize - (virtualRows.at(-1)?.end ?? totalSize) : 0;
+
+        const columnCount = table.getVisibleLeafColumns().length;
+        const paginationState = table.getState().pagination;
+        const baseRowIndex = React.useMemo(() => {
+                if (!paginationState) {
+                        return 0;
+                }
+                return (paginationState.pageIndex ?? 0) * (paginationState.pageSize ?? rows.length);
+        }, [paginationState, rows.length]);
+
+        const leftPinnedColumns = table.getState().columnPinning?.left ?? [];
+        const rightPinnedColumns = table.getState().columnPinning?.right ?? [];
+        const leftOffsets = new Map<string, number>();
+        let runningLeftOffset = 0;
+        for (const columnId of leftPinnedColumns) {
+                const column = table.getColumn(columnId);
+                if (!column || !column.getIsVisible()) continue;
+                leftOffsets.set(columnId, runningLeftOffset);
+                runningLeftOffset += column.getSize();
+        }
+
+        const rightOffsets = new Map<string, number>();
+        let runningRightOffset = 0;
+        for (const columnId of rightPinnedColumns) {
+                const column = table.getColumn(columnId);
+                if (!column || !column.getIsVisible()) continue;
+                rightOffsets.set(columnId, runningRightOffset);
+                runningRightOffset += column.getSize();
+        }
+
+        const focusRow = React.useCallback(
+                (index: number) => {
+                        if (!containerRef.current) return;
+                        requestAnimationFrame(() => {
+                                const target = containerRef.current?.querySelector<HTMLElement>(
+                                        `[data-row-index="${index}"]`
+                                );
+                                target?.focus();
+                        });
+                },
+                []
+        );
+
+        const handleRowKeyDown = React.useCallback(
+                (event: React.KeyboardEvent<HTMLTableRowElement>, rowIndex: number) => {
+                        if (event.defaultPrevented || rows.length === 0) return;
+                        if (event.key === "ArrowDown") {
+                                event.preventDefault();
+                                const nextIndex = Math.min(rowIndex + 1, rows.length - 1);
+                                rowVirtualizer.scrollToIndex(nextIndex, { align: "start" });
+                                if (nextIndex !== rowIndex) {
+                                        focusRow(nextIndex);
+                                }
+                        } else if (event.key === "ArrowUp") {
+                                event.preventDefault();
+                                const prevIndex = Math.max(rowIndex - 1, 0);
+                                rowVirtualizer.scrollToIndex(prevIndex, { align: "start" });
+                                if (prevIndex !== rowIndex) {
+                                        focusRow(prevIndex);
+                                }
+                        }
+                },
+                [focusRow, rowVirtualizer, rows.length]
+        );
+
+        const renderPinningStyles = (columnId: string, pinState: "left" | "right" | false) => {
+                if (pinState === "left") {
+                        return {
+                                position: "sticky" as const,
+                                left: leftOffsets.get(columnId) ?? 0,
+                                zIndex: 1,
+                                backgroundColor: "hsl(var(--background))",
+                        };
+                }
+                if (pinState === "right") {
+                        return {
+                                position: "sticky" as const,
+                                right: rightOffsets.get(columnId) ?? 0,
+                                zIndex: 1,
+                                backgroundColor: "hsl(var(--background))",
+                        };
+                }
+                return {};
+        };
+
+        const tablePagination = React.useMemo(() => {
+                if (renderPagination) {
+                        return renderPagination(table);
+                }
+                return (
+                        <DataTablePagination
+                                ariaControls={tableId}
+                                table={table}
+                                pageSizeOptions={pageSizeOptions}
+                        />
+                );
+        }, [pageSizeOptions, renderPagination, table, tableId]);
+
+        const emptyContent = emptyState ?? (
+                <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                        No results found.
+                </div>
+        );
+
+        const resolvedRowCount = rowCount ?? rows.length;
+
+        return (
+                <div className={cn("space-y-4", className)}>
+                        <div
+                                ref={containerRef}
+                                className={cn(
+                                        "relative overflow-auto rounded-md border border-border bg-background",
+                                        bodyClassName
+                                )}
+                                style={{ maxHeight: bodyHeight }}
+                                aria-live="polite"
+                                aria-busy={isLoading ? "true" : undefined}
+                        >
+                                <table
+                                        id={tableId}
+                                        role="grid"
+                                        aria-colcount={columnCount}
+                                        aria-rowcount={resolvedRowCount}
+                                        className={cn(
+                                                "min-w-full border-collapse text-sm [&_th]:bg-muted/60",
+                                                tableClassName
+                                        )}
+                                >
+                                        {caption ? <caption className="sr-only">{caption}</caption> : null}
+                                        <thead className="sticky top-0 z-10">
+                                                {table.getHeaderGroups().map((headerGroup) => (
+                                                        <tr key={headerGroup.id} role="row">
+                                                                {headerGroup.headers.map((header) => {
+                                                                        const isPinned = header.column.getIsPinned();
+                                                                        const pinningStyles = renderPinningStyles(
+                                                                                header.column.id,
+                                                                                isPinned
+                                                                        );
+                                                                        return (
+                                                                                <th
+                                                                                        key={header.id}
+                                                                                        role="columnheader"
+                                                                                        scope="col"
+                                                                                        className={cn(
+                                                                                                "h-12 px-4 text-left align-middle font-semibold text-foreground",
+                                                                                                isPinned &&
+                                                                                                        "border-r border-border bg-background"
+                                                                                        )}
+                                                                                        style={{
+                                                                                                width: header.getSize(),
+                                                                                                minWidth: header.column.columnDef.minSize,
+                                                                                                ...pinningStyles,
+                                                                                        }}
+                                                                                        aria-sort={
+                                                                                                header.column.getIsSorted() === "asc"
+                                                                                                        ? "ascending"
+                                                                                                        : header.column.getIsSorted() ===
+                                                                                                          "desc"
+                                                                                                                ? "descending"
+                                                                                                                : "none"
+                                                                                        }
+                                                                                >
+                                                                                        {header.isPlaceholder
+                                                                                                ? null
+                                                                                                : flexRender(
+                                                                                                          header.column.columnDef.header,
+                                                                                                          header.getContext()
+                                                                                                  )}
+                                                                                </th>
+                                                                        );
+                                                                })}
+                                                        </tr>
+                                                ))}
+                                        </thead>
+                                        <tbody role="rowgroup">
+                                                {paddingTop > 0 ? (
+                                                        <tr aria-hidden="true">
+                                                                <td colSpan={columnCount} style={{ height: paddingTop }} />
+                                                        </tr>
+                                                ) : null}
+                                                {virtualRows.map((virtualRow) => {
+                                                        const row = rows[virtualRow.index];
+                                                        return (
+                                                                <tr
+                                                                        key={row.id}
+                                                                        role="row"
+                                                                        data-row-index={row.index}
+                                                                        tabIndex={0}
+                                                                        aria-rowindex={baseRowIndex + row.index + 1}
+                                                                        className="even:bg-muted/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                        onKeyDown={(event) => handleRowKeyDown(event, row.index)}
+                                                                >
+                                                                        {row.getVisibleCells().map((cell) => {
+                                                                                const isPinned = cell.column.getIsPinned();
+                                                                                const pinningStyles = renderPinningStyles(
+                                                                                        cell.column.id,
+                                                                                        isPinned
+                                                                                );
+                                                                                return (
+                                                                                        <td
+                                                                                                key={cell.id}
+                                                                                                role="gridcell"
+                                                                                                className={cn(
+                                                                                                        "h-12 px-4 align-middle",
+                                                                                                        isPinned && "bg-background"
+                                                                                                )}
+                                                                                                style={{
+                                                                                                        width: cell.column.getSize(),
+                                                                                                        minWidth:
+                                                                                                                cell.column.columnDef.minSize,
+                                                                                                        ...pinningStyles,
+                                                                                                }}
+                                                                                        >
+                                                                                                {flexRender(
+                                                                                                        cell.column.columnDef.cell,
+                                                                                                        cell.getContext()
+                                                                                                )}
+                                                                                        </td>
+                                                                                );
+                                                                        })}
+                                                                </tr>
+                                                        );
+                                                })}
+                                                {paddingBottom > 0 ? (
+                                                        <tr aria-hidden="true">
+                                                                <td colSpan={columnCount} style={{ height: paddingBottom }} />
+                                                        </tr>
+                                                ) : null}
+                                                {!rows.length && !isLoading ? (
+                                                        <tr>
+                                                                <td colSpan={columnCount}>{emptyContent}</td>
+                                                        </tr>
+                                                ) : null}
+                                        </tbody>
+                                </table>
+                                {isLoading ? (
+                                        <div className="absolute inset-x-0 bottom-2 flex justify-center">
+                                                <span className="rounded-full bg-background px-3 py-1 text-xs text-muted-foreground shadow">
+                                                        Loading…
+                                                </span>
+                                        </div>
+                                ) : null}
+                        </div>
+                        {tablePagination}
+                </div>
+        );
+}

--- a/components/ui/data-table/index.ts
+++ b/components/ui/data-table/index.ts
@@ -1,0 +1,3 @@
+export * from "./data-table";
+export * from "./data-table-column-header";
+export * from "./data-table-pagination";

--- a/docs/perf/tables.md
+++ b/docs/perf/tables.md
@@ -1,0 +1,86 @@
+# Data table performance and accessibility
+
+The shared `DataTable` primitive under `components/ui/data-table/` wraps TanStack Table + Virtual and ships with the guardrails we need for large result sets and assistive tech users.
+
+## Core capabilities
+
+- **Row virtualization** is on by default through `@tanstack/react-virtual`. Only the visible slice of rows is rendered while maintaining the correct table semantics (`role="grid"`, `aria-rowcount`, and filler rows marked with `aria-hidden`).
+- **Column pinning** is supported via TanStack's column pinning state. Left/right pinned cells are rendered with sticky positioning, consistent background colour, and menu actions exposed in each column header.
+- **Server-driven sorting & pagination** are opt-in. The table exposes controlled state callbacks so data loaders can keep the UI in sync with remote filters while keeping keyboard + screen reader affordances intact.
+
+## Configuring the component
+
+```tsx
+import {
+  DataTable,
+  type DataTableState,
+} from "@/components/ui/data-table";
+import type { ColumnDef, ColumnPinningState, SortingState } from "@tanstack/react-table";
+
+const columns: ColumnDef<MyRow>[] = [
+  // ...define column defs (see members/todos for examples)
+];
+
+const [sorting, setSorting] = React.useState<SortingState>([]);
+const [pagination, setPagination] = React.useState({ pageIndex: 0, pageSize: 25 });
+const [columnPinning, setColumnPinning] = React.useState<ColumnPinningState>({
+  left: ["name"],
+  right: ["actions"],
+});
+
+<DataTable
+  columns={columns}
+  data={rows}
+  state={{ sorting, pagination, columnPinning }}
+  onSortingChange={setSorting}
+  onPaginationChange={setPagination}
+  onColumnPinningChange={setColumnPinning}
+  manualSorting
+  manualPagination
+  pageCount={pageCount}
+  rowCount={totalRows}
+  bodyHeight="28rem"
+  estimateRowHeight={54}
+  getRowId={(row) => row.id}
+/>;
+```
+
+Key props:
+
+- `bodyHeight` limits the scroll viewport and activates virtualization. Adjust `estimateRowHeight` if row density changes.
+- When attaching to a server data source, set `manualSorting` and/or `manualPagination` to `true` and provide the relevant callbacks/state (`onSortingChange`, `onPaginationChange`, `pageCount`, `rowCount`). The component keeps focusable rows and navigation buttons in sync while data is reloading (`aria-busy` toggles automatically when `isLoading` is true).
+- `getRowId` is strongly recommended so virtualised row focus remains stable when results shuffle.
+
+## Column header helpers
+
+Use `DataTableColumnHeader` inside your column definitions to render the accessible sort & pin menu. The dropdown exposes sort ascending/descending/reset plus pin left/right/unpin actions. Headers remain reachable through keyboard controls and show Radix icons for visual status.
+
+```tsx
+const columns: ColumnDef<MyRow>[] = [
+  {
+    accessorKey: "name",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Name" />
+    ),
+  },
+  {
+    id: "actions",
+    enableSorting: false,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Actions" className="justify-end" />
+    ),
+  },
+];
+```
+
+## Pagination UI
+
+`DataTablePagination` renders the condensed navigation footer used by the members and todos tables. It wires up the current page, page count, and total row summary with ARIA labels that reference the parent grid. You can pass a custom `renderPagination` function to `DataTable` if a screen needs a bespoke footer.
+
+## Accessibility notes
+
+- Rows are tabbable and support arrow key navigation. Moving up/down triggers the virtualizer to keep the focused row visible.
+- Column headers announce `aria-sort` changes and the table body announces loading states via `aria-busy`.
+- Sticky (pinned) columns reuse the theme background colour so focus rings remain visible in both light and dark modes.
+
+Refer to `app/dashboard/todo/components/ListOfTodo.tsx` and `app/dashboard/members/components/ListOfMembers.tsx` for full usage examples.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -38,6 +38,8 @@
         "@supabase/ssr": "^0.0.10",
         "@supabase/supabase-js": "^2.39.3",
         "@tanstack/react-query": "^5.51.9",
+        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.13.12",
         "@types/mdx": "^2.0.13",
         "@vercel/analytics": "^1.3.1",
         "@vercel/speed-insights": "^1.0.12",
@@ -3191,6 +3193,66 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tweenjs/tween.js": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@supabase/ssr": "^0.0.10",
     "@supabase/supabase-js": "^2.39.3",
     "@tanstack/react-query": "^5.51.9",
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.12",
     "@types/mdx": "^2.0.13",
     "@vercel/analytics": "^1.3.1",
     "@vercel/speed-insights": "^1.0.12",


### PR DESCRIPTION
## Summary
- add a reusable TanStack-powered `DataTable` with row virtualization, column pinning, manual sort/pagination hooks, and accessible keyboard support
- introduce column header and pagination helpers plus documentation covering performance configuration
- migrate the dashboard todo and member tables to the new data table implementation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d55d8288328aff58495cfbecf12