### PR TITLE
Add Lighthouse CI workflow and Supabase web vitals instrumentation

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,70 @@
+name: Lighthouse CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/lighthouse-ci.yml'
+      - 'app/**'
+      - 'components/**'
+      - 'public/**'
+      - 'lighthouserc.json'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+
+jobs:
+  audit:
+    name: Run Lighthouse CI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build application
+        run: pnpm build
+
+      - name: Pull Vercel environment information
+        run: pnpm dlx vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
+
+      - name: Create Vercel build
+        run: pnpm dlx vercel build --token "$VERCEL_TOKEN"
+
+      - name: Deploy preview build
+        id: vercel-deploy
+        run: |
+          preview_url=$(pnpm dlx vercel deploy --prebuilt --token "$VERCEL_TOKEN" --yes)
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+
+      - name: Run Lighthouse CI
+        env:
+          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }}
+          LHCI_BUILD_CONTEXT__COMMIT_TIME: ${{ github.event.head_commit.timestamp || github.event.pull_request.head.repo.pushed_at || '' }}
+          LHCI_BUILD_CONTEXT__EXTERNAL_BUILD_URL: ${{ steps.vercel-deploy.outputs.preview_url }}
+        run: pnpm dlx @lhci/cli autorun
+
+      - name: Upload Lighthouse HTML reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-html-reports
+          path: .lighthouseci/*.html
+          if-no-files-found: warn

--- a/app/api/vitals/route.ts
+++ b/app/api/vitals/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import { z } from "zod"
+
+import type { Database, TablesInsert, Json } from "@/lib/supabase"
+
+const ratingEnum = z.enum(["good", "needs-improvement", "poor"])
+
+const metadataSchema: z.ZodType<Record<string, unknown>> = z
+  .record(z.any())
+  .optional()
+
+const vitalsSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  value: z.number(),
+  delta: z.number().optional(),
+  rating: ratingEnum,
+  label: z.string().optional(),
+  eventName: z.string().optional(),
+  navigationType: z.string().optional(),
+  url: z.string().url(),
+  route: z.string().min(1),
+  metadata: metadataSchema,
+  timestamp: z.number().optional(),
+})
+
+function createSupabaseAdminClient(): SupabaseClient<Database> | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceRoleKey) {
+    console.error("Supabase credentials missing for vitals ingestion")
+    return null
+  }
+
+  return createClient<Database>(url, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  })
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null)
+
+  const parsed = vitalsSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Invalid vitals payload",
+        issues: parsed.error.flatten(),
+      },
+      { status: 400 }
+    )
+  }
+
+  const supabase = createSupabaseAdminClient()
+  if (!supabase) {
+    return NextResponse.json(
+      { success: false, error: "Supabase is not configured" },
+      { status: 500 }
+    )
+  }
+
+  const data = parsed.data
+  const recordedAt = data.timestamp
+    ? new Date(data.timestamp).toISOString()
+    : new Date().toISOString()
+
+  const metadata = (data.metadata ?? null) as Json | null
+
+  const metric: TablesInsert<'web_vitals'> = {
+    metric_id: data.id,
+    name: data.name,
+    value: data.value,
+    delta: data.delta ?? null,
+    rating: data.rating,
+    label: data.label ?? null,
+    event_name: data.eventName ?? null,
+    navigation_type: data.navigationType ?? null,
+    url: data.url,
+    route: data.route,
+    metadata,
+    recorded_at: recordedAt,
+  }
+
+  const { error } = await supabase.from('web_vitals').insert(metric)
+
+  if (error) {
+    console.error("Failed to record web vitals", error)
+    return NextResponse.json(
+      { success: false, error: "Unable to store vitals" },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
- import type { Metadata, Viewport } from 'next'
+import type { Metadata, Viewport } from 'next'
+import type { NextWebVitalsMetric } from 'next/app'
 import { Inter } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/next"
@@ -13,6 +14,7 @@ import { SiteHeader } from "@/components/site-header"
 import { SiteFooter } from "@/components/site-footer"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { cn } from "@/lib/utils"
+import { sendToAnalytics } from "@/utils/metrics/web-vitals"
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
@@ -148,4 +150,8 @@ enter your api info from termly.io or a provider of your choice
     </html>
     </ReactQueryClientProvider>
   )
+}
+
+export function reportWebVitals(metric: NextWebVitalsMetric) {
+  sendToAnalytics(metric)
 }

--- a/docs/perf/web-vitals.md
+++ b/docs/perf/web-vitals.md
@@ -1,0 +1,46 @@
+# Web Vitals Collection & Dashboard
+
+This project records Core Web Vitals in Supabase so the product and platform teams can monitor performance trends across critical tenant journeys.
+
+## How the pipeline works
+
+1. The Next.js runtime exports `reportWebVitals` from `app/layout.tsx`.
+2. Browser metrics are normalised in `utils/metrics/web-vitals.ts` and sent to `/api/vitals`.
+3. The API route validates each payload with Zod and persists the record in the `web_vitals` table using the Supabase service role key.
+
+Each record captures the metric id, score, rating, navigation context, and route metadata (path segments, search parameters, connection information, etc.).
+
+## Viewing the Supabase dashboard
+
+1. Sign in to [Supabase Studio](https://app.supabase.com) using the credentials for this project.
+2. Select the **Share House Portal** project, then open **Data → Tables** and choose `web_vitals` to inspect raw events.
+3. Navigate to **Data → Saved queries** and create a new query named `web_vitals_dashboard` with the SQL below:
+
+   ```sql
+   select
+     route,
+     name as metric,
+     rating,
+     percentile_cont(0.75) within group (order by value) as p75_value,
+     avg(value) as average_value,
+     count(*) as samples,
+     max(recorded_at) as last_recorded_at
+   from web_vitals
+   group by route, metric, rating
+   order by route, metric;
+   ```
+
+4. Save the query, then click **Visualize** to open the Supabase charts builder.
+5. Configure a bar or line chart using:
+   - **X axis:** `route`
+   - **Series:** `metric`
+   - **Values:** `p75_value`
+   - **Filter (optional):** `rating = 'poor'` to focus on regressions
+6. Pin the chart to a dashboard named `Web Vitals` so it is easy to access from **Reports → Dashboards**.
+7. Share the dashboard URL with stakeholders or subscribe to weekly email summaries directly in Supabase.
+
+## Troubleshooting tips
+
+- Ensure `SUPABASE_SERVICE_ROLE_KEY` is configured in the deployment environment; without it the API route will return a 500 error.
+- If no data appears, confirm that the Lighthouse CI workflow ran successfully and the client bundles were built in production mode so `reportWebVitals` executes.
+- Use Supabase's row-level security (RLS) policies to restrict access if you extend the dashboard to multi-tenant views.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -244,6 +244,22 @@ export type Database = {
         updated_at: string | null
         metadata: Json | null
       }>
+      web_vitals: SupabaseTable<{
+        id: string
+        created_at: string | null
+        metric_id: string
+        name: string
+        value: number
+        delta: number | null
+        rating: 'good' | 'needs-improvement' | 'poor'
+        label: string | null
+        event_name: string | null
+        route: string
+        url: string
+        navigation_type: string | null
+        metadata: Json | null
+        recorded_at: string | null
+      }>
     }
     Views: Record<string, never>
     Functions: {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,50 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3,
+      "startServerCommand": "pnpm start",
+      "startServerReadyPattern": "started server on",
+      "url": [
+        "http://127.0.0.1:3000/",
+        "http://127.0.0.1:3000/dashboard",
+        "http://127.0.0.1:3000/payments",
+        "http://127.0.0.1:3000/bookings"
+      ]
+    },
+    "assert": {
+      "assertions": {
+        "largest-contentful-paint": [
+          "error",
+          {
+            "maxNumericValue": 2500,
+            "aggregationMethod": "median"
+          }
+        ],
+        "interaction-to-next-paint": [
+          "error",
+          {
+            "maxNumericValue": 200,
+            "aggregationMethod": "median"
+          }
+        ],
+        "cumulative-layout-shift": [
+          "error",
+          {
+            "maxNumericValue": 0.1,
+            "aggregationMethod": "p75"
+          }
+        ],
+        "performance": [
+          "error",
+          {
+            "minScore": 0.9,
+            "aggregationMethod": "median"
+          }
+        ]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "verify": "pnpm lint && pnpm test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/utils/metrics/web-vitals.ts
+++ b/utils/metrics/web-vitals.ts
@@ -1,0 +1,113 @@
+import type { NextWebVitalsMetric } from 'next/app'
+
+type NetworkInformation = {
+  effectiveType?: string
+  downlink?: number
+  rtt?: number
+  saveData?: boolean
+}
+
+type NavigatorWithConnection = Navigator & {
+  connection?: NetworkInformation
+}
+
+type WebVitalMetadata = {
+  pathname: string
+  segments: string[]
+  searchParams: Record<string, string>
+  referrer: string | null
+  locale?: string
+  userAgent?: string
+  connection?: NetworkInformation
+  timestamp: number
+}
+
+type WebVitalPayload = {
+  id: string
+  name: string
+  value: number
+  delta?: number
+  rating: NextWebVitalsMetric['rating']
+  label?: NextWebVitalsMetric['label']
+  eventName?: string
+  navigationType?: string
+  url: string
+  route: string
+  metadata: WebVitalMetadata
+  timestamp: number
+}
+
+function shouldSendMetrics() {
+  if (process.env.NODE_ENV === 'production') {
+    return true
+  }
+
+  return process.env.NEXT_PUBLIC_ENABLE_WEB_VITALS === 'true'
+}
+
+export function sendToAnalytics(metric: NextWebVitalsMetric) {
+  if (typeof window === 'undefined' || !shouldSendMetrics()) {
+    return
+  }
+
+  const { location, document, navigator } = window
+  const segments = location.pathname.split('/').filter(Boolean)
+  const searchParams = Object.fromEntries(
+    new URLSearchParams(location.search).entries()
+  )
+
+  const navigatorWithConnection = navigator as NavigatorWithConnection
+  const connection = navigatorWithConnection.connection
+    ? {
+        effectiveType: navigatorWithConnection.connection.effectiveType,
+        downlink: navigatorWithConnection.connection.downlink,
+        rtt: navigatorWithConnection.connection.rtt,
+        saveData: navigatorWithConnection.connection.saveData,
+      }
+    : undefined
+
+  const timestamp = Date.now()
+
+  const payload: WebVitalPayload = {
+    id: metric.id,
+    name: metric.name,
+    value: metric.value,
+    delta: metric.delta,
+    rating: metric.rating,
+    label: metric.label,
+    eventName: 'eventName' in metric ? metric.eventName : undefined,
+    navigationType:
+      'navigationType' in metric ? metric.navigationType : undefined,
+    url: location.href,
+    route: location.pathname,
+    metadata: {
+      pathname: location.pathname,
+      segments,
+      searchParams,
+      referrer: document.referrer || null,
+      locale: navigator.language,
+      userAgent: navigator.userAgent,
+      connection,
+      timestamp,
+    },
+    timestamp,
+  }
+
+  const body = JSON.stringify(payload)
+
+  if (typeof navigator.sendBeacon === 'function') {
+    const queued = navigator.sendBeacon('/api/vitals', body)
+    if (queued) {
+      return
+    }
+  }
+
+  void fetch('/api/vitals', {
+    method: 'POST',
+    body,
+    keepalive: true,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add a Lighthouse CI configuration for core routes and wire up a GitHub Action that deploys a Vercel preview before running LHCI and archiving reports
- instrument `reportWebVitals` to forward metrics to a new Supabase-backed API route and extend the schema typings for the `web_vitals` table
- document the Supabase dashboard flow for the performance metrics and add a `pnpm verify` helper script

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1942b12608328b8c685670cd351b2