### PR TITLE
Add edge caching configuration for docs and help surfaces

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react"
+
+interface DocsLayoutProps {
+  children: ReactNode
+}
+
+export default function DocsLayout({ children }: DocsLayoutProps) {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-12">
+      <div className="prose prose-slate dark:prose-invert">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/app/docs/page.mdx
+++ b/app/docs/page.mdx
@@ -1,0 +1,40 @@
+export const metadata = {
+  title: "Roomsily Documentation",
+  description:
+    "Reference guides covering tenant onboarding, amenities, messaging, and administrative workflows.",
+}
+
+export const revalidate = 86400
+export const runtime = "edge"
+export const dynamic = "force-static"
+export const preferredRegion = "auto"
+
+# Roomsily product documentation
+
+Roomsily keeps co-living households running smoothly with a tight integration between payments, amenity scheduling, messaging, and visitor controls. This guide distills the most frequently referenced workflows for residents and property managers.
+
+## Quick links
+
+- **Resident portal**: Track ledgers, sign leases, and monitor amenity bookings in one place.
+- **Amenity scheduling**: Cal.com powered booking flows avoid double-booking shared resources.
+- **Messaging hub**: Supabase Realtime powers threaded conversations with polling, reactions, and moderation tools.
+- **Maintenance tickets**: Submit structured requests with attachments and follow progress inside the dashboard.
+
+## Operational guardrails
+
+Roomsily automatically enforces the guardrails defined by building managers:
+
+1. **Role-aware permissions** using Supabase RLS protect every tenant's data.
+2. **Automated reminders** highlight upcoming rent, renewals, and guest approvals.
+3. **Documenso signing** maintains a tamper-evident history of agreements and addenda.
+4. **Visitor workflows** notify the full household whenever someone stays overnight.
+
+## Support channels
+
+For additional help:
+
+- Review the [Help Center](/help) for triage guides and common fixes.
+- Contact managers through the in-app messaging feed for context-rich collaboration.
+- Reach the Roomsily support desk at `support@roomsily.com` for escalations.
+
+Caching for this documentation route is configured for a 24-hour revalidation window so content is always served from the Vercel Edge cache with `stale-while-revalidate` fallbacks.

--- a/app/help/layout.tsx
+++ b/app/help/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react"
+
+interface HelpLayoutProps {
+  children: ReactNode
+}
+
+export default function HelpLayout({ children }: HelpLayoutProps) {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-12">
+      <div className="prose prose-slate dark:prose-invert">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/app/help/page.mdx
+++ b/app/help/page.mdx
@@ -1,0 +1,43 @@
+export const metadata = {
+  title: "Roomsily Help Center",
+  description: "Self-service troubleshooting playbooks for residents, roommates, and property managers.",
+}
+
+export const revalidate = 86400
+export const runtime = "edge"
+export const dynamic = "force-static"
+export const preferredRegion = "auto"
+
+# Help Center
+
+Welcome to the Roomsily Help Center. Our goal is to unblock shared households quickly while keeping everyone aligned.
+
+## Start with status
+
+- Review the [status dashboard](/dashboard) for open maintenance tickets, pending visitor approvals, and payment holds.
+- Check the notification center for new activity or requests from roommates and property managers.
+- Confirm rent payment status inside the **Payments** tab before submitting follow-up inquiries.
+
+## Quick resolutions
+
+### Amenity bookings
+
+- Conflicts are surfaced in real time. Edit or cancel overlapping reservations from the **Schedule** view.
+- If a Supabase sync error occurs, retry the booking after refreshing—cached availability revalidates within a minute.
+
+### Messaging and announcements
+
+- Mentions trigger push notifications so the right roommates are alerted.
+- Archive resolved threads to keep the shared feed tidy.
+
+### Visitor management
+
+- Overnight visitor approvals expire automatically when departure dates pass.
+- Property managers can override or reinstate access within the **Visitors** tab.
+
+## Need more help?
+
+- Submit a support ticket by emailing `support@roomsily.com` with context, screenshots, and affected roommates.
+- Escalate urgent building issues via the property manager hotline at `+1 (415) 555-0137`.
+
+Help content is cached at the edge with a 24-hour `s-maxage` window and `stale-while-revalidate` policy so residents always receive a fast response globally.

--- a/docs/perf/edge-cache.md
+++ b/docs/perf/edge-cache.md
@@ -1,0 +1,23 @@
+# Edge cache strategy
+
+Roomsily leans on Vercel's Edge Network to ship a global, low-latency tenant experience. Public surfaces such as documentation and the help center now opt into incremental static regeneration with a 24 hour window so they are always served from the CDN.
+
+## Route configuration
+
+- `app/docs/page.mdx` and `app/help/page.mdx` export `revalidate = 86400` and run on the Edge runtime. This combination yields `Cache-Control: public, s-maxage=86400, stale-while-revalidate=86400` so the content is cached for a full day while allowing background refreshes.
+- Segment-level configuration (`runtime = "edge"`, `dynamic = "force-static"`) lives alongside the pages to guarantee static output and avoid server region fallbacks.
+- Layouts wrap the content in a lightweight prose container so the static HTML is minimal and compresses well across POPs.
+
+## CDN directives
+
+`vercel.json` now applies shared headers for `/docs`, `/help`, and legal marketing pages. The CDN serves a warm response instantly while revalidating in the background whenever stale content is requested. The home page retains a shorter one hour `s-maxage` so marketing updates land quickly while still benefiting from `stale-while-revalidate` resilience.
+
+## Observability
+
+The Playwright check in `tests/perf/edge-ttfb.spec.ts` measures time-to-first-byte for `/docs` and `/help`, enforces the cache headers, and validates the `x-vercel-id` metadata to ensure each response originates from a Vercel Edge POP and compute region. Thresholds are set to 100 ms; adjust `EDGE_TEST_REGIONS` and `EDGE_TEST_BASE_URL` env vars in CI to point at production deployments.
+
+## Operational tips
+
+- When content changes need to bypass the cache immediately, trigger a Vercel deploy or run `vercel cache purge` targeting `/docs` and `/help`.
+- If you expand the help center with dynamic data, prefer `next/headers` `cache: "force-cache"` fetches so the page remains static while the data feeds stay fresh.
+- Monitor `x-vercel-cache` values via the Playwright probe or observability tooling; frequent `MISS` responses usually indicate a misconfiguration or frequent redeploys.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@playwright/test": "^1.55.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,10 +103,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -139,13 +139,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -192,6 +192,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.55.0
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -754,6 +757,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -2812,6 +2820,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3734,6 +3747,16 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -5222,6 +5245,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
+
   '@radix-ui/number@1.0.1':
     dependencies:
       '@babel/runtime': 7.23.9
@@ -6390,16 +6417,16 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
@@ -7604,6 +7631,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8568,13 +8598,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -8596,6 +8626,7 @@ snapshots:
       '@next/swc-win32-ia32-msvc': 14.2.4
       '@next/swc-win32-x64-msvc': 14.2.4
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.55.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -8751,6 +8782,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.4.32):
     dependencies:

--- a/tests/perf/edge-ttfb.spec.ts
+++ b/tests/perf/edge-ttfb.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test"
+
+const baseUrl =
+  process.env.EDGE_TEST_BASE_URL ??
+  process.env.NEXT_PUBLIC_APP_URL ??
+  "http://localhost:3000"
+
+const regionAllowList = (process.env.EDGE_TEST_REGIONS ?? "cle1,iad1,cdg1,sin1")
+  .split(",")
+  .map((entry) => entry.trim())
+  .filter(Boolean)
+
+const targets = ["/docs", "/help"]
+
+async function measureTtfb(page: import("@playwright/test").Page) {
+  const navTiming = await page.evaluate(() => {
+    const [navigation] = performance.getEntriesByType("navigation")
+    return navigation
+      ? { responseStart: navigation.responseStart, startTime: navigation.startTime }
+      : null
+  })
+
+  if (!navTiming) {
+    throw new Error("Navigation timing data was unavailable")
+  }
+
+  return navTiming.responseStart - navTiming.startTime
+}
+
+test.describe("Vercel Edge cache", () => {
+  for (const path of targets) {
+    test(`${path} responds from the edge within 100ms TTFB`, async ({ page }) => {
+      const url = new URL(path, baseUrl)
+      const response = await page.goto(url.toString(), { waitUntil: "domcontentloaded" })
+
+      expect(response, "expected a main document response").not.toBeNull()
+
+      const headers = response!.headers()
+      const cacheControl = headers["cache-control"]
+      expect(cacheControl, "Cache-Control header missing").toBeTruthy()
+      expect(cacheControl).toContain("s-maxage=86400")
+      expect(cacheControl).toContain("stale-while-revalidate")
+
+      const xVercelId = headers["x-vercel-id"]
+      expect(xVercelId, "x-vercel-id header missing").toBeTruthy()
+
+      const idParts = xVercelId!.split("::").filter(Boolean)
+      expect(idParts.length).toBeGreaterThanOrEqual(2)
+
+      const [edgePop, computeRegion] = idParts
+      if (regionAllowList.length) {
+        expect(regionAllowList).toContain(edgePop)
+        if (computeRegion) {
+          expect(regionAllowList).toContain(computeRegion)
+        }
+      }
+
+      const cacheStatus = headers["x-vercel-cache"]
+      expect(cacheStatus ?? "HIT").toMatch(/(HIT|STALE|MISS)/)
+
+      const ttfb = await measureTtfb(page)
+      expect(ttfb).toBeGreaterThan(0)
+      expect(ttfb).toBeLessThan(100)
+    })
+  }
+})

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,40 @@
     "app/api/**/*.rs": {
       "runtime": "vercel-rust@4.0.8"
     }
-  }
+  },
+  "rewrites": [
+    { "source": "/docs", "destination": "/docs" },
+    { "source": "/help", "destination": "/help" },
+    { "source": "/docs/:path*", "destination": "/docs/:path*" },
+    { "source": "/help/:path*", "destination": "/help/:path*" }
+  ],
+  "headers": [
+    {
+      "source": "/(docs|help)(/.*)?",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, s-maxage=86400, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/(about|privacy|terms)(/.*)?",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, s-maxage=86400, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, s-maxage=3600, stale-while-revalidate=86400"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add static docs and help pages with edge revalidation config for CDN caching
- configure Vercel rewrites and cache headers so public routes honour stale-while-revalidate
- add a Playwright TTFB probe and document the edge caching approach

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d17c7f421083289accb2cbcd18ac0d