### PR TITLE
Enhance visitor booking notifications

### DIFF
--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -152,24 +152,54 @@ export function useNotifications() {
     roommates: Array<{ id: string; email: string; name: string }>
     propertyManager: { id: string; email: string; name: string }
   }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
-      // Email to property manager
-      {
+    const notifications: (NotificationData | InAppNotification)[] = []
+    const templateData = {
+      guestName: data.guestName,
+      hostName: data.hostName,
+      checkInDate: data.checkInDate,
+      checkOutDate: data.checkOutDate,
+      purpose: data.purpose,
+    }
+
+    if (data.propertyManager.email) {
+      notifications.push({
         to: data.propertyManager.email,
         subject: `New Visitor Booking: ${data.guestName}`,
         template: "visitor-booking",
-        data,
+        data: templateData,
         userId: data.propertyManager.id,
-      },
-      // In-app notifications to all roommates
-      ...data.roommates.map((roommate) => ({
+      })
+    }
+
+    notifications.push({
+      userId: data.propertyManager.id,
+      title: "New Visitor Booking",
+      message: `${data.guestName} is visiting from ${data.checkInDate} to ${data.checkOutDate}`,
+      type: "info",
+      actionUrl: "/visitors",
+      metadata: templateData,
+    })
+
+    for (const roommate of data.roommates) {
+      if (roommate.email) {
+        notifications.push({
+          to: roommate.email,
+          subject: `New Visitor Booking: ${data.guestName}`,
+          template: "visitor-booking",
+          data: templateData,
+          userId: roommate.id,
+        })
+      }
+
+      notifications.push({
         userId: roommate.id,
         title: "New Visitor Booking",
         message: `${data.guestName} is visiting from ${data.checkInDate} to ${data.checkOutDate}`,
-        type: "info" as const,
-        actionUrl: "/dashboard",
-      })),
-    ]
+        type: "info",
+        actionUrl: "/visitors",
+        metadata: templateData,
+      })
+    }
 
     return sendBulkNotifications(notifications)
   }


### PR DESCRIPTION
## Summary
- send visitor booking notification emails to roommates in addition to property managers
- add in-app notifications for property managers and include consistent metadata for visitor alerts

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d1ac6e5c4083288909917e0ad4f014