### PR TITLE
Add automated canary deployment workflow

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -1,0 +1,199 @@
+name: Canary Release Promotion
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  CANARY_SLACK_WEBHOOK: ${{ secrets.CANARY_SLACK_WEBHOOK }}
+  CANARY_EMAIL_RECIPIENTS: ${{ secrets.CANARY_EMAIL_RECIPIENTS }}
+  CANARY_EMAIL_FROM: ${{ secrets.CANARY_EMAIL_FROM }}
+  RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+
+jobs:
+  deploy_canary:
+    name: Deploy canary preview
+    runs-on: ubuntu-latest
+    outputs:
+      preview-url: ${{ steps.deploy.outputs.preview-url }}
+      deployment-id: ${{ steps.deploy.outputs.deployment-id }}
+      previous-production-id: ${{ steps.previous.outputs.production-id }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build application
+        run: pnpm build
+      - name: Capture current production deployment
+        id: previous
+        env:
+          PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$PROJECT_ID" ]; then
+            echo "Vercel credentials are missing" >&2
+            exit 1
+          fi
+          response=$(curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" "https://api.vercel.com/v6/deployments?projectId=$PROJECT_ID&target=production&limit=1")
+          previous_id=$(echo "$response" | jq -r '.deployments[0].uid // ""')
+          echo "production-id=$previous_id" >> "$GITHUB_OUTPUT"
+      - name: Deploy canary to Vercel
+        id: deploy
+        run: |
+          set -euo pipefail
+          deployment=$(pnpm dlx vercel deploy --prebuilt --yes --target=preview --token "$VERCEL_TOKEN" --scope "$VERCEL_ORG_ID" --env CANARY=1 --json)
+          echo "$deployment"
+          preview_host=$(echo "$deployment" | jq -r '.url')
+          deployment_id=$(echo "$deployment" | jq -r '.deploymentId // .uid')
+          if [ -z "$preview_host" ] || [ -z "$deployment_id" ]; then
+            echo "Failed to determine deployment metadata" >&2
+            exit 1
+          fi
+          echo "preview-url=https://$preview_host" >> "$GITHUB_OUTPUT"
+          echo "deployment-id=$deployment_id" >> "$GITHUB_OUTPUT"
+
+  rum:
+    name: Real User Monitoring gate
+    runs-on: ubuntu-latest
+    needs: deploy_canary
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Evaluate RUM metrics
+        env:
+          CANARY_URL: ${{ needs.deploy_canary.outputs.preview-url }}
+          RUM_METRICS_ENDPOINT: ${{ secrets.RUM_METRICS_ENDPOINT }}
+          RUM_METRICS_API_KEY: ${{ secrets.RUM_METRICS_API_KEY }}
+        run: node ./scripts/canary/rum-check.mjs
+
+  uptime:
+    name: Canary uptime gate
+    runs-on: ubuntu-latest
+    needs: deploy_canary
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Verify uptime
+        env:
+          CANARY_URL: ${{ needs.deploy_canary.outputs.preview-url }}
+          UPTIME_CHECK_URL: ${{ secrets.UPTIME_CHECK_URL }}
+          UPTIME_CHECK_PATH: ${{ secrets.UPTIME_CHECK_PATH }}
+          UPTIME_CHECK_API_KEY: ${{ secrets.UPTIME_CHECK_API_KEY }}
+          UPTIME_EXPECTED_STATUS: ${{ secrets.UPTIME_EXPECTED_STATUS }}
+        run: node ./scripts/canary/uptime-check.mjs
+
+  lighthouse:
+    name: Lighthouse regression gate
+    runs-on: ubuntu-latest
+    needs: deploy_canary
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run Lighthouse CI
+        env:
+          CANARY_URL: ${{ needs.deploy_canary.outputs.preview-url }}
+          LIGHTHOUSE_RUNS: ${{ secrets.LIGHTHOUSE_RUNS }}
+        run: pnpm dlx @lhci/cli@0.14.0 autorun --config=./lighthouserc.cjs
+
+  smoke:
+    name: Smoke tests
+    runs-on: ubuntu-latest
+    needs: deploy_canary
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Execute smoke suite
+        env:
+          CANARY_URL: ${{ needs.deploy_canary.outputs.preview-url }}
+          NODE_ENV: test
+        run: pnpm canary:smoke
+
+  promote:
+    name: Promote canary to production
+    runs-on: ubuntu-latest
+    needs:
+      - deploy_canary
+      - rum
+      - uptime
+      - lighthouse
+      - smoke
+    if: |
+      ${{ needs.rum.result == 'success' && needs.uptime.result == 'success' && needs.lighthouse.result == 'success' && needs.smoke.result == 'success' }}
+    steps:
+      - name: Promote deployment
+        run: pnpm dlx vercel promote ${{ needs.deploy_canary.outputs.deployment-id }} --yes --token "$VERCEL_TOKEN" --scope "$VERCEL_ORG_ID"
+      - name: Notify Slack of promotion
+        if: env.CANARY_SLACK_WEBHOOK != ''
+        env:
+          PREVIEW_URL: ${{ needs.deploy_canary.outputs.preview-url }}
+        run: |
+          payload=$(jq -n --arg text "Canary promotion succeeded for $PREVIEW_URL" '{text: $text}')
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "$CANARY_SLACK_WEBHOOK"
+      - name: Notify stakeholders via email
+        if: env.RESEND_API_KEY != '' && env.CANARY_EMAIL_RECIPIENTS != '' && env.CANARY_EMAIL_FROM != ''
+        env:
+          PREVIEW_URL: ${{ needs.deploy_canary.outputs.preview-url }}
+        run: |
+          curl -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg from "$CANARY_EMAIL_FROM" --arg to "$CANARY_EMAIL_RECIPIENTS" --arg subject 'Canary promoted to production' --arg html "<p>The canary deployment at <a href='$PREVIEW_URL'>$PREVIEW_URL</a> passed all checks and was promoted to production.</p>" '{from: $from, to: ($to | split(",")), subject: $subject, html: $html}')"
+
+  rollback:
+    name: Rollback on regression
+    runs-on: ubuntu-latest
+    needs:
+      - deploy_canary
+      - rum
+      - uptime
+      - lighthouse
+      - smoke
+    if: ${{ failure() }}
+    steps:
+      - name: Execute rollback
+        if: ${{ needs.deploy_canary.outputs.previous-production-id != '' }}
+        run: pnpm dlx vercel promote ${{ needs.deploy_canary.outputs.previous-production-id }} --yes --token "$VERCEL_TOKEN" --scope "$VERCEL_ORG_ID"
+      - name: Notify Slack of failure
+        if: env.CANARY_SLACK_WEBHOOK != ''
+        env:
+          PREVIEW_URL: ${{ needs.deploy_canary.outputs.preview-url }}
+        run: |
+          payload=$(jq -n --arg text "Canary promotion failed for $PREVIEW_URL. Rollback executed." '{text: $text}')
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "$CANARY_SLACK_WEBHOOK"
+      - name: Notify stakeholders via email
+        if: env.RESEND_API_KEY != '' && env.CANARY_EMAIL_RECIPIENTS != '' && env.CANARY_EMAIL_FROM != ''
+        env:
+          PREVIEW_URL: ${{ needs.deploy_canary.outputs.preview-url }}
+        run: |
+          curl -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg from "$CANARY_EMAIL_FROM" --arg to "$CANARY_EMAIL_RECIPIENTS" --arg subject 'Canary rollback executed' --arg html "<p>The canary deployment at <a href='$PREVIEW_URL'>$PREVIEW_URL</a> failed quality gates and has been rolled back to the last known good release.</p>" '{from: $from, to: ($to | split(",")), subject: $subject, html: $html}')"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+/.lighthouse/
 
 # debug
 npm-debug.log*

