### PR TITLE
Add error boundaries for dashboard panels

### DIFF
--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Button } from "@/components/ui/button"
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 
 import { AmenityBookingForm } from "./components/amenity-booking-form"
 import { BookingHistory } from "./components/booking-history"
@@ -82,24 +84,42 @@ export default function BookingsPage() {
       </header>
 
       {/* Stats Overview */}
-      <Suspense
-        fallback={
-          <div className="grid gap-4 md:grid-cols-4">
-            {[...Array(4)].map((_, i) => (
-              <Card key={i} className="animate-pulse">
-                <CardHeader className="pb-2">
-                  <div className="h-4 w-3/4 rounded bg-muted"></div>
-                </CardHeader>
-                <CardContent>
-                  <div className="h-8 w-1/2 rounded bg-muted"></div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        }
+      <ErrorBoundary
+        fallbackRender={({ error, reset }) => (
+          <Card className="p-6" role="alert">
+            <div className="space-y-3 text-center">
+              <p className="text-sm font-medium text-destructive">
+                Unable to load booking insights.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {error.message || "An unexpected error occurred while loading stats."}
+              </p>
+              <Button variant="outline" onClick={reset}>
+                Try again
+              </Button>
+            </div>
+          </Card>
+        )}
       >
-        <BookingStats />
-      </Suspense>
+        <Suspense
+          fallback={
+            <div className="grid gap-4 md:grid-cols-4">
+              {[...Array(4)].map((_, i) => (
+                <Card key={i} className="animate-pulse">
+                  <CardHeader className="pb-2">
+                    <div className="h-4 w-3/4 rounded bg-muted"></div>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="h-8 w-1/2 rounded bg-muted"></div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          }
+        >
+          <BookingStats />
+        </Suspense>
+      </ErrorBoundary>
 
       {/* Main Content Tabs */}
       <Tabs defaultValue="book" className="space-y-6">

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
 import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
@@ -20,10 +19,17 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let isMounted = true;
+
     const fetchDocuments = async () => {
       try {
         setLoading(true);
+        setError(null);
         const result = await getDocumentsAction(filter);
+        if (!isMounted) {
+          return;
+        }
+
         if (result.success && result.data) {
           setDocuments(result.data);
         } else {
@@ -31,13 +37,21 @@ export function DocumentsList({ filter }: DocumentsListProps) {
         }
       } catch (err) {
         console.error('Error fetching documents:', err);
-        setError('An unexpected error occurred');
+        if (isMounted) {
+          setError('An unexpected error occurred');
+        }
       } finally {
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
 
     fetchDocuments();
+
+    return () => {
+      isMounted = false;
+    };
   }, [filter]);
 
   const getStatusBadge = (status: string) => {
@@ -107,21 +121,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   }
 
   if (error) {
-    return (
-      <Card className="p-6">
-        <div className="text-center">
-          <p className="mb-2 text-destructive">Error loading documents</p>
-          <p className="text-sm text-muted-foreground">{error}</p>
-          <Button
-            variant="outline"
-            className="mt-4"
-            onClick={() => window.location.reload()}
-          >
-            Try Again
-          </Button>
-        </div>
-      </Card>
-    );
+    throw new Error(error);
   }
 
   if (documents.length === 0) {

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -3,6 +3,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Separator } from "@/components/ui/separator";
 import { FileText, Users, Clock, Upload } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary";
 import { UploadDocumentDialog } from "./components/upload-document-dialog";
 import { DocumentsStats } from "./components/documents-stats";
 import { DocumentsList } from "./components/documents-list";
@@ -10,6 +12,31 @@ import { DocumentsFilters } from "./components/documents-filters";
 import { DocumentListFilters } from '@/types/documents';
 
 export default function DocumentsPage() {
+  const renderDocumentsSection = (filter: DocumentListFilters, contextLabel: string) => (
+    <ErrorBoundary
+      resetKeys={[JSON.stringify(filter)]}
+      fallbackRender={({ error, reset }) => (
+        <Card className="p-6" role="alert">
+          <div className="space-y-3 text-center">
+            <p className="text-sm font-medium text-destructive">
+              Unable to load {contextLabel}.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {error.message || 'Please try again in a few moments.'}
+            </p>
+            <Button variant="outline" onClick={reset}>
+              Try again
+            </Button>
+          </div>
+        </Card>
+      )}
+    >
+      <Suspense fallback={<DocumentsListSkeleton />}>
+        <DocumentsList filter={filter} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
@@ -54,27 +81,19 @@ export default function DocumentsPage() {
         </div>
 
         <TabsContent value="all" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{}} />
-          </Suspense>
+          {renderDocumentsSection({}, 'documents')}
         </TabsContent>
 
         <TabsContent value="leases" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ type: ['lease'] }} />
-          </Suspense>
+          {renderDocumentsSection({ type: ['lease'] }, 'lease documents')}
         </TabsContent>
 
         <TabsContent value="pending" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['pending_signature'] }} />
-          </Suspense>
+          {renderDocumentsSection({ status: ['pending_signature'] }, 'documents awaiting signatures')}
         </TabsContent>
 
         <TabsContent value="signed" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['signed'] }} />
-          </Suspense>
+          {renderDocumentsSection({ status: ['signed'] }, 'signed documents')}
         </TabsContent>
       </Tabs>
 

--- a/components/feedback/ErrorBoundary.tsx
+++ b/components/feedback/ErrorBoundary.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import type { ComponentType, ErrorInfo, ReactNode } from 'react';
+import { Component } from 'react';
+
+export interface ErrorBoundaryFallbackProps {
+  error: Error;
+  reset: () => void;
+}
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * React component rendered when an error is caught.
+   * Receives the error and a reset handler that clears the boundary state.
+   */
+  FallbackComponent?: ComponentType<ErrorBoundaryFallbackProps>;
+  /**
+   * Render prop alternative to FallbackComponent.
+   */
+  fallbackRender?: (props: ErrorBoundaryFallbackProps) => ReactNode;
+  /**
+   * Static fallback node. Useful for simple messaging without retry support.
+   */
+  fallback?: ReactNode;
+  /**
+   * Invoked after an error has been caught.
+   */
+  onError?: (error: Error, info: ErrorInfo) => void;
+  /**
+   * Called whenever the boundary is reset either manually or via resetKeys.
+   */
+  onReset?: () => void;
+  /**
+   * Changing any value in this array will automatically reset the boundary.
+   */
+  resetKeys?: Array<unknown>;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (this.state.error && resetKeysChanged(prevProps.resetKeys, this.props.resetKeys)) {
+      this.resetErrorBoundary();
+    }
+  }
+
+  resetErrorBoundary = () => {
+    this.props.onReset?.();
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { FallbackComponent, fallback, fallbackRender, children } = this.props;
+    const { error } = this.state;
+
+    if (error) {
+      const fallbackProps: ErrorBoundaryFallbackProps = {
+        error,
+        reset: this.resetErrorBoundary,
+      };
+
+      if (fallbackRender) {
+        return fallbackRender(fallbackProps);
+      }
+
+      if (FallbackComponent) {
+        const ComponentFallback = FallbackComponent;
+        return <ComponentFallback {...fallbackProps} />;
+      }
+
+      if (fallback) {
+        return fallback;
+      }
+
+      return (
+        <div
+          role="alert"
+          className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 p-6 text-sm"
+        >
+          <div className="font-medium text-destructive">Something went wrong.</div>
+          <button
+            type="button"
+            onClick={this.resetErrorBoundary}
+            className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}
+
+function resetKeysChanged(prevKeys?: Array<unknown>, nextKeys?: Array<unknown>) {
+  if (prevKeys === nextKeys) {
+    return false;
+  }
+
+  if (!prevKeys || !nextKeys) {
+    return Boolean(prevKeys ?? nextKeys);
+  }
+
+  if (prevKeys.length !== nextKeys.length) {
+    return true;
+  }
+
+  for (let index = 0; index < prevKeys.length; index += 1) {
+    if (!Object.is(prevKeys[index], nextKeys[index])) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/docs/perf/error-handling.md
+++ b/docs/perf/error-handling.md
@@ -1,0 +1,84 @@
+# Error Handling Patterns
+
+This guide documents how we shield interactive dashboard panels from catastrophic failures while giving tenants actionable recov
+ery paths.
+
+## Goals
+
+- Prevent a runtime exception in one widget from collapsing the entire page shell.
+- Offer clear messaging and a retry affordance so users can re-attempt lightweight fetches without a full reload.
+- Ensure boundaries reset automatically as filters, tabs, or inputs change.
+
+## Shared `ErrorBoundary`
+
+Use `components/feedback/ErrorBoundary` for any client-side widget that may throw during rendering, effects, or event handling.
+It exposes a render-prop API so feature teams can tailor the fallback UI while still inheriting retry behaviour.
+
+```tsx
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary";
+
+<ErrorBoundary
+  resetKeys={[JSON.stringify(filters)]}
+  fallbackRender={({ error, reset }) => (
+    <PanelError message="Unable to load payments" detail={error.message} onRetry={reset} />
+  )}
+>
+  <PaymentsWidget filters={filters} />
+</ErrorBoundary>
+```
+
+### Retry semantics
+
+- Call the provided `reset` handler to clear the boundary state and re-render children.
+- Pass `resetKeys` so the boundary also resets when upstream inputs change (e.g., tab value, search query).
+- Optionally supply `onReset` to clear local caches or invoke analytics before retrying.
+
+### Default fallback
+
+If no render prop/component is provided the boundary renders a minimal message with a retry button. Prefer a custom fallback for
+widgets with domain-specific copy.
+
+## Widget Guidelines
+
+### Data fetching components
+
+Components such as `DocumentsList` should throw when a request fails so the boundary can render the shared fallback. Resetting
+the boundary re-mounts the widget and restarts the fetch cycle.
+
+```tsx
+if (error) {
+  throw new Error(error)
+}
+```
+
+### Presentational analytics
+
+Even static analytics like `BookingStats` should live behind a boundary so a regression in the stats layer does not break the
+booking flow. Keep the fallback concise and oriented around the insight users expected to see.
+
+### Suspense integration
+
+Wrap `Suspense` inside the boundary. This allows us to stream skeleton states while still catching runtime exceptions once the
+component resolves.
+
+```tsx
+<ErrorBoundary fallbackRender={...}>
+  <Suspense fallback={<WidgetSkeleton />}>
+    <Widget />
+  </Suspense>
+</ErrorBoundary>
+```
+
+## Monitoring
+
+Surface errors through `onError` when additional logging is required. For example, pipe the error to Sentry or Supabase logs
+while continuing to render the graceful fallback:
+
+```tsx
+<ErrorBoundary onError={(error) => captureException(error)}>
+  <RealtimeFeed />
+</ErrorBoundary>
+```
+
+By standardising boundaries around every dashboard panel we keep the portal resilient and predictable even when downstream
+integrations misbehave.


### PR DESCRIPTION
## Summary
- add a reusable feedback/ErrorBoundary component with reset support
- wrap booking stats and documents panels with error fallbacks to isolate failures
- document error-handling guidelines for interactive widgets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c5a099c8328989c2b67573e0144