### PR TITLE
Add Supabase job queue for admin bulk actions

### DIFF
--- a/app/dashboard/members/actions/admin-jobs.ts
+++ b/app/dashboard/members/actions/admin-jobs.ts
@@ -1,0 +1,936 @@
+"use server"
+
+import { createSupbaseServerClient } from '@/utils/supaone'
+import { sendInAppNotification } from '@/lib/notifications'
+import type { Database, Json } from '@/lib/supabase'
+import {
+  type AdminJobActionResponse,
+  type AdminJobDTO,
+  type AdminJobPayload,
+  type AdminJobResult,
+  type AdminJobResultEntry,
+  type BulkNotificationPayload,
+  type BulkNotificationRequest,
+  type BulkStatusUpdatePayload,
+  type BulkStatusUpdateRequest,
+  type NotificationIntent,
+  type ProfileRoleFilter,
+  type ProfileStatus,
+  type ProfileStatusFilter,
+} from '@/types/admin-jobs'
+
+const JOB_BATCH_SIZE = 10
+
+type SupabaseClient = Awaited<ReturnType<typeof createSupbaseServerClient>>
+type AdminJobRow = Database['public']['Tables']['admin_jobs']['Row']
+type ProfileRow = Database['public']['Tables']['profiles']['Row']
+
+type ProfileTarget = Pick<ProfileRow, 'id' | 'status' | 'email' | 'full_name'>
+
+type TargetResolution = {
+  targets: ProfileTarget[]
+  payload: AdminJobPayload
+}
+
+export async function listRecentAdminJobs(limit = 10): Promise<AdminJobDTO[]> {
+  const supabase = await createSupbaseServerClient()
+
+  const { data, error } = await supabase
+    .from('admin_jobs')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (error || !data) {
+    console.error('Failed to load admin jobs', error)
+    return []
+  }
+
+  return data.map(mapJobRowToDTO)
+}
+
+export async function enqueueBulkStatusUpdate(
+  request: BulkStatusUpdateRequest
+): Promise<AdminJobActionResponse> {
+  if (
+    request.sendNotification &&
+    (!request.notificationTitle || !request.notificationMessage)
+  ) {
+    return {
+      error:
+        'Notification title and message are required when notifications are enabled.',
+    }
+  }
+
+  try {
+    const supabase = await createSupbaseServerClient()
+
+    const resolved = await resolveStatusUpdateTargets(supabase, request)
+
+    if (resolved.targets.length === 0) {
+      return {
+        error: 'No members matched the selected filters.',
+      }
+    }
+
+    const {
+      data: authData,
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError) {
+      console.error('Failed to resolve admin user for job queue', authError)
+    }
+
+    const jobPayload: BulkStatusUpdatePayload = {
+      type: 'status_update',
+      targetUserIds: resolved.targets.map((target) => target.id),
+      nextStatus: request.nextStatus,
+      notify: Boolean(request.sendNotification),
+      notification:
+        request.sendNotification && request.notificationTitle
+          ? {
+              title: request.notificationTitle,
+              message: request.notificationMessage || '',
+              type: request.notificationType ?? 'info',
+              actionUrl: request.actionUrl,
+            }
+          : undefined,
+      filters: {
+        role: request.role,
+        currentStatus: request.currentStatus,
+      },
+      summary: {
+        count: resolved.targets.length,
+      },
+    }
+
+    const totalTasks = jobPayload.targetUserIds.length
+
+    const { data, error } = await supabase
+      .from('admin_jobs')
+      .insert({
+        type: 'status_update',
+        status: 'queued',
+        payload: toJson(jobPayload),
+        total_tasks: totalTasks,
+        processed_tasks: 0,
+        requested_by: authData?.user?.id ?? null,
+      })
+      .select('*')
+      .single()
+
+    if (error || !data) {
+      console.error('Failed to enqueue status update job', error)
+      return {
+        error:
+          error?.message ?? 'Unable to create the bulk status update job.',
+      }
+    }
+
+    if (totalTasks === 0) {
+      return { job: mapJobRowToDTO(data) }
+    }
+
+    const processedJob = await processJobRow(data, supabase)
+
+    return { job: processedJob }
+  } catch (error) {
+    console.error('Unexpected error while enqueuing status job', error)
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Unexpected error while creating the job.',
+    }
+  }
+}
+
+export async function enqueueBulkNotification(
+  request: BulkNotificationRequest
+): Promise<AdminJobActionResponse> {
+  if (!request.notificationTitle || !request.notificationMessage) {
+    return { error: 'Notification title and message are required.' }
+  }
+
+  try {
+    const supabase = await createSupbaseServerClient()
+
+    const resolved = await resolveNotificationTargets(supabase, request)
+
+    if (resolved.targets.length === 0) {
+      return {
+        error: 'No members matched the selected filters.',
+      }
+    }
+
+    const {
+      data: authData,
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError) {
+      console.error('Failed to resolve admin user for notification job', authError)
+    }
+
+    const jobPayload: BulkNotificationPayload = {
+      type: 'notification',
+      targetUserIds: resolved.targets.map((target) => target.id),
+      notification: {
+        title: request.notificationTitle,
+        message: request.notificationMessage,
+        type: request.notificationType,
+        actionUrl: request.actionUrl,
+      },
+      filters: {
+        role: request.role,
+        currentStatus: request.currentStatus,
+      },
+      summary: {
+        count: resolved.targets.length,
+      },
+    }
+
+    const { data, error } = await supabase
+      .from('admin_jobs')
+      .insert({
+        type: 'notification',
+        status: 'queued',
+        payload: toJson(jobPayload),
+        total_tasks: jobPayload.targetUserIds.length,
+        processed_tasks: 0,
+        requested_by: authData?.user?.id ?? null,
+      })
+      .select('*')
+      .single()
+
+    if (error || !data) {
+      console.error('Failed to enqueue notification job', error)
+      return {
+        error:
+          error?.message ?? 'Unable to create the bulk notification job.',
+      }
+    }
+
+    const processedJob = await processJobRow(data, supabase)
+
+    return { job: processedJob }
+  } catch (error) {
+    console.error('Unexpected error while enqueuing notification job', error)
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Unexpected error while creating the job.',
+    }
+  }
+}
+
+export async function pollAdminJobs(jobIds: string[]): Promise<AdminJobDTO[]> {
+  if (jobIds.length === 0) {
+    return []
+  }
+
+  const supabase = await createSupbaseServerClient()
+  const updates: AdminJobDTO[] = []
+
+  for (const jobId of jobIds) {
+    const job = await processJobById(jobId, supabase)
+    if (job) {
+      updates.push(job)
+    }
+  }
+
+  return updates
+}
+
+export async function cancelAdminJob(jobId: string): Promise<AdminJobActionResponse> {
+  const supabase = await createSupbaseServerClient()
+
+  const { data, error } = await supabase
+    .from('admin_jobs')
+    .update({
+      status: 'cancelled',
+      cancelled_at: new Date().toISOString(),
+    })
+    .eq('id', jobId)
+    .in('status', ['queued', 'running'])
+    .select('*')
+    .single()
+
+  if (error) {
+    console.error('Failed to cancel admin job', error)
+    return {
+      error: error.message ?? 'Unable to cancel the job.',
+    }
+  }
+
+  if (!data) {
+    return {
+      error: 'Only queued or running jobs can be cancelled.',
+    }
+  }
+
+  return { job: mapJobRowToDTO(data) }
+}
+
+export async function retryAdminJob(jobId: string): Promise<AdminJobActionResponse> {
+  const supabase = await createSupbaseServerClient()
+
+  const { data: jobRow, error: fetchError } = await supabase
+    .from('admin_jobs')
+    .select('*')
+    .eq('id', jobId)
+    .single()
+
+  if (fetchError || !jobRow) {
+    console.error('Failed to fetch job for retry', fetchError)
+    return {
+      error: 'Unable to locate the requested job.',
+    }
+  }
+
+  if (jobRow.status === 'running' || jobRow.status === 'queued') {
+    return { error: 'Running jobs cannot be retried.' }
+  }
+
+  const payload = parsePayload(jobRow)
+
+  if (!payload) {
+    return { error: 'Job payload is missing or invalid.' }
+  }
+
+  let refreshed: TargetResolution
+
+  try {
+    if (payload.type === 'status_update') {
+      refreshed = await resolveStatusPayloadFromJob(supabase, payload)
+    } else {
+      refreshed = await resolveNotificationPayloadFromJob(supabase, payload)
+    }
+  } catch (error) {
+    console.error('Failed to refresh job targets before retry', error)
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Unable to refresh job targets for retry.',
+    }
+  }
+
+  if (refreshed.targets.length === 0) {
+    return { error: 'No members match the original job filters anymore.' }
+  }
+
+  const { data, error } = await supabase
+    .from('admin_jobs')
+    .update({
+      status: 'queued',
+      processed_tasks: 0,
+      total_tasks: refreshed.targets.length,
+      error: null,
+      completed_at: null,
+      cancelled_at: null,
+      result: null,
+      payload: toJson(refreshed.payload),
+    })
+    .eq('id', jobId)
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    console.error('Failed to reset job for retry', error)
+    return {
+      error: error?.message ?? 'Unable to reset the job for retry.',
+    }
+  }
+
+  const processedJob = await processJobRow(data, supabase)
+  return { job: processedJob }
+}
+
+export async function getAdminJob(jobId: string): Promise<AdminJobDTO | null> {
+  const supabase = await createSupbaseServerClient()
+
+  const { data, error } = await supabase
+    .from('admin_jobs')
+    .select('*')
+    .eq('id', jobId)
+    .single()
+
+  if (error || !data) {
+    console.error('Failed to fetch admin job', error)
+    return null
+  }
+
+  if (data.status === 'queued' || data.status === 'running') {
+    return processJobRow(data, supabase)
+  }
+
+  return mapJobRowToDTO(data)
+}
+
+async function processJobById(
+  jobId: string,
+  existingClient?: SupabaseClient
+): Promise<AdminJobDTO | null> {
+  const supabase = existingClient ?? (await createSupbaseServerClient())
+
+  const { data, error } = await supabase
+    .from('admin_jobs')
+    .select('*')
+    .eq('id', jobId)
+    .single()
+
+  if (error || !data) {
+    if (error) {
+      console.error('Failed to fetch job during polling', error)
+    }
+    return null
+  }
+
+  return processJobRow(data, supabase)
+}
+
+async function processJobRow(
+  row: AdminJobRow,
+  supabase: SupabaseClient
+): Promise<AdminJobDTO> {
+  if (row.status === 'cancelled' || row.status === 'failed') {
+    return mapJobRowToDTO(row)
+  }
+
+  const payload = parsePayload(row)
+  const existingResult = parseResult(row)
+
+  if (!payload) {
+    return mapJobRowToDTO(row)
+  }
+
+  try {
+    const totalTargets = payload.targetUserIds.length
+    const processedTasks = Math.min(row.processed_tasks, totalTargets)
+
+    if (row.total_tasks !== totalTargets) {
+      row.total_tasks = totalTargets
+    }
+
+    if (totalTargets === 0) {
+      const update = await supabase
+        .from('admin_jobs')
+        .update({
+          status: 'completed',
+          total_tasks: 0,
+          processed_tasks: 0,
+          result: existingResult ? toJson(existingResult) : null,
+          error: null,
+          completed_at: new Date().toISOString(),
+        })
+        .eq('id', row.id)
+        .select('*')
+        .single()
+
+      if (update.error || !update.data) {
+        console.error('Failed to finalize empty job', update.error)
+        return mapJobRowToDTO(row)
+      }
+
+      return mapJobRowToDTO(update.data)
+    }
+
+    if (processedTasks >= totalTargets) {
+      if (row.status !== 'completed') {
+        const { data, error } = await supabase
+          .from('admin_jobs')
+          .update({
+            status: 'completed',
+            processed_tasks: totalTargets,
+            total_tasks: totalTargets,
+            error:
+              existingResult && existingResult.summary.failures > 0
+                ? `${existingResult.summary.failures} item(s) failed`
+                : null,
+            completed_at: new Date().toISOString(),
+          })
+          .eq('id', row.id)
+          .select('*')
+          .single()
+
+        if (error || !data) {
+          console.error('Failed to mark job as completed', error)
+          return mapJobRowToDTO(row)
+        }
+
+        return mapJobRowToDTO(data)
+      }
+
+      return mapJobRowToDTO(row)
+    }
+
+    const batchIds = payload.targetUserIds.slice(
+      processedTasks,
+      Math.min(processedTasks + JOB_BATCH_SIZE, totalTargets)
+    )
+
+    const batchProfiles = await fetchProfileBatch(batchIds, supabase)
+
+    const entries: AdminJobResultEntry[] = []
+
+    for (const userId of batchIds) {
+      const profile = batchProfiles.get(userId)
+      const timestamp = new Date().toISOString()
+
+      if (!profile) {
+        entries.push({
+          userId,
+          success: false,
+          action: payload.type,
+          notified: false,
+          error: 'Profile not found for this member.',
+          timestamp,
+        })
+        continue
+      }
+
+      if (payload.type === 'status_update') {
+        const entry = await processStatusUpdateTarget(
+          supabase,
+          profile,
+          payload,
+          timestamp
+        )
+        entries.push(entry)
+      } else {
+        const entry = await processNotificationTarget(
+          profile,
+          payload.notification,
+          timestamp
+        )
+        entries.push(entry)
+      }
+    }
+
+    const mergedResult = mergeResult(existingResult, entries)
+    const newProcessed = processedTasks + batchIds.length
+    const isComplete = newProcessed >= totalTargets
+    const failureCount = mergedResult.summary.failures
+
+    const updateFields: Partial<AdminJobRow> = {
+      status: isComplete ? 'completed' : 'running',
+      processed_tasks: newProcessed,
+      total_tasks: totalTargets,
+      result: toJson(mergedResult),
+      error:
+        failureCount > 0
+          ? isComplete
+            ? `${failureCount} item(s) failed`
+            : 'Encountered processing errors'
+          : null,
+      last_progress_at: new Date().toISOString(),
+      completed_at: isComplete ? new Date().toISOString() : row.completed_at,
+      payload: toJson(payload),
+    }
+
+    const { data, error } = await supabase
+      .from('admin_jobs')
+      .update(updateFields)
+      .eq('id', row.id)
+      .select('*')
+      .single()
+
+    if (error || !data) {
+      throw new Error(error?.message ?? 'Failed to persist job progress')
+    }
+
+    return mapJobRowToDTO(data)
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Unexpected error while processing job.'
+
+    const { data, error: updateError } = await supabase
+      .from('admin_jobs')
+      .update({
+        status: 'failed',
+        error: message,
+      })
+      .eq('id', row.id)
+      .select('*')
+      .single()
+
+    if (updateError) {
+      console.error('Failed to set job as failed', updateError)
+      return {
+        ...mapJobRowToDTO(row),
+        status: 'failed',
+        error: message,
+      }
+    }
+
+    return mapJobRowToDTO(data)
+  }
+}
+
+function mergeResult(
+  existing: AdminJobResult | null,
+  newEntries: AdminJobResultEntry[]
+): AdminJobResult {
+  const base: AdminJobResult =
+    existing ?? ({
+      entries: [],
+      summary: { successes: 0, failures: 0 },
+    } as AdminJobResult)
+
+  const entries = [...base.entries, ...newEntries]
+  const summary = { ...base.summary }
+
+  for (const entry of newEntries) {
+    if (entry.success) {
+      summary.successes += 1
+    } else {
+      summary.failures += 1
+    }
+  }
+
+  return {
+    entries,
+    summary,
+  }
+}
+
+async function processStatusUpdateTarget(
+  supabase: SupabaseClient,
+  profile: ProfileTarget,
+  payload: BulkStatusUpdatePayload,
+  timestamp: string
+): Promise<AdminJobResultEntry> {
+  let success = true
+  let errorMessage: string | undefined
+  let notified = false
+
+  if (profile.status === payload.nextStatus) {
+    success = false
+    errorMessage = 'Member already has the requested status.'
+  } else {
+    const { error } = await supabase
+      .from('profiles')
+      .update({ status: payload.nextStatus })
+      .eq('id', profile.id)
+
+    if (error) {
+      success = false
+      errorMessage = error.message
+    }
+  }
+
+  if (success && payload.notify && payload.notification) {
+    const notificationIntent = enrichNotificationIntent(
+      payload.notification,
+      profile
+    )
+    const notificationResult = await sendInAppNotification({
+      userId: profile.id,
+      title: notificationIntent.title,
+      message: notificationIntent.message,
+      type: notificationIntent.type,
+      actionUrl: notificationIntent.actionUrl,
+    })
+
+    notified = notificationResult.success
+
+    if (!notificationResult.success) {
+      success = false
+      errorMessage =
+        notificationResult.error ?? 'Failed to send status notification.'
+    }
+  }
+
+  return {
+    userId: profile.id,
+    success,
+    action: 'status_update',
+    notified,
+    error: errorMessage,
+    timestamp,
+  }
+}
+
+async function processNotificationTarget(
+  profile: ProfileTarget,
+  notification: NotificationIntent,
+  timestamp: string
+): Promise<AdminJobResultEntry> {
+  const notificationIntent = enrichNotificationIntent(notification, profile)
+
+  const result = await sendInAppNotification({
+    userId: profile.id,
+    title: notificationIntent.title,
+    message: notificationIntent.message,
+    type: notificationIntent.type,
+    actionUrl: notificationIntent.actionUrl,
+  })
+
+  return {
+    userId: profile.id,
+    success: result.success,
+    action: 'notification',
+    notified: result.success,
+    error: result.success
+      ? undefined
+      : result.error ?? 'Failed to send notification.',
+    timestamp,
+  }
+}
+
+function enrichNotificationIntent(
+  intent: NotificationIntent,
+  profile: ProfileTarget
+): NotificationIntent {
+  const message = intent.message
+    .replace('{name}', profile.full_name ?? 'there')
+    .replace('{status}', profile.status)
+
+  return {
+    ...intent,
+    message,
+  }
+}
+
+async function fetchProfileBatch(
+  ids: string[],
+  supabase: SupabaseClient
+): Promise<Map<string, ProfileTarget>> {
+  if (ids.length === 0) {
+    return new Map()
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, status, email, full_name')
+    .in('id', ids)
+
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Failed to load members for batch.')
+  }
+
+  const map = new Map<string, ProfileTarget>()
+
+  for (const profile of data) {
+    map.set(profile.id, {
+      id: profile.id,
+      status: profile.status as ProfileStatus,
+      email: profile.email ?? null,
+      full_name: profile.full_name ?? null,
+    })
+  }
+
+  return map
+}
+
+async function resolveStatusUpdateTargets(
+  supabase: SupabaseClient,
+  request: BulkStatusUpdateRequest
+): Promise<TargetResolution> {
+  const targets = await queryProfiles(supabase, {
+    role: request.role,
+    currentStatus: request.currentStatus,
+  })
+
+  const filtered = targets.filter(
+    (profile) => profile.status !== request.nextStatus
+  )
+
+  const payload: BulkStatusUpdatePayload = {
+    type: 'status_update',
+    targetUserIds: filtered.map((profile) => profile.id),
+    nextStatus: request.nextStatus,
+    notify: request.sendNotification,
+    notification:
+      request.sendNotification && request.notificationTitle
+        ? {
+            title: request.notificationTitle,
+            message: request.notificationMessage || '',
+            type: request.notificationType ?? 'info',
+            actionUrl: request.actionUrl,
+          }
+        : undefined,
+    filters: {
+      role: request.role,
+      currentStatus: request.currentStatus,
+    },
+    summary: {
+      count: filtered.length,
+    },
+  }
+
+  return {
+    targets: filtered,
+    payload,
+  }
+}
+
+async function resolveNotificationTargets(
+  supabase: SupabaseClient,
+  request: BulkNotificationRequest
+): Promise<TargetResolution> {
+  const targets = await queryProfiles(supabase, {
+    role: request.role,
+    currentStatus: request.currentStatus,
+  })
+
+  const payload: BulkNotificationPayload = {
+    type: 'notification',
+    targetUserIds: targets.map((profile) => profile.id),
+    notification: {
+      title: request.notificationTitle,
+      message: request.notificationMessage,
+      type: request.notificationType,
+      actionUrl: request.actionUrl,
+    },
+    filters: {
+      role: request.role,
+      currentStatus: request.currentStatus,
+    },
+    summary: {
+      count: targets.length,
+    },
+  }
+
+  return {
+    targets,
+    payload,
+  }
+}
+
+async function resolveStatusPayloadFromJob(
+  supabase: SupabaseClient,
+  payload: BulkStatusUpdatePayload
+): Promise<TargetResolution> {
+  const targets = await queryProfiles(supabase, payload.filters)
+  const filtered = targets.filter(
+    (profile) => profile.status !== payload.nextStatus
+  )
+
+  return {
+    targets: filtered,
+    payload: {
+      ...payload,
+      targetUserIds: filtered.map((profile) => profile.id),
+      summary: {
+        count: filtered.length,
+      },
+    },
+  }
+}
+
+async function resolveNotificationPayloadFromJob(
+  supabase: SupabaseClient,
+  payload: BulkNotificationPayload
+): Promise<TargetResolution> {
+  const targets = await queryProfiles(supabase, payload.filters)
+
+  return {
+    targets,
+    payload: {
+      ...payload,
+      targetUserIds: targets.map((profile) => profile.id),
+      summary: {
+        count: targets.length,
+      },
+    },
+  }
+}
+
+async function queryProfiles(
+  supabase: SupabaseClient,
+  filters: {
+    role: ProfileRoleFilter
+    currentStatus: ProfileStatusFilter
+  }
+): Promise<ProfileTarget[]> {
+  let query = supabase
+    .from('profiles')
+    .select('id, status, email, full_name, role')
+
+  if (filters.role !== 'all') {
+    query = query.eq('role', filters.role)
+  }
+
+  if (filters.currentStatus !== 'all') {
+    query = query.eq('status', filters.currentStatus)
+  }
+
+  const { data, error } = await query
+
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Failed to query member profiles.')
+  }
+
+  return data.map((profile) => ({
+    id: profile.id,
+    status: profile.status as ProfileStatus,
+    email: profile.email ?? null,
+    full_name: profile.full_name ?? null,
+  }))
+}
+
+function toJson(value: unknown): Json {
+  return JSON.parse(JSON.stringify(value)) as Json
+}
+
+function parsePayload(row: AdminJobRow): AdminJobPayload | null {
+  if (!row.payload) {
+    return null
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(row.payload)) as AdminJobPayload
+  } catch (error) {
+    console.error('Failed to parse admin job payload', error)
+    return null
+  }
+}
+
+function parseResult(row: AdminJobRow): AdminJobResult | null {
+  if (!row.result) {
+    return null
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(row.result)) as AdminJobResult
+  } catch (error) {
+    console.error('Failed to parse admin job result', error)
+    return null
+  }
+}
+
+function mapJobRowToDTO(row: AdminJobRow): AdminJobDTO {
+  return {
+    id: row.id,
+    type: row.type,
+    status: row.status,
+    totalTasks: row.total_tasks,
+    processedTasks: row.processed_tasks,
+    error: row.error ?? null,
+    requestedBy: row.requested_by ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at ?? null,
+    cancelledAt: row.cancelled_at ?? null,
+    payload: (JSON.parse(JSON.stringify(row.payload)) as AdminJobPayload) ?? {
+      type: 'notification',
+      targetUserIds: [],
+      notification: {
+        title: 'Unknown',
+        message: 'Unknown payload',
+        type: 'info',
+      },
+      filters: { role: 'all', currentStatus: 'all' },
+      summary: { count: 0 },
+    },
+    result: row.result
+      ? (JSON.parse(JSON.stringify(row.result)) as AdminJobResult)
+      : null,
+  }
+}

