### PR TITLE
Enable Supabase pooling and add connection monitoring

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -37,7 +37,16 @@ NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="your_supabase_anon_key"
 SUPABASE_SERVICE_ROLE_KEY="your_supabase_service_role_key"
 SUPABASE_JWT_SECRET="your_jwt_secret"
+SUPABASE_DB_URL="postgresql://postgres:postgres@localhost:54322/postgres"
+SUPABASE_DB_POOLER_URL="postgresql://db_user:db_password@project-ref.pooler.supabase.com:6543/postgres"
+SUPABASE_POOLER_WARNING_THRESHOLD="0.7"
+SUPABASE_POOLER_CRITICAL_THRESHOLD="0.9"
 ```
+
+- `SUPABASE_DB_URL` is used for local migrations and administrative scripts.
+- `SUPABASE_DB_POOLER_URL` should target the Supabase PgBouncer endpoint (port `6543`,
+  database `pgbouncer` or `postgres`) with `sslmode=require`.
+- Threshold variables control when connection saturation alerts fire (defaults are warning at 70% and critical at 90%).
 
 ### **APPLICATION**
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ NEXT_PUBLIC_SUPABASE_URL="your_supabase_project_url"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="your_supabase_anon_key"
 SUPABASE_SERVICE_ROLE_KEY="your_supabase_service_role_key"
 SUPABASE_JWT_SECRET="your_jwt_secret"
+SUPABASE_DB_URL="postgresql://postgres:postgres@localhost:54322/postgres"
+SUPABASE_DB_POOLER_URL="postgresql://db_user:db_password@project-ref.pooler.supabase.com:6543/postgres"
+SUPABASE_POOLER_WARNING_THRESHOLD="0.7"
+SUPABASE_POOLER_CRITICAL_THRESHOLD="0.9"
 
 # Stripe
 STRIPE_SECRET_KEY="your_stripe_secret_key"
@@ -79,6 +83,10 @@ DOCUMENSO_BASE_URL="your_documenso_instance_url"
 CALCOM_API_KEY="your_calcom_api_key"
 CALCOM_BASE_URL="your_calcom_instance_url"
 ```
+
+- Configure `SUPABASE_DB_POOLER_URL` to use the PgBouncer connection string from the
+  Supabase dashboard (port `6543`, SSL required). Threshold variables control when
+  connection saturation alerts fire.
 
 ### Database Setup
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,29 +1,16 @@
 import { headers } from "next/headers"
-import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import type { SupabaseClient } from "@supabase/supabase-js"
 
 import {
   sendEmailNotification,
   sendInAppNotification,
 } from "@/lib/notifications"
 import { getStripe } from "@/lib/stripe"
