### PR TITLE
Add bookings composite index and performance instrumentation

### DIFF
--- a/app/api/bookings/conflicts/route.ts
+++ b/app/api/bookings/conflicts/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { findBookingConflicts } from '@/lib/booking-conflicts';
+import { createClient } from '@/utils/supabase/server';
+
+const payloadSchema = z.object({
+  amenityId: z.string().min(1, 'amenityId is required'),
+  startTime: z.string().datetime({ offset: true }),
+  endTime: z.string().datetime({ offset: true }),
+  excludeBookingId: z.string().optional(),
+  limit: z.number().int().positive().max(50).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const json = await request.json().catch(() => null);
+  const parsed = payloadSchema.safeParse(json);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: 'Invalid booking conflict payload.',
+        details: parsed.error.flatten(),
+      },
+      { status: 400 }
+    );
+  }
+
+  const { amenityId, startTime, endTime, excludeBookingId, limit } = parsed.data;
+
+  if (new Date(startTime) >= new Date(endTime)) {
+    return NextResponse.json(
+      {
+        error: 'startTime must be strictly earlier than endTime.',
+      },
+      { status: 400 }
+    );
+  }
+
+  const supabase = createClient();
+
+  try {
+    const result = await findBookingConflicts(
+      supabase,
+      {
+        amenityId,
+        startTime,
+        endTime,
+        excludeBookingId,
+      },
+      { limit }
+    );
+
+    return NextResponse.json({
+      conflicts: result.conflicts,
+      metrics: result.metrics,
+    });
+  } catch (error) {
+    console.error('Failed to check booking conflicts via API route', error);
+    return NextResponse.json(
+      {
+        error: 'Unable to check booking conflicts at this time.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/docs/perf/bookings-index.md
+++ b/docs/perf/bookings-index.md
@@ -1,0 +1,32 @@
+# Amenity Booking Conflict Index Benchmark
+
+## Summary
+- Added a composite `(amenity_id, start_time, end_time)` index so range-based conflict checks hit a narrow btree path instead of scanning per amenity bucket.
+- Updated the `find_conflicting_bookings` helper to express conflicts as `start_time < $end AND end_time > $start`, the pattern that maps to the composite index.
+- Conflict lookups on a 100k row synthetic dataset now resolve in ~1.2 ms on average (max 2.52 ms), comfortably below the 10 ms SLA.
+
+## Methodology
+1. Generated 100k amenity bookings across ten amenities with uniform 30-minute slots.
+2. Exercised the conflict probe query 25× before the index to capture the baseline.
+3. Created the composite index and re-ran the probe 25× to record the optimized timings.
+4. Captured metrics using the [`scripts/perf/bookings-conflict-benchmark.mjs`](../../scripts/perf/bookings-conflict-benchmark.mjs) harness.
+
+The benchmark uses [`@electric-sql/pglite`](https://github.com/electric-sql/pglite) to run in-process PostgreSQL, matching the SQL semantics used in Supabase migrations.
+
+## Results
+| Scenario | Avg (ms) | P90 (ms) | Max (ms) |
+| --- | --- | --- | --- |
+| Before index | 7.031 | 12.758 | 12.937 |
+| After composite index | 1.217 | 1.534 | 2.522 |
+
+_Source: `npm run perf:bookings`_【8b63fa†L1-L6】
+
+## Monitoring Notes
+- `lib/booking-conflicts.ts` records the elapsed time for every conflict query and warns when it exceeds the 10 ms budget, making slow paths visible in logs.
+- `POST /api/bookings/conflicts` returns the measured duration alongside conflict rows so dashboards can alert if callers observe spikes.
+
+## Reproducing the Benchmark
+```bash
+npm install
+npm run perf:bookings
+```

--- a/lib/booking-conflicts.ts
+++ b/lib/booking-conflicts.ts
@@ -1,0 +1,99 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { performance } from 'node:perf_hooks';
+
+import type { Database } from './supabase';
+
+type BookingRow = Database['public']['Tables']['bookings']['Row'];
+
+type BookingConflictParams = {
+  amenityId: string;
+  startTime: string;
+  endTime: string;
+  excludeBookingId?: string | null;
+};
+
+type BookingConflictMetrics = {
+  durationMs: number;
+  targetMs: number;
+  withinTarget: boolean;
+};
+
+type BookingConflictOptions = {
+  limit?: number;
+  signal?: AbortSignal;
+  onObserved?: (metrics: BookingConflictMetrics) => void;
+};
+
+export type BookingConflictResult = {
+  conflicts: BookingRow[];
+  metrics: BookingConflictMetrics;
+};
+
+export const BOOKING_CONFLICT_TARGET_MS = 10;
+
+/**
+ * Fetch conflicting bookings for a given amenity using range predicates that map
+ * directly to the `(amenity_id, start_time, end_time)` composite index.
+ */
+export async function findBookingConflicts(
+  client: SupabaseClient<Database>,
+  params: BookingConflictParams,
+  options: BookingConflictOptions = {}
+): Promise<BookingConflictResult> {
+  const { amenityId, startTime, endTime, excludeBookingId } = params;
+
+  if (!amenityId) {
+    throw new Error('amenityId is required to check for booking conflicts.');
+  }
+
+  if (!startTime || !endTime) {
+    throw new Error('Both startTime and endTime are required to check booking conflicts.');
+  }
+
+  const measurementStart = performance.now();
+
+  let query = client
+    .from('bookings')
+    .select('id, amenity_id, start_time, end_time, status', { head: false })
+    .eq('amenity_id', amenityId)
+    .lt('start_time', endTime)
+    .gt('end_time', startTime)
+    .order('start_time', { ascending: true })
+    .limit(options.limit ?? 10);
+
+  if (excludeBookingId) {
+    query = query.neq('id', excludeBookingId);
+  }
+
+  if (options.signal) {
+    query = query.abortSignal(options.signal);
+  }
+
+  const { data, error } = await query;
+
+  const durationMs = performance.now() - measurementStart;
+  const metrics: BookingConflictMetrics = {
+    durationMs,
+    targetMs: BOOKING_CONFLICT_TARGET_MS,
+    withinTarget: durationMs <= BOOKING_CONFLICT_TARGET_MS,
+  };
+
+  if (options.onObserved) {
+    options.onObserved(metrics);
+  }
+
+  if (!metrics.withinTarget) {
+    console.warn(
+      `Booking conflict check took ${metrics.durationMs.toFixed(2)}ms (target ${metrics.targetMs}ms).`
+    );
+  }
+
+  if (error) {
+    throw new Error(`Failed to query booking conflicts: ${error.message}`);
+  }
+
+  return {
+    conflicts: data ?? [],
+    metrics,
+  };
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -170,6 +170,17 @@ export type Database = {
         attachments: Json | null
         metadata: Json | null
       }>
+      bookings: SupabaseTable<{
+        id: string
+        amenity_id: string
+        tenant_id: string | null
+        start_time: string
+        end_time: string
+        status: string | null
+        created_at: string | null
+        updated_at: string | null
+        metadata: Json | null
+      }>
       visitor_logs: SupabaseTable<{
         id: string
         guest_name: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -70,6 +70,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.2.7",
         "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
         "@types/eslint": "^8.56.2",
         "@types/node": "^20.19.0",
@@ -370,6 +371,13 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.17.tgz",
+      "integrity": "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "perf:bookings": "node scripts/perf/bookings-conflict-benchmark.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -72,6 +73,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.2.7",
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",

--- a/scripts/perf/bookings-conflict-benchmark.mjs
+++ b/scripts/perf/bookings-conflict-benchmark.mjs
@@ -1,0 +1,109 @@
+import { PGlite } from '@electric-sql/pglite';
+import { performance } from 'node:perf_hooks';
+
+const TOTAL_AMENITIES = 10;
+const SLOTS_PER_AMENITY = 10_000;
+const SLOT_DURATION_MINUTES = 30;
+const TOTAL_ROWS = TOTAL_AMENITIES * SLOTS_PER_AMENITY;
+
+const amenities = Array.from({ length: TOTAL_AMENITIES }, (_, index) => `amenity-${index + 1}`);
+const baseTimestamp = Date.parse('2025-01-01T00:00:00Z');
+
+const db = new PGlite();
+
+await db.query(`
+  CREATE TABLE bookings (
+    id TEXT PRIMARY KEY,
+    amenity_id TEXT NOT NULL,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ NOT NULL
+  );
+`);
+
+const chunkSize = 1_000;
+for (let offset = 0; offset < TOTAL_ROWS; offset += chunkSize) {
+  const rowsInChunk = Math.min(chunkSize, TOTAL_ROWS - offset);
+  const values = [];
+  const placeholders = [];
+
+  for (let i = 0; i < rowsInChunk; i++) {
+    const globalIndex = offset + i;
+    const amenityIndex = Math.floor(globalIndex / SLOTS_PER_AMENITY);
+    const slotIndex = globalIndex % SLOTS_PER_AMENITY;
+    const amenityId = amenities[amenityIndex];
+    const start = new Date(baseTimestamp + slotIndex * SLOT_DURATION_MINUTES * 60 * 1000);
+    const end = new Date(start.getTime() + SLOT_DURATION_MINUTES * 60 * 1000);
+
+    values.push(`booking-${globalIndex}`, amenityId, start.toISOString(), end.toISOString());
+    const placeholderOffset = i * 4;
+    placeholders.push(
+      `($${placeholderOffset + 1}, $${placeholderOffset + 2}, $${placeholderOffset + 3}, $${placeholderOffset + 4})`
+    );
+  }
+
+  await db.query(
+    `INSERT INTO bookings (id, amenity_id, start_time, end_time) VALUES ${placeholders.join(', ')}`,
+    values
+  );
+}
+
+await db.query('ANALYZE bookings;');
+
+async function benchmark(iterations) {
+  const durations = [];
+
+  for (let i = 0; i < iterations; i++) {
+    const amenityId = amenities[i % amenities.length];
+    const slotIndex = Math.floor(Math.random() * SLOTS_PER_AMENITY);
+    const start = new Date(baseTimestamp + slotIndex * SLOT_DURATION_MINUTES * 60 * 1000);
+    const end = new Date(start.getTime() + SLOT_DURATION_MINUTES * 60 * 1000);
+
+    const t0 = performance.now();
+    await db.query(
+      'SELECT id FROM bookings WHERE amenity_id = $1 AND start_time < $3 AND end_time > $2 LIMIT 1',
+      [amenityId, start.toISOString(), end.toISOString()]
+    );
+    const t1 = performance.now();
+    durations.push(t1 - t0);
+  }
+
+  durations.sort((a, b) => a - b);
+
+  const sum = durations.reduce((acc, value) => acc + value, 0);
+  const average = sum / durations.length;
+  const min = durations[0];
+  const max = durations[durations.length - 1];
+  const p90Index = Math.floor(0.9 * durations.length);
+  const p90 = durations[Math.min(p90Index, durations.length - 1)];
+
+  return { average, min, max, p90 };
+}
+
+const baseline = await benchmark(25);
+
+await db.query('CREATE INDEX idx_bookings_amenity_time_range ON bookings (amenity_id, start_time, end_time);');
+await db.query('ANALYZE bookings;');
+
+const optimized = await benchmark(25);
+
+console.log('Amenity bookings conflict benchmark (100k rows)');
+console.table([
+  {
+    phase: 'Before index',
+    averageMs: baseline.average.toFixed(3),
+    p90Ms: baseline.p90.toFixed(3),
+    maxMs: baseline.max.toFixed(3),
+  },
+  {
+    phase: 'After composite index',
+    averageMs: optimized.average.toFixed(3),
+    p90Ms: optimized.p90.toFixed(3),
+    maxMs: optimized.max.toFixed(3),
+  },
+]);
+
+if (optimized.max > 10) {
+  console.warn(`Warning: optimized conflict checks exceeded 10ms target (max ${optimized.max.toFixed(3)}ms).`);
+}
+
+await db.close();

--- a/supabase/migrations/20250105_bookings_conflict_index.sql
+++ b/supabase/migrations/20250105_bookings_conflict_index.sql
@@ -1,0 +1,60 @@
+-- Ensure amenity bookings conflict checks can leverage a composite index
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename = 'bookings'
+  ) THEN
+    EXECUTE $$
+      CREATE INDEX IF NOT EXISTS idx_bookings_amenity_time_range
+        ON public.bookings (amenity_id, start_time, end_time);
+    $$;
+  ELSE
+    RAISE NOTICE 'Skipping creation of idx_bookings_amenity_time_range because public.bookings does not exist yet.';
+  END IF;
+END $$;
+
+-- Update the conflict helper to rely on range predicates that map to the composite index
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename = 'bookings'
+  ) THEN
+    EXECUTE $ddl$
+      CREATE OR REPLACE FUNCTION public.find_conflicting_bookings(
+        p_amenity_id public.bookings.amenity_id%TYPE,
+        p_start_time public.bookings.start_time%TYPE,
+        p_end_time public.bookings.end_time%TYPE,
+        p_exclude_booking public.bookings.id%TYPE DEFAULT NULL
+      )
+      RETURNS TABLE (
+        id public.bookings.id%TYPE,
+        amenity_id public.bookings.amenity_id%TYPE,
+        start_time public.bookings.start_time%TYPE,
+        end_time public.bookings.end_time%TYPE
+      )
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        SELECT
+          b.id,
+          b.amenity_id,
+          b.start_time,
+          b.end_time
+        FROM public.bookings AS b
+        WHERE b.amenity_id = p_amenity_id
+          AND b.start_time < p_end_time
+          AND b.end_time > p_start_time
+          AND (p_exclude_booking IS NULL OR b.id <> p_exclude_booking)
+        ORDER BY b.start_time;
+      $function$;
+    $ddl$;
+  ELSE
+    RAISE NOTICE 'Skipping helper update because public.bookings does not exist yet.';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add a guarded migration that creates the `(amenity_id, start_time, end_time)` index and updates the SQL helper used for conflicts
- expose a typed booking conflict helper plus an API endpoint that records and returns query latency
- document the 100k-row benchmark results and add a runnable perf harness for regression tracking

## Testing
- npm run perf:bookings
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c7e046c8328a7375e346033ba5d