--- a/app/dashboard/members/components/BulkAdminActions.tsx
+++ b/app/dashboard/members/components/BulkAdminActions.tsx
@@ -1,0 +1,713 @@
+"use client"
+
+import {
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react'
+import { Loader2, Megaphone, Users2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Progress } from '@/components/ui/progress'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import { Separator } from '@/components/ui/separator'
+import { useToast } from '@/components/ui/use-toast'
+
+import {
+  cancelAdminJob,
+  enqueueBulkNotification,
+  enqueueBulkStatusUpdate,
+  pollAdminJobs,
+  retryAdminJob,
+} from '../actions/admin-jobs'
+import type {
+  AdminJobDTO,
+  AdminJobStatus,
+  AdminJobType,
+  BulkNotificationRequest,
+  BulkStatusUpdateRequest,
+  ProfileRoleFilter,
+  ProfileStatus,
+  ProfileStatusFilter,
+} from '@/types/admin-jobs'
+
+const ROLE_OPTIONS: Array<{ label: string; value: ProfileRoleFilter }> = [
+  { label: 'All roles', value: 'all' },
+  { label: 'Tenants', value: 'tenant' },
+  { label: 'Roommates', value: 'roommate' },
+  { label: 'Property managers', value: 'property_manager' },
+  { label: 'Admins', value: 'admin' },
+  { label: 'Standard users', value: 'user' },
+]
+
+const STATUS_OPTIONS: ProfileStatus[] = ['active', 'inactive', 'invited', 'suspended']
+const NOTIFICATION_TYPES: Array<{ label: string; value: BulkNotificationRequest['notificationType'] }> = [
+  { label: 'Info', value: 'info' },
+  { label: 'Success', value: 'success' },
+  { label: 'Warning', value: 'warning' },
+  { label: 'Error', value: 'error' },
+]
+
+const STATUS_BADGE_VARIANT: Record<AdminJobStatus, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  queued: 'outline',
+  running: 'secondary',
+  completed: 'default',
+  failed: 'destructive',
+  cancelled: 'destructive',
+}
+
+type BulkAdminActionsProps = {
+  initialJobs: AdminJobDTO[]
+}
+
+type ActionFormState = {
+  actionType: AdminJobType
+  role: ProfileRoleFilter
+  currentStatus: ProfileStatusFilter
+  nextStatus: ProfileStatus
+  sendNotification: boolean
+  notificationTitle: string
+  notificationMessage: string
+  notificationType: BulkNotificationRequest['notificationType']
+  actionUrl: string
+}
+
+export function BulkAdminActions({ initialJobs }: BulkAdminActionsProps) {
+  const [jobs, setJobs] = useState<AdminJobDTO[]>(() => sortJobs(initialJobs))
+  const [formState, setFormState] = useState<ActionFormState>({
+    actionType: 'status_update',
+    role: 'all',
+    currentStatus: 'all',
+    nextStatus: 'active',
+    sendNotification: true,
+    notificationTitle: 'Status update',
+    notificationMessage:
+      'Hi {name}, your account status has been updated to {status}.',
+    notificationType: 'info',
+    actionUrl: '/dashboard',
+  })
+  const [isPolling, setIsPolling] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const { toast } = useToast()
+
+  const activeJobIds = useMemo(
+    () =>
+      jobs
+        .filter((job) => job.status === 'queued' || job.status === 'running')
+        .map((job) => job.id),
+    [jobs]
+  )
+
+  useEffect(() => {
+    if (activeJobIds.length === 0) {
+      return
+    }
+
+    let cancelled = false
+
+    const tick = async () => {
+      setIsPolling(true)
+      try {
+        const updates = await pollAdminJobs(activeJobIds)
+        if (!cancelled && updates.length > 0) {
+          setJobs((prev) => mergeJobUpdates(prev, updates))
+        }
+      } catch (error) {
+        console.error('Failed to poll admin jobs', error)
+      } finally {
+        if (!cancelled) {
+          setIsPolling(false)
+        }
+      }
+    }
+
+    void tick()
+    const interval = setInterval(() => {
+      void tick()
+    }, 4000)
+
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [activeJobIds])
+
+  const handleSubmit = () => {
+    if (formState.actionType === 'status_update') {
+      const payload: BulkStatusUpdateRequest = {
+        role: formState.role,
+        currentStatus: formState.currentStatus,
+        nextStatus: formState.nextStatus,
+        sendNotification: formState.sendNotification,
+        notificationTitle: formState.notificationTitle,
+        notificationMessage: formState.notificationMessage,
+        notificationType: formState.notificationType,
+        actionUrl: formState.actionUrl,
+      }
+
+      startTransition(async () => {
+        const response = await enqueueBulkStatusUpdate(payload)
+        if (response.error) {
+          toast({
+            title: 'Unable to queue status update',
+            description: response.error,
+            variant: 'destructive',
+          })
+          return
+        }
+
+        if (response.job) {
+          setJobs((prev) => mergeJobUpdates(prev, [response.job]))
+          toast({
+            title: 'Bulk status update queued',
+            description: `${response.job.payload.summary?.count ?? response.job.totalTasks} member(s) will be processed.`,
+          })
+        }
+      })
+    } else {
+      const payload: BulkNotificationRequest = {
+        role: formState.role,
+        currentStatus: formState.currentStatus,
+        notificationTitle: formState.notificationTitle,
+        notificationMessage: formState.notificationMessage,
+        notificationType: formState.notificationType,
+        actionUrl: formState.actionUrl,
+      }
+
+      startTransition(async () => {
+        const response = await enqueueBulkNotification(payload)
+        if (response.error) {
+          toast({
+            title: 'Unable to queue notification',
+            description: response.error,
+            variant: 'destructive',
+          })
+          return
+        }
+
+        if (response.job) {
+          setJobs((prev) => mergeJobUpdates(prev, [response.job]))
+          toast({
+            title: 'Bulk notification queued',
+            description: `${response.job.payload.summary?.count ?? response.job.totalTasks} member(s) will be notified.`,
+          })
+        }
+      })
+    }
+  }
+
+  const handleCancel = (jobId: string) => {
+    startTransition(async () => {
+      const response = await cancelAdminJob(jobId)
+      if (response.error) {
+        toast({
+          title: 'Unable to cancel job',
+          description: response.error,
+          variant: 'destructive',
+        })
+        return
+      }
+
+      if (response.job) {
+        setJobs((prev) => mergeJobUpdates(prev, [response.job]))
+        toast({
+          title: 'Job cancelled',
+          description: 'The job will not process additional members.',
+        })
+      }
+    })
+  }
+
+  const handleRetry = (jobId: string) => {
+    startTransition(async () => {
+      const response = await retryAdminJob(jobId)
+      if (response.error) {
+        toast({
+          title: 'Unable to retry job',
+          description: response.error,
+          variant: 'destructive',
+        })
+        return
+      }
+
+      if (response.job) {
+        setJobs((prev) => mergeJobUpdates(prev, [response.job]))
+        toast({
+          title: 'Job relaunched',
+          description: `${response.job.payload.summary?.count ?? response.job.totalTasks} member(s) re-queued for processing.`,
+        })
+      }
+    })
+  }
+
+  const disableNotificationFields =
+    formState.actionType === 'status_update' && !formState.sendNotification
+
+  const isBusy = isPending || isPolling
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card className="border-muted">
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <CardTitle>Bulk admin actions</CardTitle>
+              <CardDescription>
+                Queue large member updates without blocking the dashboard. Jobs run
+                in Supabase and report progress here.
+              </CardDescription>
+            </div>
+            {isBusy ? <Loader2 className="size-5 animate-spin text-muted-foreground" /> : null}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <Tabs
+            value={formState.actionType}
+            onValueChange={(value) =>
+              setFormState((prev) => ({
+                ...prev,
+                actionType: value as ActionFormState['actionType'],
+              }))
+            }
+            className="space-y-6"
+          >
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="status_update" className="flex items-center gap-2">
+                <Users2 className="size-4" /> Status update
+              </TabsTrigger>
+              <TabsTrigger value="notification" className="flex items-center gap-2">
+                <Megaphone className="size-4" /> Notification blast
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="status_update" className="space-y-6">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="role">Role filter</Label>
+                  <Select
+                    value={formState.role}
+                    onValueChange={(value) =>
+                      setFormState((prev) => ({
+                        ...prev,
+                        role: value as ProfileRoleFilter,
+                      }))
+                    }
+                  >
+                    <SelectTrigger id="role">
+                      <SelectValue placeholder="All roles" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="current-status">Current status filter</Label>
+                  <Select
+                    value={formState.currentStatus}
+                    onValueChange={(value) =>
+                      setFormState((prev) => ({
+                        ...prev,
+                        currentStatus: value as ProfileStatusFilter,
+                      }))
+                    }
+                  >
+                    <SelectTrigger id="current-status">
+                      <SelectValue placeholder="All statuses" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All statuses</SelectItem>
+                      {STATUS_OPTIONS.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {status.charAt(0).toUpperCase() + status.slice(1)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="next-status">Set new status</Label>
+                  <Select
+                    value={formState.nextStatus}
+                    onValueChange={(value) =>
+                      setFormState((prev) => ({
+                        ...prev,
+                        nextStatus: value as ProfileStatus,
+                      }))
+                    }
+                  >
+                    <SelectTrigger id="next-status">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATUS_OPTIONS.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {status.charAt(0).toUpperCase() + status.slice(1)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="flex items-center justify-between rounded-md border border-muted p-3">
+                  <div>
+                    <Label htmlFor="send-notification" className="text-sm font-medium">
+                      Send in-app notifications
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Notify members as soon as their status changes.
+                    </p>
+                  </div>
+                  <Switch
+                    id="send-notification"
+                    checked={formState.sendNotification}
+                    onCheckedChange={(checked) =>
+                      setFormState((prev) => ({
+                        ...prev,
+                        sendNotification: checked,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+
+              <Separator />
+
+              <NotificationFields
+                formState={formState}
+                setFormState={setFormState}
+                disabled={disableNotificationFields}
+              />
+            </TabsContent>
+
+            <TabsContent value="notification" className="space-y-6">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="role-notification">Role filter</Label>
+                  <Select
+                    value={formState.role}
+                    onValueChange={(value) =>
+                      setFormState((prev) => ({
+                        ...prev,
+                        role: value as ProfileRoleFilter,
+                      }))
+                    }
+                  >
+                    <SelectTrigger id="role-notification">
+                      <SelectValue placeholder="All roles" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="current-status-notification">Status filter</Label>
+                  <Select
+                    value={formState.currentStatus}
+                    onValueChange={(value) =>
+                      setFormState((prev) => ({
+                        ...prev,
+                        currentStatus: value as ProfileStatusFilter,
+                      }))
+                    }
+                  >
+                    <SelectTrigger id="current-status-notification">
+                      <SelectValue placeholder="All statuses" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All statuses</SelectItem>
+                      {STATUS_OPTIONS.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {status.charAt(0).toUpperCase() + status.slice(1)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <NotificationFields
+                formState={formState}
+                setFormState={setFormState}
+                disabled={false}
+              />
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+        <CardFooter>
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+            Queue job
+          </Button>
+        </CardFooter>
+      </Card>
+
+      <Card className="border-muted">
+        <CardHeader>
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <CardTitle>Job queue</CardTitle>
+              <CardDescription>
+                Monitor queued bulk operations and manage retries or cancellation.
+              </CardDescription>
+            </div>
+            <Badge variant={isPolling ? 'secondary' : 'outline'}>
+              {isPolling ? 'Refreshing…' : 'Auto-refresh'}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {jobs.length === 0 ? (
+            <div className="rounded-md border border-dashed border-muted-foreground/40 p-6 text-center text-sm text-muted-foreground">
+              No jobs have been queued yet. Use the form to schedule your first bulk
+              operation.
+            </div>
+          ) : (
+            jobs.map((job) => {
+              const progress = job.totalTasks === 0
+                ? 100
+                : Math.round((job.processedTasks / job.totalTasks) * 100)
+              const failureCount = job.result?.summary.failures ?? 0
+              const canCancel = job.status === 'queued' || job.status === 'running'
+              const canRetry =
+                job.status === 'failed' ||
+                job.status === 'cancelled' ||
+                (job.status === 'completed' && failureCount > 0)
+
+              return (
+                <Card key={job.id} className="border border-muted">
+                  <CardHeader className="space-y-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="space-y-1">
+                        <CardTitle className="text-base font-semibold">
+                          {job.type === 'status_update'
+                            ? 'Status update'
+                            : 'Notification broadcast'}
+                        </CardTitle>
+                        <p className="text-xs text-muted-foreground">
+                          Requested {new Date(job.createdAt).toLocaleString()} • Updated{' '}
+                          {new Date(job.updatedAt).toLocaleTimeString()}
+                        </p>
+                      </div>
+                      <Badge variant={STATUS_BADGE_VARIANT[job.status]}>
+                        {job.status.charAt(0).toUpperCase() + job.status.slice(1)}
+                      </Badge>
+                    </div>
+                    <div className="space-y-2">
+                      <Progress value={progress} />
+                      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                        <span>
+                          {job.processedTasks}/{job.totalTasks} processed
+                        </span>
+                        <span>
+                          Targeted {job.payload.summary?.count ?? job.totalTasks} members
+                        </span>
+                        {failureCount > 0 ? (
+                          <span className="font-medium text-destructive">
+                            {failureCount} failure{failureCount === 1 ? '' : 's'}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    <div className="text-sm">
+                      <p className="font-medium">Filters</p>
+                      <p className="text-xs text-muted-foreground">
+                        Role: {formatRole(job.payload.filters.role)} • Status filter:{' '}
+                        {formatStatus(job.payload.filters.currentStatus)}
+                      </p>
+                    </div>
+                    {job.error ? (
+                      <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+                        {job.error}
+                      </div>
+                    ) : null}
+                  </CardContent>
+                  <CardFooter className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="text-xs text-muted-foreground">
+                      ID: {job.id.slice(0, 8)}…
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {canCancel ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleCancel(job.id)}
+                          disabled={isPending}
+                        >
+                          Cancel
+                        </Button>
+                      ) : null}
+                      {canRetry ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleRetry(job.id)}
+                          disabled={isPending}
+                        >
+                          Retry
+                        </Button>
+                      ) : null}
+                    </div>
+                  </CardFooter>
+                </Card>
+              )
+            })
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+type NotificationFieldsProps = {
+  formState: ActionFormState
+  setFormState: Dispatch<SetStateAction<ActionFormState>>
+  disabled: boolean
+}
+
+function NotificationFields({ formState, setFormState, disabled }: NotificationFieldsProps) {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="notification-title">Notification title</Label>
+          <Input
+            id="notification-title"
+            value={formState.notificationTitle}
+            onChange={(event) =>
+              setFormState((prev) => ({
+                ...prev,
+                notificationTitle: event.target.value,
+              }))
+            }
+            disabled={disabled}
+            placeholder="Status update"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="notification-type">Notification tone</Label>
+          <Select
+            value={formState.notificationType}
+            onValueChange={(value) =>
+              setFormState((prev) => ({
+                ...prev,
+                notificationType: value as BulkNotificationRequest['notificationType'],
+              }))
+            }
+            disabled={disabled}
+          >
+            <SelectTrigger id="notification-type">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {NOTIFICATION_TYPES.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="notification-message">Message</Label>
+        <Textarea
+          id="notification-message"
+          value={formState.notificationMessage}
+          onChange={(event) =>
+            setFormState((prev) => ({
+              ...prev,
+              notificationMessage: event.target.value,
+            }))
+          }
+          disabled={disabled}
+          rows={4}
+          placeholder="Hi {name}, ..."
+        />
+        <p className="text-xs text-muted-foreground">
+          Use placeholders like {'{name}'} and {'{status}'} to personalise the copy.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="notification-link">Call-to-action URL</Label>
+        <Input
+          id="notification-link"
+          value={formState.actionUrl}
+          onChange={(event) =>
+            setFormState((prev) => ({
+              ...prev,
+              actionUrl: event.target.value,
+            }))
+          }
+          disabled={disabled}
+          placeholder="/dashboard"
+        />
+      </div>
+    </div>
+  )
+}
+
+function mergeJobUpdates(existing: AdminJobDTO[], updates: AdminJobDTO[]): AdminJobDTO[] {
+  if (updates.length === 0) {
+    return sortJobs(existing)
+  }
+
+  const jobMap = new Map(existing.map((job) => [job.id, job]))
+
+  for (const update of updates) {
+    const current = jobMap.get(update.id)
+    jobMap.set(update.id, current ? { ...current, ...update } : update)
+  }
+
+  return sortJobs(Array.from(jobMap.values()))
+}
+
+function sortJobs(jobs: AdminJobDTO[]): AdminJobDTO[] {
+  return [...jobs].sort((a, b) => {
+    const aTime = new Date(a.createdAt).getTime()
+    const bTime = new Date(b.createdAt).getTime()
+    return bTime - aTime
+  })
+}
+
+function formatRole(role: ProfileRoleFilter): string {
+  if (role === 'all') {
+    return 'All roles'
+  }
+
+  return role
+    .split('_')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+}
+
+function formatStatus(status: ProfileStatusFilter): string {
+  if (status === 'all') {
+    return 'All statuses'
+  }
+
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}

--- a/app/dashboard/members/page.tsx
+++ b/app/dashboard/members/page.tsx
@@ -1,19 +1,26 @@
 import React from "react";
 import MemberTable from "./components/MemberTable";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import SearchMembers from "./components/SearchMembers";
 import CreateMember from "./components/create/CreateMember";
+import { BulkAdminActions } from "./components/BulkAdminActions";
+import { listRecentAdminJobs } from "./actions/admin-jobs";
 
-export default function Members() {
-	return (
-		<div className="w-full space-y-5 overflow-y-auto px-3">
-			<h1 className="text-3xl font-bold">Members</h1>
-			<div className="flex gap-2">
-				<SearchMembers />
-				<CreateMember />
-			</div>
-			<MemberTable />
-		</div>
-	);
+export default async function Members() {
+        const jobs = await listRecentAdminJobs();
+
+        return (
+                <div className="w-full space-y-6 overflow-y-auto px-3 pb-10">
+                        <h1 className="text-3xl font-bold">Members</h1>
+                        <p className="text-sm text-muted-foreground">
+                                Manage individual members or schedule large updates with the admin
+                                queue.
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                                <SearchMembers />
+                                <CreateMember />
+                        </div>
+                        <BulkAdminActions initialJobs={jobs} />
+                        <MemberTable />
+                </div>
+        );
 }

--- a/docs/perf/admin-queue.md
+++ b/docs/perf/admin-queue.md
@@ -1,0 +1,86 @@
+# Admin bulk action queue
+
+## Overview
+The admin job queue lets property managers schedule large member operations—
+like status migrations or fleet-wide notifications—without blocking the UI.
+Jobs are persisted in Supabase, processed incrementally by server actions, and
+surfaced in the dashboard with real‑time progress updates.
+
+## Data model
+- **Table:** `public.admin_jobs`
+  - `id uuid` – primary key generated with `gen_random_uuid()`.
+  - `type` – `status_update` or `notification` to describe the workload.
+  - `status` – life-cycle enum: `queued`, `running`, `completed`, `failed`, `cancelled`.
+  - `payload jsonb` – serialized job configuration (filters, targets, message).
+  - `result jsonb` – cumulative per-member outcomes and summary counts.
+  - `total_tasks` / `processed_tasks` – coarse progress counters.
+  - `error text` – latest blocking error message (if any).
+  - `requested_by uuid` – actor who created the job (`profiles.id`).
+  - Timestamp helpers: `created_at`, `updated_at`, `completed_at`, `cancelled_at`, `last_progress_at`.
+- **Profiles:** gained a `status` column (`active | inactive | invited | suspended`) to
+  support account state transitions.
+- Trigger `trg_update_admin_jobs_updated_at` keeps `updated_at` fresh on every row
+  mutation so the UI can sort without extra logic.
+
+## Server actions
+`app/dashboard/members/actions/admin-jobs.ts` exposes typed entry points:
+
+| Action | Description |
+| --- | --- |
+| `listRecentAdminJobs(limit)` | Fetches recent jobs for initial render. |
+| `enqueueBulkStatusUpdate(request)` | Resolves target members, creates a job row, and immediately processes the first batch. |
+| `enqueueBulkNotification(request)` | Queues a notification-only job with the same semantics. |
+| `pollAdminJobs(jobIds)` | Pulls active jobs, executes the next batch (10 members) per job, and returns updated DTOs. |
+| `cancelAdminJob(jobId)` | Sets job state to `cancelled` when still running/queued. |
+| `retryAdminJob(jobId)` | Refreshes targets via stored filters, resets counters, and requeues work. |
+| `getAdminJob(jobId)` | Convenience fetch that also advances queued work. |
+
+### Processing loop
+- Jobs store `targetUserIds` in the payload. Each poll loads the next batch of IDs
+  (10 at a time) and fetches current profile data.
+- **Status updates:** Each member receives a transactional profile update. When
+  notifications are enabled, an in-app message is sent with placeholder
+  substitution (`{name}`, `{status}`). Any failure marks the entry unsuccessful
+  but the job continues.
+- **Notifications:** Send in-app messages only, capturing success/failure per
+  member.
+- Results are merged into the `result` JSON (`entries` + `summary`) so the UI can
+  display historical failures.
+- Once `processed_tasks` meets `total_tasks`, the job transitions to `completed`
+  and records a human-readable error when failures > 0 (e.g., `"2 item(s) failed"`).
+- Unexpected errors trigger a `failed` status; retry rehydrates filters to build a
+  fresh target list.
+
+## Dashboard experience
+`BulkAdminActions` is a client component that receives initial jobs from the
+server and:
+- Provides a tabbed form for **Status update** and **Notification blast** flows.
+- Supports role/status filters, next-status selection, optional notification
+  toggle, and customizable copy/CTA URLs.
+- Queues jobs via server actions with optimistic toast feedback.
+- Polls active jobs every 4 seconds, driving the incremental processing loop.
+- Renders job cards showing badges, progress bars, target counts, failure
+  summaries, and affordances for cancel/retry.
+
+## Cancellation & retry semantics
+- **Cancel** only operates on `queued` or `running` jobs; it simply flips the
+  status and leaves existing progress/results intact for auditing.
+- **Retry** works for `failed`, `cancelled`, or `completed` jobs with failures.
+  Targets are recalculated using the stored filters to ensure the rerun reflects
+  current data. Counters and results reset while preserving original metadata.
+
+## Operational notes
+- Batch size is tuned to 10 to balance throughput and request duration. Adjust
+  `JOB_BATCH_SIZE` if future workloads demand finer control.
+- The queue currently uses server actions as the worker loop. For high-volume
+  environments, this can be moved to a dedicated Supabase Edge Function or CRON
+  job that drains `queued` records on a schedule.
+- Payloads intentionally capture filters and summaries to support observability
+  and future auditing exports.
+
+## Future enhancements
+- Persist per-entry failure reasons into a dedicated table for richer reporting.
+- Add email delivery to notification jobs once SMTP credentials are configured.
+- Stream real-time updates to clients via Supabase Realtime instead of polling.
+- Introduce rate limiting/priority queues if multiple admins schedule overlapping
+  workloads.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -33,6 +33,7 @@ export type Database = {
         stripe_customer_id: string | null
         rent_share: number | null
         metadata: Json | null
+        status: 'active' | 'inactive' | 'invited' | 'suspended'
       }>
       documents: SupabaseTable<{
         id: string
@@ -198,6 +199,22 @@ export type Database = {
         read: boolean | null
         created_at: string | null
         updated_at: string | null
+      }>
+      admin_jobs: SupabaseTable<{
+        id: string
+        type: 'status_update' | 'notification'
+        status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+        payload: Json
+        result: Json | null
+        total_tasks: number
+        processed_tasks: number
+        error: string | null
+        requested_by: string | null
+        created_at: string
+        updated_at: string
+        completed_at: string | null
+        cancelled_at: string | null
+        last_progress_at: string | null
       }>
       email_notifications: SupabaseTable<{
         id: string

--- a/supabase/migrations/20250105_admin_jobs_queue.sql
+++ b/supabase/migrations/20250105_admin_jobs_queue.sql
@@ -1,0 +1,37 @@
+-- Create table to manage asynchronous admin jobs for bulk operations
+create table if not exists public.admin_jobs (
+    id uuid primary key default gen_random_uuid(),
+    type text not null check (type in ('status_update', 'notification')),
+    status text not null default 'queued' check (status in ('queued', 'running', 'completed', 'failed', 'cancelled')),
+    payload jsonb not null,
+    result jsonb,
+    total_tasks integer not null default 0,
+    processed_tasks integer not null default 0,
+    error text,
+    requested_by uuid references public.profiles (id) on delete set null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    completed_at timestamptz,
+    cancelled_at timestamptz,
+    last_progress_at timestamptz
+);
+
+create index if not exists admin_jobs_status_idx on public.admin_jobs (status);
+create index if not exists admin_jobs_created_at_idx on public.admin_jobs (created_at desc);
+
+create or replace function public.update_admin_jobs_updated_at()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_update_admin_jobs_updated_at
+before update on public.admin_jobs
+for each row
+execute function public.update_admin_jobs_updated_at();
+
+alter table public.profiles
+    add column if not exists status text not null default 'active'
+    check (status in ('active', 'inactive', 'invited', 'suspended'));

--- a/types/admin-jobs.ts
+++ b/types/admin-jobs.ts
@@ -1,0 +1,113 @@
+import type { Database } from '@/lib/supabase'
+
+export type ProfileRow = Database['public']['Tables']['profiles']['Row']
+export type ProfileRole = NonNullable<ProfileRow['role']>
+export type ProfileStatus = ProfileRow['status']
+
+export type AdminJobType = 'status_update' | 'notification'
+export type AdminJobStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
+export type ProfileRoleFilter = 'all' | ProfileRole
+export type ProfileStatusFilter = 'all' | ProfileStatus
+
+export type NotificationIntent = {
+  title: string
+  message: string
+  type: 'info' | 'success' | 'warning' | 'error'
+  actionUrl?: string
+}
+
+export type BulkStatusUpdatePayload = {
+  type: 'status_update'
+  targetUserIds: string[]
+  nextStatus: ProfileStatus
+  notify: boolean
+  notification?: NotificationIntent
+  filters: {
+    role: ProfileRoleFilter
+    currentStatus: ProfileStatusFilter
+  }
+  summary?: {
+    count: number
+  }
+}
+
+export type BulkNotificationPayload = {
+  type: 'notification'
+  targetUserIds: string[]
+  notification: NotificationIntent
+  filters: {
+    role: ProfileRoleFilter
+    currentStatus: ProfileStatusFilter
+  }
+  summary?: {
+    count: number
+  }
+}
+
+export type AdminJobPayload = BulkStatusUpdatePayload | BulkNotificationPayload
+
+export type AdminJobResultEntry = {
+  userId: string
+  success: boolean
+  action: AdminJobType
+  notified?: boolean
+  error?: string
+  timestamp: string
+}
+
+export type AdminJobResultSummary = {
+  successes: number
+  failures: number
+}
+
+export type AdminJobResult = {
+  entries: AdminJobResultEntry[]
+  summary: AdminJobResultSummary
+}
+
+export type AdminJobDTO = {
+  id: string
+  type: AdminJobType
+  status: AdminJobStatus
+  totalTasks: number
+  processedTasks: number
+  error: string | null
+  requestedBy: string | null
+  createdAt: string
+  updatedAt: string
+  completedAt: string | null
+  cancelledAt: string | null
+  payload: AdminJobPayload
+  result: AdminJobResult | null
+}
+
+export type BulkStatusUpdateRequest = {
+  role: ProfileRoleFilter
+  currentStatus: ProfileStatusFilter
+  nextStatus: ProfileStatus
+  sendNotification: boolean
+  notificationTitle?: string
+  notificationMessage?: string
+  notificationType?: NotificationIntent['type']
+  actionUrl?: string
+}
+
+export type BulkNotificationRequest = {
+  role: ProfileRoleFilter
+  currentStatus: ProfileStatusFilter
+  notificationTitle: string
+  notificationMessage: string
+  notificationType: NotificationIntent['type']
+  actionUrl?: string
+}
+
+export type AdminJobActionResponse = {
+  job?: AdminJobDTO
+  error?: string
+}


### PR DESCRIPTION
## Summary
- add a Supabase migration and type updates for the admin job queue and profile status field
- implement server actions that enqueue, process, cancel and retry bulk admin jobs backed by Supabase
- add a bulk admin actions dashboard panel with progress tracking plus documentation of the queue architecture

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c5bedf8832890f462043058dd76