### PR TITLE
Add production Dockerfile and container CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# dependency directories
+node_modules
+.pnpm
+.pnp
+.pnp.cjs
+
+# build outputs
+.next
+out
+dist
+coverage
+
+# environment files
+.env*
+!.env.example
+
+# git and editor metadata
+.git
+.gitignore
+.vscode
+.idea
+*.swp
+
+# misc cache or binaries
+supabase/.temp
+supabase/.branches
+*.log
+*.tgz

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,50 @@
+name: Docker Image
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: share-house-portal:ci
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build production image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: ${{ env.IMAGE_NAME }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=https://example-project.supabase.co
+            NEXT_PUBLIC_SUPABASE_ANON_KEY=example-anon-key
+            SUPABASE_SERVICE_ROLE_KEY=example-service-role-key
+            STRIPE_SECRET_KEY=sk_test_example_secret
+            STRIPE_WEBHOOK_SECRET=whsec_example_secret
+            NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_example_key
+
+      - name: Trivy vulnerability scan
+        if: secrets.ENABLE_IMAGE_SCAN == 'true'
+        uses: aquasecurity/trivy-action@v0.20.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}
+          format: table
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:20-bookworm-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+WORKDIR /app
+RUN corepack enable
+
+FROM base AS deps
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates openssl \
+    && rm -rf /var/lib/apt/lists/*
+COPY package.json pnpm-lock.yaml* ./
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ARG NEXT_PUBLIC_SUPABASE_URL="https://example-project.supabase.co"
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY="supabase-anon-key"
+ARG SUPABASE_SERVICE_ROLE_KEY="supabase-service-role-key"
+ARG STRIPE_SECRET_KEY="stripe-secret-key"
+ARG STRIPE_WEBHOOK_SECRET="stripe-webhook-secret"
+ARG NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="stripe-publishable-key"
+ENV NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+ENV SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+ENV STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+ENV STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+RUN pnpm prune --prod
+
+FROM base AS runner
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ARG NEXT_PUBLIC_SUPABASE_URL="https://example-project.supabase.co"
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY="supabase-anon-key"
+ARG SUPABASE_SERVICE_ROLE_KEY="supabase-service-role-key"
+ARG STRIPE_SECRET_KEY="stripe-secret-key"
+ARG STRIPE_WEBHOOK_SECRET="stripe-webhook-secret"
+ARG NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="stripe-publishable-key"
+ENV NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+ENV SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+ENV STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+ENV STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+RUN useradd --create-home --uid 1001 nextjs
+WORKDIR /app
+COPY --from=builder --chown=nextjs:nextjs /app/public ./public
+COPY --from=builder --chown=nextjs:nextjs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nextjs /app/node_modules ./node_modules
+COPY --from=builder --chown=nextjs:nextjs /app/package.json ./package.json
+COPY --from=builder --chown=nextjs:nextjs /app/next.config.js ./next.config.js
+COPY --from=builder --chown=nextjs:nextjs /app/pnpm-lock.yaml ./pnpm-lock.yaml
+EXPOSE 3000
+USER nextjs
+CMD ["dumb-init", "pnpm", "start"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,49 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) to view the application.
 
+## Docker Image
+
+Build the production container image with the provided multi-stage `Dockerfile` when you need a reproducible deployment artifact.
+
+### Required build arguments
+
+These build arguments prime the Next.js build with the Supabase and Stripe configuration that is read during compilation. Provide test values locally and production secrets in your CI/CD system.
+
+| Build arg | Description |
+| --- | --- |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL exposed to the browser. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key used by the browser client. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key required for server actions. |
+| `STRIPE_SECRET_KEY` | Stripe secret key for server-side API calls. |
+| `STRIPE_WEBHOOK_SECRET` | Secret used to validate Stripe webhooks. |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key exposed to the browser. |
+
+The same values **must** be provided at runtime (for example with `docker run -e ...`) so the application can access them when serving requests.
+
+### Build and run locally
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co" \
+  --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY="your_supabase_anon_key" \
+  --build-arg SUPABASE_SERVICE_ROLE_KEY="your_supabase_service_role_key" \
+  --build-arg STRIPE_SECRET_KEY="sk_test_your_stripe_secret_key" \
+  --build-arg STRIPE_WEBHOOK_SECRET="whsec_your_webhook_secret" \
+  --build-arg NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_your_publishable_key" \
+  -t roomsily:latest .
+
+docker run --rm -p 3000:3000 \
+  -e NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co" \
+  -e NEXT_PUBLIC_SUPABASE_ANON_KEY="your_supabase_anon_key" \
+  -e SUPABASE_SERVICE_ROLE_KEY="your_supabase_service_role_key" \
+  -e STRIPE_SECRET_KEY="sk_test_your_stripe_secret_key" \
+  -e STRIPE_WEBHOOK_SECRET="whsec_your_webhook_secret" \
+  -e NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_your_publishable_key" \
+  roomsily:latest
+```
+
+Add the remaining environment variables from `.env.local` or `ENVIRONMENT_SETUP.md` as `-e` flags (or secrets in your orchestrator) to match your deployment target.
+
 ### Stripe Configuration
 
 1. Create products and prices in your Stripe dashboard


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and .dockerignore for production-ready builds
- document Supabase/Stripe build arguments and runtime env requirements in the README
- create a GitHub Actions workflow that builds the image and optionally runs a Trivy scan

## Testing
- docker build -t roomsily-test --build-arg NEXT_PUBLIC_SUPABASE_URL="https://example.supabase.co" --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY="anon" --build-arg SUPABASE_SERVICE_ROLE_KEY="service" --build-arg STRIPE_SECRET_KEY="sk_test" --build-arg STRIPE_WEBHOOK_SECRET="whsec" --build-arg NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test" . *(fails: Docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b63ccb40832890af9e008da6c9e9