-import type { Database, TablesInsert } from "@/lib/supabase"
-
-function createSupabaseAdminClient(): SupabaseClient<Database> | null {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-
-  if (!supabaseUrl || !serviceRoleKey) {
-    console.error("Supabase admin credentials are not configured")
-    return null
-  }
-
-  return createClient<Database>(supabaseUrl, serviceRoleKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  })
-}
+import {
+  getSupabaseServiceRoleClient,
+  type Database,
+  type TablesInsert,
+} from "@/lib/supabase"
 
 export async function POST(req: Request) {
   const stripe = getStripe()
@@ -34,8 +21,11 @@ export async function POST(req: Request) {
     return new Response("Webhook not configured", { status: 500 })
   }
 
-  const supabase = createSupabaseAdminClient()
-  if (!supabase) {
+  let supabase: SupabaseClient<Database>
+  try {
+    supabase = getSupabaseServiceRoleClient()
+  } catch (error) {
+    console.error("Supabase client not configured", error)
     return new Response("Supabase client not configured", { status: 500 })
   }
 

--- a/docs/perf/database.md
+++ b/docs/perf/database.md
@@ -1,0 +1,101 @@
+# Supabase Database Performance Guide
+
+This guide documents how we keep Supabase database connections healthy while
+running on Vercel edge/serverless infrastructure.
+
+## 1. Enable PgBouncer connection pooling
+
+1. In the Supabase dashboard open **Database → Connection pooling**.
+2. Enable the **PgBouncer** pooler if it is not already on.
+3. Copy the pooled connection string (host ends with `.pooler.supabase.com`) and
+   ensure it targets port `6543` with `sslmode=require`.
+4. Use the pooled credentials for any long-running job, background worker, or
+   monitoring script. The pooled endpoint automatically balances sessions across
+   the available database connections.
+
+> **Tip:** When connecting to the PgBouncer admin database, append `/pgbouncer`
+> to the DSN so that `SHOW POOLS;` works.
+
+## 2. Environment variables / DSNs
+
+Update `.env.local` (and deployment secrets) with the new pooling variables:
+
+```bash
+# Supabase credentials
+NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="anon_key"
+SUPABASE_SERVICE_ROLE_KEY="service_role_key"
+SUPABASE_JWT_SECRET="jwt_secret"
+
+# Direct and pooled Postgres DSNs
+SUPABASE_DB_URL="postgresql://postgres:postgres@localhost:54322/postgres"
+SUPABASE_DB_POOLER_URL="postgresql://user:password@project-ref.pooler.supabase.com:6543/postgres"
+
+# Alert thresholds (override defaults when required)
+SUPABASE_POOLER_WARNING_THRESHOLD="0.7"
+SUPABASE_POOLER_CRITICAL_THRESHOLD="0.9"
+```
+
+`SUPABASE_DB_URL` is still used for local Supabase CLI workflows, whereas
+`SUPABASE_DB_POOLER_URL` powers PgBouncer aware scripts.
+
+## 3. Reusing Supabase clients with keep-alive
+
+The shared Supabase module now reuses clients across requests and configures an
+Undici agent with keep-alive so that serverless executions do not spawn new TCP
+sessions for every call.
+
+Key helpers:
+
+- `getSupabaseServiceRoleClient()` – shared service-role client used by API
+  routes and background jobs.
+- `getSupabaseAnonClient()` – server-side anon client reuse for internal tasks.
+- `resetSupabaseClients()` – allows tests to reset cached clients and close the
+  shared agent.
+
+Any code that previously constructed a new Supabase service client (e.g. the
+Stripe webhook and admin auth helper) now imports `getSupabaseServiceRoleClient`
+so that a single connection pool is shared across invocations.
+
+## 4. Monitoring PgBouncer saturation
+
+`lib/monitoring/pgbouncer.ts` exposes helpers to query `SHOW POOLS;` over the
+pooling DSN and compute saturation/alert levels.
+
+Available utilities:
+
+- `fetchConnectionPoolStats()` – raw metrics per database/user pool.
+- `analyzeConnectionSaturation()` – returns stats plus any alerts triggered by
+  threshold rules.
+- `monitorConnectionPool()` – convenience helper that logs warnings and invokes
+  an optional callback for alerting.
+
+Example usage (run as a cron job or serverless scheduled function):
+
+```ts
+import { monitorConnectionPool } from '@/lib/monitoring/pgbouncer'
+import { sendEmailNotification } from '@/lib/notifications'
+
+await monitorConnectionPool({
+  async onAlert(alert) {
+    await sendEmailNotification({
+      to: 'infra@sharehouse.app',
+      subject: `[DB] ${alert.level.toUpperCase()} saturation for ${alert.database}`,
+      template: 'db-alert',
+      data: alert.stats,
+    })
+  },
+})
+```
+
+By default alerts fire at 70% (`warning`) and 90% (`critical`) saturation, but
+those can be overridden via environment variables or the options passed into the
+monitor.
+
+## 5. Operational checklist
+
+- ✅ PgBouncer is enabled and the pooled DSN is used for all long-running jobs.
+- ✅ Service role Supabase clients reuse the global keep-alive agent.
+- ✅ `monitorConnectionPool` is scheduled (e.g. GitHub Action, Vercel Cron) and
+  routes alerts to the on-call channel.
+- ✅ Thresholds reflect production capacity expectations.

--- a/lib/monitoring/pgbouncer.ts
+++ b/lib/monitoring/pgbouncer.ts
@@ -1,0 +1,259 @@
+import { Pool } from 'pg'
+
+import {
+  getPoolerSslConfig,
+  getPoolerThresholdsFromEnv,
+  getSupabasePoolerUrl,
+} from '@/lib/supabase'
+
+export type ConnectionSaturationLevel = 'warning' | 'critical'
+
+export interface ConnectionSaturationThresholds {
+  warning: number
+  critical: number
+}
+
+export interface ConnectionPoolStats {
+  database: string
+  user: string
+  activeClients: number
+  waitingClients: number
+  totalClients: number
+  serverActive: number
+  serverIdle: number
+  maxClientConnections: number
+  poolMode: string
+  maxWaitMs: number
+  saturation: number
+  serverUtilization: number
+}
+
+export interface ConnectionSaturationAlert {
+  level: ConnectionSaturationLevel
+  database: string
+  threshold: number
+  saturation: number
+  stats: ConnectionPoolStats
+  message: string
+}
+
+export interface MonitorConnectionOptions {
+  thresholds?: Partial<ConnectionSaturationThresholds>
+  onAlert?: (alert: ConnectionSaturationAlert) => Promise<void> | void
+  logger?: (alert: ConnectionSaturationAlert) => void
+}
+
+export interface ConnectionSaturationAnalysis {
+  stats: ConnectionPoolStats[]
+  alerts: ConnectionSaturationAlert[]
+  thresholds: ConnectionSaturationThresholds
+}
+
+type MonitoringGlobalState = {
+  __supabasePgbouncerPool?: Pool
+}
+
+const globalForMonitoring = globalThis as typeof globalThis & MonitoringGlobalState
+
+const toNumber = (value: unknown) => {
+  const parsed = Number(value ?? 0)
+
+  if (!Number.isFinite(parsed)) {
+    return 0
+  }
+
+  return parsed
+}
+
+const clamp01 = (value: number, fallback: number) => {
+  if (!Number.isFinite(value)) {
+    return fallback
+  }
+
+  return Math.min(Math.max(value, 0), 1)
+}
+
+const resolveThresholds = (
+  overrides: Partial<ConnectionSaturationThresholds> = {}
+): ConnectionSaturationThresholds => {
+  const envThresholds = getPoolerThresholdsFromEnv()
+  const warning = clamp01(
+    overrides.warning ?? envThresholds.warning,
+    envThresholds.warning
+  )
+  const critical = clamp01(
+    overrides.critical ?? envThresholds.critical,
+    envThresholds.critical
+  )
+
+  return {
+    warning,
+    critical: Math.max(warning, critical),
+  }
+}
+
+const formatMessage = (stat: ConnectionPoolStats) => {
+  const parts = [
+    `${stat.database} pool at ${(stat.saturation * 100).toFixed(1)}% capacity`,
+    `${stat.activeClients}/${stat.maxClientConnections} active clients`,
+  ]
+
+  if (stat.waitingClients > 0) {
+    parts.push(`${stat.waitingClients} waiting`)
+  }
+
+  if (stat.maxWaitMs > 0) {
+    parts.push(`max wait ${(stat.maxWaitMs / 1000).toFixed(1)}s`)
+  }
+
+  parts.push(`mode ${stat.poolMode}`)
+
+  return parts.join(' · ')
+}
+
+const mapPoolRow = (row: Record<string, unknown>): ConnectionPoolStats => {
+  const activeClients = toNumber(row.cl_active)
+  const waitingClients = toNumber(row.cl_waiting)
+  const totalClients = activeClients + waitingClients
+  const serverActive = toNumber(row.sv_active)
+  const serverIdle = toNumber(row.sv_idle)
+  const maxClientConnections = Math.max(
+    toNumber(row.max_client_conn),
+    totalClients
+  )
+  const maxWaitSeconds = toNumber(row.maxwait)
+  const saturation =
+    maxClientConnections > 0 ? totalClients / maxClientConnections : 0
+  const serverTotal = serverActive + serverIdle
+  const serverUtilization = serverTotal > 0 ? serverActive / serverTotal : 0
+
+  return {
+    database: String(row.database ?? 'unknown'),
+    user: String(row.user ?? 'unknown'),
+    activeClients,
+    waitingClients,
+    totalClients,
+    serverActive,
+    serverIdle,
+    maxClientConnections,
+    poolMode: String(row.pool_mode ?? 'session'),
+    maxWaitMs: Math.max(0, Math.round(maxWaitSeconds * 1000)),
+    saturation,
+    serverUtilization,
+  }
+}
+
+const createPool = () =>
+  new Pool({
+    connectionString: getSupabasePoolerUrl(),
+    ssl: getPoolerSslConfig(),
+    max: 2,
+    min: 0,
+    idleTimeoutMillis: 0,
+    allowExitOnIdle: true,
+  })
+
+const getPool = () => {
+  if (!globalForMonitoring.__supabasePgbouncerPool) {
+    globalForMonitoring.__supabasePgbouncerPool = createPool()
+  }
+
+  return globalForMonitoring.__supabasePgbouncerPool
+}
+
+export const fetchConnectionPoolStats = async () => {
+  const client = await getPool().connect()
+
+  try {
+    const result = await client.query('SHOW POOLS;')
+    return result.rows.map(mapPoolRow)
+  } finally {
+    client.release()
+  }
+}
+
+const evaluateStat = (
+  stat: ConnectionPoolStats,
+  thresholds: ConnectionSaturationThresholds
+): ConnectionSaturationAlert | null => {
+  let level: ConnectionSaturationLevel | null = null
+  let threshold = thresholds.warning
+
+  if (stat.saturation >= thresholds.critical) {
+    level = 'critical'
+    threshold = thresholds.critical
+  } else if (stat.saturation >= thresholds.warning) {
+    level = 'warning'
+    threshold = thresholds.warning
+  } else if (stat.waitingClients > 0) {
+    level = 'warning'
+    threshold = thresholds.warning
+  }
+
+  if (!level) {
+    return null
+  }
+
+  return {
+    level,
+    database: stat.database,
+    threshold,
+    saturation: stat.saturation,
+    stats: stat,
+    message: formatMessage(stat),
+  }
+}
+
+export const analyzeConnectionSaturation = async (
+  overrides: Partial<ConnectionSaturationThresholds> = {}
+): Promise<ConnectionSaturationAnalysis> => {
+  const thresholds = resolveThresholds(overrides)
+  const stats = await fetchConnectionPoolStats()
+  const alerts = stats
+    .map((stat) => evaluateStat(stat, thresholds))
+    .filter((alert): alert is ConnectionSaturationAlert => Boolean(alert))
+
+  return {
+    stats,
+    alerts,
+    thresholds,
+  }
+}
+
+export const monitorConnectionPool = async (
+  options: MonitorConnectionOptions = {}
+): Promise<ConnectionSaturationAnalysis> => {
+  const analysis = await analyzeConnectionSaturation(options.thresholds)
+
+  if (analysis.alerts.length > 0) {
+    for (const alert of analysis.alerts) {
+      if (options.logger) {
+        options.logger(alert)
+      } else {
+        console.warn('[supabase:pool]', alert.message)
+      }
+
+      if (options.onAlert) {
+        await options.onAlert(alert)
+      }
+    }
+  }
+
+  return analysis
+}
+
+export const resetConnectionMonitoring = async () => {
+  if (!globalForMonitoring.__supabasePgbouncerPool) {
+    return
+  }
+
+  const pool = globalForMonitoring.__supabasePgbouncerPool
+  globalForMonitoring.__supabasePgbouncerPool = undefined
+
+  await pool.end()
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __supabasePgbouncerPool: Pool | undefined
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,3 +1,6 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { Agent, setGlobalDispatcher } from 'undici'
+
 export type Json =
   | string
   | number
@@ -310,3 +313,195 @@ export type TablesInsert<T extends keyof PublicSchema['Tables']> =
   PublicSchema['Tables'][T]['Insert']
 export type TablesUpdate<T extends keyof PublicSchema['Tables']> =
   PublicSchema['Tables'][T]['Update']
+
+type ServiceRoleClient = SupabaseClient<Database>
+
+type SupabaseGlobalState = {
+  __supabaseServiceRoleClient?: ServiceRoleClient
+  __supabaseAnonClient?: SupabaseClient<Database>
+  __supabaseFetchAgent?: Agent
+}
+
+const globalForSupabase = globalThis as typeof globalThis & SupabaseGlobalState
+
+const DEFAULT_KEEP_ALIVE_TIMEOUT = 30_000
+const DEFAULT_KEEP_ALIVE_MAX_TIMEOUT = 120_000
+
+const ensureSupabaseFetchAgent = () => {
+  if (!globalForSupabase.__supabaseFetchAgent) {
+    const agent = new Agent({
+      connect: {
+        keepAlive: true,
+      },
+      keepAliveTimeout: DEFAULT_KEEP_ALIVE_TIMEOUT,
+      keepAliveMaxTimeout: DEFAULT_KEEP_ALIVE_MAX_TIMEOUT,
+    })
+
+    setGlobalDispatcher(agent)
+    globalForSupabase.__supabaseFetchAgent = agent
+  }
+
+  return globalForSupabase.__supabaseFetchAgent
+}
+
+const keepAliveFetch: typeof fetch = (input, init = {}) => {
+  ensureSupabaseFetchAgent()
+
+  return fetch(input, {
+    ...init,
+    keepalive: true,
+  })
+}
+
+const getSupabaseUrl = () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+
+  if (!supabaseUrl) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL is not configured')
+  }
+
+  return supabaseUrl
+}
+
+const getSupabaseAnonKey = () => {
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!anonKey) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is not configured')
+  }
+
+  return anonKey
+}
+
+const getSupabaseServiceRoleKey = () => {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!serviceRoleKey) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is not configured')
+  }
+
+  return serviceRoleKey
+}
+
+const isLocalDatabase = (connectionString: string) =>
+  /localhost|127\.0\.0\.1/.test(connectionString)
+
+export const getSupabaseDatabaseUrl = () => {
+  const databaseUrl = process.env.SUPABASE_DB_URL
+
+  if (!databaseUrl) {
+    throw new Error('SUPABASE_DB_URL is not configured')
+  }
+
+  return databaseUrl
+}
+
+export const getSupabasePoolerUrl = () => {
+  const poolerUrl = process.env.SUPABASE_DB_POOLER_URL
+
+  if (poolerUrl) {
+    return poolerUrl
+  }
+
+  return getSupabaseDatabaseUrl()
+}
+
+export const getPoolerSslConfig = () => {
+  const poolerUrl = getSupabasePoolerUrl()
+
+  if (isLocalDatabase(poolerUrl)) {
+    return false
+  }
+
+  return {
+    rejectUnauthorized: false,
+  }
+}
+
+export const getSupabaseAnonClient = (): SupabaseClient<Database> => {
+  ensureSupabaseFetchAgent()
+
+  if (!globalForSupabase.__supabaseAnonClient) {
+    globalForSupabase.__supabaseAnonClient = createClient<Database>(
+      getSupabaseUrl(),
+      getSupabaseAnonKey(),
+      {
+        auth: {
+          persistSession: false,
+        },
+        global: {
+          fetch: keepAliveFetch,
+        },
+      }
+    )
+  }
+
+  return globalForSupabase.__supabaseAnonClient
+}
+
+export const getSupabaseServiceRoleClient = (): ServiceRoleClient => {
+  ensureSupabaseFetchAgent()
+
+  if (!globalForSupabase.__supabaseServiceRoleClient) {
+    globalForSupabase.__supabaseServiceRoleClient = createClient<Database>(
+      getSupabaseUrl(),
+      getSupabaseServiceRoleKey(),
+      {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+        global: {
+          fetch: keepAliveFetch,
+        },
+      }
+    )
+  }
+
+  return globalForSupabase.__supabaseServiceRoleClient
+}
+
+export const resetSupabaseClients = () => {
+  if (globalForSupabase.__supabaseAnonClient) {
+    globalForSupabase.__supabaseAnonClient = undefined
+  }
+
+  if (globalForSupabase.__supabaseServiceRoleClient) {
+    globalForSupabase.__supabaseServiceRoleClient = undefined
+  }
+
+  if (globalForSupabase.__supabaseFetchAgent) {
+    void globalForSupabase.__supabaseFetchAgent.close()
+    globalForSupabase.__supabaseFetchAgent = undefined
+  }
+}
+
+export const getPoolerThresholdsFromEnv = () => {
+  const warning = Number(process.env.SUPABASE_POOLER_WARNING_THRESHOLD ?? '0.7')
+  const critical = Number(process.env.SUPABASE_POOLER_CRITICAL_THRESHOLD ?? '0.9')
+
+  const clamp = (value: number, fallback: number) => {
+    if (!Number.isFinite(value)) {
+      return fallback
+    }
+
+    return Math.min(Math.max(value, 0), 1)
+  }
+
+  const sanitizedWarning = clamp(warning, 0.7)
+  const sanitizedCritical = clamp(critical, 0.9)
+
+  return {
+    warning: sanitizedWarning,
+    critical: Math.max(sanitizedWarning, sanitizedCritical),
+  }
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __supabaseServiceRoleClient: ServiceRoleClient | undefined
+  // eslint-disable-next-line no-var
+  var __supabaseAnonClient: SupabaseClient<Database> | undefined
+  // eslint-disable-next-line no-var
+  var __supabaseFetchAgent: Agent | undefined
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shared-house-portal",
+  "name": "roomsily",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shared-house-portal",
+      "name": "roomsily",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
@@ -54,6 +54,7 @@
         "next": "14.2.4",
         "next-compose-plugins": "^2.2.1",
         "next-themes": "^0.2.1",
+        "pg": "^8.12.0",
         "prettier": "^2.8.8",
         "react": "^18.2.0",
         "react-day-picker": "^8.10.0",
@@ -67,6 +68,7 @@
         "tailwind-merge": "^2.2.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "0.160.0",
+        "undici": "^6.19.8",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -10012,6 +10014,95 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10160,6 +10251,45 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/potpack": {
       "version": "1.0.2",
@@ -11302,6 +11432,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -12402,6 +12541,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -13486,6 +13634,15 @@
       "integrity": "sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.16.5"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "next-compose-plugins": "^2.2.1",
     "next-themes": "^0.2.1",
     "prettier": "^2.8.8",
+    "pg": "^8.12.0",
     "react": "^18.2.0",
     "react-day-picker": "^8.10.0",
     "react-dom": "^18.2.0",
@@ -69,6 +70,7 @@
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "0.160.0",
+    "undici": "^6.19.8",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      pg:
+        specifier: ^8.12.0
+        version: 8.16.3
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -185,6 +188,9 @@ importers:
       three:
         specifier: 0.160.0
         version: 0.160.0
+      undici:
+        specifier: ^6.19.8
+        version: 6.21.3
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -3710,6 +3716,40 @@ packages:
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
+  pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
@@ -3783,6 +3823,22 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
@@ -4137,6 +4193,10 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4452,6 +4512,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@6.21.3:
+    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
+    engines: {node: '>=18.17'}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -4701,6 +4765,10 @@ packages:
 
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -8738,6 +8806,41 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
+  pg-cloudflare@1.2.7:
+    optional: true
+
+  pg-connection-string@2.9.1: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.10.1(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
+  pg-protocol@1.10.3: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.0.0: {}
 
   picocolors@1.0.1: {}
@@ -8800,6 +8903,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   potpack@1.0.2: {}
 
@@ -9219,6 +9332,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  split2@4.2.0: {}
+
   stackback@0.0.2: {}
 
   stats-gl@2.4.2(@types/three@0.176.0)(three@0.160.0):
@@ -9598,6 +9713,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@6.21.3: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.2
@@ -9907,6 +10024,8 @@ snapshots:
   xregexp@5.1.1:
     dependencies:
       '@babel/runtime-corejs3': 7.23.9
+
+  xtend@4.0.2: {}
 
   yallist@3.1.1: {}
 

--- a/utils/supa-auth-admin.tsx
+++ b/utils/supa-auth-admin.tsx
@@ -1,13 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
-import type { Database } from '@/lib/supabase'
+import { getSupabaseServiceRoleClient } from '@/lib/supabase'
 
-const supabase = createClient<Database>(process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-  auth: {
-    autoRefreshToken: false,
-    persistSession: false
-  }
-})
+const supabase = getSupabaseServiceRoleClient()
 
 // Access auth admin api
 export const adminAuthClient = supabase.auth.admin


### PR DESCRIPTION
## Summary
- enable Supabase pooling DSNs in env docs and README
- reuse shared Supabase clients with a keep-alive agent to cut connection churn
- add PgBouncer monitoring utilities and document the performance runbook

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d15d62e24483289ed6ff940615f489