### PR TITLE
Add server-driven invite redemption flow with metrics

### DIFF
--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server"
+
+type MetricsPayload = {
+  route: string
+  metric: string
+  value: number
+  threshold?: number
+  navigationStart?: number
+  serverTimestamp?: number
+}
+
+const isMetricsPayload = (payload: unknown): payload is MetricsPayload => {
+  if (!payload || typeof payload !== "object") {
+    return false
+  }
+
+  const record = payload as Record<string, unknown>
+  return (
+    typeof record.route === "string" &&
+    typeof record.metric === "string" &&
+    typeof record.value === "number"
+  )
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+
+    if (!isMetricsPayload(body)) {
+      return NextResponse.json({ error: "Invalid metrics payload" }, { status: 400 })
+    }
+
+    console.info("[metrics]", body)
+
+    return NextResponse.json({ status: "ok" }, { status: 200 })
+  } catch (error) {
+    console.warn("Failed to parse metrics payload", error)
+    return NextResponse.json({ error: "Unable to process metrics" }, { status: 400 })
+  }
+}

--- a/app/onboarding/redeem/[token]/InviteContext.tsx
+++ b/app/onboarding/redeem/[token]/InviteContext.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { createContext, useContext } from "react"
+
+import type { InvitePrefetchContext } from "./types"
+
+const InvitePrefetchContextInstance = createContext<InvitePrefetchContext | null>(null)
+
+export const InviteContextProvider = InvitePrefetchContextInstance.Provider
+
+export function useInviteContext(): InvitePrefetchContext {
+  const context = useContext(InvitePrefetchContextInstance)
+
+  if (!context) {
+    throw new Error("useInviteContext must be used within an InviteContextProvider")
+  }
+
+  return context
+}

