### PR TITLE
Optimize RLS policies to target indexed tenant predicates

### DIFF
--- a/docs/security/rls-performance.md
+++ b/docs/security/rls-performance.md
@@ -1,0 +1,59 @@
+# RLS Policy Performance Validation
+
+This document tracks the RLS policy tuning performed to keep Supabase (Postgres) row level security checks aligned with indexed columns so the planner can continue to use bitmap or index scans even when RLS is enforced.
+
+## Summary of Changes
+
+- Added a defensive `idx_profiles_unit_id` index to guarantee unit lookups from policies remain index assisted.
+- Replaced broad OR-based predicates with narrowly scoped policies on `documents`, `document_signatures`, `document_access_logs`, `leases`, `maintenance_requests`, and `visitor_logs` so every tenant-facing predicate resolves to an `auth.uid()` equality check on `tenant_id`, `unit_id`, or other indexed foreign keys.
+- Preserved property manager/admin access policies to avoid regressions while tightening tenant-scoped filters.
+
+Refer to `supabase/migrations/202502140001_rls_policy_index_tuning.sql` for the full SQL definition.
+
+## Deployment Checklist
+
+1. **Create a new migration** – already committed in this repository.
+2. **Deploy to staging** using the Supabase CLI:
+   ```bash
+   supabase db push --env staging
+   ```
+3. **Invalidate any cached PostgREST plans** so the new policies are respected immediately:
+   ```sql
+   SELECT pg_notify('pgrst', 'reload config');
+   ```
+
+## Verifying Index Usage Under RLS
+
+Run the checks below in staging (or any environment mirroring production data). The examples assume you are connected with the Supabase service key so you can impersonate tenant sessions. Replace UUIDs with real IDs from your dataset.
+
+```sql
+-- Impersonate a tenant before running EXPLAIN so RLS predicates execute
+SET SESSION AUTHORIZATION '11111111-2222-3333-4444-555555555501';
+
+-- Documents: expect idx_documents_tenant_id or idx_documents_unit_id to appear
+EXPLAIN
+SELECT id, title FROM public.documents
+WHERE tenant_id = auth.uid();
+
+-- Document signatures: signer_id index should be used
+EXPLAIN
+SELECT id FROM public.document_signatures
+WHERE signer_id = auth.uid();
+
+-- Maintenance requests: planner should choose idx_maintenance_requests_unit_id
+EXPLAIN
+SELECT id, title FROM public.maintenance_requests
+WHERE unit_id IN (
+  SELECT unit_id FROM public.profiles WHERE id = auth.uid()
+);
+
+RESET SESSION AUTHORIZATION;
+```
+
+For deeper validation, rerun the queries with `EXPLAIN (ANALYZE, BUFFERS)` while the session authorization remains set to the tenant. Confirm the output shows an `Index Scan` or `Bitmap Heap Scan` on the expected index rather than a sequential scan.
+
+## Troubleshooting
+
+- If `EXPLAIN` indicates a sequential scan, verify statistics are up to date (`ANALYZE public.<table>`), and ensure the tenant rows populate the indexed columns (`tenant_id`, `unit_id`).
+- When backfilling new `unit_id` values, temporarily disable the affected policies or execute the backfill with the service role to bypass RLS.
+- Keep `supabase db diff` snapshots for production parity before promoting the migration.

