### PR TITLE
Refactor Supabase client usage to shared singletons

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,4 +1,3 @@
-import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 
 import { Separator } from "@/components/ui/separator"
@@ -7,8 +6,7 @@ import { createClient } from "@/utils/supa-server-actions"
 import AccountForm from "./supa-account-form"
 
 export default async function SettingsAccountPage() {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)
+  const supabase = createClient()
 
   const {
     data: { user },

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/utils/supa-server-actions';
-import { cookies } from 'next/headers';
 
 
 export async function GET(req: Request) {
@@ -11,9 +10,7 @@ export async function GET(req: Request) {
   
 // Get the user from Supabase
 
-const cookieStore = cookies();
-
-const supabase = createClient(cookieStore);
+const supabase = createClient();
   
 const { data: { user }, error: userError } = await supabase.auth.getUser();
   

--- a/app/api/auth/google/route.ts
+++ b/app/api/auth/google/route.ts
@@ -11,15 +11,11 @@ from
 '@/utils/supa-server-actions'
 ; 
 
-import { cookies } from 'next/headers'
-
-import { signInWithGoogle } from '@/app/auth/actions' 
+import { signInWithGoogle } from '@/app/auth/actions'
 
 export async function GET(request: Request) {
 
-const cookieStore = cookies();
-
-const supabase = createClient(cookieStore);
+const supabase = createClient();
 
 // Register this immediately after calling createClient!
 // Because signInWithOAuth causes a redirect, you need to fetch the

--- a/app/api/sid/callback/route.tsx
+++ b/app/api/sid/callback/route.tsx
@@ -1,6 +1,5 @@
 import { createClient } from "@/utils/supa-server-actions";
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 
 export async function GET(request: Request) {
   // The `/auth/callback` route is required for the server-side auth flow implemented
@@ -10,8 +9,7 @@ export async function GET(request: Request) {
   const code = requestUrl.searchParams.get("code");
 
   if (code) {
-    const cookieStore = cookies();
-    const supabase = createClient(cookieStore);
+    const supabase = createClient();
     await supabase.auth.exchangeCodeForSession(code);
   }
 

--- a/app/auth-server-action/actions/actions.tsx
+++ b/app/auth-server-action/actions/actions.tsx
@@ -1,14 +1,12 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supa-server-actions'
 
 export async function login(formData: FormData) {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)
+  const supabase = createClient()
 
   // type-casting here for convenience
   // in practice, you should validate your inputs
@@ -28,8 +26,7 @@ export async function login(formData: FormData) {
 }
 
 export async function signup(formData: FormData) {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)
+  const supabase = createClient()
 
   // type-casting here for convenience
   // in practice, you should validate your inputs

--- a/app/contact/actions/index.tsx
+++ b/app/contact/actions/index.tsx
@@ -1,7 +1,6 @@
 "use server"
 
 import { revalidatePath } from "next/cache"
-import { cookies } from "next/headers"
 import { createClient } from "@/utils/supa-server-actions"
 
 type formData = {
@@ -11,8 +10,7 @@ type formData = {
 }
 
 export async function submitInquiry(data: formData) {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)
+  const supabase = createClient()
 
   try {
     const { error } = await supabase.from("inquiries").insert([

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import Link from 'next/link'
 import { siteConfig } from '@/config/site'
 import { Icons } from '@/components/icons'
-import { cookies } from 'next/headers'
 import { Contact } from "@/components/forms/contact";
 import { createClient } from "@/utils/supa-server-actions";
 import { redirect } from "next/navigation";
@@ -10,8 +9,7 @@ import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import { type User } from '@supabase/supabase-js'
 
 export default async function ContactPage() {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)  
+  const supabase = createClient()
 
 
   const { data, error } = await supabase.auth.getUser()

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -4,17 +4,17 @@ import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
-import { createClient } from "@/utils/supabase-browser";
+import { useSupabaseClient } from "@/utils/supabase-browser";
 
 export default function NavLinks() {
-	const pathname = usePathname();
-	const [role, setRole] = useState<string | null>(null);
+        const pathname = usePathname();
+        const [role, setRole] = useState<string | null>(null);
+        const supabase = useSupabaseClient();
 
-	useEffect(() => {
-		const load = async () => {
-			try {
-				const supabase = createClient();
-				const { data: { user } } = await supabase.auth.getUser();
+        useEffect(() => {
+                const load = async () => {
+                        try {
+                                const { data: { user } } = await supabase.auth.getUser();
 				if (!user) {
 					setRole(null);
 					return;
@@ -28,9 +28,9 @@ export default function NavLinks() {
 			} catch (e) {
 				setRole(null);
 			}
-		};
-		load();
-	}, []);
+                };
+                load();
+        }, [supabase]);
 
 	const isLandlord = role === 'property_manager' || role === 'admin' || role === 'landlord';
 

--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -2,7 +2,6 @@
 
 import { createClient } from '@/utils/supa-server-actions';
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
 import {
@@ -54,8 +53,7 @@ interface ActionResult<T = any> {
 export async function getDocumentsAction(
   filters?: DocumentListFilters
 ): Promise<ActionResult<DocumentWithLease[]>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createClient();
 
   try {
     // Check authentication
@@ -141,8 +139,7 @@ export async function getDocumentsAction(
 export async function uploadDocumentAction(
   formData: FormData
 ): Promise<ActionResult<Document>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createClient();
 
   try {
     // Check authentication
@@ -244,8 +241,7 @@ export async function uploadDocumentAction(
 export async function createSigningRequestAction(
   formData: FormData
 ): Promise<ActionResult<{ signing_url?: string; envelope_id?: string }>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createClient();
 
   try {
     // Check authentication
@@ -423,8 +419,7 @@ export async function signDocumentAction(
   documentId: string,
   signatureData?: Record<string, any>
 ): Promise<ActionResult> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createClient();
 
   try {
     // Check authentication
@@ -496,8 +491,7 @@ export async function signDocumentAction(
 export async function getSigningUrlAction(
   documentId: string
 ): Promise<ActionResult<{ signing_url: string }>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createClient();
 
   try {
     const { data: { user }, error: authError } = await supabase.auth.getUser();
@@ -546,8 +540,7 @@ export async function getSigningUrlAction(
 
 // Get document statistics
 export async function getDocumentStatsAction(): Promise<ActionResult<DocumentStats>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  const supabase = createClient();
 
   try {
     // Check authentication

--- a/app/private/page.tsx
+++ b/app/private/page.tsx
@@ -1,11 +1,9 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supa-server-actions'
 
 export default async function PrivatePage() {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)
+  const supabase = createClient()
 
   const { data, error } = await supabase.auth.getUser()
   if (error || !data?.user) {

--- a/app/schedule/actions/index.tsx
+++ b/app/schedule/actions/index.tsx
@@ -5,7 +5,6 @@ import { createGoogleCalendarEvent } from '@/lib/calendar-service';
 import { revalidatePath } from 'next/cache';
 import type { Database } from '@/lib/supabase';
 import { z } from 'zod';
-import { cookies } from 'next/headers';
 import { formatISO, isPast } from 'date-fns'; // Import formatISO here
 
 // --- Updated Zod Schema for Server Action ---
@@ -48,8 +47,7 @@ export async function scheduleMeetingAction(
   formData: FormData
 ): Promise<ActionResult> {
 
- const cookieStore = cookies();
- const supabase = createClient(cookieStore);
+ const supabase = createClient();
 
   // 1. Check Authentication
   const { data: { user }, error: authError } = await supabase.auth.getUser();

--- a/app/ssrcountries/[id]/page.tsx
+++ b/app/ssrcountries/[id]/page.tsx
@@ -1,14 +1,12 @@
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import { createClient } from '@/utils/supa-server-actions'
-import { cookies } from 'next/headers'
 import Country from './country'
 import { getCountryById } from '@/queries/country-by-id'
 
 export default async function CountryPage({ params }: { params: { id: number } }) {
   const queryClient = new QueryClient()
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)
+  const supabase = createClient()
 
   await prefetchQuery(queryClient, getCountryById(supabase, params.id))
 

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -11,7 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useNotifications } from "@/hooks/use-notifications";
-import { createClient } from "@/utils/supabase-browser";
+import { useSupabaseClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 
 const maintenanceRequestSchema = z.object({
@@ -47,7 +47,7 @@ export function MaintenanceRequestForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { notifyMaintenanceRequest } = useNotifications();
   const { toast } = useToast();
-  const supabase = createClient();
+  const supabase = useSupabaseClient();
 
   const form = useForm<MaintenanceRequestFormData>({
     resolver: zodResolver(maintenanceRequestSchema),

--- a/components/notifications/notification-center.tsx
+++ b/components/notifications/notification-center.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Bell, X, Check, CheckCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/use-toast";
-import { createClient } from "@/utils/supabase-browser";
+import { useSupabaseClient } from "@/utils/supabase-browser";
 import { cn } from "@/lib/utils";
 
 interface Notification {
@@ -27,7 +27,7 @@ export function NotificationCenter() {
   const [isOpen, setIsOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
-  const supabase = useMemo(() => createClient(), []);
+  const supabase = useSupabaseClient();
 
   const fetchNotifications = useCallback(async () => {
     setLoading(true);

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -16,7 +16,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { useNotifications } from "@/hooks/use-notifications";
-import { createClient } from "@/utils/supabase-browser";
+import { useSupabaseClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 
 const visitorBookingSchema = z.object({
@@ -40,7 +40,7 @@ export function VisitorBookingForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { notifyVisitorBooking } = useNotifications();
   const { toast } = useToast();
-  const supabase = createClient();
+  const supabase = useSupabaseClient();
 
   const form = useForm<VisitorBookingFormData>({
     resolver: zodResolver(visitorBookingSchema),

--- a/hooks/use-document-permissions.ts
+++ b/hooks/use-document-permissions.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { createClient } from '@/utils/supabase-browser';
+import { useSupabaseClient } from '@/utils/supabase-browser';
 import { DocumentWithLease } from '@/types/documents';
 
 export interface UserPermissions {
@@ -29,11 +29,11 @@ export function useDocumentPermissions(): UserPermissions {
     canEditDocument: () => false,
   });
   const [loading, setLoading] = useState(true);
+  const supabase = useSupabaseClient();
 
   useEffect(() => {
     const checkPermissions = async () => {
       try {
-        const supabase = createClient();
         const { data: { user } } = await supabase.auth.getUser();
 
         if (!user) {
@@ -109,7 +109,7 @@ export function useDocumentPermissions(): UserPermissions {
     };
 
     checkPermissions();
-  }, []);
+  }, [supabase]);
 
   return permissions;
 }

--- a/tests/supabase/singleton.test.ts
+++ b/tests/supabase/singleton.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { getSupabaseServerClient, getSupabaseServerClientTrace } from '@/utils/supabase/server'
+
+describe('supabase server client singleton', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'public-anon-key'
+
+    const globalAny = globalThis as Record<string, unknown>
+    delete globalAny.supabaseServerClient
+    delete globalAny.supabaseServerInstrumentation
+  })
+
+  it('reuses the same instance across successive calls', () => {
+    const first = getSupabaseServerClient()
+    const second = getSupabaseServerClient()
+
+    expect(second).toBe(first)
+
+    const trace = getSupabaseServerClientTrace()
+    console.log('Supabase server client trace:', trace)
+    expect(trace.initCount).toBe(1)
+    expect(trace.lastInitializedAt).toBeTypeOf('number')
+  })
+})

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,22 +1,11 @@
-import { type CookieOptions, createServerClient } from '@supabase/ssr'
-import { cookies } from 'next/headers'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
-export function createClient(cookieStore: ReturnType<typeof cookies>) {
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options })
-        },
-        remove(name: string, options: CookieOptions) {
-          cookieStore.set({ name, value: '', ...options })
-        },
-      },
-    }
-  )
+import type { Database } from '@/lib/supabase'
+
+import { getSupabaseServerClient } from './supabase/server'
+
+export function createClient(): SupabaseClient<Database> {
+  return getSupabaseServerClient()
 }
+
+export { getSupabaseServerClient }

--- a/utils/supabase-browser.ts
+++ b/utils/supabase-browser.ts
@@ -1,28 +1,86 @@
 "use client"
 
 import { createBrowserClient } from "@supabase/ssr"
-import { useMemo } from "react"
+import { createContext, useContext, useMemo, type ReactNode } from "react"
 
 import type { Database } from "@/lib/supabase"
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
 
-let client: TypedSupabaseClient
+type SupabaseBrowserInstrumentation = {
+  initCount: number
+  lastInitializedAt?: number
+}
 
-function getSupabaseBrowserClient() {
+const globalForSupabase = globalThis as unknown as {
+  supabaseBrowserClient?: TypedSupabaseClient
+  supabaseBrowserInstrumentation?: SupabaseBrowserInstrumentation
+}
+
+function getInstrumentation(): SupabaseBrowserInstrumentation {
+  if (!globalForSupabase.supabaseBrowserInstrumentation) {
+    globalForSupabase.supabaseBrowserInstrumentation = { initCount: 0 }
+  }
+
+  return globalForSupabase.supabaseBrowserInstrumentation
+}
+
+function createSupabaseBrowserClient(): TypedSupabaseClient {
+  const instrumentation = getInstrumentation()
+  instrumentation.initCount += 1
+  instrumentation.lastInitializedAt = Date.now()
+
+  if (!globalForSupabase.supabaseBrowserClient) {
+    globalForSupabase.supabaseBrowserClient = createBrowserClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+    )
+  }
+
+  return globalForSupabase.supabaseBrowserClient
+}
+
+export function getSupabaseBrowserClient(): TypedSupabaseClient {
+  if (!globalForSupabase.supabaseBrowserClient) {
+    return createSupabaseBrowserClient()
+  }
+
+  return globalForSupabase.supabaseBrowserClient
+}
+
+const SupabaseClientContext = createContext<TypedSupabaseClient | null>(null)
+
+export function SupabaseClientProvider({
+  children,
+  client,
+}: {
+  children: ReactNode
+  client?: TypedSupabaseClient
+}) {
+  const value = useMemo(() => client ?? getSupabaseBrowserClient(), [client])
+
+  return (
+    <SupabaseClientContext.Provider value={value}>
+      {children}
+    </SupabaseClientContext.Provider>
+  )
+}
+
+export function useSupabaseClient(): TypedSupabaseClient {
+  const client = useContext(SupabaseClientContext)
+
   if (client) {
     return client
   }
 
-  client = createBrowserClient<any>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
-  )
-
-  return client
+  return getSupabaseBrowserClient()
 }
 
-export default function useSupabaseBrowser() {
-  return useMemo(getSupabaseBrowserClient, [])
+export default function useSupabaseBrowser(): TypedSupabaseClient {
+  return useSupabaseClient()
+}
+
+export function getSupabaseBrowserClientTrace(): SupabaseBrowserInstrumentation {
+  return { ...getInstrumentation() }
 }
 
 // Export the createClient function for compatibility

--- a/utils/supabase/actions.ts
+++ b/utils/supabase/actions.ts
@@ -1,27 +1,11 @@
 'use server'; // Ensure this runs only on the server
 
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
 import type { Database } from '@/lib/supabase';
 
-export async function createActionClient() {
-  const cookieStore = cookies();
+import { getSupabaseServerClient } from './server';
 
-  return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string, options: CookieOptions) {
-          cookieStore.set({ name, value: '', ...options });
-        },
-      },
-    }
-  );
+export async function createActionClient(): Promise<SupabaseClient<Database>> {
+  return getSupabaseServerClient();
 }

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,19 +1,46 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 
-export function createClient() {
-  const cookieStore = cookies()
+import type { Database } from '@/lib/supabase'
 
-  return createServerClient(
+type SupabaseServerInstrumentation = {
+  initCount: number
+  lastInitializedAt?: number
+}
+
+const globalForSupabase = globalThis as unknown as {
+  supabaseServerClient?: SupabaseClient<Database>
+  supabaseServerInstrumentation?: SupabaseServerInstrumentation
+}
+
+function getInstrumentation(): SupabaseServerInstrumentation {
+  if (!globalForSupabase.supabaseServerInstrumentation) {
+    globalForSupabase.supabaseServerInstrumentation = { initCount: 0 }
+  }
+  return globalForSupabase.supabaseServerInstrumentation
+}
+
+function createSupabaseServerClient(): SupabaseClient<Database> {
+  const instrumentation = getInstrumentation()
+  instrumentation.initCount += 1
+  instrumentation.lastInitializedAt = Date.now()
+
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
         get(name: string) {
-          return cookieStore.get(name)?.value
+          try {
+            return cookies().get(name)?.value
+          } catch {
+            return undefined
+          }
         },
         set(name: string, value: string, options: CookieOptions) {
           try {
+            const cookieStore = cookies()
             cookieStore.set({ name, value, ...options })
           } catch (error) {
             // The `set` method was called from a Server Component.
@@ -23,6 +50,7 @@ export function createClient() {
         },
         remove(name: string, options: CookieOptions) {
           try {
+            const cookieStore = cookies()
             cookieStore.set({ name, value: '', ...options })
           } catch (error) {
             // The `delete` method was called from a Server Component.
@@ -34,3 +62,17 @@ export function createClient() {
     }
   )
 }
+
+export function getSupabaseServerClient(): SupabaseClient<Database> {
+  if (!globalForSupabase.supabaseServerClient) {
+    globalForSupabase.supabaseServerClient = createSupabaseServerClient()
+  }
+
+  return globalForSupabase.supabaseServerClient
+}
+
+export function getSupabaseServerClientTrace(): SupabaseServerInstrumentation {
+  return { ...getInstrumentation() }
+}
+
+export const createClient = getSupabaseServerClient


### PR DESCRIPTION
## Summary
- add a cached Supabase server client with instrumentation and expose helpers for server actions
- create a browser Supabase provider/hook and update client components to consume the shared client
- refactor server actions and forms to drop per-render createClient calls and cover the singleton behaviour with tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d17c7af07c832898fdaf555a718d36