### PR TITLE
Implement cache tagging and revalidation

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/notifications"
 import { getStripe } from "@/lib/stripe"
 import type { Database, TablesInsert } from "@/lib/supabase"
+import { revalidateTables } from "@/lib/cache/tags"
 
 function createSupabaseAdminClient(): SupabaseClient<Database> | null {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -120,6 +121,7 @@ async function handleCheckoutSessionCompleted(
         }
 
         await supabase.from("rent_payments").insert(paymentData)
+        revalidateTables('rent_payments')
 
         // Send payment receipt notification if we have tenant info
         if (tenantId) {
@@ -227,6 +229,7 @@ async function handleInvoicePaymentSucceeded(
         },
       }
       await supabase.from("rent_payments").insert(subscriptionPayment)
+      revalidateTables('rent_payments')
 
       // Update subscription status if needed
       await supabase
@@ -241,6 +244,7 @@ async function handleInvoicePaymentSucceeded(
           ).toISOString(),
         })
         .eq("stripe_subscription_id", subscription.id)
+      revalidateTables('subscriptions')
     }
   } catch (error) {
     console.error("Error handling invoice payment succeeded:", error)
@@ -256,27 +260,28 @@ async function handleSubscriptionCreated(
     // This handles when a subscription is first created
     const price = subscription.items.data[0]?.price
 
-    await supabase.from("subscriptions").insert({
-      user_id:
-        subscription.metadata?.tenant_id ||
-        "00000000-0000-0000-0000-000000000000",
-      stripe_subscription_id: subscription.id,
-      stripe_customer_id: subscription.customer,
-      status: subscription.status,
-      current_period_start: new Date(
-        subscription.current_period_start * 1000
-      ).toISOString(),
-      current_period_end: new Date(
-        subscription.current_period_end * 1000
-      ).toISOString(),
-      amount: price?.unit_amount || 0, // Convert from cents
-      currency: price?.currency?.toUpperCase() || "USD",
-      interval: "month", // Default, could be determined from price
-      metadata: {
-        ...subscription.metadata,
-        price_id: price?.id,
-      },
-    })
+  await supabase.from("subscriptions").insert({
+    user_id:
+      subscription.metadata?.tenant_id ||
+      "00000000-0000-0000-0000-000000000000",
+    stripe_subscription_id: subscription.id,
+    stripe_customer_id: subscription.customer,
+    status: subscription.status,
+    current_period_start: new Date(
+      subscription.current_period_start * 1000
+    ).toISOString(),
+    current_period_end: new Date(
+      subscription.current_period_end * 1000
+    ).toISOString(),
+    amount: price?.unit_amount || 0, // Convert from cents
+    currency: price?.currency?.toUpperCase() || "USD",
+    interval: "month", // Default, could be determined from price
+    metadata: {
+      ...subscription.metadata,
+      price_id: price?.id,
+    },
+  })
+  revalidateTables('subscriptions')
   } catch (error) {
     console.error("Error handling subscription created:", error)
     throw error
@@ -288,19 +293,20 @@ async function handleSubscriptionUpdated(
   subscription: any
 ) {
   try {
-    await supabase
-      .from("subscriptions")
-      .update({
-        status: subscription.status,
-        current_period_start: new Date(
-          subscription.current_period_start * 1000
-        ).toISOString(),
-        current_period_end: new Date(
-          subscription.current_period_end * 1000
-        ).toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq("stripe_subscription_id", subscription.id)
+  await supabase
+    .from("subscriptions")
+    .update({
+      status: subscription.status,
+      current_period_start: new Date(
+        subscription.current_period_start * 1000
+      ).toISOString(),
+      current_period_end: new Date(
+        subscription.current_period_end * 1000
+      ).toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("stripe_subscription_id", subscription.id)
+  revalidateTables('subscriptions')
   } catch (error) {
     console.error("Error handling subscription updated:", error)
     throw error
@@ -312,15 +318,16 @@ async function handleSubscriptionDeleted(
   subscription: any
 ) {
   try {
-    await supabase
-      .from("subscriptions")
-      .update({
-        status: "canceled",
-        ended_at: new Date().toISOString(),
-        canceled_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq("stripe_subscription_id", subscription.id)
+  await supabase
+    .from("subscriptions")
+    .update({
+      status: "canceled",
+      ended_at: new Date().toISOString(),
+      canceled_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("stripe_subscription_id", subscription.id)
+  revalidateTables('subscriptions')
   } catch (error) {
     console.error("Error handling subscription deleted:", error)
     throw error

--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -1,10 +1,11 @@
 'use server';
 
 import { createClient } from '@/utils/supa-server-actions';
-import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
+import { withCache } from '@/lib/cache/store';
+import { CACHE_TAGS, CACHE_TTL, getTagsForTables, revalidateTables } from '@/lib/cache/tags';
 import {
   Document,
   DocumentWithLease,
@@ -74,60 +75,84 @@ export async function getDocumentsAction(
       .eq('id', user.id)
       .single();
 
-    let query = (supabase as any)
-      .from('documents')
-      .select(`
-        *,
-        lease:leases(*),
-        signatures:document_signatures(*),
-        access_logs:document_access_logs(*, profiles:signer_id(username, full_name))
-      `)
-      .order('created_at', { ascending: false });
+    const normalizedFilters = normalizeDocumentFilters(validatedFilters);
+    const cacheKey = [
+      'documents',
+      'list',
+      user.id,
+      profile?.role ?? 'user',
+      JSON.stringify(normalizedFilters),
+    ].join(':');
+    const tags = [
+      CACHE_TAGS.documents.list,
+      ...getTagsForTables('documents', 'document_signatures', 'document_access_logs', 'leases'),
+    ];
 
-    // Scope non-admin/property_manager users to their own documents or ones they need to sign
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
-      query = query.or(
-        `tenant_id.eq.${user.id},signatures.signer_id.eq.${user.id}`
-      );
-    }
+    const documents = await withCache<DocumentWithLease[]>(
+      cacheKey,
+      { ttl: CACHE_TTL.documentsList, tags },
+      async () => {
+        let query = (supabase as any)
+          .from('documents')
+          .select(`
+            *,
+            lease:leases(*),
+            signatures:document_signatures(*),
+            access_logs:document_access_logs(*, profiles:signer_id(username, full_name))
+          `)
+          .order('created_at', { ascending: false });
 
-    // Apply filters
-    if (validatedFilters.status?.length) {
-      query = query.in('status', validatedFilters.status);
-    }
-    if (validatedFilters.type?.length) {
-      query = query.in('document_type', validatedFilters.type);
-    }
-    if (validatedFilters.tenant_id) {
-      query = query.eq('tenant_id', validatedFilters.tenant_id);
-    }
-    if (validatedFilters.unit_id) {
-      query = query.eq('unit_id', validatedFilters.unit_id);
-    }
-    if (validatedFilters.date_from) {
-      query = query.gte('created_at', validatedFilters.date_from);
-    }
-    if (validatedFilters.date_to) {
-      query = query.lte('created_at', validatedFilters.date_to);
-    }
+        if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
+          query = query.or(
+            `tenant_id.eq.${user.id},signatures.signer_id.eq.${user.id}`
+          );
+        }
 
-    const { data: documents, error } = await query;
+        if (normalizedFilters.status?.length) {
+          query = query.in('status', normalizedFilters.status);
+        }
+        if (normalizedFilters.type?.length) {
+          query = query.in('document_type', normalizedFilters.type);
+        }
+        if (normalizedFilters.tenant_id) {
+          query = query.eq('tenant_id', normalizedFilters.tenant_id);
+        }
+        if (normalizedFilters.unit_id) {
+          query = query.eq('unit_id', normalizedFilters.unit_id);
+        }
+        if (normalizedFilters.date_from) {
+          query = query.gte('created_at', normalizedFilters.date_from);
+        }
+        if (normalizedFilters.date_to) {
+          query = query.lte('created_at', normalizedFilters.date_to);
+        }
 
-    if (error) {
-      console.error('Error fetching documents:', error);
-      return { success: false, error: 'Failed to fetch documents.' };
-    }
+        const { data: documentsData, error } = await query;
 
-    // Log access
-    for (const doc of documents || []) {
-      await (supabase as any).rpc('log_document_access', {
-        p_document_id: doc.id,
-        p_action: 'view',
-        p_metadata: { source: 'documents_page' }
-      });
-    }
+        if (error) {
+          console.error('Error fetching documents:', error);
+          throw new Error('Failed to fetch documents.');
+        }
 
-    return { success: true, data: documents || [] };
+        const resolvedDocuments = documentsData || [];
+
+        for (const doc of resolvedDocuments) {
+          try {
+            await (supabase as any).rpc('log_document_access', {
+              p_document_id: doc.id,
+              p_action: 'view',
+              p_metadata: { source: 'documents_page' }
+            });
+          } catch (logError) {
+            console.error('Failed to log document access:', logError);
+          }
+        }
+
+        return resolvedDocuments;
+      }
+    );
+
+    return { success: true, data: documents };
   } catch (error) {
     console.error('Unexpected error in getDocumentsAction:', error);
     return {
@@ -229,7 +254,7 @@ export async function uploadDocumentAction(
       p_metadata: { file_name: file.name, file_size: file.size }
     });
 
-    revalidatePath('/documents');
+    revalidateTables('documents', 'document_access_logs');
     return { success: true, data: document, message: 'Document uploaded successfully.' };
   } catch (error) {
     console.error('Unexpected error in uploadDocumentAction:', error);
@@ -403,7 +428,7 @@ export async function createSigningRequestAction(
       p_metadata: { envelope_id: signingResult.id, recipients: tenantEmails }
     });
 
-    revalidatePath('/documents');
+    revalidateTables('documents', 'document_signatures');
     return {
       success: true,
       data: { envelope_id: signingResult.id },
@@ -481,7 +506,7 @@ export async function signDocumentAction(
       p_metadata: signatureData
     });
 
-    revalidatePath('/documents');
+    revalidateTables('documents', 'document_signatures');
     return { success: true, message: 'Document signed successfully.' };
   } catch (error) {
     console.error('Unexpected error in signDocumentAction:', error);
@@ -563,27 +588,40 @@ export async function getDocumentStatsAction(): Promise<ActionResult<DocumentSta
       .eq('id', user.id)
       .single();
 
-    let query = supabase.from('documents').select('status');
+    const cacheKey = ['documents', 'stats', user.id, profile?.role ?? 'user'].join(':');
+    const tags = [
+      CACHE_TAGS.documents.stats,
+      ...getTagsForTables('documents', 'document_signatures', 'document_access_logs', 'leases'),
+    ];
 
-    // If not admin/property manager, filter by tenant_id
-    if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
-      query = query.eq('tenant_id', user.id);
-    }
+    const stats = await withCache<DocumentStats>(
+      cacheKey,
+      { ttl: CACHE_TTL.documentsStats, tags },
+      async () => {
+        let query = supabase.from('documents').select('status');
 
-    const { data: documents, error } = await query;
+        if (profile?.role !== 'property_manager' && profile?.role !== 'admin') {
+          query = query.eq('tenant_id', user.id);
+        }
 
-    if (error) {
-      console.error('Error fetching document stats:', error);
-      return { success: false, error: 'Failed to fetch document statistics.' };
-    }
+        const { data: documents, error } = await query;
 
-    const stats: DocumentStats = {
-      total_documents: documents?.length || 0,
-      pending_signatures: documents?.filter(d => d.status === 'pending_signature').length || 0,
-      signed_documents: documents?.filter(d => d.status === 'signed').length || 0,
-      expired_documents: documents?.filter(d => d.status === 'expired').length || 0,
-      draft_documents: documents?.filter(d => d.status === 'draft').length || 0,
-    };
+        if (error) {
+          console.error('Error fetching document stats:', error);
+          throw new Error('Failed to fetch document statistics.');
+        }
+
+        const safeDocuments = documents || [];
+
+        return {
+          total_documents: safeDocuments.length,
+          pending_signatures: safeDocuments.filter(d => d.status === 'pending_signature').length,
+          signed_documents: safeDocuments.filter(d => d.status === 'signed').length,
+          expired_documents: safeDocuments.filter(d => d.status === 'expired').length,
+          draft_documents: safeDocuments.filter(d => d.status === 'draft').length,
+        } satisfies DocumentStats;
+      }
+    );
 
     return { success: true, data: stats };
   } catch (error) {
@@ -591,6 +629,21 @@ export async function getDocumentStatsAction(): Promise<ActionResult<DocumentSta
     return {
       success: false,
       error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
+  };
+}
+
+function normalizeDocumentFilters(filters?: DocumentListFilters) {
+  if (!filters) return {} as DocumentListFilters;
+
+  const normalized: DocumentListFilters = { ...filters };
+
+  if (filters.status) {
+    normalized.status = [...filters.status].sort();
   }
+  if (filters.type) {
+    normalized.type = [...filters.type].sort();
+  }
+
+  return normalized;
+}
 }

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -17,7 +17,7 @@ import {
   getNextOutstandingCharge,
 } from "@/lib/payments/catch-up"
 import { formatCurrency } from "@/lib/payments/currency"
-import { catchUpBalances } from "@/lib/payments/mock-data"
+import { loadCatchUpBalances } from "@/lib/payments/loaders"
 import type { CatchUpBalance } from "@/types/payments"
 
 const paymentHighlights = [
@@ -43,38 +43,6 @@ const paymentHighlights = [
   },
 ]
 
-const outstandingSummaries = catchUpBalances.map((balance) => {
-  const outstanding = calculateOutstanding(balance.charges)
-  const nextCharge = getNextOutstandingCharge(balance.charges)
-  return { balance, outstanding, nextCharge }
-})
-
-const totalOutstanding = outstandingSummaries.reduce(
-  (sum, item) => sum + item.outstanding,
-  0,
-)
-
-const activeAutopays = catchUpBalances.filter(
-  (balance) => balance.autopayStatus === "active",
-).length
-const pausedAutopays = catchUpBalances.filter(
-  (balance) => balance.autopayStatus === "paused",
-).length
-const disabledAutopays = catchUpBalances.filter(
-  (balance) => balance.autopayStatus === "disabled",
-).length
-
-const autopCoveragePercentage =
-  catchUpBalances.length > 0
-    ? Math.round((activeAutopays / catchUpBalances.length) * 100)
-    : 0
-
-const defaultCurrency = catchUpBalances[0]?.currency ?? "USD"
-
-const roommateSummaries = [...outstandingSummaries].sort(
-  (a, b) => b.outstanding - a.outstanding,
-)
-
 function describeAutopayStatus(balance: CatchUpBalance) {
   const autopayDay = formatAutopayDay(balance.autopayDay)
 
@@ -94,7 +62,41 @@ function formatFullDate(date: string) {
   return format(parseISO(date), "MMM d, yyyy")
 }
 
-export default function PaymentsPage() {
+export default async function PaymentsPage() {
+  const catchUpBalances = await loadCatchUpBalances()
+
+  const outstandingSummaries = catchUpBalances.map((balance) => {
+    const outstanding = calculateOutstanding(balance.charges)
+    const nextCharge = getNextOutstandingCharge(balance.charges)
+    return { balance, outstanding, nextCharge }
+  })
+
+  const totalOutstanding = outstandingSummaries.reduce(
+    (sum, item) => sum + item.outstanding,
+    0,
+  )
+
+  const activeAutopays = catchUpBalances.filter(
+    (balance) => balance.autopayStatus === "active",
+  ).length
+  const pausedAutopays = catchUpBalances.filter(
+    (balance) => balance.autopayStatus === "paused",
+  ).length
+  const disabledAutopays = catchUpBalances.filter(
+    (balance) => balance.autopayStatus === "disabled",
+  ).length
+
+  const autopCoveragePercentage =
+    catchUpBalances.length > 0
+      ? Math.round((activeAutopays / catchUpBalances.length) * 100)
+      : 0
+
+  const defaultCurrency = catchUpBalances[0]?.currency ?? "USD"
+
+  const roommateSummaries = [...outstandingSummaries].sort(
+    (a, b) => b.outstanding - a.outstanding,
+  )
+
   return (
     <div className="container max-w-5xl space-y-10 py-12">
       <header className="space-y-4">

--- a/lib/cache/store.ts
+++ b/lib/cache/store.ts
@@ -1,0 +1,89 @@
+export interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+  tags: string[];
+}
+
+const cacheStore = new Map<string, CacheEntry<unknown>>();
+const tagIndex = new Map<string, Set<string>>();
+
+function cleanupKey(key: string, tags: string[]) {
+  cacheStore.delete(key);
+  for (const tag of tags) {
+    const keys = tagIndex.get(tag);
+    if (!keys) continue;
+    keys.delete(key);
+    if (keys.size === 0) {
+      tagIndex.delete(tag);
+    }
+  }
+}
+
+export function clearCacheStore() {
+  cacheStore.clear();
+  tagIndex.clear();
+}
+
+export function getCacheEntry<T>(key: string): T | undefined {
+  const entry = cacheStore.get(key);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    cleanupKey(key, entry.tags);
+    return undefined;
+  }
+  return entry.value as T;
+}
+
+export interface CacheOptions {
+  ttl: number;
+  tags: string[];
+}
+
+export function setCacheEntry<T>(key: string, value: T, { ttl, tags }: CacheOptions) {
+  const uniqueTags = Array.from(new Set(tags));
+  const expiresAt = Date.now() + Math.max(ttl, 0) * 1000;
+  cacheStore.set(key, { value, expiresAt, tags: uniqueTags });
+
+  for (const tag of uniqueTags) {
+    if (!tagIndex.has(tag)) {
+      tagIndex.set(tag, new Set());
+    }
+    tagIndex.get(tag)!.add(key);
+  }
+}
+
+export async function withCache<T>(
+  key: string,
+  options: CacheOptions,
+  loader: () => Promise<T>
+): Promise<T> {
+  const cached = getCacheEntry<T>(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const value = await loader();
+  setCacheEntry(key, value, options);
+  return value;
+}
+
+export function invalidateCacheByTag(tag: string) {
+  const keys = tagIndex.get(tag);
+  if (!keys) return;
+
+  for (const key of Array.from(keys)) {
+    const entry = cacheStore.get(key);
+    if (!entry) continue;
+    cleanupKey(key, entry.tags);
+  }
+}
+
+export function invalidateCacheByTags(tags: string[]) {
+  for (const tag of new Set(tags)) {
+    invalidateCacheByTag(tag);
+  }
+}
+
+export function getCacheKeys(): string[] {
+  return Array.from(cacheStore.keys());
+}

--- a/lib/cache/tags.ts
+++ b/lib/cache/tags.ts
@@ -1,0 +1,72 @@
+import { revalidateTag } from 'next/cache';
+
+import { invalidateCacheByTag, invalidateCacheByTags } from './store';
+
+export const CACHE_TAGS = {
+  documents: {
+    list: 'documents:list',
+    stats: 'documents:stats',
+    detail: (id: string) => `documents:detail:${id}`,
+  },
+  payments: {
+    list: 'payments:list',
+    summary: 'payments:summary',
+  },
+  bookings: {
+    list: 'bookings:list',
+    summary: 'bookings:summary',
+  },
+} as const;
+
+export const CACHE_TTL = {
+  documentsList: 60,
+  documentsStats: 120,
+  paymentsSummary: 90,
+  bookingsList: 45,
+} as const;
+
+type TableTagMap = Record<string, string[]>;
+
+const TABLE_TAG_MAP: TableTagMap = {
+  documents: [CACHE_TAGS.documents.list, CACHE_TAGS.documents.stats],
+  document_signatures: [CACHE_TAGS.documents.list, CACHE_TAGS.documents.stats],
+  document_access_logs: [CACHE_TAGS.documents.list],
+  leases: [CACHE_TAGS.documents.list, CACHE_TAGS.documents.stats],
+  rent_payments: [CACHE_TAGS.payments.list, CACHE_TAGS.payments.summary],
+  subscriptions: [CACHE_TAGS.payments.list, CACHE_TAGS.payments.summary],
+  bookings: [CACHE_TAGS.bookings.list, CACHE_TAGS.bookings.summary],
+  amenity_bookings: [CACHE_TAGS.bookings.list, CACHE_TAGS.bookings.summary],
+};
+
+export type SupabaseTableWithTags = keyof typeof TABLE_TAG_MAP;
+
+export function getTagsForTables(...tables: SupabaseTableWithTags[]): string[] {
+  const tags = new Set<string>();
+  for (const table of tables) {
+    const tableTags = TABLE_TAG_MAP[table] ?? [];
+    for (const tag of tableTags) {
+      tags.add(tag);
+    }
+  }
+  return Array.from(tags);
+}
+
+export function revalidateCacheTags(...tags: string[]) {
+  const uniqueTags = Array.from(new Set(tags));
+  for (const tag of uniqueTags) {
+    invalidateCacheByTag(tag);
+    revalidateTag(tag);
+  }
+}
+
+export function revalidateTables(...tables: SupabaseTableWithTags[]) {
+  const tags = getTagsForTables(...tables);
+  if (!tags.length) return;
+  revalidateCacheTags(...tags);
+}
+
+export function purgeTablesFromCache(...tables: SupabaseTableWithTags[]) {
+  const tags = getTagsForTables(...tables);
+  if (!tags.length) return;
+  invalidateCacheByTags(tags);
+}

--- a/lib/calcom-service.ts
+++ b/lib/calcom-service.ts
@@ -1,3 +1,6 @@
+import { withCache } from '@/lib/cache/store';
+import { CACHE_TAGS, CACHE_TTL, getTagsForTables, revalidateTables } from '@/lib/cache/tags';
+
 interface CalComCreateBookingRequest {
   start: string;
   end: string;
@@ -43,24 +46,36 @@ class CalComService {
       ? `${this.baseUrl}/api/v1/event-types/${userSlug}`
       : `${this.baseUrl}/api/v1/event-types`;
 
-    try {
-      const response = await fetch(endpoint, {
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
-      });
+    const cacheKey = ['calcom', 'event-types', userSlug ?? 'all'].join(':');
+    const tags = [
+      CACHE_TAGS.bookings.list,
+      ...getTagsForTables('bookings', 'amenity_bookings'),
+    ];
 
-      if (!response.ok) {
-        throw new Error(`Failed to fetch event types: ${response.statusText}`);
+    return withCache<CalComEventType[]>(
+      cacheKey,
+      { ttl: CACHE_TTL.bookingsList, tags },
+      async () => {
+        try {
+          const response = await fetch(endpoint, {
+            headers: {
+              'Authorization': `Bearer ${this.apiKey}`,
+              'Content-Type': 'application/json',
+            },
+          });
+
+          if (!response.ok) {
+            throw new Error(`Failed to fetch event types: ${response.statusText}`);
+          }
+
+          const data = await response.json();
+          return data.eventTypes || [];
+        } catch (error) {
+          console.error('Error fetching Cal.com event types:', error);
+          return [];
+        }
       }
-
-      const data = await response.json();
-      return data.eventTypes || [];
-    } catch (error) {
-      console.error('Error fetching Cal.com event types:', error);
-      return [];
-    }
+    );
   }
 
   /**
@@ -100,11 +115,14 @@ class CalComService {
 
       const data = await response.json();
 
-      return {
+      const payload: CalComBookingResponse = {
         success: true,
         bookingId: data.booking?.id?.toString(),
         bookingUrl: data.booking?.url,
       };
+
+      revalidateTables('bookings', 'amenity_bookings');
+      return payload;
     } catch (error) {
       console.error('Error creating Cal.com booking:', error);
       return {
@@ -130,7 +148,12 @@ class CalComService {
         }
       );
 
-      return response.ok;
+      const cancelled = response.ok;
+      if (cancelled) {
+        revalidateTables('bookings', 'amenity_bookings');
+      }
+
+      return cancelled;
     } catch (error) {
       console.error('Error canceling Cal.com booking:', error);
       return false;
@@ -171,31 +194,50 @@ class CalComService {
     startDate?: string,
     endDate?: string
   ): Promise<any[]> {
-    try {
-      const params = new URLSearchParams();
-      if (startDate) params.append('startDate', startDate);
-      if (endDate) params.append('endDate', endDate);
+    const params = new URLSearchParams();
+    if (startDate) params.append('startDate', startDate);
+    if (endDate) params.append('endDate', endDate);
 
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings?${params.toString()}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
+    const cacheKey = [
+      'calcom',
+      'bookings',
+      userEmail,
+      startDate ?? 'any',
+      endDate ?? 'any',
+    ].join(':');
+    const tags = [
+      CACHE_TAGS.bookings.list,
+      CACHE_TAGS.bookings.summary,
+      ...getTagsForTables('bookings', 'amenity_bookings'),
+    ];
+
+    return withCache<any[]>(
+      cacheKey,
+      { ttl: CACHE_TTL.bookingsList, tags },
+      async () => {
+        try {
+          const response = await fetch(
+            `${this.baseUrl}/api/v1/bookings?${params.toString()}`,
+            {
+              headers: {
+                'Authorization': `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json',
+              },
+            }
+          );
+
+          if (!response.ok) {
+            throw new Error(`Failed to fetch user bookings: ${response.statusText}`);
+          }
+
+          const data = await response.json();
+          return data.bookings || [];
+        } catch (error) {
+          console.error('Error fetching Cal.com user bookings:', error);
+          return [];
         }
-      );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch user bookings: ${response.statusText}`);
       }
-
-      const data = await response.json();
-      return data.bookings || [];
-    } catch (error) {
-      console.error('Error fetching Cal.com user bookings:', error);
-      return [];
-    }
+    );
   }
 }
 

--- a/lib/payments/loaders.ts
+++ b/lib/payments/loaders.ts
@@ -1,0 +1,35 @@
+import { withCache } from '@/lib/cache/store';
+import { CACHE_TAGS, CACHE_TTL, getTagsForTables } from '@/lib/cache/tags';
+import { catchUpBalances } from './mock-data';
+import type { CatchUpBalance } from '@/types/payments';
+
+const CATCH_UP_CACHE_KEY = 'payments:catch-up:balances';
+
+function cloneBalance(balance: CatchUpBalance): CatchUpBalance {
+  return {
+    ...balance,
+    charges: balance.charges.map((charge) => ({ ...charge })),
+    contacts: {
+      ...balance.contacts,
+      roommates: balance.contacts.roommates?.map((roommate) => ({ ...roommate })),
+      propertyManager: balance.contacts.propertyManager
+        ? { ...balance.contacts.propertyManager }
+        : undefined,
+      primary: { ...balance.contacts.primary },
+    },
+  };
+}
+
+export async function loadCatchUpBalances(): Promise<CatchUpBalance[]> {
+  const tags = [
+    CACHE_TAGS.payments.list,
+    CACHE_TAGS.payments.summary,
+    ...getTagsForTables('rent_payments', 'subscriptions'),
+  ];
+
+  return withCache<CatchUpBalance[]>(
+    CATCH_UP_CACHE_KEY,
+    { ttl: CACHE_TTL.paymentsSummary, tags },
+    async () => catchUpBalances.map(cloneBalance)
+  );
+}

--- a/tests/cache-tags.test.ts
+++ b/tests/cache-tags.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, afterEach, describe, expect, it, vi, type Mock } from "vitest"
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+}))
+
+import { revalidateTag } from "next/cache"
+import { withCache, clearCacheStore } from "@/lib/cache/store"
+import { CACHE_TAGS, revalidateCacheTags, revalidateTables } from "@/lib/cache/tags"
+
+const revalidateTagMock = revalidateTag as unknown as Mock
+
+describe("cache tag helpers", () => {
+  beforeEach(() => {
+    clearCacheStore()
+    vi.useFakeTimers()
+    revalidateTagMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("serves cached values until the TTL expires", async () => {
+    let loadCount = 0
+    const cacheKey = "documents:list:test-user"
+    const tags = [CACHE_TAGS.documents.list]
+
+    const loader = async () => {
+      loadCount += 1
+      return [`doc-${loadCount}`]
+    }
+
+    const first = await withCache(cacheKey, { ttl: 5, tags }, loader)
+    expect(loadCount).toBe(1)
+    expect(first).toEqual(["doc-1"])
+
+    const second = await withCache(cacheKey, { ttl: 5, tags }, loader)
+    expect(loadCount).toBe(1)
+    expect(second).toEqual(["doc-1"])
+
+    vi.advanceTimersByTime(4000)
+    const third = await withCache(cacheKey, { ttl: 5, tags }, loader)
+    expect(loadCount).toBe(1)
+    expect(third).toEqual(["doc-1"])
+
+    vi.advanceTimersByTime(2000)
+    const fourth = await withCache(cacheKey, { ttl: 5, tags }, loader)
+    expect(loadCount).toBe(2)
+    expect(fourth).toEqual(["doc-2"])
+  })
+
+  it("only invalidates caches sharing a tag", async () => {
+    let documentLoads = 0
+    let paymentLoads = 0
+
+    await withCache("documents:list:a", { ttl: 60, tags: [CACHE_TAGS.documents.list] }, async () => {
+      documentLoads += 1
+      return [`doc-${documentLoads}`]
+    })
+
+    await withCache("payments:list:a", { ttl: 60, tags: [CACHE_TAGS.payments.list] }, async () => {
+      paymentLoads += 1
+      return [`pay-${paymentLoads}`]
+    })
+
+    expect(documentLoads).toBe(1)
+    expect(paymentLoads).toBe(1)
+
+    revalidateCacheTags(CACHE_TAGS.documents.list)
+    expect(revalidateTagMock).toHaveBeenCalledWith(CACHE_TAGS.documents.list)
+
+    const freshDocs = await withCache(
+      "documents:list:a",
+      { ttl: 60, tags: [CACHE_TAGS.documents.list] },
+      async () => {
+        documentLoads += 1
+        return [`doc-${documentLoads}`]
+      },
+    )
+    expect(documentLoads).toBe(2)
+    expect(freshDocs).toEqual(["doc-2"])
+
+    const cachedPayments = await withCache(
+      "payments:list:a",
+      { ttl: 60, tags: [CACHE_TAGS.payments.list] },
+      async () => {
+        paymentLoads += 1
+        return [`pay-${paymentLoads}`]
+      },
+    )
+    expect(paymentLoads).toBe(1)
+    expect(cachedPayments).toEqual(["pay-1"])
+  })
+
+  it("revalidates every tag mapped to a Supabase table", async () => {
+    let listLoads = 0
+    let statsLoads = 0
+
+    await withCache("documents:list:user", { ttl: 60, tags: [CACHE_TAGS.documents.list] }, async () => {
+      listLoads += 1
+      return listLoads
+    })
+    await withCache("documents:stats:user", { ttl: 60, tags: [CACHE_TAGS.documents.stats] }, async () => {
+      statsLoads += 1
+      return statsLoads
+    })
+
+    revalidateTagMock.mockClear()
+    revalidateTables("document_signatures")
+
+    expect(revalidateTagMock).toHaveBeenCalledWith(CACHE_TAGS.documents.list)
+    expect(revalidateTagMock).toHaveBeenCalledWith(CACHE_TAGS.documents.stats)
+
+    await withCache("documents:list:user", { ttl: 60, tags: [CACHE_TAGS.documents.list] }, async () => {
+      listLoads += 1
+      return listLoads
+    })
+    await withCache("documents:stats:user", { ttl: 60, tags: [CACHE_TAGS.documents.stats] }, async () => {
+      statsLoads += 1
+      return statsLoads
+    })
+
+    expect(listLoads).toBe(2)
+    expect(statsLoads).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add reusable cache store utilities and tag mapping helpers for Supabase-backed data
- switch document loaders to use the tagged cache and trigger revalidation after mutations
- expose cached loaders for payments and bookings flows, including Cal.com service integrations
- ensure Stripe webhook invalidates payment-related caches and add regression tests for tag behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d17c7fe08c832881b696dd363fc8dc