### PR TITLE
Add roommate approval workflow for visitor bookings

### DIFF
--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -8,18 +8,29 @@ import { format } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
-import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
+import {
+  fetchMemberProfile,
+  fetchMembersByUnit,
+  type MemberProfile,
+} from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { Checkbox } from "@/components/ui/checkbox";
 
 const visitorBookingSchema = z.object({
   guestName: z.string().min(2, "Guest name must be at least 2 characters"),
@@ -34,16 +45,32 @@ const visitorBookingSchema = z.object({
   purpose: z.string().min(10, "Please provide more details about the visit"),
   emergencyContact: z.string().optional(),
   specialNotes: z.string().optional(),
-});
+  roommateApprovals: z.array(z.string()).default([]),
+}).refine(
+  (data) => data.checkOutDate > data.checkInDate,
+  {
+    message: "Check-out date must be after check-in date",
+    path: ["checkOutDate"],
+  }
+);
 
 type VisitorBookingFormData = z.infer<typeof visitorBookingSchema>;
 
 export function VisitorBookingForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hostProfile, setHostProfile] = useState<MemberProfile | null>(null);
+  const [hostUserId, setHostUserId] = useState<string | null>(null);
+  const [roommates, setRoommates] = useState<MemberProfile[]>([]);
+  const [propertyManager, setPropertyManager] = useState<MemberProfile | null>(null);
+  const [isLoadingMembers, setIsLoadingMembers] = useState(true);
+  const [membersError, setMembersError] = useState<string | null>(null);
   const { notifyVisitorBooking } = useNotifications();
   const { toast } = useToast();
-  const supabase = createClient();
-  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  const supabase = useMemo(() => createClient(), []);
+  const typedSupabase = useMemo(
+    () => supabase as unknown as TypedSupabaseClient,
+    [supabase]
+  );
 
   const form = useForm<VisitorBookingFormData>({
     resolver: zodResolver(visitorBookingSchema),
@@ -54,37 +81,117 @@ export function VisitorBookingForm() {
       purpose: "",
       emergencyContact: "",
       specialNotes: "",
+      roommateApprovals: [],
     },
   });
