### PR TITLE
Add reduced motion handling and E2E coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # testing
 /coverage
+playwright-report/
+test-results/
 
 # next.js
 /.next/

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,51 +1,55 @@
 "use client"
 
-import { motion } from "framer-motion"
+import { type ElementType } from "react"
+
+import { motion, type MotionProps } from "framer-motion"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import { ChevronRight, Star, Zap, Shield } from "lucide-react"
-import { Contact } from '@/components/forms/contact'
+import { Star, Zap, Shield } from "lucide-react"
+import { Contact } from "@/components/forms/contact"
+import { useShouldReduceMotion } from "@/hooks/use-should-reduce-motion"
 
 export default function AboutPage() {
+  const shouldReduceMotion = useShouldReduceMotion()
+  const motionState = shouldReduceMotion ? "reduced" : "enabled"
+  const Section: ElementType = shouldReduceMotion ? "section" : motion.section
+  const Heading: ElementType = shouldReduceMotion ? "h1" : motion.h1
+  const AnimatedDiv: ElementType = shouldReduceMotion ? "div" : motion.div
+
+  const fadeUp = (delay = 0): MotionProps =>
+    shouldReduceMotion
+      ? {}
+      : {
+          initial: { opacity: 0, y: 16 },
+          animate: { opacity: 1, y: 0 },
+          transition: { duration: 0.12, delay, ease: "easeOut" },
+        }
+
+  const scaleIn = (delay = 0): MotionProps =>
+    shouldReduceMotion
+      ? {}
+      : {
+          initial: { opacity: 0, scale: 0.97 },
+          animate: { opacity: 1, scale: 1 },
+          transition: { duration: 0.12, delay, ease: "easeOut" },
+        }
+
   return (
-    <div className="container mx-auto px-4 py-12">
-      <motion.section
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-        className="mb-16 text-center"
-      >
-        <motion.h1
-          initial={{ scale: 0.9 }}
-          animate={{ scale: 1 }}
-          transition={{ duration: 0.5 }}
-          className="mb-4 text-4xl font-bold"
-        >
+    <div className="container mx-auto px-4 py-12" data-motion-reduced={shouldReduceMotion ? "true" : "false"}>
+      <Section {...(shouldReduceMotion ? {} : fadeUp())} data-motion={motionState} className="mb-16 text-center">
+        <Heading {...(shouldReduceMotion ? {} : scaleIn())} data-motion={motionState} className="mb-4 text-4xl font-bold">
           About Our Company
-        </motion.h1>
+        </Heading>
         <p className="text-xl text-muted-foreground">
           We&#39;re on a mission to revolutionize the industry with innovative solutions.
         </p>
-      </motion.section>
+      </Section>
 
-      <motion.section
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5, delay: 0.2 }}
-        className="mb-16"
-      >
+      <Section {...(shouldReduceMotion ? {} : fadeUp(0.04))} data-motion={motionState} className="mb-16">
         <h2 className="mb-8 text-center text-2xl font-semibold">Our Team</h2>
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           {teamMembers.map((member, index) => (
-            <motion.div
-              key={member.name}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
-            >
+            <AnimatedDiv key={member.name} {...(shouldReduceMotion ? {} : fadeUp(index * 0.04))} data-motion={motionState}>
               <Card>
                 <CardHeader className="text-center">
                   <Avatar className="mx-auto mb-4 size-24">
@@ -64,51 +68,40 @@ export default function AboutPage() {
                   <p className="text-center">{member.bio}</p>
                 </CardContent>
               </Card>
-            </motion.div>
+            </AnimatedDiv>
           ))}
         </div>
-      </motion.section>
+      </Section>
 
-      <motion.section
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5, delay: 0.4 }}
-        className="mb-16"
-      >
+      <Section {...(shouldReduceMotion ? {} : fadeUp(0.08))} data-motion={motionState} className="mb-16">
         <h2 className="mb-8 text-center text-2xl font-semibold">Our Values</h2>
         <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
           {values.map((value, index) => (
-            <motion.div
+            <AnimatedDiv
               key={value.title}
-              initial={{ opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
+              {...(shouldReduceMotion ? {} : scaleIn(index * 0.04))}
+              data-motion={motionState}
               className="text-center"
             >
               <div className="mb-4">{value.icon}</div>
               <h3 className="mb-2 text-xl font-semibold">{value.title}</h3>
               <p className="text-muted-foreground">{value.description}</p>
-            </motion.div>
+            </AnimatedDiv>
           ))}
         </div>
-      </motion.section>
+      </Section>
 
-      <motion.section
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5, delay: 0.6 }}
-        className="mb-16"
-      >
+      <Section {...(shouldReduceMotion ? {} : fadeUp(0.12))} data-motion={motionState} className="mb-16">
         <Card>
           <CardHeader>
             <CardTitle className="mb-4 text-2xl font-semibold">Contact Us</CardTitle>
             <CardDescription>Have questions? Get in touch with our team.</CardDescription>
           </CardHeader>
           <CardContent>
-          <Contact/>
+            <Contact />
           </CardContent>
         </Card>
-      </motion.section>
+      </Section>
     </div>
   )
 }

