### PR TITLE
feat: separate resident and management experiences

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,83 +1,116 @@
 "use client";
+
 import React, { useEffect, useState } from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
 import SmartLink from "@/components/navigation/SmartLink";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
 import { createClient } from "@/utils/supabase-browser";
 import { fetchMemberRole } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import {
+  Calendar,
+  ClipboardList,
+  CreditCard,
+  FileText,
+  Home,
+  MessageSquare,
+  ShoppingCart,
+  UserCheck,
+  Users,
+  Wrench,
+} from "lucide-react";
+import { resolveMemberPersona, type MemberPersona } from "@/lib/members";
+
+type NavigationEntry = {
+  href: string;
+  text: string;
+  Icon: React.ComponentType<{ className?: string }>;
+};
+
+const MANAGEMENT_LINKS: NavigationEntry[] = [
+  { href: "/dashboard", text: "Overview", Icon: Home },
+  { href: "/dashboard/members", text: "Residents", Icon: Users },
+  { href: "/payments", text: "Payments", Icon: CreditCard },
+  { href: "/documents", text: "Documents", Icon: FileText },
+  { href: "/messaging", text: "Message Board", Icon: MessageSquare },
+  { href: "/bookings", text: "Amenity Bookings", Icon: Calendar },
+  { href: "/visitors", text: "Visitor Log", Icon: UserCheck },
+  { href: "/maintenance", text: "Maintenance", Icon: Wrench },
+];
+
+const RESIDENT_LINKS: NavigationEntry[] = [
+  { href: "/dashboard", text: "Overview", Icon: Home },
+  { href: "/payments", text: "Payments", Icon: CreditCard },
+  { href: "/documents", text: "My Lease", Icon: FileText },
+  { href: "/messaging", text: "Message Board", Icon: MessageSquare },
+  { href: "/bookings", text: "Book Amenities", Icon: Calendar },
+  { href: "/visitors", text: "Visitors", Icon: UserCheck },
+  { href: "/maintenance", text: "Maintenance", Icon: Wrench },
+  { href: "/chores", text: "Chores", Icon: ClipboardList },
+  { href: "/supplies", text: "Supplies", Icon: ShoppingCart },
+];
 
 export default function NavLinks() {
-	const pathname = usePathname();
-	const [role, setRole] = useState<string | null>(null);
+  const pathname = usePathname();
+  const [persona, setPersona] = useState<MemberPersona>('unknown');
 
-	useEffect(() => {
-		const load = async () => {
-			try {
-				const supabase = createClient();
-                                const { data: { user } } = await supabase.auth.getUser();
-                                if (!user) {
-                                        setRole(null);
-                                        return;
-                                }
-                                const typedSupabase = supabase as unknown as TypedSupabaseClient;
-                                try {
-                                        const resolvedRole = await fetchMemberRole(typedSupabase, user.id);
-                                        setRole(resolvedRole || null);
-                                } catch (memberError) {
-                                        console.error("Error loading member role", memberError);
-                                        setRole(null);
-                                }
-                        } catch (e) {
-                                setRole(null);
-                        }
-		};
-		load();
-	}, []);
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const supabase = createClient();
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
 
-	const isLandlord = role === 'property_manager' || role === 'admin' || role === 'landlord';
+        if (!user) {
+          setPersona('unknown');
+          return;
+        }
 
-	const links = isLandlord
-		? [
-			{ href: "/dashboard/members", text: "Members", Icon: PersonIcon },
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-		]
-		: [
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-			{ href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
-			{ href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
-		];
+        const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
-	return (
-		<div className="space-y-5">
-			{links.map((link, index) => {
-				const Icon = link.Icon;
-				return (
-                                        <SmartLink
-                                                onClick={() =>
-                                                        document.getElementById("sidebar-close")?.click()
-                                                }
-                                                href={link.href}
-                                                key={index}
-                                                className={cn(
-                                                        "flex items-center gap-2 rounded-sm p-2",
-                                                        {
-                                                                " bg-gray-500 dark:bg-gray-700 text-white ":
-                                                                        pathname === link.href,
-                                                        }
-                                                )}
-                                                intent="navigation"
-                                        >
-                                                <Icon />
-                                                {link.text}
-                                        </SmartLink>
-				);
-			})}
-		</div>
-	);
+        try {
+          const resolvedRole = await fetchMemberRole(typedSupabase, user.id);
+          setPersona(resolveMemberPersona(resolvedRole));
+        } catch (memberError) {
+          console.error('Error loading member role', memberError);
+          setPersona('unknown');
+        }
+      } catch (error) {
+        setPersona('unknown');
+      }
+    };
+
+    load();
+  }, []);
+
+  const effectivePersona = persona === 'unknown' ? 'resident' : persona;
+  const links = effectivePersona === 'management' ? MANAGEMENT_LINKS : RESIDENT_LINKS;
+
+  return (
+    <div className="space-y-5">
+      {links.map((link) => {
+        const Icon = link.Icon;
+        const isActive = pathname === link.href;
+
+        return (
+          <SmartLink
+            onClick={() => document.getElementById('sidebar-close')?.click()}
+            href={link.href}
+            key={link.href}
+            className={cn(
+              'flex items-center gap-2 rounded-sm p-2 transition-colors hover:bg-muted',
+              {
+                'bg-gray-500 text-white dark:bg-gray-700': isActive,
+              },
+            )}
+            intent="navigation"
+          >
+            <Icon className="size-4" />
+            {link.text}
+          </SmartLink>
+        );
+      })}
+    </div>
+  );
 }

