### PR TITLE
feat(documents): add bulk upload workflow

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -6,7 +6,7 @@ import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
 import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
-import { fetchMemberRole } from '@/lib/data/members';
+import { fetchMemberProfile, fetchMemberRole } from '@/lib/data/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import {
   Document,
@@ -45,6 +45,17 @@ const documentListFiltersSchema = z.object({
   date_to: z.string().datetime().optional(),
 });
 
+const bulkPermissionScopeSchema = z.enum(['property_staff', 'all_residents', 'custom_residents']);
+
+const bulkDocumentUploadSchema = z.object({
+  document_type: z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other']),
+  requires_signature: z.boolean().default(false),
+  description: z.string().optional(),
+  title_prefix: z.string().max(120).optional(),
+  permission_scope: bulkPermissionScopeSchema,
+  shared_member_ids: z.array(z.string().uuid()).optional(),
+});
+
 // Action result interface
 interface ActionResult<T = any> {
   success: boolean;
@@ -52,6 +63,11 @@ interface ActionResult<T = any> {
   error?: string;
   message?: string;
 }
+
+type BulkUploadResult = {
+  created: Document[];
+  failed: { fileName: string; error: string }[];
+};
 
 // Get documents with optional filters
 export async function getDocumentsAction(
@@ -78,12 +94,23 @@ export async function getDocumentsAction(
       return { success: false, error: 'Failed to fetch documents.' };
     }
 
+    let profile: Awaited<ReturnType<typeof fetchMemberProfile>> | null = null;
+    try {
+      profile = await fetchMemberProfile(typedSupabase, user.id);
+    } catch (profileError) {
+      console.error('Error resolving member profile for documents:', profileError);
+    }
+
+    const effectiveRole = profile?.role ?? role;
+    const userUnitId = profile?.unit_id ?? null;
+
     let documents: DocumentWithLease[];
     try {
       documents = await fetchDocumentsList({
         client: typedSupabase,
         userId: user.id,
-        role,
+        role: effectiveRole,
+        userUnitId,
         filters: validatedFilters,
       });
     } catch (documentsError) {
@@ -206,6 +233,226 @@ export async function uploadDocumentAction(
     return { success: true, data: document, message: 'Document uploaded successfully.' };
   } catch (error) {
     console.error('Unexpected error in uploadDocumentAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+    };
+  }
+}
+
+export async function bulkUploadDocumentsAction(
+  formData: FormData
+): Promise<ActionResult<BulkUploadResult>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to upload documents.' };
+    }
+
+    const files = formData
+      .getAll('files')
+      .filter((entry): entry is File => entry instanceof File);
+
+    if (files.length === 0) {
+      return { success: false, error: 'Please select at least one file to upload.' };
+    }
+
+    const rawSharedMemberIds = formData.get('shared_member_ids');
+    let sharedMemberIds: string[] | undefined;
+    if (typeof rawSharedMemberIds === 'string' && rawSharedMemberIds.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(rawSharedMemberIds);
+        if (!Array.isArray(parsed)) {
+          throw new Error('Invalid shared member payload');
+        }
+        sharedMemberIds = parsed
+          .filter((value, index, self) => typeof value === 'string' && self.indexOf(value) === index);
+      } catch (parseError) {
+        console.error('Error parsing shared member ids for bulk upload:', parseError);
+        return { success: false, error: 'Invalid resident selection provided.' };
+      }
+    }
+
+    const rawDocumentType = formData.get('document_type');
+    const rawPermissionScope = formData.get('permission_scope');
+    const rawDescription = formData.get('description');
+    const rawTitlePrefix = formData.get('title_prefix');
+
+    const validationResult = bulkDocumentUploadSchema.safeParse({
+      document_type: typeof rawDocumentType === 'string' ? rawDocumentType : undefined,
+      requires_signature: formData.get('requires_signature') === 'true',
+      description: typeof rawDescription === 'string' ? rawDescription : undefined,
+      title_prefix: typeof rawTitlePrefix === 'string' ? rawTitlePrefix : undefined,
+      permission_scope: typeof rawPermissionScope === 'string' ? rawPermissionScope : undefined,
+      shared_member_ids: sharedMemberIds,
+    });
+
+    if (!validationResult.success) {
+      const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
+        .map(errors => errors?.join('. '))
+        .filter(Boolean)
+        .join(' ');
+      return { success: false, error: errorMessages || 'Invalid bulk upload data provided.' };
+    }
+
+    const {
+      document_type,
+      requires_signature,
+      description,
+      title_prefix,
+      permission_scope,
+      shared_member_ids: validatedMemberIds,
+    } = validationResult.data;
+
+    const memberIds = Array.isArray(validatedMemberIds) ? validatedMemberIds : [];
+
+    if (permission_scope === 'custom_residents' && memberIds.length === 0) {
+      return { success: false, error: 'Select at least one resident to share with.' };
+    }
+
+    const appliedAt = new Date().toISOString();
+    const baseSharedRoles =
+      permission_scope === 'all_residents'
+        ? ['tenant', 'roommate']
+        : permission_scope === 'property_staff'
+          ? ['property_manager', 'admin']
+          : undefined;
+    const baseSharedMemberIds = memberIds.length > 0 ? memberIds : undefined;
+
+    const buildMetadata = (fileName: string) => {
+      const metadata: Record<string, any> = {
+        permission_scope,
+        applied_by: user.id,
+        applied_at: appliedAt,
+        original_file_name: fileName,
+        bulk_upload: true,
+      };
+
+      if (baseSharedRoles) {
+        metadata.shared_roles = [...baseSharedRoles];
+      }
+
+      if (baseSharedMemberIds) {
+        metadata.shared_member_ids = [...baseSharedMemberIds];
+      }
+
+      return metadata;
+    };
+
+    const createdDocuments: Document[] = [];
+    const failedUploads: { fileName: string; error: string }[] = [];
+
+    const allowedTypes = [
+      'application/pdf',
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    ];
+    const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+    const buildDocumentTitle = (file: File) => {
+      const baseName = file.name
+        .replace(/\.[^/.]+$/, '')
+        .replace(/[_-]+/g, ' ')
+        .trim() || 'Document';
+      const prefix = title_prefix?.trim();
+      return prefix ? `${prefix} ${baseName}`.trim() : baseName;
+    };
+
+    for (const file of files) {
+      if (!allowedTypes.includes(file.type)) {
+        failedUploads.push({ fileName: file.name, error: 'Unsupported file type' });
+        continue;
+      }
+
+      if (file.size > MAX_FILE_SIZE) {
+        failedUploads.push({ fileName: file.name, error: 'File exceeds 10MB limit' });
+        continue;
+      }
+
+      const fileExt = file.name.split('.').pop() || 'pdf';
+      const storageFileName = `${Date.now()}-${Math.random().toString(36).slice(2)}.${fileExt}`;
+      const filePath = `documents/${storageFileName}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from('documents')
+        .upload(filePath, file);
+
+      if (uploadError) {
+        console.error('Error uploading file in bulk operation:', uploadError);
+        failedUploads.push({ fileName: file.name, error: 'Failed to upload file.' });
+        continue;
+      }
+
+      const { data: { publicUrl } } = supabase.storage
+        .from('documents')
+        .getPublicUrl(filePath);
+
+      const metadata = buildMetadata(file.name);
+
+      const { data: document, error: dbError } = await (supabase as any)
+        .from('documents')
+        .insert({
+          title: buildDocumentTitle(file),
+          description,
+          document_type,
+          file_url: publicUrl,
+          requires_signature,
+          metadata,
+          created_by: user.id,
+        })
+        .select()
+        .single();
+
+      if (dbError || !document) {
+        console.error('Error creating document record during bulk upload:', dbError);
+        await supabase.storage.from('documents').remove([filePath]);
+        failedUploads.push({ fileName: file.name, error: 'Failed to create document record.' });
+        continue;
+      }
+
+      try {
+        await (supabase as any).rpc('log_document_access', {
+          p_document_id: document.id,
+          p_action: 'bulk_upload',
+          p_metadata: { file_name: file.name, file_size: file.size, scope: permission_scope },
+        });
+      } catch (logError) {
+        console.error('Error logging document access for bulk upload:', logError);
+      }
+
+      createdDocuments.push(document as Document);
+    }
+
+    if (createdDocuments.length > 0) {
+      revalidatePath('/documents');
+    }
+
+    if (createdDocuments.length === 0) {
+      return {
+        success: false,
+        data: { created: [], failed: failedUploads },
+        error: failedUploads.length ? 'Failed to upload documents.' : 'No documents were uploaded.',
+      };
+    }
+
+    const message = failedUploads.length
+      ? `Uploaded ${createdDocuments.length} documents with ${failedUploads.length} failures.`
+      : `Uploaded ${createdDocuments.length} documents successfully.`;
+
+    return {
+      success: failedUploads.length === 0,
+      data: { created: createdDocuments, failed: failedUploads },
+      message,
+      error: failedUploads.length ? 'Some documents failed to upload.' : undefined,
+    };
+  } catch (error) {
+    console.error('Unexpected error in bulkUploadDocumentsAction:', error);
     return {
       success: false,
       error: error instanceof Error ? error.message : 'An unexpected error occurred.'

--- a/app/documents/components/bulk-upload-dialog.tsx
+++ b/app/documents/components/bulk-upload-dialog.tsx
@@ -1,0 +1,529 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { Switch } from '@/components/ui/switch';
+import { bulkUploadDocumentsAction } from '../actions';
+import { useDocumentPermissions } from '@/hooks/use-document-permissions';
+import { createClient } from '@/utils/supabase-browser';
+import type { DocumentType } from '@/types/documents';
+import { toast } from 'sonner';
+import { FolderPlus, Upload, Users, Shield, X } from 'lucide-react';
+
+const ALLOWED_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+];
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+interface ResidentOption {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  role: string | null;
+}
+
+type PermissionScope = 'property_staff' | 'all_residents' | 'custom_residents';
+
+type ResidentsStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+export function BulkUploadDialog() {
+  const permissions = useDocumentPermissions();
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [open, setOpen] = useState(false);
+  const [files, setFiles] = useState<File[]>([]);
+  const [documentType, setDocumentType] = useState<DocumentType>('other');
+  const [requiresSignature, setRequiresSignature] = useState(false);
+  const [titlePrefix, setTitlePrefix] = useState('');
+  const [description, setDescription] = useState('');
+  const [permissionScope, setPermissionScope] = useState<PermissionScope>('all_residents');
+  const [selectedResidentIds, setSelectedResidentIds] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [residentsStatus, setResidentsStatus] = useState<ResidentsStatus>('idle');
+  const [residents, setResidents] = useState<ResidentOption[]>([]);
+
+  useEffect(() => {
+    if (permissionScope !== 'custom_residents') {
+      setSelectedResidentIds([]);
+    }
+  }, [permissionScope]);
+
+  const loadResidents = useCallback(async () => {
+    try {
+      setResidentsStatus('loading');
+      const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        setResidentsStatus('error');
+        toast.error('You must be signed in to manage residents.');
+        return;
+      }
+
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, full_name, email, role')
+        .in('role', ['tenant', 'roommate'])
+        .order('full_name', { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      setResidents((data as ResidentOption[] | null | undefined) ?? []);
+      setResidentsStatus('loaded');
+    } catch (error) {
+      console.error('Error loading residents for bulk permissions:', error);
+      setResidentsStatus('error');
+      toast.error('Failed to load residents. Please try again.');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open && residentsStatus === 'idle') {
+      loadResidents();
+    }
+  }, [open, residentsStatus, loadResidents]);
+
+  const resetForm = useCallback(() => {
+    setFiles([]);
+    setDocumentType('other');
+    setRequiresSignature(false);
+    setTitlePrefix('');
+    setDescription('');
+    setPermissionScope('all_residents');
+    setSelectedResidentIds([]);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, []);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(event.target.files ?? []);
+    if (selectedFiles.length === 0) return;
+
+    const nextFiles: File[] = [...files];
+    const existingKeys = new Set(nextFiles.map(file => `${file.name}-${file.size}`));
+
+    for (const file of selectedFiles) {
+      if (!ALLOWED_TYPES.includes(file.type)) {
+        toast.error(`${file.name} is not a supported file type.`);
+        continue;
+      }
+
+      if (file.size > MAX_FILE_SIZE) {
+        toast.error(`${file.name} is larger than 10MB.`);
+        continue;
+      }
+
+      const key = `${file.name}-${file.size}`;
+      if (existingKeys.has(key)) {
+        continue;
+      }
+
+      existingKeys.add(key);
+      nextFiles.push(file);
+    }
+
+    setFiles(nextFiles);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const removeFile = (index: number) => {
+    setFiles(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const toggleResident = (residentId: string) => {
+    setSelectedResidentIds(prev =>
+      prev.includes(residentId)
+        ? prev.filter(id => id !== residentId)
+        : [...prev, residentId]
+    );
+  };
+
+  const selectAllResidents = () => {
+    if (residents.length === 0) return;
+    if (selectedResidentIds.length === residents.length) {
+      setSelectedResidentIds([]);
+    } else {
+      setSelectedResidentIds(residents.map(resident => resident.id));
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (files.length === 0) {
+      toast.error('Please select at least one document to upload.');
+      return;
+    }
+
+    if (permissionScope === 'custom_residents' && selectedResidentIds.length === 0) {
+      toast.error('Select at least one resident to share these documents with.');
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const formData = new FormData();
+      files.forEach(file => formData.append('files', file));
+      formData.append('document_type', documentType);
+      formData.append('requires_signature', requiresSignature.toString());
+      formData.append('permission_scope', permissionScope);
+      if (titlePrefix.trim()) {
+        formData.append('title_prefix', titlePrefix.trim());
+      }
+      if (description.trim()) {
+        formData.append('description', description.trim());
+      }
+      if (permissionScope === 'custom_residents') {
+        formData.append('shared_member_ids', JSON.stringify(selectedResidentIds));
+      }
+
+      const result = await bulkUploadDocumentsAction(formData);
+
+      if (result.success) {
+        toast.success(result.message || 'Documents uploaded successfully.');
+        resetForm();
+        setOpen(false);
+        router.refresh();
+      } else if (result.data?.created?.length) {
+        const failureCount = result.data.failed.length;
+        toast.warning(
+          result.message || `Uploaded ${result.data.created.length} documents, ${failureCount} failed.`
+        );
+        resetForm();
+        setOpen(false);
+        router.refresh();
+      } else {
+        toast.error(result.error || 'Failed to upload documents.');
+      }
+    } catch (error) {
+      console.error('Error completing bulk document upload:', error);
+      toast.error('An unexpected error occurred while uploading documents.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const formattedResidents = useMemo(() => {
+    return residents.map(resident => ({
+      ...resident,
+      displayName: resident.full_name || resident.email || 'Unknown member',
+      roleLabel: resident.role
+        ? resident.role.replace(/_/g, ' ').replace(/^\w/, char => char.toUpperCase())
+        : null,
+    }));
+  }, [residents]);
+
+  if (!permissions.canUploadDocuments) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+          resetForm();
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <FolderPlus className="mr-2 size-4" />
+          Bulk Upload
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Bulk document upload</DialogTitle>
+          <DialogDescription>
+            Add multiple files at once and apply consistent permissions to every document.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-3">
+            <Label htmlFor="bulk-files">Document files</Label>
+            <div className="rounded-lg border-2 border-dashed border-muted-foreground/30 p-6 text-center">
+              <input
+                ref={fileInputRef}
+                id="bulk-files"
+                type="file"
+                multiple
+                className="hidden"
+                onChange={handleFileChange}
+                accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif"
+              />
+              <label htmlFor="bulk-files" className="flex cursor-pointer flex-col items-center space-y-2">
+                <Upload className="size-10 text-muted-foreground" />
+                <div className="text-sm text-muted-foreground">
+                  Drag and drop files or <span className="font-semibold text-primary">browse</span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Supports PDF, Word, and image files up to 10MB each.
+                </p>
+              </label>
+            </div>
+            {files.length > 0 && (
+              <div className="space-y-2">
+                {files.map((file, index) => (
+                  <div
+                    key={`${file.name}-${index}`}
+                    className="flex items-center justify-between rounded-md border bg-muted/40 px-3 py-2 text-sm"
+                  >
+                    <div className="space-y-0.5 text-left">
+                      <p className="font-medium text-foreground">{file.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatFileSize(file.size)} • {file.type || 'Unknown type'}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => removeFile(index)}
+                    >
+                      <X className="size-4" />
+                      <span className="sr-only">Remove {file.name}</span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <Separator />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label>Permission scope</Label>
+                <Select
+                  value={permissionScope}
+                  onValueChange={(value) => setPermissionScope(value as PermissionScope)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all_residents">
+                      <div className="flex items-center space-x-2">
+                        <Users className="size-4" />
+                        <span>All tenants and roommates</span>
+                      </div>
+                    </SelectItem>
+                    <SelectItem value="property_staff">
+                      <div className="flex items-center space-x-2">
+                        <Shield className="size-4" />
+                        <span>Property managers &amp; admins</span>
+                      </div>
+                    </SelectItem>
+                    <SelectItem value="custom_residents">
+                      <div className="flex items-center space-x-2">
+                        <FolderPlus className="size-4" />
+                        <span>Custom selection</span>
+                      </div>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Choose who should immediately receive access to every uploaded document.
+                </p>
+              </div>
+
+              {permissionScope === 'custom_residents' && (
+                <div className="space-y-3 rounded-lg border p-3">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium">Select residents</p>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={residents.length === 0 || residentsStatus === 'loading'}
+                      onClick={selectAllResidents}
+                    >
+                      {selectedResidentIds.length === residents.length && residents.length > 0
+                        ? 'Clear selection'
+                        : 'Select all'}
+                    </Button>
+                  </div>
+                  {residentsStatus === 'loading' && (
+                    <p className="text-sm text-muted-foreground">Loading residents…</p>
+                  )}
+                  {residentsStatus === 'error' && (
+                    <div className="space-y-2 text-sm text-muted-foreground">
+                      <p>We couldn’t load residents right now.</p>
+                      <Button type="button" variant="outline" size="sm" onClick={loadResidents}>
+                        Try again
+                      </Button>
+                    </div>
+                  )}
+                  {residentsStatus === 'loaded' && residents.length === 0 && (
+                    <p className="text-sm text-muted-foreground">No residents available to select.</p>
+                  )}
+                  {residentsStatus === 'loaded' && residents.length > 0 && (
+                    <ScrollArea className="h-48">
+                      <div className="space-y-2 pr-2">
+                        {formattedResidents.map(resident => {
+                          const checkboxId = `resident-${resident.id}`;
+                          return (
+                            <label
+                              key={resident.id}
+                              htmlFor={checkboxId}
+                              className="flex cursor-pointer items-start justify-between rounded-md border bg-background px-3 py-2"
+                            >
+                              <div className="space-y-1 pr-3">
+                                <p className="text-sm font-medium text-foreground">{resident.displayName}</p>
+                                <p className="text-xs text-muted-foreground">
+                                  {resident.email}
+                                  {resident.roleLabel ? ` • ${resident.roleLabel}` : ''}
+                                </p>
+                              </div>
+                              <Checkbox
+                                id={checkboxId}
+                                checked={selectedResidentIds.includes(resident.id)}
+                                onCheckedChange={() => toggleResident(resident.id)}
+                              />
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </ScrollArea>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="document-type">Document type</Label>
+                <Select value={documentType} onValueChange={value => setDocumentType(value as DocumentType)}>
+                  <SelectTrigger id="document-type">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="lease">Lease Agreement</SelectItem>
+                    <SelectItem value="addendum">Addendum</SelectItem>
+                    <SelectItem value="insurance">Insurance</SelectItem>
+                    <SelectItem value="maintenance">Maintenance</SelectItem>
+                    <SelectItem value="other">Other</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="flex items-center justify-between rounded-lg border px-3 py-2">
+                <div className="space-y-1">
+                  <Label htmlFor="requires-signature" className="text-sm font-medium">
+                    Requires signature
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Mark documents as needing signatures from recipients.
+                  </p>
+                </div>
+                <Switch
+                  id="requires-signature"
+                  checked={requiresSignature}
+                  onCheckedChange={setRequiresSignature}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="title-prefix">Title prefix</Label>
+                <Input
+                  id="title-prefix"
+                  value={titlePrefix}
+                  onChange={event => setTitlePrefix(event.target.value)}
+                  placeholder="Optional prefix added before each file name"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="bulk-description">Description</Label>
+                <Textarea
+                  id="bulk-description"
+                  value={description}
+                  onChange={event => setDescription(event.target.value)}
+                  placeholder="Shared description for every document"
+                  rows={3}
+                />
+              </div>
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+            <span>{files.length} file{files.length === 1 ? '' : 's'} ready to upload</span>
+            {permissionScope === 'custom_residents' ? (
+              <span>
+                {selectedResidentIds.length} recipient{selectedResidentIds.length === 1 ? '' : 's'} selected
+              </span>
+            ) : (
+              <span>Scope: {scopeLabel(permissionScope)}</span>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting || files.length === 0}>
+              {submitting ? 'Uploading…' : 'Upload documents'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function formatFileSize(size: number) {
+  if (size >= 1024 * 1024) {
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (size >= 1024) {
+    return `${Math.round(size / 1024)} KB`;
+  }
+  return `${size} B`;
+}
+
+function scopeLabel(scope: PermissionScope) {
+  switch (scope) {
+    case 'property_staff':
+      return 'Property staff';
+    case 'custom_residents':
+      return 'Custom recipients';
+    default:
+      return 'All tenants & roommates';
+  }
+}

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -4,6 +4,7 @@ import { Separator } from "@/components/ui/separator";
 import { FileText, Users, Clock, Upload } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UploadDocumentDialog } from "./components/upload-document-dialog";
+import { BulkUploadDialog } from "./components/bulk-upload-dialog";
 import { DocumentsStats } from "./components/documents-stats";
 import { DocumentsList } from "./components/documents-list";
 import { DocumentsFilters } from "./components/documents-filters";
@@ -20,7 +21,10 @@ export default function DocumentsPage() {
               Manage leases, agreements, and household documents with secure signing and version control.
             </p>
           </div>
-          <UploadDocumentDialog />
+          <div className="flex items-center gap-2">
+            <BulkUploadDialog />
+            <UploadDocumentDialog />
+          </div>
         </div>
         <Separator />
       </header>

--- a/docs/perf/data-fetching.md
+++ b/docs/perf/data-fetching.md
@@ -7,8 +7,9 @@ Roomsily consolidates common Supabase queries into shared helpers to minimize ne
 ### `fetchDocumentsList`
 - **Purpose:** Returns the document list with leases, signatures, and access logs joined in a single round trip.
 - **Role-aware:** Automatically limits tenants/roommates to documents they own or must sign while allowing property managers and admins to view everything.
+- **Bulk permissions aware:** Includes documents shared via metadata (`shared_member_ids`, `shared_roles`, `shared_unit_ids`) so bulk uploads honour their audience.
 - **Filters:** Supports status, type, tenant, unit, and created-at range filters.
-- **Usage:** Pass a Supabase client along with the requesting user id, their role (or `null`), and optional filters. The helper throws on Supabase errors so wrap calls in `try/catch` inside server actions or client hooks.
+- **Usage:** Pass a Supabase client along with the requesting user id, their role (or `null`), the user’s unit id when available, and optional filters. The helper throws on Supabase errors so wrap calls in `try/catch` inside server actions or client hooks.
 
 ### `fetchDocumentStats`
 - **Purpose:** Computes document counts (total, signed, pending signatures, expired, drafts).

--- a/lib/data/documents.ts
+++ b/lib/data/documents.ts
@@ -10,6 +10,7 @@ type FetchDocumentsParams = {
   client: SupabaseClientLike;
   userId: string;
   role: MemberRole | null | undefined;
+  userUnitId?: string | null;
   filters?: DocumentListFilters;
 };
 
@@ -36,6 +37,7 @@ export async function fetchDocumentsList({
   client,
   userId,
   role,
+  userUnitId,
   filters = {},
 }: FetchDocumentsParams): Promise<DocumentWithLease[]> {
   let query = (client as any)
@@ -44,7 +46,22 @@ export async function fetchDocumentsList({
     .order('created_at', { ascending: false });
 
   if (role !== 'property_manager' && role !== 'admin') {
-    query = query.or(`tenant_id.eq.${userId},signatures.signer_id.eq.${userId}`);
+    const escapeValue = (value: string) => value.replace(/"/g, '\\"');
+    const orFilters = [
+      `tenant_id.eq.${userId}`,
+      `signatures.signer_id.eq.${userId}`,
+      `metadata->shared_member_ids.cs.{"${escapeValue(userId)}"}`,
+    ];
+
+    if (role) {
+      orFilters.push(`metadata->shared_roles.cs.{"${escapeValue(role)}"}`);
+    }
+
+    if (userUnitId) {
+      orFilters.push(`metadata->shared_unit_ids.cs.{"${escapeValue(userUnitId)}"}`);
+    }
+
+    query = query.or(orFilters.join(','));
   }
 
   if (filters.status?.length) {

--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -67,11 +67,18 @@ describe('fetchDocumentsList', () => {
       client: supabase,
       userId: 'user-123',
       role: 'tenant',
+      userUnitId: 'unit-456',
       filters,
     });
 
     expect(documents).toEqual([{ id: 'doc-1' }]);
-    expect(query.or).toHaveBeenCalledWith('tenant_id.eq.user-123,signatures.signer_id.eq.user-123');
+    expect(query.or).toHaveBeenCalled();
+    const orFilters = query.or.mock.calls[0]?.[0];
+    expect(orFilters).toContain('tenant_id.eq.user-123');
+    expect(orFilters).toContain('signatures.signer_id.eq.user-123');
+    expect(orFilters).toContain('metadata->shared_member_ids.cs.{"user-123"}');
+    expect(orFilters).toContain('metadata->shared_roles.cs.{"tenant"}');
+    expect(orFilters).toContain('metadata->shared_unit_ids.cs.{"unit-456"}');
     expect(query.in).toHaveBeenCalledWith('status', filters.status);
     expect(query.in).toHaveBeenCalledWith('document_type', filters.type);
     expect(query.eq).toHaveBeenCalledWith('tenant_id', filters.tenant_id);


### PR DESCRIPTION
## Summary
- add a bulk upload dialog that supports multi-file imports, permission scopes, and resident selection
- extend document actions with a bulk upload server action and metadata-aware scoping
- update document list querying, docs, and tests to recognise shared access metadata

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ac9e35248328bd14402d3e9da455