--- a/supabase/migrations/202502140001_rls_policy_index_tuning.sql
+++ b/supabase/migrations/202502140001_rls_policy_index_tuning.sql
@@ -1,0 +1,184 @@
+-- Align RLS policies with indexed tenant and unit predicates to improve planner choices
+
+-- Ensure profiles.unit_id is indexed for unit-scoped policy checks
+CREATE INDEX IF NOT EXISTS idx_profiles_unit_id ON public.profiles(unit_id);
+
+-- Documents
+DROP POLICY IF EXISTS "Users can view documents they're associated with" ON public.documents;
+
+CREATE POLICY "Document access for creators" ON public.documents
+  FOR SELECT USING (created_by = auth.uid());
+
+CREATE POLICY "Document access for assigned tenant" ON public.documents
+  FOR SELECT USING (tenant_id = auth.uid());
+
+CREATE POLICY "Document access for unit members" ON public.documents
+  FOR SELECT USING (
+    unit_id IS NOT NULL AND unit_id IN (
+      SELECT unit_id
+      FROM public.profiles
+      WHERE id = auth.uid() AND unit_id IS NOT NULL
+    )
+  );
+
+CREATE POLICY "Document access for signers" ON public.documents
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.document_signatures ds
+      WHERE ds.document_id = documents.id AND ds.signer_id = auth.uid()
+    )
+  );
+
+-- Document signatures
+DROP POLICY IF EXISTS "Users can view signatures for documents they can access" ON public.document_signatures;
+
+CREATE POLICY "Signers can view their signatures" ON public.document_signatures
+  FOR SELECT USING (signer_id = auth.uid());
+
+CREATE POLICY "Document creators can view signatures" ON public.document_signatures
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = document_signatures.document_id AND d.created_by = auth.uid()
+    )
+  );
+
+CREATE POLICY "Assigned tenants can view document signatures" ON public.document_signatures
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = document_signatures.document_id AND d.tenant_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Unit members can view document signatures" ON public.document_signatures
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = document_signatures.document_id
+        AND d.unit_id IS NOT NULL
+        AND d.unit_id IN (
+          SELECT unit_id
+          FROM public.profiles
+          WHERE id = auth.uid() AND unit_id IS NOT NULL
+        )
+    )
+  );
+
+-- Document access logs
+DROP POLICY IF EXISTS "Users can view access logs for documents they can access" ON public.document_access_logs;
+
+CREATE POLICY "Actors can view their document access logs" ON public.document_access_logs
+  FOR SELECT USING (user_id = auth.uid());
+
+CREATE POLICY "Document creators can view access logs" ON public.document_access_logs
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = document_access_logs.document_id AND d.created_by = auth.uid()
+    )
+  );
+
+CREATE POLICY "Assigned tenants can view access logs" ON public.document_access_logs
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = document_access_logs.document_id AND d.tenant_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Unit members can view document access logs" ON public.document_access_logs
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = document_access_logs.document_id
+        AND d.unit_id IS NOT NULL
+        AND d.unit_id IN (
+          SELECT unit_id
+          FROM public.profiles
+          WHERE id = auth.uid() AND unit_id IS NOT NULL
+        )
+    )
+  );
+
+-- Leases
+DROP POLICY IF EXISTS "Users can view leases for documents they can access" ON public.leases;
+
+CREATE POLICY "Lease access for document creator" ON public.leases
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = leases.document_id AND d.created_by = auth.uid()
+    )
+  );
+
+CREATE POLICY "Lease access for assigned tenant" ON public.leases
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = leases.document_id AND d.tenant_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Lease access for listed tenants" ON public.leases
+  FOR SELECT USING (auth.uid() = ANY(tenant_ids));
+
+CREATE POLICY "Lease access for unit members" ON public.leases
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.documents d
+      WHERE d.id = leases.document_id
+        AND d.unit_id IS NOT NULL
+        AND d.unit_id IN (
+          SELECT unit_id
+          FROM public.profiles
+          WHERE id = auth.uid() AND unit_id IS NOT NULL
+        )
+    )
+  );
+
+-- Maintenance requests
+DROP POLICY IF EXISTS "Users can view maintenance requests for their unit" ON public.maintenance_requests;
+
+CREATE POLICY "Maintenance requests visible to requester" ON public.maintenance_requests
+  FOR SELECT USING (requested_by = auth.uid());
+
+CREATE POLICY "Maintenance requests visible to unit members" ON public.maintenance_requests
+  FOR SELECT USING (
+    unit_id IS NOT NULL AND unit_id IN (
+      SELECT unit_id
+      FROM public.profiles
+      WHERE id = auth.uid() AND unit_id IS NOT NULL
+    )
+  );
+
+-- Visitor logs
+DROP POLICY IF EXISTS "Users can view visitor logs for their unit" ON public.visitor_logs;
+
+CREATE POLICY "Visitor logs visible to host" ON public.visitor_logs
+  FOR SELECT USING (host_id = auth.uid());
+
+CREATE POLICY "Visitor logs visible to unit members" ON public.visitor_logs
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles host
+      WHERE host.id = visitor_logs.host_id
+        AND host.unit_id IS NOT NULL
+        AND host.unit_id IN (
+          SELECT unit_id
+          FROM public.profiles
+          WHERE id = auth.uid() AND unit_id IS NOT NULL
+        )
+    )
+  );


### PR DESCRIPTION
## Summary
- add a migration that replaces broad OR-based document, lease, and activity policies with per-index auth.uid() predicates and adds a profiles.unit_id index
- adjust maintenance and visitor visibility policies to reuse indexed unit membership while preserving requester/host access
- document the rollout and EXPLAIN verification steps in docs/security/rls-performance.md

## Testing
- not run (Supabase migrations require remote database)

------
https://chatgpt.com/codex/tasks/task_e_68d17c7bc7b08328a4cc3341cfc251cf