### PR TITLE
Refactor notification data fetching to React Query

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,78 +1,63 @@
-"use client";
-import React, { useEffect, useState } from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
-import Link from "next/link";
-import { cn } from "@/lib/utils";
-import { usePathname } from "next/navigation";
-import { createClient } from "@/utils/supabase-browser";
+"use client"
+
+import { useMemo } from "react"
+import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+import { cn } from "@/lib/utils"
+import { useUserProfile } from "@/hooks/use-user-profile"
 
 export default function NavLinks() {
-	const pathname = usePathname();
-	const [role, setRole] = useState<string | null>(null);
+  const pathname = usePathname()
+  const { data: profile } = useUserProfile()
 
-	useEffect(() => {
-		const load = async () => {
-			try {
-				const supabase = createClient();
-				const { data: { user } } = await supabase.auth.getUser();
-				if (!user) {
-					setRole(null);
-					return;
-				}
-				const { data: profile } = await supabase
-					.from('profiles')
-					.select('role')
-					.eq('id', user.id)
-					.single();
-				setRole(profile?.role || null);
-			} catch (e) {
-				setRole(null);
-			}
-		};
-		load();
-	}, []);
+  const role = profile?.role ?? null
+  const isLandlord = useMemo(
+    () => role === "property_manager" || role === "admin" || role === "landlord",
+    [role]
+  )
 
-	const isLandlord = role === 'property_manager' || role === 'admin' || role === 'landlord';
+  const links = useMemo(
+    () =>
+      isLandlord
+        ? [
+            { href: "/dashboard/members", text: "Members", Icon: PersonIcon },
+            { href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
+            { href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
+            { href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
+          ]
+        : [
+            { href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
+            { href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
+            { href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
+            { href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
+            { href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
+          ],
+    [isLandlord]
+  )
 
-	const links = isLandlord
-		? [
-			{ href: "/dashboard/members", text: "Members", Icon: PersonIcon },
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-		]
-		: [
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-			{ href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
-			{ href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
-		];
-
-	return (
-		<div className="space-y-5">
-			{links.map((link, index) => {
-				const Icon = link.Icon;
-				return (
-					<Link
-						onClick={() =>
-							document.getElementById("sidebar-close")?.click()
-						}
-						href={link.href}
-						key={index}
-						className={cn(
-							"flex items-center gap-2 rounded-sm p-2",
-							{
-								" bg-gray-500 dark:bg-gray-700 text-white ":
-									pathname === link.href,
-							}
-						)}
-					>
-						<Icon />
-						{link.text}
-					</Link>
-				);
-			})}
-		</div>
-	);
+  return (
+    <div className="space-y-5">
+      {links.map((link, index) => {
+        const Icon = link.Icon
+        return (
+          <Link
+            onClick={() => document.getElementById("sidebar-close")?.click()}
+            href={link.href}
+            key={index}
+            className={cn(
+              "flex items-center gap-2 rounded-sm p-2",
+              {
+                " bg-gray-500 dark:bg-gray-700 text-white ": pathname === link.href,
+              }
+            )}
+          >
+            <Icon />
+            {link.text}
+          </Link>
+        )
+      })}
+    </div>
+  )
 }

--- a/app/ssrcountries/[id]/page.tsx
+++ b/app/ssrcountries/[id]/page.tsx
@@ -1,12 +1,13 @@
-import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import { createClient } from '@/utils/supa-server-actions'
 import { cookies } from 'next/headers'
 import Country from './country'
 import { getCountryById } from '@/queries/country-by-id'
+import { createServerQueryClient, dehydrateQueryClient } from '@/lib/react-query'
+import { ReactQueryHydrate } from '@/components/react-query-hydrate'
 
 export default async function CountryPage({ params }: { params: { id: number } }) {
-  const queryClient = new QueryClient()
+  const queryClient = createServerQueryClient()
   const cookieStore = cookies()
   const supabase = createClient(cookieStore)
 
@@ -15,8 +16,8 @@ export default async function CountryPage({ params }: { params: { id: number } }
   return (
     // Neat! Serialization is now as easy as passing props.
     // HydrationBoundary is a Client Component, so hydration will happen there.
-    <HydrationBoundary state={dehydrate(queryClient)}>
+    <ReactQueryHydrate state={dehydrateQueryClient(queryClient)}>
       <Country id={params.id} />
-    </HydrationBoundary>
+    </ReactQueryHydrate>
   )
 }

--- a/components/notifications/notification-center.tsx
+++ b/components/notifications/notification-center.tsx
@@ -1,177 +1,200 @@
-"use client";
+"use client"
 
-import { useState, useEffect, useCallback, useMemo } from "react";
-import { Bell, X, Check, CheckCheck } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import { useToast } from "@/components/ui/use-toast";
-import { createClient } from "@/utils/supabase-browser";
-import { cn } from "@/lib/utils";
+import { useEffect, useMemo, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { Bell, X, Check, CheckCheck } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { useToast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import { useSupabaseQuery } from "@/hooks/use-supabase-query"
+import { useCurrentUser } from "@/hooks/use-current-user"
 
 interface Notification {
-  id: string;
-  title: string;
-  message: string;
-  type: 'info' | 'success' | 'warning' | 'error';
-  action_url?: string;
-  read: boolean;
-  created_at: string;
+  id: string
+  title: string
+  message: string
+  type: "info" | "success" | "warning" | "error"
+  action_url?: string
+  read: boolean
+  created_at: string
 }
 
 export function NotificationCenter() {
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [unreadCount, setUnreadCount] = useState(0);
-  const [isOpen, setIsOpen] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const { toast } = useToast();
-  const supabase = useMemo(() => createClient(), []);
+  const [isOpen, setIsOpen] = useState(false)
+  const { toast } = useToast()
+  const supabase = useSupabaseBrowser()
+  const queryClient = useQueryClient()
+  const { data: user } = useCurrentUser()
 
-  const fetchNotifications = useCallback(async () => {
-    setLoading(true);
-    try {
+  const notificationsQueryKey = useMemo(
+    () => ["notifications", user?.id ?? null],
+    [user?.id]
+  )
+
+  const {
+    data: notifications = [],
+    isLoading,
+  } = useSupabaseQuery<Notification[]>({
+    queryKey: notificationsQueryKey,
+    enabled: Boolean(user?.id),
+    placeholderData: [],
+    queryFn: async () => {
+      if (!user?.id) return []
+
       const { data, error } = await (supabase as any)
-        .from('notifications')
-        .select('*')
-        .order('created_at', { ascending: false })
-        .limit(50);
+        .from("notifications")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false })
+        .limit(50)
 
-      if (error) throw error;
+      if (error) throw error
 
-      setNotifications(data || []);
-      setUnreadCount(data?.filter((n: any) => !n.read).length || 0);
-    } catch (error) {
-      console.error('Failed to fetch notifications:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [supabase]);
+      return (data as Notification[]) ?? []
+    },
+  })
+
+  const unreadCount = useMemo(
+    () => notifications.filter((notification) => !notification.read).length,
+    [notifications]
+  )
 
   useEffect(() => {
-    fetchNotifications();
+    if (!user?.id) return
 
-    // Subscribe to real-time notifications
-    const channel = supabase
-      .channel('notifications')
+    const channel = (supabase as any)
+      .channel(`notifications:user:${user.id}`)
       .on(
-        'postgres_changes',
+        "postgres_changes",
         {
-          event: 'INSERT',
-          schema: 'public',
-          table: 'notifications',
+          event: "INSERT",
+          schema: "public",
+          table: "notifications",
+          filter: `user_id=eq.${user.id}`,
         },
-        (payload) => {
-          const newNotification = payload.new as Notification;
-          setNotifications(prev => [newNotification, ...prev]);
-          setUnreadCount(prev => prev + 1);
+        (payload: { new: Notification }) => {
+          const newNotification = payload.new
+          queryClient.setQueryData<Notification[]>(notificationsQueryKey, (prev) => {
+            const current = prev ?? []
 
-          // Show toast for new notification
+            if (current.some((notification) => notification.id === newNotification.id)) {
+              return current
+            }
+
+            return [newNotification, ...current].slice(0, 50)
+          })
+
           toast({
             title: newNotification.title,
             description: newNotification.message,
-            variant: newNotification.type === 'error' ? 'destructive' :
-                    newNotification.type === 'warning' ? 'default' : 'default',
-          });
+            variant:
+              newNotification.type === "error"
+                ? "destructive"
+                : newNotification.type === "warning"
+                ? "default"
+                : "default",
+          })
         }
       )
-      .subscribe();
+      .subscribe()
 
     return () => {
-      supabase.removeChannel(channel);
-    };
-  }, [fetchNotifications, supabase, toast]);
+      supabase.removeChannel(channel)
+    }
+  }, [notificationsQueryKey, queryClient, supabase, toast, user?.id])
 
   const markAsRead = async (notificationId: string) => {
     try {
       const { error } = await (supabase as any)
-        .from('notifications')
+        .from("notifications")
         .update({ read: true })
-        .eq('id', notificationId);
+        .eq("id", notificationId)
 
-      if (error) throw error;
+      if (error) throw error
 
-      setNotifications(prev =>
-        prev.map(n =>
-          n.id === notificationId ? { ...n, read: true } : n
+      queryClient.setQueryData<Notification[]>(notificationsQueryKey, (prev) =>
+        (prev ?? []).map((notification) =>
+          notification.id === notificationId
+            ? { ...notification, read: true }
+            : notification
         )
-      );
-      setUnreadCount(prev => Math.max(0, prev - 1));
+      )
     } catch (error) {
-      console.error('Failed to mark notification as read:', error);
+      console.error("Failed to mark notification as read:", error)
     }
-  };
+  }
 
   const markAllAsRead = async () => {
     try {
-      const unreadIds = notifications.filter(n => !n.read).map(n => n.id);
+      const unreadIds = notifications.filter((notification) => !notification.read).map((n) => n.id)
 
-      if (unreadIds.length === 0) return;
+      if (unreadIds.length === 0) return
 
       const { error } = await (supabase as any)
-        .from('notifications')
+        .from("notifications")
         .update({ read: true })
-        .in('id', unreadIds);
+        .in("id", unreadIds)
 
-      if (error) throw error;
+      if (error) throw error
 
-      setNotifications(prev =>
-        prev.map(n => ({ ...n, read: true }))
-      );
-      setUnreadCount(0);
+      queryClient.setQueryData<Notification[]>(notificationsQueryKey, (prev) =>
+        (prev ?? []).map((notification) => ({ ...notification, read: true }))
+      )
 
       toast({
         title: "All notifications marked as read",
-      });
+      })
     } catch (error) {
-      console.error('Failed to mark all notifications as read:', error);
+      console.error("Failed to mark all notifications as read:", error)
     }
-  };
+  }
 
   const deleteNotification = async (notificationId: string) => {
     try {
       const { error } = await (supabase as any)
-        .from('notifications')
+        .from("notifications")
         .delete()
-        .eq('id', notificationId);
+        .eq("id", notificationId)
 
-      if (error) throw error;
+      if (error) throw error
 
-      const deletedNotification = notifications.find(n => n.id === notificationId);
-      setNotifications(prev => prev.filter(n => n.id !== notificationId));
-
-      if (deletedNotification && !deletedNotification.read) {
-        setUnreadCount(prev => Math.max(0, prev - 1));
-      }
+      queryClient.setQueryData<Notification[]>(notificationsQueryKey, (prev) =>
+        (prev ?? []).filter((notification) => notification.id !== notificationId)
+      )
     } catch (error) {
-      console.error('Failed to delete notification:', error);
+      console.error("Failed to delete notification:", error)
     }
-  };
+  }
 
   const getTypeColor = (type: string) => {
     switch (type) {
-      case 'success':
-        return 'border-green-200 bg-green-100 text-green-800';
-      case 'warning':
-        return 'border-yellow-200 bg-yellow-100 text-yellow-800';
-      case 'error':
-        return 'border-red-200 bg-red-100 text-red-800';
+      case "success":
+        return "border-green-200 bg-green-100 text-green-800"
+      case "warning":
+        return "border-yellow-200 bg-yellow-100 text-yellow-800"
+      case "error":
+        return "border-red-200 bg-red-100 text-red-800"
       default:
-        return 'border-blue-200 bg-blue-100 text-blue-800';
+        return "border-blue-200 bg-blue-100 text-blue-800"
     }
-  };
+  }
 
   const formatTime = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
+    const date = new Date(dateString)
+    const now = new Date()
+    const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60))
 
-    if (diffInMinutes < 1) return 'Just now';
-    if (diffInMinutes < 60) return `${diffInMinutes}m ago`;
-    if (diffInMinutes < 1440) return `${Math.floor(diffInMinutes / 60)}h ago`;
-    return date.toLocaleDateString();
-  };
+    if (diffInMinutes < 1) return "Just now"
+    if (diffInMinutes < 60) return `${diffInMinutes}m ago`
+    if (diffInMinutes < 1440) return `${Math.floor(diffInMinutes / 60)}h ago`
+    return date.toLocaleDateString()
+  }
 
   return (
     <div className="relative">
@@ -187,7 +210,7 @@ export function NotificationCenter() {
             variant="destructive"
             className="absolute -right-1 -top-1 flex size-5 items-center justify-center p-0 text-xs"
           >
-            {unreadCount > 99 ? '99+' : unreadCount}
+            {unreadCount > 99 ? "99+" : unreadCount}
           </Badge>
         )}
       </Button>
@@ -220,7 +243,7 @@ export function NotificationCenter() {
           </CardHeader>
           <CardContent className="p-0">
             <ScrollArea className="h-80">
-              {loading ? (
+              {isLoading ? (
                 <div className="p-4 text-center text-sm text-muted-foreground">
                   Loading notifications...
                 </div>
@@ -239,11 +262,11 @@ export function NotificationCenter() {
                         )}
                         onClick={() => {
                           if (!notification.read) {
-                            markAsRead(notification.id);
+                            markAsRead(notification.id)
                           }
                           if (notification.action_url) {
-                            window.location.href = notification.action_url;
-                            setIsOpen(false);
+                            window.location.href = notification.action_url
+                            setIsOpen(false)
                           }
                         }}
                       >
@@ -268,9 +291,9 @@ export function NotificationCenter() {
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  markAsRead(notification.id);
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  markAsRead(notification.id)
                                 }}
                                 className="size-6"
                               >
@@ -280,9 +303,9 @@ export function NotificationCenter() {
                             <Button
                               variant="ghost"
                               size="icon"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                deleteNotification(notification.id);
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                deleteNotification(notification.id)
                               }}
                               className="size-6 text-muted-foreground hover:text-destructive"
                             >
@@ -301,5 +324,5 @@ export function NotificationCenter() {
         </Card>
       )}
     </div>
-  );
+  )
 }

--- a/components/react-query-client-provider.tsx
+++ b/components/react-query-client-provider.tsx
@@ -1,25 +1,17 @@
 'use client'
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
+
+import { createQueryClient } from '@/lib/react-query'
 
 export const ReactQueryClientProvider = ({
   children,
 }: {
   children: React.ReactNode
 }) => {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            // With SSR, we usually want to set some default staleTime
-            // above 0 to avoid refetching immediately on the client
-            staleTime: 60 * 1000,
-          },
-        },
-      })
-  )
+  const [queryClient] = useState(createQueryClient)
+
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   )

