### PR TITLE
feat: centralize responsive image handling

### DIFF
--- a/app/account/avatar.tsx
+++ b/app/account/avatar.tsx
@@ -1,7 +1,7 @@
-'use client'
-import React, { useEffect, useState } from 'react'
-import useSupabaseBrowser from '@/utils/supabase-browser'
-import Image from 'next/image'
+"use client"
+import React, { useEffect, useState } from "react"
+import { ResponsiveImage } from "@/components/media/responsive-image"
+import useSupabaseBrowser from "@/utils/supabase-browser"
 
 export default function Avatar({
   uid,
@@ -65,13 +65,14 @@ export default function Avatar({
   return (
     <div>
       {avatarUrl ? (
-        <Image
+        <ResponsiveImage
           width={size}
           height={size}
           src={avatarUrl}
           alt="Avatar"
           className="relative flex size-10 shrink-0 overflow-hidden rounded-full"
           style={{ height: size, width: size }}
+          sizes={`${size}px`}
         />
       ) : (
         <div className="avatar no-image" style={{ height: size, width: size }} />

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,9 +1,9 @@
 import { Metadata } from "next"
-import Image from "next/image"
 import Link from "next/link"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
+import { ResponsiveImage } from "@/components/media/responsive-image"
 import AuthForm from "@/app/auth/components/AuthForm"
 import { AuthFormLegacy } from '@/app/auth-server-action/components/AuthFormLegacy'
 
@@ -16,19 +16,22 @@ export default function OnboardingPage() {
   return (
     <>
       <div className="hidden">
-        <Image
+        <ResponsiveImage
           src="/images/house-portal-1.jpg"
           width={1280}
           height={843}
           alt="Roomsily household workspace"
           className="block dark:hidden"
+          priority
+          sizes="100vw"
         />
-        <Image
+        <ResponsiveImage
           src="/images/house-portal-2.jpg"
           width={1280}
           height={843}
           alt="Roommate Collaboration"
           className="hidden"
+          sizes="100vw"
         />
       </div>
       <div className="container relative mx-auto grid h-[640px] grid-cols-1 flex-col items-center justify-center md:grid-cols-2 lg:max-w-none lg:px-0">
@@ -43,14 +46,14 @@ export default function OnboardingPage() {
         </Link>
         <div className="relative hidden h-full flex-col bg-muted p-10 text-white md:flex dark:border-r">
           <div className="absolute inset-0 bg-gradient-to-r from-gray-700 via-gray-900 to-black">
-          <Image
-          src="/images/house-portal-2.jpg"
-          width={2048}
-          height={2048}
-          alt="Roommate Collaboration"
-          style={{objectFit: "contain"}}
-          
-        />
+            <ResponsiveImage
+              src="/images/house-portal-2.jpg"
+              width={2048}
+              height={2048}
+              alt="Roommate Collaboration"
+              style={{ objectFit: "contain" }}
+              priority
+            />
           </div>
           <div className="relative z-20 flex items-center text-lg font-medium">
             <svg

--- a/components/media/constants.ts
+++ b/components/media/constants.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_BLUR_DATA_URL =
+  "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczMicgaGVpZ2h0PSczMicgdmlld0JveD0nMCAwIDMyIDMyJyBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSdub25lJz48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9J2cnIHgxPScwJyB5MT0nMCcgeDI9JzEnIHkyPScxJz48c3RvcCBvZmZzZXQ9JzAnIHN0b3AtY29sb3I9JyNlMmU4ZjAnLz48c3RvcCBvZmZzZXQ9JzEnIHN0b3AtY29sb3I9JyNjYmQ1ZjUnLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0nMzInIGhlaWdodD0nMzInIGZpbGw9J3VybCgjZyknLz48L3N2Zz4="
+
+export const RESPONSIVE_IMAGE_SIZES =
+  "(min-width: 1536px) 1400px, (min-width: 1280px) 1200px, (min-width: 1024px) 1024px, (min-width: 768px) 768px, (min-width: 640px) 640px, 100vw"

--- a/components/media/index.ts
+++ b/components/media/index.ts
@@ -1,0 +1,3 @@
+export * from "@/components/media/constants"
+export * from "@/components/media/responsive-image"
+export * from "@/components/media/mdx-image"

--- a/components/media/mdx-image.tsx
+++ b/components/media/mdx-image.tsx
@@ -1,0 +1,32 @@
+import { type ComponentPropsWithoutRef } from "react"
+
+import { cn } from "@/lib/utils"
+
+import { RESPONSIVE_IMAGE_SIZES } from "@/components/media/constants"
+import {
+  ResponsiveImage,
+  type ResponsiveImageProps,
+} from "@/components/media/responsive-image"
+
+export type MdxImageProps = ComponentPropsWithoutRef<"img"> &
+  Pick<ResponsiveImageProps, "priority" | "quality" | "sizes"> & {
+    src: ResponsiveImageProps["src"]
+    alt: string
+  }
+
+export function MdxImage({
+  className,
+  sizes = RESPONSIVE_IMAGE_SIZES,
+  ...props
+}: MdxImageProps) {
+  return (
+    <ResponsiveImage
+      className={cn(
+        "my-8 w-full rounded-lg border border-border bg-muted/30 object-cover",
+        className
+      )}
+      sizes={sizes}
+      {...props}
+    />
+  )
+}

--- a/components/media/responsive-image.tsx
+++ b/components/media/responsive-image.tsx
@@ -1,0 +1,54 @@
+import Image, { type ImageProps } from "next/image"
+import { forwardRef } from "react"
+
+import {
+  DEFAULT_BLUR_DATA_URL,
+  RESPONSIVE_IMAGE_SIZES,
+} from "@/components/media/constants"
+
+export type ResponsiveImageProps = Omit<
+  ImageProps,
+  "placeholder" | "blurDataURL" | "sizes" | "unoptimized"
+> & {
+  placeholder?: ImageProps["placeholder"]
+  blurDataURL?: ImageProps["blurDataURL"]
+  sizes?: ImageProps["sizes"]
+  unoptimized?: ImageProps["unoptimized"]
+}
+
+export const ResponsiveImage = forwardRef<HTMLImageElement, ResponsiveImageProps>(
+  (
+    {
+      alt,
+      placeholder = "blur",
+      sizes = RESPONSIVE_IMAGE_SIZES,
+      blurDataURL,
+      unoptimized,
+      ...rest
+    },
+    ref
+  ) => {
+    const shouldDisableOptimization =
+      typeof rest.src === "string" &&
+      (rest.src.startsWith("data:") || rest.src.startsWith("blob:"))
+
+    const resolvedBlurDataURL =
+      placeholder === "blur"
+        ? blurDataURL ?? DEFAULT_BLUR_DATA_URL
+        : blurDataURL
+
+    return (
+      <Image
+        ref={ref}
+        alt={alt}
+        placeholder={placeholder}
+        blurDataURL={resolvedBlurDataURL}
+        sizes={sizes}
+        unoptimized={unoptimized ?? shouldDisableOptimization}
+        {...rest}
+      />
+    )
+  }
+)
+
+ResponsiveImage.displayName = "ResponsiveImage"

--- a/docs/design/images.md
+++ b/docs/design/images.md
@@ -1,0 +1,29 @@
+# Image Authoring Guidelines
+
+These conventions help us keep media performant, accessible, and consistent with the Share House Portal design system.
+
+## Components
+
+- Always render product imagery through [`<ResponsiveImage>`](../../components/media/responsive-image.tsx). The wrapper enables blur placeholders, responsive `sizes`, and automatic fallbacks for `blob:`/`data:` URLs.
+- Supply an explicit `width` and `height` (or `fill`) along with an accurate `alt` description. This prevents layout shifts and keeps assets eligible for Next.js optimization.
+- When an image is the primary visual above the fold (e.g. hero art or dashboard hero cards), set `priority` to surface it as the Largest Contentful Paint (LCP) candidate and allow the browser to preload.
+- Prefer modern formats (AVIF or WebP) exported at source; the Next.js optimizer will honour these where available and transparently fall back to JPEG/PNG.
+- Set contextual `sizes` when an image is not full width—for example `sizes="(min-width: 768px) 50vw, 100vw"` for side-by-side layouts.
+
+## MDX Content
+
+- Plain `<img>` tags inside MDX are automatically swapped with `<MdxImage>`, so Markdown authors can continue using standard syntax while inheriting the responsive behaviour.
+- Include `width` and `height` attributes in MDX (e.g. `<img src="/images/example.jpg" alt="Amenity schedule" width={1280} height={720} />`) to preserve aspect ratio.
+- For callouts that must load quickly, add `priority` or a custom `sizes` string via JSX attributes.
+
+## Performance & LCP Expectations
+
+- Optimized responses from `/_next/image` are cached at the CDN layer for one year with immutable directives. Avoid reusing filenames for different assets so cache invalidation remains predictable.
+- Aim for an LCP below **2.5 s on mid-tier mobile** (Fast 3G) and **<1.5 s on desktop**. Keep hero imagery under ~200 KB whenever possible and serve appropriately scaled variants via the provided `sizes` presets.
+- Use lazy loading (the default behaviour) for content below the fold and reserve `priority` for a single, critical hero image per route.
+
+## Source Management
+
+- Stick to the allowlisted hosts declared in `next.config.js` for remote assets. Add new domains explicitly before using them in components or MDX content.
+- Store frequently reused imagery in `public/images/` with descriptive names; dynamic or user-generated media should remain in Supabase storage.
+- Document attribution and licensing for third-party imagery alongside the asset or within the relevant MDX section.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,7 +1,10 @@
-import type { MDXComponents } from 'mdx/types'
+import type { MDXComponents } from "mdx/types"
+
+import { MdxImage } from "@/components/media/mdx-image"
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
+    img: MdxImage,
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,23 @@
 // content security policy requirements vary from app to app head to https://nextjs.org/docs/pages/building-your-application/configuring/content-security-policy to learn how to configure nonces within middleware and or how to set policies within your next.config file
 
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
-import { NextResponse, type NextRequest } from 'next/server'
+import { createServerClient, type CookieOptions } from "@supabase/ssr"
+import { NextResponse, type NextRequest } from "next/server"
+
+const IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 
 export async function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname.startsWith("/_next/image")) {
+    const response = NextResponse.next({
+      request: {
+        headers: request.headers,
+      },
+    })
+    response.headers.set("Cache-Control", IMAGE_CACHE_CONTROL)
+    response.headers.set("CDN-Cache-Control", IMAGE_CACHE_CONTROL)
+    response.headers.set("Vercel-CDN-Cache-Control", IMAGE_CACHE_CONTROL)
+    return response
+  }
+
   let response = NextResponse.next({
     request: {
       headers: request.headers,
@@ -11,8 +25,8 @@ export async function middleware(request: NextRequest) {
   })
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+    process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "",
     {
       cookies: {
         get(name: string) {
@@ -38,7 +52,7 @@ export async function middleware(request: NextRequest) {
         remove(name: string, options: CookieOptions) {
           request.cookies.set({
             name,
-            value: '',
+            value: "",
             ...options,
           })
           response = NextResponse.next({
@@ -48,7 +62,7 @@ export async function middleware(request: NextRequest) {
           })
           response.cookies.set({
             name,
-            value: '',
+            value: "",
             ...options,
           })
         },
@@ -63,18 +77,12 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * Feel free to modify this pattern to include more paths.
-     */
+    "/_next/image(.*)",
     {
-      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      source: "/((?!api|_next/static|favicon.ico).*)",
       missing: [
-        { type: 'header', key: 'next-router-prefetch' },
-        { type: 'header', key: 'purpose', value: 'prefetch' },
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
       ],
     },
   ],

--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,12 @@
 /** @type {import('next').NextConfig} */
 
 const withPlugins = require("next-compose-plugins")
-const withMDX = require('@next/mdx')()
+const withMDX = require("@next/mdx")()
 // Temporarily disable PWA to fix build issue
 // const withPWA = require("@ducanh2912/next-pwa").default({
 //   dest: "public",
-// });
+// })
+
 const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-eval' 'unsafe-inline' *.supabase.co googleapis.com;
@@ -23,115 +24,113 @@ const ContentSecurityPolicy = `
 const securityHeaders = [
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
   {
-    key: 'Content-Security-Policy',
-    value: ContentSecurityPolicy.replace(/\n/g, ''),
+    key: "Content-Security-Policy",
+    value: ContentSecurityPolicy.replace(/\n/g, ""),
   },
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
   {
-    key: 'Referrer-Policy',
-    value: 'strict-origin-when-cross-origin',
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
   },
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
   {
-    key: 'X-Frame-Options',
-    value: 'DENY',
+    key: "X-Frame-Options",
+    value: "DENY",
   },
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
   {
-    key: 'X-Content-Type-Options',
-    value: 'nosniff',
+    key: "X-Content-Type-Options",
+    value: "nosniff",
   },
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control
   {
-    key: 'X-DNS-Prefetch-Control',
-    value: 'on',
+    key: "X-DNS-Prefetch-Control",
+    value: "on",
   },
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
   {
-    key: 'Strict-Transport-Security',
-    value: 'max-age=31536000; includeSubDomains',
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains",
   },
   {
-    key: 'X-XSS-Protection',
-    value: '1; mode=block',
+    key: "X-XSS-Protection",
+    value: "1; mode=block",
   },
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
   {
-    key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=(), payment=()',
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=()",
   },
 ]
 
+const imageDeviceSizes = [360, 640, 768, 1024, 1280, 1536]
+
 const nextConfig = {
-  webpack: config => {
-    config.externals.push('pino-pretty', 'lokijs', 'encoding')
+  webpack: (config) => {
+    config.externals.push("pino-pretty", "lokijs", "encoding")
     return config
   },
   experimental: {
     mdxRs: true,
   },
-    images : {
-      remotePatterns: [
+  images: {
+    formats: ["image/avif", "image/webp"],
+    deviceSizes: imageDeviceSizes,
+    remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'quantumone.b-cdn.net',
-        port: '',
-        pathname: '/onyx/**',
+        protocol: "https",
+        hostname: "quantumone.b-cdn.net",
+        port: "",
+        pathname: "/onyx/**",
       },
       {
-        protocol: 'https',
-        hostname: 'unpkg.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "unpkg.com",
+        port: "",
+        pathname: "/**",
       },
       {
-        protocol: 'https',
-        hostname: 'lh3.googleusercontent.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        port: "",
+        pathname: "/**",
       },
       {
-        protocol: 'https',
-        hostname: 'youtube.com',
-        port: '',
-        pathname: '/embed/HR6a2aHhY_c?si=L2O3Cf7pQ-0HHhsP',
-      },
-
-      {
-        protocol: 'https',
-        hostname: 'quantumone.b-cdn.net',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "youtube.com",
+        port: "",
+        pathname: "/embed/HR6a2aHhY_c?si=L2O3Cf7pQ-0HHhsP",
       },
       {
-        protocol: 'https',
-        hostname: 'images.unsplash.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "quantumone.b-cdn.net",
+        port: "",
+        pathname: "/**",
       },
-
       {
-
-        protocol: 'https',
-        hostname: 'api.web3modal.com',
-        port: '',
-      
+        protocol: "https",
+        hostname: "images.unsplash.com",
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "api.web3modal.com",
+        port: "",
+        pathname: "/**",
       },
     ],
   },
-   async headers() {
-      return [
-        {
-          source: '/(.*)',
-          headers: securityHeaders,
-        },
-      ]
-    },
-
-
-   pageExtensions: ['ts', 'tsx', 'mdx', 'js', 'jsx', 'rs'],
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ]
+  },
+  pageExtensions: ["ts", "tsx", "mdx", "js", "jsx", "rs"],
 }
 
 module.exports = withMDX(nextConfig)
 // module.exports = withPlugins([withPWA, withMDX], nextConfig)
-


### PR DESCRIPTION
## Summary
- add media wrappers that centralize Next.js image defaults, blur placeholders, and MDX integration
- tune image optimization defaults in next.config.js and send long-lived cache headers for /_next/image
- document authoring guidelines and update onboarding/account UIs to use the shared responsive image component

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c8726f48328a1b9ba31cf1eb215