### PR TITLE
Add ETag utilities and conditional caching tests

### DIFF
--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server"
+
+import { buildCollectionCacheMetadata } from "@/lib/utils"
+
+type DocumentRecord = {
+  id: string
+  title: string
+  status:
+    | "draft"
+    | "pending_signature"
+    | "signed"
+    | "expired"
+    | "cancelled"
+  updated_at: string
+  tenant_id: string
+}
+
+type RevisionKey = "current" | "revision2"
+
+const documentRevisions: Record<RevisionKey, DocumentRecord[]> = {
+  current: [
+    {
+      id: "doc-1",
+      title: "Lease Agreement",
+      status: "signed",
+      updated_at: "2024-06-12T09:00:00.000Z",
+      tenant_id: "tenant-1",
+    },
+    {
+      id: "doc-2",
+      title: "Move-in Checklist",
+      status: "pending_signature",
+      updated_at: "2024-06-18T17:30:00.000Z",
+      tenant_id: "tenant-2",
+    },
+  ],
+  revision2: [
+    {
+      id: "doc-1",
+      title: "Lease Agreement",
+      status: "signed",
+      updated_at: "2024-06-12T09:00:00.000Z",
+      tenant_id: "tenant-1",
+    },
+    {
+      id: "doc-2",
+      title: "Move-in Checklist",
+      status: "signed",
+      updated_at: "2024-07-01T12:45:00.000Z",
+      tenant_id: "tenant-2",
+    },
+    {
+      id: "doc-3",
+      title: "Guest Policy",
+      status: "draft",
+      updated_at: "2024-07-04T08:15:00.000Z",
+      tenant_id: "tenant-3",
+    },
+  ],
+}
+
+const DEFAULT_REVISION: RevisionKey = "current"
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const revisionParam = url.searchParams.get("revision")
+  const revision =
+    revisionParam && revisionParam in documentRevisions
+      ? (revisionParam as RevisionKey)
+      : DEFAULT_REVISION
+
+  const records = documentRevisions[revision]
+  const cacheMetadata = buildCollectionCacheMetadata(records)
+  const ifNoneMatch = request.headers.get("if-none-match")
+
+  if (ifNoneMatch && ifNoneMatch === cacheMetadata.etag) {
+    return new NextResponse(null, {
+      status: 304,
+      headers: {
+        ETag: cacheMetadata.etag,
+      },
+    })
+  }
+
+  const response = NextResponse.json(
+    {
+      documents: records,
+      meta: {
+        count: cacheMetadata.count,
+        latestUpdatedAt: cacheMetadata.latestUpdatedAt,
+        revision,
+      },
+    },
+    {
+      status: 200,
+    }
+  )
+
+  response.headers.set("ETag", cacheMetadata.etag)
+
+  return response
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,125 @@
+import { createHash } from "crypto"
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+
+type TimestampInput = string | number | Date | null | undefined
+
+export interface CollectionCacheSignature {
+  count: number
+  latestUpdatedAtMs: number
+}
+
+const fetchResponseCache = new Map<string, { etag: string; data: unknown }>()
+
+const toTimestamp = (value: TimestampInput): number => {
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.getTime() : 0
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = new Date(value)
+    const time = parsed.getTime()
+    return Number.isFinite(time) ? time : 0
+  }
+
+  return 0
+}
+
+export function getCollectionCacheSignature<
+  T extends { updated_at?: TimestampInput }
+>(
+  rows: T[] | null | undefined,
+  options?: { count?: number | null; fallbackUpdatedAt?: TimestampInput }
+): CollectionCacheSignature {
+  const count = options?.count ?? rows?.length ?? 0
+  let latestUpdatedAtMs = 0
+
+  for (const row of rows ?? []) {
+    const timestamp = toTimestamp(row.updated_at)
+    if (timestamp > latestUpdatedAtMs) {
+      latestUpdatedAtMs = timestamp
+    }
+  }
+
+  if (latestUpdatedAtMs === 0 && options?.fallbackUpdatedAt) {
+    latestUpdatedAtMs = toTimestamp(options.fallbackUpdatedAt)
+  }
+
+  return {
+    count,
+    latestUpdatedAtMs,
+  }
+}
+
+const createWeakEtag = (signature: CollectionCacheSignature): string => {
+  const base = `${signature.count}:${signature.latestUpdatedAtMs}`
+  const digest = createHash("sha1").update(base).digest("base64")
+  const urlSafeDigest = digest
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "")
+
+  return `W/"${urlSafeDigest}"`
+}
+
+export function buildCollectionCacheMetadata<
+  T extends { updated_at?: TimestampInput }
+>(
+  rows: T[] | null | undefined,
+  options?: { count?: number | null; fallbackUpdatedAt?: TimestampInput }
+): {
+  etag: string
+  count: number
+  latestUpdatedAt: string | null
+} {
+  const signature = getCollectionCacheSignature(rows, options)
+  const latestUpdatedAt =
+    signature.latestUpdatedAtMs > 0
+      ? new Date(signature.latestUpdatedAtMs).toISOString()
+      : null
+
+  return {
+    etag: createWeakEtag(signature),
+    count: signature.count,
+    latestUpdatedAt,
+  }
+}
+
+const resolveCacheKey = (
+  input: RequestInfo | URL,
+  init?: FetcherInit
+): string | undefined => {
+  if (init?.cacheKey) {
+    return init.cacheKey
+  }
+
+  if (typeof input === "string") {
+    return `${init?.method ?? "GET"}:${input}`
+  }
+
+  if (input instanceof URL) {
+    return `${init?.method ?? "GET"}:${input.toString()}`
+  }
+
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return `${input.method}:${input.url}`
+  }
+
+  return undefined
+}
+
+export interface FetcherInit extends RequestInit {
+  cacheKey?: string
+  skipCache?: boolean
+}
+
+export const clearFetcherCache = () => {
+  fetchResponseCache.clear()
+}
 
 
 export function cn(...inputs: ClassValue[]) {
@@ -9,25 +129,61 @@ export function cn(...inputs: ClassValue[]) {
 
 
 export async function fetcher<JSON = any>(
-  input: RequestInfo,
-  init?: RequestInit
+  input: RequestInfo | URL,
+  init?: FetcherInit
 ): Promise<JSON> {
-  const res = await fetch(input, init)
+  const cacheKey = init?.skipCache ? undefined : resolveCacheKey(input, init)
+  const cachedEntry = cacheKey ? fetchResponseCache.get(cacheKey) : undefined
 
-  if (!res.ok) {
-    const json = await res.json()
-    if (json.error) {
-      const error = new Error(json.error) as Error & {
-        status: number
-      }
-      error.status = res.status
-      throw error
-    } else {
-      throw new Error('An unexpected error occurred')
-    }
+  const headers = new Headers(init?.headers ?? {})
+  if (cachedEntry?.etag) {
+    headers.set("If-None-Match", cachedEntry.etag)
+  }
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/json")
   }
 
-  return res.json()
+  const response = await fetch(input, { ...init, headers })
+
+  if (response.status === 304) {
+    if (cachedEntry) {
+      return cachedEntry.data as JSON
+    }
+
+    throw new Error("Received 304 response without cached data")
+  }
+
+  let payload: any = null
+  const contentType = response.headers.get("Content-Type") ?? ""
+  if (contentType.includes("application/json")) {
+    payload = await response.json().catch(() => null)
+  }
+
+  if (!response.ok) {
+    if (payload && typeof payload === "object" && "error" in payload) {
+      const error = new Error((payload as { error: string }).error) as Error & {
+        status: number
+      }
+      error.status = response.status
+      throw error
+    }
+
+    const error = new Error("An unexpected error occurred") as Error & {
+      status: number
+    }
+    error.status = response.status
+    throw error
+  }
+
+  const etag = response.headers.get("ETag")
+  if (cacheKey && etag) {
+    fetchResponseCache.set(cacheKey, {
+      etag,
+      data: payload as JSON,
+    })
+  }
+
+  return payload as JSON
 }
 
 export function formatDate(input: string | number | Date): string {

--- a/tests/api-cache.test.ts
+++ b/tests/api-cache.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { GET as getDocuments } from "@/app/api/documents/route"
+import {
+  buildCollectionCacheMetadata,
+  clearFetcherCache,
+  fetcher,
+} from "@/lib/utils"
+
+describe("documents API caching", () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    clearFetcherCache()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    clearFetcherCache()
+    vi.restoreAllMocks()
+  })
+
+  const createRequest = (url: string, init?: RequestInit) =>
+    new Request(url, init)
+
+  it("generates consistent cache metadata from documents", () => {
+    const records = [
+      { id: "1", updated_at: "2024-05-01T00:00:00.000Z" },
+      { id: "2", updated_at: "2024-06-10T08:15:00.000Z" },
+    ]
+
+    const metadata = buildCollectionCacheMetadata(records)
+    expect(metadata.count).toBe(2)
+    expect(metadata.latestUpdatedAt).toBe("2024-06-10T08:15:00.000Z")
+    expect(metadata.etag).toMatch(/^W\/\"[A-Za-z0-9_-]+\"$/)
+  })
+
+  it("returns 200 with an ETag for the first request", async () => {
+    const request = createRequest("http://localhost/api/documents")
+    const response = await getDocuments(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("etag")).toBeTruthy()
+
+    const body = await response.json()
+    expect(body.meta.count).toBe(body.documents.length)
+    expect(body.meta.latestUpdatedAt).toBeTruthy()
+  })
+
+  it("returns 304 when If-None-Match matches the generated ETag", async () => {
+    const initialRequest = createRequest("http://localhost/api/documents")
+    const initialResponse = await getDocuments(initialRequest)
+    const etag = initialResponse.headers.get("etag")
+
+    expect(etag).toBeTruthy()
+
+    const conditionalRequest = createRequest("http://localhost/api/documents", {
+      headers: {
+        "If-None-Match": etag!,
+      },
+    })
+
+    const conditionalResponse = await getDocuments(conditionalRequest)
+    expect(conditionalResponse.status).toBe(304)
+    expect(conditionalResponse.headers.get("etag")).toBe(etag)
+  })
+
+  it("reuses cached data when fetcher encounters a 304", async () => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url
+
+      const request = createRequest(url, init)
+      return getDocuments(request)
+    }) as typeof fetch
+
+    const first = await fetcher<{
+      documents: Array<{ id: string; updated_at: string }>
+      meta: { revision: string }
+    }>("http://localhost/api/documents")
+
+    expect(first.documents).toHaveLength(2)
+    expect(first.meta.revision).toBe("current")
+
+    const second = await fetcher<typeof first>(
+      "http://localhost/api/documents"
+    )
+
+    expect(second).toEqual(first)
+
+    const updated = await fetcher<typeof first>(
+      "http://localhost/api/documents?revision=revision2"
+    )
+
+    expect(updated.documents.length).toBe(3)
+    expect(updated.meta.revision).toBe("revision2")
+    expect(updated).not.toEqual(first)
+  })
+})


### PR DESCRIPTION
## Summary
- add utilities to derive collection ETags and teach the shared fetcher to reuse cached payloads on 304 responses
- expose a sample documents API route that emits collection metadata and honours If-None-Match
- cover the conditional request flow with vitest integration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d17c50da588328a0c355b88ae40254