### PR TITLE
Add multi-channel notifications with user preferences

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -77,6 +77,23 @@ GOOGLE_OWNER_REFRESH_TOKEN="your_google_refresh_token"
 RESEND_API_KEY="re_your_resend_api_key"
 ```
 
+### **SMS (OPTIONAL)**
+```bash
+TWILIO_ACCOUNT_SID="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+TWILIO_AUTH_TOKEN="your_twilio_auth_token"
+# Provide either a messaging service SID or a from number
+TWILIO_MESSAGING_SERVICE_SID="MGxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+TWILIO_FROM_NUMBER="+15551234567"
+```
+
+### **WEB PUSH (OPTIONAL)**
+```bash
+WEB_PUSH_PUBLIC_KEY="your_vapid_public_key"
+WEB_PUSH_PRIVATE_KEY="your_vapid_private_key"
+WEB_PUSH_CONTACT_EMAIL="admin@roomsily.app"
+NEXT_PUBLIC_WEB_PUSH_PUBLIC_KEY="your_vapid_public_key"
+```
+
 ## 🛠️ **HOW TO GET THESE KEYS**
 
 ### **1. Supabase Setup**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Roomsily (www.roomsily) is a comprehensive co-living portal that helps roommates
 
 ### 💬 **Communication**
 - **Realtime Messaging**: Roommate-to-roommate communication with threads
-- **Notifications**: In-app and email notifications for important events
+- **Notifications**: In-app, email, text message, and push notifications for important events
 - **Maintenance Requests**: Issue tracking and resolution workflow
 
 ### 🏢 **Admin Features**

--- a/app/account/loaders.ts
+++ b/app/account/loaders.ts
@@ -10,16 +10,20 @@ import type { Database } from "@/lib/supabase"
 
 import { createClient } from "@/utils/supa-server-actions"
 
-import type { AccountProfile } from "./types"
+import type {
+  AccountNotificationPreferences,
+  AccountProfile,
+} from "./types"
 
 type ProfileRow = Pick<
   Database["public"]["Tables"]["profiles"]["Row"],
-  "full_name" | "username" | "website" | "avatar_url" | "email"
+  "full_name" | "username" | "website" | "avatar_url" | "email" | "phone"
 >
 
 export interface AccountPageData {
   user: User | null
   profile: AccountProfile | null
+  preferences: AccountNotificationPreferences
 }
 
 export async function loadAccountPageData(): Promise<AccountPageData> {
@@ -31,12 +35,22 @@ export async function loadAccountPageData(): Promise<AccountPageData> {
   } = await supabase.auth.getUser()
 
   if (!user) {
-    return { user: null, profile: null }
+    return {
+      user: null,
+      profile: null,
+      preferences: {
+        emailEnabled: true,
+        smsEnabled: false,
+        pushEnabled: false,
+        smsPhoneNumber: null,
+        pushSubscription: null,
+      },
+    }
   }
 
   const { data, error } = await supabase
     .from("profiles")
-    .select("full_name, username, website, avatar_url, email")
+    .select("full_name, username, website, avatar_url, email, phone")
     .eq("id", user.id)
     .maybeSingle<ProfileRow>()
 
@@ -51,8 +65,34 @@ export async function loadAccountPageData(): Promise<AccountPageData> {
         website: data.website,
         avatarUrl: data.avatar_url,
         email: data.email,
+        phone: data.phone,
       }
     : null
 
-  return { user, profile }
+  const { data: preferencesRow, error: preferencesError } = await supabase
+    .from("notification_preferences")
+    .select(
+      "email_enabled, sms_enabled, push_enabled, sms_phone_number, push_subscription"
+    )
+    .eq("user_id", user.id)
+    .maybeSingle<
+      Database["public"]["Tables"]["notification_preferences"]["Row"]
+    >()
+
+  if (preferencesError && preferencesError.code !== "PGRST116") {
+    console.error("Failed to load notification preferences", preferencesError)
+  }
+
+  const preferences: AccountNotificationPreferences = {
+    emailEnabled: preferencesRow?.email_enabled ?? true,
+    smsEnabled: preferencesRow?.sms_enabled ?? false,
+    pushEnabled: preferencesRow?.push_enabled ?? false,
+    smsPhoneNumber:
+      preferencesRow?.sms_phone_number ?? profile?.phone ?? null,
+    pushSubscription: (preferencesRow?.push_subscription as
+      | AccountNotificationPreferences["pushSubscription"]
+      | null) ?? null,
+  }
+
+  return { user, profile, preferences }
 }

--- a/app/account/notification-preferences-form.tsx
+++ b/app/account/notification-preferences-form.tsx
@@ -1,0 +1,327 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import { useToast } from "@/components/ui/use-toast"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+import type { AccountNotificationPreferences } from "./types"
+
+interface NotificationPreferencesFormProps {
+  userId: string
+  initialPreferences: AccountNotificationPreferences
+}
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/")
+  const rawData = atob(base64)
+  const outputArray = new Uint8Array(rawData.length)
+  for (let i = 0; i < rawData.length; i += 1) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray
+}
+
+export default function NotificationPreferencesForm({
+  userId,
+  initialPreferences,
+}: NotificationPreferencesFormProps) {
+  const supabase = useSupabaseBrowser()
+  const { toast } = useToast()
+  const [formState, setFormState] = useState(initialPreferences)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isPushSyncing, setIsPushSyncing] = useState(false)
+  const [supportsPush, setSupportsPush] = useState(false)
+
+  const vapidPublicKey = useMemo(
+    () => process.env.NEXT_PUBLIC_WEB_PUSH_PUBLIC_KEY ?? "",
+    [],
+  )
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      setSupportsPush(false)
+      return
+    }
+    const hasSupport =
+      "serviceWorker" in navigator &&
+      "PushManager" in window &&
+      "Notification" in window
+    setSupportsPush(hasSupport)
+  }, [])
+
+  const updateField = <K extends keyof AccountNotificationPreferences>(
+    field: K,
+    value: AccountNotificationPreferences[K],
+  ) => {
+    setFormState((previous) => ({ ...previous, [field]: value }))
+  }
+
+  const ensurePushSubscription = useCallback(async () => {
+    if (typeof window === "undefined") {
+      toast({
+        title: "Push not available",
+        description: "Push notifications are only supported in the browser.",
+        variant: "destructive",
+      })
+      return null
+    }
+
+    if (!supportsPush) {
+      toast({
+        title: "Push not supported",
+        description: "This browser does not support push notifications.",
+        variant: "destructive",
+      })
+      return null
+    }
+
+    if (!vapidPublicKey) {
+      toast({
+        title: "Push not configured",
+        description: "Web push keys are missing. Contact your administrator.",
+        variant: "destructive",
+      })
+      return null
+    }
+
+    if (typeof Notification === "undefined") {
+      toast({
+        title: "Push not supported",
+        description: "This browser does not support notifications.",
+        variant: "destructive",
+      })
+      return null
+    }
+
+    const permission = await Notification.requestPermission()
+    if (permission !== "granted") {
+      toast({
+        title: "Permission required",
+        description: "Push notifications require notification permission.",
+        variant: "destructive",
+      })
+      return null
+    }
+
+    try {
+      let registration = await navigator.serviceWorker.getRegistration()
+      if (!registration) {
+        registration = await navigator.serviceWorker.register("/sw.js")
+      }
+
+      if (!registration) {
+        toast({
+          title: "Registration failed",
+          description: "We could not register the push service worker.",
+          variant: "destructive",
+        })
+        return null
+      }
+
+      let subscription = await registration.pushManager.getSubscription()
+      if (!subscription) {
+        const applicationServerKey = urlBase64ToUint8Array(vapidPublicKey)
+        subscription = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey,
+        })
+      }
+
+      return subscription.toJSON()
+    } catch (error) {
+      console.error("Failed to create push subscription", error)
+      toast({
+        title: "Push setup failed",
+        description:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred while enabling push notifications.",
+        variant: "destructive",
+      })
+      return null
+    }
+  }, [supportsPush, toast, vapidPublicKey])
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (formState.smsEnabled && !formState.smsPhoneNumber) {
+      toast({
+        title: "Phone number required",
+        description: "Add a mobile number to receive text alerts.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setIsSaving(true)
+
+    let pushSubscription = formState.pushSubscription
+
+    try {
+      if (formState.pushEnabled) {
+        setIsPushSyncing(true)
+        const subscription = await ensurePushSubscription()
+        setIsPushSyncing(false)
+
+        if (!subscription) {
+          setIsSaving(false)
+          return
+        }
+
+        pushSubscription = subscription
+      } else if (typeof window !== "undefined" && supportsPush) {
+        const registration = await navigator.serviceWorker.getRegistration()
+        const activeSubscription = await registration?.pushManager.getSubscription()
+        if (activeSubscription) {
+          await activeSubscription.unsubscribe().catch(() => undefined)
+        }
+        pushSubscription = null
+      }
+
+      const { error } = await supabase
+        .from("notification_preferences")
+        .upsert(
+          {
+            user_id: userId,
+            email_enabled: formState.emailEnabled,
+            sms_enabled: formState.smsEnabled,
+            push_enabled: formState.pushEnabled,
+            sms_phone_number: formState.smsPhoneNumber || null,
+            push_subscription: pushSubscription,
+          },
+          { onConflict: "user_id" }
+        )
+
+      if (error) {
+        throw error
+      }
+
+      setFormState((previous) => ({
+        ...previous,
+        smsPhoneNumber: formState.smsPhoneNumber,
+        emailEnabled: formState.emailEnabled,
+        smsEnabled: formState.smsEnabled,
+        pushEnabled: formState.pushEnabled,
+        pushSubscription,
+      }))
+
+      toast({
+        title: "Notification preferences updated",
+        description: "We'll use your latest contact preferences from now on.",
+      })
+    } catch (error) {
+      console.error("Failed to update notification preferences", error)
+      toast({
+        title: "Unable to update preferences",
+        description:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred while saving your preferences.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSaving(false)
+      setIsPushSyncing(false)
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Notification channels</h2>
+        <p className="text-sm text-muted-foreground">
+          Fine-tune how we reach you for payments, bookings, and documents. You can
+          opt out of any channel at any time.
+        </p>
+      </div>
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <div className="space-y-4">
+          <div className="flex items-start justify-between gap-4 rounded-md border p-4">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">Email</p>
+              <p className="text-sm text-muted-foreground">
+                Receive full summaries, receipts, and booking confirmations in your inbox.
+              </p>
+            </div>
+            <Switch
+              id="email-enabled"
+              checked={formState.emailEnabled}
+              onCheckedChange={(checked) => updateField("emailEnabled", checked)}
+            />
+          </div>
+          <div className="flex flex-col gap-4 rounded-md border p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">Text messages</p>
+                <p className="text-sm text-muted-foreground">
+                  Get quick SMS alerts for time-sensitive updates like maintenance or visitors.
+                </p>
+              </div>
+              <Switch
+                id="sms-enabled"
+                checked={formState.smsEnabled}
+                onCheckedChange={(checked) => updateField("smsEnabled", checked)}
+              />
+            </div>
+            <div>
+              <label
+                className="text-sm font-medium leading-none"
+                htmlFor="sms-phone"
+              >
+                Mobile number
+              </label>
+              <Input
+                id="sms-phone"
+                type="tel"
+                placeholder="+1 555-123-4567"
+                value={formState.smsPhoneNumber ?? ""}
+                onChange={(event) => updateField("smsPhoneNumber", event.target.value)}
+                aria-describedby="sms-helper"
+              />
+              <p id="sms-helper" className="mt-1 text-xs text-muted-foreground">
+                Standard carrier rates may apply.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start justify-between gap-4 rounded-md border p-4">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">Push notifications</p>
+              <p className="text-sm text-muted-foreground">
+                Enable browser push notifications for instant updates even when the app is closed.
+              </p>
+              {!supportsPush || !vapidPublicKey ? (
+                <p className="text-xs text-muted-foreground">
+                  Push notifications require a compatible browser and configured web push keys.
+                </p>
+              ) : null}
+            </div>
+            <Switch
+              id="push-enabled"
+              checked={formState.pushEnabled && supportsPush && Boolean(vapidPublicKey)}
+              disabled={!supportsPush || !vapidPublicKey || isPushSyncing}
+              onCheckedChange={(checked) => updateField("pushEnabled", checked)}
+            />
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button type="submit" disabled={isSaving || isPushSyncing}>
+            {isSaving ? "Saving preferences..." : "Save preferences"}
+          </Button>
+          {isPushSyncing ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              <span>Updating push subscription…</span>
+            </div>
+          ) : null}
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -3,10 +3,11 @@ import { redirect } from "next/navigation"
 import { Separator } from "@/components/ui/separator"
 
 import AccountForm from "./supa-account-form"
+import NotificationPreferencesForm from "./notification-preferences-form"
 import { loadAccountPageData } from "./loaders"
 
 export default async function SettingsAccountPage() {
-  const { user, profile } = await loadAccountPageData()
+  const { user, profile, preferences } = await loadAccountPageData()
 
   if (!user) {
     redirect("/auth")
@@ -23,6 +24,11 @@ export default async function SettingsAccountPage() {
         </div>
         <Separator />
         <AccountForm profile={profile} user={user} />
+        <Separator />
+        <NotificationPreferencesForm
+          userId={user.id}
+          initialPreferences={preferences}
+        />
       </div>
     </div>
   )

--- a/app/account/supa-account-form.tsx
+++ b/app/account/supa-account-form.tsx
@@ -24,6 +24,7 @@ type ProfileState = {
   website: string
   avatarUrl: string
   email: string
+  phone: string
 }
 
 function createProfileState(user: User, profile: AccountProfile | null): ProfileState {
@@ -33,6 +34,7 @@ function createProfileState(user: User, profile: AccountProfile | null): Profile
     website: profile?.website ?? "",
     avatarUrl: profile?.avatarUrl ?? "",
     email: profile?.email ?? user.email ?? "",
+    phone: profile?.phone ?? "",
   }
 }
 
@@ -55,6 +57,7 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
           website: payload.website || null,
           avatar_url: payload.avatarUrl || null,
           email: payload.email || null,
+          phone: payload.phone || null,
           updated_at: new Date().toISOString(),
         })
 
@@ -156,6 +159,21 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
             value={profileState.website}
             onChange={handleChange("website")}
             placeholder="https://sharehouse.example"
+          />
+        </div>
+        <div className="flex flex-col">
+          <label
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            htmlFor="phone"
+          >
+            Mobile number
+          </label>
+          <Input
+            id="phone"
+            type="tel"
+            value={profileState.phone}
+            onChange={handleChange("phone")}
+            placeholder="+1 555-123-4567"
           />
         </div>
         <button

--- a/app/account/types.ts
+++ b/app/account/types.ts
@@ -4,4 +4,18 @@ export interface AccountProfile {
   website: string | null
   avatarUrl: string | null
   email: string | null
+  phone: string | null
+}
+
+export interface AccountNotificationPreferences {
+  emailEnabled: boolean
+  smsEnabled: boolean
+  pushEnabled: boolean
+  smsPhoneNumber: string | null
+  pushSubscription:
+    | {
+        endpoint: string
+        keys: { p256dh: string; auth: string }
+      }
+    | null
 }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -7,8 +7,13 @@ import {
   sendBulkNotifications,
   sendEmailNotification,
   sendInAppNotification,
+  sendPushNotification,
+  sendTextNotification,
   type InAppNotification,
   type NotificationData,
+  type NotificationPayload,
+  type PushNotification,
+  type TextNotification,
 } from "@/lib/notifications"
 import type { Database } from "@/lib/supabase"
 import { createClient } from "@/utils/supa-server-actions"
@@ -222,9 +227,11 @@ export async function GET(request: NextRequest) {
 type NotificationRequest =
   | { type: "email"; notification: NotificationData }
   | { type: "in-app"; notification: InAppNotification }
+  | { type: "text"; notification: TextNotification }
+  | { type: "push"; notification: PushNotification }
   | {
       type: "bulk"
-      notifications: (NotificationData | InAppNotification)[]
+      notifications: NotificationPayload[]
     }
 
 export async function POST(request: Request) {
@@ -239,6 +246,16 @@ export async function POST(request: Request) {
       }
       case "in-app": {
         const result = await sendInAppNotification(payload.notification)
+        const status = result.success ? 200 : 400
+        return NextResponse.json(result, { status })
+      }
+      case "text": {
+        const result = await sendTextNotification(payload.notification)
+        const status = result.success ? 200 : 400
+        return NextResponse.json(result, { status })
+      }
+      case "push": {
+        const result = await sendPushNotification(payload.notification)
         const status = result.success ? 200 : 400
         return NextResponse.json(result, { status })
       }

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -1,12 +1,18 @@
 "use client"
 
-import type { InAppNotification, NotificationData } from "@/lib/notifications"
+import type {
+  InAppNotification,
+  NotificationData,
+  NotificationPayload,
+  PushNotification,
+  TextNotification,
+} from "@/lib/notifications"
 import { useToast } from "@/components/ui/use-toast"
 
-type NotificationResult = { success: boolean; error?: string }
+type NotificationResult = { success: boolean; error?: string; skipped?: boolean }
 type BulkNotificationResult = {
   success: boolean
-  results: Array<{ index: number; success: boolean; error: unknown }>
+  results: Array<{ index: number; success: boolean; error: unknown; skipped?: boolean }>
 }
 
 async function postNotification<T>(payload: unknown): Promise<T> {
@@ -47,8 +53,11 @@ export function useNotifications() {
       })
       if (result.success) {
         toast({
-          title: "Email sent",
-          description: "Notification email has been sent successfully.",
+          title: result.skipped ? "Email skipped" : "Email sent",
+          description: result.skipped
+            ? "This recipient has email notifications disabled."
+            : "Notification email has been sent successfully.",
+          variant: result.skipped ? "default" : undefined,
         })
       } else {
         toast({
@@ -98,8 +107,78 @@ export function useNotifications() {
     }
   }
 
+  const sendTextNotification = async (notification: TextNotification) => {
+    try {
+      const result = await postNotification<NotificationResult>({
+        type: "text",
+        notification: { ...notification, channel: "sms" },
+      })
+
+      if (result.success) {
+        toast({
+          title: result.skipped ? "Text message skipped" : "Text message sent",
+          description: result.skipped
+            ? "The recipient has opted out of text alerts."
+            : "SMS notification delivered to the carrier.",
+          variant: result.skipped ? "default" : undefined,
+        })
+      } else {
+        toast({
+          title: "Text message failed",
+          description: result.error || "Failed to send text message.",
+          variant: "destructive",
+        })
+      }
+
+      return result
+    } catch (error) {
+      console.error("Text notification error", error)
+      toast({
+        title: "Notification failed",
+        description: "Failed to send text notification.",
+        variant: "destructive",
+      })
+      return { success: false, error: "Unexpected error" }
+    }
+  }
+
+  const sendPushNotification = async (notification: PushNotification) => {
+    try {
+      const result = await postNotification<NotificationResult>({
+        type: "push",
+        notification: { ...notification, channel: "push" },
+      })
+
+      if (result.success) {
+        toast({
+          title: result.skipped ? "Push skipped" : "Push sent",
+          description: result.skipped
+            ? "The recipient disabled push alerts."
+            : "Push notification dispatched successfully.",
+          variant: result.skipped ? "default" : undefined,
+        })
+      } else {
+        toast({
+          title: "Push failed",
+          description: result.error || "Failed to send push notification.",
+          variant: "destructive",
+        })
+      }
+
+      return result
+    } catch (error) {
+      console.error("Push notification error", error)
+      toast({
+        title: "Notification failed",
+        description: "Failed to send push notification.",
+        variant: "destructive",
+      })
+      return { success: false, error: "Unexpected error" }
+    }
+  }
+
   const sendBulkNotifications = async (
-    notifications: (NotificationData | InAppNotification)[]
+    notifications: NotificationPayload[]
   ) => {
     try {
       const response = await postNotification<BulkNotificationResult>({
@@ -108,6 +187,7 @@ export function useNotifications() {
       })
       const successCount = response.results.filter((r) => r.success).length
       const failureCount = response.results.length - successCount
+      const skippedCount = response.results.filter((r) => r.skipped).length
 
       if (successCount > 0) {
         toast({
@@ -115,8 +195,8 @@ export function useNotifications() {
           description: `${successCount} notification${
             successCount > 1 ? "s" : ""
           } sent successfully${
-            failureCount > 0 ? `, ${failureCount} failed` : ""
-          }.`,
+            skippedCount > 0 ? `, ${skippedCount} skipped` : ""
+          }${failureCount > 0 ? `, ${failureCount} failed` : ""}.`,
         })
       }
 
