### PR TITLE
Add CodeQL workflow for JavaScript/TypeScript security scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,20 @@
+name: share-house-portal-codeql
+packs:
+  javascript:
+    - codeql/javascript-queries
+    - codeql/javascript-experimental-web
+queries:
+  - uses: codeql/javascript-queries#security-extended
+  - uses: codeql/javascript-queries#security-and-quality
+paths:
+  - app
+  - components
+  - hooks
+  - lib
+  - middleware.ts
+  - scripts
+  - utils
+paths-ignore:
+  - node_modules
+  - tests
+  - public

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '0 5 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+  pull-requests: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,18 @@
 # Security Policy
-See nextconfig.js for CSP and header config. 
+See nextconfig.js for CSP and header config.
+
+## Code Scanning & Triage Expectations
+
+Automated [CodeQL](https://codeql.github.com/) analysis runs for JavaScript/TypeScript on every pull request targeting `main`, every push to `main`, and on a scheduled weekly scan. Alerts surface inline on PRs and in the repository **Security > Code scanning alerts** tab.
+
+When a CodeQL alert fires:
+
+- Treat high or critical severity findings as release blockers. Resolve or mitigate them before merging the PR.
+- For medium/low severity alerts, document the risk and planned remediation in the PR discussion or open an issue before merging.
+- If an alert is a false positive, dismiss it in the Security tab with a justification so we keep an auditable trail.
+- Assign remediation follow-up issues to the feature owner and track them through completion.
+
+The security champion for the sprint should review open CodeQL alerts at least once per week to ensure nothing regresses.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow scanning the JavaScript/TypeScript stack on push, PRs, and a weekly schedule
- configure CodeQL to use web security focused query suites and packs against app source paths
- document how CodeQL alerts surface and the expectations for triaging them

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1b636baf88328850e1cffbe21f4c1