### PR TITLE
Document GHAS enforcement and add gitleaks scan

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,53 @@
+name: gitleaks secret scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  scan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          tmpdir=$(mktemp -d)
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_linux_x64.tar.gz | tar -xz -C "$tmpdir"
+          sudo install -m 755 "$tmpdir/gitleaks" /usr/local/bin/gitleaks
+
+      - name: Run gitleaks
+        id: gitleaks
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          if gitleaks detect --source . --report-format sarif --report-path gitleaks.sarif --redact; then
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+          else
+            exit_code=$?
+            echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+            exit "${exit_code}"
+          fi
+
+      - name: Upload SARIF report
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+
+      - name: Fail if gitleaks detected secrets
+        if: steps.gitleaks.outputs.exit_code != '0'
+        run: |
+          echo "gitleaks detected potential secrets. Review the SARIF report in the code scanning alerts for details." >&2
+          exit 1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,28 @@
 # Security Policy
-See nextconfig.js for CSP and header config. 
+
+See `next.config.js` for CSP and header configuration.
+
+## GitHub Advanced Security enforcement
+
+Secret scanning and push protection **must** remain enabled for this repository whenever the organisation has a GitHub Advanced Security licence available. To verify or configure the settings:
+
+1. Navigate to **Settings → Code security and analysis**.
+2. In the **GitHub Advanced Security** section, ensure **Secret scanning** and **Push protection** are both switched on for the repository (or managed via the organisation policy).
+3. If the toggles are disabled because licences are exhausted, contact the security team to request allocation before merging changes that expand the use of secrets.
+
+### Handling blocked pushes
+
+When push protection identifies a credential:
+
+1. Review the push feedback for the file path and detected secret type.
+2. Remove the secret from the commit history (for example, with `git revert`, `git reset`, or `git commit --amend`) and ensure the secret does not exist in any staged files.
+3. Rotate or revoke the exposed credential in the upstream system before attempting another push.
+4. Re-run your push after the secret is removed. Only request a temporary bypass from the security team when a detection is a confirmed false positive and document the justification in the pull request.
+
+## Automated secret scanning
+
+In addition to GitHub Advanced Security, the repository runs a `gitleaks` workflow on every push to `main` and on all pull requests. The workflow produces a SARIF report that is published to GitHub code scanning for long-lived visibility. Update the workflow or provide a custom allowlist if newly-added files trigger intentional findings.
 
 ## Reporting a Vulnerability
 
-Please head to Advisories to submit a private vulnerability report.
-If needed, check out the docs explaining [how to submit a private vulnerability report](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository#enabling-or-disabling-private-vulnerability-reporting-for-a-repository).
+Please head to Advisories to submit a private vulnerability report. If needed, check out the docs explaining [how to submit a private vulnerability report](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository#enabling-or-disabling-private-vulnerability-reporting-for-a-repository).


### PR DESCRIPTION
## Summary
- document the expectation that GitHub Advanced Security secret scanning and push protection remain enabled and describe remediation steps for blocked pushes
- note the redundant gitleaks automation that augments GitHub Advanced Security coverage
- add a dedicated gitleaks GitHub Actions workflow that installs the CLI, uploads SARIF findings, and fails builds when secrets are detected

## Testing
- not run (documentation and CI configuration changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d1b635dd888328be4ba646fd424ba4