### PR TITLE
Defer heavy dashboard visuals behind progressive tabs

### DIFF
--- a/app/dashboard/(dashboard)/components/analytics-charts.tsx
+++ b/app/dashboard/(dashboard)/components/analytics-charts.tsx
@@ -1,0 +1,258 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+const rentCollectionData = [
+  { month: "Jan", collected: 94 },
+  { month: "Feb", collected: 96 },
+  { month: "Mar", collected: 98 },
+  { month: "Apr", collected: 97 },
+  { month: "May", collected: 99 },
+  { month: "Jun", collected: 100 },
+]
+
+const maintenanceData = [
+  { month: "Jan", resolved: 8 },
+  { month: "Feb", resolved: 11 },
+  { month: "Mar", resolved: 9 },
+  { month: "Apr", resolved: 13 },
+  { month: "May", resolved: 15 },
+  { month: "Jun", resolved: 12 },
+]
+
+const churnData = [
+  { label: "Renewing", value: 64 },
+  { label: "Undecided", value: 22 },
+  { label: "Moving", value: 14 },
+]
+
+export default function AnalyticsCharts() {
+  const maxRentCollection = useMemo(
+    () => Math.max(...rentCollectionData.map((entry) => entry.collected)),
+    []
+  )
+
+  const maxMaintenance = useMemo(
+    () => Math.max(...maintenanceData.map((entry) => entry.resolved)),
+    []
+  )
+
+  const maintenancePath = useMemo(() => {
+    if (maintenanceData.length === 0) {
+      return ""
+    }
+
+    const points = maintenanceData.map((entry, index) => {
+      const x = (index / (maintenanceData.length - 1)) * 100
+      const y = 100 - (entry.resolved / maxMaintenance) * 100
+      return `${x},${y}`
+    })
+
+    return `M0,100 L${points.join(" ")} L100,100 Z`
+  }, [maxMaintenance])
+
+  const totalChurn = useMemo(
+    () => churnData.reduce((total, entry) => total + entry.value, 0),
+    []
+  )
+
+  const churnSlices = useMemo(() => {
+    if (totalChurn === 0) {
+      return []
+    }
+
+    let cursor = 0
+
+    return churnData.map((entry) => {
+      const sliceAngle = (entry.value / totalChurn) * 360
+      const start = cursor
+      const end = cursor + sliceAngle
+      cursor = end
+
+      const x1 = 50 + 50 * Math.cos((Math.PI * start) / 180)
+      const y1 = 50 + 50 * Math.sin((Math.PI * start) / 180)
+      const x2 = 50 + 50 * Math.cos((Math.PI * end) / 180)
+      const y2 = 50 + 50 * Math.sin((Math.PI * end) / 180)
+      const largeArc = sliceAngle > 180 ? 1 : 0
+      const midAngle = start + sliceAngle / 2
+      const labelRadius = 32
+      const labelX = 50 + labelRadius * Math.cos((Math.PI * midAngle) / 180)
+      const labelY = 50 + labelRadius * Math.sin((Math.PI * midAngle) / 180)
+
+      return {
+        entry,
+        path: `M50,50 L${x1},${y1} A50,50 0 ${largeArc} 1 ${x2},${y2} Z`,
+        labelX,
+        labelY,
+      }
+    })
+  }, [totalChurn])
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between text-lg">
+              Rent collection velocity
+              <Badge variant="outline" className="text-xs font-medium">
+                +3.2% vs last quarter
+              </Badge>
+            </CardTitle>
+            <CardDescription>
+              Percentage of rent collected on time by month for the current lease cycle.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex h-56 items-end gap-3">
+              {rentCollectionData.map((entry) => (
+                <div key={entry.month} className="flex flex-1 flex-col items-center gap-2">
+                  <div className="relative flex size-full items-end justify-center rounded-md bg-gradient-to-t from-primary/10 via-primary/40 to-primary/80">
+                    <div
+                      className="w-full rounded-md bg-primary"
+                      style={{
+                        height: `${(entry.collected / maxRentCollection) * 100}%`,
+                      }}
+                    />
+                  </div>
+                  <div className="text-xs font-medium text-muted-foreground">{entry.month}</div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between text-lg">
+              Maintenance resolution pace
+              <Badge variant="secondary" className="text-xs font-medium">
+                SLA hit 92%
+              </Badge>
+            </CardTitle>
+            <CardDescription>
+              Tickets resolved per month with cumulative pace towards the quarterly SLA target.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <svg
+              viewBox="0 0 100 100"
+              className="h-56 w-full overflow-visible rounded-lg bg-gradient-to-b from-primary/5 via-background to-background"
+              role="img"
+              aria-label="Maintenance tickets resolved per month"
+            >
+              <defs>
+                <linearGradient id="maintenanceGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                  <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity="0.8" />
+                  <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity="0.1" />
+                </linearGradient>
+              </defs>
+              <path d={maintenancePath} fill="url(#maintenanceGradient)" stroke="hsl(var(--primary))" strokeWidth="1.2" />
+              {maintenanceData.map((entry, index) => {
+                const x = (index / (maintenanceData.length - 1)) * 100
+                const y = 100 - (entry.resolved / maxMaintenance) * 100
+                return (
+                  <g key={entry.month}>
+                    <circle cx={x} cy={y} r={1.5} fill="hsl(var(--primary))" />
+                    <text
+                      x={x}
+                      y={y - 4}
+                      textAnchor="middle"
+                      className="fill-foreground text-[3px]"
+                    >
+                      {entry.resolved}
+                    </text>
+                  </g>
+                )
+              })}
+              <g className="fill-muted-foreground text-[3px]">
+                {maintenanceData.map((entry, index) => {
+                  const x = (index / (maintenanceData.length - 1)) * 100
+                  return (
+                    <text key={entry.month} x={x} y={104} textAnchor="middle">
+                      {entry.month}
+                    </text>
+                  )
+                })}
+              </g>
+            </svg>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-border/70">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between text-lg">
+            Renewal sentiment snapshot
+            <Badge variant="outline" className="text-xs font-medium">
+              Survey sample 48 residents
+            </Badge>
+          </CardTitle>
+          <CardDescription>
+            Aggregate of the latest roommate sentiment survey indicating intent to renew.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,240px)]">
+            <div className="flex items-center justify-center">
+              <div className="relative size-40" role="img" aria-label="Resident renewal sentiment distribution">
+                <svg viewBox="0 0 100 100" className="absolute inset-0">
+                  {churnSlices.map(({ entry, path, labelX, labelY }) => (
+                    <g key={entry.label}>
+                      <path d={path} fill={segmentColor(entry.label)} />
+                      <text
+                        x={labelX}
+                        y={labelY}
+                        textAnchor="middle"
+                        className="fill-background text-[10px] font-semibold"
+                      >
+                        {`${entry.value}%`}
+                      </text>
+                    </g>
+                  ))}
+                </svg>
+                <div className="absolute inset-6 rounded-full bg-background shadow-inner" />
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <span className="text-sm font-semibold text-muted-foreground">Renewal mix</span>
+                </div>
+              </div>
+            </div>
+            <dl className="space-y-3">
+              {churnData.map((entry) => (
+                <div key={entry.label} className="flex items-center justify-between rounded-lg border border-border/60 p-3">
+                  <div className="flex items-center gap-2">
+                    <span className="size-2 rounded-full" style={{ backgroundColor: segmentColor(entry.label) }} />
+                    <dt className="text-sm font-medium text-foreground">{entry.label}</dt>
+                  </div>
+                  <dd className="text-sm font-semibold text-muted-foreground">{entry.value}%</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function segmentColor(label: string) {
+  switch (label) {
+    case "Renewing":
+      return "hsl(var(--primary))"
+    case "Undecided":
+      return "hsl(var(--chart-2, 215 20% 65%))"
+    case "Moving":
+      return "hsl(var(--destructive))"
+    default:
+      return "hsl(var(--muted))"
+  }
+}

--- a/app/dashboard/(dashboard)/components/insights-panel.tsx
+++ b/app/dashboard/(dashboard)/components/insights-panel.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import dynamic from "next/dynamic"
+import { track } from "@vercel/analytics/react"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { cn } from "@/lib/utils"
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <div className="flex h-56 items-center justify-center rounded-lg border border-dashed border-border/60 bg-muted/30 text-sm text-muted-foreground">
+      {label}
+    </div>
+  )
+}
+
+const AnalyticsCharts = dynamic(() => import("./analytics-charts"), {
+  ssr: false,
+  loading: () => <LoadingState label="Preparing analytics…" />,
+})
+
+const FeaturePrism = dynamic(() => import("@/components/feature-prism"), {
+  ssr: false,
+  loading: () => <LoadingState label="Warming up 3D preview…" />,
+})
+
+const SECTION_CONFIG = [
+  {
+    value: "analytics",
+    label: "Analytics",
+    description: "Key rent, maintenance, and renewal metrics in chart form.",
+    loaderLabel: "Preparing analytics…",
+    Component: AnalyticsCharts,
+  },
+  {
+    value: "visualization",
+    label: "3D Floorplan",
+    description: "Interactive holographic preview of the shared household layout.",
+    loaderLabel: "Warming up 3D preview…",
+    Component: FeaturePrism,
+  },
+] as const
+
+type SectionKey = (typeof SECTION_CONFIG)[number]["value"]
+
+type Surface = "tabs" | "accordion"
+
+export default function InsightsPanel() {
+  const [activeTab, setActiveTab] = useState<SectionKey>("analytics")
+  const [openSection, setOpenSection] = useState<SectionKey | null>("analytics")
+  const [loadedSections, setLoadedSections] = useState<Record<SectionKey, boolean>>({
+    analytics: true,
+    visualization: false,
+  })
+
+  const markSectionOpened = useCallback(
+    (section: SectionKey, surface: Surface, meta?: Record<string, unknown>) => {
+      setLoadedSections((previous) =>
+        previous[section] ? previous : { ...previous, [section]: true }
+      )
+      track("progressive_disclosure_surface_opened", {
+        section,
+        surface,
+        ...meta,
+      })
+    },
+    []
+  )
+
+  useEffect(() => {
+    markSectionOpened("analytics", "tabs", { initial: true })
+  }, [markSectionOpened])
+
+  const handleTabChange = useCallback(
+    (value: string) => {
+      const matching = SECTION_CONFIG.find((item) => item.value === value)
+      if (!matching) {
+        return
+      }
+
+      const section = matching.value
+      setActiveTab(section)
+      setOpenSection((current) => (current === section ? current : section))
+      markSectionOpened(section, "tabs")
+    },
+    [markSectionOpened]
+  )
+
+  const toggleAccordionSection = useCallback(
+    (section: SectionKey) => {
+      setOpenSection((current) => {
+        const next = current === section ? null : section
+        if (next) {
+          setActiveTab(next)
+          markSectionOpened(next, "accordion")
+        }
+        return next
+      })
+    },
+    [markSectionOpened]
+  )
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle className="text-2xl font-semibold">Progressive insights</CardTitle>
+        <CardDescription>
+          Analytics charts and 3D previews only mount after a tenant opts to explore them.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="hidden md:block">
+          <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-4">
+            <TabsList>
+              {SECTION_CONFIG.map((section) => (
+                <TabsTrigger key={section.value} value={section.value} className="text-sm font-medium">
+                  {section.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {SECTION_CONFIG.map((section) => (
+              <TabsContent key={section.value} value={section.value} className="space-y-4">
+                <p className="text-sm text-muted-foreground">{section.description}</p>
+                {loadedSections[section.value] ? (
+                  <section.Component />
+                ) : (
+                  <LoadingState label={section.loaderLabel} />
+                )}
+              </TabsContent>
+            ))}
+          </Tabs>
+        </div>
+
+        <div className="space-y-3 md:hidden" role="list">
+          {SECTION_CONFIG.map((section) => {
+            const isOpen = openSection === section.value
+            return (
+              <div
+                key={section.value}
+                className="rounded-lg border border-border/60 bg-card/80 backdrop-blur"
+                role="listitem"
+              >
+                <button
+                  type="button"
+                  onClick={() => toggleAccordionSection(section.value)}
+                  className="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium"
+                  aria-expanded={isOpen}
+                >
+                  <span>{section.label}</span>
+                  <span className="text-xs text-muted-foreground">{isOpen ? "Hide" : "Reveal"}</span>
+                </button>
+                <div
+                  className={cn(
+                    "grid overflow-hidden transition-[grid-template-rows] duration-300 ease-in-out",
+                    isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+                  )}
+                >
+                  <div className="min-h-0 space-y-3 px-4 pb-4 text-sm text-muted-foreground">
+                    {isOpen && <p>{section.description}</p>}
+                    {isOpen ? (
+                      loadedSections[section.value] ? (
+                        <section.Component />
+                      ) : (
+                        <LoadingState label={section.loaderLabel} />
+                      )
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -2,6 +2,8 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Link from "next/link"
 
+import InsightsPanel from "./components/insights-panel"
+
 export default function DashboardPage() {
   return (
     <div className="w-full space-y-6">
@@ -59,6 +61,8 @@ export default function DashboardPage() {
           </Link>
         </CardContent>
       </Card>
+
+      <InsightsPanel />
     </div>
   )
 }

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -1,0 +1,26 @@
+# Progressive disclosure for expensive surfaces
+
+We defer rendering of heavyweight UI such as analytics charts, holographic/3D previews, and third-party widgets until residents explicitly opt into them. This keeps the dashboard responsive on lower-powered devices and avoids shipping megabytes of unused JavaScript on first paint.
+
+## Patterns
+
+- **Tabbed insights (`md` and larger):** group related high-cost panels behind shadcn `Tabs`. Set the default tab to the most critical metric and defer loading of other panels until the user activates them.
+- **Accordion reveal (`sm` and smaller):** mirror the same content in a vertically stacked disclosure so mobile tenants can progressively reveal one surface at a time.
+- **Dynamic imports:** always wrap these panels with `next/dynamic` and disable SSR (`ssr: false`) so the code-split bundle only loads after the relevant tab/accordion opens.
+- **First-view gating:** track which surfaces have been opened and render a loading placeholder until the first reveal. Subsequent opens should reuse the hydrated component.
+
+## Instrumentation
+
+- Use `track` from `@vercel/analytics/react` to record each reveal event. Include the surface (`tabs` or `accordion`) and panel identifier (e.g. `analytics`, `visualization`) so product can correlate interaction rates with performance metrics.
+- Fire an `initial: true` event for the default tab to preserve baseline usage metrics.
+- When adding new expensive panels, update the tracking payload to include extra context (e.g. property id, feature flag) if available.
+
+## Authoring checklist
+
+1. Create the heavy panel as its own client component to isolate the split chunk.
+2. Export a progressive wrapper (tabs + accordion) that:
+   - keeps state of visited panels,
+   - calls `track` on every reveal,
+   - and renders a graceful loading skeleton until the dynamic import resolves.
+3. Document the new panel in this file with rationale and any edge-case handling.
+4. Verify that `pnpm lint` (and any relevant tests) continue to pass before opening a PR.


### PR DESCRIPTION
## Summary
- add a progressive insights panel to the dashboard that defers analytics charts and the 3D feature prism behind tabs/accordion with dynamic imports and instrumentation
- introduce a reusable analytics charts component that renders rent, maintenance, and renewal visualisations on demand
- capture progressive disclosure guidance in docs/design/progressive-disclosure.md for future heavy surfaces

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d599f1c8328b7fc5ac7147acfb5