--- a/components/react-query-hydrate.tsx
+++ b/components/react-query-hydrate.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { HydrationBoundary, type HydrationBoundaryProps } from "@tanstack/react-query"
+
+export function ReactQueryHydrate(props: HydrationBoundaryProps) {
+  return <HydrationBoundary {...props} />
+}

--- a/hooks/use-current-user.ts
+++ b/hooks/use-current-user.ts
@@ -1,0 +1,41 @@
+"use client"
+
+import { useEffect } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import type { User } from "@supabase/supabase-js"
+
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+export const currentUserQueryKey = ["auth", "current-user"] as const
+
+export function useCurrentUser() {
+  const supabase = useSupabaseBrowser()
+  const queryClient = useQueryClient()
+
+  const queryResult = useQuery<User | null>({
+    queryKey: currentUserQueryKey,
+    queryFn: async () => {
+      const { data, error } = await supabase.auth.getUser()
+      if (error) throw error
+      return data.user ?? null
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  })
+
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      queryClient.setQueryData(currentUserQueryKey, session?.user ?? null)
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [supabase, queryClient])
+
+  return queryResult
+}

--- a/hooks/use-document-permissions.ts
+++ b/hooks/use-document-permissions.ts
@@ -1,115 +1,87 @@
-'use client';
+"use client"
 
