### PR TITLE
Enable partial catch-up payments and persist balances

### DIFF
--- a/app/payments/_components/catch-up-payment-card.tsx
+++ b/app/payments/_components/catch-up-payment-card.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState, useTransition } from "react"
+import { useEffect, useMemo, useState, useTransition } from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { format, parseISO } from "date-fns"
 import { useForm } from "react-hook-form"
@@ -70,13 +70,19 @@ type QuickAmount = {
 }
 
 export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
-  const schema = useMemo(() => createCatchUpFormSchema(balances), [balances])
+  const [balancesState, setBalancesState] = useState(balances)
+  const schema = useMemo(() => createCatchUpFormSchema(balancesState), [balancesState])
+
+  useEffect(() => {
+    setBalancesState(balances)
+  }, [balances])
+
   const form = useForm<CatchUpPaymentFormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
-      roommateId: balances[0]?.roommateId ?? "",
-      amount: balances[0]
-        ? calculateOutstanding(balances[0].charges).toFixed(2)
+      roommateId: balancesState[0]?.roommateId ?? "",
+      amount: balancesState[0]
+        ? calculateOutstanding(balancesState[0].charges).toFixed(2)
         : "",
       includePropertyManager: false,
       note: "",
@@ -89,9 +95,45 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
   const amountInputValue = form.watch("amount")
 
   const selectedBalance = useMemo(
-    () => balances.find((balance) => balance.roommateId === selectedRoommateId),
-    [balances, selectedRoommateId],
+    () => balancesState.find((balance) => balance.roommateId === selectedRoommateId),
+    [balancesState, selectedRoommateId],
   )
