### PR TITLE
Add CODEOWNERS coverage and branch protection guidance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# This file defines the default reviewers responsible for various parts of the codebase.
+# Keep the mapping in sync with the teams documented in SECURITY.md.
+
+*       @roomsily/engineering-leads
+
+# Next.js app surfaces and front-end experience
+app/    @roomsily/tenant-experience
+
+# Shared libraries used across the monorepo
+lib/    @roomsily/shared-libraries
+
+# Supabase database schema, migrations, and auth configuration
+supabase/ @roomsily/platform-infra

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,9 @@ See nextconfig.js for CSP and header config.
 
 Please head to Advisories to submit a private vulnerability report.
 If needed, check out the docs explaining [how to submit a private vulnerability report](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository#enabling-or-disabling-private-vulnerability-reporting-for-a-repository).
+
+## CODEOWNERS & Branch Protection Expectations
+
+- `.github/CODEOWNERS` enumerates the teams responsible for major areas of the repository (e.g., `app/`, `lib/`, `supabase/`). Update the file as soon as ownership changes or new surface areas are introduced so that review responsibilities remain accurate.
+- Coordinate with the GitHub organization administrators to ensure all protected branches (at minimum `main` and any release branches) have the **Require review from Code Owners** branch protection rule enabled. This keeps high-sensitivity areas gated on the appropriate subject-matter experts.
+- When onboarding or offboarding teammates, update CODEOWNERS within one business day and confirm the corresponding GitHub teams remain in sync. Document significant ownership changes in the engineering changelog to maintain situational awareness.


### PR DESCRIPTION
## Summary
- add a CODEOWNERS file to cover the app, library, and Supabase directories with the appropriate owning teams
- document CODEOWNERS maintenance expectations and branch protection requirements in SECURITY.md

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1b63decb4832893ae304f89f8181b