-import { useEffect, useState } from 'react';
-import { createClient } from '@/utils/supabase-browser';
-import { DocumentWithLease } from '@/types/documents';
+import { useMemo } from "react"
+
+import { useCurrentUser } from "@/hooks/use-current-user"
+import { useUserProfile } from "@/hooks/use-user-profile"
+import { DocumentWithLease } from "@/types/documents"
 
 export interface UserPermissions {
-  isTenant: boolean;
-  isRoommate: boolean;
-  isPropertyManager: boolean;
-  isAdmin: boolean;
-  canUploadDocuments: boolean;
-  canCreateSigningRequests: boolean;
-  canViewDocument: (document: DocumentWithLease) => boolean;
-  canSignDocument: (document: DocumentWithLease) => boolean;
-  canEditDocument: (document: DocumentWithLease) => boolean;
+  isTenant: boolean
+  isRoommate: boolean
+  isPropertyManager: boolean
+  isAdmin: boolean
+  canUploadDocuments: boolean
+  canCreateSigningRequests: boolean
+  canViewDocument: (document: DocumentWithLease) => boolean
+  canSignDocument: (document: DocumentWithLease) => boolean
+  canEditDocument: (document: DocumentWithLease) => boolean
+}
+
+const ANONYMOUS_PERMISSIONS: UserPermissions = {
+  isTenant: false,
+  isRoommate: false,
+  isPropertyManager: false,
+  isAdmin: false,
+  canUploadDocuments: false,
+  canCreateSigningRequests: false,
+  canViewDocument: () => false,
+  canSignDocument: () => false,
+  canEditDocument: () => false,
 }
 
 export function useDocumentPermissions(): UserPermissions {
-  const [permissions, setPermissions] = useState<UserPermissions>({
-    isTenant: false,
-    isRoommate: false,
-    isPropertyManager: false,
-    isAdmin: false,
-    canUploadDocuments: false,
-    canCreateSigningRequests: false,
-    canViewDocument: () => false,
-    canSignDocument: () => false,
-    canEditDocument: () => false,
-  });
-  const [loading, setLoading] = useState(true);
+  const { data: user } = useCurrentUser()
+  const { data: profile } = useUserProfile()
 
-  useEffect(() => {
-    const checkPermissions = async () => {
-      try {
-        const supabase = createClient();
-        const { data: { user } } = await supabase.auth.getUser();
+  return useMemo<UserPermissions>(() => {
+    const userId = user?.id
+    const role = profile?.role
 
-        if (!user) {
-          setPermissions({
-            isTenant: false,
-            isRoommate: false,
-            isPropertyManager: false,
-            isAdmin: false,
-            canUploadDocuments: false,
-            canCreateSigningRequests: false,
-            canViewDocument: () => false,
-            canSignDocument: () => false,
-            canEditDocument: () => false,
-          });
-          return;
-        }
+    if (!userId || !role) {
+      return ANONYMOUS_PERMISSIONS
+    }
 
-        // Get user profile with role
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('role')
-          .eq('id', user.id)
-          .single();
+    const isPropertyManager = role === "property_manager"
+    const isAdmin = role === "admin"
+    const isTenant = role === "tenant"
+    const isRoommate = role === "roommate"
 
-        const role = profile?.role || 'user';
-        const isPropertyManager = role === 'property_manager';
-        const isAdmin = role === 'admin';
-        const isTenant = role === 'tenant';
-        const isRoommate = role === 'roommate';
+    const canUploadDocuments = isPropertyManager || isAdmin
+    const canCreateSigningRequests = isPropertyManager || isAdmin
 
-        const userPermissions: UserPermissions = {
-          isTenant,
-          isRoommate,
-          isPropertyManager,
-          isAdmin,
-          canUploadDocuments: isPropertyManager || isAdmin,
-          canCreateSigningRequests: isPropertyManager || isAdmin,
+    const canViewDocument = (document: DocumentWithLease) => {
+      if (isPropertyManager || isAdmin) return true
+      if (document.tenant_id === userId) return true
+      if (document.lease?.tenant_ids?.includes(userId)) return true
+      return false
+    }
 
-          canViewDocument: (document: DocumentWithLease) => {
-            // Property managers and admins can view all documents
-            if (isPropertyManager || isAdmin) return true;
+    const canSignDocument = (document: DocumentWithLease) => {
+      if (!document.requires_signature) return false
 
-            // Users can view documents they're associated with
-            if (document.tenant_id === user.id) return true;
+      return (
+        document.signatures?.some(
+          (signature) => signature.signer_id === userId && signature.status === "pending"
+        ) ?? false
+      )
+    }
 
-            // For leases, check if user is a tenant on the lease
-            if (document.lease?.tenant_ids?.includes(user.id)) return true;
+    const canEditDocument = (document: DocumentWithLease) => {
+      void document
+      return isPropertyManager || isAdmin
+    }
 
-            return false;
-          },
-
-          canSignDocument: (document: DocumentWithLease) => {
-            // Check if document requires signature and has pending signatures for this user
-            if (!document.requires_signature) return false;
-
-            return document.signatures?.some(
-              sig => sig.signer_id === user.id && sig.status === 'pending'
-            ) || false;
-          },
-
-          canEditDocument: (document: DocumentWithLease) => {
-            // Only property managers and admins can edit documents
-            return isPropertyManager || isAdmin;
-          },
-        };
-
-        setPermissions(userPermissions);
-      } catch (error) {
-        console.error('Error checking document permissions:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    checkPermissions();
-  }, []);
-
-  return permissions;
+    return {
+      isTenant,
+      isRoommate,
+      isPropertyManager,
+      isAdmin,
+      canUploadDocuments,
+      canCreateSigningRequests,
+      canViewDocument,
+      canSignDocument,
+      canEditDocument,
+    }
+  }, [profile?.role, user?.id])
 }

--- a/hooks/use-supabase-query.ts
+++ b/hooks/use-supabase-query.ts
@@ -1,0 +1,73 @@
+"use client"
+
+import {
+  type QueryFunctionContext,
+  type QueryKey,
+  type UseQueryOptions,
+  type UseQueryResult,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { QUERY_DEDUPING_INTERVAL } from "@/lib/react-query"
+
+const lastFetchAt = new Map<string, number>()
+
+function hashKey(key: QueryKey) {
+  try {
+    return JSON.stringify(key)
+  } catch (error) {
+    return String(key)
+  }
+}
+
+export type SupabaseQueryOptions<TQueryFnData, TError, TData> = Omit<
+  UseQueryOptions<TQueryFnData, TError, TData, QueryKey>,
+  "queryKey" | "queryFn"
+> & {
+  queryKey: QueryKey
+  queryFn: (context: QueryFunctionContext<QueryKey>) => Promise<TQueryFnData>
+  dedupingInterval?: number
+}
+
+export function useSupabaseQuery<
+  TQueryFnData,
+  TError = Error,
+  TData = TQueryFnData
+>(
+  options: SupabaseQueryOptions<TQueryFnData, TError, TData>
+): UseQueryResult<TData, TError> {
+  const queryClient = useQueryClient()
+  const {
+    queryKey,
+    queryFn,
+    dedupingInterval = QUERY_DEDUPING_INTERVAL,
+    ...rest
+  } = options
+
+  return useQuery({
+    ...rest,
+    queryKey,
+    queryFn: async (context) => {
+      const key = hashKey(context.queryKey)
+      const now = Date.now()
+      const lastFetched = lastFetchAt.get(key)
+
+      if (
+        typeof dedupingInterval === "number" &&
+        dedupingInterval > 0 &&
+        lastFetched &&
+        now - lastFetched < dedupingInterval
+      ) {
+        const cached = queryClient.getQueryData<TQueryFnData>(context.queryKey)
+        if (cached !== undefined) {
+          return cached as TQueryFnData
+        }
+      }
+
+      const result = await queryFn(context)
+      lastFetchAt.set(key, Date.now())
+      return result
+    },
+  })
+}

--- a/hooks/use-user-profile.ts
+++ b/hooks/use-user-profile.ts
@@ -1,0 +1,39 @@
+"use client"
+
+import type { PostgrestError } from "@supabase/supabase-js"
+
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+import { useCurrentUser } from "./use-current-user"
+import { useSupabaseQuery } from "./use-supabase-query"
+
+export interface UserProfile {
+  id: string
+  full_name?: string | null
+  role?: string | null
+  unit_id?: string | null
+}
+
+export function useUserProfile() {
+  const supabase = useSupabaseBrowser()
+  const { data: user } = useCurrentUser()
+
+  return useSupabaseQuery<UserProfile | null, PostgrestError>({
+    queryKey: ["profiles", user?.id ?? null],
+    enabled: Boolean(user?.id),
+    queryFn: async () => {
+      if (!user?.id) return null
+
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("id, full_name, role, unit_id")
+        .eq("id", user.id)
+        .maybeSingle()
+
+      if (error) throw error
+
+      return (data as UserProfile | null) ?? null
+    },
+    placeholderData: null,
+  })
+}

--- a/lib/react-query.ts
+++ b/lib/react-query.ts
@@ -1,0 +1,31 @@
+import { QueryClient, type QueryClientConfig, dehydrate, type DehydratedState } from "@tanstack/react-query"
+
+export const QUERY_STALE_TIME = 2 * 60 * 1000 // 2 minutes
+export const QUERY_DEDUPING_INTERVAL = 30 * 1000 // 30 seconds
+export const QUERY_GC_TIME = 30 * 60 * 1000 // 30 minutes
+
+const queryClientConfig: QueryClientConfig = {
+  defaultOptions: {
+    queries: {
+      staleTime: QUERY_STALE_TIME,
+      gcTime: QUERY_GC_TIME,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      meta: {
+        dedupingInterval: QUERY_DEDUPING_INTERVAL,
+      },
+    },
+  },
+}
+
+export function createQueryClient() {
+  return new QueryClient(queryClientConfig)
+}
+
+export function createServerQueryClient() {
+  return createQueryClient()
+}
+
+export function dehydrateQueryClient(queryClient: QueryClient): DehydratedState {
+  return dehydrate(queryClient)
+}

--- a/tests/react-query-client.test.ts
+++ b/tests/react-query-client.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest"
+import { QueryObserver, focusManager } from "@tanstack/react-query"
+
+import { createQueryClient } from "@/lib/react-query"
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe("React Query client focus behaviour", () => {
+  it("does not refetch when window focus occurs and data is fresh", async () => {
+    const queryClient = createQueryClient()
+    const fetchSpy = vi.fn().mockResolvedValue("test-value")
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: ["focus-test"],
+      queryFn: fetchSpy,
+    })
+
+    const unsubscribe = observer.subscribe(() => {})
+    await flushMicrotasks()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    fetchSpy.mockClear()
+    focusManager.setFocused(true)
+    await flushMicrotasks()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    unsubscribe()
+    queryClient.clear()
+  })
+
+  it("dedupes rapid visibility changes triggered in quick succession", async () => {
+    const queryClient = createQueryClient()
+    const fetchSpy = vi.fn().mockResolvedValue("visibility-value")
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: ["visibility-test"],
+      queryFn: fetchSpy,
+    })
+
+    const unsubscribe = observer.subscribe(() => {})
+    await flushMicrotasks()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    fetchSpy.mockClear()
+    focusManager.setFocused(false)
+    focusManager.setFocused(true)
+    focusManager.setFocused(false)
+    focusManager.setFocused(true)
+    await flushMicrotasks()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    unsubscribe()
+    queryClient.clear()
+  })
+})


### PR DESCRIPTION
## Summary
- replace the notification center's manual Supabase polling with user-scoped React Query hooks and realtime cache updates
- add shared React Query utilities (client config, hydration wrapper, Supabase query hooks) and reuse them for nav links and document permissions
- cover the React Query focus behaviour with unit tests while keeping server hydration aligned with the new client defaults

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d17c82a3e08328addc47322cdf6c57