--- a/config/canary/thresholds.json
+++ b/config/canary/thresholds.json
@@ -1,0 +1,17 @@
+{
+  "rum": {
+    "clsP75": 0.1,
+    "fidP75": 100,
+    "lcpP75": 2500
+  },
+  "uptime": {
+    "maxResponseTimeMs": 1500,
+    "expectedStatus": 200
+  },
+  "lighthouse": {
+    "performance": 0.9,
+    "accessibility": 0.9,
+    "bestPractices": 0.9,
+    "seo": 0.9
+  }
+}

--- a/docs/deployment/canary.md
+++ b/docs/deployment/canary.md
@@ -1,0 +1,69 @@
+# Canary Deployment Flow
+
+This document explains how the Roomsily portal promotes code merged into `main` through a canary environment, validates release quality, and promotes to production. The automation lives in `.github/workflows/canary-deploy.yml` and is triggered automatically on merges to `main`.
+
+## Pipeline Overview
+
+1. **Build & Deploy**
+   - The workflow installs dependencies with `pnpm`, builds the Next.js application, and deploys it to a dedicated Vercel preview using `vercel deploy --target=preview` with `CANARY=1` in the environment.
+   - The preview URL and deployment ID are captured for subsequent jobs.
+   - The workflow also records the current production deployment ID so it can revert if checks fail.
+2. **Quality Gates**
+   - **RUM guard** – `scripts/canary/rum-check.mjs` fetches real user monitoring metrics from `RUM_METRICS_ENDPOINT` (or `https://<preview>/api/canary/rum-summary`) and validates them against the thresholds defined in `config/canary/thresholds.json`.
+   - **Uptime guard** – `scripts/canary/uptime-check.mjs` probes `CANARY_URL` (or `UPTIME_CHECK_URL`) and ensures we return the expected status in less than the configured response budget.
+   - **Lighthouse** – `pnpm canary:lighthouse` runs Lighthouse CI against the preview URL with score assertions sourced from `config/canary/thresholds.json` via `lighthouserc.cjs`.
+   - **Smoke suite** – `pnpm canary:smoke` executes the Vitest tests under `tests/` to confirm core flows still work.
+3. **Promotion or Rollback**
+   - If all gates succeed, the workflow promotes the canary deployment with `vercel promote <deploymentId>` and posts announcements to Slack and email.
+   - If any gate fails, the workflow promotes the previously recorded production deployment (rolling back) and notifies stakeholders of the failure.
+
+## Required Secrets
+
+Configure the following secrets in the repository or organisation settings before enabling the workflow:
+
+| Secret | Purpose |
+| --- | --- |
+| `VERCEL_TOKEN` | Vercel access token used for deploy/promote calls. |
+| `VERCEL_ORG_ID` | Organisation scope for the Roomsily project. |
+| `VERCEL_PROJECT_ID` | Project ID for the portal. |
+| `CANARY_SLACK_WEBHOOK` | Incoming webhook URL for the delivery-status Slack channel. |
+| `RESEND_API_KEY` | API key for sending transactional emails via Resend. |
+| `CANARY_EMAIL_FROM` | Sender address for rollout notifications. |
+| `CANARY_EMAIL_RECIPIENTS` | Comma-separated list of stakeholders to email. |
+| `RUM_METRICS_ENDPOINT` (optional) | Override metrics endpoint for RUM checks. |
+| `RUM_METRICS_API_KEY` (optional) | API key for the metrics endpoint. |
+| `UPTIME_CHECK_URL` / `UPTIME_CHECK_PATH` (optional) | Override endpoint for uptime probes if different from `/api/health`. |
+| `UPTIME_CHECK_API_KEY` / `UPTIME_EXPECTED_STATUS` (optional) | Authentication and custom status expectations for uptime probes. |
+| `LIGHTHOUSE_RUNS` (optional) | Number of Lighthouse runs to average per release. |
+
+## Threshold Configuration
+
+`config/canary/thresholds.json` centralises the budgets enforced by automation. Update these numbers when performance budgets change and keep them in sync with observability dashboards. The same file powers the RUM, uptime, and Lighthouse checks.
+
+## Rollback Playbook
+
+Automation mirrors the manual playbook:
+
+1. Capture the ID of the latest production deployment before creating the canary.
+2. If any gate fails, immediately alias production back to that saved deployment using `vercel promote <previousDeploymentId>`.
+3. Publish Slack and email alerts explaining the failure and linking the canary URL for investigation.
+4. Leave the failed canary deployment active for debugging, but block promotion until the regression is fixed and merged.
+
+Because the workflow implements the exact steps above, engineers can still execute the same commands locally if needed.
+
+## Notifications
+
+Slack and email alerts fire on both promotion success and rollback. Messages include the preview URL to aid debugging and audit. Update the Slack channel or mailing list by changing the corresponding secrets.
+
+## Local Verification
+
+To reproduce the gates locally against a running canary deployment, export `CANARY_URL` and run:
+
+```bash
+pnpm canary:rum
+pnpm canary:uptime
+pnpm canary:lighthouse
+pnpm canary:smoke
+```
+
+Ensure the metrics APIs you rely on are reachable from your environment and that the thresholds file matches expectations before adjusting automation.

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -1,0 +1,33 @@
+const thresholds = require('./config/canary/thresholds.json');
+
+const canaryUrl = process.env.CANARY_URL;
+if (!canaryUrl) {
+  throw new Error('CANARY_URL must be set to run Lighthouse checks');
+}
+
+const numberOfRuns = Number(process.env.LIGHTHOUSE_RUNS || 1);
+
+module.exports = {
+  ci: {
+    collect: {
+      url: [canaryUrl],
+      numberOfRuns,
+      settings: {
+        chromeFlags: '--no-sandbox',
+        preset: 'desktop'
+      }
+    },
+    assert: {
+      assertions: {
+        'categories:performance': ['error', { minScore: thresholds.lighthouse.performance }],
+        'categories:accessibility': ['error', { minScore: thresholds.lighthouse.accessibility }],
+        'categories:best-practices': ['error', { minScore: thresholds.lighthouse.bestPractices }],
+        'categories:seo': ['error', { minScore: thresholds.lighthouse.seo }]
+      }
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: '.lighthouse'
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "canary:rum": "node ./scripts/canary/rum-check.mjs",
+    "canary:uptime": "node ./scripts/canary/uptime-check.mjs",
+    "canary:smoke": "vitest run --dir tests --reporter=dot",
+    "canary:lighthouse": "pnpm dlx @lhci/cli@0.14.0 autorun --config=./lighthouserc.cjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/scripts/canary/rum-check.mjs
+++ b/scripts/canary/rum-check.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const thresholdsPath = path.resolve(__dirname, '../../config/canary/thresholds.json');
+const thresholdsRaw = await readFile(thresholdsPath, 'utf8');
+const thresholds = JSON.parse(thresholdsRaw);
+
+const previewUrl = process.env.CANARY_URL;
+const metricsEndpoint = process.env.RUM_METRICS_ENDPOINT || (previewUrl ? new URL('/api/canary/rum-summary', previewUrl).toString() : null);
+
+if (!metricsEndpoint) {
+  console.error('RUM metrics endpoint not configured. Set RUM_METRICS_ENDPOINT or provide CANARY_URL.');
+  process.exit(1);
+}
+
+const headers = {};
+if (process.env.RUM_METRICS_API_KEY) {
+  headers['Authorization'] = `Bearer ${process.env.RUM_METRICS_API_KEY}`;
+}
+
+const response = await fetch(metricsEndpoint, { headers });
+if (!response.ok) {
+  console.error(`Failed to load RUM metrics from ${metricsEndpoint}. Received status ${response.status}.`);
+  process.exit(1);
+}
+
+const payload = await response.json();
+const metrics = {
+  clsP75: Number(payload.clsP75 ?? payload.cls?.p75 ?? payload.cumulativeLayoutShift?.p75 ?? NaN),
+  fidP75: Number(payload.fidP75 ?? payload.fid?.p75 ?? payload.firstInputDelay?.p75 ?? NaN),
+  lcpP75: Number(payload.lcpP75 ?? payload.lcp?.p75 ?? payload.largestContentfulPaint?.p75 ?? NaN)
+};
+
+const missing = Object.entries(metrics).filter(([, value]) => Number.isNaN(value)).map(([key]) => key);
+if (missing.length > 0) {
+  console.error(`Missing expected RUM metrics: ${missing.join(', ')}.`);
+  process.exit(1);
+}
+
+const violations = [];
+if (metrics.clsP75 > thresholds.rum.clsP75) {
+  violations.push(`p75 CLS ${metrics.clsP75} exceeds threshold ${thresholds.rum.clsP75}`);
+}
+if (metrics.fidP75 > thresholds.rum.fidP75) {
+  violations.push(`p75 FID ${metrics.fidP75} exceeds threshold ${thresholds.rum.fidP75}ms`);
+}
+if (metrics.lcpP75 > thresholds.rum.lcpP75) {
+  violations.push(`p75 LCP ${metrics.lcpP75} exceeds threshold ${thresholds.rum.lcpP75}ms`);
+}
+
+if (violations.length > 0) {
+  console.error('RUM regression detected:\n- ' + violations.join('\n- '));
+  process.exit(1);
+}
+
+console.log('RUM metrics are within thresholds.');

--- a/scripts/canary/uptime-check.mjs
+++ b/scripts/canary/uptime-check.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const thresholdsPath = path.resolve(__dirname, '../../config/canary/thresholds.json');
+const thresholdsRaw = await readFile(thresholdsPath, 'utf8');
+const thresholds = JSON.parse(thresholdsRaw);
+
+const baseUrl = process.env.UPTIME_CHECK_URL || process.env.CANARY_URL;
+if (!baseUrl) {
+  console.error('Uptime check requires CANARY_URL or UPTIME_CHECK_URL.');
+  process.exit(1);
+}
+
+const checkPath = process.env.UPTIME_CHECK_PATH || '/api/health';
+const probeUrl = new URL(checkPath, baseUrl).toString();
+const headers = {};
+if (process.env.UPTIME_CHECK_API_KEY) {
+  headers['Authorization'] = `Bearer ${process.env.UPTIME_CHECK_API_KEY}`;
+}
+
+const start = performance.now();
+const response = await fetch(probeUrl, { headers });
+const duration = performance.now() - start;
+
+if (response.status !== (process.env.UPTIME_EXPECTED_STATUS ? Number(process.env.UPTIME_EXPECTED_STATUS) : thresholds.uptime.expectedStatus)) {
+  console.error(`Uptime check failed. Expected status ${process.env.UPTIME_EXPECTED_STATUS || thresholds.uptime.expectedStatus} but received ${response.status}.`);
+  process.exit(1);
+}
+
+if (!response.ok) {
+  console.error(`Probe to ${probeUrl} failed with status ${response.status}.`);
+  process.exit(1);
+}
+
+if (duration > thresholds.uptime.maxResponseTimeMs) {
+  console.error(`Uptime regression detected: response time ${duration.toFixed(2)}ms exceeds threshold ${thresholds.uptime.maxResponseTimeMs}ms.`);
+  process.exit(1);
+}
+
+console.log(`Uptime check passed in ${duration.toFixed(2)}ms.`);


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys a Vercel canary on main merges, runs RUM/uptime/Lighthouse/smoke gates, and promotes or rolls back with stakeholder notifications
- add reusable canary quality gate scripts, thresholds, and Lighthouse CI configuration
- document the canary deployment process, required secrets, thresholds, and rollback playbook

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d43e53c8328926ce6ad3dd8d877