### PR TITLE
Revamp dashboard experience

### DIFF
--- a/app/dashboard/(dashboard)/components/dashboard-metrics.tsx
+++ b/app/dashboard/(dashboard)/components/dashboard-metrics.tsx
@@ -1,0 +1,60 @@
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getDashboardMetrics } from "../data"
+import { CalendarDays, CreditCard, UsersRound, Wrench } from "lucide-react"
+
+type TrendCopyKey = "up" | "down" | "neutral"
+
+type TrendCopy = Record<TrendCopyKey, { prefix: string }>
+
+const iconMap = {
+  rent: CreditCard,
+  calendar: CalendarDays,
+  roommates: UsersRound,
+  maintenance: Wrench,
+} as const
+
+const trendCopy: TrendCopy = {
+  up: {
+    prefix: "Improving",
+  },
+  down: {
+    prefix: "Stable",
+  },
+  neutral: {
+    prefix: "Scheduled",
+  },
+}
+
+export async function DashboardMetrics() {
+  const metrics = await getDashboardMetrics()
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {metrics.map((metric) => {
+        const Icon = iconMap[metric.icon]
+        const trend = trendCopy[metric.trend.direction]
+
+        return (
+          <Card key={metric.id} className="border-border/60 shadow-none">
+            <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-3">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {metric.label}
+              </CardTitle>
+              <Badge variant="outline" className="flex size-9 items-center justify-center border-muted-foreground/40 bg-muted/60">
+                <Icon className="size-4 text-primary" />
+              </Badge>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p className="text-2xl font-semibold text-foreground">{metric.value}</p>
+              <p className="text-xs text-muted-foreground">{metric.helperText}</p>
+              <p className="text-xs font-medium text-primary">
+                {trend.prefix} • {metric.trend.label}
+              </p>
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/dashboard/(dashboard)/components/dashboard-quick-actions.tsx
+++ b/app/dashboard/(dashboard)/components/dashboard-quick-actions.tsx
@@ -1,0 +1,41 @@
+import SmartLink from "@/components/navigation/SmartLink"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getQuickActions } from "../data"
+import { ArrowUpRight } from "lucide-react"
+
+export async function DashboardQuickActions() {
+  const actions = await getQuickActions()
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="pb-4">
+        <CardTitle className="text-base font-semibold">Quick actions</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Jump straight into the tasks residents complete most.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {actions.map((action) => (
+          <div
+            key={action.id}
+            className="flex flex-col gap-1 rounded-lg border border-transparent p-3 transition-colors hover:border-border/70 hover:bg-muted/50"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-foreground">{action.label}</p>
+                <p className="text-xs text-muted-foreground">{action.description}</p>
+              </div>
+              <SmartLink href={action.href} className="shrink-0" intent="navigation">
+                <Button variant="ghost" size="icon" className="size-8">
+                  <ArrowUpRight className="size-4" />
+                  <span className="sr-only">{`Go to ${action.label}`}</span>
+                </Button>
+              </SmartLink>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/(dashboard)/components/dashboard-welcome.tsx
+++ b/app/dashboard/(dashboard)/components/dashboard-welcome.tsx
@@ -1,19 +1,34 @@
-import Link from "next/link"
-
 import { Button } from "@/components/ui/button"
+import SmartLink from "@/components/navigation/SmartLink"
 import { getWelcomeMessage } from "../data"
 
 export async function DashboardWelcome() {
-        const message = await getWelcomeMessage()
+  const message = await getWelcomeMessage()
 
-        return (
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                        <h2 className="text-2xl font-bold tracking-tight">{message.title}</h2>
-                        <div className="flex gap-2">
-                                <Link href={message.ctaHref}>
-                                        <Button size="sm">{message.ctaLabel}</Button>
-                                </Link>
-                        </div>
-                </div>
-        )
+  return (
+    <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+      <div className="space-y-1">
+        <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">
+          Resident dashboard
+        </p>
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          {message.title}
+        </h1>
+        <p className="text-sm text-muted-foreground sm:text-base">{message.subtitle}</p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <SmartLink href={message.primaryAction.href} intent="critical">
+          <Button size="sm">{message.primaryAction.label}</Button>
+        </SmartLink>
+        {message.secondaryAction ? (
+          <SmartLink href={message.secondaryAction.href} intent="passive">
+            <Button variant="outline" size="sm">
+              {message.secondaryAction.label}
+            </Button>
+          </SmartLink>
+        ) : null}
+      </div>
+    </div>
+  )
 }

--- a/app/dashboard/(dashboard)/components/maintenance-overview-card.tsx
+++ b/app/dashboard/(dashboard)/components/maintenance-overview-card.tsx
@@ -1,0 +1,72 @@
+import SmartLink from "@/components/navigation/SmartLink"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getMaintenanceTickets } from "../data"
+import { Wrench } from "lucide-react"
+
+const statusLabels: Record<"scheduled" | "in_progress" | "awaiting_vendor", string> = {
+  scheduled: "Scheduled",
+  in_progress: "In progress",
+  awaiting_vendor: "Awaiting vendor",
+}
+
+const priorityVariants: Record<"low" | "medium" | "high", "outline" | "secondary" | "destructive" | "complete"> = {
+  low: "outline",
+  medium: "secondary",
+  high: "destructive",
+}
+
+export async function MaintenanceOverviewCard() {
+  const tickets = await getMaintenanceTickets()
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Wrench className="size-5 text-primary" />
+            Maintenance snapshot
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Track active work orders from your property team.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ul className="space-y-3">
+          {tickets.map((ticket) => (
+            <li
+              key={ticket.id}
+              className="rounded-lg border border-dashed border-border/70 p-3"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-foreground">{ticket.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Last updated {new Date(ticket.updatedAt).toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant={priorityVariants[ticket.priority]} className="uppercase">
+                    {ticket.priority} priority
+                  </Badge>
+                  <Badge variant="outline">{statusLabels[ticket.status]}</Badge>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <SmartLink href="/maintenance" className="inline-flex" intent="standard">
+          <Button variant="outline" size="sm" className="w-full sm:w-auto">
+            View maintenance queue
+          </Button>
+        </SmartLink>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/(dashboard)/components/next-rent-card.tsx
+++ b/app/dashboard/(dashboard)/components/next-rent-card.tsx
@@ -1,39 +1,98 @@
-import Link from "next/link"
-
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import SmartLink from "@/components/navigation/SmartLink"
 import { getRentSummary } from "../data"
+import { CalendarDays, Clock, RefreshCcw } from "lucide-react"
 
 export async function NextRentCard() {
-        const summary = await getRentSummary()
-        const formattedAmount = new Intl.NumberFormat("en-US", {
-                style: "currency",
-                currency: "USD",
-        }).format(summary.amount)
+  const summary = await getRentSummary()
+  const formattedAmount = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(summary.amount)
+  const formattedBalance = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(summary.balance)
 
-        return (
-                <Card>
-                        <CardHeader>
-                                <CardTitle>Next rent due</CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                                <div className="text-sm text-muted-foreground">Amount</div>
-                                <div className="text-2xl font-semibold">{formattedAmount}</div>
-                                <div className="mt-1 text-sm text-muted-foreground">
-                                        Due on {new Date(summary.dueDate).toLocaleDateString(undefined, {
-                                                month: "long",
-                                                day: "numeric",
-                                        })}
-                                </div>
-                                {summary.autopayEnabled && (
-                                        <div className="mt-2 text-xs text-muted-foreground">
-                                                Autopay is enabled for this unit.
-                                        </div>
-                                )}
-                                <Link href="/payments" className="mt-4 inline-block">
-                                        <Button size="sm">View details</Button>
-                                </Link>
-                        </CardContent>
-                </Card>
-        )
+  const dueDate = new Date(summary.dueDate)
+  const today = new Date()
+  const msPerDay = 1000 * 60 * 60 * 24
+  const diffInDays = Math.ceil((dueDate.getTime() - today.getTime()) / msPerDay)
+
+  const dueDescriptor =
+    diffInDays > 1
+      ? `Due in ${diffInDays} days`
+      : diffInDays === 1
+        ? "Due tomorrow"
+        : diffInDays === 0
+          ? "Due today"
+          : `Overdue by ${Math.abs(diffInDays)} days`
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="text-lg font-semibold">Next rent due</CardTitle>
+          <p className="text-sm text-muted-foreground">Unit 3B • Shared balance</p>
+        </div>
+        <Badge variant={summary.autopayEnabled ? "secondary" : "outline"} className="flex items-center gap-1">
+          <RefreshCcw className="size-3.5" />
+          {summary.autopayEnabled ? "Autopay on" : "Autopay off"}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Amount due</p>
+            <p className="text-3xl font-semibold">{formattedAmount}</p>
+          </div>
+          <div className="rounded-lg bg-muted/50 px-3 py-2 text-right">
+            <p className="text-xs text-muted-foreground">Outstanding balance</p>
+            <p className="text-sm font-medium">
+              {summary.balance > 0 ? formattedBalance : "No balance"}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="flex items-center gap-3 rounded-md border border-dashed border-border/60 p-3">
+            <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <CalendarDays className="size-5" />
+            </div>
+            <div>
+              <p className="text-sm font-medium">
+                {dueDate.toLocaleDateString(undefined, {
+                  month: "long",
+                  day: "numeric",
+                })}
+              </p>
+              <p className="text-xs text-muted-foreground">{dueDescriptor}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 rounded-md border border-dashed border-border/60 p-3">
+            <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Clock className="size-5" />
+            </div>
+            <div>
+              <p className="text-sm font-medium">
+                Last paid {new Date(summary.lastPaymentDate).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}
+              </p>
+              <p className="text-xs text-muted-foreground">We’ll email receipts after processing</p>
+            </div>
+          </div>
+        </div>
+
+        <SmartLink href="/payments" className="inline-flex" intent="critical">
+          <Button size="sm" className="w-full sm:w-auto">
+            Manage payments
+          </Button>
+        </SmartLink>
+      </CardContent>
+    </Card>
+  )
 }

--- a/app/dashboard/(dashboard)/components/recent-documents-card.tsx
+++ b/app/dashboard/(dashboard)/components/recent-documents-card.tsx
@@ -1,29 +1,68 @@
-import Link from "next/link"
-
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { getRecentDocuments } from "../data"
+import { Badge } from "@/components/ui/badge"
+import SmartLink from "@/components/navigation/SmartLink"
+
+const statusCopy: Record<"action_required" | "viewed" | "new", { label: string; variant: "default" | "outline" | "secondary" | "destructive" }>
+  = {
+    action_required: {
+      label: "Action required",
+      variant: "destructive",
+    },
+    viewed: {
+      label: "Up to date",
+      variant: "secondary",
+    },
+    new: {
+      label: "New",
+      variant: "default",
+    },
+  }
 
 export async function RecentDocumentsCard() {
-        const documents = await getRecentDocuments()
+  const documents = await getRecentDocuments()
 
-        return (
-                <Card>
-                        <CardHeader>
-                                <CardTitle>Latest documents</CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                                <ul className="space-y-2 text-sm">
-                                        {documents.map((document) => (
-                                                <li key={document.name}>{document.name}</li>
-                                        ))}
-                                </ul>
-                                <Link href="/documents" className="mt-4 inline-block">
-                                        <Button variant="outline" size="sm">
-                                                Open
-                                        </Button>
-                                </Link>
-                        </CardContent>
-                </Card>
-        )
+  return (
+    <Card className="h-full">
+      <CardHeader className="pb-4">
+        <div className="space-y-1">
+          <CardTitle>Documents & agreements</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Your latest leases, policies, and shared notes in one place.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ul className="space-y-3">
+          {documents.map((document) => {
+            const { label, variant } = statusCopy[document.status]
+            return (
+              <li
+                key={document.name}
+                className="flex items-start justify-between gap-4 rounded-md border border-transparent p-2 transition-colors hover:border-border/80"
+              >
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-foreground">{document.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {document.category} • Updated {new Date(document.updatedAt).toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </p>
+                </div>
+                <Badge variant={variant}>{label}</Badge>
+              </li>
+            )
+          })}
+        </ul>
+
+        <SmartLink href="/documents" className="inline-flex" intent="standard">
+          <Button variant="outline" size="sm" className="w-full sm:w-auto">
+            Browse documents
+          </Button>
+        </SmartLink>
+      </CardContent>
+    </Card>
+  )
 }

--- a/app/dashboard/(dashboard)/components/roommate-board-card.tsx
+++ b/app/dashboard/(dashboard)/components/roommate-board-card.tsx
@@ -1,31 +1,90 @@
-import Link from "next/link"
-
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { getRoommateUpdates } from "../data"
+import { Badge } from "@/components/ui/badge"
+import SmartLink from "@/components/navigation/SmartLink"
+import { MessageSquare } from "lucide-react"
+
+const topicCopy: Record<"maintenance" | "announcement" | "logistics", { label: string; variant: "outline" | "secondary" | "default" }>
+  = {
+    maintenance: {
+      label: "Maintenance",
+      variant: "outline",
+    },
+    announcement: {
+      label: "Announcement",
+      variant: "secondary",
+    },
+    logistics: {
+      label: "Logistics",
+      variant: "default",
+    },
+  }
+
+function formatRelativeTime(timestamp: string) {
+  const now = new Date()
+  const date = new Date(timestamp)
+  const diff = now.getTime() - date.getTime()
+
+  const minutes = Math.round(diff / (1000 * 60))
+  if (minutes < 1) {
+    return "Just now"
+  }
+  if (minutes < 60) {
+    return `${minutes} min ago`
+  }
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) {
+    return `${hours} hr${hours > 1 ? "s" : ""} ago`
+  }
+  const days = Math.round(hours / 24)
+  return `${days} day${days > 1 ? "s" : ""} ago`
+}
 
 export async function RoommateBoardCard() {
-        const updates = await getRoommateUpdates()
+  const updates = await getRoommateUpdates()
 
-        return (
-                <Card>
-                        <CardHeader>
-                                <CardTitle>Roommate board</CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                                <ul className="space-y-2 text-sm">
-                                        {updates.map((update) => (
-                                                <li key={update.id}>
-                                                        <span className="font-medium">{update.author}</span>: {update.message}
-                                                </li>
-                                        ))}
-                                </ul>
-                                <Link href="/messaging" className="mt-4 inline-block">
-                                        <Button variant="outline" size="sm">
-                                                Go to messages
-                                        </Button>
-                                </Link>
-                        </CardContent>
-                </Card>
-        )
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <MessageSquare className="size-5 text-primary" />
+            Roommate board
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Keep the household in sync with quick updates and replies.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ul className="space-y-3">
+          {updates.map((update) => {
+            const { label, variant } = topicCopy[update.topic]
+            return (
+              <li
+                key={update.id}
+                className="rounded-lg border border-transparent bg-muted/40 p-3 transition-colors hover:border-border/70 hover:bg-muted/60"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                    <span>{update.author}</span>
+                    <Badge variant={variant}>{label}</Badge>
+                  </div>
+                  <span className="text-xs text-muted-foreground">{formatRelativeTime(update.timestamp)}</span>
+                </div>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{update.message}</p>
+              </li>
+            )
+          })}
+        </ul>
+
+        <SmartLink href="/messaging" className="inline-flex" intent="navigation">
+          <Button variant="outline" size="sm" className="w-full sm:w-auto">
+            Open message board
+          </Button>
+        </SmartLink>
+      </CardContent>
+    </Card>
+  )
 }

--- a/app/dashboard/(dashboard)/components/skeletons.tsx
+++ b/app/dashboard/(dashboard)/components/skeletons.tsx
@@ -13,3 +13,14 @@ export function DashboardCardSkeleton() {
 export function DashboardBoardSkeleton() {
         return <Skeleton className="h-48 w-full" />
 }
+
+export function DashboardStatsSkeleton() {
+        return (
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                        <Skeleton className="h-32 w-full" />
+                        <Skeleton className="h-32 w-full" />
+                        <Skeleton className="h-32 w-full" />
+                        <Skeleton className="h-32 w-full" />
+                </div>
+        )
+}

--- a/app/dashboard/(dashboard)/components/upcoming-bookings-card.tsx
+++ b/app/dashboard/(dashboard)/components/upcoming-bookings-card.tsx
@@ -1,0 +1,77 @@
+import SmartLink from "@/components/navigation/SmartLink"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getUpcomingBookings } from "../data"
+import { CalendarCheck } from "lucide-react"
+
+const statusCopy: Record<"confirmed" | "pending" | "waitlisted", { label: string; variant: "secondary" | "outline" | "destructive" }>
+  = {
+    confirmed: {
+      label: "Confirmed",
+      variant: "secondary",
+    },
+    pending: {
+      label: "Awaiting approval",
+      variant: "outline",
+    },
+    waitlisted: {
+      label: "Waitlisted",
+      variant: "destructive",
+    },
+  }
+
+export async function UpcomingBookingsCard() {
+  const bookings = await getUpcomingBookings()
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <CalendarCheck className="size-5 text-primary" />
+            Upcoming amenity bookings
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Coordinate shared spaces without double-booking.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ul className="space-y-3">
+          {bookings.map((booking) => {
+            const { label, variant } = statusCopy[booking.status]
+            return (
+              <li
+                key={booking.id}
+                className="rounded-lg border border-border/60 p-3 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{booking.amenity}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {new Date(booking.date).toLocaleDateString(undefined, {
+                        weekday: "short",
+                        month: "short",
+                        day: "numeric",
+                      })}
+                      {" • "}
+                      {booking.timeframe}
+                    </p>
+                  </div>
+                  <Badge variant={variant}>{label}</Badge>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+
+        <SmartLink href="/schedule" className="inline-flex" intent="standard">
+          <Button variant="outline" size="sm" className="w-full sm:w-auto">
+            Manage bookings
+          </Button>
+        </SmartLink>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/(dashboard)/data.ts
+++ b/app/dashboard/(dashboard)/data.ts
@@ -2,100 +2,330 @@ import "server-only"
 
 import { cache } from "react"
 
+type WelcomeMessage = {
+  title: string
+  subtitle: string
+  primaryAction: {
+    href: string
+    label: string
+  }
+  secondaryAction?: {
+    href: string
+    label: string
+  }
+}
+
 type RentSummary = {
-        amount: number
-        dueDate: string
-        autopayEnabled: boolean
+  amount: number
+  dueDate: string
+  autopayEnabled: boolean
+  balance: number
+  lastPaymentDate: string
+  status: "due_soon" | "overdue" | "paid"
 }
 
 type DocumentSummary = {
-        name: string
-        href: string
+  name: string
+  href: string
+  category: string
+  status: "action_required" | "viewed" | "new"
+  updatedAt: string
 }
 
 type RoommateUpdate = {
-        id: string
-        author: string
-        message: string
-        timestamp: string
+  id: string
+  author: string
+  message: string
+  timestamp: string
+  topic: "maintenance" | "announcement" | "logistics"
+}
+
+type DashboardMetric = {
+  id: string
+  label: string
+  value: string
+  helperText: string
+  trend: {
+    direction: "up" | "down" | "neutral"
+    label: string
+  }
+  icon: "rent" | "calendar" | "roommates" | "maintenance"
+}
+
+type QuickAction = {
+  id: string
+  label: string
+  description: string
+  href: string
+}
+
+type UpcomingBooking = {
+  id: string
+  amenity: string
+  date: string
+  timeframe: string
+  status: "confirmed" | "pending" | "waitlisted"
+}
+
+type MaintenanceTicket = {
+  id: string
+  title: string
+  status: "scheduled" | "in_progress" | "awaiting_vendor"
+  priority: "low" | "medium" | "high"
+  updatedAt: string
 }
 
 async function wait(ms: number) {
-        return new Promise((resolve) => setTimeout(resolve, ms))
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-async function fetchWelcomeMessage() {
-        await wait(120)
-        return {
-                title: "Welcome back",
-                ctaHref: "/payments",
-                ctaLabel: "Pay rent",
-        }
+async function fetchWelcomeMessage(): Promise<WelcomeMessage> {
+  await wait(120)
+  return {
+    title: "Welcome back, Jordan",
+    subtitle: "Here’s what’s happening with Unit 3B today.",
+    primaryAction: {
+      href: "/payments",
+      label: "Settle rent",
+    },
+    secondaryAction: {
+      href: "/schedule",
+      label: "Book an amenity",
+    },
+  }
 }
 
 export const getWelcomeMessage = cache(fetchWelcomeMessage)
 
 export function loadWelcomeMessageUncached() {
-        return fetchWelcomeMessage()
+  return fetchWelcomeMessage()
 }
 
 async function fetchRentSummary(): Promise<RentSummary> {
-        await wait(240)
-        return {
-                amount: 1260,
-                dueDate: "2024-08-01",
-                autopayEnabled: true,
-        }
+  await wait(240)
+  return {
+    amount: 1260,
+    dueDate: "2024-08-01",
+    autopayEnabled: true,
+    balance: 0,
+    lastPaymentDate: "2024-07-01",
+    status: "due_soon",
+  }
 }
 
 export const getRentSummary = cache(fetchRentSummary)
 
 export function loadRentSummaryUncached() {
-        return fetchRentSummary()
+  return fetchRentSummary()
 }
 
 async function fetchRecentDocuments(): Promise<DocumentSummary[]> {
-        await wait(180)
-        return [
-                {
-                        name: "Lease agreement v2.pdf",
-                        href: "/documents",
-                },
-                {
-                        name: "House rules.pdf",
-                        href: "/documents",
-                },
-        ]
+  await wait(180)
+  return [
+    {
+      name: "Lease agreement v2.pdf",
+      href: "/documents",
+      category: "Lease",
+      status: "viewed",
+      updatedAt: "2024-06-15",
+    },
+    {
+      name: "House rules.pdf",
+      href: "/documents",
+      category: "Policies",
+      status: "new",
+      updatedAt: "2024-07-10",
+    },
+    {
+      name: "September chore rotation.pdf",
+      href: "/documents",
+      category: "Chores",
+      status: "action_required",
+      updatedAt: "2024-07-22",
+    },
+  ]
 }
 
 export const getRecentDocuments = cache(fetchRecentDocuments)
 
 export function loadRecentDocumentsUncached() {
-        return fetchRecentDocuments()
+  return fetchRecentDocuments()
 }
 
 async function fetchRoommateUpdates(): Promise<RoommateUpdate[]> {
-        await wait(320)
-        return [
-                {
-                        id: "1",
-                        author: "Jordan",
-                        message: "Wi-Fi is down, rebooted router.",
-                        timestamp: new Date().toISOString(),
-                },
-                {
-                        id: "2",
-                        author: "Avery",
-                        message: "Parking spot swap this weekend?",
-                        timestamp: new Date().toISOString(),
-                },
-        ]
+  await wait(320)
+  const now = new Date()
+  return [
+    {
+      id: "1",
+      author: "Jordan",
+      message: "Wi-Fi was down earlier — rebooted the router and it’s stable again.",
+      timestamp: new Date(now.getTime() - 1000 * 60 * 45).toISOString(),
+      topic: "maintenance",
+    },
+    {
+      id: "2",
+      author: "Avery",
+      message: "Can we swap parking spots this weekend while my guests visit?",
+      timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 5).toISOString(),
+      topic: "logistics",
+    },
+    {
+      id: "3",
+      author: "Property manager",
+      message: "Reminder: fire alarm inspection on Thursday at 10:00 AM.",
+      timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 24).toISOString(),
+      topic: "announcement",
+    },
+  ]
 }
 
 export const getRoommateUpdates = cache(fetchRoommateUpdates)
 
 export function loadRoommateUpdatesUncached() {
-        return fetchRoommateUpdates()
+  return fetchRoommateUpdates()
 }
 
-export type { DocumentSummary, RentSummary, RoommateUpdate }
+async function fetchDashboardMetrics(): Promise<DashboardMetric[]> {
+  await wait(160)
+  return [
+    {
+      id: "rent",
+      label: "This month’s rent",
+      value: "$1,260",
+      helperText: "Due in 5 days",
+      trend: { direction: "neutral", label: "Autopay scheduled" },
+      icon: "rent",
+    },
+    {
+      id: "calendar",
+      label: "Upcoming bookings",
+      value: "3",
+      helperText: "Kitchen, TV room & parking",
+      trend: { direction: "up", label: "+1 vs last week" },
+      icon: "calendar",
+    },
+    {
+      id: "roommates",
+      label: "Roommate updates",
+      value: "4",
+      helperText: "New notes in the last 24h",
+      trend: { direction: "up", label: "Active thread" },
+      icon: "roommates",
+    },
+    {
+      id: "maintenance",
+      label: "Open maintenance",
+      value: "2",
+      helperText: "Both scheduled for this week",
+      trend: { direction: "down", label: "No overdue items" },
+      icon: "maintenance",
+    },
+  ]
+}
+
+export const getDashboardMetrics = cache(fetchDashboardMetrics)
+
+export function loadDashboardMetricsUncached() {
+  return fetchDashboardMetrics()
+}
+
+async function fetchQuickActions(): Promise<QuickAction[]> {
+  await wait(140)
+  return [
+    {
+      id: "payments",
+      label: "Record a payment",
+      description: "Log an off-platform rent payment",
+      href: "/payments",
+    },
+    {
+      id: "amenity",
+      label: "Reserve an amenity",
+      description: "Kitchen, TV room, parking & more",
+      href: "/schedule",
+    },
+    {
+      id: "visitor",
+      label: "Register a visitor",
+      description: "Stay compliant with overnight policy",
+      href: "/visitors",
+    },
+  ]
+}
+
+export const getQuickActions = cache(fetchQuickActions)
+
+export function loadQuickActionsUncached() {
+  return fetchQuickActions()
+}
+
+async function fetchUpcomingBookings(): Promise<UpcomingBooking[]> {
+  await wait(200)
+  return [
+    {
+      id: "booking-1",
+      amenity: "Kitchen",
+      date: "2024-07-26",
+      timeframe: "5:00 – 7:00 PM",
+      status: "confirmed",
+    },
+    {
+      id: "booking-2",
+      amenity: "Parking spot",
+      date: "2024-07-27",
+      timeframe: "All day",
+      status: "pending",
+    },
+    {
+      id: "booking-3",
+      amenity: "PlayStation nook",
+      date: "2024-07-28",
+      timeframe: "8:00 – 10:00 PM",
+      status: "confirmed",
+    },
+  ]
+}
+
+export const getUpcomingBookings = cache(fetchUpcomingBookings)
+
+export function loadUpcomingBookingsUncached() {
+  return fetchUpcomingBookings()
+}
+
+async function fetchMaintenanceTickets(): Promise<MaintenanceTicket[]> {
+  await wait(220)
+  return [
+    {
+      id: "maintenance-1",
+      title: "Washer door latch replacement",
+      status: "scheduled",
+      priority: "medium",
+      updatedAt: "2024-07-22T14:30:00.000Z",
+    },
+    {
+      id: "maintenance-2",
+      title: "HVAC seasonal tune-up",
+      status: "in_progress",
+      priority: "high",
+      updatedAt: "2024-07-21T09:00:00.000Z",
+    },
+  ]
+}
+
+export const getMaintenanceTickets = cache(fetchMaintenanceTickets)
+
+export function loadMaintenanceTicketsUncached() {
+  return fetchMaintenanceTickets()
+}
+
+export type {
+  DashboardMetric,
+  DocumentSummary,
+  MaintenanceTicket,
+  QuickAction,
+  RentSummary,
+  RoommateUpdate,
+  UpcomingBooking,
+  WelcomeMessage,
+}

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -1,67 +1,67 @@
-import Link from "next/link"
 import { Suspense } from "react"
 
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import SmartLink from "@/components/navigation/SmartLink"
+import { DashboardWelcome } from "./components/dashboard-welcome"
+import { NextRentCard } from "./components/next-rent-card"
+import { RecentDocumentsCard } from "./components/recent-documents-card"
+import { RoommateBoardCard } from "./components/roommate-board-card"
+import { DashboardMetrics } from "./components/dashboard-metrics"
+import { DashboardQuickActions } from "./components/dashboard-quick-actions"
+import { UpcomingBookingsCard } from "./components/upcoming-bookings-card"
+import { MaintenanceOverviewCard } from "./components/maintenance-overview-card"
+import {
+  DashboardBoardSkeleton,
+  DashboardCardSkeleton,
+  DashboardHeaderSkeleton,
+  DashboardStatsSkeleton,
+} from "./components/skeletons"
 
 export default function DashboardPage() {
   return (
-    <div className="w-full space-y-6">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="text-2xl font-bold tracking-tight">Welcome back</h2>
-        <div className="flex gap-2">
-          <SmartLink href="/payments">
-            <Button size="sm">Pay rent</Button>
-          </SmartLink>
+    <div className="space-y-8">
+      <Suspense fallback={<DashboardHeaderSkeleton />}>
+        <DashboardWelcome />
+      </Suspense>
+
+      <div className="grid gap-4 xl:grid-cols-[2fr_1fr]">
+        <Suspense fallback={<DashboardStatsSkeleton />}>
+          <DashboardMetrics />
+        </Suspense>
+        <Suspense
+          fallback={
+            <div className="h-full">
+              <DashboardCardSkeleton />
+            </div>
+          }
+        >
+          <DashboardQuickActions />
+        </Suspense>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <div className="space-y-4 xl:col-span-2">
+          <div className="grid gap-4 md:grid-cols-2">
+            <Suspense fallback={<DashboardCardSkeleton />}>
+              <NextRentCard />
+            </Suspense>
+            <Suspense fallback={<DashboardCardSkeleton />}>
+              <RecentDocumentsCard />
+            </Suspense>
+          </div>
+
+          <Suspense fallback={<DashboardBoardSkeleton />}>
+            <RoommateBoardCard />
+          </Suspense>
+        </div>
+
+        <div className="space-y-4">
+          <Suspense fallback={<DashboardCardSkeleton />}>
+            <UpcomingBookingsCard />
+          </Suspense>
+          <Suspense fallback={<DashboardCardSkeleton />}>
+            <MaintenanceOverviewCard />
+          </Suspense>
         </div>
       </div>
-
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardTitle>Next rent due</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-sm text-muted-foreground">Amount</div>
-            <div className="text-2xl font-semibold">$1,260.00</div>
-            <div className="mt-1 text-sm text-muted-foreground">Due on the 1st</div>
-            <SmartLink href="/payments" className="mt-4 inline-block">
-              <Button size="sm">View details</Button>
-            </SmartLink>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Latest documents</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="space-y-2 text-sm">
-              <li>Lease agreement v2.pdf</li>
-              <li>House rules.pdf</li>
-            </ul>
-            <SmartLink href="/documents" className="mt-4 inline-block">
-              <Button variant="outline" size="sm">Open</Button>
-            </SmartLink>
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Roommate board</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ul className="space-y-2 text-sm">
-            <li>Jordan: Wi-Fi is down, rebooted router.</li>
-            <li>Avery: Parking spot swap this weekend?</li>
-          </ul>
-          <SmartLink href="/messaging" className="mt-4 inline-block">
-            <Button variant="outline" size="sm">Go to messages</Button>
-          </SmartLink>
-        </CardContent>
-      </Card>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- redesign the dashboard shell to use suspense-driven sections, new quick actions, and richer content cards
- expand the mock dashboard data to power rent, document, roommate, booking, and maintenance summaries
- add dedicated cards for rent, documents, roommate activity, amenity bookings, and maintenance with improved status and action affordances

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1acea4c808328900622fe9accd264