### PR TITLE
Implement KPI cache refresh

### DIFF
--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -1,12 +1,78 @@
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Link from "next/link"
 
-export default function DashboardPage() {
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { loadDashboardKpis } from "@/lib/dashboard-kpis"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+})
+
+export default async function DashboardPage() {
+  const supabase = await createSupbaseServerClientReadOnly()
+
+  let kpis: Awaited<ReturnType<typeof loadDashboardKpis>> | null = null
+  let kpiError: string | null = null
+
+  try {
+    kpis = await loadDashboardKpis(supabase)
+  } catch (error) {
+    console.error("Failed to load dashboard KPIs", error)
+    kpiError = "We couldn't load the latest household metrics."
+  }
+
+  const metricCards = [
+    {
+      title: "Rent collected this month",
+      value: kpis ? currencyFormatter.format(kpis.totalRentCollectedThisMonth) : "—",
+      helper: "Successful payments recorded this billing cycle.",
+    },
+    {
+      title: "Overdue rent payments",
+      value: kpis ? kpis.overdueRentPayments.toString() : "—",
+      helper: "Payments pending or failed beyond their due date.",
+    },
+    {
+      title: "Active leases",
+      value: kpis ? kpis.activeLeases.toString() : "—",
+      helper: "Leases currently marked as active in the system.",
+    },
+    {
+      title: "Open maintenance requests",
+      value: kpis ? kpis.openMaintenanceRequests.toString() : "—",
+      helper: "Requests awaiting completion or in progress.",
+    },
+    {
+      title: "Visitors in next 7 days",
+      value: kpis ? kpis.upcomingVisitorsNext7Days.toString() : "—",
+      helper: "Approved or pending visitor stays scheduled soon.",
+    },
+    {
+      title: "Documents awaiting signature",
+      value: kpis ? kpis.pendingDocumentsAwaitingSignature.toString() : "—",
+      helper: "Draft or pending documents that still require signatures.",
+    },
+  ]
+
   return (
     <div className="w-full space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="text-2xl font-bold tracking-tight">Welcome back</h2>
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Welcome back</h2>
+          {kpis && (
+            <p className="mt-1 text-sm text-muted-foreground">
+              KPIs loaded from {kpis.source} in {kpis.loadTimeMs.toFixed(1)} ms. Last updated{" "}
+              {new Date(kpis.computedAt).toLocaleString()}.
+            </p>
+          )}
+          {kpis?.cacheError && (
+            <p className="mt-1 text-sm text-amber-600">Last refresh warning: {kpis.cacheError}</p>
+          )}
+          {kpiError && <p className="mt-1 text-sm text-destructive">{kpiError}</p>}
+        </div>
         <div className="flex gap-2">
           <Link href="/payments">
             <Button size="sm">Pay rent</Button>
@@ -15,34 +81,17 @@ export default function DashboardPage() {
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardTitle>Next rent due</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-sm text-muted-foreground">Amount</div>
-            <div className="text-2xl font-semibold">$1,260.00</div>
-            <div className="mt-1 text-sm text-muted-foreground">Due on the 1st</div>
-            <Link href="/payments" className="mt-4 inline-block">
-              <Button size="sm">View details</Button>
-            </Link>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Latest documents</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="space-y-2 text-sm">
-              <li>Lease agreement v2.pdf</li>
-              <li>House rules.pdf</li>
-            </ul>
-            <Link href="/documents" className="mt-4 inline-block">
-              <Button variant="outline" size="sm">Open</Button>
-            </Link>
-          </CardContent>
-        </Card>
+        {metricCards.map((metric) => (
+          <Card key={metric.title}>
+            <CardHeader>
+              <CardTitle>{metric.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">{metric.value}</div>
+              <p className="mt-2 text-sm text-muted-foreground">{metric.helper}</p>
+            </CardContent>
+          </Card>
+        ))}
       </div>
 
       <Card>
@@ -55,7 +104,9 @@ export default function DashboardPage() {
             <li>Avery: Parking spot swap this weekend?</li>
           </ul>
           <Link href="/messaging" className="mt-4 inline-block">
-            <Button variant="outline" size="sm">Go to messages</Button>
+            <Button variant="outline" size="sm">
+              Go to messages
+            </Button>
           </Link>
         </CardContent>
       </Card>

--- a/docs/perf/kpi-cache.md
+++ b/docs/perf/kpi-cache.md
@@ -1,0 +1,60 @@
+# KPI cache refresh pipeline
+
+The dashboard now reads from a persisted cache (`public.kpi_cache`) that is refreshed by a Supabase Edge Function. This document covers deployment, scheduling, and alerting so the cache stays healthy in production.
+
+## Components
+
+| Layer | Purpose |
+| --- | --- |
+| `public.calculate_dashboard_kpis()` | PL/pgSQL helper that aggregates rent, maintenance, visitor, lease, and document KPIs.
+| `public.kpi_cache` | Stores the most recent KPI payload, metadata, TTL, and any error message written by the refresh job.
+| `supabase/functions/kpi-cache-refresh` | Edge function invoked by cron. It recalculates KPIs, upserts the cache row, records timing, and fires failure webhooks.
+
+## Deploying the edge function
+
+```bash
+# Ensure env vars exist in Supabase: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
+# CRON_SECRET (arbitrary bearer token), and optional KPI_CACHE_ALERT_WEBHOOK.
+supabase functions deploy kpi-cache-refresh \
+  --project-ref <project-ref> \
+  --no-verify-jwt
+```
+
+After deployment, record the public invoke URL for use in the scheduler (format: `https://<project-ref>.functions.supabase.co/kpi-cache-refresh`).
+
+## Scheduling with Supabase cron
+
+Create a cron trigger that calls the function on a fixed cadence (example: every 5 minutes):
+
+```bash
+supabase functions schedule create kpi-cache-refresh \
+  --project-ref <project-ref> \
+  --cron "*/5 * * * *" \
+  --request-url "/kpi-cache-refresh" \
+  --request-method POST \
+  --headers "Authorization=Bearer ${CRON_SECRET}"
+```
+
+### Operational notes
+
+- Rotate `CRON_SECRET` periodically; update the schedule headers and the `CRON_SECRET` secret in the project.
+- The function writes `compute_duration_ms`, `computed_at`, `expires_at`, and any `error` string into `public.kpi_cache`. Monitoring this table allows quick visibility into stale caches.
+- The cache TTL is 15 minutes. The Next.js loader treats anything older than that as stale and will trigger a recalculation on-demand.
+
+## Failure alerts
+
+Set the optional webhook environment variable to receive alerts (Slack, MS Teams, PagerDuty, etc.):
+
+```bash
+supabase secrets set KPI_CACHE_ALERT_WEBHOOK=https://hooks.slack.com/services/XXX/YYY/ZZZ \
+  CRON_SECRET=<strong-random-string> \
+  --project-ref <project-ref>
+```
+
+When the refresh fails (including database errors or auth misconfiguration) the function posts `"KPI cache refresh failed: <message>"` to the webhook and persists the error column in `public.kpi_cache` for auditability.
+
+## Verifying end-to-end
+
+1. Manually trigger a refresh: `curl -X POST https://<project-ref>.functions.supabase.co/kpi-cache-refresh -H "Authorization: Bearer ${CRON_SECRET}"`.
+2. Inspect `public.kpi_cache` – `computed_at` should update and `error` should be `NULL`.
+3. Load the dashboard. The header shows the data source (`cache` vs `recalculated`) and the measured load time, which should remain ≤ 80 ms for cache hits.

--- a/lib/dashboard-kpis.ts
+++ b/lib/dashboard-kpis.ts
@@ -1,0 +1,117 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { performance as nodePerformance } from 'node:perf_hooks'
+
+import type { Database } from '@/lib/supabase'
+
+const CACHE_KEY = 'dashboard'
+const CACHE_SCOPE = 'global'
+const DEFAULT_MAX_AGE_MS = 15 * 60 * 1000
+
+const performanceNow = () => {
+  if (typeof globalThis.performance !== 'undefined' && typeof globalThis.performance.now === 'function') {
+    return globalThis.performance.now()
+  }
+
+  return nodePerformance.now()
+}
+
+export type DashboardKpiPayload = {
+  totalRentCollectedThisMonth: number
+  overdueRentPayments: number
+  activeLeases: number
+  openMaintenanceRequests: number
+  upcomingVisitorsNext7Days: number
+  pendingDocumentsAwaitingSignature: number
+}
+
+export type DashboardKpiResult = DashboardKpiPayload & {
+  computedAt: string
+  source: 'cache' | 'recalculated'
+  loadTimeMs: number
+  cacheHit: boolean
+  cacheError?: string | null
+}
+
+type SupabaseLike = SupabaseClient<Database>
+
+type LoadOptions = {
+  maxAgeMs?: number
+  now?: () => number
+  perfNow?: () => number
+}
+
+function normalisePayload(payload: Record<string, unknown> | null | undefined): DashboardKpiPayload {
+  const safeNumber = (value: unknown) => {
+    if (value === null || value === undefined) return 0
+    const numericValue = typeof value === 'string' ? Number.parseFloat(value) : Number(value)
+    return Number.isFinite(numericValue) ? numericValue : 0
+  }
+
+  return {
+    totalRentCollectedThisMonth: safeNumber(payload?.totalRentCollectedThisMonth),
+    overdueRentPayments: Math.trunc(safeNumber(payload?.overdueRentPayments)),
+    activeLeases: Math.trunc(safeNumber(payload?.activeLeases)),
+    openMaintenanceRequests: Math.trunc(safeNumber(payload?.openMaintenanceRequests)),
+    upcomingVisitorsNext7Days: Math.trunc(safeNumber(payload?.upcomingVisitorsNext7Days)),
+    pendingDocumentsAwaitingSignature: Math.trunc(safeNumber(payload?.pendingDocumentsAwaitingSignature)),
+  }
+}
+
+export async function loadDashboardKpis(
+  supabase: SupabaseLike,
+  options: LoadOptions = {}
+): Promise<DashboardKpiResult> {
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS
+  const nowFn = options.now ?? (() => Date.now())
+  const perfFn = options.perfNow ?? performanceNow
+
+  const cacheStart = perfFn()
+  const { data: cacheRow, error: cacheError } = await supabase
+    .from('kpi_cache')
+    .select('payload, computed_at, expires_at, error')
+    .match({ key: CACHE_KEY, scope: CACHE_SCOPE })
+    .order('computed_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  const cacheDurationMs = perfFn() - cacheStart
+
+  const nowMs = nowFn()
+  if (cacheRow?.payload && !cacheError) {
+    const expiresAtMs = cacheRow.expires_at ? Date.parse(cacheRow.expires_at) : undefined
+    const computedAtMs = cacheRow.computed_at ? Date.parse(cacheRow.computed_at) : undefined
+    const fallbackExpiry = typeof computedAtMs === 'number' ? computedAtMs + maxAgeMs : nowMs + maxAgeMs
+    const freshnessDeadline = typeof expiresAtMs === 'number' ? Math.min(expiresAtMs, fallbackExpiry) : fallbackExpiry
+    const isFresh = freshnessDeadline >= nowMs
+
+    if (isFresh) {
+      const payload = normalisePayload(cacheRow.payload as Record<string, unknown>)
+      return {
+        ...payload,
+        computedAt: cacheRow.computed_at ?? new Date(nowMs).toISOString(),
+        source: 'cache',
+        loadTimeMs: cacheDurationMs,
+        cacheHit: true,
+        cacheError: cacheRow.error ?? null,
+      }
+    }
+  }
+
+  const fallbackStart = perfFn()
+  const { data: recalculated, error: recalculationError } = await supabase.rpc('calculate_dashboard_kpis')
+  const fallbackDurationMs = perfFn() - fallbackStart
+
+  if (recalculationError) {
+    throw new Error(`Failed to calculate dashboard KPIs: ${recalculationError.message}`)
+  }
+
+  const payload = normalisePayload(recalculated as Record<string, unknown> | null | undefined)
+
+  return {
+    ...payload,
+    computedAt: new Date(nowMs).toISOString(),
+    source: 'recalculated',
+    loadTimeMs: fallbackDurationMs,
+    cacheHit: false,
+    cacheError: cacheError?.message ?? cacheRow?.error ?? null,
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -199,6 +199,16 @@ export type Database = {
         created_at: string | null
         updated_at: string | null
       }>
+      kpi_cache: SupabaseTable<{
+        key: string
+        scope: string
+        payload: Json
+        computed_at: string
+        expires_at: string | null
+        compute_duration_ms: number | null
+        source: string
+        error: string | null
+      }>
       email_notifications: SupabaseTable<{
         id: string
         user_id: string | null
@@ -258,6 +268,10 @@ export type Database = {
       update_updated_at_column: {
         Args: Record<string, never>
         Returns: unknown
+      }
+      calculate_dashboard_kpis: {
+        Args: Record<string, never>
+        Returns: Json
       }
     }
     Enums: Record<string, never>

--- a/supabase/functions/kpi-cache-refresh/index.ts
+++ b/supabase/functions/kpi-cache-refresh/index.ts
@@ -1,0 +1,106 @@
+import { createClient } from 'https://deno.land/x/supabase@1.7.7/mod.ts'
+
+const KPI_CACHE_KEY = 'dashboard'
+const KPI_CACHE_SCOPE = 'global'
+const CACHE_TTL_MS = 15 * 60 * 1000
+
+Deno.serve(async (req) => {
+  const cronSecret = Deno.env.get('CRON_SECRET')
+  const incomingSecret = req.headers.get('authorization') ?? req.headers.get('Authorization')
+  if (cronSecret && incomingSecret !== `Bearer ${cronSecret}`) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    const message = 'Missing Supabase credentials for KPI cache refresh.'
+    await notifyFailure(message)
+    return response({ ok: false, message }, 500)
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { persistSession: false },
+  })
+
+  const startedAt = performance.now()
+  const computedAt = new Date().toISOString()
+  let metrics: Record<string, unknown> | null = null
+
+  try {
+    const { data, error } = await supabase.rpc('calculate_dashboard_kpis')
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    metrics = data as Record<string, unknown> | null
+    const payload = { ...(metrics ?? {}), computedAt }
+
+    const { error: upsertError } = await supabase
+      .from('kpi_cache')
+      .upsert(
+        {
+          key: KPI_CACHE_KEY,
+          scope: KPI_CACHE_SCOPE,
+          payload,
+          computed_at: computedAt,
+          expires_at: new Date(Date.now() + CACHE_TTL_MS).toISOString(),
+          compute_duration_ms: Math.round(performance.now() - startedAt),
+          source: 'edge_function',
+          error: null,
+        },
+        { onConflict: 'key', returning: 'minimal' }
+      )
+
+    if (upsertError) {
+      throw new Error(upsertError.message)
+    }
+
+    return response({ ok: true, source: 'edge_function', computeDurationMs: Math.round(performance.now() - startedAt) })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown KPI cache failure'
+    await supabase
+      .from('kpi_cache')
+      .upsert(
+        {
+          key: KPI_CACHE_KEY,
+          scope: KPI_CACHE_SCOPE,
+          payload: metrics ?? {},
+          computed_at: computedAt,
+          expires_at: new Date(Date.now() + CACHE_TTL_MS).toISOString(),
+          compute_duration_ms: Math.round(performance.now() - startedAt),
+          source: 'edge_function',
+          error: message,
+        },
+        { onConflict: 'key', returning: 'minimal' }
+      )
+      .catch(() => undefined)
+
+    await notifyFailure(message)
+
+    return response({ ok: false, message }, 500)
+  }
+})
+
+function response(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+async function notifyFailure(message: string) {
+  const webhook = Deno.env.get('KPI_CACHE_ALERT_WEBHOOK')
+  if (!webhook) return
+
+  try {
+    await fetch(webhook, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: `KPI cache refresh failed: ${message}` }),
+    })
+  } catch (error) {
+    console.error('Failed to send KPI cache alert', error)
+  }
+}

--- a/supabase/migrations/20250106_kpi_cache.sql
+++ b/supabase/migrations/20250106_kpi_cache.sql
@@ -1,0 +1,86 @@
+-- Create KPI cache table to store aggregated dashboard metrics
+CREATE TABLE public.kpi_cache (
+  key TEXT PRIMARY KEY,
+  scope TEXT NOT NULL DEFAULT 'global',
+  payload JSONB NOT NULL,
+  computed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMP WITH TIME ZONE,
+  compute_duration_ms INTEGER,
+  source TEXT NOT NULL DEFAULT 'manual',
+  error TEXT
+);
+
+CREATE INDEX idx_kpi_cache_scope ON public.kpi_cache(scope);
+CREATE INDEX idx_kpi_cache_expires_at ON public.kpi_cache(expires_at);
+
+ALTER TABLE public.kpi_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can read KPI cache"
+  ON public.kpi_cache
+  FOR SELECT
+  USING (auth.uid() IS NOT NULL);
+
+-- Function that aggregates operational KPIs for the dashboard
+CREATE OR REPLACE FUNCTION public.calculate_dashboard_kpis()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  rent_collected_this_month NUMERIC;
+  overdue_payments_count INTEGER;
+  active_leases_count INTEGER;
+  open_maintenance_count INTEGER;
+  upcoming_visitors_count INTEGER;
+  pending_documents_count INTEGER;
+  response JSONB;
+BEGIN
+  SELECT COALESCE(SUM(amount), 0)::NUMERIC / 100
+    INTO rent_collected_this_month
+  FROM public.rent_payments
+  WHERE status IN ('succeeded', 'completed')
+    AND date_trunc('month', COALESCE(processed_at, created_at)) = date_trunc('month', NOW());
+
+  SELECT COUNT(*)
+    INTO overdue_payments_count
+  FROM public.rent_payments
+  WHERE status IN ('pending', 'failed');
+
+  SELECT COUNT(*)
+    INTO active_leases_count
+  FROM public.leases
+  WHERE status = 'active';
+
+  SELECT COUNT(*)
+    INTO open_maintenance_count
+  FROM public.maintenance_requests
+  WHERE status IN ('pending', 'in_progress');
+
+  SELECT COUNT(*)
+    INTO upcoming_visitors_count
+  FROM public.visitor_logs
+  WHERE status IN ('pending', 'approved')
+    AND check_in_date >= NOW()
+    AND check_in_date < NOW() + INTERVAL '7 days';
+
+  SELECT COUNT(*)
+    INTO pending_documents_count
+  FROM public.documents
+  WHERE requires_signature IS TRUE
+    AND status IN ('draft', 'pending_signature');
+
+  response := jsonb_build_object(
+    'totalRentCollectedThisMonth', COALESCE(rent_collected_this_month, 0),
+    'overdueRentPayments', COALESCE(overdue_payments_count, 0),
+    'activeLeases', COALESCE(active_leases_count, 0),
+    'openMaintenanceRequests', COALESCE(open_maintenance_count, 0),
+    'upcomingVisitorsNext7Days', COALESCE(upcoming_visitors_count, 0),
+    'pendingDocumentsAwaitingSignature', COALESCE(pending_documents_count, 0)
+  );
+
+  RETURN response;
+END;
+$$;
+
+COMMENT ON FUNCTION public.calculate_dashboard_kpis IS 'Aggregates frequently used dashboard KPIs for caching and realtime display.';

--- a/tests/perf/dashboard-kpis.test.ts
+++ b/tests/perf/dashboard-kpis.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { loadDashboardKpis } from '@/lib/dashboard-kpis'
+
+type QueryResponse = {
+  data: {
+    payload: Record<string, unknown> | null
+    computed_at: string | null
+    expires_at: string | null
+    error?: string | null
+  } | null
+  error: { message: string } | null
+}
+
+class QueryBuilderStub {
+  constructor(private response: QueryResponse, private delayMs: number) {}
+
+  select() {
+    return this
+  }
+
+  match() {
+    return this
+  }
+
+  order() {
+    return this
+  }
+
+  limit() {
+    return this
+  }
+
+  async maybeSingle() {
+    if (this.delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.delayMs))
+    }
+
+    return this.response
+  }
+}
+
+function createSupabaseStub({
+  cacheResponse,
+  cacheDelay = 0,
+  recalculatedResponse,
+  recalculatedDelay = 0,
+}: {
+  cacheResponse: QueryResponse
+  cacheDelay?: number
+  recalculatedResponse: { data: Record<string, unknown> | null; error: { message: string } | null }
+  recalculatedDelay?: number
+}) {
+  const supabase = {
+    from: vi.fn(() => new QueryBuilderStub(cacheResponse, cacheDelay)),
+    rpc: vi.fn(async () => {
+      if (recalculatedDelay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, recalculatedDelay))
+      }
+
+      return recalculatedResponse
+    }),
+  }
+
+  return supabase
+}
+
+describe('loadDashboardKpis', () => {
+  it('returns cached metrics within the 80ms performance budget', async () => {
+    const computedAt = new Date().toISOString()
+    const cacheResponse: QueryResponse = {
+      data: {
+        payload: {
+          totalRentCollectedThisMonth: 2450.75,
+          overdueRentPayments: 1,
+          activeLeases: 3,
+          openMaintenanceRequests: 2,
+          upcomingVisitorsNext7Days: 1,
+          pendingDocumentsAwaitingSignature: 2,
+        },
+        computed_at: computedAt,
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+      error: null,
+    }
+
+    const supabase = createSupabaseStub({
+      cacheResponse,
+      cacheDelay: 20,
+      recalculatedResponse: { data: null, error: null },
+    })
+
+    const result = await loadDashboardKpis(supabase as never)
+
+    expect(result.source).toBe('cache')
+    expect(result.cacheHit).toBe(true)
+    expect(result.loadTimeMs).toBeLessThan(80)
+    expect(result.totalRentCollectedThisMonth).toBeCloseTo(2450.75)
+    expect(supabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it('falls back to recalculation when the cache is stale', async () => {
+    const oldComputed = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    const cacheResponse: QueryResponse = {
+      data: {
+        payload: {
+          totalRentCollectedThisMonth: 1000,
+          overdueRentPayments: 5,
+          activeLeases: 2,
+          openMaintenanceRequests: 4,
+          upcomingVisitorsNext7Days: 3,
+          pendingDocumentsAwaitingSignature: 1,
+        },
+        computed_at: oldComputed,
+        expires_at: new Date(Date.now() - 30_000).toISOString(),
+        error: 'previous failure',
+      },
+      error: null,
+    }
+
+    const supabase = createSupabaseStub({
+      cacheResponse,
+      recalculatedResponse: {
+        data: {
+          totalRentCollectedThisMonth: '3120.50',
+          overdueRentPayments: 0,
+          activeLeases: 4,
+          openMaintenanceRequests: 1,
+          upcomingVisitorsNext7Days: 2,
+          pendingDocumentsAwaitingSignature: 0,
+        },
+        error: null,
+      },
+      recalculatedDelay: 10,
+    })
+
+    const result = await loadDashboardKpis(supabase as never, {
+      maxAgeMs: 5 * 60 * 1000,
+    })
+
+    expect(result.source).toBe('recalculated')
+    expect(result.cacheHit).toBe(false)
+    expect(result.cacheError).toBe('previous failure')
+    expect(result.totalRentCollectedThisMonth).toBeCloseTo(3120.5)
+    expect(result.openMaintenanceRequests).toBe(1)
+    expect(supabase.rpc).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add a `kpi_cache` table, aggregation function, and edge function for scheduled KPI refreshes
- update the dashboard loader to read from cached KPIs with a recalculation fallback and surface metadata in the UI
- document the refresh job workflow and add perf-focused tests to keep cache hits under 80 ms

## Testing
- pnpm test -- --reporter=verbose
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c6f23cc8328a57134a2ffd100fd