### PR TITLE
feat(payments): add receipt history export and detail view

### DIFF
--- a/app/payments/_components/receipt-history-card.tsx
+++ b/app/payments/_components/receipt-history-card.tsx
@@ -1,0 +1,266 @@
+import { format, parseISO } from "date-fns"
+import { Download, FileText } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import { formatCurrency } from "@/lib/payments/currency"
+import {
+  createPaymentHistoryCsv,
+  summarizeReceiptHistory,
+} from "@/lib/payments/receipts"
+import type { PaymentReceiptHistoryEntry } from "@/types/payments"
+
+interface ReceiptHistoryCardProps {
+  receipts: PaymentReceiptHistoryEntry[]
+}
+
+const statusStyles: Record<
+  PaymentReceiptHistoryEntry["status"],
+  { label: string; variant: "secondary" | "outline" | "destructive" }
+> = {
+  paid: { label: "Paid", variant: "secondary" },
+  processing: { label: "Processing", variant: "outline" },
+  refunded: { label: "Refunded", variant: "destructive" },
+}
+
+function formatPeriod(
+  periodStart: string | undefined,
+  periodEnd: string | undefined,
+) {
+  if (!periodStart && !periodEnd) {
+    return "—"
+  }
+
+  if (periodStart && periodEnd) {
+    const start = format(parseISO(periodStart), "MMM d")
+    const end = format(parseISO(periodEnd), "MMM d, yyyy")
+    return `${start} – ${end}`
+  }
+
+  const singleDate = periodStart ?? periodEnd
+  return singleDate ? format(parseISO(singleDate), "MMM d, yyyy") : "—"
+}
+
+function encodeCsvForDownload(content: string) {
+  return `data:text/csv;charset=utf-8,${encodeURIComponent(content)}`
+}
+
+export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
+  if (!receipts.length) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Receipt history</CardTitle>
+          <CardDescription>
+            Download Stripe-issued receipts once you have completed your first
+            payment cycle.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  const summary = summarizeReceiptHistory(receipts)
+  const csvContent = createPaymentHistoryCsv(receipts)
+  const csvDownloadHref = encodeCsvForDownload(csvContent)
+
+  const currentYear = new Date().getFullYear()
+  const paidReceiptsThisYear = receipts.filter((receipt) => {
+    const paymentDate = new Date(receipt.paymentDate)
+    return (
+      !Number.isNaN(paymentDate.getTime()) &&
+      paymentDate.getFullYear() === currentYear &&
+      receipt.status === "paid"
+    )
+  }).length
+
+  const lastReceiptLabel = summary.lastReceiptDate
+    ? format(parseISO(summary.lastReceiptDate), "MMM d, yyyy")
+    : "—"
+
+  const defaultCurrency = receipts[0]?.currency ?? "USD"
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1.5">
+          <CardTitle>Receipt history</CardTitle>
+          <CardDescription>
+            Download itemized receipts and export the full payment ledger for
+            reimbursements, tax season, or dispute resolution.
+          </CardDescription>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button asChild variant="outline" size="sm" className="gap-2">
+            <a href={csvDownloadHref} download="roomsily-payment-history.csv">
+              <Download className="size-4" aria-hidden="true" />
+              Export CSV
+            </a>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <dl className="grid gap-4 sm:grid-cols-3">
+          <div className="space-y-1 rounded-lg border bg-muted/30 p-4">
+            <dt className="text-xs font-medium uppercase text-muted-foreground">
+              Receipts YTD
+            </dt>
+            <dd className="text-lg font-semibold">
+              {paidReceiptsThisYear}
+            </dd>
+            <p className="text-xs text-muted-foreground">
+              {formatCurrency(summary.yearToDateAmount, defaultCurrency)}
+              {" total processed"}
+            </p>
+          </div>
+          <div className="space-y-1 rounded-lg border bg-muted/30 p-4">
+            <dt className="text-xs font-medium uppercase text-muted-foreground">
+              Reimbursable line items
+            </dt>
+            <dd className="text-lg font-semibold">
+              {summary.reimbursableLineItems}
+            </dd>
+            <p className="text-xs text-muted-foreground">
+              Utilities, fees, and maintenance tracked for audits
+            </p>
+          </div>
+          <div className="space-y-1 rounded-lg border bg-muted/30 p-4">
+            <dt className="text-xs font-medium uppercase text-muted-foreground">
+              Last receipt issued
+            </dt>
+            <dd className="text-lg font-semibold">{lastReceiptLabel}</dd>
+            <p className="text-xs text-muted-foreground">
+              Stay audit-ready with consolidated records
+            </p>
+          </div>
+        </dl>
+        <ScrollArea className="max-h-[540px]">
+          <div className="min-w-[760px] overflow-hidden rounded-lg border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/60 text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium">Payment</th>
+                  <th className="px-4 py-3 text-left font-medium">Period</th>
+                  <th className="px-4 py-3 text-left font-medium">Line items</th>
+                  <th className="px-4 py-3 text-right font-medium">Amount</th>
+                  <th className="px-4 py-3 text-left font-medium">Status</th>
+                  <th className="px-4 py-3 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {receipts.map((receipt) => {
+                  const status = statusStyles[receipt.status]
+                  return (
+                    <tr key={receipt.id} className="align-top">
+                      <td className="p-4">
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium text-foreground">
+                            {receipt.issuedTo}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {format(parseISO(receipt.paymentDate), "MMM d, yyyy")} · {receipt.paymentMethod}
+                          </p>
+                          {receipt.memo ? (
+                            <p className="text-xs text-muted-foreground">
+                              {receipt.memo}
+                            </p>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td className="p-4 text-sm text-muted-foreground">
+                        {formatPeriod(receipt.periodStart, receipt.periodEnd)}
+                      </td>
+                      <td className="p-4">
+                        <ul className="space-y-1">
+                          {receipt.lineItems.map((item) => (
+                            <li
+                              key={item.id}
+                              className="flex items-start justify-between gap-3 text-xs text-muted-foreground"
+                            >
+                              <span className="max-w-[220px] text-sm text-foreground">
+                                {item.description}
+                              </span>
+                              <span
+                                className={cn(
+                                  "text-sm font-medium",
+                                  item.totalAmount < 0 && "text-destructive",
+                                )}
+                              >
+                                {formatCurrency(item.totalAmount, receipt.currency)}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </td>
+                      <td className="p-4 text-right">
+                        <div
+                          className={cn(
+                            "text-sm font-semibold",
+                            receipt.amount < 0 && "text-destructive",
+                          )}
+                        >
+                          {formatCurrency(receipt.amount, receipt.currency)}
+                        </div>
+                        {receipt.amount < 0 ? (
+                          <p className="text-xs text-muted-foreground">Credit issued</p>
+                        ) : null}
+                      </td>
+                      <td className="p-4">
+                        <Badge variant={status.variant}>{status.label}</Badge>
+                      </td>
+                      <td className="p-4">
+                        <div className="flex flex-col items-end gap-2">
+                          <Button
+                            asChild
+                            variant="outline"
+                            size="sm"
+                            className="w-full gap-1"
+                          >
+                            <a
+                              href={receipt.receiptUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              <Download className="size-4" aria-hidden="true" />
+                              Receipt
+                            </a>
+                          </Button>
+                          {receipt.invoiceUrl ? (
+                            <Button
+                              asChild
+                              variant="ghost"
+                              size="sm"
+                              className="w-full gap-1"
+                            >
+                              <a
+                                href={receipt.invoiceUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <FileText className="size-4" aria-hidden="true" />
+                                Invoice
+                              </a>
+                            </Button>
+                          ) : null}
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/payments/loaders.ts
+++ b/app/payments/loaders.ts
@@ -2,9 +2,16 @@
 
 import "server-only"
 
-import { catchUpBalances } from "@/lib/payments/mock-data"
-import type { CatchUpBalance } from "@/types/payments"
+import { catchUpBalances, receiptHistory } from "@/lib/payments/mock-data"
+import type {
+  CatchUpBalance,
+  PaymentReceiptHistoryEntry,
+} from "@/types/payments"
 
 export async function loadCatchUpBalances(): Promise<CatchUpBalance[]> {
   return catchUpBalances
+}
+
+export async function loadReceiptHistory(): Promise<PaymentReceiptHistoryEntry[]> {
+  return receiptHistory
 }

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -8,7 +8,6 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
-import { Button } from "@/components/ui/button"
 import { StripeActions } from "./_components/stripe-actions"
 import { CatchUpPaymentCard } from "./_components/catch-up-payment-card"
 import {
@@ -19,7 +18,8 @@ import {
 import { formatCurrency } from "@/lib/payments/currency"
 import type { CatchUpBalance } from "@/types/payments"
 
-import { loadCatchUpBalances } from "./loaders"
+import { loadCatchUpBalances, loadReceiptHistory } from "./loaders"
+import { ReceiptHistoryCard } from "./_components/receipt-history-card"
 
 const paymentHighlights = [
   {
@@ -64,7 +64,10 @@ function formatFullDate(date: string) {
 }
 
 export default async function PaymentsPage() {
-  const catchUpBalances = await loadCatchUpBalances()
+  const [catchUpBalances, receiptHistory] = await Promise.all([
+    loadCatchUpBalances(),
+    loadReceiptHistory(),
+  ])
   const outstandingSummaries = catchUpBalances.map((balance) => {
     const outstanding = calculateOutstanding(balance.charges)
     const nextCharge = getNextOutstandingCharge(balance.charges)
@@ -218,6 +221,7 @@ export default async function PaymentsPage() {
         </div>
         <CatchUpPaymentCard balances={catchUpBalances} />
       </section>
+      <ReceiptHistoryCard receipts={receiptHistory} />
     </div>
   )
 }

--- a/lib/payments/mock-data.ts
+++ b/lib/payments/mock-data.ts
@@ -1,4 +1,4 @@
-import type { CatchUpBalance } from "@/types/payments"
+import type { CatchUpBalance, PaymentReceiptHistoryEntry } from "@/types/payments"
 
 export const catchUpBalances: CatchUpBalance[] = [
   {
@@ -145,5 +145,125 @@ export const catchUpBalances: CatchUpBalance[] = [
         email: "morgan.ellis@sharehouse.example",
       },
     },
+  },
+]
+
+export const receiptHistory: PaymentReceiptHistoryEntry[] = [
+  {
+    id: "rcpt_avery_2024_06",
+    issuedTo: "Avery Chen",
+    paymentDate: "2024-06-01",
+    periodStart: "2024-06-01",
+    periodEnd: "2024-06-30",
+    currency: "USD",
+    amount: 1335,
+    status: "paid",
+    paymentMethod: "Visa •••• 4242 (Autopay)",
+    receiptUrl: "https://receipts.roomsily.dev/rcpt_avery_2024_06.pdf",
+    invoiceUrl: "https://receipts.roomsily.dev/invoice_avery_2024_06",
+    memo: "Includes rent share plus reimbursable Wi-Fi and maintenance fees.",
+    lineItems: [
+      {
+        id: "avery_rent_june",
+        description: "June rent share",
+        category: "rent",
+        quantity: 1,
+        unitAmount: 1260,
+        totalAmount: 1260,
+      },
+      {
+        id: "avery_wifi_june",
+        description: "Wi-Fi reimbursement",
+        category: "utilities",
+        quantity: 1,
+        unitAmount: 45,
+        totalAmount: 45,
+      },
+      {
+        id: "avery_maintenance_june",
+        description: "Community maintenance fee",
+        category: "maintenance",
+        quantity: 1,
+        unitAmount: 30,
+        totalAmount: 30,
+      },
+    ],
+  },
+  {
+    id: "rcpt_jordan_2024_05",
+    issuedTo: "Jordan Blake",
+    paymentDate: "2024-05-12",
+    periodStart: "2024-05-01",
+    periodEnd: "2024-05-31",
+    currency: "USD",
+    amount: 880,
+    status: "paid",
+    paymentMethod: "ACH checking •••• 1100",
+    receiptUrl: "https://receipts.roomsily.dev/rcpt_jordan_2024_05.pdf",
+    invoiceUrl: "https://receipts.roomsily.dev/invoice_jordan_2024_05",
+    memo: "Manual catch-up payment covering parking and partial rent.",
+    lineItems: [
+      {
+        id: "jordan_rent_may",
+        description: "May rent share (partial)",
+        category: "rent",
+        quantity: 1,
+        unitAmount: 800,
+        totalAmount: 800,
+      },
+      {
+        id: "jordan_parking_may",
+        description: "Parking spot 17",
+        category: "parking",
+        quantity: 1,
+        unitAmount: 80,
+        totalAmount: 80,
+      },
+    ],
+  },
+  {
+    id: "rcpt_priya_2024_04",
+    issuedTo: "Priya Desai",
+    paymentDate: "2024-04-30",
+    periodStart: "2024-04-01",
+    periodEnd: "2024-04-30",
+    currency: "USD",
+    amount: 1260,
+    status: "paid",
+    paymentMethod: "Visa •••• 3188",
+    receiptUrl: "https://receipts.roomsily.dev/rcpt_priya_2024_04.pdf",
+    invoiceUrl: "https://receipts.roomsily.dev/invoice_priya_2024_04",
+    memo: "Autopay rent receipt for April billing period.",
+    lineItems: [
+      {
+        id: "priya_rent_april",
+        description: "April rent share",
+        category: "rent",
+        quantity: 1,
+        unitAmount: 1260,
+        totalAmount: 1260,
+      },
+    ],
+  },
+  {
+    id: "rcpt_unit_refund_2024_03",
+    issuedTo: "Unit 3B",
+    paymentDate: "2024-03-18",
+    currency: "USD",
+    amount: -60,
+    status: "refunded",
+    paymentMethod: "Roomsily credit",
+    receiptUrl: "https://receipts.roomsily.dev/rcpt_unit_refund_2024_03.pdf",
+    memo: "Refund issued after duplicate community maintenance charge.",
+    lineItems: [
+      {
+        id: "unit_maintenance_refund",
+        description: "Maintenance fee adjustment",
+        category: "maintenance",
+        quantity: 1,
+        unitAmount: -60,
+        totalAmount: -60,
+      },
+    ],
   },
 ]

--- a/lib/payments/receipts.ts
+++ b/lib/payments/receipts.ts
@@ -1,0 +1,106 @@
+import { roundToCurrency } from "./currency"
+import type {
+  PaymentReceiptHistoryEntry,
+  PaymentReceiptLineItem,
+} from "@/types/payments"
+
+const reimbursableCategories: PaymentReceiptLineItem["category"][] = [
+  "utilities",
+  "fees",
+  "maintenance",
+]
+
+export interface ReceiptHistorySummary {
+  yearToDateAmount: number
+  reimbursableLineItems: number
+  lastReceiptDate: string | null
+}
+
+export function summarizeReceiptHistory(
+  receipts: PaymentReceiptHistoryEntry[],
+): ReceiptHistorySummary {
+  const currentYear = new Date().getFullYear()
+
+  let yearToDateAmount = 0
+  let reimbursableLineItems = 0
+  let lastReceiptDate: Date | null = null
+
+  for (const receipt of receipts) {
+    const paymentDate = new Date(receipt.paymentDate)
+
+    if (!Number.isNaN(paymentDate.getTime())) {
+      if (!lastReceiptDate || paymentDate > lastReceiptDate) {
+        lastReceiptDate = paymentDate
+      }
+
+      if (paymentDate.getFullYear() === currentYear && receipt.status === "paid") {
+        yearToDateAmount += receipt.amount
+      }
+    }
+
+    reimbursableLineItems += receipt.lineItems.filter((item) =>
+      reimbursableCategories.includes(item.category),
+    ).length
+  }
+
+  return {
+    yearToDateAmount: roundToCurrency(yearToDateAmount),
+    reimbursableLineItems,
+    lastReceiptDate: lastReceiptDate ? lastReceiptDate.toISOString() : null,
+  }
+}
+
+export function createPaymentHistoryCsv(
+  receipts: PaymentReceiptHistoryEntry[],
+): string {
+  const headers = [
+    "Receipt ID",
+    "Issued To",
+    "Payment Date",
+    "Period Start",
+    "Period End",
+    "Status",
+    "Amount",
+    "Currency",
+    "Payment Method",
+    "Line Items",
+    "Memo",
+    "Receipt URL",
+    "Invoice URL",
+  ]
+
+  const rows = receipts.map((receipt) => {
+    const lineItems = receipt.lineItems
+      .map((item) => {
+        const formattedAmount = item.totalAmount.toFixed(2)
+        return `${item.description} [${item.category}] ${formattedAmount}`
+      })
+      .join(" | ")
+
+    return [
+      receipt.id,
+      receipt.issuedTo,
+      receipt.paymentDate,
+      receipt.periodStart ?? "",
+      receipt.periodEnd ?? "",
+      receipt.status,
+      receipt.amount.toFixed(2),
+      receipt.currency,
+      receipt.paymentMethod,
+      lineItems,
+      receipt.memo ?? "",
+      receipt.receiptUrl,
+      receipt.invoiceUrl ?? "",
+    ]
+  })
+
+  const toCsvRow = (values: string[]) =>
+    values
+      .map((value) => {
+        const sanitized = value.replace(/"/g, '""')
+        return `"${sanitized}"`
+      })
+      .join(",")
+
+  return [headers, ...rows].map((row) => toCsvRow(row)).join("\n")
+}

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -75,3 +75,30 @@ export interface CatchUpPaymentFormValues {
   includePropertyManager: boolean
   note?: string
 }
+
+export type PaymentReceiptStatus = "paid" | "processing" | "refunded"
+
+export interface PaymentReceiptLineItem {
+  id: string
+  description: string
+  category: CatchUpChargeCategory
+  quantity?: number
+  unitAmount?: number
+  totalAmount: number
+}
+
+export interface PaymentReceiptHistoryEntry {
+  id: string
+  issuedTo: string
+  paymentDate: string
+  currency: string
+  amount: number
+  status: PaymentReceiptStatus
+  paymentMethod: string
+  periodStart?: string
+  periodEnd?: string
+  receiptUrl: string
+  invoiceUrl?: string
+  memo?: string
+  lineItems: PaymentReceiptLineItem[]
+}


### PR DESCRIPTION
## Summary
- add a receipt history card with CSV export, inline stats, and download actions
- define mock receipt data, payment receipt types, and a loader to surface the history
- introduce receipt helpers and wire the payments page to render the new panel

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ad04a8f883288bc1cfce23d6796d