### PR TITLE
Improve visitor booking microcopy and support feedback tracking

### DIFF
--- a/app/api/support-feedback/route.ts
+++ b/app/api/support-feedback/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+const feedbackSchema = z.object({
+  source: z.string().min(1, "Source is required"),
+  action: z.string().min(1, "Action is required"),
+  status: z.enum(["pending", "resolved", "escalated"]),
+  description: z.string().max(2000).optional(),
+  metadata: z.record(z.any()).optional(),
+})
+
+export async function POST(request: Request) {
+  try {
+    const json = await request.json().catch(() => null)
+    const parsed = feedbackSchema.safeParse(json)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: parsed.error.flatten() },
+        { status: 400 }
+      )
+    }
+
+    const supabase = await createSupbaseServerClient()
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+
+    if (userError) {
+      return NextResponse.json(
+        { success: false, error: userError.message },
+        { status: 500 }
+      )
+    }
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Not authenticated" },
+        { status: 401 }
+      )
+    }
+
+    const { error } = await supabase.from("support_feedback_events").insert({
+      user_id: user.id,
+      source: parsed.data.source,
+      action: parsed.data.action,
+      status: parsed.data.status,
+      description: parsed.data.description ?? null,
+      metadata: parsed.data.metadata ?? {},
+    })
+
+    if (error) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unexpected error logging feedback"
+
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    )
+  }
+}

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -9,15 +9,17 @@ import { CalendarIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
+import { recordSupportFeedback } from "@/utils/support-feedback";
+
+const ESTIMATED_SUBMISSION_SECONDS = 8;
 
 const visitorBookingSchema = z.object({
   guestName: z.string().min(2, "Guest name must be at least 2 characters"),
@@ -42,6 +44,21 @@ export function VisitorBookingForm() {
   const { toast } = useToast();
   const supabase = createClient();
 
+  const trackSupportFeedback = (
+    action: string,
+    status: "pending" | "resolved" | "escalated",
+    description?: string,
+    metadata?: Record<string, unknown>
+  ) => {
+    void recordSupportFeedback({
+      source: "visitor_booking",
+      action,
+      status,
+      description,
+      metadata,
+    });
+  };
+
   const form = useForm<VisitorBookingFormData>({
     resolver: zodResolver(visitorBookingSchema),
     defaultValues: {
@@ -56,6 +73,19 @@ export function VisitorBookingForm() {
 
   const onSubmit = async (data: VisitorBookingFormData) => {
     setIsSubmitting(true);
+
+    toast({
+      title: "Submitting overnight visitor request",
+      description: `We’re saving your visitor details and queuing notifications now. This usually takes about ${ESTIMATED_SUBMISSION_SECONDS} seconds. Feel free to keep browsing while we finish.`,
+      duration: 6000,
+    });
+
+    trackSupportFeedback("submission_started", "pending", undefined, {
+      estimatedSeconds: ESTIMATED_SUBMISSION_SECONDS,
+      guestName: data.guestName,
+      checkInDate: data.checkInDate.toISOString(),
+      checkOutDate: data.checkOutDate.toISOString(),
+    });
 
     try {
       // Get current user info
@@ -83,7 +113,7 @@ export function VisitorBookingForm() {
       const propertyManager = unitData?.find(p => p.role === 'property_manager');
 
       if (!propertyManager) {
-        throw new Error("Property manager not found for this unit");
+        throw new Error("We couldn’t locate a property manager for your unit. Please contact support before logging overnight guests.");
       }
 
       // Create visitor booking record
@@ -126,17 +156,31 @@ export function VisitorBookingForm() {
       });
 
       toast({
-        title: "Visitor booking submitted",
-        description: "Your visitor booking has been submitted and notifications sent.",
+        title: "Visitor request submitted",
+        description: "We saved the visit details and pinged your roommates and property manager. They'll review it in the visitor log.",
+      });
+
+      trackSupportFeedback("submission_completed", "resolved", undefined, {
+        bookingId: booking?.id ?? null,
+        guestName: data.guestName,
+        roommateCount: roommates.length,
       });
 
       form.reset();
     } catch (error) {
       console.error('Error submitting visitor booking:', error);
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "We couldn’t submit your visitor request. Please try again or contact your property manager.";
       toast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to submit visitor booking",
+        title: "Visitor request not sent",
+        description: `${errorMessage} If this keeps happening, let your property manager know so we can help.`,
         variant: "destructive",
+      });
+      trackSupportFeedback("submission_failed", "escalated", errorMessage, {
+        guestName: data.guestName,
+        error: errorMessage,
       });
     } finally {
       setIsSubmitting(false);
@@ -152,10 +196,14 @@ export function VisitorBookingForm() {
             name="guestName"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Guest Name *</FormLabel>
+                <FormLabel>Guest full name *</FormLabel>
                 <FormControl>
-                  <Input placeholder="Enter guest's full name" {...field} />
+                  <Input placeholder="As shown on their government ID" {...field} />
                 </FormControl>
+                <FormDescription>
+                  Use the exact name from your guest’s identification so building security can confirm their arrival without
+                  delays.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -166,10 +214,13 @@ export function VisitorBookingForm() {
             name="guestEmail"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Guest Email *</FormLabel>
+                <FormLabel>Guest email for updates *</FormLabel>
                 <FormControl>
                   <Input type="email" placeholder="guest@example.com" {...field} />
                 </FormControl>
+                <FormDescription>
+                  We’ll send arrival reminders and policy notes to this address so everyone knows what to expect.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -181,10 +232,13 @@ export function VisitorBookingForm() {
           name="guestPhone"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Guest Phone (Optional)</FormLabel>
+              <FormLabel>Guest phone (optional)</FormLabel>
               <FormControl>
-                <Input placeholder="+1 (555) 123-4567" {...field} />
+                <Input placeholder="Include country code if outside the US" {...field} />
               </FormControl>
+              <FormDescription>
+                We’ll only call this number if there’s a check-in issue or an emergency during the stay.
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}
@@ -210,7 +264,7 @@ export function VisitorBookingForm() {
                         {field.value ? (
                           format(field.value, "PPP")
                         ) : (
-                          <span>Pick a date</span>
+                          <span>Select arrival date</span>
                         )}
                         <CalendarIcon className="ml-auto size-4 opacity-50" />
                       </Button>
@@ -228,6 +282,9 @@ export function VisitorBookingForm() {
                     />
                   </PopoverContent>
                 </Popover>
+                <FormDescription>
+                  Choose the arrival day your guest will check in. Same-day visits are allowed until quiet hours begin.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -252,7 +309,7 @@ export function VisitorBookingForm() {
                         {field.value ? (
                           format(field.value, "PPP")
                         ) : (
-                          <span>Pick a date</span>
+                          <span>Select departure date</span>
                         )}
                         <CalendarIcon className="ml-auto size-4 opacity-50" />
                       </Button>
@@ -270,6 +327,9 @@ export function VisitorBookingForm() {
                     />
                   </PopoverContent>
                 </Popover>
+                <FormDescription>
+                  Set the day your guest will leave so we can keep overnight limits accurate.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -284,11 +344,14 @@ export function VisitorBookingForm() {
               <FormLabel>Purpose of Visit *</FormLabel>
               <FormControl>
                 <Textarea
-                  placeholder="Please describe the purpose of the visit and any special requirements..."
+                  placeholder="Explain why your guest is staying and any plans roommates should know about"
                   className="min-h-[80px]"
                   {...field}
                 />
               </FormControl>
+              <FormDescription>
+                Share context—celebration, family visit, or support—so roommates understand the reason for the stay.
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}
@@ -299,10 +362,13 @@ export function VisitorBookingForm() {
           name="emergencyContact"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Emergency Contact (Optional)</FormLabel>
+              <FormLabel>Emergency contact (optional)</FormLabel>
               <FormControl>
-                <Input placeholder="Name and phone number of emergency contact" {...field} />
+                <Input placeholder="Name and phone number to reach if we can’t contact the guest" {...field} />
               </FormControl>
+              <FormDescription>
+                Add a backup contact we can reach if there’s a safety concern while your guest is on-site.
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}
@@ -313,22 +379,42 @@ export function VisitorBookingForm() {
           name="specialNotes"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Special Notes (Optional)</FormLabel>
+              <FormLabel>Special notes (optional)</FormLabel>
               <FormControl>
                 <Textarea
-                  placeholder="Any additional notes or requirements..."
+                  placeholder="Parking needs, accessibility notes, or quiet hours reminders"
                   className="min-h-[60px]"
                   {...field}
                 />
               </FormControl>
+              <FormDescription>
+                Mention anything that helps your roommates prepare—vehicle details, sleeping arrangements, or building access.
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}
         />
 
-        <Button type="submit" disabled={isSubmitting} className="w-full">
-          {isSubmitting ? "Submitting..." : "Submit Visitor Booking"}
-        </Button>
+        <div className="space-y-2">
+          <Button type="submit" disabled={isSubmitting} className="w-full">
+            {isSubmitting
+              ? `Submitting request (≈${ESTIMATED_SUBMISSION_SECONDS}s)`
+              : "Submit overnight visitor request"}
+          </Button>
+          {isSubmitting ? (
+            <p
+              className="text-center text-sm text-muted-foreground"
+              aria-live="polite"
+              role="status"
+            >
+              {`We’re saving your visitor booking and notifying everyone now. This usually wraps up in about ${ESTIMATED_SUBMISSION_SECONDS} seconds.`}
+            </p>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground">
+              We’ll alert your roommates and property manager as soon as you send this request.
+            </p>
+          )}
+        </div>
       </form>
     </Form>
   );

--- a/docs/design/microcopy.md
+++ b/docs/design/microcopy.md
@@ -1,0 +1,40 @@
+# UX Microcopy Guidelines
+
+Clear, empathetic microcopy keeps roommates informed about what the portal is doing on their behalf. Use the principles below when adding or updating product text.
+
+## Principles
+- **Set expectations.** Explain what will happen next and how long it usually takes.
+- **Reduce ambiguity.** Replace generic verbs like “Submit” or “Send” with phrasing that reflects the exact action (for example, “Submit overnight visitor request”).
+- **Keep ownership clear.** Identify who is being notified or responsible for follow-up so tenants know the task is moving forward.
+- **Offer reassurance.** When background tasks run asynchronously, tell users they can continue working elsewhere.
+
+## Loading & Background Tasks
+- Include estimated wait times in inline status text (e.g., “Submitting request (≈8s)”).
+- Pair long-running operations with a non-blocking toast that calls out the task (“Working in the background… feel free to keep browsing”).
+- Announce live updates with `aria-live="polite"` so assistive technology surfaces the status change.
+- Avoid spinner-only states; always add a sentence explaining what the system is doing.
+
+## Visitor Booking Microcopy
+- Labels should reference the real-world artifact the resident needs (e.g., “Guest full name” instead of “Name”).
+- Use `FormDescription` to clarify why each field is required (“We’ll send arrival reminders to this address”).
+- Success toasts must confirm the booking was saved **and** that notifications were triggered.
+- Error copy should include an action or escalation path (“If this keeps happening, let your property manager know so we can help.”).
+
+## Notification Messaging
+- Reference the audience in status copy (“We’re sending "{subject}" to {recipients}.”).
+- Provide timing hints in toasts (`showBackgroundToast`) so staff knows when to expect delivery.
+- Log support feedback events (`recordSupportFeedback`) for every notification failure or retry so we can measure reductions in “stuck” reports.
+
+## Support Feedback Tracking
+- Use the `/api/support-feedback` endpoint with the `recordSupportFeedback` helper to log:
+  - The action name (e.g., `bulk_dispatch_error`).
+  - The status (`pending`, `resolved`, or `escalated`).
+  - Optional metadata such as booking IDs, counts, or error messages.
+- Log a `pending` event when long-running work starts, mark it `resolved` on success, and mark it `escalated` on any failure that needs follow-up.
+- Keep descriptions short but searchable; they appear in dashboards for property managers.
+
+## Voice & Tone Checklist
+- Use plain language: “We”/“you” is preferred to passive phrasing.
+- Highlight next steps or who is notified instead of repeating system jargon.
+- Offer gratitude or reassurance sparingly—one sentence is enough.
+- Avoid technical references in user-facing copy (e.g., “API error”). Summarize the impact instead.

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -2,6 +2,7 @@
 
 import type { InAppNotification, NotificationData } from "@/lib/notifications"
 import { useToast } from "@/components/ui/use-toast"
+import { recordSupportFeedback } from "@/utils/support-feedback"
 
 type NotificationResult = { success: boolean; error?: string }
 type BulkNotificationResult = {
@@ -36,33 +37,100 @@ async function postNotification<T>(payload: unknown): Promise<T> {
   return data as T
 }
 
+const formatRecipients = (recipients: string | string[]) =>
+  (Array.isArray(recipients) ? recipients : [recipients]).filter(Boolean)
+
 export function useNotifications() {
   const { toast } = useToast()
 
+  const submitSupportFeedback = (
+    action: string,
+    status: "pending" | "resolved" | "escalated",
+    description?: string,
+    metadata?: Record<string, unknown>
+  ) => {
+    void recordSupportFeedback({
+      source: "notifications",
+      action,
+      status,
+      description,
+      metadata,
+    })
+  }
+
+  const showBackgroundToast = (
+    description: string,
+    seconds: number
+  ) => {
+    toast({
+      title: "Working in the background",
+      description: `${description} This typically takes about ${seconds} seconds — you can continue using the portal while we finish up.`,
+      duration: 5000,
+    })
+  }
+
   const sendEmail = async (notification: NotificationData) => {
+    const recipients = formatRecipients(notification.to)
+    const recipientList =
+      recipients.length === 1
+        ? recipients[0]
+        : recipients.join(', ')
+
     try {
+      showBackgroundToast(
+        `Sending "${notification.subject}" to ${recipientList || "the selected recipients"}.`,
+        5
+      )
+      submitSupportFeedback("email_dispatch_started", "pending", undefined, {
+        subject: notification.subject,
+        recipients,
+      })
+
       const result = await postNotification<NotificationResult>({
         type: "email",
         notification,
       })
       if (result.success) {
         toast({
-          title: "Email sent",
-          description: "Notification email has been sent successfully.",
+          title: "Email update delivered",
+          description: `"${notification.subject}" is on its way to ${recipientList || "the specified recipients"}.`,
+        })
+        submitSupportFeedback("email_dispatch_completed", "resolved", undefined, {
+          subject: notification.subject,
+          recipients,
         })
       } else {
         toast({
-          title: "Email failed",
-          description: result.error || "Failed to send email notification.",
+          title: "Email delivery issue",
+          description:
+            result.error ||
+            `We couldn't deliver "${notification.subject}" to ${recipientList || "the specified recipients"}.`,
           variant: "destructive",
         })
+        submitSupportFeedback(
+          "email_dispatch_failed",
+          "escalated",
+          result.error,
+          {
+            subject: notification.subject,
+            recipients,
+          }
+        )
       }
       return result
     } catch (error) {
       toast({
-        title: "Error",
-        description: "An unexpected error occurred while sending email.",
+        title: "Email delivery error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred while sending the email notification.",
         variant: "destructive",
+      })
+      submitSupportFeedback("email_dispatch_error", "escalated", undefined, {
+        subject: notification.subject,
+        recipients,
+        error: error instanceof Error ? error.message : error,
       })
       return { success: false, error: "Unexpected error" }
     }
@@ -70,6 +138,20 @@ export function useNotifications() {
 
   const sendInAppNotification = async (notification: InAppNotification) => {
     try {
+      showBackgroundToast(
+        `Posting "${notification.title}" to the notification center.`,
+        3
+      )
+      submitSupportFeedback(
+        "in_app_dispatch_started",
+        "pending",
+        undefined,
+        {
+          title: notification.title,
+          userId: notification.userId,
+        }
+      )
+
       const result = await postNotification<NotificationResult>({
         type: "in-app",
         notification,
@@ -86,6 +168,10 @@ export function useNotifications() {
               ? "default"
               : "default",
         })
+        submitSupportFeedback("in_app_dispatch_completed", "resolved", undefined, {
+          title: notification.title,
+          userId: notification.userId,
+        })
       }
       return result
     } catch (error) {
@@ -93,6 +179,11 @@ export function useNotifications() {
         title: "Notification failed",
         description: "Failed to send in-app notification.",
         variant: "destructive",
+      })
+      submitSupportFeedback("in_app_dispatch_error", "escalated", undefined, {
+        title: notification.title,
+        userId: notification.userId,
+        error: error instanceof Error ? error.message : error,
       })
       return { success: false, error: "Unexpected error" }
     }
@@ -102,6 +193,14 @@ export function useNotifications() {
     notifications: (NotificationData | InAppNotification)[]
   ) => {
     try {
+      showBackgroundToast(
+        "Dispatching notifications to residents and managers.",
+        7
+      )
+      submitSupportFeedback("bulk_dispatch_started", "pending", undefined, {
+        notificationCount: notifications.length,
+      })
+
       const response = await postNotification<BulkNotificationResult>({
         type: "bulk",
         notifications,
@@ -118,25 +217,39 @@ export function useNotifications() {
             failureCount > 0 ? `, ${failureCount} failed` : ""
           }.`,
         })
+        submitSupportFeedback("bulk_dispatch_completed", "resolved", undefined, {
+          successCount,
+          failureCount,
+        })
       }
 
       if (failureCount > 0) {
         toast({
-          title: "Some notifications failed",
+          title: "Some notifications need attention",
           description: `${failureCount} notification${
             failureCount > 1 ? "s" : ""
-          } could not be sent.`,
+          } could not be sent. Review the activity log for details.`,
           variant: "destructive",
+        })
+        submitSupportFeedback("bulk_dispatch_partial_failure", "escalated", undefined, {
+          successCount,
+          failureCount,
         })
       }
 
       return response.results
     } catch (error) {
       toast({
-        title: "Error",
+        title: "Notification dispatch error",
         description:
-          "An unexpected error occurred while sending notifications.",
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred while sending notifications.",
         variant: "destructive",
+      })
+      submitSupportFeedback("bulk_dispatch_error", "escalated", undefined, {
+        error: error instanceof Error ? error.message : error,
+        notificationCount: notifications.length,
       })
       return []
     }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -210,6 +210,18 @@ export type Database = {
         error_message: string | null
         metadata: Json | null
       }>
+      support_feedback_events: SupabaseTable<{
+        id: string
+        user_id: string | null
+        source: string
+        action: string
+        status: 'pending' | 'resolved' | 'escalated'
+        description: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+        resolved_at: string | null
+      }>
       meetings: SupabaseTable<{
         id: string
         user_id: string

--- a/supabase/migrations/20250115_support_feedback_events.sql
+++ b/supabase/migrations/20250115_support_feedback_events.sql
@@ -1,0 +1,45 @@
+-- Track UX support feedback and "stuck" reports for overnight visitor and notification flows
+CREATE TABLE public.support_feedback_events (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  source TEXT NOT NULL,
+  action TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'resolved', 'escalated')),
+  description TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  resolved_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX idx_support_feedback_events_user_id ON public.support_feedback_events(user_id);
+CREATE INDEX idx_support_feedback_events_status ON public.support_feedback_events(status);
+CREATE INDEX idx_support_feedback_events_created_at ON public.support_feedback_events(created_at DESC);
+
+ALTER TABLE public.support_feedback_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can insert their support feedback" ON public.support_feedback_events
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can view their own support feedback" ON public.support_feedback_events
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Managers can view support feedback" ON public.support_feedback_events
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Managers can update support feedback" ON public.support_feedback_events
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE TRIGGER update_support_feedback_events_updated_at
+  BEFORE UPDATE ON public.support_feedback_events
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/utils/support-feedback.ts
+++ b/utils/support-feedback.ts
@@ -1,0 +1,28 @@
+export type SupportFeedbackStatus = 'pending' | 'resolved' | 'escalated'
+
+export interface SupportFeedbackPayload {
+  source: string
+  action: string
+  status: SupportFeedbackStatus
+  description?: string
+  metadata?: Record<string, unknown>
+}
+
+export async function recordSupportFeedback(
+  payload: SupportFeedbackPayload
+) {
+  try {
+    const response = await fetch('/api/support-feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => null)
+      console.error('Failed to record support feedback', errorBody)
+    }
+  } catch (error) {
+    console.error('Support feedback logging error:', error)
+  }
+}


### PR DESCRIPTION
## Summary
- refine the visitor booking flow with descriptive labels, inline loading copy, and background toasts while tracking feedback events
- add a support feedback API endpoint, client helper, and Supabase migration for `support_feedback_events`
- enhance notification hooks to show background progress messaging and document UX microcopy guidelines in `docs/design/microcopy.md`

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c4eb3008328b7daa746e5f6d432