### PR TITLE
Reset documents error state before refetch

### DIFF
--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -23,9 +23,11 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     const fetchDocuments = async () => {
       try {
         setLoading(true);
+        setError(null);
         const result = await getDocumentsAction(filter);
         if (result.success && result.data) {
           setDocuments(result.data);
+          setError(null);
         } else {
           setError(result.error || 'Failed to fetch documents');
         }


### PR DESCRIPTION
## Summary
- clear the documents list error state when a new fetch cycle starts and after successful loads so the grid can display new data

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ac83f73083288718bdc254d56a23