--- a/docs/design/motion.md
+++ b/docs/design/motion.md
@@ -1,0 +1,35 @@
+# Motion Design Guidelines
+
+These guidelines codify how motion is used across the Share House Portal so that interactions feel responsive without
+compromising accessibility.
+
+## Respect user preferences
+
+- Every animated component must gate motion behind a [`prefers-reduced-motion`](https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-motion)
+  check and render an immediate static fallback when reduction is requested.
+- Use the shared `useShouldReduceMotion` hook, which synchronously reads the media query via `useSyncExternalStore` so the
+  fallback is available on the first paint.
+- Expose a `data-motion` attribute on animated elements to make the applied state (`enabled` vs `reduced`) easy to inspect and
+  to unlock automated testing.
+
+## Animation primitives
+
+- Limit transitions to **opacity** and **transform** properties. Avoid layout-changing properties such as `top`, `left`,
+  `height`, or `width` because they trigger layout thrash and reduce perceived performance.
+- Keep transition durations below **120 ms** and prefer easing curves such as `easeOut` that decelerate into the final state.
+- Use staggered delays sparingly—when necessary keep offsets under 40 ms to avoid slow cascades.
+- Treat scale adjustments as micro-interactions; cap the delta to ±0.05 to prevent jarring size changes.
+
+## Testing
+
+- Add Playwright coverage for any surface that introduces motion. Tests should:
+  - Start a browser context with `reducedMotion: "reduce"` and assert that animated elements report `data-motion="reduced"`.
+  - Ensure inline styles do not reintroduce `transform` or `opacity` transitions when motion is disabled.
+- Integrate the tests into `npx playwright test` so that CI blocks regressions automatically.
+
+## Implementation checklist
+
+- [ ] Guard all Framer Motion components with the shared `useShouldReduceMotion` hook.
+- [ ] Provide semantic fallbacks (static markup, no transform styles) when motion is disabled.
+- [ ] Update the design documentation when introducing new motion patterns or easing curves.
+- [ ] Audit legacy components before launch to ensure they conform to these rules.

--- a/hooks/use-should-reduce-motion.ts
+++ b/hooks/use-should-reduce-motion.ts
@@ -1,0 +1,49 @@
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+const MEDIA_QUERY = "(prefers-reduced-motion: reduce)"
+
+type StoreSubscriber = () => void
+
+const getSnapshot = () => {
+  if (typeof window === "undefined") {
+    return true
+  }
+
+  return window.matchMedia(MEDIA_QUERY).matches
+}
+
+const subscribe = (callback: StoreSubscriber) => {
+  if (typeof window === "undefined") {
+    return () => {}
+  }
+
+  const mediaQueryList = window.matchMedia(MEDIA_QUERY)
+
+  const listener = () => callback()
+
+  if (typeof mediaQueryList.addEventListener === "function") {
+    mediaQueryList.addEventListener("change", listener)
+  } else {
+    mediaQueryList.addListener(listener)
+  }
+
+  return () => {
+    if (typeof mediaQueryList.removeEventListener === "function") {
+      mediaQueryList.removeEventListener("change", listener)
+    } else {
+      mediaQueryList.removeListener(listener)
+    }
+  }
+}
+
+/**
+ * Returns whether the current environment requests reduced motion. The hook uses
+ * `useSyncExternalStore` so that we can synchronously read the media query
+ * during rendering and avoid playing animations on the first paint when a user
+ * prefers reduced motion.
+ */
+export function useShouldReduceMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => true)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -71,6 +71,7 @@
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+        "@playwright/test": "^1.55.0",
         "@types/eslint": "^8.56.2",
         "@types/node": "^20.19.0",
         "@types/react": "^18.3.3",
@@ -1472,6 +1473,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -10042,6 +10059,53 @@
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -73,6 +74,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@playwright/test": "^1.55.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "@playwright/test"
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000"
+const webServerCommand = process.env.PLAYWRIGHT_WEB_SERVER_COMMAND ?? "npm run dev"
+
+export default defineConfig({
+  testDir: "./tests/playwright",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    viewport: { width: 1280, height: 720 },
+  },
+  webServer: {
+    command: webServerCommand,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      NEXT_DISABLE_TELEMETRY: "1",
+      NEXT_TELEMETRY_DISABLED: "1",
+    },
+  },
+})

--- a/tests/playwright/reduced-motion.spec.ts
+++ b/tests/playwright/reduced-motion.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("motion accessibility", () => {
+  test("defaults to motion-enabled animations when allowed", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "no-preference" })
+    await page.goto("/about")
+
+    await page.waitForFunction(() =>
+      Array.from(document.querySelectorAll("[data-motion]")).every(
+        (node) => node.getAttribute("data-motion") === "enabled",
+      ),
+    )
+
+    const motionStates = await page.$$eval("[data-motion]", (nodes) =>
+      nodes.map((node) => ({
+        state: node.getAttribute("data-motion"),
+        style: node.getAttribute("style") ?? "",
+      })),
+    )
+
+    expect(motionStates.every(({ state }) => state === "enabled")).toBe(true)
+    expect(motionStates.some(({ style }) => /transform|opacity/.test(style))).toBe(true)
+  })
+
+  test.describe("with prefers-reduced-motion", () => {
+    test.use({ reducedMotion: "reduce" })
+
+    test("disables framer-motion driven animations", async ({ page }) => {
+      await page.emulateMedia({ reducedMotion: "reduce" })
+      await page.goto("/about")
+
+      await page.waitForFunction(() =>
+        Array.from(document.querySelectorAll("[data-motion]")).every(
+          (node) => node.getAttribute("data-motion") === "reduced",
+        ),
+      )
+
+      const motionStates = await page.$$eval("[data-motion]", (nodes) =>
+        nodes.map((node) => ({
+          state: node.getAttribute("data-motion"),
+          style: node.getAttribute("style") ?? "",
+        })),
+      )
+
+      expect(motionStates.every(({ state }) => state === "reduced")).toBe(true)
+      for (const { style } of motionStates) {
+        expect(style).not.toMatch(/transform|opacity/)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared `useShouldReduceMotion` hook and gate the About page's animations with instant fallbacks
- document motion design guidelines and add Playwright configuration plus reduced-motion Playwright tests
- wire the reduced-motion tests into package scripts and ignore generated Playwright artifacts

## Testing
- npm run test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d17c5941e083288ba4fec82c793aeb