@@ -152,7 +232,7 @@ export function useNotifications() {
     roommates: Array<{ id: string; email: string; name: string }>
     propertyManager: { id: string; email: string; name: string }
   }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
+    const notifications: NotificationPayload[] = [
       // Email to property manager
       {
         to: data.propertyManager.email,
@@ -169,6 +249,30 @@ export function useNotifications() {
         type: "info" as const,
         actionUrl: "/dashboard",
       })),
+      {
+        channel: "sms",
+        userId: data.propertyManager.id,
+        message: `${data.guestName} requested an overnight stay (${data.checkInDate} - ${data.checkOutDate}). Review in Roomsily.`,
+      },
+      {
+        channel: "push",
+        userId: data.propertyManager.id,
+        title: "New visitor booking",
+        body: `${data.guestName} is visiting ${data.checkInDate} - ${data.checkOutDate}.`,
+        data: { url: "/dashboard" },
+      },
+      ...data.roommates.map((roommate) => ({
+        channel: "sms" as const,
+        userId: roommate.id,
+        message: `${data.guestName} is visiting from ${data.checkInDate} to ${data.checkOutDate}.`,
+      })),
+      ...data.roommates.map((roommate) => ({
+        channel: "push" as const,
+        userId: roommate.id,
+        title: "Guest visit scheduled",
+        body: `${data.guestName} arrives ${data.checkInDate}.`,
+        data: { url: "/dashboard" },
+      })),
     ]
 
     return sendBulkNotifications(notifications)
