### PR TITLE
Add roommate ledger transparency to payments

### DIFF
--- a/app/payments/_components/roommate-ledger.tsx
+++ b/app/payments/_components/roommate-ledger.tsx
@@ -1,0 +1,226 @@
+import { Fragment } from "react"
+import { format, parseISO } from "date-fns"
+
+import { Badge, type BadgeProps } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { formatCurrency, roundToCurrency } from "@/lib/payments/currency"
+import { cn } from "@/lib/utils"
+import type {
+  LedgerActorRole,
+  LedgerEntryType,
+  RoommateLedger,
+} from "@/types/payments"
+
+interface RoommateLedgerProps {
+  ledgers: RoommateLedger[]
+}
+
+type LedgerRow = RoommateLedger["entries"][number] & { balanceAfter: number }
+
+const ledgerEntryTypeMeta: Record<
+  LedgerEntryType,
+  { label: string; badgeVariant: BadgeProps["variant"] }
+> = {
+  contribution: { label: "Contribution", badgeVariant: "complete" },
+  adjustment: { label: "Adjustment", badgeVariant: "outline" },
+}
+
+const actorRoleLabels: Record<LedgerActorRole, string> = {
+  roommate: "Roommate",
+  property_manager: "Property manager",
+}
+
+export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
+  if (ledgers.length === 0) {
+    return null
+  }
+
+  const derivedLedgers = ledgers.map((ledger) => {
+    let running = roundToCurrency(ledger.startingBalance)
+    const rows: LedgerRow[] = ledger.entries.map((entry) => {
+      running = roundToCurrency(running + entry.amount)
+      return { ...entry, balanceAfter: running }
+    })
+
+    return {
+      ledger,
+      rows,
+      currentOutstanding: running,
+      contributionsCount: ledger.entries.filter(
+        (entry) => entry.type === "contribution",
+      ).length,
+      adjustmentsCount: ledger.entries.filter(
+        (entry) => entry.type === "adjustment",
+      ).length,
+      lastUpdated: rows.at(-1)?.date ?? null,
+    }
+  })
+
+  const sortedLedgers = [...derivedLedgers].sort(
+    (a, b) => b.currentOutstanding - a.currentOutstanding,
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Roomsily ledger</CardTitle>
+        <CardDescription>
+          Track individual roommate contributions alongside property manager
+          adjustments for a shared source of truth.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-10">
+        {sortedLedgers.map(
+          (
+            {
+              ledger,
+              rows,
+              currentOutstanding,
+              contributionsCount,
+              adjustmentsCount,
+              lastUpdated,
+            },
+            index,
+          ) => {
+            const lastUpdatedLabel = lastUpdated
+              ? format(parseISO(lastUpdated), "MMM d, yyyy")
+              : null
+            const contributionsCopy =
+              contributionsCount === 1
+                ? "1 contribution"
+                : `${contributionsCount} contributions`
+            const adjustmentsCopy =
+              adjustmentsCount === 1
+                ? "1 adjustment"
+                : `${adjustmentsCount} adjustments`
+
+            return (
+              <Fragment key={ledger.roommateId}>
+                <div className="space-y-4">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold">{ledger.roommateName}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {ledger.unitLabel}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {contributionsCopy} · {adjustmentsCopy}
+                      </p>
+                      {lastUpdatedLabel ? (
+                        <p className="text-xs text-muted-foreground">
+                          Last activity {lastUpdatedLabel}
+                        </p>
+                      ) : null}
+                    </div>
+                    <div className="text-right">
+                      <p className="text-xs uppercase text-muted-foreground">
+                        Outstanding
+                      </p>
+                      <p className="text-sm font-semibold">
+                        {formatCurrency(currentOutstanding, ledger.currency)}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Started at {formatCurrency(ledger.startingBalance, ledger.currency)}
+                      </p>
+                    </div>
+                  </div>
+                  {rows.length > 0 ? (
+                    <div className="overflow-hidden rounded-lg border">
+                      <div className="grid grid-cols-[110px_minmax(0,1fr)_140px_140px] bg-muted/40 px-4 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:grid-cols-[120px_minmax(0,1fr)_150px_150px]">
+                        <span>Date</span>
+                        <span>Details</span>
+                        <span className="text-right">Change</span>
+                        <span className="text-right">Balance</span>
+                      </div>
+                      <div className="[&>div:not(:last-child)]:border-b">
+                        {rows.map((entry) => {
+                          const entryDate = parseISO(entry.date)
+                          const formattedDate = format(entryDate, "MMM d")
+                          const formattedYear = format(entryDate, "yyyy")
+                          const amountClass =
+                            entry.amount < 0
+                              ? "text-emerald-600"
+                              : entry.amount > 0
+                                ? "text-rose-600"
+                                : "text-muted-foreground"
+                          const entryTypeMeta = ledgerEntryTypeMeta[entry.type]
+
+                          return (
+                            <div
+                              key={entry.id}
+                              className="grid grid-cols-[110px_minmax(0,1fr)_140px_140px] gap-x-4 px-4 py-3 text-sm sm:grid-cols-[120px_minmax(0,1fr)_150px_150px]"
+                            >
+                              <div>
+                                <p className="font-medium">{formattedDate}</p>
+                                <p className="text-xs text-muted-foreground">
+                                  {formattedYear}
+                                </p>
+                              </div>
+                              <div className="space-y-1">
+                                <p className="font-medium">{entry.description}</p>
+                                <p className="text-xs text-muted-foreground">
+                                  Logged by {entry.actor.name} ·
+                                  {" "}
+                                  {actorRoleLabels[entry.actor.role]}
+                                </p>
+                                {entry.note ? (
+                                  <p className="text-xs text-muted-foreground">
+                                    {entry.note}
+                                  </p>
+                                ) : null}
+                              </div>
+                              <div className="flex flex-col items-end gap-1 text-right">
+                                <span className={cn("font-semibold", amountClass)}>
+                                  {formatLedgerChange(entry.amount, ledger.currency)}
+                                </span>
+                                <Badge
+                                  variant={entryTypeMeta.badgeVariant}
+                                  className="w-fit"
+                                >
+                                  {entryTypeMeta.label}
+                                </Badge>
+                              </div>
+                              <div className="text-right">
+                                <p className="font-semibold">
+                                  {formatCurrency(entry.balanceAfter, ledger.currency)}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  Running balance
+                                </p>
+                              </div>
+                            </div>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="rounded-lg border border-dashed bg-muted/30 p-6 text-sm text-muted-foreground">
+                      No ledger activity recorded yet.
+                    </div>
+                  )}
+                </div>
+                {index < sortedLedgers.length - 1 ? <Separator /> : null}
+              </Fragment>
+            )
+          },
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function formatLedgerChange(amount: number, currency: string): string {
+  if (amount === 0) {
+    return formatCurrency(0, currency)
+  }
+
+  const prefix = amount > 0 ? "+" : "-"
+  return `${prefix}${formatCurrency(Math.abs(amount), currency)}`
+}

--- a/app/payments/loaders.ts
+++ b/app/payments/loaders.ts
@@ -2,9 +2,13 @@
 
 import "server-only"
 
-import { catchUpBalances } from "@/lib/payments/mock-data"
-import type { CatchUpBalance } from "@/types/payments"
+import { catchUpBalances, roommateLedgers } from "@/lib/payments/mock-data"
+import type { CatchUpBalance, RoommateLedger } from "@/types/payments"
 
 export async function loadCatchUpBalances(): Promise<CatchUpBalance[]> {
   return catchUpBalances
+}
+
+export async function loadRoommateLedgers(): Promise<RoommateLedger[]> {
+  return roommateLedgers
 }

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -8,9 +8,9 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
-import { Button } from "@/components/ui/button"
 import { StripeActions } from "./_components/stripe-actions"
 import { CatchUpPaymentCard } from "./_components/catch-up-payment-card"
+import { RoommateLedger } from "./_components/roommate-ledger"
 import {
   calculateOutstanding,
   formatAutopayDay,
@@ -19,7 +19,7 @@ import {
 import { formatCurrency } from "@/lib/payments/currency"
 import type { CatchUpBalance } from "@/types/payments"
 
-import { loadCatchUpBalances } from "./loaders"
+import { loadCatchUpBalances, loadRoommateLedgers } from "./loaders"
 
 const paymentHighlights = [
   {
@@ -64,7 +64,10 @@ function formatFullDate(date: string) {
 }
 
 export default async function PaymentsPage() {
-  const catchUpBalances = await loadCatchUpBalances()
+  const [catchUpBalances, roommateLedgers] = await Promise.all([
+    loadCatchUpBalances(),
+    loadRoommateLedgers(),
+  ])
   const outstandingSummaries = catchUpBalances.map((balance) => {
     const outstanding = calculateOutstanding(balance.charges)
     const nextCharge = getNextOutstandingCharge(balance.charges)
@@ -218,6 +221,7 @@ export default async function PaymentsPage() {
         </div>
         <CatchUpPaymentCard balances={catchUpBalances} />
       </section>
+      <RoommateLedger ledgers={roommateLedgers} />
     </div>
   )
 }

--- a/lib/payments/mock-data.ts
+++ b/lib/payments/mock-data.ts
@@ -1,4 +1,4 @@
-import type { CatchUpBalance } from "@/types/payments"
+import type { CatchUpBalance, RoommateLedger } from "@/types/payments"
 
 export const catchUpBalances: CatchUpBalance[] = [
   {
@@ -145,5 +145,213 @@ export const catchUpBalances: CatchUpBalance[] = [
         email: "morgan.ellis@sharehouse.example",
       },
     },
+  },
+]
+
+export const roommateLedgers: RoommateLedger[] = [
+  {
+    roommateId: "rm_avery",
+    roommateName: "Avery Chen",
+    unitLabel: "Unit 3B",
+    currency: "USD",
+    startingBalance: 0,
+    entries: [
+      {
+        id: "rm_avery_rent_june_posted",
+        date: "2024-05-28",
+        description: "Posted June rent share",
+        amount: 1260,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Rent share added to the shared ledger ahead of autopay.",
+      },
+      {
+        id: "rm_avery_autopay_june",
+        date: "2024-06-01",
+        description: "Autopay - June rent share",
+        amount: -1000,
+        type: "contribution",
+        actor: {
+          name: "Avery Chen",
+          role: "roommate",
+        },
+        note: "Partial autopay captured from preferred payment method.",
+      },
+      {
+        id: "rm_avery_wifi_trueup",
+        date: "2024-06-05",
+        description: "Wi-Fi reimbursement",
+        amount: 45,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Fiber upgrade reimbursement split across the unit.",
+      },
+      {
+        id: "rm_avery_maintenance_fee",
+        date: "2024-06-10",
+        description: "Community maintenance fee",
+        amount: 30,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Shared amenity refresh charge from the property manager.",
+      },
+    ],
+  },
+  {
+    roommateId: "rm_jordan",
+    roommateName: "Jordan Blake",
+    unitLabel: "Unit 3B",
+    currency: "USD",
+    startingBalance: 0,
+    entries: [
+      {
+        id: "rm_jordan_rent_june_posted",
+        date: "2024-05-28",
+        description: "Posted June rent share",
+        amount: 1260,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+      },
+      {
+        id: "rm_jordan_parking_assignment",
+        date: "2024-05-29",
+        description: "Parking spot 17",
+        amount: 80,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Monthly reserved parking fee added to ledger.",
+      },
+      {
+        id: "rm_jordan_manual_payment",
+        date: "2024-05-30",
+        description: "Manual payment - rent catch up",
+        amount: -780,
+        type: "contribution",
+        actor: {
+          name: "Jordan Blake",
+          role: "roommate",
+        },
+        note: "Partial payment posted after autopay pause.",
+      },
+      {
+        id: "rm_jordan_utilities_trueup",
+        date: "2024-06-02",
+        description: "Shared utilities true-up",
+        amount: 62,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+      },
+      {
+        id: "rm_jordan_late_fee",
+        date: "2024-06-04",
+        description: "Late fee while autopay paused",
+        amount: 20,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Fee added per lease agreement after autopay pause.",
+      },
+      {
+        id: "rm_jordan_parking_payment",
+        date: "2024-06-06",
+        description: "Parking true-up payment",
+        amount: -40,
+        type: "contribution",
+        actor: {
+          name: "Jordan Blake",
+          role: "roommate",
+        },
+        note: "Paid half of the parking balance via one-time checkout.",
+      },
+      {
+        id: "rm_jordan_late_fee_waived",
+        date: "2024-06-07",
+        description: "Late fee waived",
+        amount: -20,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Waived after repayment plan confirmed with roommates.",
+      },
+    ],
+  },
+  {
+    roommateId: "rm_priya",
+    roommateName: "Priya Desai",
+    unitLabel: "Unit 3B",
+    currency: "USD",
+    startingBalance: 0,
+    entries: [
+      {
+        id: "rm_priya_rent_june_posted",
+        date: "2024-05-28",
+        description: "Posted June rent share",
+        amount: 1260,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Recurring rent share added while autopay is disabled.",
+      },
+      {
+        id: "rm_priya_supplies_reimbursement",
+        date: "2024-06-04",
+        description: "Household supplies reimbursement",
+        amount: 38,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Reimbursement for bulk cleaning supplies delivered in May.",
+      },
+      {
+        id: "rm_priya_courtesy_credit",
+        date: "2024-06-06",
+        description: "Courtesy credit - cleaning overlap",
+        amount: -25,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Temporary credit while reviewing contractor invoice.",
+      },
+      {
+        id: "rm_priya_credit_reversed",
+        date: "2024-06-08",
+        description: "Credit reversed after vendor invoice",
+        amount: 25,
+        type: "adjustment",
+        actor: {
+          name: "Morgan Ellis",
+          role: "property_manager",
+        },
+        note: "Charge reinstated once the final cleaning invoice arrived.",
+      },
+    ],
   },
 ]

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -75,3 +75,31 @@ export interface CatchUpPaymentFormValues {
   includePropertyManager: boolean
   note?: string
 }
+
+export type LedgerEntryType = "contribution" | "adjustment"
+
+export type LedgerActorRole = "roommate" | "property_manager"
+
+export interface LedgerEntryActor {
+  name: string
+  role: LedgerActorRole
+}
+
+export interface LedgerEntry {
+  id: string
+  date: string
+  description: string
+  amount: number
+  type: LedgerEntryType
+  actor: LedgerEntryActor
+  note?: string
+}
+
+export interface RoommateLedger {
+  roommateId: string
+  roommateName: string
+  unitLabel: string
+  currency: string
+  startingBalance: number
+  entries: LedgerEntry[]
+}


### PR DESCRIPTION
## Summary
- add ledger domain types and mock roommate ledger data to the payments mocks
- expose a loader and server component that render roommate contribution and adjustment history
- surface the new Roomsily ledger card on the payments page to visualise running balances for each roommate

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ad010a788328a3b6c544a9f0ca06