### PR TITLE
Optimize hero media priority hints

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
  import type { Metadata, Viewport } from 'next'
+import { headers } from "next/headers"
 import { Inter } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/next"
@@ -109,10 +110,30 @@ interface RootLayoutProps {
 
 
 export default function RootLayout({ children }: RootLayoutProps) {
+  const requestHeaders = headers()
+  const currentPath = requestHeaders.get("next-url") ?? "/"
+  const isPrimaryRoute = currentPath === "/" || currentPath.startsWith("/?")
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const preloadTargets =
+    isPrimaryRoute && supabaseUrl
+      ? [new URL("/auth/v1/session", supabaseUrl).toString()]
+      : []
+
   return (
     <ReactQueryClientProvider>
     <html lang="en" suppressHydrationWarning>
-    <head></head>
+    <head>
+      {preloadTargets.map((href) => (
+        <link
+          key={href}
+          rel="preload"
+          as="fetch"
+          href={href}
+          crossOrigin="anonymous"
+        />
+      ))}
+    </head>
       <body className={cn(
             "min-h-screen bg-background font-sans antialiased",
             fontSans.variable

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -43,14 +43,16 @@ export default function OnboardingPage() {
         </Link>
         <div className="relative hidden h-full flex-col bg-muted p-10 text-white md:flex dark:border-r">
           <div className="absolute inset-0 bg-gradient-to-r from-gray-700 via-gray-900 to-black">
-          <Image
-          src="/images/house-portal-2.jpg"
-          width={2048}
-          height={2048}
-          alt="Roommate Collaboration"
-          style={{objectFit: "contain"}}
-          
-        />
+            <Image
+              src="/images/house-portal-2.jpg"
+              width={2048}
+              height={2048}
+              alt="Roommate Collaboration"
+              priority
+              fetchPriority="high"
+              sizes="(min-width: 1024px) 50vw, (min-width: 768px) 100vw, 100vw"
+              style={{ objectFit: "contain" }}
+            />
           </div>
           <div className="relative z-20 flex items-center text-lg font-medium">
             <svg

--- a/docs/perf/priority-hints.md
+++ b/docs/perf/priority-hints.md
@@ -1,0 +1,28 @@
+# Priority Hints Validation
+
+## Summary
+- Added a high-priority fetch hint to the onboarding hero image so the primary visual loads with LCP priority.
+- Prefetched the initial Supabase session request from the document head on the marketing route to reduce authentication latency without impacting secondary routes.
+
+## Measurement Plan
+- Run a WebPageTest "Performance" run against the production marketing URL (`/`) to capture updated LCP timings. Use the "Simple" configuration or the `/perf` API endpoint with the following script:
+  ```text
+  navigate https://{deployment-domain}/
+  ```
+- Record the resulting LCP value, filmstrip, and waterfall, comparing it with the previous baseline in this document.
+
+## Local Verification Attempt
+Because external WebPageTest runs are not possible inside this container, a Lighthouse collection was attempted as a proxy:
+
+```bash
+npx @lhci/cli collect --url=http://localhost:3000 \
+  --numberOfRuns=1 \
+  --settings.preset=desktop \
+  --start-server-command="pnpm dev"
+```
+
+The run failed with `The CHROME_PATH environment variable must be set to a Chrome/Chromium executable`, which blocks gathering local LCP telemetry. Capture a Lighthouse JSON report or rerun the WebPageTest measurement from an environment with Chrome available to populate before/after figures here.
+
+## Next Steps
+- Re-run the WebPageTest `/perf` measurement once deployed and append the resulting LCP, render start, and request waterfall screenshots in this file.
+- If Chrome is available locally, rerun the `lhci collect` command above to obtain a Lighthouse report for archival alongside the WebPageTest data.


### PR DESCRIPTION
## Summary
- elevate the onboarding hero image to high fetch priority for faster LCP paint
- add conditional Supabase session preload hints in the root layout head for the marketing route
- document the measurement plan and local constraints in docs/perf/priority-hints.md

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c76ba408328ac6e369a61461605