### PR TITLE
Implement visitor stay limits and history tracking

### DIFF
--- a/app/visitors/page.tsx
+++ b/app/visitors/page.tsx
@@ -1,20 +1,4 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { VisitorBookingForm } from "@/components/visitors/visitor-booking-form";
-
-const visitorHighlights = [
-  {
-    title: "Easy Guest Registration",
-    description: "Register overnight visitors with all necessary details and get approval from roommates.",
-  },
-  {
-    title: "Automatic Notifications",
-    description: "Roommates and property managers are automatically notified of new visitor requests.",
-  },
-  {
-    title: "Stay Limits",
-    description: "Enforce policy limits on consecutive nights and track visitor history.",
-  },
-];
+import { VisitorExperience } from "@/components/visitors/visitor-experience";
 
 export default function VisitorsPage() {
   return (
@@ -28,34 +12,7 @@ export default function VisitorsPage() {
         </div>
       </header>
 
-      <div className="grid gap-8 lg:grid-cols-2">
-        <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Register New Visitor</CardTitle>
-              <CardDescription>
-                Fill out the form to register an overnight guest. All roommates will be notified automatically.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <VisitorBookingForm />
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="space-y-6">
-          <div className="grid gap-6">
-            {visitorHighlights.map((item) => (
-              <Card key={item.title}>
-                <CardHeader>
-                  <CardTitle className="text-lg">{item.title}</CardTitle>
-                  <CardDescription>{item.description}</CardDescription>
-                </CardHeader>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </div>
+      <VisitorExperience />
     </div>
   );
 }

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -1,49 +1,82 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
-import { format } from "date-fns";
+import { differenceInCalendarDays, format, isAfter, startOfToday } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
+import {
+  VISITOR_POLICY,
+  VisitorPolicyError,
+  ensureVisitorStayWithinPolicy,
+} from "@/lib/data/visitors";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import type { Database } from "@/lib/supabase";
 
-const visitorBookingSchema = z.object({
-  guestName: z.string().min(2, "Guest name must be at least 2 characters"),
-  guestEmail: z.string().email("Please enter a valid email address"),
-  guestPhone: z.string().optional(),
-  checkInDate: z.date({
-    required_error: "Check-in date is required",
-  }),
-  checkOutDate: z.date({
-    required_error: "Check-out date is required",
-  }),
-  purpose: z.string().min(10, "Please provide more details about the visit"),
-  emergencyContact: z.string().optional(),
-  specialNotes: z.string().optional(),
-});
+const visitorBookingSchema = z
+  .object({
+    guestName: z.string().min(2, "Guest name must be at least 2 characters"),
+    guestEmail: z.string().email("Please enter a valid email address"),
+    guestPhone: z.string().optional(),
+    checkInDate: z.date({
+      required_error: "Check-in date is required",
+    }),
+    checkOutDate: z.date({
+      required_error: "Check-out date is required",
+    }),
+    purpose: z.string().min(10, "Please provide more details about the visit"),
+    emergencyContact: z.string().optional(),
+    specialNotes: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    const { checkInDate, checkOutDate } = data;
+
+    if (!isAfter(checkOutDate, checkInDate)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["checkOutDate"],
+        message: "Check-out date must be after the check-in date",
+      });
+      return;
+    }
+
+    const nights = differenceInCalendarDays(checkOutDate, checkInDate);
+
+    if (nights > VISITOR_POLICY.maxConsecutiveNights) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["checkOutDate"],
+        message: `Visitors may stay a maximum of ${VISITOR_POLICY.maxConsecutiveNights} consecutive nights`,
+      });
+    }
+  });
 
 type VisitorBookingFormData = z.infer<typeof visitorBookingSchema>;
 
