### PR TITLE
Add safe build script and update CI to run it

### DIFF
--- a/.github/workflows/css-size.yml
+++ b/.github/workflows/css-size.yml
@@ -16,14 +16,22 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
+
+      - name: Run safe build checks
+        run: pnpm safe-build
 
       - name: Verify purged CSS size
-        run: npm run css:purge
+        run: pnpm css:purge

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -140,8 +140,9 @@ CREATE TABLE public.documents (
 
 1. Copy this template to `.env.local`
 2. Fill in your actual API keys
-3. Run database migrations or create tables manually in Supabase
-4. Restart your development server: `npm run dev`
+3. Install dependencies with `pnpm install`
+4. Run the validation suite: `pnpm safe-build`
+5. Start or restart your development server: `pnpm dev`
 
 ## ⚠️ **SECURITY NOTES**
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Roomsily (www.roomsily) is a comprehensive co-living portal that helps roommates
 
 ### Prerequisites
 - Node.js 18+
-- npm/yarn/pnpm
+- pnpm (preferred package manager)
+- npm or yarn (optional, if your workflow relies on them)
 - Supabase account
 - Stripe account
 - Vercel account (for deployment)
@@ -93,11 +94,21 @@ supabase db push
 
 ```bash
 # Install dependencies
-npm install
+pnpm install
 
 # Start development server
-npm run dev
+pnpm dev
 ```
+
+### Preflight checks
+
+Run the aggregated safe build workflow before pushing changes or triggering a deployment:
+
+```bash
+pnpm safe-build
+```
+
+This command sequentially runs linting, TypeScript checks, unit tests, and the production build so that CI and local workflows surface issues before any deployment artifacts are produced.
 
 Open [http://localhost:3000](http://localhost:3000) to view the application.
 

--- a/lib/data/documents.ts
+++ b/lib/data/documents.ts
@@ -2,7 +2,7 @@ import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import type { DocumentListFilters, DocumentStats, DocumentWithLease } from '@/types/documents';
 import type { Database } from '@/lib/supabase';
 
-type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
+export type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
 
 type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "safe-build": "pnpm lint && pnpm typecheck && pnpm test && pnpm build",
     "css:purge": "node scripts/check-css-size.mjs"
   },
   "dependencies": {

--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import { fetchDocumentStats, fetchDocumentsList, type SupabaseClientLike } from '@/lib/data/documents';
 import type { DocumentListFilters } from '@/types/documents';
 
 type QueryResult<T> = { data: T; error: { message: string } | null };
@@ -40,13 +40,13 @@ function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
   return builder as QueryBuilder<T>;
 }
 
-function createSupabaseStub<T extends unknown[]>(query: QueryBuilder<T>) {
+function createSupabaseStub<T extends unknown[]>(query: QueryBuilder<T>): SupabaseClientLike {
   return {
     from: vi.fn((table: string) => {
       expect(table).toBe('documents');
       return query;
     }),
-  };
+  } as unknown as SupabaseClientLike;
 }
 
 describe('fetchDocumentsList', () => {


### PR DESCRIPTION
## Summary
- add a pnpm-based `safe-build` script and expose a `typecheck` command that powers it
- update the css-size workflow to use pnpm and execute `safe-build` before generating CSS artifacts
- export the Supabase client test shim and refresh developer docs to explain the safe build workflow

## Testing
- CI=1 pnpm safe-build

------
https://chatgpt.com/codex/tasks/task_e_68d1b63faf908328b3a4ba216cdd2a25