@@ -181,7 +285,7 @@ export function useNotifications() {
     priority: string
     propertyManager: { id: string; email: string; name: string }
   }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
+    const notifications: NotificationPayload[] = [
       // Email to property manager
       {
         to: data.propertyManager.email,
@@ -198,6 +302,18 @@ export function useNotifications() {
         type: "warning" as const,
         actionUrl: "/dashboard",
       },
+      {
+        channel: "sms",
+        userId: data.propertyManager.id,
+        message: `Maintenance alert: ${data.title} reported by ${data.requesterName}.`,
+      },
+      {
+        channel: "push",
+        userId: data.propertyManager.id,
+        title: "Maintenance request",
+        body: `${data.requesterName} reported "${data.title}"`,
+        data: { url: "/dashboard" },
+      },
     ]
 
     return sendBulkNotifications(notifications)
@@ -211,7 +327,7 @@ export function useNotifications() {
     tenantEmail: string
     tenantId: string
   }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
+    const notifications: NotificationPayload[] = [
       // Email receipt to tenant
       {
         to: data.tenantEmail,
@@ -228,6 +344,18 @@ export function useNotifications() {
         type: "success" as const,
         actionUrl: "/payments",
       },
+      {
+        channel: "sms",
+        userId: data.tenantId,
+        message: `Thanks! We received your $${data.amount} payment for ${data.description}.`,
+      },
+      {
+        channel: "push",
+        userId: data.tenantId,
+        title: "Payment processed",
+        body: `We received your $${data.amount} payment.`,
+        data: { url: "/payments" },
+      },
     ]
 
     return sendBulkNotifications(notifications)
@@ -240,7 +368,7 @@ export function useNotifications() {
     signerEmail: string
     signerId: string
   }) => {
-    const notifications: (NotificationData | InAppNotification)[] = [
+    const notifications: NotificationPayload[] = [
       // Email confirmation to signer
       {
         to: data.signerEmail,
@@ -257,6 +385,18 @@ export function useNotifications() {
         type: "success" as const,
         actionUrl: "/documents",
       },
+      {
+        channel: "sms",
+        userId: data.signerId,
+        message: `You signed "${data.documentTitle}" on ${data.signedAt}.`,
+      },
+      {
+        channel: "push",
+        userId: data.signerId,
+        title: "Document signed",
+        body: `"${data.documentTitle}" is complete.`,
+        data: { url: "/documents" },
+      },
     ]
 
     return sendBulkNotifications(notifications)
@@ -266,6 +406,8 @@ export function useNotifications() {
     sendEmail,
     sendInAppNotification,
     sendBulkNotifications,
+    sendPushNotification,
+    sendTextNotification,
     notifyVisitorBooking,
     notifyMaintenanceRequest,
     notifyPaymentReceipt,

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,13 +1,17 @@
 "use server"
 
-import { createSupbaseServerClient } from "@/utils/supaone"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import webPush from "web-push"
 import { Resend } from "resend"
+
+import type { Database, Json } from "@/lib/supabase"
+import { createSupbaseServerClient } from "@/utils/supaone"
 
 export interface NotificationData {
   to: string | string[]
   subject: string
   template: string
-  data?: Record<string, any>
+  data?: Record<string, unknown>
   userId?: string
 }
 
@@ -17,37 +21,298 @@ export interface InAppNotification {
   message: string
   type: "info" | "success" | "warning" | "error"
   actionUrl?: string
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 }
+
+export interface TextNotification {
+  channel?: "sms"
+  userId?: string
+  phoneNumber?: string
+  message: string
+  mediaUrl?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface PushNotificationAction {
+  action: string
+  title: string
+}
+
+export type PushSubscriptionPayload = {
+  endpoint: string
+  keys: { p256dh: string; auth: string }
+}
+
+export interface PushNotification {
+  channel?: "push"
+  userId: string
+  title: string
+  body: string
+  data?: Record<string, unknown>
+  icon?: string
+  actions?: PushNotificationAction[]
+  subscription?: PushSubscriptionPayload
+  metadata?: Record<string, unknown>
+}
+
+export type NotificationPayload =
+  | NotificationData
+  | InAppNotification
+  | TextNotification
+  | PushNotification
+
+export interface NotificationResponse {
+  success: boolean
+  error?: string
+  data?: unknown
+  skipped?: boolean
+}
+
+type NotificationPreferences = {
+  emailEnabled: boolean
+  smsEnabled: boolean
+  pushEnabled: boolean
+  smsPhoneNumber: string | null
+  pushSubscription: PushSubscriptionPayload | null
+}
+
+type NotificationPreferencesRow =
+  Database["public"]["Tables"]["notification_preferences"]["Row"]
+
+type ProfilePhoneRow = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "phone"
+>
+
+type EmailStatus = "sent" | "failed" | "pending"
+type SmsStatus = "sent" | "failed" | "skipped" | "queued"
+type PushStatus = "sent" | "failed" | "skipped"
 
 class NotificationService {
   private resend: Resend | null = null
+  private twilioConfig:
+    | {
+        accountSid: string
+        authToken: string
+        fromNumber?: string
+        messagingServiceSid?: string
+      }
+    | null = null
+  private supabaseAdmin: SupabaseClient<Database> | null = null
+  private preferencesCache = new Map<string, NotificationPreferences>()
+  private webPushConfigured = false
 
   constructor() {
-    const apiKey = process.env.RESEND_API_KEY
-    if (apiKey && apiKey !== "re_your_resend_api_key_here") {
-      this.resend = new Resend(apiKey)
+    const resendApiKey = process.env.RESEND_API_KEY
+    if (resendApiKey && resendApiKey !== "re_your_resend_api_key_here") {
+      this.resend = new Resend(resendApiKey)
+    }
+
+    const accountSid = process.env.TWILIO_ACCOUNT_SID
+    const authToken = process.env.TWILIO_AUTH_TOKEN
+    const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID
+    const fromNumber = process.env.TWILIO_FROM_NUMBER
+
+    if (accountSid && authToken && (messagingServiceSid || fromNumber)) {
+      this.twilioConfig = {
+        accountSid,
+        authToken,
+        fromNumber: fromNumber || undefined,
+        messagingServiceSid: messagingServiceSid || undefined,
+      }
+    }
+
+    const publicKey = process.env.WEB_PUSH_PUBLIC_KEY
+    const privateKey = process.env.WEB_PUSH_PRIVATE_KEY
+    const contactEmail = process.env.WEB_PUSH_CONTACT_EMAIL || "notifications@roomsily.com"
+
+    if (publicKey && privateKey) {
+      try {
+        webPush.setVapidDetails(`mailto:${contactEmail}`, publicKey, privateKey)
+        this.webPushConfigured = true
+      } catch (error) {
+        console.error("Failed to configure web push", error)
+        this.webPushConfigured = false
+      }
     }
   }
 
-  async sendEmail(notification: NotificationData) {
+  private async getSupabaseClient(): Promise<SupabaseClient<Database>> {
+    if (this.supabaseAdmin) {
+      return this.supabaseAdmin
+    }
+
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+    if (url && serviceRoleKey) {
+      this.supabaseAdmin = createClient<Database>(url, serviceRoleKey, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      })
+      return this.supabaseAdmin
+    }
+
+    return (await createSupbaseServerClient()) as SupabaseClient<Database>
+  }
+
+  private async getNotificationPreferences(userId: string) {
+    if (this.preferencesCache.has(userId)) {
+      return this.preferencesCache.get(userId)!
+    }
+
+    try {
+      const supabase = await this.getSupabaseClient()
+      const { data: preferenceRow, error: preferencesError } = await supabase
+        .from("notification_preferences")
+        .select(
+          "email_enabled, sms_enabled, push_enabled, sms_phone_number, push_subscription"
+        )
+        .eq("user_id", userId)
+        .maybeSingle<NotificationPreferencesRow>()
+
+      if (preferencesError && preferencesError.code !== "PGRST116") {
+        console.error("Failed to fetch notification preferences", preferencesError)
+      }
+
+      let smsPhoneNumber = preferenceRow?.sms_phone_number ?? null
+      if (!smsPhoneNumber) {
+        const { data: profile, error: profileError } = await supabase
+          .from("profiles")
+          .select("phone")
+          .eq("id", userId)
+          .maybeSingle<ProfilePhoneRow>()
+
+        if (profileError && profileError.code !== "PGRST116") {
+          console.error("Failed to fetch profile for notification preferences", profileError)
+        }
+
+        smsPhoneNumber = profile?.phone ?? null
+      }
+
+      const preferences: NotificationPreferences = {
+        emailEnabled: preferenceRow?.email_enabled ?? true,
+        smsEnabled: preferenceRow?.sms_enabled ?? false,
+        pushEnabled: preferenceRow?.push_enabled ?? false,
+        smsPhoneNumber,
+        pushSubscription: (preferenceRow?.push_subscription as PushSubscriptionPayload | null) ?? null,
+      }
+
+      this.preferencesCache.set(userId, preferences)
+      return preferences
+    } catch (error) {
+      console.error("Unable to resolve notification preferences", error)
+      return {
+        emailEnabled: true,
+        smsEnabled: false,
+        pushEnabled: false,
+        smsPhoneNumber: null,
+        pushSubscription: null,
+      }
+    }
+  }
+
+  private async storeEmailNotification(
+    notification: NotificationData,
+    status: EmailStatus,
+    errorMessage?: string | null
+  ) {
+    if (!notification.userId) return
+
+    try {
+      const supabase = await this.getSupabaseClient()
+      await (supabase as any).from("email_notifications").insert({
+        user_id: notification.userId,
+        recipient: Array.isArray(notification.to)
+          ? notification.to.join(", ")
+          : notification.to,
+        subject: notification.subject,
+        template: notification.template,
+        status,
+        sent_at: new Date().toISOString(),
+        error_message: errorMessage ?? null,
+        metadata: notification.data as Json | null,
+      })
+    } catch (error) {
+      console.error("Failed to store email notification:", error)
+    }
+  }
+
+  private async storeSmsNotification(params: {
+    userId?: string
+    phoneNumber: string
+    message: string
+    status: SmsStatus
+    providerMessageId?: string | null
+    errorMessage?: string | null
+    metadata?: Record<string, unknown>
+  }) {
+    try {
+      const supabase = await this.getSupabaseClient()
+      await (supabase as any).from("sms_notifications").insert({
+        user_id: params.userId ?? null,
+        phone_number: params.phoneNumber,
+        message: params.message,
+        status: params.status,
+        provider_message_id: params.providerMessageId ?? null,
+        error_message: params.errorMessage ?? null,
+        metadata: (params.metadata ?? null) as Json | null,
+        created_at: new Date().toISOString(),
+      })
+    } catch (error) {
+      console.error("Failed to store SMS notification:", error)
+    }
+  }
+
+  private async storePushNotification(params: {
+    userId?: string
+    endpoint: string
+    payload: Record<string, unknown>
+    status: PushStatus
+    errorMessage?: string | null
+    metadata?: Record<string, unknown>
+  }) {
+    try {
+      const supabase = await this.getSupabaseClient()
+      await (supabase as any).from("push_notifications").insert({
+        user_id: params.userId ?? null,
+        endpoint: params.endpoint,
+        payload: params.payload as Json,
+        status: params.status,
+        error_message: params.errorMessage ?? null,
+        metadata: (params.metadata ?? null) as Json | null,
+        created_at: new Date().toISOString(),
+      })
+    } catch (error) {
+      console.error("Failed to store push notification:", error)
+    }
+  }
+
+  async sendEmail(notification: NotificationData): Promise<NotificationResponse> {
     if (!this.resend) {
-      console.warn(
-        "Resend API key not configured. Skipping email notification."
-      )
+      console.warn("Resend API key not configured. Skipping email notification.")
       return { success: false, error: "Email service not configured" }
     }
 
     try {
+      if (notification.userId) {
+        const preferences = await this.getNotificationPreferences(notification.userId)
+        if (!preferences.emailEnabled) {
+          await this.storeEmailNotification(
+            notification,
+            "pending",
+            "Email channel disabled by user preferences"
+          )
+          return { success: true, skipped: true }
+        }
+      }
+
       const recipients = Array.isArray(notification.to)
         ? notification.to
         : [notification.to]
 
       const emailTemplates = {
         "visitor-booking": this.getVisitorBookingTemplate(notification.data),
-        "maintenance-request": this.getMaintenanceRequestTemplate(
-          notification.data
-        ),
+        "maintenance-request": this.getMaintenanceRequestTemplate(notification.data),
         "payment-receipt": this.getPaymentReceiptTemplate(notification.data),
         "document-signed": this.getDocumentSignedTemplate(notification.data),
         welcome: this.getWelcomeTemplate(notification.data),
@@ -67,28 +332,26 @@ class NotificationService {
       })
 
       if (error) {
+        await this.storeEmailNotification(notification, "failed", error.message)
         console.error("Failed to send email:", error)
         return { success: false, error: error.message }
       }
 
-      // Store email notification in database for tracking
-      if (notification.userId) {
-        await this.storeEmailNotification(notification)
-      }
-
+      await this.storeEmailNotification(notification, "sent")
       return { success: true, data }
     } catch (error) {
-      console.error("Email sending error:", error)
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
+      const message = error instanceof Error ? error.message : "Unknown error"
+      if (notification.userId) {
+        await this.storeEmailNotification(notification, "failed", message)
       }
+      console.error("Email sending error:", error)
+      return { success: false, error: message }
     }
   }
 
-  async sendInAppNotification(notification: InAppNotification) {
+  async sendInAppNotification(notification: InAppNotification): Promise<NotificationResponse> {
     try {
-      const supabase = await createSupbaseServerClient()
+      const supabase = await this.getSupabaseClient()
 
       const { data, error } = await (supabase as any)
         .from("notifications")
@@ -98,10 +361,11 @@ class NotificationService {
           message: notification.message,
           type: notification.type,
           action_url: notification.actionUrl,
-          metadata: notification.metadata,
+          metadata: (notification.metadata ?? null) as Json | null,
           read: false,
           created_at: new Date().toISOString(),
         })
+        .select()
 
       if (error) {
         console.error("Failed to create in-app notification:", error)
@@ -110,24 +374,200 @@ class NotificationService {
 
       return { success: true, data }
     } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error"
       console.error("In-app notification error:", error)
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      }
+      return { success: false, error: message }
     }
   }
 
-  async sendBulkNotification(
-    notifications: (NotificationData | InAppNotification)[]
-  ) {
+  async sendTextNotification(notification: TextNotification): Promise<NotificationResponse> {
+    if (!this.twilioConfig) {
+      console.warn("Twilio credentials are not configured. Skipping SMS notification.")
+      return { success: false, error: "Text message service not configured" }
+    }
+
+    let phoneNumber = notification.phoneNumber
+    if (notification.userId) {
+      const preferences = await this.getNotificationPreferences(notification.userId)
+      if (!preferences.smsEnabled) {
+        if (preferences.smsPhoneNumber) {
+          await this.storeSmsNotification({
+            userId: notification.userId,
+            phoneNumber: preferences.smsPhoneNumber,
+            message: notification.message,
+            status: "skipped",
+            errorMessage: "SMS channel disabled by user preferences",
+            metadata: notification.metadata,
+          })
+        }
+        return { success: true, skipped: true }
+      }
+      phoneNumber = phoneNumber ?? preferences.smsPhoneNumber ?? undefined
+    }
+
+    if (!phoneNumber) {
+      console.warn("No phone number available for SMS notification")
+      return { success: false, error: "Recipient phone number is missing" }
+    }
+
+    const body = new URLSearchParams({
+      To: phoneNumber,
+      Body: notification.message,
+    })
+
+    if (notification.mediaUrl) {
+      body.append("MediaUrl", notification.mediaUrl)
+    }
+
+    if (this.twilioConfig.messagingServiceSid) {
+      body.append("MessagingServiceSid", this.twilioConfig.messagingServiceSid)
+    } else if (this.twilioConfig.fromNumber) {
+      body.append("From", this.twilioConfig.fromNumber)
+    } else {
+      return { success: false, error: "No Twilio sender configured" }
+    }
+
+    const endpoint = `https://api.twilio.com/2010-04-01/Accounts/${this.twilioConfig.accountSid}/Messages.json`
+
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${this.twilioConfig.accountSid}:${this.twilioConfig.authToken}`
+          ).toString("base64")}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body,
+      })
+
+      const payload = (await response.json().catch(() => null)) as
+        | { sid?: string; message?: string; error_message?: string }
+        | null
+
+      if (!response.ok) {
+        const errorMessage =
+          payload?.message || payload?.error_message || "Failed to send SMS notification"
+        await this.storeSmsNotification({
+          userId: notification.userId,
+          phoneNumber,
+          message: notification.message,
+          status: "failed",
+          errorMessage,
+          metadata: notification.metadata,
+        })
+        return { success: false, error: errorMessage }
+      }
+
+      await this.storeSmsNotification({
+        userId: notification.userId,
+        phoneNumber,
+        message: notification.message,
+        status: "sent",
+        providerMessageId: payload?.sid ?? null,
+        metadata: notification.metadata,
+      })
+
+      return { success: true, data: payload }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error"
+      await this.storeSmsNotification({
+        userId: notification.userId,
+        phoneNumber,
+        message: notification.message,
+        status: "failed",
+        errorMessage: message,
+        metadata: notification.metadata,
+      })
+      console.error("SMS notification error:", error)
+      return { success: false, error: message }
+    }
+  }
+
+  async sendPushNotification(notification: PushNotification): Promise<NotificationResponse> {
+    if (!this.webPushConfigured) {
+      console.warn("Web push keys are not configured. Skipping push notification.")
+      return { success: false, error: "Push notification service not configured" }
+    }
+
+    const preferences = await this.getNotificationPreferences(notification.userId)
+    if (!preferences.pushEnabled) {
+      if (preferences.pushSubscription) {
+        await this.storePushNotification({
+          userId: notification.userId,
+          endpoint: preferences.pushSubscription.endpoint,
+          payload: {
+            title: notification.title,
+            body: notification.body,
+            data: notification.data ?? null,
+            icon: notification.icon ?? null,
+            actions: notification.actions ?? null,
+          },
+          status: "skipped",
+          errorMessage: "Push channel disabled by user preferences",
+          metadata: notification.metadata,
+        })
+      }
+      return { success: true, skipped: true }
+    }
+
+    const subscription = notification.subscription ?? preferences.pushSubscription
+    if (!subscription) {
+      console.warn("No push subscription available for user", notification.userId)
+      return { success: false, error: "Missing push subscription" }
+    }
+
+    const payload = {
+      title: notification.title,
+      body: notification.body,
+      data: notification.data ?? null,
+      icon: notification.icon ?? null,
+      actions: notification.actions ?? null,
+    }
+
+    try {
+      const response = await webPush.sendNotification(subscription, JSON.stringify(payload))
+
+      await this.storePushNotification({
+        userId: notification.userId,
+        endpoint: subscription.endpoint,
+        payload,
+        status: "sent",
+        metadata: notification.metadata,
+      })
+
+      return { success: true, data: response }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error"
+      await this.storePushNotification({
+        userId: notification.userId,
+        endpoint: subscription.endpoint,
+        payload,
+        status: "failed",
+        errorMessage: message,
+        metadata: notification.metadata,
+      })
+      console.error("Push notification error:", error)
+      return { success: false, error: message }
+    }
+  }
+
+  async sendBulkNotification(notifications: NotificationPayload[]) {
     const results = await Promise.allSettled(
       notifications.map((notification) => {
-        if ("to" in notification) {
-          return this.sendEmail(notification)
-        } else {
-          return this.sendInAppNotification(notification)
+        if ((notification as TextNotification).channel === "sms") {
+          return this.sendTextNotification(notification as TextNotification)
         }
+
+        if ((notification as PushNotification).channel === "push") {
+          return this.sendPushNotification(notification as PushNotification)
+        }
+
+        if ("to" in notification) {
+          return this.sendEmail(notification as NotificationData)
+        }
+
+        return this.sendInAppNotification(notification as InAppNotification)
       })
     )
 
@@ -135,37 +575,19 @@ class NotificationService {
       index,
       success: result.status === "fulfilled" ? result.value.success : false,
       error: result.status === "rejected" ? result.reason : result.value.error,
+      skipped: result.status === "fulfilled" ? result.value.skipped ?? false : false,
     }))
   }
 
-  private async storeEmailNotification(notification: NotificationData) {
-    try {
-      const supabase = await createSupbaseServerClient()
-
-      await (supabase as any).from("email_notifications").insert({
-        user_id: notification.userId,
-        recipient: Array.isArray(notification.to)
-          ? notification.to.join(", ")
-          : notification.to,
-        subject: notification.subject,
-        template: notification.template,
-        status: "sent",
-        sent_at: new Date().toISOString(),
-      })
-    } catch (error) {
-      console.error("Failed to store email notification:", error)
-    }
-  }
-
-  private getVisitorBookingTemplate(data?: any) {
+  private getVisitorBookingTemplate(data?: Record<string, unknown>) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>New Overnight Visitor Booking</h2>
         <p><strong>Guest:</strong> ${data?.guestName || "Unknown"}</p>
         <p><strong>Host:</strong> ${data?.hostName || "Unknown"}</p>
-        <p><strong>Dates:</strong> ${data?.checkInDate || "Unknown"} to ${
-      data?.checkOutDate || "Unknown"
-    }</p>
+        <p><strong>Dates:</strong> ${
+          data?.checkInDate || "Unknown"
+        } to ${data?.checkOutDate || "Unknown"}</p>
         <p><strong>Purpose:</strong> ${data?.purpose || "Not specified"}</p>
         <p>Please review this booking request in the dashboard.</p>
         <a href="${
@@ -175,17 +597,13 @@ class NotificationService {
     `
   }
 
-  private getMaintenanceRequestTemplate(data?: any) {
+  private getMaintenanceRequestTemplate(data?: Record<string, unknown>) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>New Maintenance Request</h2>
-        <p><strong>Requested by:</strong> ${
-          data?.requesterName || "Unknown"
-        }</p>
+        <p><strong>Requested by:</strong> ${data?.requesterName || "Unknown"}</p>
         <p><strong>Issue:</strong> ${data?.title || "Unknown"}</p>
-        <p><strong>Description:</strong> ${
-          data?.description || "No description provided"
-        }</p>
+        <p><strong>Description:</strong> ${data?.description || "No description provided"}</p>
         <p><strong>Priority:</strong> ${data?.priority || "Normal"}</p>
         <a href="${
           process.env.NEXT_PUBLIC_APP_URL
@@ -194,32 +612,26 @@ class NotificationService {
     `
   }
 
-  private getPaymentReceiptTemplate(data?: any) {
+  private getPaymentReceiptTemplate(data?: Record<string, unknown>) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>Payment Receipt</h2>
         <p><strong>Tenant:</strong> ${data?.tenantName || "Unknown"}</p>
         <p><strong>Amount:</strong> $${data?.amount || "0.00"}</p>
-        <p><strong>Description:</strong> ${
-          data?.description || "Rent payment"
-        }</p>
-        <p><strong>Date:</strong> ${
-          data?.date || new Date().toLocaleDateString()
-        }</p>
+        <p><strong>Description:</strong> ${data?.description || "Rent payment"}</p>
+        <p><strong>Date:</strong> ${data?.date || new Date().toLocaleDateString()}</p>
         <p>Thank you for your payment!</p>
       </div>
     `
   }
 
-  private getDocumentSignedTemplate(data?: any) {
+  private getDocumentSignedTemplate(data?: Record<string, unknown>) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>Document Signed</h2>
         <p><strong>Document:</strong> ${data?.documentTitle || "Unknown"}</p>
         <p><strong>Signed by:</strong> ${data?.signerName || "Unknown"}</p>
-        <p><strong>Date:</strong> ${
-          data?.signedAt || new Date().toLocaleDateString()
-        }</p>
+        <p><strong>Date:</strong> ${data?.signedAt || new Date().toLocaleDateString()}</p>
         <a href="${
           process.env.NEXT_PUBLIC_APP_URL
         }/documents" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View Document</a>
@@ -227,7 +639,7 @@ class NotificationService {
     `
   }
 
-  private getWelcomeTemplate(data?: any) {
+  private getWelcomeTemplate(data?: Record<string, unknown>) {
     return `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>Welcome to Roomsily!</h2>
@@ -257,8 +669,14 @@ export async function sendInAppNotification(notification: InAppNotification) {
   return notificationService.sendInAppNotification(notification)
 }
 
-export async function sendBulkNotifications(
-  notifications: (NotificationData | InAppNotification)[]
-) {
+export async function sendTextNotification(notification: TextNotification) {
+  return notificationService.sendTextNotification(notification)
+}
+
+export async function sendPushNotification(notification: PushNotification) {
+  return notificationService.sendPushNotification(notification)
+}
+
+export async function sendBulkNotifications(notifications: NotificationPayload[]) {
   return notificationService.sendBulkNotification(notifications)
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -210,6 +210,40 @@ export type Database = {
         error_message: string | null
         metadata: Json | null
       }>
+      notification_preferences: SupabaseTable<{
+        user_id: string
+        email_enabled: boolean
+        sms_enabled: boolean
+        push_enabled: boolean
+        sms_phone_number: string | null
+        push_subscription: Json | null
+        quiet_hours: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
+      sms_notifications: SupabaseTable<{
+        id: string
+        user_id: string | null
+        phone_number: string
+        message: string
+        status: 'sent' | 'failed' | 'skipped' | 'queued'
+        provider_message_id: string | null
+        error_message: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
+      push_notifications: SupabaseTable<{
+        id: string
+        user_id: string | null
+        endpoint: string
+        payload: Json
+        status: 'sent' | 'failed' | 'skipped'
+        error_message: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
       meetings: SupabaseTable<{
         id: string
         user_id: string

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "0.160.0",
+    "web-push": "^3.6.7",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       three:
         specifier: 0.160.0
         version: 0.160.0
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -2067,6 +2070,9 @@ packages:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2149,6 +2155,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bn.js@4.12.2:
+    resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -2990,6 +2999,10 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -3493,6 +3506,9 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -4013,6 +4029,9 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4625,6 +4644,11 @@ packages:
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webgl-constants@1.1.1:
     resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
@@ -6718,6 +6742,13 @@ snapshots:
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.2
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -6797,6 +6828,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bn.js@4.12.2: {}
 
   brace-expansion@1.1.11:
     dependencies:
@@ -7866,10 +7899,12 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8496,7 +8531,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8527,6 +8562,8 @@ snapshots:
       mime-db: 1.52.0
 
   mimic-response@3.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -9079,6 +9116,8 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.21.0:
     dependencies:
@@ -9793,6 +9832,16 @@ snapshots:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.0
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webgl-constants@1.1.1: {}
 

--- a/supabase/migrations/20250108_notification_channels.sql
+++ b/supabase/migrations/20250108_notification_channels.sql
@@ -1,0 +1,104 @@
+-- Notification channel enhancements
+
+-- Table to store per-user notification channel preferences
+CREATE TABLE IF NOT EXISTS public.notification_preferences (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  sms_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  push_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  sms_phone_number TEXT,
+  push_subscription JSONB,
+  quiet_hours JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Table to keep an audit log of SMS notifications
+CREATE TABLE IF NOT EXISTS public.sms_notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  phone_number TEXT NOT NULL,
+  message TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'sent' CHECK (status IN ('sent', 'failed', 'skipped', 'queued')),
+  provider_message_id TEXT,
+  error_message TEXT,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Table to keep an audit log of web push notifications
+CREATE TABLE IF NOT EXISTS public.push_notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  endpoint TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  status TEXT NOT NULL DEFAULT 'sent' CHECK (status IN ('sent', 'failed', 'skipped')),
+  error_message TEXT,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for faster lookups
+CREATE INDEX IF NOT EXISTS idx_notification_preferences_updated_at
+  ON public.notification_preferences(updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sms_notifications_user_id
+  ON public.sms_notifications(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_sms_notifications_created_at
+  ON public.sms_notifications(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_push_notifications_user_id
+  ON public.push_notifications(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_push_notifications_created_at
+  ON public.push_notifications(created_at DESC);
+
+-- Ensure RLS is enabled
+ALTER TABLE public.notification_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sms_notifications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.push_notifications ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies for notification_preferences
+CREATE POLICY IF NOT EXISTS "Users view their notification preferences"
+  ON public.notification_preferences
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY IF NOT EXISTS "Users insert their notification preferences"
+  ON public.notification_preferences
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY IF NOT EXISTS "Users update their notification preferences"
+  ON public.notification_preferences
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- RLS policies for sms_notifications
+CREATE POLICY IF NOT EXISTS "Users view their SMS notifications"
+  ON public.sms_notifications
+  FOR SELECT
+  USING (user_id IS NOT NULL AND auth.uid() = user_id);
+
+-- RLS policies for push_notifications
+CREATE POLICY IF NOT EXISTS "Users view their push notifications"
+  ON public.push_notifications
+  FOR SELECT
+  USING (user_id IS NOT NULL AND auth.uid() = user_id);
+
+-- Reuse the shared updated_at trigger
+CREATE TRIGGER IF NOT EXISTS update_notification_preferences_updated_at
+  BEFORE UPDATE ON public.notification_preferences
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER IF NOT EXISTS update_sms_notifications_updated_at
+  BEFORE UPDATE ON public.sms_notifications
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER IF NOT EXISTS update_push_notifications_updated_at
+  BEFORE UPDATE ON public.push_notifications
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- add Supabase tables for notification preferences along with SMS and push audit logs
- extend the server notification service, API route, and client hooks to deliver email, SMS, push, and in-app messages while honoring user channel settings
- expose notification controls in the account page, capture phone numbers, and document new Twilio and web push environment variables

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ae80e6248328b865336520b39610