### PR TITLE
Add feature flag infrastructure for streaming and virtualization

### DIFF
--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -21,6 +21,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { AmenityBookingForm } from "./components/amenity-booking-form"
 import { BookingHistory } from "./components/booking-history"
 import { BookingStats } from "./components/booking-stats"
+import { resolveFeatureFlags } from '@/lib/feature-flags'
 
 const amenities = [
   {
@@ -65,7 +66,24 @@ const amenities = [
   },
 ]
 
-export default function BookingsPage() {
+export default async function BookingsPage() {
+  const { streamingSsr } = await resolveFeatureFlags()
+
+  const statsFallback = (
+    <div className="grid gap-4 md:grid-cols-4">
+      {[...Array(4)].map((_, i) => (
+        <Card key={i} className="animate-pulse">
+          <CardHeader className="pb-2">
+            <div className="h-4 w-3/4 rounded bg-muted"></div>
+          </CardHeader>
+          <CardContent>
+            <div className="h-8 w-1/2 rounded bg-muted"></div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
@@ -82,24 +100,13 @@ export default function BookingsPage() {
       </header>
 
       {/* Stats Overview */}
-      <Suspense
-        fallback={
-          <div className="grid gap-4 md:grid-cols-4">
-            {[...Array(4)].map((_, i) => (
-              <Card key={i} className="animate-pulse">
-                <CardHeader className="pb-2">
-                  <div className="h-4 w-3/4 rounded bg-muted"></div>
-                </CardHeader>
-                <CardContent>
-                  <div className="h-8 w-1/2 rounded bg-muted"></div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        }
-      >
+      {streamingSsr ? (
+        <Suspense fallback={statsFallback}>
+          <BookingStats />
+        </Suspense>
+      ) : (
         <BookingStats />
-      </Suspense>
+      )}
 
       {/* Main Content Tabs */}
       <Tabs defaultValue="book" className="space-y-6">

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,23 +1,28 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
-import { getDocumentsAction } from '../actions';
-import { DocumentActions } from './document-actions';
-import { formatDistanceToNow } from 'date-fns';
-import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import { DocumentWithLease, DocumentListFilters } from "@/types/documents";
+import { getDocumentsAction } from "../actions";
+import { DocumentActions } from "./document-actions";
+import { formatDistanceToNow } from "date-fns";
+import { FileText, Users, Calendar, Eye } from "lucide-react";
+import { useFeatureFlag } from "@/hooks/use-feature-flag";
+import { useVirtualizedList } from "@/hooks/use-virtualized-list";
 
 interface DocumentsListProps {
   filter: DocumentListFilters;
 }
 
+const VIRTUALIZATION_THRESHOLD = 12;
+
 export function DocumentsList({ filter }: DocumentsListProps) {
   const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const virtualizationFlag = useFeatureFlag("virtualizedLists");
 
   useEffect(() => {
     const fetchDocuments = async () => {
@@ -39,6 +44,14 @@ export function DocumentsList({ filter }: DocumentsListProps) {
 
     fetchDocuments();
   }, [filter]);
+
+  const virtualization = useVirtualizedList({
+    itemCount: documents.length,
+    estimateHeight: 192,
+    overscan: 6,
+    enabled:
+      virtualizationFlag && !loading && documents.length >= VIRTUALIZATION_THRESHOLD,
+  });
 
   const getStatusBadge = (status: string) => {
     const variants = {
@@ -140,77 +153,98 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     );
   }
 
-  return (
-    <div className="space-y-4">
-      {documents.map((doc) => (
-        <Card key={doc.id} className="transition-shadow hover:shadow-md">
-          <CardHeader className="pb-3">
-            <div className="flex items-start justify-between">
-              <div className="flex items-start space-x-3">
-                <div className="mt-1">
-                  {getTypeIcon(doc.document_type)}
+  const renderDocumentCard = (doc: DocumentWithLease) => (
+    <Card key={doc.id} className="transition-shadow hover:shadow-md">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between">
+          <div className="flex items-start space-x-3">
+            <div className="mt-1">{getTypeIcon(doc.document_type)}</div>
+            <div className="space-y-1">
+              <h3 className="font-medium leading-none">{doc.title}</h3>
+              {doc.description && (
+                <p className="text-sm text-muted-foreground">{doc.description}</p>
+              )}
+              <div className="flex items-center space-x-4 text-xs text-muted-foreground">
+                <div className="flex items-center space-x-1">
+                  <Calendar className="size-3" />
+                  <span>
+                    {formatDistanceToNow(new Date(doc.created_at), { addSuffix: true })}
+                  </span>
                 </div>
-                <div className="space-y-1">
-                  <h3 className="font-medium leading-none">{doc.title}</h3>
-                  {doc.description && (
-                    <p className="text-sm text-muted-foreground">
-                      {doc.description}
-                    </p>
-                  )}
-                  <div className="flex items-center space-x-4 text-xs text-muted-foreground">
-                    <div className="flex items-center space-x-1">
-                      <Calendar className="size-3" />
-                      <span>
-                        {formatDistanceToNow(new Date(doc.created_at), { addSuffix: true })}
-                      </span>
-                    </div>
-                    {doc.lease && (
-                      <div className="flex items-center space-x-1">
-                        <Users className="size-3" />
-                        <span>Lease • {doc.lease.tenant_ids?.length || 0} tenants</span>
-                      </div>
-                    )}
-                    {doc.signatures && doc.signatures.length > 0 && (
-                      <div className="flex items-center space-x-1">
-                        <Eye className="size-3" />
-                        <span>
-                          {doc.signatures.filter(s => s.status === 'signed').length}/
-                          {doc.signatures.length} signed
-                        </span>
-                      </div>
-                    )}
+                {doc.lease && (
+                  <div className="flex items-center space-x-1">
+                    <Users className="size-3" />
+                    <span>Lease • {doc.lease.tenant_ids?.length || 0} tenants</span>
                   </div>
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                {getStatusBadge(doc.status)}
-                <DocumentActions document={doc} />
-              </div>
-            </div>
-          </CardHeader>
-          {doc.signatures && doc.signatures.length > 0 && (
-            <CardContent className="pt-0">
-              <div className="flex items-center space-x-2">
-                <span className="text-xs text-muted-foreground">Signers:</span>
-                {doc.signatures.slice(0, 3).map((signature) => (
-                  <Badge
-                    key={signature.id}
-                    variant={signature.status === 'signed' ? 'default' : 'outline'}
-                    className="text-xs"
-                  >
-                    {signature.signer_name || signature.signer_email.split('@')[0]}
-                  </Badge>
-                ))}
-                {doc.signatures.length > 3 && (
-                  <Badge variant="secondary" className="text-xs">
-                    +{doc.signatures.length - 3} more
-                  </Badge>
+                )}
+                {doc.signatures && doc.signatures.length > 0 && (
+                  <div className="flex items-center space-x-1">
+                    <Eye className="size-3" />
+                    <span>
+                      {doc.signatures.filter((s) => s.status === 'signed').length}/
+                      {doc.signatures.length} signed
+                    </span>
+                  </div>
                 )}
               </div>
-            </CardContent>
-          )}
-        </Card>
-      ))}
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            {getStatusBadge(doc.status)}
+            <DocumentActions document={doc} />
+          </div>
+        </div>
+      </CardHeader>
+      {doc.signatures && doc.signatures.length > 0 && (
+        <CardContent className="pt-0">
+          <div className="flex items-center space-x-2">
+            <span className="text-xs text-muted-foreground">Signers:</span>
+            {doc.signatures.slice(0, 3).map((signature) => (
+              <Badge
+                key={signature.id}
+                variant={signature.status === 'signed' ? 'default' : 'outline'}
+                className="text-xs"
+              >
+                {signature.signer_name || signature.signer_email.split('@')[0]}
+              </Badge>
+            ))}
+            {doc.signatures.length > 3 && (
+              <Badge variant="secondary" className="text-xs">
+                +{doc.signatures.length - 3} more
+              </Badge>
+            )}
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+
+  if (virtualization.enabled) {
+    const visibleDocuments = documents.slice(
+      virtualization.startIndex,
+      virtualization.endIndex,
+    );
+
+    return (
+      <div
+        ref={virtualization.containerRef}
+        className="relative max-h-[32rem] overflow-auto"
+      >
+        <div style={{ height: virtualization.totalHeight }} className="relative">
+          <div
+            className="absolute inset-x-0 top-0 space-y-4"
+            style={{ transform: `translateY(${virtualization.offset}px)` }}
+          >
+            {visibleDocuments.map((doc) => renderDocumentCard(doc))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {documents.map((doc) => renderDocumentCard(doc))}
     </div>
   );
 }

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,23 +1,59 @@
-import { Suspense } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { FileText, Users, Clock, Upload } from 'lucide-react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { UploadDocumentDialog } from "./components/upload-document-dialog";
-import { DocumentsStats } from "./components/documents-stats";
-import { DocumentsList } from "./components/documents-list";
-import { DocumentsFilters } from "./components/documents-filters";
-import { DocumentListFilters } from '@/types/documents';
+import { Suspense } from "react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { FileText, Users, Clock, Upload } from "lucide-react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { UploadDocumentDialog } from "./components/upload-document-dialog"
+import { DocumentsStats } from "./components/documents-stats"
+import { DocumentsList } from "./components/documents-list"
+import { DocumentsFilters } from "./components/documents-filters"
+import { DocumentListFilters } from "@/types/documents"
+import { resolveFeatureFlags } from "@/lib/feature-flags"
 
-export default function DocumentsPage() {
+export default async function DocumentsPage() {
+  const { streamingSsr } = await resolveFeatureFlags()
+
+  const statsFallback = (
+    <div className="grid gap-4 md:grid-cols-4">
+      {[...Array(4)].map((_, i) => (
+        <Card key={i} className="animate-pulse">
+          <CardHeader className="pb-2">
+            <div className="h-4 w-3/4 rounded bg-muted"></div>
+          </CardHeader>
+          <CardContent>
+            <div className="h-8 w-1/2 rounded bg-muted"></div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+
+  const renderDocumentsList = (filter: DocumentListFilters) =>
+    streamingSsr ? (
+      <Suspense fallback={<DocumentsListSkeleton />}>
+        <DocumentsList filter={filter} />
+      </Suspense>
+    ) : (
+      <DocumentsList filter={filter} />
+    )
+
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
         <div className="flex items-center justify-between">
           <div className="space-y-2">
-            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Documents</h1>
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+              Documents
+            </h1>
             <p className="text-base text-muted-foreground sm:text-lg">
-              Manage leases, agreements, and household documents with secure signing and version control.
+              Manage leases, agreements, and household documents with secure
+              signing and version control.
             </p>
           </div>
           <UploadDocumentDialog />
@@ -26,20 +62,13 @@ export default function DocumentsPage() {
       </header>
 
       {/* Stats Overview */}
-      <Suspense fallback={<div className="grid gap-4 md:grid-cols-4">
-        {[...Array(4)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader className="pb-2">
-              <div className="h-4 w-3/4 rounded bg-muted"></div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-8 w-1/2 rounded bg-muted"></div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>}>
+      {streamingSsr ? (
+        <Suspense fallback={statsFallback}>
+          <DocumentsStats />
+        </Suspense>
+      ) : (
         <DocumentsStats />
-      </Suspense>
+      )}
 
       {/* Main Content Tabs */}
       <Tabs defaultValue="all" className="space-y-6">
@@ -54,27 +83,19 @@ export default function DocumentsPage() {
         </div>
 
         <TabsContent value="all" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{}} />
-          </Suspense>
+          {renderDocumentsList({})}
         </TabsContent>
 
         <TabsContent value="leases" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ type: ['lease'] }} />
-          </Suspense>
+          {renderDocumentsList({ type: ["lease"] })}
         </TabsContent>
 
         <TabsContent value="pending" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['pending_signature'] }} />
-          </Suspense>
+          {renderDocumentsList({ status: ["pending_signature"] })}
         </TabsContent>
 
         <TabsContent value="signed" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['signed'] }} />
-          </Suspense>
+          {renderDocumentsList({ status: ["signed"] })}
         </TabsContent>
       </Tabs>
 
@@ -137,7 +158,7 @@ export default function DocumentsPage() {
         </Card>
       </div>
     </div>
-  );
+  )
 }
 
 function DocumentsListSkeleton() {
@@ -166,5 +187,5 @@ function DocumentsListSkeleton() {
         </Card>
       ))}
     </div>
-  );
+  )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,8 @@ import { SiteHeader } from "@/components/site-header"
 import { SiteFooter } from "@/components/site-footer"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { cn } from "@/lib/utils"
+import { FeatureFlagProvider } from '@/components/feature-flag-provider'
+import { resolveFeatureFlags } from '@/lib/feature-flags'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
@@ -108,44 +110,51 @@ interface RootLayoutProps {
 }
 
 
-export default function RootLayout({ children }: RootLayoutProps) {
+export default async function RootLayout({ children }: RootLayoutProps) {
+  const featureFlags = await resolveFeatureFlags()
+
   return (
-    <ReactQueryClientProvider>
     <html lang="en" suppressHydrationWarning>
-    <head></head>
-      <body className={cn(
-            "min-h-screen bg-background font-sans antialiased",
-            fontSans.variable
-          )}
-        >
-<ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-             <div className="relative flex min-h-screen flex-col">
-              <SiteHeader />
-              <div className="flex-1">{children}<Toaster/><Analytics/><SpeedInsights/></div>
-              
-   </div>           
-<SiteFooter/>
+      <head></head>
+      <body
+        className={cn(
+          "min-h-screen bg-background font-sans antialiased",
+          fontSans.variable,
+        )}
+      >
+        <ReactQueryClientProvider>
+          <FeatureFlagProvider initialFlags={featureFlags}>
+            <ThemeProvider
+              attribute="class"
+              defaultTheme="system"
+              enableSystem
+              disableTransitionOnChange
+            >
+              <div className="relative flex min-h-screen flex-col">
+                <SiteHeader />
+                <div className="flex-1">
+                  {children}
+                  <Toaster />
+                  <Analytics />
+                  <SpeedInsights />
+                </div>
+                <SiteFooter />
+              </div>
 
+              {/*
+              enter your api info from termly.io or a provider of your choice
+              <Script
+                type="text/javascript"
+                src="https://app.termly.io/resource-blocker/123456789abcdefg"
+              />
 
-{/*
-enter your api info from termly.io or a provider of your choice
-<Script
-  type="text/javascript"
-  src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
-
-*/}
-   <CookieButton />    
-          </ThemeProvider>
-        
-
-
-</body>
+              */}
+              <CookieButton />
+              <TailwindIndicator />
+            </ThemeProvider>
+          </FeatureFlagProvider>
+        </ReactQueryClientProvider>
+      </body>
     </html>
-    </ReactQueryClientProvider>
   )
 }

--- a/components/feature-flag-provider.tsx
+++ b/components/feature-flag-provider.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { createContext, useMemo } from 'react'
+
+import type { FeatureFlagName } from '@/config/feature-flags'
+import type { FeatureFlagSnapshot } from '@/lib/feature-flags'
+
+export type FeatureFlagContextValue = {
+  flags: FeatureFlagSnapshot
+}
+
+export const FeatureFlagContext =
+  createContext<FeatureFlagContextValue | null>(null)
+
+interface FeatureFlagProviderProps {
+  children: React.ReactNode
+  initialFlags: FeatureFlagSnapshot
+}
+
+export function FeatureFlagProvider({
+  children,
+  initialFlags,
+}: FeatureFlagProviderProps) {
+  const value = useMemo(
+    () => ({ flags: initialFlags }),
+    [initialFlags],
+  )
+
+  return (
+    <FeatureFlagContext.Provider value={value}>
+      {children}
+    </FeatureFlagContext.Provider>
+  )
+}
+
+export function withFeatureFlag<T extends FeatureFlagName>(
+  flags: FeatureFlagSnapshot,
+  flag: T,
+) {
+  return flags[flag]
+}

--- a/config/feature-flags.ts
+++ b/config/feature-flags.ts
@@ -1,0 +1,58 @@
+export const appEnvironments = ["development", "preview", "production"] as const
+
+export type AppEnvironment = (typeof appEnvironments)[number]
+
+export const featureFlagConfig = {
+  streamingSsr: {
+    description:
+      "Enable React suspense boundaries to stream server-rendered payloads for slow data dependencies.",
+    defaults: {
+      development: true,
+      preview: true,
+      production: false,
+    },
+  },
+  virtualizedLists: {
+    description:
+      "Window large collection views on the client to reduce DOM weight while scrolling long datasets.",
+    defaults: {
+      development: true,
+      preview: false,
+      production: false,
+    },
+  },
+} as const satisfies Record<
+  string,
+  {
+    description: string
+    defaults: Record<AppEnvironment, boolean>
+  }
+>
+
+export type FeatureFlagName = keyof typeof featureFlagConfig
+
+export type FeatureFlagDefinition =
+  (typeof featureFlagConfig)[FeatureFlagName]
+
+export const featureFlagNames = Object.keys(
+  featureFlagConfig,
+) as FeatureFlagName[]
+
+export function getDefaultFlagsForEnv(
+  environment: AppEnvironment,
+): Record<FeatureFlagName, boolean> {
+  return featureFlagNames.reduce<Record<FeatureFlagName, boolean>>(
+    (accumulator, flag) => {
+      accumulator[flag] = featureFlagConfig[flag].defaults[environment]
+      return accumulator
+    },
+    {} as Record<FeatureFlagName, boolean>,
+  )
+}
+
+export function getFeatureFlagDefault(
+  flag: FeatureFlagName,
+  environment: AppEnvironment,
+): boolean {
+  return featureFlagConfig[flag].defaults[environment]
+}

--- a/docs/product/feature-flags.md
+++ b/docs/product/feature-flags.md
@@ -1,0 +1,35 @@
+# Feature Flags
+
+Roomsily ships new platform optimisations behind feature flags so that we can validate behaviour per environment, stage rollouts, and recover quickly if issues arise. Flags are stored in Supabase (`public.feature_flags`) and mirrored in code to guarantee typed access across the stack.
+
+## Flag inventory
+
+| Flag | Description | Development | Preview | Production |
+| --- | --- | --- | --- | --- |
+| `streamingSsr` | Streams suspense boundaries for data-heavy pages (documents, bookings) instead of waiting for the full payload. | ✅ | ✅ | ⛔ |
+| `virtualizedLists` | Enables windowing for large client-side collections (e.g. document lists) to reduce DOM cost and improve scroll performance. | ✅ | ⛔ | ⛔ |
+
+Defaults are declared in [`config/feature-flags.ts`](../../config/feature-flags.ts) and applied automatically whenever a Supabase override is not present.
+
+## Rollout policy
+
+1. **Develop in isolation** – implement the feature guarded by a typed flag and verify locally (`development`).
+2. **Enable on preview** – once QA passes, flip the flag for the corresponding `preview` environment row in Supabase to expose the behaviour on Vercel preview deployments.
+3. **Observe telemetry** – monitor Core Web Vitals, Supabase logs, and error tracking for at least one full day. If anything regresses, toggle the flag off immediately.
+4. **Production launch** – update the `production` row when confidence is high. Document launch details (date, owner, metrics) in the table comment or in this changelog for traceability.
+
+Flags should never be deleted without migrating existing rows and cleaning up the associated config entry to keep the type system in sync.
+
+## Implementation guidelines
+
+- Server components call `resolveFeatureFlags()` from [`lib/feature-flags.ts`](../../lib/feature-flags.ts) to merge Supabase overrides with environment defaults.
+- `app/layout.tsx` injects a `FeatureFlagProvider`, enabling client components to consume flags via the `useFeatureFlag` hook.
+- Optimisations such as streaming SSR and list virtualisation must render sensible fallbacks when flags are disabled so we can safely roll back.
+- When adding a new flag, update this document, the config file, and create the corresponding Supabase migration so every environment has matching schema.
+
+## Operations checklist
+
+- [ ] Update Supabase rows for the target environments (remember unique keys are `(slug, environment)`).
+- [ ] Announce rollout plans in the product channel with expected metrics to watch.
+- [ ] Capture before/after performance snapshots (LCP, hydration time, memory footprint) to validate impact.
+- [ ] Schedule a follow-up to remove stale flags or graduate them into defaults once they have been stable for a full release cycle.

--- a/hooks/use-feature-flag.ts
+++ b/hooks/use-feature-flag.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useContext } from 'react'
+
+import type { FeatureFlagName } from '@/config/feature-flags'
+import { FeatureFlagContext } from '@/components/feature-flag-provider'
+
+export function useFeatureFlag(flag: FeatureFlagName): boolean {
+  const context = useContext(FeatureFlagContext)
+
+  if (!context) {
+    throw new Error('useFeatureFlag must be used within a FeatureFlagProvider')
+  }
+
+  return context.flags[flag]
+}
+
+export function useFeatureFlags() {
+  const context = useContext(FeatureFlagContext)
+
+  if (!context) {
+    throw new Error('useFeatureFlags must be used within a FeatureFlagProvider')
+  }
+
+  return context.flags
+}

--- a/hooks/use-virtualized-list.ts
+++ b/hooks/use-virtualized-list.ts
@@ -1,0 +1,91 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+type UseVirtualizedListOptions = {
+  itemCount: number
+  estimateHeight: number
+  overscan?: number
+  enabled?: boolean
+}
+
+type VirtualizedListResult = {
+  containerRef: React.RefObject<HTMLDivElement>
+  startIndex: number
+  endIndex: number
+  offset: number
+  totalHeight: number
+  enabled: boolean
+}
+
+export function useVirtualizedList({
+  itemCount,
+  estimateHeight,
+  overscan = 6,
+  enabled = true,
+}: UseVirtualizedListOptions): VirtualizedListResult {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [scrollTop, setScrollTop] = useState(0)
+  const [viewportHeight, setViewportHeight] = useState(0)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const container = containerRef.current
+    if (!container) return
+
+    const updateViewport = () => {
+      setViewportHeight(container.clientHeight)
+    }
+
+    const handleScroll = () => {
+      setScrollTop(container.scrollTop)
+    }
+
+    updateViewport()
+    container.addEventListener('scroll', handleScroll)
+    window.addEventListener('resize', updateViewport)
+
+    return () => {
+      container.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('resize', updateViewport)
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) return
+    const container = containerRef.current
+    if (!container) return
+
+    setViewportHeight(container.clientHeight)
+  }, [enabled, itemCount])
+
+  const effectiveViewport = viewportHeight || estimateHeight * 6
+
+  const startIndex = enabled
+    ? Math.max(0, Math.floor(scrollTop / estimateHeight) - overscan)
+    : 0
+  const endIndex = enabled
+    ? Math.min(
+        itemCount,
+        Math.ceil((scrollTop + effectiveViewport) / estimateHeight) + overscan,
+      )
+    : itemCount
+
+  const safeEndIndex = Math.max(startIndex, endIndex)
+
+  const offset = enabled ? startIndex * estimateHeight : 0
+  const totalHeight = useMemo(
+    () => itemCount * estimateHeight,
+    [itemCount, estimateHeight],
+  )
+
+  return {
+    containerRef,
+    startIndex,
+    endIndex: safeEndIndex,
+    offset,
+    totalHeight,
+    enabled: enabled && itemCount > 0,
+  }
+}

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,90 @@
+import 'server-only'
+
+import { cache } from 'react'
+import { createClient } from '@supabase/supabase-js'
+
+import type {
+  AppEnvironment,
+  FeatureFlagName,
+} from '@/config/feature-flags'
+import {
+  featureFlagNames,
+  getDefaultFlagsForEnv,
+} from '@/config/feature-flags'
+import type { Database } from './supabase'
+
+function getSupabaseAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !key) {
+    console.warn(
+      'Supabase credentials missing — feature flags will fall back to defaults.',
+    )
+    return null
+  }
+
+  return createClient<Database>(url, key, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  })
+}
+
+const getCachedAdminClient = cache(getSupabaseAdminClient)
+
+export function getRuntimeEnvironment(): AppEnvironment {
+  const vercelEnv = process.env.VERCEL_ENV
+  if (
+    vercelEnv === 'production' ||
+    vercelEnv === 'preview' ||
+    vercelEnv === 'development'
+  ) {
+    return vercelEnv
+  }
+
+  return process.env.NODE_ENV === 'production' ? 'production' : 'development'
+}
+
+export const resolveFeatureFlags = cache(
+  async (
+    environment: AppEnvironment = getRuntimeEnvironment(),
+  ): Promise<Record<FeatureFlagName, boolean>> => {
+    const defaults = getDefaultFlagsForEnv(environment)
+    const client = getCachedAdminClient()
+
+    if (!client) {
+      return defaults
+    }
+
+    const { data, error } = await client
+      .from('feature_flags')
+      .select('slug, enabled')
+      .eq('environment', environment)
+
+    if (error) {
+      console.error('Failed to load feature flag overrides from Supabase', error)
+      return defaults
+    }
+
+    const overrides = { ...defaults }
+    for (const row of data ?? []) {
+      if (featureFlagNames.includes(row.slug as FeatureFlagName)) {
+        overrides[row.slug as FeatureFlagName] = row.enabled
+      }
+    }
+
+    return overrides
+  },
+)
+
+export async function getFeatureFlagValue(
+  flag: FeatureFlagName,
+  environment?: AppEnvironment,
+): Promise<boolean> {
+  const flags = await resolveFeatureFlags(environment)
+  return flags[flag]
+}
+
+export type FeatureFlagSnapshot = Awaited<ReturnType<typeof resolveFeatureFlags>>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,3 +1,8 @@
+import type {
+  AppEnvironment,
+  FeatureFlagName,
+} from '@/config/feature-flags'
+
 export type Json =
   | string
   | number
@@ -196,6 +201,17 @@ export type Database = {
         action_url: string | null
         metadata: Json | null
         read: boolean | null
+        created_at: string | null
+        updated_at: string | null
+      }>
+      feature_flags: SupabaseTable<{
+        id: string
+        slug: FeatureFlagName
+        environment: AppEnvironment
+        description: string | null
+        enabled: boolean
+        rollout_percentage: number | null
+        targeting: Json | null
         created_at: string | null
         updated_at: string | null
       }>

--- a/supabase/migrations/20250105_feature_flags.sql
+++ b/supabase/migrations/20250105_feature_flags.sql
@@ -1,0 +1,42 @@
+-- Feature flag table to coordinate progressive delivery across environments
+CREATE TABLE IF NOT EXISTS public.feature_flags (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL,
+  environment TEXT NOT NULL CHECK (environment IN ('development', 'preview', 'production')),
+  description TEXT,
+  enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  rollout_percentage SMALLINT CHECK (rollout_percentage BETWEEN 0 AND 100),
+  targeting JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE (slug, environment)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flags_environment ON public.feature_flags(environment);
+CREATE INDEX IF NOT EXISTS idx_feature_flags_slug ON public.feature_flags(slug);
+
+ALTER TABLE public.feature_flags ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can read feature flags" ON public.feature_flags
+  FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Admins can manage feature flags" ON public.feature_flags
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+CREATE TRIGGER update_feature_flags_updated_at
+  BEFORE UPDATE ON public.feature_flags
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- add typed feature flag configuration plus Supabase-backed resolver and provider wiring
- guard streaming SSR pages and the document list virtualization behind the new flags
- document rollout policy and create the Supabase migration for the `feature_flags` table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d79f4f083288955a0f6e118c029