+
+  const applyPaymentResultToBalances = (
+    result: CatchUpPaymentSubmissionResult,
+  ) => {
+    const allocationMap = new Map(
+      result.allocations.map((allocation) => [allocation.chargeId, allocation]),
+    )
+    const paymentDate = new Date().toISOString().slice(0, 10)
+
+    setBalancesState((previous) =>
+      previous.map((balance) => {
+        if (balance.roommateId !== result.roommateId) {
+          return balance
+        }
+
+        const updatedCharges = balance.charges.map((charge) => {
+          const allocation = allocationMap.get(charge.id)
+          if (!allocation) {
+            return charge
+          }
+
+          return {
+            ...charge,
+            outstandingAmount: allocation.remainingBalance,
+          }
+        })
+
+        return {
+          ...balance,
+          charges: updatedCharges,
+          lastPaymentAmount: result.amount,
+          lastPaymentDate: paymentDate,
+        }
+      }),
+    )
+  }
 
   const handleRoommateChange = (roommateId: string) => {
     form.setValue("roommateId", roommateId, {
@@ -100,7 +142,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
       shouldValidate: true,
     })
 
-    const balance = balances.find((item) => item.roommateId === roommateId)
+    const balance = balancesState.find((item) => item.roommateId === roommateId)
     if (!balance) {
       form.setValue("amount", "", {
         shouldDirty: false,
@@ -236,6 +278,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
           note: sanitizedNote,
         })
 
+        applyPaymentResultToBalances(result)
         setLastResult(result)
         toast({
           title: `Catch-up scheduled for ${result.roommateName}`,
@@ -300,7 +343,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        {balances.map((balance) => (
+                        {balancesState.map((balance) => (
                           <SelectItem key={balance.roommateId} value={balance.roommateId}>
                             {balance.roommateName} · {balance.unitLabel}
                           </SelectItem>

--- a/app/payments/actions.ts
+++ b/app/payments/actions.ts
@@ -10,6 +10,7 @@ import {
   generateMockPaymentIntentId,
 } from "@/lib/payments/catch-up"
 import { formatCurrency, roundToCurrency } from "@/lib/payments/currency"
+import { recordCatchUpPayment } from "@/lib/payments/mock-data"
 import type { CatchUpPaymentSubmissionResult } from "@/types/payments"
 
 import { loadCatchUpBalances } from "./loaders"
@@ -59,6 +60,13 @@ export async function submitCatchUpPayment(
   const projectedBalance = roundToCurrency(
     calculateOutstanding(updatedCharges),
   )
+  const normalizedAmount = roundToCurrency(amount)
+
+  recordCatchUpPayment({
+    roommateId: balance.roommateId,
+    amount: normalizedAmount,
+    allocations,
+  })
 
   const allocationDetails = allocations.map((allocation) => {
     const originalCharge = balance.charges.find(
@@ -92,7 +100,7 @@ export async function submitCatchUpPayment(
     paymentIntentId: generateMockPaymentIntentId(),
     roommateId: balance.roommateId,
     roommateName: balance.roommateName,
-    amount: roundToCurrency(amount),
+    amount: normalizedAmount,
     currency: balance.currency,
     projectedBalance,
     allocations: allocationDetails,

--- a/app/payments/loaders.ts
+++ b/app/payments/loaders.ts
@@ -1,10 +1,11 @@
+
 "use server"
 
 import "server-only"
 
-import { catchUpBalances } from "@/lib/payments/mock-data"
+import { getCatchUpBalances } from "@/lib/payments/mock-data"
 import type { CatchUpBalance } from "@/types/payments"
 
 export async function loadCatchUpBalances(): Promise<CatchUpBalance[]> {
-  return catchUpBalances
+  return getCatchUpBalances()
 }

--- a/lib/payments/mock-data.ts
+++ b/lib/payments/mock-data.ts
@@ -1,6 +1,31 @@
-import type { CatchUpBalance } from "@/types/payments"
 
-export const catchUpBalances: CatchUpBalance[] = [
+import type {
+  CatchUpBalance,
+  CatchUpContact,
+  CatchUpPaymentAllocation,
+} from "@/types/payments"
+
+import { applyAllocationsToCharges } from "./catch-up"
+
+function cloneContact(contact: CatchUpContact): CatchUpContact {
+  return { ...contact }
+}
+
+function cloneBalance(balance: CatchUpBalance): CatchUpBalance {
+  return {
+    ...balance,
+    charges: balance.charges.map((charge) => ({ ...charge })),
+    contacts: {
+      primary: cloneContact(balance.contacts.primary),
+      roommates: balance.contacts.roommates?.map(cloneContact),
+      propertyManager: balance.contacts.propertyManager
+        ? cloneContact(balance.contacts.propertyManager)
+        : undefined,
+    },
+  }
+}
+
+const baseCatchUpBalances: CatchUpBalance[] = [
   {
     roommateId: "rm_avery",
     roommateName: "Avery Chen",
@@ -147,3 +172,38 @@ export const catchUpBalances: CatchUpBalance[] = [
     },
   },
 ]
+
+let catchUpBalancesState = baseCatchUpBalances.map(cloneBalance)
+
+export const catchUpBalances = baseCatchUpBalances
+
+export function getCatchUpBalances(): CatchUpBalance[] {
+  return catchUpBalancesState.map(cloneBalance)
+}
+
+export function recordCatchUpPayment({
+  roommateId,
+  amount,
+  allocations,
+}: {
+  roommateId: string
+  amount: number
+  allocations: CatchUpPaymentAllocation[]
+}): void {
+  const balance = catchUpBalancesState.find(
+    (item) => item.roommateId === roommateId,
+  )
+
+  if (!balance) {
+    return
+  }
+
+  const updatedCharges = applyAllocationsToCharges(balance.charges, allocations)
+  balance.charges = updatedCharges.map((charge) => ({ ...charge }))
+  balance.lastPaymentAmount = amount
+  balance.lastPaymentDate = new Date().toISOString().slice(0, 10)
+}
+
+export function resetCatchUpBalances(): void {
+  catchUpBalancesState = baseCatchUpBalances.map(cloneBalance)
+}

--- a/tests/catch-up.test.ts
+++ b/tests/catch-up.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
 
 import {
   allocatePaymentToCharges,
@@ -9,7 +9,13 @@ import {
 } from "@/lib/payments/catch-up"
 import type { CatchUpCharge } from "@/types/payments"
 
+import { submitCatchUpPayment } from "@/app/payments/actions"
 import { loadCatchUpBalances } from "@/app/payments/loaders"
+import { resetCatchUpBalances } from "@/lib/payments/mock-data"
+
+beforeEach(() => {
+  resetCatchUpBalances()
+})
 
 const sampleCharges: CatchUpCharge[] = [
   {
@@ -97,5 +103,26 @@ describe("catch-up helpers", () => {
       expect(balance.roommateId).toMatch(/^rm_/)
       expect(balance.charges.length).toBeGreaterThan(0)
     }
+  })
+
+  it("persists partial catch-up payments for future loads", async () => {
+    const balancesBefore = await loadCatchUpBalances()
+    const target = balancesBefore[0]
+    const outstandingBefore = calculateOutstanding(target.charges)
+    const partialAmount = Math.min(200, outstandingBefore)
+
+    const result = await submitCatchUpPayment({
+      roommateId: target.roommateId,
+      amount: partialAmount,
+      includePropertyManager: false,
+    })
+
+    expect(result.projectedBalance).toBeCloseTo(outstandingBefore - partialAmount)
+
+    const balancesAfter = await loadCatchUpBalances()
+    const updated = balancesAfter.find((balance) => balance.roommateId === target.roommateId)
+
+    expect(updated).toBeDefined()
+    expect(calculateOutstanding(updated!.charges)).toBeCloseTo(result.projectedBalance)
   })
 })


### PR DESCRIPTION
## Summary
- maintain local roommate balances in the catch-up payment card and apply submission results so partial payments immediately update previews
- persist catch-up allocations in the in-memory payment store and wire the loader/action stack to use it
- extend the catch-up helper tests to reset shared state and verify partial payments carry forward across requests

## Testing
- pnpm vitest

------
https://chatgpt.com/codex/tasks/task_e_68d1acfd38148328beee2c0bc0891378