+
+  useEffect(() => {
+    let isActive = true;
+
+    const loadMemberData = async () => {
+      setIsLoadingMembers(true);
+      setMembersError(null);
+
+      try {
+        const {
+          data: { user },
+          error: authError,
+        } = await supabase.auth.getUser();
+
+        if (authError) {
+          throw authError;
+        }
+
+        if (!user) {
+          throw new Error("Not authenticated");
+        }
+
+        const profile = await fetchMemberProfile(typedSupabase, user.id);
+
+        if (!profile) {
+          throw new Error("Profile not found");
+        }
+
+        if (!profile.unit_id) {
+          throw new Error("User is not assigned to a unit");
+        }
+
+        const unitMembers = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
+          excludeUserId: user.id,
+        });
+
+        if (!isActive) {
+          return;
+        }
+
+        const roommateMembers = unitMembers.filter(
+          (member) => member.role === "tenant" || member.role === "roommate"
+        );
+        const managerMember =
+          unitMembers.find((member) => member.role === "property_manager") ?? null;
+
+        setHostProfile(profile);
+        setHostUserId(user.id);
+        setRoommates(roommateMembers);
+        setPropertyManager(managerMember);
+
+        if (!managerMember) {
+          setMembersError(
+            "No property manager is assigned to your unit. Visitor approvals cannot be submitted until one is added."
+          );
+        }
+
+        form.setValue(
+          "roommateApprovals",
+          roommateMembers.map((member) => member.id),
+          { shouldValidate: true }
+        );
+        form.clearErrors("roommateApprovals");
+      } catch (error) {
+        if (!isActive) {
+          return;
+        }
+
+        console.error("Error loading member data:", error);
+        setMembersError(
+          error instanceof Error
+            ? error.message
+            : "Failed to load household members"
+        );
+      } finally {
+        if (isActive) {
+          setIsLoadingMembers(false);
+        }
+      }
+    };
+
+    void loadMemberData();
+
+    return () => {
+      isActive = false;
+    };
+  }, [form, supabase, typedSupabase]);
 
   const onSubmit = async (data: VisitorBookingFormData) => {
     setIsSubmitting(true);
 
     try {
-      // Get current user info
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
-
-      // Get user profile
-      const profile = await fetchMemberProfile(typedSupabase, user.id);
-
-      if (!profile) throw new Error("Profile not found");
-
-      if (!profile.unit_id) {
-        throw new Error("User is not assigned to a unit");
+      if (!hostUserId || !hostProfile) {
+        throw new Error("Unable to determine host information. Please refresh and try again.");
       }
-
-      const unitMembers = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
-        excludeUserId: user.id,
-      });
-
-      const roommates = unitMembers.filter(
-        member => member.role === 'tenant' || member.role === 'roommate'
-      );
-      const propertyManager = unitMembers.find(member => member.role === 'property_manager');
 
       if (!propertyManager) {
         throw new Error("Property manager not found for this unit");
+      }
+
+      const selectedRoommateIds = data.roommateApprovals ?? [];
+
+      if (roommates.length > 0 && selectedRoommateIds.length === 0) {
+        form.setError("roommateApprovals", {
+          type: "manual",
+          message: "Select at least one roommate to request approval from.",
+        });
+        return;
       }
 
       // Create visitor booking record
@@ -94,7 +201,7 @@ export function VisitorBookingForm() {
           guest_name: data.guestName,
           guest_email: data.guestEmail,
           guest_phone: data.guestPhone,
-          host_id: user.id,
+          host_id: hostUserId,
           check_in_date: data.checkInDate.toISOString(),
           check_out_date: data.checkOutDate.toISOString(),
           purpose: data.purpose,
@@ -107,14 +214,32 @@ export function VisitorBookingForm() {
 
       if (bookingError) throw bookingError;
 
+      if (booking && selectedRoommateIds.length > 0) {
+        const { error: approvalsError } = await (supabase as any)
+          .from('visitor_approvals')
+          .insert(
+            selectedRoommateIds.map((roommateId) => ({
+              visitor_log_id: booking.id,
+              roommate_id: roommateId,
+              status: 'pending',
+            }))
+          );
+
+        if (approvalsError) throw approvalsError;
+      }
+
+      const roommatesToNotify = roommates.filter((roommate) =>
+        (data.roommateApprovals ?? []).includes(roommate.id)
+      );
+
       // Send notifications
       await notifyVisitorBooking({
         guestName: data.guestName,
-        hostName: profile.full_name || user.email || 'Unknown',
+        hostName: hostProfile.full_name || hostProfile.email || 'Unknown',
         checkInDate: format(data.checkInDate, 'MMM dd, yyyy'),
         checkOutDate: format(data.checkOutDate, 'MMM dd, yyyy'),
         purpose: data.purpose,
-        roommates: roommates.map(r => ({
+        roommates: roommatesToNotify.map(r => ({
           id: r.id,
           email: r.email || '',
           name: r.full_name || r.email || 'Unknown',
@@ -128,10 +253,22 @@ export function VisitorBookingForm() {
 
       toast({
         title: "Visitor booking submitted",
-        description: "Your visitor booking has been submitted and notifications sent.",
+        description:
+          roommatesToNotify.length > 0
+            ? `Your visitor booking has been submitted. Approval requests were sent to ${roommatesToNotify.length} roommate${
+                roommatesToNotify.length > 1 ? 's' : ''
+              }.`
+            : "Your visitor booking has been submitted and the property manager has been notified.",
       });
 
       form.reset();
+      if (roommates.length > 0) {
+        form.setValue(
+          'roommateApprovals',
+          roommates.map((roommate) => roommate.id),
+          { shouldValidate: true }
+        );
+      }
     } catch (error) {
       console.error('Error submitting visitor booking:', error);
       toast({
@@ -147,6 +284,12 @@ export function VisitorBookingForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {membersError ? (
+          <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            {membersError}
+          </div>
+        ) : null}
+
         <div className="grid gap-4 md:grid-cols-2">
           <FormField
             control={form.control}
@@ -279,6 +422,63 @@ export function VisitorBookingForm() {
 
         <FormField
           control={form.control}
+          name="roommateApprovals"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Roommate Approvals</FormLabel>
+              <FormDescription>
+                Select the roommates who need to approve this overnight stay. Everyone you
+                select will receive an in-app notification with the request.
+              </FormDescription>
+              <div className="space-y-3">
+                {isLoadingMembers ? (
+                  <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                    Loading household members...
+                  </div>
+                ) : roommates.length === 0 ? (
+                  <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                    No roommates are assigned to your unit, so no approvals are required.
+                  </div>
+                ) : (
+                  roommates.map((roommate) => {
+                    const isSelected = field.value?.includes(roommate.id) ?? false;
+
+                    return (
+                      <label
+                        key={roommate.id}
+                        className="flex items-start gap-3 rounded-md border p-3"
+                      >
+                        <Checkbox
+                          checked={isSelected}
+                          onCheckedChange={(checked) => {
+                            const currentValue = field.value ?? [];
+                            const nextValue = checked
+                              ? [...currentValue, roommate.id]
+                              : currentValue.filter((id) => id !== roommate.id);
+                            field.onChange(nextValue);
+                          }}
+                          disabled={isSubmitting}
+                        />
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium leading-none">
+                            {roommate.full_name || roommate.email || "Unknown roommate"}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            Approval request will be sent to this roommate.
+                          </p>
+                        </div>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
           name="purpose"
           render={({ field }) => (
             <FormItem>
@@ -327,7 +527,11 @@ export function VisitorBookingForm() {
           )}
         />
 
-        <Button type="submit" disabled={isSubmitting} className="w-full">
+        <Button
+          type="submit"
+          disabled={isSubmitting || isLoadingMembers || !!membersError}
+          className="w-full"
+        >
           {isSubmitting ? "Submitting..." : "Submit Visitor Booking"}
         </Button>
       </form>

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -165,9 +165,15 @@ export function useNotifications() {
       ...data.roommates.map((roommate) => ({
         userId: roommate.id,
         title: "New Visitor Booking",
-        message: `${data.guestName} is visiting from ${data.checkInDate} to ${data.checkOutDate}`,
+        message: `${data.guestName} is visiting from ${data.checkInDate} to ${data.checkOutDate}. Please review and record your approval in the visitor log.`,
         type: "info" as const,
-        actionUrl: "/dashboard",
+        actionUrl: "/visitors",
+        metadata: {
+          requiresApproval: true,
+          visitorName: data.guestName,
+          checkInDate: data.checkInDate,
+          checkOutDate: data.checkOutDate,
+        },
       })),
     ]
 

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -167,7 +167,16 @@ class NotificationService {
       data?.checkOutDate || "Unknown"
     }</p>
         <p><strong>Purpose:</strong> ${data?.purpose || "Not specified"}</p>
-        <p>Please review this booking request in the dashboard.</p>
+        ${
+          Array.isArray(data?.roommates) && data?.roommates.length
+            ? `<p><strong>Awaiting approvals from:</strong> ${data.roommates
+                .map((roommate: { name?: string; email?: string }) =>
+                  roommate?.name || roommate?.email || "Unknown"
+                )
+                .join(", ")}</p>`
+            : ""
+        }
+        <p>Please review this booking request and track roommate approvals in the dashboard.</p>
         <a href="${
           process.env.NEXT_PUBLIC_APP_URL
         }/dashboard" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View in Dashboard</a>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -187,6 +187,16 @@ export type Database = {
         created_at: string | null
         updated_at: string | null
       }>
+      visitor_approvals: SupabaseTable<{
+        id: string
+        visitor_log_id: string
+        roommate_id: string
+        status: 'pending' | 'approved' | 'rejected'
+        responded_at: string | null
+        response_notes: string | null
+        created_at: string | null
+        updated_at: string | null
+      }>
       notifications: SupabaseTable<{
         id: string
         user_id: string

--- a/supabase/migrations/20250114_add_visitor_approvals.sql
+++ b/supabase/migrations/20250114_add_visitor_approvals.sql
@@ -1,0 +1,91 @@
+-- Create visitor_approvals table to track roommate approvals for overnight guests
+CREATE TABLE public.visitor_approvals (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  visitor_log_id UUID NOT NULL REFERENCES public.visitor_logs(id) ON DELETE CASCADE,
+  roommate_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+  responded_at TIMESTAMP WITH TIME ZONE,
+  response_notes TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_visitor_approvals_log_roommate
+  ON public.visitor_approvals(visitor_log_id, roommate_id);
+CREATE INDEX idx_visitor_approvals_roommate_id
+  ON public.visitor_approvals(roommate_id);
+CREATE INDEX idx_visitor_approvals_status
+  ON public.visitor_approvals(status);
+
+ALTER TABLE public.visitor_approvals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Roommates can view their approvals" ON public.visitor_approvals
+  FOR SELECT USING (roommate_id = auth.uid());
+
+CREATE POLICY "Hosts can view approvals for their visitors" ON public.visitor_approvals
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.visitor_logs vl
+      WHERE vl.id = visitor_approvals.visitor_log_id
+        AND vl.host_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Property managers can view visitor approvals" ON public.visitor_approvals
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.visitor_logs vl
+      JOIN public.profiles host_profile ON host_profile.id = vl.host_id
+      JOIN public.profiles manager_profile ON manager_profile.id = auth.uid()
+      WHERE vl.id = visitor_approvals.visitor_log_id
+        AND manager_profile.role = 'property_manager'
+        AND manager_profile.unit_id IS NOT NULL
+        AND manager_profile.unit_id = host_profile.unit_id
+    )
+  );
+
+CREATE POLICY "Hosts can create visitor approvals" ON public.visitor_approvals
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.visitor_logs vl
+      WHERE vl.id = visitor_approvals.visitor_log_id
+        AND vl.host_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Roommates can update their approvals" ON public.visitor_approvals
+  FOR UPDATE USING (roommate_id = auth.uid())
+  WITH CHECK (roommate_id = auth.uid());
+
+CREATE POLICY "Property managers can update visitor approvals" ON public.visitor_approvals
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.visitor_logs vl
+      JOIN public.profiles host_profile ON host_profile.id = vl.host_id
+      JOIN public.profiles manager_profile ON manager_profile.id = auth.uid()
+      WHERE vl.id = visitor_approvals.visitor_log_id
+        AND manager_profile.role = 'property_manager'
+        AND manager_profile.unit_id IS NOT NULL
+        AND manager_profile.unit_id = host_profile.unit_id
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.visitor_logs vl
+      JOIN public.profiles host_profile ON host_profile.id = vl.host_id
+      JOIN public.profiles manager_profile ON manager_profile.id = auth.uid()
+      WHERE vl.id = visitor_approvals.visitor_log_id
+        AND manager_profile.role = 'property_manager'
+        AND manager_profile.unit_id IS NOT NULL
+        AND manager_profile.unit_id = host_profile.unit_id
+    )
+  );
+
+CREATE TRIGGER update_visitor_approvals_updated_at
+  BEFORE UPDATE ON public.visitor_approvals
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- add a Supabase migration and types for visitor approval records tied to visitor logs
- extend the visitor booking form to load roommates, request approvals, and create approval records alongside notifications
- enrich roommate notifications and manager emails to highlight required approvals for overnight guests

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ac6539a4832881d22145887149a8