-export function VisitorBookingForm() {
+interface VisitorBookingFormProps {
+  onBookingCreated?: (booking: Database["public"]["Tables"]["visitor_logs"]["Row"]) => void;
+}
+
+export function VisitorBookingForm({ onBookingCreated }: VisitorBookingFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { notifyVisitorBooking } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
   const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  const today = useMemo(() => startOfToday(), []);
+  const earliestAllowedDate = useMemo(() => new Date("1900-01-01"), []);
 
   const form = useForm<VisitorBookingFormData>({
     resolver: zodResolver(visitorBookingSchema),
@@ -56,6 +89,15 @@ export function VisitorBookingForm() {
       specialNotes: "",
     },
   });
+
+  const checkInDateValue = form.watch("checkInDate");
+  const checkOutDateValue = form.watch("checkOutDate");
+  const selectedNights =
+    checkInDateValue &&
+    checkOutDateValue &&
+    isAfter(checkOutDateValue, checkInDateValue)
+      ? differenceInCalendarDays(checkOutDateValue, checkInDateValue)
+      : null;
 
   const onSubmit = async (data: VisitorBookingFormData) => {
     setIsSubmitting(true);
@@ -86,6 +128,13 @@ export function VisitorBookingForm() {
       if (!propertyManager) {
         throw new Error("Property manager not found for this unit");
       }
+
+      const policyResult = await ensureVisitorStayWithinPolicy(typedSupabase, {
+        hostId: user.id,
+        guestEmail: data.guestEmail,
+        checkInDate: data.checkInDate,
+        checkOutDate: data.checkOutDate,
+      });
 
       // Create visitor booking record
       const { data: booking, error: bookingError } = await (supabase as any)
@@ -128,17 +177,31 @@ export function VisitorBookingForm() {
 
       toast({
         title: "Visitor booking submitted",
-        description: "Your visitor booking has been submitted and notifications sent.",
+        description: `Your visitor booking has been submitted. This stay counts as ${policyResult.requestedNights} night${
+          policyResult.requestedNights === 1 ? "" : "s"
+        } (longest streak for this guest: ${policyResult.consecutiveNights}/${VISITOR_POLICY.maxConsecutiveNights} nights).`,
       });
+
+      if (booking) {
+        onBookingCreated?.(booking as Database["public"]["Tables"]["visitor_logs"]["Row"]);
+      }
 
       form.reset();
     } catch (error) {
       console.error('Error submitting visitor booking:', error);
-      toast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to submit visitor booking",
-        variant: "destructive",
-      });
+      if (error instanceof VisitorPolicyError) {
+        toast({
+          title: "Stay exceeds policy limits",
+          description: `This guest would accumulate ${error.consecutiveNights} consecutive nights which exceeds the ${error.limit}-night limit. Please shorten or shift the visit.`,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Error",
+          description: error instanceof Error ? error.message : "Failed to submit visitor booking",
+          variant: "destructive",
+        });
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -223,7 +286,7 @@ export function VisitorBookingForm() {
                       selected={field.value}
                       onSelect={field.onChange}
                       disabled={(date) =>
-                        date < new Date() || date < new Date("1900-01-01")
+                        date < today || date < earliestAllowedDate
                       }
                       initialFocus
                     />
@@ -264,9 +327,24 @@ export function VisitorBookingForm() {
                       mode="single"
                       selected={field.value}
                       onSelect={field.onChange}
-                      disabled={(date) =>
-                        date < new Date() || date < new Date("1900-01-01")
-                      }
+                      disabled={(date) => {
+                        if (date < today || date < earliestAllowedDate) {
+                          return true;
+                        }
+
+                        if (!checkInDateValue) {
+                          return false;
+                        }
+
+                        if (date <= checkInDateValue) {
+                          return true;
+                        }
+
+                        return (
+                          differenceInCalendarDays(date, checkInDateValue) >
+                          VISITOR_POLICY.maxConsecutiveNights
+                        );
+                      }}
                       initialFocus
                     />
                   </PopoverContent>
@@ -276,6 +354,13 @@ export function VisitorBookingForm() {
             )}
           />
         </div>
+
+        {selectedNights !== null && (
+          <p className="text-sm text-muted-foreground">
+            This request covers {selectedNights} night{selectedNights === 1 ? "" : "s"}. Policy limit:{" "}
+            {VISITOR_POLICY.maxConsecutiveNights} consecutive nights.
+          </p>
+        )}
 
         <FormField
           control={form.control}

--- a/components/visitors/visitor-experience.tsx
+++ b/components/visitors/visitor-experience.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { VisitorBookingForm } from "./visitor-booking-form";
+import { VisitorHistory } from "./visitor-history";
+import { VisitorPolicyCard } from "./visitor-policy-card";
+
+const visitorHighlights = [
+  {
+    title: "Easy Guest Registration",
+    description:
+      "Register overnight visitors with all necessary details and get approval from roommates.",
+  },
+  {
+    title: "Automatic Notifications",
+    description:
+      "Roommates and property managers are automatically notified of new visitor requests.",
+  },
+];
+
+export function VisitorExperience() {
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-2">
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Register New Visitor</CardTitle>
+            <CardDescription>
+              Fill out the form to register an overnight guest. All roommates will be notified automatically.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <VisitorBookingForm onBookingCreated={() => setHistoryRefreshKey((key) => key + 1)} />
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-6">
+        <VisitorPolicyCard />
+        <VisitorHistory refreshKey={historyRefreshKey} />
+        <div className="grid gap-6">
+          {visitorHighlights.map((item) => (
+            <Card key={item.title}>
+              <CardHeader>
+                <CardTitle className="text-lg">{item.title}</CardTitle>
+                <CardDescription>{item.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/visitors/visitor-history.tsx
+++ b/components/visitors/visitor-history.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { differenceInCalendarDays, format, parseISO } from "date-fns";
+
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  VISITOR_POLICY,
+  fetchVisitorHistory,
+  summarizeVisitorHistory,
+  type VisitorLogRow,
+} from "@/lib/data/visitors";
+import { createClient } from "@/utils/supabase-browser";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+
+interface VisitorHistoryProps {
+  refreshKey?: number;
+}
+
+const statusLabels: Record<NonNullable<VisitorLogRow["status"]>, string> = {
+  pending: "Pending",
+  approved: "Approved",
+  rejected: "Rejected",
+  completed: "Completed",
+};
+
+const statusVariants: Record<NonNullable<VisitorLogRow["status"]>, BadgeProps["variant"]> = {
+  pending: "secondary",
+  approved: "complete",
+  rejected: "destructive",
+  completed: "default",
+};
+
+export function VisitorHistory({ refreshKey = 0 }: VisitorHistoryProps) {
+  const supabase = createClient();
+  const typedSupabase = useMemo(
+    () => supabase as unknown as TypedSupabaseClient,
+    [supabase]
+  );
+  const [history, setHistory] = useState<VisitorLogRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadHistory() {
+      setIsLoading(true);
+      setError(null);
+
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+
+      if (userError) {
+        if (isMounted) {
+          setError(userError.message);
+          setHistory([]);
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      if (!user) {
+        if (isMounted) {
+          setError("Sign in to view visitor history.");
+          setHistory([]);
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      try {
+        const logs = await fetchVisitorHistory(typedSupabase, user.id);
+        if (isMounted) {
+          setHistory(logs);
+        }
+      } catch (historyError) {
+        if (isMounted) {
+          setError(
+            historyError instanceof Error
+              ? historyError.message
+              : "Failed to load visitor history"
+          );
+          setHistory([]);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadHistory();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [refreshKey, supabase, typedSupabase]);
+
+  const summary = useMemo(() => summarizeVisitorHistory(history), [history]);
+
+  const recentEntries = useMemo(
+    () =>
+      history.slice(0, 5).map((entry) => {
+        const checkIn = entry.check_in_date ? parseISO(entry.check_in_date) : null;
+        const checkOut = entry.check_out_date ? parseISO(entry.check_out_date) : null;
+        const nights =
+          checkIn && checkOut
+            ? Math.max(0, differenceInCalendarDays(checkOut, checkIn))
+            : null;
+
+        return { ...entry, checkIn, checkOut, nights };
+      }),
+    [history]
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Visitor History</CardTitle>
+        <CardDescription>
+          Review recent overnight guests and how close you are to the stay limit.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+            <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+            <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+          </div>
+        ) : error ? (
+          <p className="text-sm text-muted-foreground">{error}</p>
+        ) : (
+          <>
+            <div className="grid gap-2 rounded-lg border bg-muted/40 p-4 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Policy limit</span>
+                <span className="font-medium">
+                  {VISITOR_POLICY.maxConsecutiveNights} consecutive nights
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Unique visitors</span>
+                <span className="font-medium">{summary.uniqueVisitors}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Total nights logged</span>
+                <span className="font-medium">{summary.totalNights}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Longest stay</span>
+                <span className="font-medium">
+                  {summary.longestStay} night{summary.longestStay === 1 ? "" : "s"}
+                </span>
+              </div>
+              {summary.lastVisit && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Last visitor</span>
+                  <span className="font-medium">
+                    {summary.lastVisit.guestName || "Unknown"} ·{" "}
+                    {format(summary.lastVisit.checkInDate, "MMM d, yyyy")}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-3">
+              <p className="text-sm font-medium">Recent stays</p>
+              {recentEntries.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No overnight visitors recorded yet.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {recentEntries.map((entry) => {
+                    const status = (entry.status ?? "pending") as NonNullable<
+                      VisitorLogRow["status"]
+                    >;
+                    const label = statusLabels[status] ?? status;
+                    const variant = statusVariants[status] ?? "secondary";
+
+                    return (
+                      <li key={entry.id} className="rounded-lg border p-3 text-sm">
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium">{entry.guest_name}</span>
+                          <Badge variant={variant}>{label}</Badge>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {entry.checkIn ? format(entry.checkIn, "MMM d, yyyy") : "—"} →{" "}
+                          {entry.checkOut ? format(entry.checkOut, "MMM d, yyyy") : "—"}
+                          {typeof entry.nights === "number" && (
+                            <> · {entry.nights} night{entry.nights === 1 ? "" : "s"}</>
+                          )}
+                        </p>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/visitors/visitor-policy-card.tsx
+++ b/components/visitors/visitor-policy-card.tsx
@@ -1,0 +1,22 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { VISITOR_POLICY } from "@/lib/data/visitors";
+
+export function VisitorPolicyCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Stay Limits</CardTitle>
+        <CardDescription>
+          Overnight guests can stay up to {VISITOR_POLICY.maxConsecutiveNights} consecutive nights per visit.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li>• Requests exceeding the limit are blocked before submission.</li>
+          <li>• Back-to-back bookings for the same guest count toward the streak.</li>
+          <li>• Managers can review exceptions from the visitor log in Supabase.</li>
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/data/visitors.ts
+++ b/lib/data/visitors.ts
@@ -1,0 +1,253 @@
+import { differenceInCalendarDays, parseISO, startOfDay, startOfToday, subDays } from "date-fns";
+
+import type { Database } from "@/lib/supabase";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+
+const ACTIVE_VISITOR_STATUSES = ["pending", "approved", "completed"] as const;
+
+export const VISITOR_POLICY = {
+  /** Maximum number of consecutive nights a visitor can stay */
+  maxConsecutiveNights: 5,
+  /** Number of days of history to show in the dashboard */
+  historyWindowDays: 180,
+} as const;
+
+export type VisitorLogRow = Database["public"]["Tables"]["visitor_logs"]["Row"];
+
+type SupabaseClientLike = Pick<TypedSupabaseClient, "from">;
+
+export interface VisitorPolicyErrorDetails {
+  limit: number;
+  requestedNights: number;
+  consecutiveNights: number;
+}
+
+export class VisitorPolicyError extends Error {
+  readonly limit: number;
+
+  readonly requestedNights: number;
+
+  readonly consecutiveNights: number;
+
+  constructor({ limit, requestedNights, consecutiveNights }: VisitorPolicyErrorDetails) {
+    super(
+      `This request would result in ${consecutiveNights} consecutive nights which exceeds the policy limit of ${limit}.`
+    );
+    this.name = "VisitorPolicyError";
+    this.limit = limit;
+    this.requestedNights = requestedNights;
+    this.consecutiveNights = consecutiveNights;
+  }
+}
+
+interface DateInterval {
+  start: Date;
+  end: Date;
+}
+
+function normaliseDate(value: string | Date | null): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = value instanceof Date ? value : parseISO(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return startOfDay(parsed);
+}
+
+function calculateNights(start: Date, end: Date): number {
+  return Math.max(0, differenceInCalendarDays(end, start));
+}
+
+function calculateLongestConsecutiveNights(intervals: DateInterval[]): number {
+  if (!intervals.length) {
+    return 0;
+  }
+
+  const sorted = intervals
+    .map((interval) => ({
+      start: startOfDay(interval.start),
+      end: startOfDay(interval.end),
+    }))
+    .filter((interval) => interval.end > interval.start)
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  if (!sorted.length) {
+    return 0;
+  }
+
+  let longest = 0;
+  let currentStart = sorted[0].start;
+  let currentEnd = sorted[0].end;
+
+  const commitCurrent = () => {
+    const nights = calculateNights(currentStart, currentEnd);
+    if (nights > longest) {
+      longest = nights;
+    }
+  };
+
+  for (let index = 1; index < sorted.length; index += 1) {
+    const interval = sorted[index];
+
+    if (interval.start <= currentEnd) {
+      if (interval.end > currentEnd) {
+        currentEnd = interval.end;
+      }
+      continue;
+    }
+
+    commitCurrent();
+    currentStart = interval.start;
+    currentEnd = interval.end;
+  }
+
+  commitCurrent();
+
+  return longest;
+}
+
+export async function ensureVisitorStayWithinPolicy(
+  client: SupabaseClientLike,
+  {
+    hostId,
+    guestEmail,
+    checkInDate,
+    checkOutDate,
+  }: {
+    hostId: string;
+    guestEmail: string;
+    checkInDate: Date;
+    checkOutDate: Date;
+  }
+): Promise<{ consecutiveNights: number; requestedNights: number }> {
+  const normalisedCheckIn = startOfDay(checkInDate);
+  const normalisedCheckOut = startOfDay(checkOutDate);
+  const requestedNights = calculateNights(normalisedCheckIn, normalisedCheckOut);
+
+  const { data, error } = await client
+    .from("visitor_logs")
+    .select("check_in_date, check_out_date, status")
+    .eq("host_id", hostId)
+    .eq("guest_email", guestEmail)
+    .in("status", ACTIVE_VISITOR_STATUSES as unknown as string[]);
+
+  if (error) {
+    throw new Error(`Failed to verify visitor policy: ${error.message}`);
+  }
+
+  const intervals: DateInterval[] = (data ?? [])
+    .filter((log) => log.check_in_date && log.check_out_date)
+    .map((log) => ({
+      start: normaliseDate(log.check_in_date)!,
+      end: normaliseDate(log.check_out_date)!,
+    }));
+
+  intervals.push({
+    start: normalisedCheckIn,
+    end: normalisedCheckOut,
+  });
+
+  const consecutiveNights = calculateLongestConsecutiveNights(intervals);
+
+  if (consecutiveNights > VISITOR_POLICY.maxConsecutiveNights) {
+    throw new VisitorPolicyError({
+      limit: VISITOR_POLICY.maxConsecutiveNights,
+      requestedNights,
+      consecutiveNights,
+    });
+  }
+
+  return { consecutiveNights, requestedNights };
+}
+
+export async function fetchVisitorHistory(
+  client: SupabaseClientLike,
+  hostId: string,
+  {
+    limit = 10,
+    sinceDays = VISITOR_POLICY.historyWindowDays,
+  }: {
+    limit?: number;
+    sinceDays?: number;
+  } = {}
+): Promise<VisitorLogRow[]> {
+  let query = client
+    .from("visitor_logs")
+    .select("id, guest_name, guest_email, guest_phone, check_in_date, check_out_date, status")
+    .eq("host_id", hostId)
+    .order("check_in_date", { ascending: false })
+    .limit(limit);
+
+  if (sinceDays > 0) {
+    const sinceDate = subDays(startOfToday(), sinceDays).toISOString();
+    query = query.gte("check_in_date", sinceDate);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Failed to load visitor history: ${error.message}`);
+  }
+
+  return (data as VisitorLogRow[] | null | undefined) ?? [];
+}
+
+export interface VisitorHistorySummary {
+  totalNights: number;
+  uniqueVisitors: number;
+  longestStay: number;
+  lastVisit?: {
+    guestName: string;
+    checkInDate: Date;
+    checkOutDate: Date;
+    nights: number;
+    status: VisitorLogRow["status"] | null;
+  };
+}
+
+export function summarizeVisitorHistory(logs: VisitorLogRow[]): VisitorHistorySummary {
+  const uniqueVisitors = new Set<string>();
+  let totalNights = 0;
+  let longestStay = 0;
+  let lastVisit: VisitorHistorySummary["lastVisit"];
+
+  for (const log of logs) {
+    const checkIn = normaliseDate(log.check_in_date);
+    const checkOut = normaliseDate(log.check_out_date);
+
+    if (log.guest_email) {
+      uniqueVisitors.add(log.guest_email.toLowerCase());
+    }
+
+    if (!checkIn || !checkOut) {
+      continue;
+    }
+
+    const nights = calculateNights(checkIn, checkOut);
+    totalNights += nights;
+    if (nights > longestStay) {
+      longestStay = nights;
+    }
+
+    if (!lastVisit || checkIn > lastVisit.checkInDate) {
+      lastVisit = {
+        guestName: log.guest_name,
+        checkInDate: checkIn,
+        checkOutDate: checkOut,
+        nights,
+        status: log.status,
+      };
+    }
+  }
+
+  return {
+    totalNights,
+    uniqueVisitors: uniqueVisitors.size,
+    longestStay,
+    lastVisit,
+  };
+}


### PR DESCRIPTION
## Summary
- add visitor policy helpers to enforce consecutive night limits and summarize visitor history
- validate visitor booking requests against policy rules and surface feedback in the booking form
- add visitor history and policy cards to the visitors page alongside refreshed layout

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ac7275088328be75ebb98ce40dcc