### PR TITLE
Notify all property managers on maintenance requests

### DIFF
--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -80,13 +80,19 @@ export function MaintenanceRequestForm() {
         throw new Error("User is not assigned to a unit");
       }
 
-      const [propertyManager] = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
-        roles: ['property_manager'],
-      });
+      const propertyManagers = await fetchMembersByUnit(
+        typedSupabase,
+        profile.unit_id,
+        {
+          roles: ['property_manager'],
+        }
+      );
 
-      if (!propertyManager) {
+      if (!propertyManagers.length) {
         throw new Error("Property manager not found for this unit");
       }
+
+      const primaryManager = propertyManagers[0];
 
       // Create maintenance request record
       const { data: request, error: requestError } = await (supabase as any)
@@ -100,6 +106,7 @@ export function MaintenanceRequestForm() {
           requested_by: user.id,
           unit_id: profile.unit_id,
           status: 'pending',
+          assigned_to: primaryManager?.id ?? null,
         })
         .select()
         .single();
@@ -112,11 +119,11 @@ export function MaintenanceRequestForm() {
         title: data.title,
         description: data.description,
         priority: data.priority,
-        propertyManager: {
-          id: propertyManager.id,
-          email: propertyManager.email || '',
-          name: propertyManager.full_name || propertyManager.email || 'Unknown',
-        },
+        propertyManagers: propertyManagers.map((manager) => ({
+          id: manager.id,
+          email: manager.email || '',
+          name: manager.full_name || manager.email || 'Unknown',
+        })),
       });
 
       toast({

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -9,6 +9,73 @@ type BulkNotificationResult = {
   results: Array<{ index: number; success: boolean; error: unknown }>
 }
 
+export type MaintenanceNotificationManager = {
+  id: string
+  email?: string | null
+  name?: string | null
+}
+
+export type MaintenanceNotificationPayload = {
+  requesterName: string
+  title: string
+  description: string
+  priority: string
+  propertyManagers: MaintenanceNotificationManager[]
+}
+
+export function buildMaintenanceRequestNotifications({
+  requesterName,
+  title,
+  description,
+  priority,
+  propertyManagers,
+}: MaintenanceNotificationPayload): (NotificationData | InAppNotification)[] {
+  const uniqueManagers = Array.from(
+    new Map(
+      propertyManagers
+        .filter((manager) => manager && manager.id)
+        .map((manager) => [manager.id, manager])
+    ).values()
+  )
+
+  return uniqueManagers.flatMap((manager) => {
+    const notifications: (NotificationData | InAppNotification)[] = [
+      {
+        userId: manager.id,
+        title: "New Maintenance Request",
+        message: `${requesterName} reported: ${title}`,
+        type: "warning" as const,
+        actionUrl: "/dashboard",
+        metadata: {
+          priority,
+          description,
+          requesterName,
+          title,
+          managerName: manager.name ?? null,
+        },
+      },
+    ]
+
+    const recipient = manager.email?.trim()
+    if (recipient) {
+      notifications.unshift({
+        to: recipient,
+        subject: `New Maintenance Request: ${title}`,
+        template: "maintenance-request",
+        data: {
+          requesterName,
+          title,
+          description,
+          priority,
+        },
+        userId: manager.id,
+      })
+    }
+
+    return notifications
+  })
+}
+
 async function postNotification<T>(payload: unknown): Promise<T> {
   const response = await fetch("/api/notifications", {
     method: "POST",
@@ -174,31 +241,14 @@ export function useNotifications() {
     return sendBulkNotifications(notifications)
   }
 
-  const notifyMaintenanceRequest = async (data: {
-    requesterName: string
-    title: string
-    description: string
-    priority: string
-    propertyManager: { id: string; email: string; name: string }
-  }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
-      // Email to property manager
-      {
-        to: data.propertyManager.email,
-        subject: `New Maintenance Request: ${data.title}`,
-        template: "maintenance-request",
-        data,
-        userId: data.propertyManager.id,
-      },
-      // In-app notification to property manager
-      {
-        userId: data.propertyManager.id,
-        title: "New Maintenance Request",
-        message: `${data.requesterName} reported: ${data.title}`,
-        type: "warning" as const,
-        actionUrl: "/dashboard",
-      },
-    ]
+  const notifyMaintenanceRequest = async (
+    data: MaintenanceNotificationPayload
+  ): Promise<Array<{ index: number; success: boolean; error: unknown }>> => {
+    const notifications = buildMaintenanceRequestNotifications(data)
+
+    if (notifications.length === 0) {
+      return []
+    }
 
     return sendBulkNotifications(notifications)
   }

--- a/tests/hooks/use-notifications.test.ts
+++ b/tests/hooks/use-notifications.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMaintenanceRequestNotifications,
+  type MaintenanceNotificationPayload,
+} from '@/hooks/use-notifications';
+import type { InAppNotification, NotificationData } from '@/lib/notifications';
+
+describe('buildMaintenanceRequestNotifications', () => {
+  const basePayload: Omit<MaintenanceNotificationPayload, 'propertyManagers'> = {
+    requesterName: 'Taylor Tenant',
+    title: 'Leaky faucet',
+    description: 'Water is dripping nonstop under the kitchen sink.',
+    priority: 'high',
+  };
+
+  it('creates email and in-app notifications for each property manager', () => {
+    const notifications = buildMaintenanceRequestNotifications({
+      ...basePayload,
+      propertyManagers: [
+        { id: 'pm-1', email: 'pm1@example.com', name: 'Avery Agent' },
+        { id: 'pm-2', email: 'pm2@example.com', name: 'Blake Broker' },
+      ],
+    });
+
+    const emailNotifications = notifications.filter(
+      (notification): notification is NotificationData => 'template' in notification,
+    );
+    const inAppNotifications = notifications.filter(
+      (notification): notification is InAppNotification => !('template' in notification),
+    );
+
+    expect(emailNotifications).toHaveLength(2);
+    expect(inAppNotifications).toHaveLength(2);
+    expect(emailNotifications.map((notification) => notification.to)).toEqual([
+      'pm1@example.com',
+      'pm2@example.com',
+    ]);
+    expect(inAppNotifications.map((notification) => notification.userId)).toEqual([
+      'pm-1',
+      'pm-2',
+    ]);
+    expect(
+      inAppNotifications.every(
+        (notification) => notification.metadata?.priority === basePayload.priority,
+      ),
+    ).toBe(true);
+  });
+
+  it('skips email notifications when an address is missing but keeps the in-app alert', () => {
+    const notifications = buildMaintenanceRequestNotifications({
+      ...basePayload,
+      propertyManagers: [{ id: 'pm-3', email: '', name: 'Carey Coordinator' }],
+    });
+
+    expect(notifications).toHaveLength(1);
+    expect('template' in notifications[0]).toBe(false);
+    expect((notifications[0] as InAppNotification).userId).toBe('pm-3');
+  });
+
+  it('deduplicates property managers by user id', () => {
+    const notifications = buildMaintenanceRequestNotifications({
+      ...basePayload,
+      propertyManagers: [
+        { id: 'pm-4', email: 'primary@example.com', name: 'Devon Director' },
+        { id: 'pm-4', email: 'duplicate@example.com', name: 'Duplicate' },
+      ],
+    });
+
+    expect(notifications).toHaveLength(2);
+
+    const userIds = notifications.map((notification) =>
+      'template' in notification
+        ? (notification as NotificationData).userId ?? null
+        : notification.userId,
+    );
+
+    expect(new Set(userIds)).toEqual(new Set(['pm-4']));
+  });
+});


### PR DESCRIPTION
## Summary
- fetch every property manager for a unit when submitting a maintenance request and assign the primary contact
- fan out maintenance notifications to all property managers through a reusable builder
- add unit tests covering maintenance notification generation edge cases

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ac5a538c83288a27f9a223661e0d