### PR TITLE
Implement chore schedule caching and UI

### DIFF
--- a/app/chores/actions.ts
+++ b/app/chores/actions.ts
@@ -1,0 +1,127 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { z } from 'zod'
+
+import { revalidateChoreScheduleForUnit } from '@/lib/chores/schedule'
+import { createClient } from '@/utils/supa-server-actions'
+
+const upsertChoreSchema = z.object({
+  id: z.string().uuid().optional(),
+  household_id: z.string().uuid(),
+  title: z.string().min(1),
+  cadence: z.string().min(1),
+  points: z.coerce.number().int().min(0),
+  active: z.boolean().optional(),
+})
+
+const deleteChoreSchema = z.object({
+  id: z.string().uuid(),
+  household_id: z.string().uuid(),
+})
+
+type ActionResult = {
+  success: boolean
+  error?: string
+}
+
+export async function upsertChoreDefinitionAction(input: unknown): Promise<ActionResult> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return { success: false, error: 'Authentication required to manage chores.' }
+  }
+
+  const parsed = upsertChoreSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.errors.map((issue) => issue.message).join(' ')
+    return { success: false, error: message || 'Invalid chore payload provided.' }
+  }
+
+  const chore = parsed.data
+
+  let previousHouseholdId: string | null = null
+  if (chore.id) {
+    const { data: existing } = await supabase
+      .from('chores')
+      .select('household_id')
+      .eq('id', chore.id)
+      .single()
+    previousHouseholdId = existing?.household_id ?? null
+  }
+
+  const mutationPayload = {
+    title: chore.title,
+    cadence: chore.cadence,
+    points: chore.points,
+    active: chore.active ?? true,
+    household_id: chore.household_id,
+  }
+
+  const mutation = chore.id
+    ? supabase.from('chores').update(mutationPayload).eq('id', chore.id)
+    : supabase.from('chores').insert(mutationPayload)
+
+  const { error } = await mutation
+
+  if (error) {
+    console.error('Failed to upsert chore definition', error)
+    return { success: false, error: 'Unable to save chore definition. Please try again.' }
+  }
+
+  const unitIds = new Set<string>()
+  if (previousHouseholdId) {
+    unitIds.add(previousHouseholdId)
+  }
+  unitIds.add(chore.household_id)
+
+  unitIds.forEach((unitId) => revalidateChoreScheduleForUnit(unitId))
+
+  return { success: true }
+}
+
+export async function deleteChoreDefinitionAction(input: unknown): Promise<ActionResult> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return { success: false, error: 'Authentication required to manage chores.' }
+  }
+
+  const parsed = deleteChoreSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.errors.map((issue) => issue.message).join(' ')
+    return { success: false, error: message || 'Invalid chore reference provided.' }
+  }
+
+  const chore = parsed.data
+
+  const { data: existing } = await supabase
+    .from('chores')
+    .select('household_id')
+    .eq('id', chore.id)
+    .single()
+
+  const { error } = await supabase.from('chores').delete().eq('id', chore.id)
+
+  if (error) {
+    console.error('Failed to delete chore definition', error)
+    return { success: false, error: 'Unable to delete chore definition. Please try again.' }
+  }
+
+  const unitId = existing?.household_id ?? chore.household_id
+  revalidateChoreScheduleForUnit(unitId)
+
+  return { success: true }
+}

