### PR TITLE
Implement PDF worker-backed document viewer

### DIFF
--- a/app/documents/components/document-viewer-dialog.tsx
+++ b/app/documents/components/document-viewer-dialog.tsx
@@ -1,12 +1,294 @@
 'use client';
 
 
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { DocumentWithLease } from '@/types/documents';
-import { Download, ExternalLink, FileText } from 'lucide-react';
+import { Download, ExternalLink, FileText, Loader2 } from 'lucide-react';
 import { format } from 'date-fns';
+
+const PDF_WORKER_URL = new URL('../../../workers/pdf-viewer.worker.ts', import.meta.url);
+const DEFAULT_RENDER_SCALE = 1.5;
+
+type PdfWorkerMessage =
+  | { type: 'loaded'; payload: { numPages: number } }
+  | { type: 'progress'; payload: { loaded: number; total?: number } }
+  | { type: 'page'; payload: { pageNumber: number; width: number; height: number }; imageBitmap: ImageBitmap }
+  | { type: 'error'; payload: { message: string } }
+  | { type: 'released' };
+
+type PdfWorkerRequest =
+  | { type: 'load'; payload: { url: string; credentials?: RequestCredentials } }
+  | { type: 'renderPage'; payload: { pageNumber: number; scale?: number } }
+  | { type: 'release' };
+
+interface RenderedPage {
+  pageNumber: number;
+  width: number;
+  height: number;
+  bitmap: ImageBitmap | null;
+  rendered: boolean;
+}
+
+interface PdfViewerProps {
+  src: string;
+  open: boolean;
+}
+
+function PdfPage({ page, onRendered }: { page: RenderedPage; onRendered: (pageNumber: number) => void }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const { bitmap, height, pageNumber, width } = page;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+
+    if (!canvas || !bitmap) {
+      return;
+    }
+
+    canvas.width = Math.ceil(width);
+    canvas.height = Math.ceil(height);
+
+    const context = canvas.getContext('2d', { alpha: false });
+
+    if (!context) {
+      bitmap.close();
+      onRendered(pageNumber);
+      return;
+    }
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+    bitmap.close();
+    onRendered(pageNumber);
+  }, [bitmap, height, onRendered, pageNumber, width]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="mb-4 w-full rounded border bg-white shadow-sm last:mb-0 dark:bg-zinc-950"
+      style={{ aspectRatio: `${width} / ${height}` }}
+    />
+  );
+}
+
+function PdfViewer({ open, src }: PdfViewerProps) {
+  const [pages, setPages] = useState<RenderedPage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<number | null>(null);
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const workerRef = useRef<Worker | null>(null);
+  const nextPageRef = useRef(1);
+  const totalPagesRef = useRef(0);
+  const pagesRef = useRef<RenderedPage[]>([]);
+
+  useEffect(() => {
+    pagesRef.current = pages;
+  }, [pages]);
+
+  const handleRendered = useCallback((pageNumber: number) => {
+    setPages((prev) =>
+      prev.map((page) =>
+        page.pageNumber === pageNumber ? { ...page, bitmap: null, rendered: true } : page,
+      ),
+    );
+  }, []);
+
+  const renderedCount = useMemo(
+    () => pages.reduce((total, page) => (page.rendered ? total + 1 : total), 0),
+    [pages],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setPages([]);
+      setIsLoading(false);
+      setProgress(null);
+      setNumPages(null);
+      setError(null);
+      return undefined;
+    }
+
+    if (!src.toLowerCase().endsWith('.pdf')) {
+      setPages([]);
+      setIsLoading(false);
+      setProgress(null);
+      setNumPages(null);
+      setError('Preview is only available for PDF documents.');
+      return undefined;
+    }
+
+    if (typeof window === 'undefined' || typeof Worker === 'undefined') {
+      setPages([]);
+      setIsLoading(false);
+      setProgress(null);
+      setNumPages(null);
+      setError('PDF preview is not supported in this environment.');
+      return undefined;
+    }
+
+    let cancelled = false;
+    let worker: Worker;
+
+    try {
+      worker = new Worker(PDF_WORKER_URL, { type: 'module' });
+    } catch (workerError) {
+      console.error('Failed to initialise PDF worker', workerError);
+      setError('Unable to initialise the PDF preview worker.');
+      setIsLoading(false);
+      return undefined;
+    }
+
+    workerRef.current = worker;
+    setPages([]);
+    setError(null);
+    setProgress(null);
+    setNumPages(null);
+    setIsLoading(true);
+    nextPageRef.current = 1;
+    totalPagesRef.current = 0;
+
+    const handleMessage = (event: MessageEvent<PdfWorkerMessage>) => {
+      const message = event.data;
+
+      if (cancelled) {
+        if ('imageBitmap' in message) {
+          message.imageBitmap.close();
+        }
+        return;
+      }
+
+      switch (message.type) {
+        case 'loaded': {
+          totalPagesRef.current = message.payload.numPages;
+          setNumPages(message.payload.numPages);
+
+          if (message.payload.numPages > 0) {
+            const nextPage = nextPageRef.current;
+            worker.postMessage({
+              type: 'renderPage',
+              payload: { pageNumber: nextPage, scale: DEFAULT_RENDER_SCALE },
+            } satisfies PdfWorkerRequest);
+            nextPageRef.current = nextPage + 1;
+          } else {
+            setIsLoading(false);
+          }
+          break;
+        }
+        case 'progress': {
+          if (typeof message.payload.total === 'number' && message.payload.total > 0) {
+            setProgress(Math.round((message.payload.loaded / message.payload.total) * 100));
+          }
+          break;
+        }
+        case 'page': {
+          setIsLoading(false);
+          const { height, pageNumber, width } = message.payload;
+          const bitmap = message.imageBitmap;
+
+          setPages((prev) => {
+            const existingIndex = prev.findIndex((page) => page.pageNumber === pageNumber);
+            if (existingIndex !== -1) {
+              const next = [...prev];
+              next[existingIndex] = { pageNumber, width, height, bitmap, rendered: false };
+              return next;
+            }
+
+            const next = [...prev, { pageNumber, width, height, bitmap, rendered: false }];
+            next.sort((a, b) => a.pageNumber - b.pageNumber);
+            return next;
+          });
+
+          if (nextPageRef.current <= totalPagesRef.current) {
+            const nextPage = nextPageRef.current;
+            worker.postMessage({
+              type: 'renderPage',
+              payload: { pageNumber: nextPage, scale: DEFAULT_RENDER_SCALE },
+            } satisfies PdfWorkerRequest);
+            nextPageRef.current = nextPage + 1;
+          }
+          break;
+        }
+        case 'error': {
+          pagesRef.current.forEach((page) => page.bitmap?.close());
+          setPages([]);
+          setError(message.payload.message);
+          setIsLoading(false);
+          break;
+        }
+        case 'released': {
+          break;
+        }
+      }
+    };
+
+    worker.addEventListener('message', handleMessage);
+
+    worker.postMessage({ type: 'load', payload: { url: src } } satisfies PdfWorkerRequest);
+
+    return () => {
+      cancelled = true;
+      pagesRef.current.forEach((page) => page.bitmap?.close());
+      worker.removeEventListener('message', handleMessage);
+      worker.postMessage({ type: 'release' } satisfies PdfWorkerRequest);
+      worker.terminate();
+      workerRef.current = null;
+      setPages([]);
+      setIsLoading(false);
+      setProgress(null);
+      setNumPages(null);
+    };
+  }, [open, src]);
+
+  const renderingProgress = useMemo(() => {
+    if (!numPages || numPages === 0) {
+      return null;
+    }
+
+    return Math.round((renderedCount / numPages) * 100);
+  }, [numPages, renderedCount]);
+
+  return (
+    <div className="flex h-[600px] flex-col overflow-hidden rounded-lg border bg-background">
+      <div className="border-b bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
+        {error ? (
+          <span>{error}</span>
+        ) : numPages ? (
+          <span>
+            Rendering {renderedCount} of {numPages} pages
+            {typeof renderingProgress === 'number' ? ` (${renderingProgress}%)` : ''}
+          </span>
+        ) : progress !== null ? (
+          <span>Fetching document… {progress}%</span>
+        ) : (
+          <span>Preparing document preview…</span>
+        )}
+      </div>
+      <div className="flex-1 overflow-y-auto bg-muted/10 p-4">
+        {error ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Unable to display document preview.
+          </div>
+        ) : isLoading && pages.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center space-y-3 text-sm text-muted-foreground">
+            <Loader2 className="size-6 animate-spin" />
+            <span>Rendering first page…</span>
+          </div>
+        ) : pages.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            No preview available.
+          </div>
+        ) : (
+          pages.map((page) => <PdfPage key={page.pageNumber} page={page} onRendered={handleRendered} />)
+        )}
+      </div>
+    </div>
+  );
+}
 
 interface DocumentViewerDialogProps {
   open: boolean;
@@ -162,30 +444,24 @@ export function DocumentViewerDialog({
           {/* Document Preview */}
           <div className="min-h-0 flex-1">
             {document.file_url ? (
-              <div className="h-[600px] w-full overflow-hidden rounded-lg border">
-                {document.file_url.toLowerCase().endsWith('.pdf') ? (
-                  <iframe
-                    src={`${document.file_url}#toolbar=0&navpanes=0&scrollbar=0`}
-                    className="size-full"
-                    title={document.title}
-                  />
-                ) : (
-                  <div className="flex h-full items-center justify-center bg-muted/20">
-                    <div className="text-center">
-                      <FileText className="mx-auto mb-4 size-16 text-muted-foreground" />
-                      <p className="mb-2 text-muted-foreground">
-                        Preview not available for this file type
-                      </p>
-                      <Button onClick={handleDownload} variant="outline">
-                        <Download className="mr-2 size-4" />
-                        Download to View
-                      </Button>
-                    </div>
+              document.file_url.toLowerCase().endsWith('.pdf') ? (
+                <PdfViewer key={document.id} open={open} src={document.file_url} />
+              ) : (
+                <div className="flex h-[600px] items-center justify-center rounded-lg border bg-muted/20">
+                  <div className="text-center">
+                    <FileText className="mx-auto mb-4 size-16 text-muted-foreground" />
+                    <p className="mb-2 text-muted-foreground">
+                      Preview not available for this file type
+                    </p>
+                    <Button onClick={handleDownload} variant="outline">
+                      <Download className="mr-2 size-4" />
+                      Download to View
+                    </Button>
                   </div>
-                )}
-              </div>
+                </div>
+              )
             ) : (
-              <div className="flex h-[600px] items-center justify-center rounded-lg bg-muted/20">
+              <div className="flex h-[600px] items-center justify-center rounded-lg border bg-muted/20">
                 <div className="text-center">
                   <FileText className="mx-auto mb-4 size-16 text-muted-foreground" />
                   <p className="text-muted-foreground">Document file not available</p>

--- a/docs/perf/pdf-worker.md
+++ b/docs/perf/pdf-worker.md
@@ -1,0 +1,80 @@
+# PDF Worker Integration
+
+The document viewer now streams PDF pages using a dedicated Web Worker. Rendering moves off the main thread to keep the UI responsive while residents scroll through large leases or house manuals.
+
+## Architecture Overview
+
+1. **Worker bootstrap (`workers/pdf-viewer.worker.ts`)**
+   - Fetches the PDF binary using `fetch`.
+   - Loads the document through `pdfjs-dist` and keeps a `PDFDocumentProxy` in memory.
+   - Renders individual pages into an `OffscreenCanvas`, converts each draw to an `ImageBitmap`, and posts it back to the UI thread.
+   - Emits progress, error, and lifecycle events so the viewer can reflect loading state.
+
+2. **Viewer (`DocumentViewerDialog`)**
+   - Spawns the worker with `new Worker(new URL('../../../workers/pdf-viewer.worker.ts', import.meta.url), { type: 'module' })` when the dialog opens on a PDF.
+   - Requests pages sequentially to balance throughput with responsiveness. The next page is only requested after the previous page is delivered.
+   - Draws each `ImageBitmap` onto an HTML canvas and releases the bitmap immediately to avoid leaking GPU memory.
+
+3. **UI/UX**
+   - Presents incremental status: fetching progress, render progress, and graceful fallbacks on error or unsupported browsers.
+   - Keeps the dialog interactive because parsing, decoding, and rasterisation happen outside the main thread.
+
+## Message Contract
+
+| Direction    | Type         | Payload                                                                                         |
+|--------------|--------------|-------------------------------------------------------------------------------------------------|
+| UI → Worker  | `load`       | `{ url: string, credentials?: RequestCredentials }` — fetch and parse a new document.           |
+| UI → Worker  | `renderPage` | `{ pageNumber: number, scale?: number }` — render the requested page using the specified scale. |
+| UI → Worker  | `release`    | `void` — destroy cached PDF state and clean up resources.                                       |
+| Worker → UI  | `progress`   | `{ loaded: number, total?: number }` — network download progress from PDF.js.                  |
+| Worker → UI  | `loaded`     | `{ numPages: number }` — document parsed and ready to stream pages.                             |
+| Worker → UI  | `page`       | `{ pageNumber: number, width: number, height: number }` + `ImageBitmap` transfer for the page. |
+| Worker → UI  | `error`      | `{ message: string }` — recoverable failure (network, render, or unsupported feature).         |
+| Worker → UI  | `released`   | `void` — acknowledgement after clean-up.                                                        |
+
+## Adding the Worker to Another Viewer
+
+1. **Create the worker**
+   ```ts
+   const worker = new Worker(new URL('../../workers/pdf-viewer.worker.ts', import.meta.url), {
+     type: 'module',
+   });
+   worker.postMessage({ type: 'load', payload: { url: fileUrl } });
+   ```
+
+2. **Stream pages**
+   ```ts
+   worker.addEventListener('message', (event) => {
+     if (event.data.type === 'loaded') {
+       worker.postMessage({ type: 'renderPage', payload: { pageNumber: 1 } });
+     }
+
+     if (event.data.type === 'page') {
+       const { imageBitmap } = event.data;
+       const canvas = canvasRef.current;
+       const ctx = canvas?.getContext('2d');
+       ctx?.drawImage(imageBitmap, 0, 0);
+       imageBitmap.close();
+     }
+   });
+   ```
+
+3. **Tear down**
+   ```ts
+   worker.postMessage({ type: 'release' });
+   worker.terminate();
+   ```
+
+## Performance Notes
+
+- **Sequential streaming** keeps the number of concurrent `renderPage` calls low, so slow devices are not overwhelmed.
+- **OffscreenCanvas → ImageBitmap** keeps rasterisation work off the main thread and leverages zero-copy transfers.
+- Bitmaps are explicitly closed after drawing to free GPU memory.
+- Download and render progress are surfaced to the UI to help debug slow documents.
+
+## Troubleshooting
+
+- If you encounter `OffscreenCanvas is not supported`, either polyfill or gracefully fall back to the old download/open flow.
+- Always call `release` before terminating the worker when swapping to a different document to avoid dangling ArrayBuffers in memory.
+- When testing locally with Supabase storage URLs, ensure CORS allows the worker origin to fetch the asset.
+

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "next": "14.2.4",
     "next-compose-plugins": "^2.2.1",
     "next-themes": "^0.2.1",
+    "pdfjs-dist": "^5.4.149",
     "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-day-picker": "^8.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      pdfjs-dist:
+        specifier: ^5.4.149
+        version: 5.4.149
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -663,6 +666,70 @@ packages:
 
   '@mediapipe/tasks-vision@0.10.8':
     resolution: {integrity: sha512-Rp7ll8BHrKB3wXaRFKhrltwZl1CiXGdibPxuWXvqGnKTnv8fqa/nvftYNuSbf+pbJWKYCXdBtYTITdAUTGGh0Q==}
+
+  '@napi-rs/canvas-android-arm64@0.1.80':
+    resolution: {integrity: sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.80':
+    resolution: {integrity: sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.80':
+    resolution: {integrity: sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.80':
+    resolution: {integrity: sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.80':
+    resolution: {integrity: sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.80':
+    resolution: {integrity: sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
+    resolution: {integrity: sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.80':
+    resolution: {integrity: sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.80':
+    resolution: {integrity: sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.80':
+    resolution: {integrity: sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.80':
+    resolution: {integrity: sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==}
+    engines: {node: '>= 10'}
 
   '@next/env@14.2.4':
     resolution: {integrity: sha512-3EtkY5VDkuV2+lNmKlbkibIJxcO4oIHEhBWne6PaAp+76J9KoSsGvNikp6ivzAT8dhhBMYrm6op2pS1ApG0Hzg==}
@@ -3704,6 +3771,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pdfjs-dist@5.4.149:
+    resolution: {integrity: sha512-Xe8/1FMJEQPUVSti25AlDpwpUm2QAVmNOpFP0SIahaPIOKBKICaefbzogLdwey3XGGoaP4Lb9wqiw2e9Jqp0LA==}
+    engines: {node: '>=20.16.0 || >=22.3.0'}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -5163,6 +5234,50 @@ snapshots:
       react: 18.2.0
 
   '@mediapipe/tasks-vision@0.10.8': {}
+
+  '@napi-rs/canvas-android-arm64@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas@0.1.80':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.80
+      '@napi-rs/canvas-darwin-arm64': 0.1.80
+      '@napi-rs/canvas-darwin-x64': 0.1.80
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.80
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.80
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.80
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.80
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.80
+      '@napi-rs/canvas-linux-x64-musl': 0.1.80
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.80
+    optional: true
 
   '@next/env@14.2.4': {}
 
@@ -8729,6 +8844,10 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pdfjs-dist@5.4.149:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.80
 
   peberminta@0.9.0: {}
 

--- a/workers/pdf-viewer.worker.ts
+++ b/workers/pdf-viewer.worker.ts
@@ -1,0 +1,163 @@
+/// <reference lib="webworker" />
+
+import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
+import type { PDFDocumentLoadingTask, PDFDocumentProxy } from 'pdfjs-dist/types/src/display/api';
+
+interface LoadMessage {
+  type: 'load';
+  payload: {
+    url: string;
+    credentials?: RequestCredentials;
+  };
+}
+
+interface RenderPageMessage {
+  type: 'renderPage';
+  payload: {
+    pageNumber: number;
+    scale?: number;
+  };
+}
+
+interface ReleaseMessage {
+  type: 'release';
+}
+
+type WorkerRequest = LoadMessage | RenderPageMessage | ReleaseMessage;
+
+type WorkerResponse =
+  | { type: 'loaded'; payload: { numPages: number } }
+  | { type: 'progress'; payload: { loaded: number; total?: number } }
+  | { type: 'page'; payload: { pageNumber: number; width: number; height: number }; imageBitmap: ImageBitmap }
+  | { type: 'error'; payload: { message: string } }
+  | { type: 'released' };
+
+declare const self: DedicatedWorkerGlobalScope;
+
+let loadingTask: PDFDocumentLoadingTask | null = null;
+let pdfDocument: PDFDocumentProxy | null = null;
+
+GlobalWorkerOptions.workerPort = self as unknown as Worker;
+
+const postError = (message: string) => {
+  const response: WorkerResponse = {
+    type: 'error',
+    payload: { message },
+  };
+  self.postMessage(response);
+};
+
+const destroyDocument = async () => {
+  if (loadingTask) {
+    try {
+      await loadingTask.destroy();
+    } catch (error) {
+      console.warn('Failed to destroy loading task', error);
+    }
+    loadingTask = null;
+  }
+
+  if (pdfDocument) {
+    try {
+      await pdfDocument.destroy();
+    } catch (error) {
+      console.warn('Failed to destroy pdf document', error);
+    }
+    pdfDocument = null;
+  }
+};
+
+self.addEventListener('message', async (event: MessageEvent<WorkerRequest>) => {
+  const { type, payload } = event.data;
+
+  switch (type) {
+    case 'load': {
+      await destroyDocument();
+
+      try {
+        const response = await fetch(payload.url, {
+          credentials: payload.credentials ?? 'same-origin',
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch PDF (${response.status})`);
+        }
+
+        const data = await response.arrayBuffer();
+        loadingTask = getDocument({ data });
+
+        loadingTask.onProgress = (progressData) => {
+          const progress: WorkerResponse = {
+            type: 'progress',
+            payload: {
+              loaded: progressData.loaded,
+              total: progressData.total,
+            },
+          };
+          self.postMessage(progress);
+        };
+
+        pdfDocument = await loadingTask.promise;
+
+        const responseMessage: WorkerResponse = {
+          type: 'loaded',
+          payload: { numPages: pdfDocument.numPages },
+        };
+        self.postMessage(responseMessage);
+      } catch (error) {
+        await destroyDocument();
+        postError(error instanceof Error ? error.message : 'Unknown error while loading PDF');
+      }
+      break;
+    }
+
+    case 'renderPage': {
+      if (!pdfDocument) {
+        postError('PDF document has not been loaded.');
+        return;
+      }
+
+      try {
+        const { pageNumber, scale = 1.5 } = payload;
+        const page = await pdfDocument.getPage(pageNumber);
+        const viewport = page.getViewport({ scale });
+
+        if (typeof OffscreenCanvas === 'undefined') {
+          throw new Error('OffscreenCanvas is not supported in this environment.');
+        }
+
+        const canvas = new OffscreenCanvas(Math.ceil(viewport.width), Math.ceil(viewport.height));
+        const context = canvas.getContext('2d', { alpha: false });
+
+        if (!context) {
+          throw new Error('Unable to create canvas context for PDF rendering.');
+        }
+
+        await page.render({ canvasContext: context, viewport }).promise;
+
+        const bitmap = canvas.transferToImageBitmap();
+        const responseMessage: WorkerResponse = {
+          type: 'page',
+          payload: {
+            pageNumber,
+            width: viewport.width,
+            height: viewport.height,
+          },
+          imageBitmap: bitmap,
+        };
+
+        self.postMessage(responseMessage, [bitmap]);
+      } catch (error) {
+        postError(error instanceof Error ? error.message : 'Unknown error while rendering page');
+      }
+      break;
+    }
+
+    case 'release': {
+      await destroyDocument();
+      const responseMessage: WorkerResponse = { type: 'released' };
+      self.postMessage(responseMessage);
+      break;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a pdf.js powered web worker that streams rendered pages back to the UI thread
- replace the iframe preview with a worker-driven canvas viewer that posts sequential render requests and shows progress
- document the worker contract and integration steps for future viewers

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d17c6b960083289866fca675ef6bd5