--- a/app/onboarding/redeem/[token]/InviteRedemptionContent.tsx
+++ b/app/onboarding/redeem/[token]/InviteRedemptionContent.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
+import { CalendarCheck, Home, MapPin, Bed, Bath, Ruler } from "lucide-react"
+
+import { InviteContextProvider, useInviteContext } from "./InviteContext"
+import { InviteRedemptionForm } from "./InviteRedemptionForm"
+import { InviteRouteMetrics } from "./InviteRouteMetrics"
+import type { InvitePrefetchContext } from "./types"
+
+const formatAddress = (context: InvitePrefetchContext) => {
+  const { property } = context
+  const line2 = property.addressLine2 ? `, ${property.addressLine2}` : ""
+  const localityParts = [property.city, property.state, property.postalCode].filter(Boolean)
+  const locality = localityParts.length ? `, ${localityParts.join(", ")}` : ""
+  return `${property.addressLine1}${line2}${locality}`
+}
+
+function PropertyOverview() {
+  const context = useInviteContext()
+  const unit = context.unit
+  const property = context.property
+  const formattedAddress = formatAddress(context)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Home className="size-5" />
+          {property.name}
+        </CardTitle>
+        <CardDescription>
+          {context.invitedByName
+            ? `${context.invitedByName} invited you to join this household.`
+            : "You’re joining this household."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div className="flex items-start gap-3">
+          <MapPin className="mt-1 size-4 text-muted-foreground" />
+          <div>
+            <p className="font-medium">{formattedAddress}</p>
+            {property.timezone ? (
+              <p className="text-muted-foreground">Timezone: {property.timezone}</p>
+            ) : null}
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="space-y-2">
+          <p className="font-medium">Unit {unit.label}</p>
+          <div className="flex flex-wrap items-center gap-3 text-muted-foreground">
+            {typeof unit.bedrooms === "number" ? (
+              <span className="inline-flex items-center gap-1">
+                <Bed className="size-4" /> {unit.bedrooms} bedrooms
+              </span>
+            ) : null}
+            {typeof unit.bathrooms === "number" ? (
+              <span className="inline-flex items-center gap-1">
+                <Bath className="size-4" /> {unit.bathrooms} baths
+              </span>
+            ) : null}
+            {typeof unit.floorArea === "number" ? (
+              <span className="inline-flex items-center gap-1">
+                <Ruler className="size-4" /> {unit.floorArea} sq ft
+              </span>
+            ) : null}
+            {unit.availableFrom ? (
+              <span className="inline-flex items-center gap-1">
+                <CalendarCheck className="size-4" /> Available {unit.availableFrom}
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        {context.notes ? (
+          <div className="rounded-md bg-muted p-3 text-muted-foreground">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Invite note</p>
+            <p>{context.notes}</p>
+          </div>
+        ) : null}
+
+        {property.amenities.length ? (
+          <div className="space-y-2">
+            <p className="font-medium">Household amenities</p>
+            <div className="flex flex-wrap gap-2">
+              {property.amenities.map((amenity) => (
+                <Badge key={amenity} variant="secondary">
+                  {amenity}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}
+
+type InviteRedemptionContentProps = {
+  context: InvitePrefetchContext
+}
+
+export default function InviteRedemptionContent({ context }: InviteRedemptionContentProps) {
+  return (
+    <InviteContextProvider value={context}>
+      <InviteRouteMetrics route="onboarding/redeem" serverTimestamp={context.serverRenderedAt} />
+      <div className="container max-w-6xl space-y-10 py-12">
+        <header className="space-y-2 text-center">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            Complete your Roomsily onboarding
+          </h1>
+          <p className="text-base text-muted-foreground sm:text-lg">
+            {context.invitedByName
+              ? `${context.invitedByName} invited you to Unit ${context.unit.label} at ${context.property.name}.`
+              : `You’re joining Unit ${context.unit.label} at ${context.property.name}.`}
+          </p>
+        </header>
+
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(320px,380px)]">
+          <Card className="shadow-sm">
+            <CardHeader>
+              <CardTitle>Tell us about yourself</CardTitle>
+              <CardDescription>
+                Confirm your contact information and acknowledge the household policies to unlock your account.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <InviteRedemptionForm />
+            </CardContent>
+          </Card>
+
+          <PropertyOverview />
+        </div>
+      </div>
+    </InviteContextProvider>
+  )
+}

--- a/app/onboarding/redeem/[token]/InviteRedemptionForm.tsx
+++ b/app/onboarding/redeem/[token]/InviteRedemptionForm.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import { FormEvent, useMemo, useState, useTransition } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/components/ui/use-toast"
+
+import { useInviteContext } from "./InviteContext"
+import { completeInviteRedemption } from "./actions"
+
+const formatCurrency = (value: number | null, currency: string | null) => {
+  if (value === null) {
+    return null
+  }
+
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency ?? "USD",
+      maximumFractionDigits: 0,
+    }).format(value)
+  } catch (error) {
+    console.warn("Unable to format currency", error)
+    return value.toString()
+  }
+}
+
+export function InviteRedemptionForm() {
+  const context = useInviteContext()
+  const [fullName, setFullName] = useState("")
+  const [phone, setPhone] = useState("")
+  const [rentShare, setRentShare] = useState("")
+  const [formNotes, setFormNotes] = useState("")
+  const [acceptPolicies, setAcceptPolicies] = useState(false)
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle")
+  const [isPending, startTransition] = useTransition()
+
+  const recommendedRentShare = useMemo(() => {
+    const metadataValue = context.inviteMetadata?.rent_share_recommendation
+
+    if (typeof metadataValue === "number") {
+      return metadataValue
+    }
+
+    if (typeof metadataValue === "string") {
+      const parsed = Number(metadataValue)
+      if (!Number.isNaN(parsed)) {
+        return parsed
+      }
+    }
+
+    if (typeof context.unit.rent === "number") {
+      return Math.round(context.unit.rent / 2)
+    }
+
+    return null
+  }, [context.inviteMetadata, context.unit.rent])
+
+  const formattedRentShare = useMemo(
+    () => formatCurrency(recommendedRentShare, context.unit.currency),
+    [recommendedRentShare, context.unit.currency]
+  )
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const numericRentShare = rentShare.trim() ? Number(rentShare) : null
+    const resolvedRentShare =
+      numericRentShare !== null && !Number.isNaN(numericRentShare)
+        ? numericRentShare
+        : recommendedRentShare
+
+    startTransition(() => {
+      completeInviteRedemption({
+        inviteToken: context.inviteToken,
+        fullName: fullName.trim(),
+        phone: phone.trim(),
+        rentShare: resolvedRentShare ?? null,
+        notes: formNotes.trim(),
+        acceptPolicies,
+      })
+        .then((result) => {
+          if (result.ok) {
+            setStatus("success")
+            toast({
+              title: "Invite redeemed",
+              description: result.message,
+            })
+          } else {
+            setStatus("error")
+            toast({
+              title: "Unable to redeem invite",
+              description: result.message,
+              variant: "destructive",
+            })
+          }
+        })
+        .catch((error) => {
+          console.error("Invite redemption failed", error)
+          setStatus("error")
+          toast({
+            title: "Something went wrong",
+            description: "Please try again in a moment.",
+            variant: "destructive",
+          })
+        })
+    })
+  }
+
+  const submitDisabled = isPending || !acceptPolicies || !fullName.trim()
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="fullName">Full name</Label>
+          <Input
+            id="fullName"
+            name="fullName"
+            value={fullName}
+            autoComplete="name"
+            placeholder="Jamie Lee"
+            onChange={(event) => setFullName(event.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="phone">Mobile phone</Label>
+          <Input
+            id="phone"
+            name="phone"
+            type="tel"
+            value={phone}
+            autoComplete="tel"
+            placeholder="(555) 555-1234"
+            onChange={(event) => setPhone(event.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" value={context.inviteeEmail} readOnly className="bg-muted" />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="rentShare">Monthly rent share</Label>
+          <Input
+            id="rentShare"
+            name="rentShare"
+            inputMode="decimal"
+            value={rentShare}
+            placeholder={formattedRentShare ?? ""}
+            onChange={(event) => setRentShare(event.target.value)}
+          />
+          {formattedRentShare ? (
+            <p className="text-xs text-muted-foreground">
+              Recommended share based on invite details: {formattedRentShare}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="notes">Move-in notes</Label>
+        <Textarea
+          id="notes"
+          name="notes"
+          value={formNotes}
+          placeholder={context.notes ?? "Let the household know about your move-in preferences."}
+          onChange={(event) => setFormNotes(event.target.value)}
+          rows={4}
+        />
+      </div>
+
+      <div className="flex items-start space-x-3 rounded-lg border border-border p-4">
+        <Checkbox
+          id="acceptPolicies"
+          checked={acceptPolicies}
+          onCheckedChange={(checked) => setAcceptPolicies(Boolean(checked))}
+        />
+        <Label htmlFor="acceptPolicies" className="cursor-pointer">
+          I agree to the household policies and acknowledge the move-in details for {context.property.name}.
+        </Label>
+      </div>
+
+      <Button type="submit" disabled={submitDisabled} className="w-full sm:w-auto">
+        {isPending ? "Processing..." : "Join the household"}
+      </Button>
+
+      {status === "success" ? (
+        <p className="text-sm text-green-600">
+          You’re all set! We’ll notify the household lead that you’ve confirmed your spot.
+        </p>
+      ) : null}
+      {status === "error" ? (
+        <p className="text-sm text-destructive">
+          We couldn’t finalize the invite. Double-check the form and try again.
+        </p>
+      ) : null}
+    </form>
+  )
+}

--- a/app/onboarding/redeem/[token]/InviteRouteMetrics.tsx
+++ b/app/onboarding/redeem/[token]/InviteRouteMetrics.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useEffect } from "react"
+
+const TTI_THRESHOLD_MS = 200
+
+type InviteRouteMetricsProps = {
+  route: string
+  serverTimestamp: number
+}
+
+const sendMetrics = (payload: Record<string, unknown>) => {
+  try {
+    if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
+      const blob = new Blob([JSON.stringify(payload)], { type: "application/json" })
+      navigator.sendBeacon("/api/metrics", blob)
+      return
+    }
+
+    void fetch("/api/metrics", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    })
+  } catch (error) {
+    console.warn("Failed to record invite metrics", error)
+  }
+}
+
+const computeNavigationStart = (): number => {
+  if (typeof performance === "undefined") {
+    return Date.now()
+  }
+
+  if (performance.timeOrigin) {
+    return performance.timeOrigin
+  }
+
+  const timing = (performance as Performance & { timing?: PerformanceTiming }).timing
+  return timing?.navigationStart ?? Date.now()
+}
+
+export function InviteRouteMetrics({ route, serverTimestamp }: InviteRouteMetricsProps) {
+  useEffect(() => {
+    const navigationStart = computeNavigationStart()
+
+    const recordMetric = () => {
+      const tti = performance.now()
+      const metricPayload = {
+        route,
+        metric: "tti",
+        value: Math.round(tti),
+        navigationStart,
+        serverTimestamp,
+        threshold: TTI_THRESHOLD_MS,
+      }
+
+      if (tti > TTI_THRESHOLD_MS) {
+        console.warn(`Invite redemption TTI exceeded threshold: ${tti.toFixed(0)}ms`)
+      } else {
+        console.info(`Invite redemption TTI: ${tti.toFixed(0)}ms`)
+      }
+
+      sendMetrics(metricPayload)
+    }
+
+    if ("requestIdleCallback" in window) {
+      ;(window as typeof window & { requestIdleCallback: (cb: IdleRequestCallback) => number }).requestIdleCallback(
+        () => recordMetric()
+      )
+    } else {
+      const timeout = window.setTimeout(recordMetric, 0)
+      return () => window.clearTimeout(timeout)
+    }
+
+    return undefined
+  }, [route, serverTimestamp])
+
+  return null
+}

--- a/app/onboarding/redeem/[token]/actions.ts
+++ b/app/onboarding/redeem/[token]/actions.ts
@@ -1,0 +1,67 @@
+"use server"
+
+import { cookies } from "next/headers"
+
+import { createClient } from "@/utils/supa-server-actions"
+
+type CompleteInviteInput = {
+  inviteToken: string
+  fullName: string
+  phone: string
+  rentShare: number | null
+  notes: string
+  acceptPolicies: boolean
+}
+
+type CompleteInviteResult = {
+  ok: boolean
+  message: string
+}
+
+export async function completeInviteRedemption(input: CompleteInviteInput): Promise<CompleteInviteResult> {
+  if (!input.acceptPolicies) {
+    return {
+      ok: false,
+      message: "You must accept the household policies to continue.",
+    }
+  }
+
+  const cookieStore = cookies()
+  const client = createClient(cookieStore)
+
+  const hasSupabaseConfig = Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  )
+
+  if (!hasSupabaseConfig) {
+    return {
+      ok: true,
+      message: "Invite captured locally. Configure Supabase to persist acceptance.",
+    }
+  }
+
+  const updatePayload = {
+    status: "accepted" as const,
+    metadata: {
+      ...input,
+      completedAt: new Date().toISOString(),
+    },
+  }
+
+  const { error } = await client
+    .from("household_invites")
+    .update(updatePayload)
+    .eq("token", input.inviteToken)
+
+  if (error) {
+    return {
+      ok: false,
+      message: error.message ?? "Unable to redeem invite right now.",
+    }
+  }
+
+  return {
+    ok: true,
+    message: "Invite redeemed! Welcome to your new household.",
+  }
+}

--- a/app/onboarding/redeem/[token]/loader.ts
+++ b/app/onboarding/redeem/[token]/loader.ts
@@ -1,0 +1,205 @@
+import { cache } from "react"
+import { cookies } from "next/headers"
+import { notFound } from "next/navigation"
+
+import { createClient } from "@/utils/supa-server-actions"
+import type { Tables } from "@/lib/supabase"
+
+import type { InvitePrefetchContext } from "./types"
+
+const fallbackInvites: Record<
+  string,
+  {
+    invite: Tables<"household_invites">
+    unit: Tables<"units">
+    property: Tables<"properties">
+  }
+> = {
+  "demo-welcome-token": {
+    invite: {
+      id: "invite-demo-001",
+      token: "demo-welcome-token",
+      email: "jamie.lee@example.com",
+      status: "pending",
+      invited_by: "user-taylor-morgan",
+      property_id: "property-demo-001",
+      unit_id: "unit-demo-3b",
+      message: "Excited to have you join the household. Move-in is scheduled for June 1st!",
+      created_at: new Date("2024-05-12T10:00:00Z").toISOString(),
+      expires_at: new Date("2024-07-01T23:59:59Z").toISOString(),
+      metadata: {
+        invited_by_name: "Taylor Morgan",
+        rent_share_recommendation: 1275,
+      },
+    },
+    unit: {
+      id: "unit-demo-3b",
+      property_id: "property-demo-001",
+      unit_number: "3B",
+      bedrooms: 2,
+      bathrooms: 2,
+      floor_area: 980,
+      rent: 2550,
+      currency: "USD",
+      available_from: "2024-06-01",
+      created_at: null,
+      updated_at: null,
+      metadata: {
+        parking: "Underground spot 17",
+        features: ["Balcony", "In-unit laundry", "South-facing windows"],
+      },
+    },
+    property: {
+      id: "property-demo-001",
+      name: "Hudson Loft Residences",
+      address_line1: "88 Riverside Avenue",
+      address_line2: "Lobby 4",
+      city: "Jersey City",
+      state: "NJ",
+      postal_code: "07302",
+      country: "US",
+      timezone: "America/New_York",
+      created_at: null,
+      updated_at: null,
+      metadata: {
+        amenities: ["Rooftop Deck", "Co-working Lounge", "Bike Storage", "Secure Package Room"],
+      },
+    },
+  },
+}
+
+const parseMetadata = (value: Tables<"household_invites">["metadata"]): Record<string, unknown> | null => {
+  if (!value || Array.isArray(value) || typeof value !== "object") {
+    return null
+  }
+  return value as Record<string, unknown>
+}
+
+const parsePropertyMetadata = (value: Tables<"properties">["metadata"]): Record<string, unknown> | null => {
+  if (!value || Array.isArray(value) || typeof value !== "object") {
+    return null
+  }
+  return value as Record<string, unknown>
+}
+
+const parseUnitMetadata = (value: Tables<"units">["metadata"]): Record<string, unknown> | null => {
+  if (!value || Array.isArray(value) || typeof value !== "object") {
+    return null
+  }
+  return value as Record<string, unknown>
+}
+
+const extractAmenities = (metadata: Record<string, unknown> | null): string[] => {
+  if (!metadata) {
+    return []
+  }
+
+  const amenities = metadata["amenities"]
+  if (!Array.isArray(amenities)) {
+    return []
+  }
+
+  return amenities.filter((item): item is string => typeof item === "string")
+}
+
+const normalizeContext = (
+  record: {
+    invite: Tables<"household_invites">
+    unit: Tables<"units">
+    property: Tables<"properties">
+  }
+): InvitePrefetchContext => {
+  const inviteMetadata = parseMetadata(record.invite.metadata)
+  const unitMetadata = parseUnitMetadata(record.unit.metadata)
+  const propertyMetadata = parsePropertyMetadata(record.property.metadata)
+
+  const invitedByName = inviteMetadata?.invited_by_name
+  const normalizedInvitedByName = typeof invitedByName === "string" ? invitedByName : null
+
+  return {
+    inviteToken: record.invite.token,
+    inviteeEmail: record.invite.email,
+    invitedByName: normalizedInvitedByName,
+    notes: record.invite.message ?? null,
+    inviteMetadata: inviteMetadata,
+    unit: {
+      id: record.unit.id,
+      label: record.unit.unit_number,
+      bedrooms: record.unit.bedrooms,
+      bathrooms: record.unit.bathrooms,
+      floorArea: record.unit.floor_area,
+      rent: record.unit.rent,
+      currency: record.unit.currency,
+      availableFrom: record.unit.available_from,
+      metadata: unitMetadata,
+    },
+    property: {
+      id: record.property.id,
+      name: record.property.name,
+      addressLine1: record.property.address_line1,
+      addressLine2: record.property.address_line2,
+      city: record.property.city,
+      state: record.property.state,
+      postalCode: record.property.postal_code,
+      country: record.property.country,
+      timezone: record.property.timezone,
+      amenities: extractAmenities(propertyMetadata),
+      metadata: propertyMetadata,
+    },
+    serverRenderedAt: Date.now(),
+  }
+}
+
+export const loadInviteContext = cache(async (token: string): Promise<InvitePrefetchContext> => {
+  const cookieStore = cookies()
+  const client = createClient(cookieStore)
+
+  const canQuerySupabase = Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  )
+
+  if (canQuerySupabase) {
+    try {
+      const { data, error } = await client
+        .from("household_invites")
+        .select(
+          `*,
+          unit:units(*),
+          property:properties(*)`
+        )
+        .eq("token", token)
+        .maybeSingle()
+
+      if (error) {
+        console.error("Failed to load invite context from Supabase", error)
+      } else if (data && data.unit && data.property) {
+        return normalizeContext({
+          invite: {
+            id: data.id,
+            token: data.token,
+            email: data.email,
+            status: data.status,
+            invited_by: data.invited_by,
+            property_id: data.property_id,
+            unit_id: data.unit_id,
+            message: data.message,
+            created_at: data.created_at,
+            expires_at: data.expires_at,
+            metadata: data.metadata,
+          },
+          unit: data.unit,
+          property: data.property,
+        })
+      }
+    } catch (error) {
+      console.error("Unexpected error while loading invite context", error)
+    }
+  }
+
+  const fallback = fallbackInvites[token]
+  if (!fallback) {
+    notFound()
+  }
+
+  return normalizeContext(fallback)
+})

--- a/app/onboarding/redeem/[token]/page.tsx
+++ b/app/onboarding/redeem/[token]/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next"
+
+import InviteRedemptionContent from "./InviteRedemptionContent"
+import { loadInviteContext } from "./loader"
+
+type InviteRedemptionPageProps = {
+  params: { token: string }
+}
+
+export const metadata: Metadata = {
+  title: "Redeem your Roomsily invite",
+  description: "Confirm your details to join your household portal.",
+}
+
+export default async function InviteRedemptionPage({ params }: InviteRedemptionPageProps) {
+  const context = await loadInviteContext(params.token)
+
+  return <InviteRedemptionContent context={context} />
+}

--- a/app/onboarding/redeem/[token]/types.ts
+++ b/app/onboarding/redeem/[token]/types.ts
@@ -1,0 +1,32 @@
+export type InvitePrefetchContext = {
+  inviteToken: string
+  inviteeEmail: string
+  invitedByName: string | null
+  notes: string | null
+  inviteMetadata: Record<string, unknown> | null
+  unit: {
+    id: string
+    label: string
+    bedrooms: number | null
+    bathrooms: number | null
+    floorArea: number | null
+    rent: number | null
+    currency: string | null
+    availableFrom: string | null
+    metadata: Record<string, unknown> | null
+  }
+  property: {
+    id: string
+    name: string
+    addressLine1: string
+    addressLine2: string | null
+    city: string
+    state: string | null
+    postalCode: string | null
+    country: string
+    timezone: string | null
+    amenities: string[]
+    metadata: Record<string, unknown> | null
+  }
+  serverRenderedAt: number
+}

--- a/docs/engineering/onboarding.md
+++ b/docs/engineering/onboarding.md
@@ -1,0 +1,31 @@
+# Tenant Onboarding via Invite Redemption
+
+This document explains how the invite redemption flow works in the Roomsily tenant portal. The new workflow preloads invite context on the server so the client form can hydrate instantly, and it instruments the route to keep time-to-interactive (TTI) under 200 ms.
+
+## Route overview
+
+- **Path:** `/onboarding/redeem/[token]`
+- **Purpose:** Allow an invited roommate to confirm their contact details, acknowledge household policies, and activate access to their assigned unit.
+- **Server data loader:** `app/onboarding/redeem/[token]/loader.ts` queries Supabase for the invite, unit, and property records. When Supabase credentials are not present (e.g., during local demos) the loader falls back to deterministic seed data so the experience still renders without client-side fetches.
+- **Prefetched context:** The loader produces a serialisable `InvitePrefetchContext` object. The page passes this into `InviteContextProvider` so all client components (form, property overview, perf instrumentation) can read the same data without issuing duplicate network calls or waiting for suspense fallbacks.
+
+## Client components
+
+- **`InviteRedemptionForm`:** Renders the acceptance form with the invitee's email, recommended rent share, and move-in notes pre-populated from the server context. Because the data is already hydrated, the form no longer shows intermediate spinners.
+- **`InviteRouteMetrics`:** Runs on the client after hydration, measures the TTI using `performance.now()`, and sends the result to `/api/metrics` (falls back to `fetch` when `sendBeacon` is unavailable). Warnings are logged if the 200 ms threshold is exceeded so regressions are easy to spot during development.
+- **`PropertyOverview`:** Displays the property address, unit characteristics, amenities, and any invite notes alongside the form to keep the roommate confident about what they are accepting.
+
+## Metrics endpoint
+
+`app/api/metrics/route.ts` accepts POST requests from the client instrumentation and writes structured logs to the server console. The handler validates payload shape before logging to avoid noisy output from malformed requests. Future iterations can forward these metrics to Vercel Analytics or another telemetry backend.
+
+## Demo token
+
+For local development without Supabase credentials, navigate to `/onboarding/redeem/demo-welcome-token`. The loader will serve the embedded Hudson Loft Residences fixture so designers and PMs can review the end-to-end flow without configuring the database.
+
+## Updating the flow
+
+1. Modify the `InvitePrefetchContext` type when new fields are needed across the form or property summary. Update the loader and context provider at the same time to keep the shape in sync.
+2. Keep the server loader as the single source of truth. Any additional client component should consume the context via `useInviteContext` to prevent data fetching duplication.
+3. If the acceptance flow starts writing to additional Supabase tables, extend `completeInviteRedemption` in `actions.ts` so updates happen in the same transaction that marks the invite as accepted.
+4. When changing UI copy or validation rules, run `npm run lint` to ensure the TypeScript build and lint checks continue to pass.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -244,6 +244,47 @@ export type Database = {
         updated_at: string | null
         metadata: Json | null
       }>
+      properties: SupabaseTable<{
+        id: string
+        name: string
+        address_line1: string
+        address_line2: string | null
+        city: string
+        state: string | null
+        postal_code: string | null
+        country: string
+        timezone: string | null
+        created_at: string | null
+        updated_at: string | null
+        metadata: Json | null
+      }>
+      units: SupabaseTable<{
+        id: string
+        property_id: string
+        unit_number: string
+        bedrooms: number | null
+        bathrooms: number | null
+        floor_area: number | null
+        rent: number | null
+        currency: string | null
+        available_from: string | null
+        created_at: string | null
+        updated_at: string | null
+        metadata: Json | null
+      }>
+      household_invites: SupabaseTable<{
+        id: string
+        token: string
+        email: string
+        status: 'pending' | 'accepted' | 'expired' | 'revoked'
+        invited_by: string | null
+        property_id: string
+        unit_id: string
+        message: string | null
+        created_at: string | null
+        expires_at: string | null
+        metadata: Json | null
+      }>
     }
     Views: Record<string, never>
     Functions: {


### PR DESCRIPTION
## Summary
- add Supabase table typings for properties, units, and household invites and preload invite context on the server
- build the `/onboarding/redeem/[token]` flow with a context provider, redemption form, metrics instrumentation, and Supabase-backed server action
- expose a `/api/metrics` endpoint and document the onboarding workflow and demo token in the engineering docs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c702844832893ff644461a90b13