### PR TITLE
Enhance payments highlights with feature details

### DIFF
--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -1,4 +1,5 @@
 import { format, parseISO } from "date-fns"
+import { CheckCircle2 } from "lucide-react"
 
 import {
   Card,
@@ -26,21 +27,41 @@ const paymentHighlights = [
     title: "AutoPay scheduling",
     description:
       "Enable recurring rent collection with configurable due dates, grace periods, and automatic late fee handling.",
+    points: [
+      "Assign custom due dates per lease or roommate share.",
+      "Set grace windows before late fees automatically post.",
+      "Keep everyone informed with proactive autopay reminders.",
+    ],
   },
   {
     title: "One-time catch up",
     description:
       "Support partial or one-off payments so roommates can settle balances without waiting for the next billing cycle.",
+    points: [
+      "Accept partial payments against outstanding charges instantly.",
+      "Apply settlements across multiple invoices in a single flow.",
+      "Log property manager adjustments so every credit is traceable.",
+    ],
   },
   {
     title: "Receipt history",
     description:
       "Download itemized receipts and export payment history for reimbursement, tax, or dispute resolution needs.",
+    points: [
+      "Generate PDF or CSV exports on demand for bookkeeping.",
+      "Surface line items for rent, deposits, and utilities in one view.",
+      "Attach notes and documentation to streamline disputes.",
+    ],
   },
   {
     title: "Roomsily ledger",
     description:
       "Track individual roommate contributions alongside property manager adjustments to maintain full transparency.",
+    points: [
+      "Monitor running balances per roommate with live updates.",
+      "Contrast autopay coverage with manual payments at a glance.",
+      "Share the same ledger with roommates, managers, and admins.",
+    ],
   },
 ]
 
@@ -110,11 +131,21 @@ export default async function PaymentsPage() {
       </header>
       <div className="grid gap-6 md:grid-cols-2">
         {paymentHighlights.map((item) => (
-          <Card key={item.title}>
+          <Card key={item.title} className="h-full">
             <CardHeader>
               <CardTitle>{item.title}</CardTitle>
               <CardDescription>{item.description}</CardDescription>
             </CardHeader>
+            <CardContent>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {item.points.map((point) => (
+                  <li key={point} className="flex items-start gap-2">
+                    <CheckCircle2 className="mt-0.5 size-4 text-primary" />
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
           </Card>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add a check icon list to the payments highlight cards for clearer scannability
- expand each payments highlight with concrete bullet points covering scheduling, catch-up flows, receipts, and ledger transparency

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1acf40e1883289b6f862e57c39f34