### PR TITLE
Add resilient Supabase connectivity with offline queuing

### DIFF
--- a/app/account/avatar.tsx
+++ b/app/account/avatar.tsx
@@ -2,6 +2,8 @@
 import React, { useEffect, useState } from 'react'
 import useSupabaseBrowser from '@/utils/supabase-browser'
 import Image from 'next/image'
+import { useSupabaseConnectivity } from '@/components/network/supabase-connectivity-provider'
+import { stableHash } from '@/lib/utils'
 
 export default function Avatar({
   uid,
@@ -17,6 +19,7 @@ export default function Avatar({
   const supabase = useSupabaseBrowser()
   const [avatarUrl, setAvatarUrl] = useState<string | null>(url)
   const [uploading, setUploading] = useState(false)
+  const { enqueueMutation, status } = useSupabaseConnectivity()
 
   useEffect(() => {
     async function downloadImage(path: string) {
@@ -48,14 +51,36 @@ export default function Avatar({
       const fileExt = file.name.split('.').pop()
       const filePath = `${uid}-${Math.random()}.${fileExt}`
 
-      const { error: uploadError } = await supabase.storage.from('avatars').upload(filePath, file)
+      const mutationKey = `avatar-upload:${stableHash({
+        uid,
+        name: file.name,
+        modified: file.lastModified,
+        size: file.size,
+      })}`
 
-      if (uploadError) {
-        throw uploadError
+      const mutationPromise = enqueueMutation(mutationKey, async () => {
+        const { error: uploadError } = await supabase.storage
+          .from('avatars')
+          .upload(filePath, file)
+
+        if (uploadError) {
+          throw uploadError
+        }
+
+        onUpload(filePath)
+      })
+
+      if (status === 'online') {
+        await mutationPromise
+      } else {
+        alert('You are offline. We will upload your avatar when the connection returns.')
+        mutationPromise.catch(error => {
+          console.error('Error uploading avatar: ', error)
+          alert('Error uploading avatar!')
+        })
       }
-
-      onUpload(filePath)
     } catch (error) {
+      console.log('Error uploading avatar: ', error)
       alert('Error uploading avatar!')
     } finally {
       setUploading(false)

--- a/app/account/supa-account-form.tsx
+++ b/app/account/supa-account-form.tsx
@@ -6,6 +6,8 @@ import useSupabaseBrowser from '@/utils/supabase-browser'
 import { type User } from '@supabase/supabase-js'
 import Avatar from './avatar'
 import { Input } from '@/components/ui/input'
+import { useSupabaseConnectivity } from '@/components/network/supabase-connectivity-provider'
+import { stableHash } from '@/lib/utils'
 
 export default function AccountForm({ user }: { user: User | null }) {
   const supabase = useSupabaseBrowser()
@@ -16,6 +18,7 @@ export default function AccountForm({ user }: { user: User | null }) {
   const [avatar_url, setAvatarUrl] = useState<string | null>(null)
 const [email, setEmail] = useState<string | null>(null)
 const [waddress, setWaddress] = useState<string | null>(null)
+  const { enqueueMutation, status } = useSupabaseConnectivity()
 const languages = [
   { label: "English", value: "en" },
   { label: "French", value: "fr" },
@@ -61,39 +64,74 @@ const languages = [
     getProfile()
   }, [user, getProfile])
 
-  async function updateProfile({
-    username,
-    website,
-    avatar_url,
-    email,
-  }: {
-    username: string | null
-    fullname: string | null
-    website: string | null
-    avatar_url: string | null
-    email: string | null
-
-  }) {
-    try {
+  const updateProfile = useCallback(
+    async ({
+      username,
+      fullname: fullNameValue,
+      website,
+      avatar_url,
+      email,
+    }: {
+      username: string | null
+      fullname: string | null
+      website: string | null
+      avatar_url: string | null
+      email: string | null
+    }) => {
       setLoading(true)
 
-      const { error } = await supabase.from('profiles').upsert({
+      const profilePayload = {
         id: user?.id as string,
-        full_name: fullname,
+        full_name: fullNameValue ?? fullname,
         username,
         website,
         avatar_url,
         email,
         updated_at: new Date().toISOString(),
+      }
+
+      const mutationKey = `profile-update:${stableHash({
+        id: user?.id ?? 'unknown',
+        full_name: profilePayload.full_name,
+        username,
+        website,
+        avatar_url,
+        email,
+      })}`
+
+      const mutationPromise = enqueueMutation(mutationKey, async () => {
+        const { error } = await supabase.from('profiles').upsert(profilePayload)
+
+        if (error) throw error
       })
-      if (error) throw error
-      alert('Account updated!')
-    } catch (error) {
-      alert('Error updating the data!')
-    } finally {
+
+      if (status === 'online') {
+        try {
+          await mutationPromise
+          alert('Account updated!')
+        } catch (error) {
+          console.error('Error updating the data!', error)
+          alert('Error updating the data!')
+        } finally {
+          setLoading(false)
+        }
+        return
+      }
+
+      alert('You are offline. We saved your changes and will sync when you reconnect.')
+      mutationPromise
+        .then(() => {
+          alert('Account updated!')
+        })
+        .catch(error => {
+          console.error('Error updating the data!', error)
+          alert('Error updating the data!')
+        })
+
       setLoading(false)
-    }
-  }
+    },
+    [enqueueMutation, fullname, status, supabase, user?.id]
+  )
 
   return (
     <div className="                                   w-full space-y-8 px-2 py-8">
@@ -104,7 +142,7 @@ const languages = [
       size={144}
       onUpload={(url) => {
         setAvatarUrl(url)
-        updateProfile({ fullname, username, website, email, avatar_url: url })
+        void updateProfile({ fullname, username, website, email, avatar_url: url })
       }}
     />
  <div className="flex flex-col">
@@ -148,7 +186,7 @@ const languages = [
 
         <button
           className={buttonVariants({ variant: "outline" })}
-          onClick={() => updateProfile({ fullname, username, website, email, avatar_url })}
+          onClick={() => void updateProfile({ fullname, username, website, email, avatar_url })}
           disabled={loading}
         >
           {loading ? 'Loading ...' : 'Update Account'}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,8 @@ import { SiteHeader } from "@/components/site-header"
 import { SiteFooter } from "@/components/site-footer"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { cn } from "@/lib/utils"
+import { SupabaseConnectivityProvider } from "@/components/network/supabase-connectivity-provider"
+import { SupabaseOfflineBanner } from "@/components/network/supabase-offline-banner"
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
@@ -111,41 +113,45 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <ReactQueryClientProvider>
-    <html lang="en" suppressHydrationWarning>
-    <head></head>
-      <body className={cn(
+      <html lang="en" suppressHydrationWarning>
+        <head></head>
+        <body
+          className={cn(
             "min-h-screen bg-background font-sans antialiased",
             fontSans.variable
           )}
         >
-<ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-             <div className="relative flex min-h-screen flex-col">
-              <SiteHeader />
-              <div className="flex-1">{children}<Toaster/><Analytics/><SpeedInsights/></div>
-              
-   </div>           
-<SiteFooter/>
-
-
-{/*
+          <SupabaseConnectivityProvider>
+            <ThemeProvider
+              attribute="class"
+              defaultTheme="system"
+              enableSystem
+              disableTransitionOnChange
+            >
+              <div className="relative flex min-h-screen flex-col">
+                <SupabaseOfflineBanner />
+                <SiteHeader />
+                <div className="flex-1">
+                  {children}
+                  <Toaster />
+                  <Analytics />
+                  <SpeedInsights />
+                </div>
+                <SiteFooter />
+              </div>
+              <TailwindIndicator />
+              {/*
 enter your api info from termly.io or a provider of your choice
 <Script
   type="text/javascript"
   src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
 
 */}
-   <CookieButton />    
-          </ThemeProvider>
-        
-
-
-</body>
-    </html>
+              <CookieButton />
+            </ThemeProvider>
+          </SupabaseConnectivityProvider>
+        </body>
+      </html>
     </ReactQueryClientProvider>
   )
 }

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -13,6 +13,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
+import { useSupabaseConnectivity } from "@/components/network/supabase-connectivity-provider";
+import { stableHash } from "@/lib/utils";
 
 const maintenanceRequestSchema = z.object({
   title: z.string().min(5, "Title must be at least 5 characters"),
@@ -48,6 +50,8 @@ export function MaintenanceRequestForm() {
   const { notifyMaintenanceRequest } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
+  const { enqueueMutation, status } = useSupabaseConnectivity();
+  const isOnline = status === "online";
 
   const form = useForm<MaintenanceRequestFormData>({
     resolver: zodResolver(maintenanceRequestSchema),
@@ -63,84 +67,115 @@ export function MaintenanceRequestForm() {
   const onSubmit = async (data: MaintenanceRequestFormData) => {
     setIsSubmitting(true);
 
-    try {
-      // Get current user info
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
+    const mutationKey = `maintenance-request:${stableHash({
+      title: data.title.trim().toLowerCase(),
+      description: data.description.trim().toLowerCase(),
+      priority: data.priority,
+      location: (data.location || '').trim().toLowerCase(),
+    })}`
 
-      // Get user profile
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('full_name, unit_id')
-        .eq('id', user.id)
-        .single();
+    const mutationPromise = enqueueMutation(mutationKey, async () => {
+      try {
+        const {
+          data: { user }
+        } = await supabase.auth.getUser()
 
-      if (!profile) throw new Error("Profile not found");
+        if (!user) throw new Error("Not authenticated")
 
-      if (!profile.unit_id) {
-        throw new Error("User is not assigned to a unit");
-      }
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('full_name, unit_id')
+          .eq('id', user.id)
+          .single()
 
-      // Get property manager for this unit
-      const { data: propertyManager } = await supabase
-        .from('profiles')
-        .select('id, full_name, email')
-        .eq('unit_id', profile.unit_id!)
-        .eq('role', 'property_manager')
-        .single();
+        if (!profile) throw new Error("Profile not found")
 
-      if (!propertyManager) {
-        throw new Error("Property manager not found for this unit");
-      }
+        if (!profile.unit_id) {
+          throw new Error("User is not assigned to a unit")
+        }
 
-      // Create maintenance request record
-      const { data: request, error: requestError } = await (supabase as any)
-        .from('maintenance_requests')
-        .insert({
+        const { data: propertyManager } = await supabase
+          .from('profiles')
+          .select('id, full_name, email')
+          .eq('unit_id', profile.unit_id!)
+          .eq('role', 'property_manager')
+          .single()
+
+        if (!propertyManager) {
+          throw new Error("Property manager not found for this unit")
+        }
+
+        const { error: requestError } = await (supabase as any)
+          .from('maintenance_requests')
+          .insert({
+            title: data.title,
+            description: data.description,
+            priority: data.priority,
+            category: data.category || null,
+            location: data.location || null,
+            requested_by: user.id,
+            unit_id: (profile as any).unit_id,
+            status: 'pending',
+          })
+          .select()
+          .single()
+
+        if (requestError) throw requestError
+
+        await notifyMaintenanceRequest({
+          requesterName: (profile as any).full_name || user.email || 'Unknown',
           title: data.title,
           description: data.description,
           priority: data.priority,
-          category: data.category || null,
-          location: data.location || null,
-          requested_by: user.id,
-          unit_id: (profile as any).unit_id,
-          status: 'pending',
+          propertyManager: {
+            id: propertyManager.id,
+            email: propertyManager.email || '',
+            name: propertyManager.full_name || propertyManager.email || 'Unknown',
+          },
         })
-        .select()
-        .single();
 
-      if (requestError) throw requestError;
+        toast({
+          title: "Maintenance request submitted",
+          description: "Your maintenance request has been submitted and notifications sent.",
+        })
 
-      // Send notifications
-      await notifyMaintenanceRequest({
-        requesterName: (profile as any).full_name || user.email || 'Unknown',
-        title: data.title,
-        description: data.description,
-        priority: data.priority,
-        propertyManager: {
-          id: propertyManager.id,
-          email: propertyManager.email || '',
-          name: propertyManager.full_name || propertyManager.email || 'Unknown',
-        },
-      });
+        form.reset()
+      } catch (error) {
+        console.error('Error submitting maintenance request:', error)
+        toast({
+          title: "Error",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Failed to submit maintenance request",
+          variant: "destructive",
+        })
+        throw error
+      }
+    })
 
-      toast({
-        title: "Maintenance request submitted",
-        description: "Your maintenance request has been submitted and notifications sent.",
-      });
-
-      form.reset();
-    } catch (error) {
-      console.error('Error submitting maintenance request:', error);
-      toast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to submit maintenance request",
-        variant: "destructive",
-      });
-    } finally {
-      setIsSubmitting(false);
+    if (isOnline) {
+      try {
+        await mutationPromise
+      } catch (error) {
+        console.error('Maintenance request submission failed:', error)
+      } finally {
+        setIsSubmitting(false)
+      }
+      return
     }
-  };
+
+    toast({
+      title: "Working offline",
+      description: "We'll submit your maintenance request once you're back online.",
+    })
+
+    mutationPromise.catch(error => {
+      console.error('Queued maintenance request failed:', error)
+    })
+
+    setIsSubmitting(false)
+  }
 
   return (
     <Form {...form}>

--- a/components/network/supabase-connectivity-provider.tsx
+++ b/components/network/supabase-connectivity-provider.tsx
@@ -1,0 +1,216 @@
+"use client"
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
+import { createClient } from "@/utils/supabase-browser"
+
+export type SupabaseStatus = "online" | "offline" | "reconnecting"
+
+type MutationTask = {
+  key: string
+  execute: () => Promise<unknown>
+  resolve: (value: unknown) => void
+  reject: (error: unknown) => void
+  promise: Promise<unknown>
+}
+
+type SupabaseConnectivityContextValue = {
+  status: SupabaseStatus
+  isOffline: boolean
+  isReconnecting: boolean
+  pendingMutations: number
+  enqueueMutation: <T>(key: string, execute: () => Promise<T>) => Promise<T>
+}
+
+const SupabaseConnectivityContext = createContext<SupabaseConnectivityContextValue | undefined>(
+  undefined
+)
+
+export function SupabaseConnectivityProvider({
+  children
+}: {
+  children: React.ReactNode
+}) {
+  const supabase = useMemo(() => createClient(), [])
+  const [connectionState, setConnectionState] = useState(() =>
+    supabase.realtime.connectionState()
+  )
+  const [networkOnline, setNetworkOnline] = useState(
+    typeof navigator === "undefined" ? true : navigator.onLine
+  )
+  const [pendingMutations, setPendingMutations] = useState(0)
+  const queueRef = useRef<MutationTask[]>([])
+  const taskMapRef = useRef<Map<string, MutationTask>>(new Map())
+  const processingRef = useRef(false)
+  const statusRef = useRef<SupabaseStatus>("online")
+
+  useEffect(() => {
+    supabase.realtime.connect()
+
+    const updateConnectionState = () => {
+      setConnectionState(supabase.realtime.connectionState())
+    }
+
+    updateConnectionState()
+    const interval = setInterval(updateConnectionState, 1000)
+
+    return () => {
+      clearInterval(interval)
+      supabase.realtime.disconnect()
+    }
+  }, [supabase])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const handleOnline = () => setNetworkOnline(true)
+    const handleOffline = () => setNetworkOnline(false)
+
+    window.addEventListener("online", handleOnline)
+    window.addEventListener("offline", handleOffline)
+
+    return () => {
+      window.removeEventListener("online", handleOnline)
+      window.removeEventListener("offline", handleOffline)
+    }
+  }, [])
+
+  const status: SupabaseStatus = useMemo(() => {
+    if (!networkOnline) {
+      return "offline"
+    }
+
+    if (connectionState === "open") {
+      return "online"
+    }
+
+    if (connectionState === "connecting" || connectionState === "closing") {
+      return "reconnecting"
+    }
+
+    return "offline"
+  }, [connectionState, networkOnline])
+
+  statusRef.current = status
+
+  const runTask = useCallback(async (task: MutationTask) => {
+    try {
+      const result = await task.execute()
+      task.resolve(result)
+
+      taskMapRef.current.delete(task.key)
+    } catch (error) {
+      if (statusRef.current !== "online") {
+        queueRef.current.unshift(task)
+        setPendingMutations(queueRef.current.length)
+        return
+      }
+
+      task.reject(error)
+      taskMapRef.current.delete(task.key)
+    } finally {
+      setPendingMutations(queueRef.current.length)
+    }
+  }, [])
+
+  const isReady = status === "online"
+
+  const processQueue = useCallback(async () => {
+    if (!isReady || processingRef.current) {
+      return
+    }
+
+    processingRef.current = true
+
+    try {
+      while (queueRef.current.length > 0 && statusRef.current === "online") {
+        const task = queueRef.current.shift()
+
+        if (!task) {
+          continue
+        }
+
+        setPendingMutations(queueRef.current.length)
+        await runTask(task)
+      }
+    } finally {
+      processingRef.current = false
+    }
+  }, [isReady, runTask])
+
+  useEffect(() => {
+    if (status === "online") {
+      void processQueue()
+    }
+  }, [status, processQueue])
+
+  const enqueueMutation = useCallback(
+    <T,>(key: string, execute: () => Promise<T>) => {
+      const existingTask = taskMapRef.current.get(key)
+
+      if (existingTask) {
+        return existingTask.promise as Promise<T>
+      }
+
+      let resolve!: (value: T) => void
+      let reject!: (error: unknown) => void
+
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+
+      const task: MutationTask = {
+        key,
+        execute,
+        resolve,
+        reject,
+        promise
+      }
+
+      taskMapRef.current.set(key, task)
+
+      if (isReady) {
+        void runTask(task)
+      } else {
+        queueRef.current.push(task)
+        setPendingMutations(queueRef.current.length)
+      }
+
+      void processQueue()
+
+      return promise
+    },
+    [isReady, processQueue, runTask]
+  )
+
+  const value = useMemo(
+    () => ({
+      status,
+      isOffline: status === "offline",
+      isReconnecting: status === "reconnecting",
+      pendingMutations,
+      enqueueMutation
+    }),
+    [enqueueMutation, pendingMutations, status]
+  )
+
+  return (
+    <SupabaseConnectivityContext.Provider value={value}>
+      {children}
+    </SupabaseConnectivityContext.Provider>
+  )
+}
+
+export function useSupabaseConnectivity() {
+  const context = useContext(SupabaseConnectivityContext)
+
+  if (!context) {
+    throw new Error(
+      "useSupabaseConnectivity must be used within a SupabaseConnectivityProvider"
+    )
+  }
+
+  return context
+}

--- a/components/network/supabase-offline-banner.tsx
+++ b/components/network/supabase-offline-banner.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { WifiOff } from "lucide-react"
+
+import { useSupabaseConnectivity } from "./supabase-connectivity-provider"
+
+export function SupabaseOfflineBanner() {
+  const { status, pendingMutations } = useSupabaseConnectivity()
+
+  if (status === "online") {
+    return null
+  }
+
+  const isOffline = status === "offline"
+  const bannerColor = isOffline ? "bg-rose-600" : "bg-amber-500"
+  const label = isOffline ? "Offline mode" : "Reconnecting to Supabase"
+  const pendingLabel =
+    pendingMutations > 0
+      ? `${pendingMutations} pending update${pendingMutations === 1 ? "" : "s"}`
+      : "Changes sync automatically once the connection is restored."
+
+  return (
+    <div className={`sticky top-0 z-50 w-full ${bannerColor} text-white`}>
+      <div className="mx-auto flex max-w-5xl flex-col gap-1 px-4 py-2 text-sm md:flex-row md:items-center md:justify-between md:gap-4">
+        <div className="flex items-center gap-2">
+          <WifiOff className="size-4" aria-hidden="true" />
+          <span className="font-medium">{label}</span>
+          {pendingMutations > 0 && (
+            <span className="text-xs text-white/80">{pendingLabel}</span>
+          )}
+        </div>
+        {pendingMutations === 0 && (
+          <span className="text-xs text-white/80">{pendingLabel}</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/notifications/notification-center.tsx
+++ b/components/notifications/notification-center.tsx
@@ -9,7 +9,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/use-toast";
 import { createClient } from "@/utils/supabase-browser";
-import { cn } from "@/lib/utils";
+import { cn, stableHash } from "@/lib/utils";
+import { useSupabaseConnectivity } from "@/components/network/supabase-connectivity-provider";
 
 interface Notification {
   id: string;
@@ -28,6 +29,7 @@ export function NotificationCenter() {
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
   const supabase = useMemo(() => createClient(), []);
+  const { enqueueMutation } = useSupabaseConnectivity();
 
   const fetchNotifications = useCallback(async () => {
     setLoading(true);
@@ -83,71 +85,99 @@ export function NotificationCenter() {
     };
   }, [fetchNotifications, supabase, toast]);
 
-  const markAsRead = async (notificationId: string) => {
-    try {
+  const markAsRead = (notificationId: string) => {
+    setNotifications(prev =>
+      prev.map(n => (n.id === notificationId ? { ...n, read: true } : n))
+    )
+    setUnreadCount(prev => Math.max(0, prev - 1))
+
+    const mutationKey = `notifications:mark-read:${notificationId}`
+
+    const mutation = enqueueMutation(mutationKey, async () => {
       const { error } = await (supabase as any)
         .from('notifications')
         .update({ read: true })
-        .eq('id', notificationId);
+        .eq('id', notificationId)
 
-      if (error) throw error;
+      if (error) throw error
+    })
 
-      setNotifications(prev =>
-        prev.map(n =>
-          n.id === notificationId ? { ...n, read: true } : n
-        )
-      );
-      setUnreadCount(prev => Math.max(0, prev - 1));
-    } catch (error) {
-      console.error('Failed to mark notification as read:', error);
-    }
-  };
-
-  const markAllAsRead = async () => {
-    try {
-      const unreadIds = notifications.filter(n => !n.read).map(n => n.id);
-
-      if (unreadIds.length === 0) return;
-
-      const { error } = await (supabase as any)
-        .from('notifications')
-        .update({ read: true })
-        .in('id', unreadIds);
-
-      if (error) throw error;
-
-      setNotifications(prev =>
-        prev.map(n => ({ ...n, read: true }))
-      );
-      setUnreadCount(0);
-
+    mutation.catch(error => {
+      console.error('Failed to mark notification as read:', error)
       toast({
-        title: "All notifications marked as read",
-      });
-    } catch (error) {
-      console.error('Failed to mark all notifications as read:', error);
-    }
-  };
+        title: "Sync failed",
+        description: "We couldn't update that notification. We'll refresh your inbox.",
+        variant: "destructive",
+      })
+      fetchNotifications()
+    })
+  }
 
-  const deleteNotification = async (notificationId: string) => {
-    try {
+  const markAllAsRead = () => {
+    const unreadIds = notifications.filter(n => !n.read).map(n => n.id)
+
+    if (unreadIds.length === 0) return
+
+    setNotifications(prev => prev.map(n => ({ ...n, read: true })))
+    setUnreadCount(0)
+
+    const mutationKey = `notifications:mark-all:${stableHash(unreadIds)}`
+
+    const mutation = enqueueMutation(mutationKey, async () => {
+      const { error } = await (supabase as any)
+        .from('notifications')
+        .update({ read: true })
+        .in('id', unreadIds)
+
+      if (error) throw error
+    })
+
+    mutation
+      .then(() => {
+        toast({
+          title: "All notifications marked as read",
+        })
+      })
+      .catch(error => {
+        console.error('Failed to mark all notifications as read:', error)
+        toast({
+          title: "Sync failed",
+          description: "We couldn't update notifications. We'll refresh your inbox.",
+          variant: "destructive",
+        })
+        fetchNotifications()
+      })
+  }
+
+  const deleteNotification = (notificationId: string) => {
+    const deletedNotification = notifications.find(n => n.id === notificationId)
+    setNotifications(prev => prev.filter(n => n.id !== notificationId))
+
+    if (deletedNotification && !deletedNotification.read) {
+      setUnreadCount(prev => Math.max(0, prev - 1))
+    }
+
+    const mutationKey = `notifications:delete:${notificationId}`
+
+    const mutation = enqueueMutation(mutationKey, async () => {
       const { error } = await (supabase as any)
         .from('notifications')
         .delete()
-        .eq('id', notificationId);
+        .eq('id', notificationId)
 
-      if (error) throw error;
+      if (error) throw error
+    })
 
-      const deletedNotification = notifications.find(n => n.id === notificationId);
-      setNotifications(prev => prev.filter(n => n.id !== notificationId));
-
-      if (deletedNotification && !deletedNotification.read) {
-        setUnreadCount(prev => Math.max(0, prev - 1));
-      }
-    } catch (error) {
-      console.error('Failed to delete notification:', error);
-    }
-  };
+    mutation.catch(error => {
+      console.error('Failed to delete notification:', error)
+      toast({
+        title: "Sync failed",
+        description: "We couldn't delete that notification. We'll refresh your inbox.",
+        variant: "destructive",
+      })
+      fetchNotifications()
+    })
+  }
 
   const getTypeColor = (type: string) => {
     switch (type) {

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -18,6 +18,8 @@ import { cn } from "@/lib/utils";
 import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
+import { useSupabaseConnectivity } from "@/components/network/supabase-connectivity-provider";
+import { stableHash } from "@/lib/utils";
 
 const visitorBookingSchema = z.object({
   guestName: z.string().min(2, "Guest name must be at least 2 characters"),
@@ -41,6 +43,8 @@ export function VisitorBookingForm() {
   const { notifyVisitorBooking } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
+  const { enqueueMutation, status } = useSupabaseConnectivity();
+  const isOnline = status === "online";
 
   const form = useForm<VisitorBookingFormData>({
     resolver: zodResolver(visitorBookingSchema),
@@ -57,91 +61,123 @@ export function VisitorBookingForm() {
   const onSubmit = async (data: VisitorBookingFormData) => {
     setIsSubmitting(true);
 
-    try {
-      // Get current user info
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
+    const mutationKey = `visitor-booking:${stableHash({
+      guestEmail: data.guestEmail.toLowerCase(),
+      checkIn: data.checkInDate.toISOString(),
+      checkOut: data.checkOutDate.toISOString(),
+      purpose: data.purpose.trim().toLowerCase(),
+    })}`
 
-      // Get user profile
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('full_name, email, unit_id')
-        .eq('id', user.id)
-        .single();
+    const mutationPromise = enqueueMutation(mutationKey, async () => {
+      try {
+        const {
+          data: { user }
+        } = await supabase.auth.getUser()
 
-      if (!profile) throw new Error("Profile not found");
+        if (!user) throw new Error("Not authenticated")
 
-      // Get roommates and property manager
-      // This assumes there's a units table with tenant relationships
-      const { data: unitData } = await supabase
-        .from('profiles')
-        .select('id, full_name, email, role')
-        .eq('unit_id', profile.unit_id!)
-        .neq('id', user.id);
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('full_name, email, unit_id')
+          .eq('id', user.id)
+          .single()
 
-      const roommates = unitData?.filter(p => p.role === 'tenant' || p.role === 'roommate') || [];
-      const propertyManager = unitData?.find(p => p.role === 'property_manager');
+        if (!profile) throw new Error("Profile not found")
 
-      if (!propertyManager) {
-        throw new Error("Property manager not found for this unit");
-      }
+        const { data: unitData } = await supabase
+          .from('profiles')
+          .select('id, full_name, email, role')
+          .eq('unit_id', profile.unit_id!)
+          .neq('id', user.id)
 
-      // Create visitor booking record
-      const { data: booking, error: bookingError } = await (supabase as any)
-        .from('visitor_logs')
-        .insert({
-          guest_name: data.guestName,
-          guest_email: data.guestEmail,
-          guest_phone: data.guestPhone,
-          host_id: user.id,
-          check_in_date: data.checkInDate.toISOString(),
-          check_out_date: data.checkOutDate.toISOString(),
+        const roommates = unitData?.filter(
+          (p: any) => p.role === 'tenant' || p.role === 'roommate'
+        ) || []
+        const propertyManager = unitData?.find((p: any) => p.role === 'property_manager')
+
+        if (!propertyManager) {
+          throw new Error("Property manager not found for this unit")
+        }
+
+        const { error: bookingError } = await (supabase as any)
+          .from('visitor_logs')
+          .insert({
+            guest_name: data.guestName,
+            guest_email: data.guestEmail,
+            guest_phone: data.guestPhone,
+            host_id: user.id,
+            check_in_date: data.checkInDate.toISOString(),
+            check_out_date: data.checkOutDate.toISOString(),
+            purpose: data.purpose,
+            emergency_contact: data.emergencyContact,
+            special_notes: data.specialNotes,
+            status: 'pending',
+          })
+          .select()
+          .single()
+
+        if (bookingError) throw bookingError
+
+        await notifyVisitorBooking({
+          guestName: data.guestName,
+          hostName: profile.full_name || user.email || 'Unknown',
+          checkInDate: format(data.checkInDate, 'MMM dd, yyyy'),
+          checkOutDate: format(data.checkOutDate, 'MMM dd, yyyy'),
           purpose: data.purpose,
-          emergency_contact: data.emergencyContact,
-          special_notes: data.specialNotes,
-          status: 'pending',
+          roommates: roommates.map((r: any) => ({
+            id: r.id,
+            email: r.email || '',
+            name: r.full_name || r.email || 'Unknown',
+          })),
+          propertyManager: {
+            id: propertyManager.id,
+            email: propertyManager.email || '',
+            name: propertyManager.full_name || propertyManager.email || 'Unknown',
+          },
         })
-        .select()
-        .single();
 
-      if (bookingError) throw bookingError;
+        toast({
+          title: "Visitor booking submitted",
+          description: "Your visitor booking has been submitted and notifications sent.",
+        })
 
-      // Send notifications
-      await notifyVisitorBooking({
-        guestName: data.guestName,
-        hostName: profile.full_name || user.email || 'Unknown',
-        checkInDate: format(data.checkInDate, 'MMM dd, yyyy'),
-        checkOutDate: format(data.checkOutDate, 'MMM dd, yyyy'),
-        purpose: data.purpose,
-        roommates: roommates.map(r => ({
-          id: r.id,
-          email: r.email || '',
-          name: r.full_name || r.email || 'Unknown',
-        })),
-        propertyManager: {
-          id: propertyManager.id,
-          email: propertyManager.email || '',
-          name: propertyManager.full_name || propertyManager.email || 'Unknown',
-        },
-      });
+        form.reset()
+      } catch (error) {
+        console.error('Error submitting visitor booking:', error)
+        toast({
+          title: "Error",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Failed to submit visitor booking",
+          variant: "destructive",
+        })
+        throw error
+      }
+    })
 
-      toast({
-        title: "Visitor booking submitted",
-        description: "Your visitor booking has been submitted and notifications sent.",
-      });
-
-      form.reset();
-    } catch (error) {
-      console.error('Error submitting visitor booking:', error);
-      toast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to submit visitor booking",
-        variant: "destructive",
-      });
-    } finally {
-      setIsSubmitting(false);
+    if (isOnline) {
+      try {
+        await mutationPromise
+      } catch (error) {
+        console.error('Visitor booking submission failed:', error)
+      } finally {
+        setIsSubmitting(false)
+      }
+      return
     }
-  };
+
+    toast({
+      title: "Working offline",
+      description: "We'll submit your visitor booking once you're back online.",
+    })
+
+    mutationPromise.catch(error => {
+      console.error('Queued visitor booking failed:', error)
+    })
+
+    setIsSubmitting(false)
+  }
 
   return (
     <Form {...form}>

--- a/docs/perf/network-resilience.md
+++ b/docs/perf/network-resilience.md
@@ -1,0 +1,78 @@
+# Network Resilience Toolkit
+
+This application now ships with a set of client-side resiliency primitives to keep Supabase-backed
+interactions predictable during degraded network conditions. The patterns below explain how the
+retryable fetcher, Supabase connectivity monitor, mutation queueing, and UI affordances work
+together.
+
+## Fetcher resilience
+
+- `lib/utils.ts` exports a `fetcher` helper that wraps `window.fetch` with exponential backoff,
+  jitter, and retry-aware idempotency keys.
+- Retries are attempted for 408/425/429 responses and all `>=500` server errors. Network errors also
+  retry automatically.
+- When the request method is `POST`, the helper attaches an `Idempotency-Key` header. The key is
+  generated once per call (or supplied explicitly) so that all retries for the same request are safe
+  to replay on the server.
+- JSON responses are parsed automatically; non-JSON responses fall back to raw text.
+
+Use the helper instead of raw `fetch` for API calls that should survive transient failures:
+
+```ts
+const result = await fetcher<MyPayload>("/api/notifications", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(payload),
+})
+```
+
+## Supabase connectivity provider
+
+- `components/network/supabase-connectivity-provider.tsx` exposes
+  `SupabaseConnectivityProvider` and `useSupabaseConnectivity()`.
+- The provider keeps a lightweight realtime connection open, monitors `navigator.onLine`, and polls
+  Supabase's realtime connection state once per second.
+- It maintains a mutation queue (`enqueueMutation`) with client-side deduplication. A mutation key is
+  required; combine it with `stableHash` to derive deterministic keys from payloads.
+- When the connection is offline or reconnecting, new mutations are queued. Once the realtime client
+  reports an open connection, the queue flushes sequentially.
+- Mutations re-queue automatically if a network interruption occurs mid-flight so work is not lost.
+
+### Using `enqueueMutation`
+
+```ts
+const { enqueueMutation } = useSupabaseConnectivity()
+const key = `profiles:update:${stableHash(payload)}`
+
+await enqueueMutation(key, async () => {
+  const { error } = await supabase.from("profiles").upsert(payload)
+  if (error) throw error
+})
+```
+
+- If an identical key is already queued or executing, `enqueueMutation` returns the existing promise
+  so duplicate writes are avoided.
+- Wrap optimistic UI updates around `enqueueMutation` to keep the interface responsive. Attach
+  `.catch()` handlers when you need to trigger a data refresh or surface errors after reconnecting.
+
+## Offline banner & user messaging
+
+- `SupabaseOfflineBanner` surfaces a sticky banner whenever the provider reports `offline` or
+  `reconnecting`. It shows the number of queued mutations so tenants understand their changes are
+  staged.
+- Forms that queue work (visitor booking, maintenance requests, account profile updates) now show a
+  toast when actions are cached offline and replay when connectivity resumes.
+
+## Components updated to use the queue
+
+- Visitor bookings, maintenance requests, notification reads/deletes, avatar uploads, and profile
+  updates all run inside `enqueueMutation` to gain offline queuing and deduping.
+- `stableHash` in `lib/utils` generates deterministic keys for composite payloads, ensuring queued
+  work is merged rather than duplicated.
+
+## Testing & future work
+
+- Exercise offline scenarios by toggling network throttling in DevTools; the banner should appear and
+  queued mutations should persist until connectivity returns.
+- When adding new Supabase mutations, prefer `enqueueMutation` with a descriptive key and reuse the
+  shared fetcher for HTTP requests so future resiliency improvements apply automatically.

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -2,6 +2,7 @@
 
 import type { InAppNotification, NotificationData } from "@/lib/notifications"
 import { useToast } from "@/components/ui/use-toast"
+import { fetcher, stableHash } from "@/lib/utils"
 
 type NotificationResult = { success: boolean; error?: string }
 type BulkNotificationResult = {
@@ -10,27 +11,22 @@ type BulkNotificationResult = {
 }
 
 async function postNotification<T>(payload: unknown): Promise<T> {
-  const response = await fetch("/api/notifications", {
+  const idempotencyKey = `notifications:${stableHash(payload)}`
+
+  const data = (await fetcher<T | { error?: string }>("/api/notifications", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
-  })
+    idempotencyKey,
+  })) as T | { error?: string }
 
-  const data = (await response.json().catch(() => null)) as
-    | T
-    | { error?: string }
-    | null
-
-  if (!response.ok || !data) {
-    const message =
-      data &&
-      typeof data === "object" &&
-      "error" in data &&
-      typeof data.error === "string"
-        ? data.error
-        : "Failed to send notification"
-
-    throw new Error(message)
+  if (
+    data &&
+    typeof data === "object" &&
+    "error" in data &&
+    typeof (data as { error?: unknown }).error === "string"
+  ) {
+    throw new Error((data as { error: string }).error)
   }
 
   return data as T

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,33 +1,129 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+type ExtendedRequestInit = RequestInit & {
+  retry?: number
+  retryDelay?: number
+  idempotencyKey?: string
+}
+
+const DEFAULT_RETRY_ATTEMPTS = 3
+const DEFAULT_RETRY_DELAY = 300
+const RETRYABLE_STATUS_CODES = new Set([408, 425, 429])
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export const sleep = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms))
 
+const createIdempotencyKey = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+const createErrorWithStatus = (message: string, status: number) => {
+  const error = new Error(message) as Error & { status: number }
+  error.status = status
+  return error
+}
+
+const parseResponse = async <JSON>(res: Response): Promise<JSON> => {
+  if (res.status === 204) {
+    return undefined as JSON
+  }
+
+  const contentType = res.headers.get('content-type') || ''
+
+  if (contentType.includes('application/json')) {
+    return (await res.json()) as JSON
+  }
+
+  const text = await res.text()
+  return text as unknown as JSON
+}
 
 export async function fetcher<JSON = any>(
   input: RequestInfo,
-  init?: RequestInit
+  init?: ExtendedRequestInit
 ): Promise<JSON> {
-  const res = await fetch(input, init)
+  const {
+    retry = DEFAULT_RETRY_ATTEMPTS,
+    retryDelay = DEFAULT_RETRY_DELAY,
+    idempotencyKey: providedKey,
+    ...fetchInit
+  } = init ?? {}
 
-  if (!res.ok) {
-    const json = await res.json()
-    if (json.error) {
-      const error = new Error(json.error) as Error & {
-        status: number
+  const method = (fetchInit.method ?? 'GET').toUpperCase()
+  const idempotencyKey =
+    method === 'POST'
+      ? providedKey ?? createIdempotencyKey()
+      : undefined
+
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= retry; attempt++) {
+    try {
+      const headers = new Headers(fetchInit.headers ?? {})
+
+      if (idempotencyKey && !headers.has('Idempotency-Key')) {
+        headers.set('Idempotency-Key', idempotencyKey)
       }
-      error.status = res.status
-      throw error
-    } else {
-      throw new Error('An unexpected error occurred')
+
+      const response = await fetch(input, { ...fetchInit, headers })
+
+      if (!response.ok) {
+        const shouldRetry =
+          RETRYABLE_STATUS_CODES.has(response.status) ||
+          response.status >= 500
+
+        let payload: unknown = null
+
+        if (response.status !== 204) {
+          try {
+            payload = await response.clone().json()
+          } catch (error) {
+            payload = null
+          }
+        }
+
+        const message =
+          payload &&
+          typeof payload === 'object' &&
+          payload !== null &&
+          'error' in payload &&
+          typeof (payload as { error: unknown }).error === 'string'
+            ? (payload as { error: string }).error
+            : `Request failed with status ${response.status}`
+
+        const error = createErrorWithStatus(message, response.status)
+
+        if (!shouldRetry || attempt === retry) {
+          throw error
+        }
+
+        lastError = error
+      } else {
+        return await parseResponse<JSON>(response)
+      }
+    } catch (error) {
+      lastError = error
+
+      if (attempt === retry) {
+        throw error
+      }
     }
+
+    const exponentialDelay = retryDelay * 2 ** attempt
+    const jitter = exponentialDelay * 0.5 * Math.random()
+    await sleep(exponentialDelay + jitter)
   }
 
-  return res.json()
+  throw (lastError ?? new Error('Request failed'))
 }
 
 export function formatDate(input: string | number | Date): string {
@@ -51,13 +147,39 @@ export const runAsyncFnWithoutBlocking = (
   fn()
 }
 
-export const sleep = (ms: number) =>
-  new Promise(resolve => setTimeout(resolve, ms))
-
 export const getStringFromBuffer = (buffer: ArrayBuffer) =>
   Array.from(new Uint8Array(buffer))
     .map(b => b.toString(16).padStart(2, '0'))
     .join('')
+
+const normaliseValue = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(item => normaliseValue(item)).join(',')}]`
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, val]) => `${key}:${normaliseValue(val)}`)
+
+  return `{${entries.join(',')}}`
+}
+
+export const stableHash = (value: unknown): string => {
+  const input = typeof value === 'string' ? value : normaliseValue(value)
+
+  let hash = 0
+
+  for (let index = 0; index < input.length; index++) {
+    hash = (hash << 5) - hash + input.charCodeAt(index)
+    hash |= 0
+  }
+
+  return Math.abs(hash).toString(16)
+}
 
 export enum ResultCode {
   InvalidCredentials = 'INVALID_CREDENTIALS',


### PR DESCRIPTION
## Summary
- add a retryable fetch helper with jitter, idempotency keys, and stable hashing utilities
- introduce a Supabase connectivity provider, offline banner, and enqueueMutation API used by forms, notifications, and profile updates
- document the new network resilience patterns and offline UX expectations

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d17c5b957c832894a82fd979342829