### PR TITLE
Add encrypted document storage and secure download logging

### DIFF
--- a/app/api/documents/[documentId]/download/route.ts
+++ b/app/api/documents/[documentId]/download/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { Buffer } from 'node:buffer';
+
+import { decryptBuffer } from '@/lib/encryption';
+import { createClient } from '@/utils/supa-server-actions';
+
+function extractClientIp(request: NextRequest): string | null {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    const [first] = forwardedFor.split(',');
+    if (first) return first.trim();
+  }
+
+  const realIp = request.headers.get('x-real-ip');
+  if (realIp) {
+    return realIp.trim();
+  }
+
+  return request.ip ?? null;
+}
+
+export async function GET(request: NextRequest, { params }: { params: { documentId: string } }) {
+  const { documentId } = params;
+
+  if (!documentId) {
+    return NextResponse.json({ error: 'Document id is required.' }, { status: 400 });
+  }
+
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  const { data: document, error: documentError } = await (supabase as any)
+    .from('documents')
+    .select('*')
+    .eq('id', documentId)
+    .single();
+
+  if (documentError || !document) {
+    return NextResponse.json({ error: 'Document not found.' }, { status: 404 });
+  }
+
+  if (!document.storage_path || !document.encryption_iv || !document.encryption_tag) {
+    return NextResponse.json({ error: 'Document file is unavailable.' }, { status: 422 });
+  }
+
+  const { data: downloadData, error: downloadError } = await supabase.storage
+    .from('documents')
+    .download(document.storage_path);
+
+  if (downloadError || !downloadData) {
+    return NextResponse.json({ error: 'Failed to retrieve document file.' }, { status: 500 });
+  }
+
+  const encryptedBuffer = Buffer.from(await downloadData.arrayBuffer());
+  let decryptedBuffer: Buffer;
+  try {
+    decryptedBuffer = decryptBuffer({
+      cipherText: encryptedBuffer,
+      iv: document.encryption_iv,
+      authTag: document.encryption_tag,
+      algorithm: document.encryption_algorithm,
+    });
+  } catch (error) {
+    console.error('Failed to decrypt document:', error);
+    return NextResponse.json({ error: 'Failed to decrypt document.' }, { status: 500 });
+  }
+
+  const metadata = (document.metadata || {}) as Record<string, any>;
+  const fileMetadata = (metadata.file || {}) as Record<string, any>;
+  const fileName = (fileMetadata.originalName as string) || `${document.title}.pdf`;
+  const mimeType = (fileMetadata.mimeType as string) || 'application/octet-stream';
+
+  const mode = request.nextUrl.searchParams.has('download') ? 'download' : 'view';
+  const disposition = mode === 'download' ? 'attachment' : 'inline';
+
+  const response = new NextResponse(decryptedBuffer, {
+    headers: {
+      'Content-Type': mimeType,
+      'Content-Disposition': `${disposition}; filename="${encodeURIComponent(fileName)}"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+
+  const clientIp = extractClientIp(request);
+  const userAgent = request.headers.get('user-agent');
+
+  try {
+    await (supabase as any).rpc('log_document_access', {
+      p_document_id: document.id,
+      p_action: mode === 'download' ? 'download' : 'view',
+      p_metadata: {
+        mode,
+        storage_path: document.storage_path,
+        mime_type: mimeType,
+      },
+      p_ip_address: clientIp,
+      p_user_agent: userAgent,
+    });
+  } catch (error) {
+    console.error('Failed to log document access:', error);
+  }
+
+  return response;
+}

--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -4,9 +4,11 @@ import { createClient } from '@/utils/supa-server-actions';
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { z } from 'zod';
+import { Buffer } from 'node:buffer';
 import { documensoService } from '@/lib/documenso';
 import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
+import { decryptBuffer, encryptBuffer } from '@/lib/encryption';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import {
   Document,
@@ -91,16 +93,27 @@ export async function getDocumentsAction(
       return { success: false, error: 'Failed to fetch documents.' };
     }
 
-    // Log access
-    for (const doc of documents) {
+    const documentsWithSecureUrl = documents.map(doc => {
+      const metadata = (doc.metadata || {}) as Record<string, any>;
+      return {
+        ...doc,
+        metadata,
+        file_url: doc.storage_path ? `/api/documents/${doc.id}/download` : doc.file_url || null,
+      };
+    });
+
+    for (const doc of documentsWithSecureUrl) {
       await (supabase as any).rpc('log_document_access', {
         p_document_id: doc.id,
         p_action: 'view',
-        p_metadata: { source: 'documents_page' }
+        p_metadata: {
+          source: 'documents_page',
+          storage_path: doc.storage_path || null,
+        },
       });
     }
 
-    return { success: true, data: documents };
+    return { success: true, data: documentsWithSecureUrl };
   } catch (error) {
     console.error('Unexpected error in getDocumentsAction:', error);
     return {
@@ -152,33 +165,53 @@ export async function uploadDocumentAction(
 
     const validatedData = validationResult.data;
 
-    // Upload file to Supabase Storage
-    const fileExt = file.name.split('.').pop();
-    const fileName = `${Date.now()}-${Math.random().toString(36).substring(2)}.${fileExt}`;
+    const fileExt = file.name.includes('.') ? file.name.split('.').pop() : undefined;
+    const randomName = `${Date.now()}-${Math.random().toString(36).substring(2)}`;
+    const fileName = fileExt ? `${randomName}.${fileExt}` : randomName;
     const filePath = `documents/${fileName}`;
 
-    const { data: uploadData, error: uploadError } = await supabase.storage
+    const fileBuffer = Buffer.from(await file.arrayBuffer());
+    const encryptedPayload = encryptBuffer(fileBuffer);
+
+    const { error: uploadError } = await supabase.storage
       .from('documents')
-      .upload(filePath, file);
+      .upload(filePath, encryptedPayload.cipherText, {
+        contentType: 'application/octet-stream',
+        cacheControl: '0',
+      });
 
     if (uploadError) {
       console.error('Error uploading file:', uploadError);
       return { success: false, error: 'Failed to upload file.' };
     }
 
-    // Get public URL
-    const { data: { publicUrl } } = supabase.storage
-      .from('documents')
-      .getPublicUrl(filePath);
-
     // Create document record
+    const metadata = {
+      ...(validatedData.requires_signature ? { requires_signature: true } : {}),
+      file: {
+        originalName: file.name,
+        mimeType: file.type || 'application/octet-stream',
+        size: file.size,
+        extension: fileExt || null,
+      },
+      encryption: {
+        algorithm: encryptedPayload.algorithm,
+      },
+    };
+
     const { data: document, error: dbError } = await (supabase as any)
       .from('documents')
       .insert({
         title: validatedData.title,
         description: validatedData.description,
         document_type: validatedData.document_type,
-        file_url: publicUrl,
+        file_url: null,
+        storage_path: filePath,
+        encryption_iv: encryptedPayload.iv,
+        encryption_tag: encryptedPayload.authTag,
+        encryption_algorithm: encryptedPayload.algorithm,
+        encrypted_at: new Date().toISOString(),
+        metadata,
         tenant_id: validatedData.tenant_id,
         unit_id: validatedData.unit_id,
         requires_signature: validatedData.requires_signature,
@@ -199,11 +232,21 @@ export async function uploadDocumentAction(
     await (supabase as any).rpc('log_document_access', {
       p_document_id: document.id,
       p_action: 'upload',
-      p_metadata: { file_name: file.name, file_size: file.size }
+      p_metadata: {
+        file_name: file.name,
+        file_size: file.size,
+        storage_path: filePath,
+        encryption_algorithm: encryptedPayload.algorithm,
+      },
     });
 
     revalidatePath('/documents');
-    return { success: true, data: document, message: 'Document uploaded successfully.' };
+    const documentWithUrl = {
+      ...document,
+      file_url: document.storage_path ? `/api/documents/${document.id}/download` : null,
+    };
+
+    return { success: true, data: documentWithUrl, message: 'Document uploaded successfully.' };
   } catch (error) {
     console.error('Unexpected error in uploadDocumentAction:', error);
     return {
@@ -272,14 +315,33 @@ export async function createSigningRequestAction(
       return { success: false, error: 'You do not have permission to create signing requests for this document.' };
     }
 
-    // Download file from Supabase Storage
-    const fileResponse = await fetch(document.file_url!);
-    if (!fileResponse.ok) {
+    if (!document.storage_path || !document.encryption_iv || !document.encryption_tag) {
+      return { success: false, error: 'Document file metadata is incomplete.' };
+    }
+
+    const { data: downloadData, error: downloadError } = await supabase.storage
+      .from('documents')
+      .download(document.storage_path);
+
+    if (downloadError || !downloadData) {
+      console.error('Error downloading document for signing request:', downloadError);
       return { success: false, error: 'Failed to download document file.' };
     }
 
-    const fileBlob = await fileResponse.blob();
-    const file = new File([fileBlob], `${document.title}.pdf`, { type: 'application/pdf' });
+    const encryptedBuffer = Buffer.from(await downloadData.arrayBuffer());
+    const decryptedBuffer = decryptBuffer({
+      cipherText: encryptedBuffer,
+      iv: document.encryption_iv,
+      authTag: document.encryption_tag,
+      algorithm: document.encryption_algorithm,
+    });
+
+    const documentMetadata = (document.metadata || {}) as Record<string, any>;
+    const fileMetadata = (documentMetadata.file || {}) as Record<string, any>;
+    const originalFileName = (fileMetadata.originalName as string) || `${document.title}.pdf`;
+    const mimeType = (fileMetadata.mimeType as string) || 'application/pdf';
+
+    const file = new File([decryptedBuffer], originalFileName, { type: mimeType });
 
     // Upload file to Documenso to obtain documentDataId
     const uploadResult = await documensoService.uploadDocument(file);

--- a/app/documents/components/document-actions.tsx
+++ b/app/documents/components/document-actions.tsx
@@ -27,6 +27,9 @@ export function DocumentActions({ document }: DocumentActionsProps) {
   const [loading, setLoading] = useState<string | null>(null);
   const permissions = useDocumentPermissions();
 
+  const appendQueryParam = (url: string, param: string) =>
+    url.includes('?') ? `${url}&${param}` : `${url}?${param}`;
+
   const handleView = () => {
     setShowViewer(true);
   };
@@ -64,7 +67,8 @@ export function DocumentActions({ document }: DocumentActionsProps) {
 
   const handleDownload = () => {
     if (document.file_url) {
-      window.open(document.file_url, '_blank');
+      const downloadUrl = appendQueryParam(document.file_url, 'download=1');
+      window.open(downloadUrl, '_blank');
     }
   };
 

--- a/app/documents/components/document-viewer-dialog.tsx
+++ b/app/documents/components/document-viewer-dialog.tsx
@@ -19,15 +19,25 @@ export function DocumentViewerDialog({
   onOpenChange,
   document
 }: DocumentViewerDialogProps) {
+  const appendQueryParam = (url: string, param: string) =>
+    url.includes('?') ? `${url}&${param}` : `${url}?${param}`;
+
+  const metadata = (document.metadata || {}) as Record<string, any>;
+  const fileMetadata = (metadata.file || {}) as Record<string, any>;
+  const mimeType = typeof fileMetadata.mimeType === 'string' ? fileMetadata.mimeType : '';
+  const isPdf = mimeType.toLowerCase().includes('pdf');
+  const previewUrl = document.file_url ? appendQueryParam(document.file_url, 'preview=1') : null;
+  const downloadUrl = document.file_url ? appendQueryParam(document.file_url, 'download=1') : null;
+
   const handleDownload = () => {
-    if (document.file_url) {
-      window.open(document.file_url, '_blank');
+    if (downloadUrl) {
+      window.open(downloadUrl, '_blank');
     }
   };
 
   const handleOpenExternal = () => {
-    if (document.file_url) {
-      window.open(document.file_url, '_blank');
+    if (previewUrl) {
+      window.open(previewUrl, '_blank');
     }
   };
 
@@ -163,9 +173,9 @@ export function DocumentViewerDialog({
           <div className="min-h-0 flex-1">
             {document.file_url ? (
               <div className="h-[600px] w-full overflow-hidden rounded-lg border">
-                {document.file_url.toLowerCase().endsWith('.pdf') ? (
+                {isPdf && previewUrl ? (
                   <iframe
-                    src={`${document.file_url}#toolbar=0&navpanes=0&scrollbar=0`}
+                    src={`${previewUrl}#toolbar=0&navpanes=0&scrollbar=0`}
                     className="size-full"
                     title={document.title}
                   />

--- a/lib/encryption.ts
+++ b/lib/encryption.ts
@@ -2,32 +2,77 @@
 
 import crypto from "crypto"
 
-// In a real application, use a secure environment variable for this
-const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || "your-secure-encryption-key-min-32-chars"
-const IV_LENGTH = 16 // For AES, this is always 16
+const ALGORITHM = "aes-256-gcm"
+const IV_LENGTH = 12
 
-export async function encrypt(text: string): Promise<string> {
+const rawKey =
+  process.env.DOCUMENT_ENCRYPTION_KEY ||
+  process.env.ENCRYPTION_KEY ||
+  "your-secure-encryption-key-min-32-chars"
+
+const ENCRYPTION_KEY = crypto.createHash("sha256").update(rawKey).digest()
+
+export type EncryptedPayload = {
+  cipherText: Buffer
+  iv: string
+  authTag: string
+  algorithm: string
+}
+
+export function encryptBuffer(buffer: Buffer): EncryptedPayload {
   const iv = crypto.randomBytes(IV_LENGTH)
-  // Use type assertion to fix the TypeScript error
-  const key = Buffer.from(ENCRYPTION_KEY)
-  // Specify the algorithm type explicitly
-  const cipher = crypto.createCipheriv("aes-256-cbc" as crypto.CipherCCMTypes, key, iv)
-  let encrypted = cipher.update(text)
-  encrypted = Buffer.concat([encrypted, cipher.final()])
-  return `${iv.toString("hex")}:${encrypted.toString("hex")}`
+  const cipher = crypto.createCipheriv(ALGORITHM, ENCRYPTION_KEY, iv)
+  const cipherText = Buffer.concat([cipher.update(buffer), cipher.final()])
+  const authTag = cipher.getAuthTag().toString("hex")
+
+  return {
+    cipherText,
+    iv: iv.toString("hex"),
+    authTag,
+    algorithm: ALGORITHM.toUpperCase(),
+  }
 }
 
-export async function decrypt(text: string): Promise<string> {
-  const [ivHex, encryptedHex] = text.split(":")
-  const iv = Buffer.from(ivHex, "hex")
-  const encryptedText = Buffer.from(encryptedHex, "hex")
-  // Use type assertion to fix the TypeScript error
-  const key = Buffer.from(ENCRYPTION_KEY)
-  // Specify the algorithm type explicitly
-  const decipher = crypto.createDecipheriv("aes-256-cbc" as crypto.CipherCCMTypes, key, iv)
-  let decrypted = decipher.update(encryptedText)
-  decrypted = Buffer.concat([decrypted, decipher.final()])
-  return decrypted.toString()
+type DecryptParams = {
+  cipherText: Buffer
+  iv: string
+  authTag: string
+  algorithm?: string | null
 }
 
+export function decryptBuffer({
+  cipherText,
+  iv,
+  authTag,
+  algorithm,
+}: DecryptParams): Buffer {
+  const normalizedAlgorithm = (algorithm || ALGORITHM).toLowerCase()
+  if (normalizedAlgorithm !== ALGORITHM) {
+    throw new Error(`Unsupported encryption algorithm: ${algorithm}`)
+  }
 
+  const decipher = crypto.createDecipheriv(ALGORITHM, ENCRYPTION_KEY, Buffer.from(iv, "hex"))
+  decipher.setAuthTag(Buffer.from(authTag, "hex"))
+
+  return Buffer.concat([decipher.update(cipherText), decipher.final()])
+}
+
+export function encrypt(text: string): string {
+  const { cipherText, iv, authTag } = encryptBuffer(Buffer.from(text, "utf8"))
+  return `${iv}:${authTag}:${cipherText.toString("hex")}`
+}
+
+export function decrypt(payload: string): string {
+  const [iv, authTag, cipherHex] = payload.split(":")
+  if (!iv || !authTag || !cipherHex) {
+    throw new Error("Invalid encrypted payload format")
+  }
+
+  const decrypted = decryptBuffer({
+    cipherText: Buffer.from(cipherHex, "hex"),
+    iv,
+    authTag,
+  })
+
+  return decrypted.toString("utf8")
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -43,6 +43,11 @@ export type Database = {
         document_type: 'lease' | 'addendum' | 'insurance' | 'maintenance' | 'other'
         status: 'draft' | 'pending_signature' | 'signed' | 'expired' | 'cancelled'
         file_url: string | null
+        storage_path: string | null
+        encryption_iv: string | null
+        encryption_tag: string | null
+        encryption_algorithm: string | null
+        encrypted_at: string | null
         documenso_envelope_id: string | null
         documenso_template_id: string | null
         metadata: Json | null

--- a/supabase/migrations/20250215_secure_document_storage.sql
+++ b/supabase/migrations/20250215_secure_document_storage.sql
@@ -1,0 +1,26 @@
+-- Secure document storage enhancements
+ALTER TABLE public.documents
+  ADD COLUMN storage_path TEXT,
+  ADD COLUMN encryption_iv TEXT,
+  ADD COLUMN encryption_tag TEXT,
+  ADD COLUMN encryption_algorithm TEXT DEFAULT 'AES-256-GCM',
+  ADD COLUMN encrypted_at TIMESTAMP WITH TIME ZONE;
+
+CREATE OR REPLACE FUNCTION log_document_access(
+  p_document_id UUID,
+  p_action TEXT,
+  p_metadata JSONB DEFAULT '{}',
+  p_ip_address INET DEFAULT NULL,
+  p_user_agent TEXT DEFAULT NULL
+)
+RETURNS UUID AS $$
+DECLARE
+  v_log_id UUID;
+BEGIN
+  INSERT INTO public.document_access_logs (document_id, user_id, action, metadata, ip_address, user_agent)
+  VALUES (p_document_id, auth.uid(), p_action, COALESCE(p_metadata, '{}'::jsonb), p_ip_address, p_user_agent)
+  RETURNING id INTO v_log_id;
+
+  RETURN v_log_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -13,6 +13,11 @@ export interface Document {
   document_type: DocumentType;
   status: DocumentStatus;
   file_url?: string;
+  storage_path?: string;
+  encryption_iv?: string | null;
+  encryption_tag?: string | null;
+  encryption_algorithm?: string | null;
+  encrypted_at?: string | null;
   documenso_envelope_id?: string;
   documenso_template_id?: string;
   metadata: Record<string, any>;


### PR DESCRIPTION
## Summary
- encrypt document uploads with AES-256-GCM, persist encryption metadata, and extend Supabase types/schema
- add a secure download API that decrypts files on access and records detailed audit information
- update document UI flows to use the secure endpoint for previews, downloads, and sharing links

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ac8946b083288931389ebd47176f