### PR TITLE
Add AutoPay scheduling configuration and tests

### DIFF
--- a/app/payments/_components/autopay-schedule-card.tsx
+++ b/app/payments/_components/autopay-schedule-card.tsx
@@ -1,0 +1,511 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { format, parseISO } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import {
+  calculateLateFeeAmount,
+  getAutopayScheduleWindow,
+  getBillingPeriod,
+} from "@/lib/payments/autopay"
+import { formatCurrency } from "@/lib/payments/currency"
+import type {
+  AutopayScheduleConfig,
+  AutopayStatus,
+} from "@/types/payments"
+
+const autopayStatusCopy: Record<
+  AutopayStatus,
+  { label: string; variant: "complete" | "secondary" | "outline" }
+> = {
+  active: { label: "Autopay active", variant: "complete" },
+  paused: { label: "Autopay paused", variant: "secondary" },
+  disabled: { label: "Autopay off", variant: "outline" },
+}
+
+const dueDayOptions = Array.from({ length: 28 }, (_, index) => index + 1)
+const autopayLeadOptions = [0, 1, 2, 3, 5, 7]
+const graceOptions = [0, 1, 2, 3, 4, 5, 7]
+
+type AutopayScheduleCardProps = {
+  schedule: AutopayScheduleConfig
+}
+
+type AutopayFormState = {
+  dueDay: number
+  autopayLeadDays: number
+  gracePeriodDays: number
+  lateFeeMode: "flat" | "percentage"
+  lateFeeValue: string
+  lateFeeCap: string
+}
+
+function formatTimeOfDay(time: string, timezone: string): string {
+  const [hoursString, minutesString] = time.split(":")
+  const hours = Number.parseInt(hoursString ?? "0", 10)
+  const minutes = Number.parseInt(minutesString ?? "0", 10)
+  const baseDate = new Date()
+  baseDate.setHours(hours, minutes, 0, 0)
+
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: timezone,
+    }).format(baseDate)
+  } catch {
+    return `${time} ${timezone}`
+  }
+}
+
+function getTimezoneAbbreviation(timezone: string, reference: Date): string {
+  try {
+    const parts = new Intl.DateTimeFormat(undefined, {
+      timeZone: timezone,
+      timeZoneName: "short",
+    }).formatToParts(reference)
+    const timeZoneNamePart = parts.find((part) => part.type === "timeZoneName")
+    return timeZoneNamePart?.value ?? timezone
+  } catch {
+    return timezone
+  }
+}
+
+function safeFormatDate(value: string, pattern: string): string {
+  if (!value) {
+    return "—"
+  }
+
+  const parsed = parseISO(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return "—"
+  }
+
+  try {
+    return format(parsed, pattern)
+  } catch {
+    return "—"
+  }
+}
+
+function describeLateFee(
+  rule: AutopayScheduleConfig["settings"]["lateFee"],
+  projectedLateFee: number,
+  currency: string,
+): string {
+  if (rule.mode === "flat") {
+    return `${formatCurrency(rule.amount, currency)} flat fee`
+  }
+
+  if (typeof rule.cap === "number") {
+    return `${formatCurrency(projectedLateFee, currency)} (${rule.percentage}% · capped at ${formatCurrency(rule.cap, currency)})`
+  }
+
+  return `${formatCurrency(projectedLateFee, currency)} (${rule.percentage}% of rent)`
+}
+
+export function AutoPayScheduleCard({ schedule }: AutopayScheduleCardProps) {
+  const initialLateFee = schedule.settings.lateFee
+  const initialLateFeeMode = initialLateFee.mode
+  const initialLateFeeValue =
+    initialLateFeeMode === "flat"
+      ? initialLateFee.amount.toString()
+      : initialLateFee.percentage.toString()
+  const initialLateFeeCap =
+    initialLateFeeMode === "percentage" && typeof initialLateFee.cap === "number"
+      ? initialLateFee.cap.toString()
+      : ""
+
+  const [enabled, setEnabled] = useState(schedule.autopayEnabled)
+  const [formState, setFormState] = useState<AutopayFormState>({
+    dueDay: schedule.settings.dueDay,
+    autopayLeadDays: schedule.settings.autopayLeadDays,
+    gracePeriodDays: schedule.settings.gracePeriodDays,
+    lateFeeMode: initialLateFeeMode,
+    lateFeeValue: initialLateFeeValue,
+    lateFeeCap: initialLateFeeCap,
+  })
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null)
+
+  const computed = useMemo(() => {
+    const parsedValue = Number.parseFloat(formState.lateFeeValue)
+    const safeValue = Number.isFinite(parsedValue) ? parsedValue : 0
+    const parsedCap = Number.parseFloat(formState.lateFeeCap)
+    const safeCap = Number.isFinite(parsedCap) ? parsedCap : undefined
+
+    const lateFee =
+      formState.lateFeeMode === "flat"
+        ? { mode: "flat" as const, amount: safeValue }
+        : { mode: "percentage" as const, percentage: safeValue, cap: safeCap }
+
+    const updatedSchedule: AutopayScheduleConfig = {
+      ...schedule,
+      autopayEnabled: enabled,
+      settings: {
+        ...schedule.settings,
+        dueDay: formState.dueDay,
+        autopayLeadDays: formState.autopayLeadDays,
+        gracePeriodDays: formState.gracePeriodDays,
+        lateFee,
+      },
+    }
+
+    return {
+      schedule: updatedSchedule,
+      window: getAutopayScheduleWindow(updatedSchedule),
+      billingPeriod: getBillingPeriod(updatedSchedule),
+      projectedLateFee: calculateLateFeeAmount(updatedSchedule),
+    }
+  }, [enabled, formState, schedule])
+
+  const autopayTimeLabel = useMemo(
+    () => formatTimeOfDay(schedule.settings.autopayTime, schedule.settings.timezone),
+    [schedule.settings.autopayTime, schedule.settings.timezone],
+  )
+
+  const timezoneLabel = useMemo(
+    () => getTimezoneAbbreviation(schedule.settings.timezone, computed.window.autopayDate),
+    [computed.window.autopayDate, schedule.settings.timezone],
+  )
+
+  const autopayLeadCopy =
+    formState.autopayLeadDays === 0
+      ? "on the due date"
+      : `${formState.autopayLeadDays} day${formState.autopayLeadDays === 1 ? "" : "s"} before rent is due`
+
+  const coverage = useMemo(() => {
+    const breakdown = computed.schedule.participants.reduce<
+      Record<AutopayStatus, number>
+    >(
+      (accumulator, participant) => {
+        accumulator[participant.autopayStatus] += 1
+        return accumulator
+      },
+      { active: 0, paused: 0, disabled: 0 },
+    )
+
+    const total = computed.schedule.participants.length
+    const percentage = total > 0 ? Math.round((breakdown.active / total) * 100) : 0
+
+    return { ...breakdown, total, percentage }
+  }, [computed.schedule.participants])
+
+  const retryWindowLabel = format(computed.window.retryWindowEnd, "MMM d")
+  const billingWindowLabel = `${format(computed.billingPeriod.start, "MMM d")} – ${format(
+    computed.billingPeriod.end,
+    "MMM d",
+  )}`
+
+  const nextAutopayPrimary = enabled
+    ? format(computed.window.autopayDate, "MMM d")
+    : "Autopay disabled"
+  const nextAutopaySecondary = enabled
+    ? `Runs at ${autopayTimeLabel} ${timezoneLabel} (${autopayLeadCopy})`
+    : "Turn on AutoPay to draft rent before the due date."
+
+  const lastRunDate = safeFormatDate(computed.schedule.lastRun.processedAt, "MMM d, yyyy")
+  const lastRunStatusCopy: Record<
+    AutopayScheduleConfig["lastRun"]["status"],
+    string
+  > = {
+    succeeded: "Succeeded",
+    partial: "Partial",
+    failed: "Failed",
+  }
+
+  const handleSave = () => {
+    setLastSavedAt(new Date())
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>AutoPay schedule</CardTitle>
+        <CardDescription>
+          Configure recurring rent collection, grace periods, and late fee automation.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-lg border bg-muted/40 p-4">
+            <p className="text-xs uppercase text-muted-foreground">Next AutoPay</p>
+            <p className="text-base font-semibold">{nextAutopayPrimary}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {enabled ? `${nextAutopaySecondary} · Retries through ${retryWindowLabel}` : nextAutopaySecondary}
+            </p>
+          </div>
+          <div className="rounded-lg border bg-muted/40 p-4">
+            <p className="text-xs uppercase text-muted-foreground">Rent due</p>
+            <p className="text-base font-semibold">
+              {format(computed.window.dueDate, "MMM d")}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">Billing window {billingWindowLabel}</p>
+          </div>
+          <div className="rounded-lg border bg-muted/40 p-4">
+            <p className="text-xs uppercase text-muted-foreground">Grace period</p>
+            <p className="text-base font-semibold">
+              {formState.gracePeriodDays} day{formState.gracePeriodDays === 1 ? "" : "s"}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Late fee posts {format(computed.window.lateFeeDate, "MMM d")}
+            </p>
+          </div>
+          <div className="rounded-lg border bg-muted/40 p-4">
+            <p className="text-xs uppercase text-muted-foreground">Late fee</p>
+            <p className="text-base font-semibold">
+              {describeLateFee(
+                computed.schedule.settings.lateFee,
+                computed.projectedLateFee,
+                computed.schedule.currency,
+              )}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Applies if unpaid after grace window
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4 rounded-lg border bg-muted/20 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium">Enable AutoPay</p>
+              <p className="text-xs text-muted-foreground">
+                Automatically draft roommate shares before the due date.
+              </p>
+            </div>
+            <Switch checked={enabled} onCheckedChange={setEnabled} />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Rent due day</Label>
+              <Select
+                value={formState.dueDay.toString()}
+                onValueChange={(value) =>
+                  setFormState((previous) => ({
+                    ...previous,
+                    dueDay: Number.parseInt(value, 10),
+                  }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select due day" />
+                </SelectTrigger>
+                <SelectContent>
+                  {dueDayOptions.map((day) => (
+                    <SelectItem key={day} value={day.toString()}>
+                      {day}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Applies to every monthly billing cycle
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label>AutoPay lead time</Label>
+              <Select
+                value={formState.autopayLeadDays.toString()}
+                onValueChange={(value) =>
+                  setFormState((previous) => ({
+                    ...previous,
+                    autopayLeadDays: Number.parseInt(value, 10),
+                  }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select lead time" />
+                </SelectTrigger>
+                <SelectContent>
+                  {autopayLeadOptions.map((day) => (
+                    <SelectItem key={day} value={day.toString()}>
+                      {day === 0
+                        ? "Same day"
+                        : `${day} day${day === 1 ? "" : "s"} before due date`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Draft payments {autopayLeadCopy}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label>Grace period (days)</Label>
+              <Select
+                value={formState.gracePeriodDays.toString()}
+                onValueChange={(value) =>
+                  setFormState((previous) => ({
+                    ...previous,
+                    gracePeriodDays: Number.parseInt(value, 10),
+                  }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select grace period" />
+                </SelectTrigger>
+                <SelectContent>
+                  {graceOptions.map((day) => (
+                    <SelectItem key={day} value={day.toString()}>
+                      {day === 0 ? "No grace" : `${day} day${day === 1 ? "" : "s"}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Late fees begin after this many extra days
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label>Late fee type</Label>
+              <Select
+                value={formState.lateFeeMode}
+                onValueChange={(value) =>
+                  setFormState((previous) => ({
+                    ...previous,
+                    lateFeeMode: value as "flat" | "percentage",
+                  }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select fee type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="flat">Flat amount</SelectItem>
+                  <SelectItem value="percentage">Percentage of rent</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Choose how late fees are calculated
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label>
+                {formState.lateFeeMode === "percentage"
+                  ? "Late fee percentage"
+                  : "Late fee amount"}
+              </Label>
+              <Input
+                inputMode="decimal"
+                min={0}
+                step={formState.lateFeeMode === "percentage" ? "0.1" : "1"}
+                type="number"
+                value={formState.lateFeeValue}
+                onChange={(event) =>
+                  setFormState((previous) => ({
+                    ...previous,
+                    lateFeeValue: event.target.value,
+                  }))
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                {formState.lateFeeMode === "percentage"
+                  ? "Percentage of the monthly rent share"
+                  : "Flat amount assessed when payment is late"}
+              </p>
+            </div>
+            {formState.lateFeeMode === "percentage" ? (
+              <div className="space-y-2">
+                <Label>Maximum late fee (optional)</Label>
+                <Input
+                  inputMode="decimal"
+                  min={0}
+                  step="1"
+                  type="number"
+                  value={formState.lateFeeCap}
+                  onChange={(event) =>
+                    setFormState((previous) => ({
+                      ...previous,
+                      lateFeeCap: event.target.value,
+                    }))
+                  }
+                  placeholder="No cap"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Cap the percentage-based fee at a set amount
+                </p>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium">Roommate coverage</p>
+              <p className="text-xs text-muted-foreground">
+                {coverage.total > 0
+                  ? `${coverage.active}/${coverage.total} roommates on AutoPay · ${coverage.percentage}% coverage`
+                  : "No roommates have enabled AutoPay yet."}
+              </p>
+            </div>
+          </div>
+          <div className="space-y-3">
+            {computed.schedule.participants.map((participant) => (
+              <div
+                key={participant.roommateId}
+                className="flex flex-wrap items-start justify-between gap-3 rounded-lg border bg-muted/30 p-3"
+              >
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">{participant.roommateName}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {formatCurrency(participant.rentShare, computed.schedule.currency)} · {participant.paymentMethod}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Last payment {safeFormatDate(participant.lastPaymentDate, "MMM d, yyyy")}
+                  </p>
+                </div>
+                <div className="flex flex-col items-end gap-1">
+                  <Badge variant={autopayStatusCopy[participant.autopayStatus].variant}>
+                    {autopayStatusCopy[participant.autopayStatus].label}
+                  </Badge>
+                  <p className="text-xs text-muted-foreground">
+                    Share {formatCurrency(participant.rentShare, computed.schedule.currency)}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-xs text-muted-foreground">
+          <span>
+            Last run {lastRunDate} · {lastRunStatusCopy[computed.schedule.lastRun.status]} · {formatCurrency(
+              computed.schedule.lastRun.totalCollected,
+              computed.schedule.currency,
+            )} collected
+          </span>
+          {lastSavedAt ? (
+            <span className="block sm:ml-2 sm:inline">
+              Draft saved {format(lastSavedAt, "MMM d, yyyy h:mm a")}
+            </span>
+          ) : null}
+        </div>
+        <Button type="button" onClick={handleSave}>
+          Save schedule
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/app/payments/loaders.ts
+++ b/app/payments/loaders.ts
@@ -2,9 +2,13 @@
 
 import "server-only"
 
-import { catchUpBalances } from "@/lib/payments/mock-data"
-import type { CatchUpBalance } from "@/types/payments"
+import { autopaySchedule, catchUpBalances } from "@/lib/payments/mock-data"
+import type { AutopayScheduleConfig, CatchUpBalance } from "@/types/payments"
 
 export async function loadCatchUpBalances(): Promise<CatchUpBalance[]> {
   return catchUpBalances
+}
+
+export async function loadAutopaySchedule(): Promise<AutopayScheduleConfig> {
+  return autopaySchedule
 }

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -10,6 +10,7 @@ import {
 import { Separator } from "@/components/ui/separator"
 import { Button } from "@/components/ui/button"
 import { StripeActions } from "./_components/stripe-actions"
+import { AutoPayScheduleCard } from "./_components/autopay-schedule-card"
 import { CatchUpPaymentCard } from "./_components/catch-up-payment-card"
 import {
   calculateOutstanding,
@@ -19,7 +20,7 @@ import {
 import { formatCurrency } from "@/lib/payments/currency"
 import type { CatchUpBalance } from "@/types/payments"
 
-import { loadCatchUpBalances } from "./loaders"
+import { loadAutopaySchedule, loadCatchUpBalances } from "./loaders"
 
 const paymentHighlights = [
   {
@@ -64,7 +65,10 @@ function formatFullDate(date: string) {
 }
 
 export default async function PaymentsPage() {
-  const catchUpBalances = await loadCatchUpBalances()
+  const [catchUpBalances, autopaySchedule] = await Promise.all([
+    loadCatchUpBalances(),
+    loadAutopaySchedule(),
+  ])
   const outstandingSummaries = catchUpBalances.map((balance) => {
     const outstanding = calculateOutstanding(balance.charges)
     const nextCharge = getNextOutstandingCharge(balance.charges)
@@ -120,6 +124,7 @@ export default async function PaymentsPage() {
       </div>
       <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
         <div className="space-y-6">
+          <AutoPayScheduleCard schedule={autopaySchedule} />
           <Card>
             <CardHeader>
               <CardTitle>Catch-up snapshot</CardTitle>

--- a/lib/payments/autopay.ts
+++ b/lib/payments/autopay.ts
@@ -1,0 +1,110 @@
+import { addDays, addMonths, isAfter, startOfDay } from "date-fns"
+
+import type {
+  AutopayScheduleConfig,
+  AutopayScheduleSettings,
+} from "@/types/payments"
+
+import { roundToCurrency } from "./currency"
+
+function clampDayToMonth(reference: Date, targetDay: number): Date {
+  const safeDay = Math.min(
+    Math.max(Math.round(targetDay), 1),
+    new Date(reference.getFullYear(), reference.getMonth() + 1, 0).getDate(),
+  )
+
+  return startOfDay(new Date(reference.getFullYear(), reference.getMonth(), safeDay))
+}
+
+export function getNextDueDate(
+  settings: AutopayScheduleSettings,
+  referenceDate: Date = new Date(),
+): Date {
+  const normalizedReference = startOfDay(referenceDate)
+  const currentMonthDue = clampDayToMonth(normalizedReference, settings.dueDay)
+
+  if (isAfter(normalizedReference, currentMonthDue)) {
+    const nextMonth = addMonths(normalizedReference, 1)
+    return clampDayToMonth(nextMonth, settings.dueDay)
+  }
+
+  return currentMonthDue
+}
+
+export function getPreviousDueDate(
+  settings: AutopayScheduleSettings,
+  referenceDate: Date = new Date(),
+): Date {
+  const nextDue = getNextDueDate(settings, referenceDate)
+  const previousMonth = addMonths(nextDue, -1)
+  return clampDayToMonth(previousMonth, settings.dueDay)
+}
+
+export function getAutopayChargeDate(
+  settings: AutopayScheduleSettings,
+  referenceDate: Date = new Date(),
+): Date {
+  const dueDate = getNextDueDate(settings, referenceDate)
+  const leadDays = Math.max(settings.autopayLeadDays, 0)
+  return startOfDay(addDays(dueDate, -leadDays))
+}
+
+export interface AutopayScheduleWindow {
+  autopayDate: Date
+  dueDate: Date
+  gracePeriodEnd: Date
+  lateFeeDate: Date
+  retryWindowEnd: Date
+}
+
+export function getAutopayScheduleWindow(
+  schedule: AutopayScheduleConfig,
+  referenceDate: Date = new Date(),
+): AutopayScheduleWindow {
+  const dueDate = getNextDueDate(schedule.settings, referenceDate)
+  const autopayDate = getAutopayChargeDate(schedule.settings, referenceDate)
+  const graceDays = Math.max(schedule.settings.gracePeriodDays, 0)
+  const retryDays = Math.max(schedule.settings.retryWindowDays, 0)
+  const gracePeriodEnd = startOfDay(addDays(dueDate, graceDays))
+  const retryWindowEnd = startOfDay(addDays(autopayDate, retryDays))
+
+  return {
+    autopayDate,
+    dueDate,
+    gracePeriodEnd,
+    lateFeeDate: gracePeriodEnd,
+    retryWindowEnd,
+  }
+}
+
+export function getBillingPeriod(
+  schedule: AutopayScheduleConfig,
+  referenceDate: Date = new Date(),
+): { start: Date; end: Date } {
+  const nextDue = getNextDueDate(schedule.settings, referenceDate)
+  const previousDue = clampDayToMonth(addMonths(nextDue, -1), schedule.settings.dueDay)
+
+  return {
+    start: previousDue,
+    end: nextDue,
+  }
+}
+
+export function calculateLateFeeAmount(
+  schedule: AutopayScheduleConfig,
+  baseAmount: number = schedule.rentAmount,
+): number {
+  const rule = schedule.settings.lateFee
+
+  if (rule.mode === "flat") {
+    return roundToCurrency(rule.amount)
+  }
+
+  const calculated = roundToCurrency((rule.percentage / 100) * baseAmount)
+  if (typeof rule.cap === "number") {
+    return roundToCurrency(Math.min(calculated, rule.cap))
+  }
+
+  return calculated
+}
+

--- a/lib/payments/mock-data.ts
+++ b/lib/payments/mock-data.ts
@@ -1,4 +1,4 @@
-import type { CatchUpBalance } from "@/types/payments"
+import type { AutopayScheduleConfig, CatchUpBalance } from "@/types/payments"
 
 export const catchUpBalances: CatchUpBalance[] = [
   {
@@ -147,3 +147,56 @@ export const catchUpBalances: CatchUpBalance[] = [
     },
   },
 ]
+
+export const autopaySchedule: AutopayScheduleConfig = {
+  id: "autopay_unit_3b",
+  unitId: "unit_3b",
+  unitLabel: "Unit 3B",
+  currency: "USD",
+  rentAmount: 3780,
+  autopayEnabled: true,
+  settings: {
+    dueDay: 1,
+    autopayLeadDays: 2,
+    gracePeriodDays: 4,
+    retryWindowDays: 2,
+    autopayTime: "09:00",
+    timezone: "America/Los_Angeles",
+    lateFee: {
+      mode: "percentage",
+      percentage: 5,
+      cap: 150,
+    },
+  },
+  participants: [
+    {
+      roommateId: "rm_avery",
+      roommateName: "Avery Chen",
+      rentShare: 1260,
+      autopayStatus: "active",
+      paymentMethod: "Visa •••• 4242",
+      lastPaymentDate: "2024-05-28",
+    },
+    {
+      roommateId: "rm_jordan",
+      roommateName: "Jordan Blake",
+      rentShare: 1260,
+      autopayStatus: "paused",
+      paymentMethod: "Chase Checking •••• 9938",
+      lastPaymentDate: "2024-05-12",
+    },
+    {
+      roommateId: "rm_priya",
+      roommateName: "Priya Desai",
+      rentShare: 1260,
+      autopayStatus: "disabled",
+      paymentMethod: "Setup required",
+      lastPaymentDate: "2024-04-30",
+    },
+  ],
+  lastRun: {
+    processedAt: "2024-06-01T09:00:00-07:00",
+    status: "succeeded",
+    totalCollected: 1260,
+  },
+}

--- a/tests/autopay.test.ts
+++ b/tests/autopay.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  calculateLateFeeAmount,
+  getAutopayScheduleWindow,
+  getBillingPeriod,
+  getNextDueDate,
+} from "@/lib/payments/autopay"
+import type { AutopayScheduleConfig } from "@/types/payments"
+
+const baseSchedule: AutopayScheduleConfig = {
+  id: "autopay_test",
+  unitId: "unit_test",
+  unitLabel: "Unit Test",
+  currency: "USD",
+  rentAmount: 1500,
+  autopayEnabled: true,
+  settings: {
+    dueDay: 1,
+    autopayLeadDays: 3,
+    gracePeriodDays: 4,
+    retryWindowDays: 2,
+    autopayTime: "09:00",
+    timezone: "America/New_York",
+    lateFee: {
+      mode: "percentage",
+      percentage: 5,
+      cap: 100,
+    },
+  },
+  participants: [],
+  lastRun: {
+    processedAt: "2024-05-01T09:00:00-04:00",
+    status: "succeeded",
+    totalCollected: 1500,
+  },
+}
+
+describe("autopay scheduling helpers", () => {
+  it("computes the next due date relative to the reference day", () => {
+    const beforeDue = getNextDueDate(baseSchedule.settings, new Date("2024-04-28T00:00:00Z"))
+    const afterDue = getNextDueDate(baseSchedule.settings, new Date("2024-05-05T00:00:00Z"))
+
+    expect(beforeDue.toISOString().slice(0, 10)).toBe("2024-05-01")
+    expect(afterDue.toISOString().slice(0, 10)).toBe("2024-06-01")
+  })
+
+  it("describes the upcoming autopay window with grace and retry periods", () => {
+    const window = getAutopayScheduleWindow(baseSchedule, new Date("2024-05-15T00:00:00Z"))
+
+    expect(window.dueDate.toISOString().slice(0, 10)).toBe("2024-06-01")
+    expect(window.autopayDate.toISOString().slice(0, 10)).toBe("2024-05-29")
+    expect(window.gracePeriodEnd.toISOString().slice(0, 10)).toBe("2024-06-05")
+    expect(window.lateFeeDate.toISOString().slice(0, 10)).toBe("2024-06-05")
+    expect(window.retryWindowEnd.toISOString().slice(0, 10)).toBe("2024-05-31")
+  })
+
+  it("calculates late fees with percentage caps and flat amounts", () => {
+    const percentageFee = calculateLateFeeAmount(baseSchedule)
+    expect(percentageFee).toBeCloseTo(75)
+
+    const flatSchedule: AutopayScheduleConfig = {
+      ...baseSchedule,
+      settings: {
+        ...baseSchedule.settings,
+        lateFee: {
+          mode: "flat",
+          amount: 60,
+        },
+      },
+    }
+
+    expect(calculateLateFeeAmount(flatSchedule)).toBe(60)
+  })
+
+  it("returns the billing period range spanning one cycle", () => {
+    const period = getBillingPeriod(baseSchedule, new Date("2024-05-15T00:00:00Z"))
+
+    expect(period.start.toISOString().slice(0, 10)).toBe("2024-05-01")
+    expect(period.end.toISOString().slice(0, 10)).toBe("2024-06-01")
+  })
+})

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -75,3 +75,52 @@ export interface CatchUpPaymentFormValues {
   includePropertyManager: boolean
   note?: string
 }
+
+export type LateFeeRule =
+  | {
+      mode: "flat"
+      amount: number
+    }
+  | {
+      mode: "percentage"
+      percentage: number
+      cap?: number
+    }
+
+export interface AutopayRunSummary {
+  processedAt: string
+  status: "succeeded" | "partial" | "failed"
+  totalCollected: number
+}
+
+export interface AutopayParticipant {
+  roommateId: string
+  roommateName: string
+  rentShare: number
+  autopayStatus: AutopayStatus
+  paymentMethod: string
+  lastPaymentDate: string
+  autopayDayOverride?: number
+}
+
+export interface AutopayScheduleSettings {
+  dueDay: number
+  autopayLeadDays: number
+  gracePeriodDays: number
+  retryWindowDays: number
+  autopayTime: string
+  timezone: string
+  lateFee: LateFeeRule
+}
+
+export interface AutopayScheduleConfig {
+  id: string
+  unitId: string
+  unitLabel: string
+  currency: string
+  rentAmount: number
+  autopayEnabled: boolean
+  settings: AutopayScheduleSettings
+  participants: AutopayParticipant[]
+  lastRun: AutopayRunSummary
+}


### PR DESCRIPTION
## Summary
- add an AutoPay scheduling card so managers can configure due dates, lead times, grace periods, and late fee behavior
- introduce shared utilities and mock data to calculate autopay windows and late-fee projections
- cover the new scheduling logic with dedicated unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1acf920e48328b1cfc8078a1b3a5d