--- a/app/chores/page.tsx
+++ b/app/chores/page.tsx
@@ -1,8 +1,126 @@
-export default function ChoresPage() {
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { addDays, format, startOfWeek } from 'date-fns'
+
+import { getChoreScheduleForUnit, type ChoreOccurrence } from '@/lib/chores/schedule'
+import { createClient } from '@/utils/supa-server-actions'
+
+type OccurrenceWithDate = ChoreOccurrence & { dueDate: Date }
+
+export default async function ChoresPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth')
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('unit_id, full_name')
+    .eq('id', user.id)
+    .single()
+
+  if (profileError) {
+    console.error('Failed to load profile for chores page', profileError)
+  }
+
+  if (!profile?.unit_id) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Chores</h1>
+        <p className="text-muted-foreground">
+          We do not have a unit assignment on file yet. Once you join a unit you will see the shared chores schedule here.
+        </p>
+      </div>
+    )
+  }
+
+  const schedule = await getChoreScheduleForUnit(profile.unit_id)
+
+  const grouped = schedule.occurrences.reduce<Map<string, OccurrenceWithDate[]>>((map, occurrence) => {
+    const dueDate = new Date(occurrence.dueAt)
+    const weekStart = startOfWeek(dueDate, { weekStartsOn: 1 })
+    const key = weekStart.toISOString()
+    const current = map.get(key) ?? []
+    current.push({ ...occurrence, dueDate })
+    map.set(key, current)
+    return map
+  }, new Map())
+
+  const sortedWeeks = Array.from(grouped.entries()).sort(
+    ([a], [b]) => new Date(a).getTime() - new Date(b).getTime()
+  )
+
+  const rangeStart = new Date(schedule.rangeStart)
+  const rangeEnd = new Date(schedule.rangeEnd)
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Chores</h1>
-      <p className="text-muted-foreground">Shared chore assignments and schedule will appear here.</p>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">Chores</h1>
+        <p className="text-muted-foreground">
+          Upcoming shared chores for the next eight weeks. Assignments update automatically as definitions change.
+        </p>
+        <div className="rounded-lg border bg-muted/40 px-4 py-3">
+          <p className="text-sm text-muted-foreground">
+            Showing chores from <span className="font-medium text-foreground">{format(rangeStart, 'MMM d')}</span> to{' '}
+            <span className="font-medium text-foreground">{format(rangeEnd, 'MMM d')}</span>.{` `}
+            {schedule.occurrences.length > 0
+              ? `${schedule.occurrences.length} assignment${schedule.occurrences.length === 1 ? '' : 's'} queued.`
+              : 'No assignments detected in this window.'}
+          </p>
+          <p className="text-xs text-muted-foreground">Cached at {format(new Date(schedule.generatedAt), 'MMM d, h:mm a')}.</p>
+        </div>
+      </div>
+
+      {sortedWeeks.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No chores are scheduled for this unit in the next eight weeks. Add or enable chores to populate the rotation.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {sortedWeeks.map(([weekKey, occurrences]) => {
+            const weekStart = new Date(weekKey)
+            const weekEnd = addDays(weekStart, 6)
+            const weeklyPoints = occurrences.reduce((total, occ) => total + occ.points, 0)
+
+            const sortedOccurrences = [...occurrences].sort(
+              (a, b) => a.dueDate.getTime() - b.dueDate.getTime()
+            )
+
+            return (
+              <section key={weekKey} className="overflow-hidden rounded-lg border bg-card">
+                <div className="border-b bg-muted/30 px-4 py-3">
+                  <h2 className="text-lg font-semibold">
+                    Week of {format(weekStart, 'MMM d')} – {format(weekEnd, 'MMM d')}
+                  </h2>
+                  <p className="text-sm text-muted-foreground">
+                    {sortedOccurrences.length} chore{sortedOccurrences.length === 1 ? '' : 's'} • {weeklyPoints} points
+                  </p>
+                </div>
+                <ul className="divide-y">
+                  {sortedOccurrences.map((occurrence) => (
+                    <li key={occurrence.id} className="flex items-center justify-between px-4 py-3">
+                      <div className="space-y-1">
+                        <p className="font-medium leading-none">{occurrence.title}</p>
+                        <p className="text-sm text-muted-foreground">
+                          Due {format(occurrence.dueDate, 'EEEE, MMM d')}
+                        </p>
+                      </div>
+                      <div className="text-sm font-medium text-muted-foreground">{occurrence.points} pts</div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/docs/perf/chores.md
+++ b/docs/perf/chores.md
@@ -1,0 +1,60 @@
+# Chore Schedule Expansion & Caching
+
+This document explains how household chores are expanded from their RRULE definitions and cached for fast rendering in the UI.
+
+## Overview
+
+- Chore definitions live in the `public.chores` table (one row per recurring task).
+- The server routine located at `lib/chores/schedule.ts` expands each chore's RRULE into concrete occurrences covering the next eight weeks.
+- Expanded results are cached per unit/household with [`unstable_cache`](https://nextjs.org/docs/app/api-reference/functions/unstable_cache) to avoid recomputing schedules on every request.
+- The chores page (`app/chores/page.tsx`) consumes the pre-expanded schedule so the UI renders instantly without client-side hydration delays.
+
+## Expansion Flow
+
+1. `getChoreScheduleForUnit(unitId)` resolves a Supabase admin client (service role if available, otherwise anon key).
+2. All active chores scoped to the given `household_id` are fetched.
+3. Each chore's cadence is interpreted as either:
+   - A literal RRULE string (optional `DTSTART` supported), or
+   - A shorthand cadence (`daily`, `weekly`, `biweekly`, `monthly`, `one_time`).
+4. RRULEs are expanded using the [`rrule`](https://github.com/jakubroztocil/rrule) package across a fixed window: _start of today → start of day eight weeks out_.
+5. Occurrences are sorted chronologically and wrapped with metadata (points, title, cadence, canonical RRULE).
+
+### Cache Envelope
+
+Each cache entry serialises the following payload:
+
+| Field | Description |
+| --- | --- |
+| `unitId` | The unit/household identifier used for expansion. |
+| `rangeStart` / `rangeEnd` | ISO timestamps delimiting the eight-week window. |
+| `generatedAt` | ISO timestamp of when the cache entry was produced. |
+| `occurrences[]` | List of chore occurrences (id, dueAt, points, RRULE, etc.). |
+
+The cache is memoised for one hour (`revalidate: 3600`) to balance freshness with compute cost. Tags are attached so specific units can be invalidated without flushing the global cache.
+
+## Cache Keys & Tags
+
+| Type | Format |
+| --- | --- |
+| Base key | `['chore-schedule', unitId]` |
+| Global tag | `chore-schedule:all` |
+| Unit tag | `chore-schedule:unit:<unitId>` |
+
+These values live in `lib/chores/schedule.ts`. All cache operations should reuse the constants exported from that module rather than hard-coding strings elsewhere.
+
+## Invalidation Hooks
+
+Two helpers are exported for mutation flows:
+
+- `revalidateChoreScheduleForUnit(unitId)` revalidates a single unit cache.
+- `revalidateAllChoreSchedules()` clears every cached schedule.
+
+Server actions under `app/chores/actions.ts` call these hooks after mutating chore definitions. The upsert action also revalidates the original unit when a chore is moved between households to avoid stale data in the source cache.
+
+When wiring new chore management surfaces, call the relevant helper immediately after persisting changes to guarantee the schedule shown to tenants reflects the latest definition.
+
+## Operational Notes
+
+- Missing `SUPABASE_SERVICE_ROLE_KEY` falls back to the anon key, so ensure RLS policies allow read access for chores when relying on this mode.
+- Expansion assumes RRULEs reference UTC timestamps. Non-UTC inputs are parsed but should be avoided to prevent timezone drift in the UI.
+- The eight-week window is intentionally fixed; long-range projections should call the expansion routine directly with a wider horizon (future enhancement).

--- a/lib/chores/schedule.ts
+++ b/lib/chores/schedule.ts
@@ -1,0 +1,230 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { addWeeks, startOfDay } from 'date-fns'
+import { revalidateTag, unstable_cache } from 'next/cache'
+import { RRule } from 'rrule'
+
+import type { Database } from '@/lib/supabase'
+
+const CHORE_SCHEDULE_GLOBAL_TAG = 'chore-schedule:all'
+const CHORE_SCHEDULE_UNIT_PREFIX = 'chore-schedule:unit:'
+const CHORE_SCHEDULE_REVALIDATE_SECONDS = 60 * 60 // 1 hour cache TTL
+
+type RawChore = Database['public']['Tables']['chores']['Row'] & {
+  rrule?: string | null
+  start_date?: string | null
+}
+
+export interface ChoreOccurrence {
+  id: string
+  choreId: string
+  title: string
+  cadence: string
+  dueAt: string
+  points: number
+  rrule: string
+}
+
+export interface ChoreSchedule {
+  unitId: string
+  rangeStart: string
+  rangeEnd: string
+  generatedAt: string
+  occurrences: ChoreOccurrence[]
+}
+
+let cachedAdminClient: SupabaseClient<Database> | null = null
+
+function getSupabaseAdminClient(): SupabaseClient<Database> {
+  if (cachedAdminClient) {
+    return cachedAdminClient
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL must be configured to fetch chore schedules.')
+  }
+
+  if (!serviceRoleKey && !anonKey) {
+    throw new Error('Either SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY must be configured to fetch chore schedules.')
+  }
+
+  const keyToUse = serviceRoleKey ?? anonKey!
+
+  cachedAdminClient = createClient<Database>(supabaseUrl, keyToUse, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+
+  return cachedAdminClient
+}
+
+function parseRuleSegments(source: string) {
+  const segments = source
+    .split(/\s*(?:\r\n|\n|\r)\s*/)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+
+  let ruleBody = ''
+  let dtstart: Date | null = null
+
+  for (const segment of segments) {
+    if (/^DTSTART/i.test(segment)) {
+      const value = segment.split(':')[1]
+      const parsed = value ? parseRRuleDate(value) : null
+      if (parsed) {
+        dtstart = parsed
+      }
+    } else if (/^RRULE:/i.test(segment)) {
+      ruleBody = segment.replace(/^RRULE:/i, '')
+    } else if (segment.includes('=')) {
+      // Handle bare RRULE content without prefix
+      ruleBody = segment
+    }
+  }
+
+  if (!ruleBody && segments.length === 1) {
+    ruleBody = segments[0]
+  }
+
+  return { ruleBody, dtstart }
+}
+
+function parseRRuleDate(value: string) {
+  const trimmed = value.trim()
+  const normalized = normalizeDateValue(trimmed)
+  const parsed = new Date(normalized)
+  if (!Number.isNaN(parsed.valueOf())) {
+    return parsed
+  }
+  return null
+}
+
+function normalizeDateValue(value: string) {
+  if (/^\d{8}T\d{6}Z?$/.test(value)) {
+    const year = value.slice(0, 4)
+    const month = value.slice(4, 6)
+    const day = value.slice(6, 8)
+    const hour = value.slice(9, 11)
+    const minute = value.slice(11, 13)
+    const second = value.slice(13, 15)
+    const zone = value.endsWith('Z') ? 'Z' : ''
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}${zone}`
+  }
+
+  if (/^\d{8}$/.test(value)) {
+    const year = value.slice(0, 4)
+    const month = value.slice(4, 6)
+    const day = value.slice(6, 8)
+    return `${year}-${month}-${day}`
+  }
+
+  return value
+}
+
+function resolveChoreRule(raw: RawChore, rangeStart: Date) {
+  const cadence = raw.rrule ?? raw.cadence ?? ''
+  const sanitized = cadence.trim()
+
+  if (!sanitized) {
+    return new RRule({ freq: RRule.WEEKLY, dtstart: rangeStart })
+  }
+
+  const { ruleBody, dtstart } = parseRuleSegments(sanitized)
+  const resolvedStart = raw.start_date
+    ? new Date(raw.start_date)
+    : dtstart ?? rangeStart
+
+  if (/FREQ=/i.test(ruleBody)) {
+    const parsed = RRule.parseString(ruleBody)
+    return new RRule({ ...parsed, dtstart: parsed.dtstart ?? resolvedStart })
+  }
+
+  switch (sanitized.toLowerCase()) {
+    case 'daily':
+      return new RRule({ freq: RRule.DAILY, dtstart: resolvedStart })
+    case 'biweekly':
+      return new RRule({ freq: RRule.WEEKLY, interval: 2, dtstart: resolvedStart })
+    case 'monthly':
+      return new RRule({ freq: RRule.MONTHLY, dtstart: resolvedStart })
+    case 'one_time':
+      return new RRule({ freq: RRule.DAILY, count: 1, dtstart: resolvedStart })
+    case 'weekly':
+    default:
+      return new RRule({ freq: RRule.WEEKLY, dtstart: resolvedStart })
+  }
+}
+
+function mapOccurrence(chore: RawChore, occurrence: Date, rule: RRule): ChoreOccurrence {
+  const isoDue = occurrence.toISOString()
+
+  return {
+    id: `${chore.id}:${isoDue}`,
+    choreId: chore.id,
+    title: chore.title,
+    cadence: chore.cadence,
+    dueAt: isoDue,
+    points: chore.points,
+    rrule: rule.toString(),
+  }
+}
+
+async function fetchAndExpandChores(unitId: string): Promise<ChoreSchedule> {
+  const supabase = getSupabaseAdminClient()
+  const rangeStart = startOfDay(new Date())
+  const rangeEnd = addWeeks(rangeStart, 8)
+
+  const { data, error } = await supabase
+    .from('chores')
+    .select('id,title,cadence,points,active,household_id')
+    .eq('household_id', unitId)
+
+  if (error) {
+    throw new Error(`Failed to load chores for unit ${unitId}: ${error.message}`)
+  }
+
+  const activeChores = (data as RawChore[] | null)?.filter((chore) => chore.active) ?? []
+
+  const occurrences = activeChores.flatMap((chore) => {
+    const rule = resolveChoreRule(chore, rangeStart)
+    const expanded = rule.between(rangeStart, rangeEnd, true)
+    return expanded.map((occurrence) => mapOccurrence(chore, occurrence, rule))
+  })
+
+  occurrences.sort((a, b) => new Date(a.dueAt).getTime() - new Date(b.dueAt).getTime())
+
+  return {
+    unitId,
+    rangeStart: rangeStart.toISOString(),
+    rangeEnd: rangeEnd.toISOString(),
+    generatedAt: new Date().toISOString(),
+    occurrences,
+  }
+}
+
+function createUnitCache(unitId: string) {
+  return unstable_cache(
+    () => fetchAndExpandChores(unitId),
+    ['chore-schedule', unitId],
+    {
+      revalidate: CHORE_SCHEDULE_REVALIDATE_SECONDS,
+      tags: [CHORE_SCHEDULE_GLOBAL_TAG, `${CHORE_SCHEDULE_UNIT_PREFIX}${unitId}`],
+    }
+  )
+}
+
+export async function getChoreScheduleForUnit(unitId: string) {
+  return createUnitCache(unitId)()
+}
+
+export function revalidateChoreScheduleForUnit(unitId: string) {
+  revalidateTag(`${CHORE_SCHEDULE_UNIT_PREFIX}${unitId}`)
+}
+
+export function revalidateAllChoreSchedules() {
+  revalidateTag(CHORE_SCHEDULE_GLOBAL_TAG)
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-hook-form": "^7.49.3",
     "react-icons": "^5.0.1",
     "resend": "^4.8.0",
+    "rrule": "^2.8.1",
     "sharp": "^0.32.6",
     "sonner": "^1.5.0",
     "stripe": "16.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       resend:
         specifier: ^4.8.0
         version: 4.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      rrule:
+        specifier: ^2.8.1
+        version: 2.8.1
       sharp:
         specifier: ^0.32.6
         version: 0.32.6
@@ -4000,6 +4003,9 @@ packages:
     resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrule@2.8.1:
+    resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -9060,6 +9066,10 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.52.0
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
+
+  rrule@2.8.1:
+    dependencies:
+      tslib: 2.6.2
 
   run-parallel@1.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- expand chore RRULEs on the server with per-unit caching and invalidation helpers
- expose server actions that call the cache revalidation hooks after chore mutations
- render the chores page from the pre-expanded schedule and document the caching model

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d17c64a2148328a28a6f64b73fb7e9