### PR TITLE
Add accessibility audits for messaging and bookings

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,36 @@
+name: Accessibility checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  accessibility:
+    name: Run accessibility tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Run accessibility tests
+        run: npm run test:a11y

--- a/app/bookings/components/amenity-booking-form.tsx
+++ b/app/bookings/components/amenity-booking-form.tsx
@@ -14,12 +14,15 @@ interface Amenity {
 
 export function AmenityBookingForm({ amenity }: { amenity: Amenity }) {
   const [loading, setLoading] = useState(false);
+  const [statusMessage, setStatusMessage] = useState("");
 
   const handleBook = async () => {
     setLoading(true);
+    setStatusMessage(`Opening booking flow for ${amenity.name}`);
     try {
       // Placeholder: open Cal.com or show a toast
       toast.success(`Opening booking flow for ${amenity.name}`);
+      await new Promise((resolve) => setTimeout(resolve, 400));
     } finally {
       setLoading(false);
     }
@@ -27,9 +30,12 @@ export function AmenityBookingForm({ amenity }: { amenity: Amenity }) {
 
   return (
     <div className="flex items-center justify-between">
-      <Button onClick={handleBook} disabled={loading}>
+      <Button onClick={handleBook} disabled={loading} aria-busy={loading}>
         {loading ? 'Booking…' : 'Book now'}
       </Button>
+      <span aria-live="polite" className="sr-only">
+        {statusMessage}
+      </span>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -99,8 +99,6 @@ export const viewport: Viewport =  {
   ],
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
 }
 
 interface RootLayoutProps {

--- a/components/cookie-button.tsx
+++ b/components/cookie-button.tsx
@@ -1,30 +1,22 @@
-import { siteConfig } from '@/config/site'
-import { Icons } from '@/components/icons'
-import { buttonVariants } from '@/components/ui/button'
-import Link from 'next/link'
-import { cn } from '@/lib/utils'
-
+import { Icons } from "@/components/icons"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
 export function CookieButton() {
-
-return (
-<div className="fixed bottom-0 right-0 z-50">
-
-              <div
-                className={buttonVariants({
-                  size: "icon",
-                  variant: "ghost",
-                })}
-              >
-
-       <a href="#" className={cn("yourConsentManager")}>
-
-                <Icons.cookie className="size-5" />
-</a>
-                <span className="sr-only">Cookie Preferences</span>
-              </div>
-
-</div>
-
- )
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      <a
+        href="#"
+        className={cn(
+          "yourConsentManager",
+          buttonVariants({ size: "icon", variant: "ghost" }),
+          "rounded-full border border-border bg-background/80 backdrop-blur focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+        )}
+        aria-label="Open cookie preferences dialog"
+      >
+        <Icons.cookie className="size-5" aria-hidden="true" />
+        <span className="sr-only">Open cookie preferences dialog</span>
+      </a>
+    </div>
+  )
 }

--- a/components/notifications/notification-center.tsx
+++ b/components/notifications/notification-center.tsx
@@ -176,24 +176,33 @@ export function NotificationCenter() {
   return (
     <div className="relative">
       <Button
+        aria-label={isOpen ? "Close notifications" : "Open notifications"}
+        aria-expanded={isOpen}
+        aria-controls="notification-center-popover"
         variant="ghost"
         size="icon"
         onClick={() => setIsOpen(!isOpen)}
         className="relative"
       >
-        <Bell className="size-5" />
+        <Bell className="size-5" aria-hidden="true" />
         {unreadCount > 0 && (
           <Badge
             variant="destructive"
             className="absolute -right-1 -top-1 flex size-5 items-center justify-center p-0 text-xs"
           >
-            {unreadCount > 99 ? '99+' : unreadCount}
+            {unreadCount > 99 ? "99+" : unreadCount}
           </Badge>
         )}
       </Button>
 
       {isOpen && (
-        <Card className="absolute right-0 top-12 z-50 max-h-96 w-96 shadow-lg">
+        <Card
+          id="notification-center-popover"
+          className="absolute right-0 top-12 z-50 max-h-96 w-96 shadow-lg"
+          role="dialog"
+          aria-modal="false"
+          aria-label="Notifications"
+        >
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Notifications</CardTitle>
             <div className="flex gap-2">
@@ -213,8 +222,9 @@ export function NotificationCenter() {
                 size="icon"
                 onClick={() => setIsOpen(false)}
                 className="size-6"
+                aria-label="Close notifications"
               >
-                <X className="size-3" />
+                <X className="size-3" aria-hidden="true" />
               </Button>
             </div>
           </CardHeader>
@@ -234,9 +244,12 @@ export function NotificationCenter() {
                     <div key={notification.id}>
                       <div
                         className={cn(
-                          "cursor-pointer p-3 transition-colors hover:bg-muted/50",
+                          "cursor-pointer p-3 transition-colors hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                           !notification.read && "bg-muted/20"
                         )}
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`View notification: ${notification.title}`}
                         onClick={() => {
                           if (!notification.read) {
                             markAsRead(notification.id);
@@ -244,6 +257,18 @@ export function NotificationCenter() {
                           if (notification.action_url) {
                             window.location.href = notification.action_url;
                             setIsOpen(false);
+                          }
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            if (!notification.read) {
+                              markAsRead(notification.id);
+                            }
+                            if (notification.action_url) {
+                              window.location.href = notification.action_url;
+                              setIsOpen(false);
+                            }
                           }
                         }}
                       >
@@ -273,8 +298,9 @@ export function NotificationCenter() {
                                   markAsRead(notification.id);
                                 }}
                                 className="size-6"
+                                aria-label={`Mark ${notification.title} as read`}
                               >
-                                <Check className="size-3" />
+                                <Check className="size-3" aria-hidden="true" />
                               </Button>
                             )}
                             <Button
@@ -285,8 +311,9 @@ export function NotificationCenter() {
                                 deleteNotification(notification.id);
                               }}
                               className="size-6 text-muted-foreground hover:text-destructive"
+                              aria-label={`Delete ${notification.title}`}
                             >
-                              <X className="size-3" />
+                              <X className="size-3" aria-hidden="true" />
                             </Button>
                           </div>
                         </div>

--- a/docs/accessibility/report.md
+++ b/docs/accessibility/report.md
@@ -1,0 +1,35 @@
+# Accessibility Audit Report
+
+_Last updated: 2025-09-22_
+
+## Summary
+- Integrated automated accessibility regression checks with Playwright and axe-core covering the messaging and bookings surface areas.
+- Remediated notification center controls to provide descriptive aria labels, keyboard focus styling, and operable keyboard handlers.
+- Added keyboard-only regression coverage to ensure tenants can navigate amenity booking workflows without a pointer device.
+
+## Automated Coverage
+| Area | Tooling | Command |
+| --- | --- | --- |
+| Messaging page | Playwright + axe-core | `npm run test:a11y -- --grep messaging` |
+| Bookings page (axe scan) | Playwright + axe-core | `npm run test:a11y -- --grep bookings` |
+| Bookings page (keyboard flow) | Playwright | `npm run test:a11y -- --grep "Bookings keyboard"` |
+
+To execute the full suite locally run:
+
+```bash
+npm run test:a11y
+```
+
+## Keyboard-only Flows
+The following flows are exercised in automated tests and verified to work without a mouse:
+
+1. **Amenity booking**
+   - Press `Tab` until the **Book Amenity** tab receives focus, then use the arrow keys to switch to other tab panels and return.
+   - Continue tabbing until the first **Book now** button is focused.
+   - Press `Enter` to trigger the Cal.com booking toast for the Kitchen amenity.
+2. **Notification center management**
+   - Focus the bell icon button in the global header to open notifications. The control now exposes an explicit aria-label and focus ring.
+   - Use `Tab` to move through each notification card. Each card is keyboard focusable with `Enter`/`Space` activation alongside dedicated “mark read” and “delete” icon buttons that provide aria labels.
+
+## Status
+All scoped automated checks are currently passing. Future audits should extend coverage to additional high-traffic routes (payments, messaging threads) and realtime interactions as they mature.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -70,7 +70,9 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
         "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+        "@playwright/test": "^1.55.0",
         "@types/eslint": "^8.56.2",
         "@types/node": "^20.19.0",
         "@types/react": "^18.3.3",
@@ -97,6 +99,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+      "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1472,6 +1487,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -10042,6 +10073,53 @@
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:a11y": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -72,7 +73,9 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@playwright/test": "^1.55.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test"
+
+const PORT = process.env.PORT ?? "3000"
+
+export default defineConfig({
+  testDir: "./playwright",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: `npm run dev -- --hostname 127.0.0.1 --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+    env: {
+      NEXT_DISABLE_VERSION_CHECK: "1",
+      NEXT_TELEMETRY_DISABLED: "1",
+    },
+  },
+})

--- a/playwright/bookings-a11y.spec.ts
+++ b/playwright/bookings-a11y.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test"
+import AxeBuilder from "@axe-core/playwright"
+
+test.describe("Bookings page accessibility", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/bookings")
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa"])
+      .analyze()
+
+    expect(results.violations).toEqual([])
+  })
+})

--- a/playwright/bookings-keyboard.spec.ts
+++ b/playwright/bookings-keyboard.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test, type Locator } from "@playwright/test"
+
+test.describe("Bookings keyboard navigation", () => {
+  test("supports switching tabs and booking via keyboard only", async ({ page }) => {
+    await page.goto("/bookings")
+
+    const tabTo = async (roleLocator: Locator) => {
+      await roleLocator.first().waitFor({ state: "visible" })
+
+      for (let i = 0; i < 50; i++) {
+        const isFocused = await roleLocator.evaluate(
+          (element) => element === document.activeElement
+        )
+
+        if (isFocused) {
+          return
+        }
+
+        await page.keyboard.press("Tab")
+      }
+
+      throw new Error("Failed to focus element using keyboard navigation")
+    }
+
+    const bookAmenityTab = page.getByRole("tab", { name: "Book Amenity" })
+    await tabTo(bookAmenityTab)
+    await expect(bookAmenityTab).toBeFocused()
+
+    await page.keyboard.press("ArrowRight")
+
+    const bookingHistoryTab = page.getByRole("tab", { name: "Booking History" })
+    await expect(bookingHistoryTab).toHaveAttribute("data-state", "active")
+    await expect(page.getByText("Yesterday 6–8pm")).toBeVisible()
+
+    await page.keyboard.press("ArrowLeft")
+    await expect(bookAmenityTab).toHaveAttribute("data-state", "active")
+
+    const bookNowButton = page.getByRole("button", { name: "Book now" }).first()
+    await tabTo(bookNowButton)
+    await expect(bookNowButton).toBeFocused()
+
+    await page.keyboard.press("Enter")
+    await expect(page.getByText("Opening booking flow for Kitchen")).toBeVisible()
+  })
+})

--- a/playwright/messaging-a11y.spec.ts
+++ b/playwright/messaging-a11y.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test"
+import AxeBuilder from "@axe-core/playwright"
+
+test.describe("Messaging page accessibility", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/messaging")
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa"])
+      .analyze()
+
+    expect(results.violations).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- add Playwright-based axe accessibility scans for the messaging and bookings pages plus a keyboard-only regression scenario
- resolve axe findings by improving notification center semantics, the cookie preferences trigger, amenity booking feedback, and viewport zoom behaviour
- document the audit status and hook the new checks into CI

## Testing
- npm run lint
- npm test
- npm run test:a11y

------
https://chatgpt.com/codex/tasks/task_e_68d17c599bf48328b58aaa0bec4772bd