--- a/app/dashboard/members/components/LegacyMemberTable.tsx
+++ b/app/dashboard/members/components/LegacyMemberTable.tsx
@@ -5,33 +5,37 @@ import ListOfMembers from "./ListOfMembers"
 
 const LEGACY_MEMBERS: DashboardMember[] = [
         {
-                name: "Admin Member",
-                role: "admin",
+                name: "Avery Chen",
+                role: "tenant",
+                persona: "resident",
                 createdAt: new Date().toDateString(),
                 status: "active",
         },
         {
-                name: "Non Admin User",
-                role: "user",
-                createdAt: new Date().toDateString(),
-                status: "active",
-        },
-        {
-                name: "Administrator",
-                role: "admin",
+                name: "Jordan Blake",
+                role: "roommate",
+                persona: "resident",
                 createdAt: new Date().toDateString(),
                 status: "resigned",
         },
         {
-                name: "Satoshi",
-                role: "user",
+                name: "Morgan Ellis",
+                role: "property_manager",
+                persona: "management",
+                createdAt: new Date().toDateString(),
+                status: "active",
+        },
+        {
+                name: "Sonia Patel",
+                role: "landlord",
+                persona: "management",
                 createdAt: new Date().toDateString(),
                 status: "active",
         },
 ]
 
 export function LegacyMemberTable() {
-        const tableHeader = ["Name", "Role", "Joined", "Status"]
+        const tableHeader = ["Name & Profile", "Role", "Joined", "Status", "Actions"]
         return (
                 <Table headers={tableHeader}>
                         <ListOfMembers members={LEGACY_MEMBERS} />

--- a/app/dashboard/members/components/ListOfMembers.tsx
+++ b/app/dashboard/members/components/ListOfMembers.tsx
@@ -7,41 +7,66 @@ import { cn } from "@/lib/utils"
 import { DashboardMember } from "../data"
 import EditMember from "./edit/EditMember"
 
+const personaStyles: Record<DashboardMember["persona"], string> = {
+        resident: "bg-blue-100 text-blue-700 dark:bg-blue-950/60 dark:text-blue-300",
+        management: "bg-purple-100 text-purple-700 dark:bg-purple-950/60 dark:text-purple-300",
+}
+
+const roleLabels: Record<DashboardMember["role"], string> = {
+        admin: "Admin",
+        user: "User",
+        tenant: "Tenant",
+        roommate: "Roommate",
+        property_manager: "Property Manager",
+        landlord: "Landlord",
+        null: "Unknown",
+}
+
+const roleStyles: Partial<Record<DashboardMember["role"], string>> = {
+        admin: "border-red-300 bg-red-50 text-red-600 dark:border-red-400 dark:bg-red-950/60 dark:text-red-300",
+        tenant: "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-400 dark:bg-emerald-950/60 dark:text-emerald-300",
+        roommate: "border-teal-300 bg-teal-50 text-teal-700 dark:border-teal-400 dark:bg-teal-950/60 dark:text-teal-300",
+        property_manager: "border-indigo-300 bg-indigo-50 text-indigo-700 dark:border-indigo-400 dark:bg-indigo-950/60 dark:text-indigo-300",
+        landlord: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-400 dark:bg-amber-950/60 dark:text-amber-300",
+}
+
 export default function ListOfMembers({ members }: { members: DashboardMember[] }) {
         return (
                 <div className="mx-2 rounded-sm bg-white dark:bg-inherit">
                         {members.map((member, index) => {
                                 return (
-                                        <div
-                                                className="grid grid-cols-5 rounded-sm p-3 align-middle font-normal"
-                                                key={member.name + index}
-                                        >
-                                                <h1>{member.name}</h1>
+                                        <div className="grid grid-cols-5 rounded-sm p-3 align-middle font-normal" key={member.name + index}>
+                                                <div className="space-y-1">
+                                                        <h1 className="font-medium">{member.name}</h1>
+                                                        <span
+                                                                className={cn(
+                                                                        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+                                                                        personaStyles[member.persona],
+                                                                )}
+                                                        >
+                                                                {member.persona === "resident" ? "Resident" : "Management"}
+                                                        </span>
+                                                </div>
 
                                                 <div>
                                                         <span
                                                                 className={cn(
-                                                                        "rounded-full border-[.5px] px-2 py-1 text-sm capitalize shadow dark:bg-zinc-800",
-                                                                        {
-                                                                                "border-green-500 bg-green-200 text-green-600":
-                                                                                        member.role === "admin",
-                                                                                "border-zinc-300 bg-yellow-50 px-4 text-yellow-700 dark:border-yellow-700 dark:text-yellow-300":
-                                                                                        member.role === "user",
-                                                                        },
+                                                                        "inline-flex items-center rounded-full border px-3 py-0.5 text-sm font-medium capitalize shadow-sm",
+                                                                        roleStyles[member.role] ?? "border-zinc-200 bg-zinc-100 text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200",
                                                                 )}
                                                         >
-                                                                {member.role}
+                                                                {roleLabels[member.role] ?? "Role"}
                                                         </span>
                                                 </div>
                                                 <h1>{member.createdAt}</h1>
                                                 <div>
                                                         <span
                                                                 className={cn(
-                                                                        "rounded-full border border-zinc-300 px-2 py-1 text-sm capitalize dark:bg-zinc-800",
+                                                                        "inline-flex items-center rounded-full border px-3 py-0.5 text-sm capitalize dark:bg-zinc-800",
                                                                         {
-                                                                                "bg-green-200 px-4 text-green-600 dark:border-green-400":
+                                                                                "border-green-300 bg-green-100 text-green-700 dark:border-green-400 dark:text-green-300":
                                                                                         member.status === "active",
-                                                                                "bg-red-100 text-red-500 dark:border-red-400 dark:text-red-300":
+                                                                                "border-red-300 bg-red-100 text-red-600 dark:border-red-400 dark:text-red-300":
                                                                                         member.status === "resigned",
                                                                         },
                                                                 )}

--- a/app/dashboard/members/components/MemberTable.tsx
+++ b/app/dashboard/members/components/MemberTable.tsx
@@ -5,7 +5,7 @@ import ListOfMembers from "./ListOfMembers"
 
 export default async function MemberTable() {
         const members = await getDashboardMembers()
-        const tableHeader = ["Name", "Role", "Joined", "Status"]
+        const tableHeader = ["Name & Profile", "Role", "Joined", "Status", "Actions"]
 
         return (
                 <Table headers={tableHeader}>

--- a/app/dashboard/members/components/create/CreateForm.tsx
+++ b/app/dashboard/members/components/create/CreateForm.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect } from "react";
 import { Input } from "@/components/ui/input";
 
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -7,63 +8,94 @@ import * as z from "zod";
 
 import { Button } from "@/components/ui/button";
 import {
-	Form,
-	FormControl,
-	FormDescription,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
+        Form,
+        FormControl,
+        FormDescription,
+        FormField,
+        FormItem,
+        FormLabel,
+        FormMessage,
 } from "@/components/ui/form";
 import { toast } from "@/components/ui/use-toast";
 
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
 } from "@/components/ui/select";
 import { createMember, updateMemberById } from "../../actions";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import { cn } from "@/lib/utils";
+import {
+        RESIDENT_ROLES,
+        MANAGEMENT_ROLES,
+        rolesForPersona,
+} from "@/lib/members";
+import type { AssignableRole } from "@/lib/members";
+
+const profileTypes = ["resident", "management"] as const;
+const assignableRoles = [...RESIDENT_ROLES, ...MANAGEMENT_ROLES] as const;
 
 const FormSchema = z
-	.object({
-		name: z.string().min(2, {
-			message: "Username must be at least 2 characters.",
-		}),
-		role: z.enum(["user", "admin"]),
-		status: z.enum(["active", "resigned"]),
-		email: z.string().email(),
-		password: z
-			.string()
-			.min(6, { message: "Password should be 6 characters" }),
-		confirm: z
-			.string()
-			.min(6, { message: "Password should be 6 characters" }),
-	})
-	.refine((data) => data.confirm === data.password, {
-		message: "Passowrd doesn't match",
-		path: ["confirm"],
-	});
+        .object({
+                name: z.string().min(2, {
+                        message: "Username must be at least 2 characters.",
+                }),
+                persona: z.enum(profileTypes),
+                role: z.enum(assignableRoles),
+                status: z.enum(["active", "resigned"]),
+                email: z.string().email(),
+                password: z
+                        .string()
+                        .min(6, { message: "Password should be 6 characters" }),
+                confirm: z
+                        .string()
+                        .min(6, { message: "Password should be 6 characters" }),
+        })
+        .refine((data) => data.confirm === data.password, {
+                message: "Passowrd doesn't match",
+                path: ["confirm"],
+        })
+        .refine(
+                (data) => rolesForPersona(data.persona).includes(data.role),
+                {
+                        message: "Select a role that matches the profile type.",
+                        path: ["role"],
+                },
+        );
 
 export default function MemberForm() {
-	const roles = ["admin", "user"];
-	const status = ["active", "resigned"];
+        const status = ["active", "resigned"];
 
-	const form = useForm<z.infer<typeof FormSchema>>({
-		resolver: zodResolver(FormSchema),
-		defaultValues: {
-			name: "",
-			role: "user",
-			status: "active",
-			email: "",
-		},
-	});
+        const form = useForm<z.infer<typeof FormSchema>>({
+                resolver: zodResolver(FormSchema),
+                defaultValues: {
+                        name: "",
+                        persona: "resident",
+                        role: RESIDENT_ROLES[0],
+                        status: "active",
+                        email: "",
+                },
+        });
 
-	function onSubmit(data: z.infer<typeof FormSchema>) {
-		createMember();
+        const persona = form.watch("persona");
+
+        useEffect(() => {
+                const availableRoles = rolesForPersona(persona);
+                const currentRole = form.getValues("role") as AssignableRole;
+
+                if (!availableRoles.includes(currentRole)) {
+                        form.setValue("role", availableRoles[0], {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                        });
+                }
+        }, [form, persona]);
+
+        function onSubmit(data: z.infer<typeof FormSchema>) {
+                createMember();
 
 		document.getElementById("create-trigger")?.click();
 
@@ -85,10 +117,10 @@ export default function MemberForm() {
 				onSubmit={form.handleSubmit(onSubmit)}
 				className="w-full space-y-6 p-2"
 			>
-				<FormField
-					control={form.control}
-					name="email"
-					render={({ field }) => (
+                                <FormField
+                                        control={form.control}
+                                        name="email"
+                                        render={({ field }) => (
 						<FormItem>
 							<FormLabel>Email</FormLabel>
 							<FormControl>
@@ -137,10 +169,10 @@ export default function MemberForm() {
 						</FormItem>
 					)}
 				/>
-				<FormField
-					control={form.control}
-					name="name"
-					render={({ field }) => (
+                                <FormField
+                                        control={form.control}
+                                        name="name"
+                                        render={({ field }) => (
 						<FormItem>
 							<FormLabel>Username</FormLabel>
 							<FormControl>
@@ -156,42 +188,67 @@ export default function MemberForm() {
 						</FormItem>
 					)}
 				/>
-				<FormField
-					control={form.control}
-					name="role"
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Role</FormLabel>
-							<Select
-								onValueChange={field.onChange}
-								defaultValue={field.value}
-							>
-								<FormControl>
-									<SelectTrigger>
-										<SelectValue placeholder="Select a role" />
-									</SelectTrigger>
-								</FormControl>
-								<SelectContent>
-									{roles.map((role, index) => {
-										return (
-											<SelectItem
-												value={role}
-												key={index}
-											>
-												{role}
-											</SelectItem>
-										);
-									})}
-								</SelectContent>
-							</Select>
+                                <FormField
+                                        control={form.control}
+                                        name="persona"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Profile type</FormLabel>
+                                                        <Select
+                                                                onValueChange={field.onChange}
+                                                                defaultValue={field.value}
+                                                        >
+                                                                <FormControl>
+                                                                        <SelectTrigger>
+                                                                                <SelectValue placeholder="Select a profile type" />
+                                                                        </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                        {profileTypes.map((type) => (
+                                                                                <SelectItem key={type} value={type}>
+                                                                                        {type === "resident" ? "Resident" : "Property management"}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                        <FormDescription>
+                                                                Choose whether this member lives in the home or manages it.
+                                                        </FormDescription>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <FormField
+                                        control={form.control}
+                                        name="role"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Role</FormLabel>
+                                                        <Select
+                                                                onValueChange={field.onChange}
+                                                                defaultValue={field.value}
+                                                        >
+                                                                <FormControl>
+                                                                        <SelectTrigger>
+                                                                                <SelectValue placeholder="Select a role" />
+                                                                        </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                        {(persona === "management" ? MANAGEMENT_ROLES : RESIDENT_ROLES).map((role) => (
+                                                                                <SelectItem value={role} key={role}>
+                                                                                        {role.replace("_", " ")}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
 
 							<FormMessage />
 						</FormItem>
 					)}
 				/>
-				<FormField
-					control={form.control}
-					name="status"
+                                <FormField
+                                        control={form.control}
+                                        name="status"
 					render={({ field }) => (
 						<FormItem>
 							<FormLabel>Status</FormLabel>

--- a/app/dashboard/members/components/edit/AdvanceForm.tsx
+++ b/app/dashboard/members/components/edit/AdvanceForm.tsx
@@ -1,147 +1,193 @@
 "use client";
 
+import { useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 import { Button } from "@/components/ui/button";
 import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
-	FormDescription,
+        Form,
+        FormControl,
+        FormField,
+        FormItem,
+        FormLabel,
+        FormMessage,
+        FormDescription,
 } from "@/components/ui/form";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
 } from "@/components/ui/select";
 import { toast } from "@/components/ui/use-toast";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import { cn } from "@/lib/utils";
+import { RESIDENT_ROLES, MANAGEMENT_ROLES, rolesForPersona } from "@/lib/members";
+import type { AssignableRole } from "@/lib/members";
 
-const FormSchema = z.object({
-	role: z.enum(["admin", "user"]),
-	status: z.enum(["active", "resigned"]),
-});
+const profileTypes = ["resident", "management"] as const;
+const assignableRoles = [...RESIDENT_ROLES, ...MANAGEMENT_ROLES] as const;
+
+const FormSchema = z
+        .object({
+                persona: z.enum(profileTypes),
+                role: z.enum(assignableRoles),
+                status: z.enum(["active", "resigned"]),
+        })
+        .refine(
+                (data) => rolesForPersona(data.persona).includes(data.role),
+                {
+                        message: "Role must align with the selected profile type.",
+                        path: ["role"],
+                },
+        );
 
 export default function AdvanceForm() {
-	const roles = ["admin", "user"];
-	const status = ["active", "resigned"];
+        const status = ["active", "resigned"];
 
-	const form = useForm<z.infer<typeof FormSchema>>({
-		resolver: zodResolver(FormSchema),
-		defaultValues: {
-			role: "user",
-			status: "active",
-		},
-	});
+        const form = useForm<z.infer<typeof FormSchema>>({
+                resolver: zodResolver(FormSchema),
+                defaultValues: {
+                        persona: "resident",
+                        role: RESIDENT_ROLES[0],
+                        status: "active",
+                },
+        });
 
-	function onSubmit(data: z.infer<typeof FormSchema>) {
-		toast({
-			title: "You submitted the following values:",
-			description: (
-				<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-					<code className="text-white">
-						{JSON.stringify(data, null, 2)}
-					</code>
-				</pre>
-			),
-		});
-	}
+        const persona = form.watch("persona");
 
-	return (
-		<Form {...form}>
-			<form
-				onSubmit={form.handleSubmit(onSubmit)}
-				className="w-full space-y-6"
-			>
-				<FormField
-					control={form.control}
-					name="role"
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Role</FormLabel>
-							<Select
-								onValueChange={field.onChange}
-								defaultValue={field.value}
-							>
-								<FormControl>
-									<SelectTrigger>
-										<SelectValue placeholder="Select a role" />
-									</SelectTrigger>
-								</FormControl>
-								<SelectContent>
-									{roles.map((role, index) => {
-										return (
-											<SelectItem
-												value={role}
-												key={index}
-											>
-												{role}
-											</SelectItem>
-										);
-									})}
-								</SelectContent>
-							</Select>
+        useEffect(() => {
+                const availableRoles = rolesForPersona(persona);
+                const currentRole = form.getValues("role") as AssignableRole;
 
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
-				<FormField
-					control={form.control}
-					name="status"
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Status</FormLabel>
-							<Select
-								onValueChange={field.onChange}
-								defaultValue={field.value}
-							>
-								<FormControl>
-									<SelectTrigger>
-										<SelectValue placeholder="Select user status" />
-									</SelectTrigger>
-								</FormControl>
-								<SelectContent>
-									{status.map((status, index) => {
-										return (
-											<SelectItem
-												value={status}
-												key={index}
-											>
-												{status}
-											</SelectItem>
-										);
-									})}
-								</SelectContent>
-							</Select>
-							<FormDescription>
-								status resign mean the user is no longer work
-								here.
-							</FormDescription>
+                if (!availableRoles.includes(currentRole)) {
+                        form.setValue("role", availableRoles[0], {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                        });
+                }
+        }, [form, persona]);
 
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
-				<Button
-					type="submit"
-					className="flex w-full items-center gap-2"
-					variant="outline"
-				>
-					Update{" "}
-					<AiOutlineLoading3Quarters
-						className={cn(" animate-spin", "hidden")}
-					/>
-				</Button>
-			</form>
-		</Form>
-	);
+        function onSubmit(data: z.infer<typeof FormSchema>) {
+                toast({
+                        title: "You submitted the following values:",
+                        description: (
+                                <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+                                        <code className="text-white">
+                                                {JSON.stringify(data, null, 2)}
+                                        </code>
+                                </pre>
+                        ),
+                });
+        }
+
+        return (
+                <Form {...form}>
+                        <form
+                                onSubmit={form.handleSubmit(onSubmit)}
+                                className="w-full space-y-6"
+                        >
+                                <FormField
+                                        control={form.control}
+                                        name="persona"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Profile type</FormLabel>
+                                                        <Select
+                                                                onValueChange={field.onChange}
+                                                                defaultValue={field.value}
+                                                        >
+                                                                <FormControl>
+                                                                        <SelectTrigger>
+                                                                                <SelectValue placeholder="Select a profile type" />
+                                                                        </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                        {profileTypes.map((type) => (
+                                                                                <SelectItem key={type} value={type}>
+                                                                                        {type === "resident" ? "Resident" : "Property management"}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                        <FormDescription>
+                                                                Keep residents and management separated so permissions stay accurate.
+                                                        </FormDescription>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <FormField
+                                        control={form.control}
+                                        name="role"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Role</FormLabel>
+                                                        <Select
+                                                                onValueChange={field.onChange}
+                                                                defaultValue={field.value}
+                                                        >
+                                                                <FormControl>
+                                                                        <SelectTrigger>
+                                                                                <SelectValue placeholder="Select a role" />
+                                                                        </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                        {(persona === "management" ? MANAGEMENT_ROLES : RESIDENT_ROLES).map((role) => (
+                                                                                <SelectItem value={role} key={role}>
+                                                                                        {role.replace("_", " ")}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <FormField
+                                        control={form.control}
+                                        name="status"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Status</FormLabel>
+                                                        <Select
+                                                                onValueChange={field.onChange}
+                                                                defaultValue={field.value}
+                                                        >
+                                                                <FormControl>
+                                                                        <SelectTrigger>
+                                                                                <SelectValue placeholder="Select user status" />
+                                                                        </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                        {status.map((item) => (
+                                                                                <SelectItem value={item} key={item}>
+                                                                                        {item}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                        <FormDescription>
+                                                                Status &quot;resigned&quot; means the member is no longer active in the property.
+                                                        </FormDescription>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <Button
+                                        type="submit"
+                                        className="flex w-full items-center gap-2"
+                                        variant="outline"
+                                >
+                                        Update{" "}
+                                        <AiOutlineLoading3Quarters
+                                                className={cn(" animate-spin", "hidden")}
+                                        />
+                                </Button>
+                        </form>
+                </Form>
+        );
 }

--- a/app/dashboard/members/data.ts
+++ b/app/dashboard/members/data.ts
@@ -2,9 +2,12 @@ import "server-only"
 
 import { cache } from "react"
 
+import type { MemberRole } from "@/lib/members"
+
 export type DashboardMember = {
         name: string
-        role: "admin" | "user"
+        role: MemberRole
+        persona: "resident" | "management"
         createdAt: string
         status: "active" | "resigned"
 }
@@ -17,26 +20,30 @@ export const getDashboardMembers = cache(async (): Promise<DashboardMember[]> =>
         await wait(260)
         return [
                 {
-                        name: "Admin Member",
-                        role: "admin",
+                        name: "Avery Chen",
+                        role: "tenant",
+                        persona: "resident",
                         createdAt: new Date().toDateString(),
                         status: "active",
                 },
                 {
-                        name: "Non Admin User",
-                        role: "user",
-                        createdAt: new Date().toDateString(),
-                        status: "active",
-                },
-                {
-                        name: "Administrator",
-                        role: "admin",
+                        name: "Jordan Blake",
+                        role: "roommate",
+                        persona: "resident",
                         createdAt: new Date().toDateString(),
                         status: "resigned",
                 },
                 {
-                        name: "Satoshi",
-                        role: "user",
+                        name: "Morgan Ellis",
+                        role: "property_manager",
+                        persona: "management",
+                        createdAt: new Date().toDateString(),
+                        status: "active",
+                },
+                {
+                        name: "Sonia Patel",
+                        role: "landlord",
+                        persona: "management",
                         createdAt: new Date().toDateString(),
                         status: "active",
                 },

--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
 import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
+import { isManagementRole } from '@/lib/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import {
   Document,
@@ -268,7 +269,7 @@ export async function createSigningRequestAction(
       return { success: false, error: 'You do not have permission to create signing requests for this document.' };
     }
 
-    if (role !== 'property_manager' && role !== 'admin' && document.tenant_id !== user.id) {
+    if (!isManagementRole(role) && document.tenant_id !== user.id) {
       return { success: false, error: 'You do not have permission to create signing requests for this document.' };
     }
 

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -1,4 +1,5 @@
-import { format, parseISO } from "date-fns"
+import { redirect } from "next/navigation";
+import { format, parseISO } from "date-fns";
 
 import {
   Card,
@@ -6,110 +7,120 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
-import { Button } from "@/components/ui/button"
-import { StripeActions } from "./_components/stripe-actions"
-import { CatchUpPaymentCard } from "./_components/catch-up-payment-card"
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import { StripeActions } from "./_components/stripe-actions";
+import { CatchUpPaymentCard } from "./_components/catch-up-payment-card";
 import {
   calculateOutstanding,
   formatAutopayDay,
   getNextOutstandingCharge,
-} from "@/lib/payments/catch-up"
-import { formatCurrency } from "@/lib/payments/currency"
-import type { CatchUpBalance } from "@/types/payments"
+} from "@/lib/payments/catch-up";
+import { formatCurrency } from "@/lib/payments/currency";
+import type { CatchUpBalance } from "@/types/payments";
+import { loadCatchUpBalances } from "./loaders";
+import { createSupbaseServerClient } from "@/utils/supaone";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { fetchMemberProfile } from "@/lib/data/members";
+import { resolveMemberPersona } from "@/lib/members";
 
-import { loadCatchUpBalances } from "./loaders"
-
-const paymentHighlights = [
+const managementHighlights = [
   {
-    title: "AutoPay scheduling",
+    title: "Autopay scheduling",
     description:
-      "Enable recurring rent collection with configurable due dates, grace periods, and automatic late fee handling.",
+      "Configure due dates, grace periods, and late fee rules so rent collection stays predictable for every unit.",
   },
   {
     title: "One-time catch up",
     description:
-      "Support partial or one-off payments so roommates can settle balances without waiting for the next billing cycle.",
+      "Support partial or one-off payments so residents can settle balances without waiting for the next billing cycle.",
   },
   {
     title: "Receipt history",
     description:
-      "Download itemized receipts and export payment history for reimbursement, tax, or dispute resolution needs.",
+      "Export itemised receipts and payment histories for audits, reimbursements, or dispute resolution in seconds.",
   },
   {
     title: "Roomsily ledger",
     description:
-      "Track individual roommate contributions alongside property manager adjustments to maintain full transparency.",
+      "Monitor each roommate's contributions alongside property manager adjustments to maintain full transparency.",
   },
-]
+];
+
+const residentHighlights = [
+  {
+    title: "Know your autopay",
+    description:
+      "See when rent is scheduled, pause autopay if needed, and confirm the payment method on file.",
+  },
+  {
+    title: "Catch up anytime",
+    description:
+      "Send a one-off payment to clear outstanding balances without waiting for the next automatic charge.",
+  },
+  {
+    title: "Track every charge",
+    description:
+      "Review what still needs to be paid, including utilities, parking, or shared reimbursements.",
+  },
+  {
+    title: "Get help fast",
+    description:
+      "Reach your property manager or landlord instantly when you have questions about rent or receipts.",
+  },
+];
 
 function describeAutopayStatus(balance: CatchUpBalance) {
-  const autopayDay = formatAutopayDay(balance.autopayDay)
+  const autopayDay = formatAutopayDay(balance.autopayDay);
 
   switch (balance.autopayStatus) {
     case "active":
-      return `Autopay active · ${autopayDay} each month`
+      return `Autopay active · ${autopayDay} each month`;
     case "paused":
-      return `Autopay paused · resumes ${autopayDay}`
+      return `Autopay paused · resumes ${autopayDay}`;
     case "disabled":
-      return "Autopay off"
+      return "Autopay off";
   }
 
-  return ""
+  return "";
 }
 
 function formatFullDate(date: string) {
-  return format(parseISO(date), "MMM d, yyyy")
+  return format(parseISO(date), "MMM d, yyyy");
 }
 
-export default async function PaymentsPage() {
-  const catchUpBalances = await loadCatchUpBalances()
-  const outstandingSummaries = catchUpBalances.map((balance) => {
-    const outstanding = calculateOutstanding(balance.charges)
-    const nextCharge = getNextOutstandingCharge(balance.charges)
-    return { balance, outstanding, nextCharge }
-  })
+type ResidentPaymentsOverviewProps = {
+  balance: CatchUpBalance | null;
+  defaultCurrency: string;
+  displayName: string;
+  managerContact?: CatchUpBalance["contacts"]["propertyManager"] | null;
+};
 
-  const totalOutstanding = outstandingSummaries.reduce(
-    (sum, item) => sum + item.outstanding,
-    0,
-  )
-
-  const activeAutopays = catchUpBalances.filter(
-    (balance) => balance.autopayStatus === "active",
-  ).length
-  const pausedAutopays = catchUpBalances.filter(
-    (balance) => balance.autopayStatus === "paused",
-  ).length
-  const disabledAutopays = catchUpBalances.filter(
-    (balance) => balance.autopayStatus === "disabled",
-  ).length
-
-  const autopCoveragePercentage =
-    catchUpBalances.length > 0
-      ? Math.round((activeAutopays / catchUpBalances.length) * 100)
-      : 0
-
-  const defaultCurrency = catchUpBalances[0]?.currency ?? "USD"
-
-  const roommateSummaries = [...outstandingSummaries].sort(
-    (a, b) => b.outstanding - a.outstanding,
-  )
+function ResidentPaymentsOverview({
+  balance,
+  defaultCurrency,
+  displayName,
+  managerContact,
+}: ResidentPaymentsOverviewProps) {
+  const outstanding = balance ? calculateOutstanding(balance.charges) : 0;
+  const nextCharge = balance ? getNextOutstandingCharge(balance.charges) : null;
+  const autopayDescription = balance ? describeAutopayStatus(balance) : "Autopay not configured yet";
 
   return (
-    <div className="container max-w-5xl space-y-10 py-12">
+    <div className="container max-w-4xl space-y-10 py-12">
       <header className="space-y-4">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Payments</h1>
           <p className="text-base text-muted-foreground sm:text-lg">
-            Manage rent, deposits, and roommate contributions with Stripe-powered autopay and real-time status updates.
+            Hi {displayName}, review your rent balance, autopay status, and property manager contact details in one place.
           </p>
         </div>
         <Separator />
       </header>
+
       <div className="grid gap-6 md:grid-cols-2">
-        {paymentHighlights.map((item) => (
+        {residentHighlights.map((item) => (
           <Card key={item.title}>
             <CardHeader>
               <CardTitle>{item.title}</CardTitle>
@@ -118,6 +129,179 @@ export default async function PaymentsPage() {
           </Card>
         ))}
       </div>
+
+      {balance ? (
+        <>
+          <section className="grid gap-6 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Autopay status</CardTitle>
+                <CardDescription>Keep tabs on your recurring rent payment.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <p className="text-sm text-muted-foreground">{autopayDescription}</p>
+                <div className="text-sm text-muted-foreground">
+                  Monthly share · {formatCurrency(balance.monthlyShare, balance.currency)}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Last payment · {formatFullDate(balance.lastPaymentDate)} · {formatCurrency(balance.lastPaymentAmount, balance.currency)}
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Outstanding balance</CardTitle>
+                <CardDescription>Everything left to pay before you&apos;re fully caught up.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="text-2xl font-semibold">
+                  {formatCurrency(outstanding, balance.currency)}
+                </div>
+                {nextCharge ? (
+                  <p className="text-sm text-muted-foreground">
+                    Next charge · {nextCharge.description} due {format(parseISO(nextCharge.dueDate), "MMM d")}
+                  </p>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No upcoming charges — great job staying current!</p>
+                )}
+              </CardContent>
+            </Card>
+          </section>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Charge breakdown</CardTitle>
+              <CardDescription>Line items still waiting on payment.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {balance.charges.length ? (
+                <ul className="space-y-3">
+                  {balance.charges.map((charge) => (
+                    <li
+                      key={charge.id}
+                      className="flex flex-wrap items-start justify-between gap-3 rounded-lg border bg-muted/30 p-3"
+                    >
+                      <div>
+                        <p className="text-sm font-medium">{charge.description}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Due {formatFullDate(charge.dueDate)} · {charge.category}
+                        </p>
+                      </div>
+                      <p className="text-sm font-semibold">
+                        {formatCurrency(charge.outstandingAmount, balance.currency)}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted-foreground">There are no open charges right now.</p>
+              )}
+            </CardContent>
+          </Card>
+
+          {managerContact ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Need help?</CardTitle>
+                <CardDescription>Contact your property manager or landlord for assistance.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div>
+                  <p className="text-sm font-medium">{managerContact.name}</p>
+                  <p className="text-sm text-muted-foreground">{managerContact.email}</p>
+                </div>
+                <Button asChild variant="outline" size="sm">
+                  <a href={`mailto:${managerContact.email}`}>Email {managerContact.name.split(' ')[0] || 'manager'}</a>
+                </Button>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          <section className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+            <CatchUpPaymentCard balances={[balance]} />
+            <Card>
+              <CardHeader>
+                <CardTitle>Manage payments with Stripe</CardTitle>
+                <CardDescription>
+                  Create a quick checkout session, open the billing portal, or share payment metadata with your manager.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <StripeActions />
+              </CardContent>
+            </Card>
+          </section>
+        </>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>No balances yet</CardTitle>
+            <CardDescription>
+              We couldn&apos;t find any rent balances connected to your profile. Reach out to your property manager if you expected charges here.
+            </CardDescription>
+          </CardHeader>
+          {managerContact ? (
+            <CardContent>
+              <Button asChild variant="outline" size="sm">
+                <a href={`mailto:${managerContact.email}`}>Email {managerContact.name}</a>
+              </Button>
+            </CardContent>
+          ) : null}
+        </Card>
+      )}
+    </div>
+  );
+}
+
+type ManagementPaymentsOverviewProps = {
+  catchUpBalances: CatchUpBalance[];
+  defaultCurrency: string;
+};
+
+function ManagementPaymentsOverview({
+  catchUpBalances,
+  defaultCurrency,
+}: ManagementPaymentsOverviewProps) {
+  const outstandingSummaries = catchUpBalances.map((balance) => {
+    const outstanding = calculateOutstanding(balance.charges);
+    const nextCharge = getNextOutstandingCharge(balance.charges);
+    return { balance, outstanding, nextCharge };
+  });
+
+  const totalOutstanding = outstandingSummaries.reduce((sum, item) => sum + item.outstanding, 0);
+
+  const activeAutopays = catchUpBalances.filter((balance) => balance.autopayStatus === "active").length;
+  const pausedAutopays = catchUpBalances.filter((balance) => balance.autopayStatus === "paused").length;
+  const disabledAutopays = catchUpBalances.filter((balance) => balance.autopayStatus === "disabled").length;
+
+  const autopCoveragePercentage =
+    catchUpBalances.length > 0 ? Math.round((activeAutopays / catchUpBalances.length) * 100) : 0;
+
+  const roommateSummaries = [...outstandingSummaries].sort((a, b) => b.outstanding - a.outstanding);
+
+  return (
+    <div className="container max-w-5xl space-y-10 py-12">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Payments</h1>
+          <p className="text-base text-muted-foreground sm:text-lg">
+            Monitor rent, deposits, and reimbursements across every resident while keeping autopay and reconciliation under your control.
+          </p>
+        </div>
+        <Separator />
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {managementHighlights.map((item) => (
+          <Card key={item.title}>
+            <CardHeader>
+              <CardTitle>{item.title}</CardTitle>
+              <CardDescription>{item.description}</CardDescription>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+
       <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
         <div className="space-y-6">
           <Card>
@@ -130,9 +314,7 @@ export default async function PaymentsPage() {
             <CardContent>
               <dl className="grid gap-4 sm:grid-cols-3">
                 <div className="space-y-1 rounded-lg border bg-muted/40 p-4">
-                  <dt className="text-xs uppercase text-muted-foreground">
-                    Outstanding total
-                  </dt>
+                  <dt className="text-xs uppercase text-muted-foreground">Outstanding total</dt>
                   <dd className="text-lg font-semibold">
                     {formatCurrency(totalOutstanding, defaultCurrency)}
                   </dd>
@@ -141,9 +323,7 @@ export default async function PaymentsPage() {
                   </p>
                 </div>
                 <div className="space-y-1 rounded-lg border bg-muted/40 p-4">
-                  <dt className="text-xs uppercase text-muted-foreground">
-                    Autopay coverage
-                  </dt>
+                  <dt className="text-xs uppercase text-muted-foreground">Autopay coverage</dt>
                   <dd className="text-lg font-semibold">
                     {activeAutopays}/{catchUpBalances.length}
                   </dd>
@@ -152,9 +332,7 @@ export default async function PaymentsPage() {
                   </p>
                 </div>
                 <div className="space-y-1 rounded-lg border bg-muted/40 p-4">
-                  <dt className="text-xs uppercase text-muted-foreground">
-                    Catch-up required
-                  </dt>
+                  <dt className="text-xs uppercase text-muted-foreground">Catch-up required</dt>
                   <dd className="text-lg font-semibold">
                     {pausedAutopays + disabledAutopays}
                   </dd>
@@ -199,7 +377,7 @@ export default async function PaymentsPage() {
                         Next: {nextCharge.description} due {format(parseISO(nextCharge.dueDate), "MMM d")}
                       </p>
                     ) : (
-                      <p className="text-xs text-muted-foreground">No outstanding charges</p>
+                      <p className="text-xs text-muted-foreground">No upcoming charges</p>
                     )}
                   </div>
                 </div>
@@ -209,7 +387,7 @@ export default async function PaymentsPage() {
           <Card>
             <CardHeader>
               <CardTitle>Pay with Stripe</CardTitle>
-              <CardDescription>Create a quick checkout or open Billing Portal</CardDescription>
+              <CardDescription>Create a quick checkout or open the Billing Portal</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
               <StripeActions />
@@ -219,5 +397,55 @@ export default async function PaymentsPage() {
         <CatchUpPaymentCard balances={catchUpBalances} />
       </section>
     </div>
-  )
+  );
+}
+
+export default async function PaymentsPage() {
+  const supabase = await createSupbaseServerClient();
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth");
+  }
+
+  const profile = await fetchMemberProfile(typedSupabase, user.id);
+  const persona = resolveMemberPersona(profile?.role ?? null);
+
+  const catchUpBalances = await loadCatchUpBalances();
+  const defaultCurrency = catchUpBalances[0]?.currency ?? "USD";
+
+  if (persona === "management") {
+    return (
+      <ManagementPaymentsOverview
+        catchUpBalances={catchUpBalances}
+        defaultCurrency={defaultCurrency}
+      />
+    );
+  }
+
+  const normalizedEmail = profile?.email?.toLowerCase();
+  const residentBalance = normalizedEmail
+    ? catchUpBalances.find(
+        (balance) => balance.contacts.primary.email.toLowerCase() === normalizedEmail,
+      )
+    : undefined;
+
+  const managerContact = residentBalance?.contacts.propertyManager
+    ?? catchUpBalances.find((balance) => balance.contacts.propertyManager)?.contacts
+      .propertyManager
+    ?? null;
+
+  const displayName = profile?.full_name || profile?.email || "Resident";
+
+  return (
+    <ResidentPaymentsOverview
+      balance={residentBalance ?? null}
+      defaultCurrency={defaultCurrency}
+      displayName={displayName}
+      managerContact={managerContact}
+    />
+  );
 }

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -14,6 +14,7 @@ import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
+import { isManagementRole } from "@/lib/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
 const maintenanceRequestSchema = z.object({
@@ -80,12 +81,14 @@ export function MaintenanceRequestForm() {
         throw new Error("User is not assigned to a unit");
       }
 
-      const [propertyManager] = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
-        roles: ['property_manager'],
+      const managementMembers = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
+        persona: 'management',
       });
 
+      const propertyManager = managementMembers.find(member => isManagementRole(member.role));
+
       if (!propertyManager) {
-        throw new Error("Property manager not found for this unit");
+        throw new Error("Property manager or landlord not found for this unit");
       }
 
       // Create maintenance request record

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -19,6 +19,7 @@ import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
+import { isManagementRole, isResidentRole } from "@/lib/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
 const visitorBookingSchema = z.object({
@@ -78,13 +79,11 @@ export function VisitorBookingForm() {
         excludeUserId: user.id,
       });
 
-      const roommates = unitMembers.filter(
-        member => member.role === 'tenant' || member.role === 'roommate'
-      );
-      const propertyManager = unitMembers.find(member => member.role === 'property_manager');
+      const roommates = unitMembers.filter(member => isResidentRole(member.role));
+      const propertyManager = unitMembers.find(member => isManagementRole(member.role));
 
       if (!propertyManager) {
-        throw new Error("Property manager not found for this unit");
+        throw new Error("Property manager or landlord not found for this unit");
       }
 
       // Create visitor booking record

--- a/hooks/use-document-permissions.ts
+++ b/hooks/use-document-permissions.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { createClient } from '@/utils/supabase-browser';
 import { DocumentWithLease } from '@/types/documents';
 import { fetchMemberRole } from '@/lib/data/members';
+import { isManagementRole } from '@/lib/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 
 export interface UserPermissions {
@@ -61,23 +62,25 @@ export function useDocumentPermissions(): UserPermissions {
           console.error('Error loading member role:', roleError);
         }
 
-        const resolvedRole = role || 'user';
-        const isPropertyManager = resolvedRole === 'property_manager';
-        const isAdmin = resolvedRole === 'admin';
+        const resolvedRole = role ?? null;
         const isTenant = resolvedRole === 'tenant';
         const isRoommate = resolvedRole === 'roommate';
+        const isPropertyManager =
+          resolvedRole === 'property_manager' || resolvedRole === 'landlord';
+        const isAdmin = resolvedRole === 'admin';
+        const isManagement = isManagementRole(resolvedRole) || isAdmin;
 
         const userPermissions: UserPermissions = {
           isTenant,
           isRoommate,
           isPropertyManager,
           isAdmin,
-          canUploadDocuments: isPropertyManager || isAdmin,
-          canCreateSigningRequests: isPropertyManager || isAdmin,
+          canUploadDocuments: isManagement,
+          canCreateSigningRequests: isManagement,
 
           canViewDocument: (document: DocumentWithLease) => {
             // Property managers and admins can view all documents
-            if (isPropertyManager || isAdmin) return true;
+            if (isManagement) return true;
 
             // Users can view documents they're associated with
             if (document.tenant_id === user.id) return true;
@@ -99,7 +102,7 @@ export function useDocumentPermissions(): UserPermissions {
 
           canEditDocument: (document: DocumentWithLease) => {
             // Only property managers and admins can edit documents
-            return isPropertyManager || isAdmin;
+            return isManagement;
           },
         };
 

--- a/lib/data/documents.ts
+++ b/lib/data/documents.ts
@@ -1,10 +1,9 @@
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import type { DocumentListFilters, DocumentStats, DocumentWithLease } from '@/types/documents';
-import type { Database } from '@/lib/supabase';
+import type { MemberRole } from '@/lib/members';
+import { isManagementRole } from '@/lib/members';
 
 type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
-
-type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
 
 type FetchDocumentsParams = {
   client: SupabaseClientLike;
@@ -43,7 +42,7 @@ export async function fetchDocumentsList({
     .select(DOCUMENT_SELECT)
     .order('created_at', { ascending: false });
 
-  if (role !== 'property_manager' && role !== 'admin') {
+  if (!isManagementRole(role)) {
     query = query.or(`tenant_id.eq.${userId},signatures.signer_id.eq.${userId}`);
   }
 
@@ -84,7 +83,7 @@ export async function fetchDocumentStats({
 }: FetchDocumentStatsParams): Promise<DocumentStats> {
   let query = client.from('documents').select('status');
 
-  if (role !== 'property_manager' && role !== 'admin') {
+  if (!isManagementRole(role)) {
     query = query.eq('tenant_id', userId);
   }
 

--- a/lib/data/members.ts
+++ b/lib/data/members.ts
@@ -1,9 +1,22 @@
+import 'server-only';
+
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import type { Database } from '@/lib/supabase';
+import type { MemberPersona, MemberRole } from '@/lib/members';
+import { rolesForPersona } from '@/lib/members';
 
 type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
 
-export type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
+export type { MemberRole, MemberPersona, AssignableRole } from '@/lib/members';
+export {
+  RESIDENT_ROLES,
+  MANAGEMENT_ROLES,
+  isManagementRole,
+  isResidentRole,
+  resolveMemberPersona,
+  rolesForPersona,
+  isAssignableRole,
+} from '@/lib/members';
 
 export type MemberProfile = Pick<
   Database['public']['Tables']['profiles']['Row'],
@@ -53,6 +66,7 @@ export async function fetchMemberProfile(
 interface FetchMembersByUnitOptions {
   excludeUserId?: string;
   roles?: MemberRole[];
+  persona?: Exclude<MemberPersona, 'unknown'>;
 }
 
 export async function fetchMembersByUnit(
@@ -69,7 +83,10 @@ export async function fetchMembersByUnit(
     query = query.neq('id', options.excludeUserId);
   }
 
-  if (options.roles?.length) {
+  if (options.persona) {
+    const personaRoles = Array.from(rolesForPersona(options.persona));
+    query = query.in('role', personaRoles as MemberRole[]);
+  } else if (options.roles?.length) {
     query = query.in('role', options.roles);
   }
 

--- a/lib/members.ts
+++ b/lib/members.ts
@@ -1,0 +1,46 @@
+import type { Database } from '@/lib/supabase';
+
+export type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
+
+export const RESIDENT_ROLES = ['tenant', 'roommate'] as const;
+export const MANAGEMENT_ROLES = ['property_manager', 'landlord', 'admin'] as const;
+
+export type ResidentRole = (typeof RESIDENT_ROLES)[number];
+export type ManagementRole = (typeof MANAGEMENT_ROLES)[number];
+export type AssignableRole = ResidentRole | ManagementRole;
+
+export type MemberPersona = 'resident' | 'management' | 'unknown';
+
+export function isResidentRole(
+  role: MemberRole | null | undefined
+): role is ResidentRole {
+  return role === 'tenant' || role === 'roommate';
+}
+
+export function isManagementRole(
+  role: MemberRole | null | undefined
+): role is ManagementRole {
+  return role === 'property_manager' || role === 'landlord' || role === 'admin';
+}
+
+export function isAssignableRole(
+  role: MemberRole | null | undefined
+): role is AssignableRole {
+  return isResidentRole(role) || isManagementRole(role);
+}
+
+export function resolveMemberPersona(role: MemberRole | null | undefined): MemberPersona {
+  if (isResidentRole(role)) {
+    return 'resident';
+  }
+
+  if (isManagementRole(role)) {
+    return 'management';
+  }
+
+  return 'unknown';
+}
+
+export function rolesForPersona(persona: Exclude<MemberPersona, 'unknown'>): readonly AssignableRole[] {
+  return persona === 'resident' ? RESIDENT_ROLES : MANAGEMENT_ROLES;
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -26,7 +26,7 @@ export type Database = {
         username: string | null
         website: string | null
         avatar_url: string | null
-        role: 'tenant' | 'roommate' | 'property_manager' | 'admin' | 'user' | null
+        role: 'tenant' | 'roommate' | 'property_manager' | 'landlord' | 'admin' | 'user' | null
         unit_id: string | null
         phone: string | null
         language: string | null

--- a/supabase/migrations/20250318_landlord_role_support.sql
+++ b/supabase/migrations/20250318_landlord_role_support.sql
@@ -1,0 +1,87 @@
+BEGIN;
+
+-- Extend document access for landlords alongside property managers and admins
+ALTER POLICY "Property managers can view all documents" ON public.documents
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+ALTER POLICY "Property managers can update documents" ON public.documents
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+ALTER POLICY "Property managers can view all signatures" ON public.document_signatures
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+ALTER POLICY "Property managers can view all access logs" ON public.document_access_logs
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+ALTER POLICY "Property managers can view all leases" ON public.leases
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+-- Payments and subscriptions visibility for landlords
+ALTER POLICY "Property managers can view all rent payments" ON public.rent_payments
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+ALTER POLICY "Property managers can view all subscriptions" ON public.subscriptions
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+-- Inquiries inbox for landlords
+ALTER POLICY "Property managers can view inquiries" ON public.inquiries
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+-- Maintenance and visitor workflows recognise landlords as approvers
+ALTER POLICY "Property managers can update maintenance requests" ON public.maintenance_requests
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+ALTER POLICY "Property managers can update visitor logs" ON public.visitor_logs
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'landlord', 'admin')
+    )
+  );
+
+COMMIT;

--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -93,6 +93,19 @@ describe('fetchDocumentsList', () => {
     expect(query.or).not.toHaveBeenCalled();
   });
 
+  it('skips scoping for landlords', async () => {
+    const query = createDocumentsQuery({ data: [], error: null });
+    const supabase = createSupabaseStub(query);
+
+    await fetchDocumentsList({
+      client: supabase,
+      userId: 'landlord-1',
+      role: 'landlord',
+    });
+
+    expect(query.or).not.toHaveBeenCalled();
+  });
+
   it('throws when Supabase returns an error', async () => {
     const query = createDocumentsQuery({ data: null as any, error: { message: 'boom' } });
     const supabase = createSupabaseStub(query);
@@ -136,6 +149,15 @@ describe('fetchDocumentStats', () => {
     const supabase = createSupabaseStub(query);
 
     await fetchDocumentStats({ client: supabase, userId: 'admin-1', role: 'admin' });
+
+    expect(query.eq).not.toHaveBeenCalled();
+  });
+
+  it('omits tenant filter for landlords', async () => {
+    const query = createDocumentsQuery({ data: [], error: null });
+    const supabase = createSupabaseStub(query);
+
+    await fetchDocumentStats({ client: supabase, userId: 'landlord-1', role: 'landlord' });
 
     expect(query.eq).not.toHaveBeenCalled();
   });

--- a/tests/lib/data/members.test.ts
+++ b/tests/lib/data/members.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fetchMemberProfile, fetchMemberRole, fetchMembersByUnit } from '@/lib/data/members';
+import { rolesForPersona } from '@/lib/members';
 
 type SingleResult<T> = { data: T; error: { message: string } | null };
 
@@ -125,6 +126,20 @@ describe('fetchMembersByUnit', () => {
     expect(builder.neq).toHaveBeenCalledWith('id', 'user-2');
     expect(builder.in).toHaveBeenCalledWith('role', ['tenant']);
     expect(result).toEqual(members);
+  });
+
+  it('filters by persona when provided', async () => {
+    const members = [
+      { id: 'pm-1', email: 'pm@example.com', full_name: 'Manager', role: 'property_manager', unit_id: 'unit-1' },
+    ];
+    const builder = createMultiBuilder({ data: members, error: null });
+    const supabase = createProfilesStub(builder);
+
+    await fetchMembersByUnit(supabase as any, 'unit-1', {
+      persona: 'management',
+    });
+
+    expect(builder.in).toHaveBeenCalledWith('role', Array.from(rolesForPersona('management')));
   });
 
   it('throws when supabase returns an error', async () => {


### PR DESCRIPTION
## Summary
- add reusable member persona helpers and update document access logic to treat landlords like property managers
- split the payments dashboard into resident and management views with persona-aware navigation
- surface profile type selection throughout member management and extend Supabase policies to cover landlords

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d1ad834c388328bd4187be43c21409