### PR TITLE
Harden Supabase cookie handling

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -37,7 +37,11 @@ NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="your_supabase_anon_key"
 SUPABASE_SERVICE_ROLE_KEY="your_supabase_service_role_key"
 SUPABASE_JWT_SECRET="your_jwt_secret"
+SUPABASE_COOKIE_DOMAIN=".roomsily.com" # Optional: share auth across subdomains
+SUPABASE_ALLOW_INSECURE_COOKIES="false" # Optional: set to "true" for custom HTTP dev hosts
 ```
+
+The Supabase client now forces `Secure`, `HttpOnly`, and `SameSite=Lax` defaults before forwarding cookies. Local development on `http://localhost` continues to function without additional configuration—the helper automatically downgrades cookies when it detects a loopback host. If you test against a custom development hostname that still uses plain HTTP, set `SUPABASE_ALLOW_INSECURE_COOKIES="true"` so that session cookies are accepted by the browser.
 
 ### **APPLICATION**
 ```bash

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,12 +3,30 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
+import {
+  computeCookieSecurityContext,
+  withSupabaseCookieDefaults,
+} from '@/utils/supabase/cookie-helpers'
+
 export async function middleware(request: NextRequest) {
   let response = NextResponse.next({
     request: {
       headers: request.headers,
     },
   })
+
+  const securityContext = computeCookieSecurityContext({
+    envDomain: process.env.SUPABASE_COOKIE_DOMAIN,
+    forwardedHost: request.headers.get('x-forwarded-host'),
+    host: request.headers.get('host'),
+    protocol:
+      request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol,
+    allowInsecure: process.env.SUPABASE_ALLOW_INSECURE_COOKIES === 'true',
+    defaultSecure: process.env.NODE_ENV !== 'development',
+  })
+
+  const applyCookieDefaults = (options: CookieOptions) =>
+    withSupabaseCookieDefaults(options, securityContext)
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL || '',
@@ -19,10 +37,11 @@ export async function middleware(request: NextRequest) {
           return request.cookies.get(name)?.value
         },
         set(name: string, value: string, options: CookieOptions) {
+          const normalized = applyCookieDefaults(options)
           request.cookies.set({
             name,
             value,
-            ...options,
+            ...normalized,
           })
           response = NextResponse.next({
             request: {
@@ -32,14 +51,15 @@ export async function middleware(request: NextRequest) {
           response.cookies.set({
             name,
             value,
-            ...options,
+            ...normalized,
           })
         },
         remove(name: string, options: CookieOptions) {
+          const normalized = applyCookieDefaults(options)
           request.cookies.set({
             name,
             value: '',
-            ...options,
+            ...normalized,
           })
           response = NextResponse.next({
             request: {
@@ -49,7 +69,7 @@ export async function middleware(request: NextRequest) {
           response.cookies.set({
             name,
             value: '',
-            ...options,
+            ...normalized,
           })
         },
       },

--- a/tests/supabase-cookies.test.ts
+++ b/tests/supabase-cookies.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import { type CookieOptions } from '@supabase/ssr'
+
+import {
+  computeCookieSecurityContext,
+  withSupabaseCookieDefaults,
+} from '@/utils/supabase/cookie-helpers'
+
+describe('supabase cookie security helpers', () => {
+  it('applies secure defaults for production hosts', () => {
+    const context = computeCookieSecurityContext({
+      host: 'app.roomsily.com:443',
+      protocol: 'https',
+    })
+
+    const normalized = withSupabaseCookieDefaults({}, context)
+
+    expect(normalized.httpOnly).toBe(true)
+    expect(normalized.secure).toBe(true)
+    expect(normalized.sameSite).toBe('lax')
+    expect(normalized.domain).toBe('app.roomsily.com')
+  })
+
+  it('retains strict SameSite directives when supplied', () => {
+    const context = computeCookieSecurityContext({
+      host: 'roomsily.com',
+      protocol: 'https',
+    })
+
+    const normalized = withSupabaseCookieDefaults(
+      { sameSite: 'strict' },
+      context,
+    )
+
+    expect(normalized.sameSite).toBe('strict')
+    expect(normalized.httpOnly).toBe(true)
+    expect(normalized.secure).toBe(true)
+  })
+
+  it('converts unsafe SameSite directives to lax', () => {
+    const context = computeCookieSecurityContext({
+      host: 'roomsily.com',
+      protocol: 'https',
+    })
+
+    const normalized = withSupabaseCookieDefaults(
+      { sameSite: 'none' } as CookieOptions,
+      context,
+    )
+
+    expect(normalized.sameSite).toBe('lax')
+  })
+
+  it('omits domain and secure flags for localhost', () => {
+    const context = computeCookieSecurityContext({
+      host: 'localhost:3000',
+      protocol: 'http',
+    })
+
+    const normalized = withSupabaseCookieDefaults({}, context)
+
+    expect(context.domain).toBeUndefined()
+    expect(context.secure).toBe(false)
+    expect(normalized.domain).toBeUndefined()
+    expect(normalized.secure).toBe(false)
+    expect(normalized.httpOnly).toBe(true)
+  })
+
+  it('respects explicit insecure overrides', () => {
+    const context = computeCookieSecurityContext({
+      host: 'roomsily.com',
+      protocol: 'https',
+      allowInsecure: true,
+    })
+
+    const normalized = withSupabaseCookieDefaults({}, context)
+
+    expect(context.secure).toBe(false)
+    expect(normalized.secure).toBe(false)
+  })
+
+  it('prefers configured domains over derived hosts', () => {
+    const context = computeCookieSecurityContext({
+      envDomain: '.roomsily.com',
+      host: 'sub.roomsily.com',
+      protocol: 'https',
+    })
+
+    const normalized = withSupabaseCookieDefaults(
+      { domain: 'ignored.roomsily.com' },
+      context,
+    )
+
+    expect(context.domain).toBe('.roomsily.com')
+    expect(normalized.domain).toBe('.roomsily.com')
+  })
+
+  it('derives domains from forwarded host headers', () => {
+    const context = computeCookieSecurityContext({
+      forwardedHost: 'api.roomsily.com:8443',
+      protocol: 'https',
+    })
+
+    expect(context.domain).toBe('api.roomsily.com')
+    expect(context.secure).toBe(true)
+  })
+})

--- a/utils/supa-server-actions.ts
+++ b/utils/supa-server-actions.ts
@@ -1,7 +1,17 @@
 import { type CookieOptions, createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import {
+  getSupabaseCookieSecurityContext,
+  withSupabaseCookieDefaults,
+} from '@/utils/supabase/cookie-helpers'
+
 export function createClient(cookieStore: ReturnType<typeof cookies>) {
+  const securityContext = getSupabaseCookieSecurityContext()
+
+  const applyCookieDefaults = (options: CookieOptions) =>
+    withSupabaseCookieDefaults(options, securityContext)
+
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL || '',
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
@@ -11,10 +21,12 @@ export function createClient(cookieStore: ReturnType<typeof cookies>) {
           return cookieStore.get(name)?.value
         },
         set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options })
+          const normalized = applyCookieDefaults(options)
+          cookieStore.set({ name, value, ...normalized })
         },
         remove(name: string, options: CookieOptions) {
-          cookieStore.set({ name, value: '', ...options })
+          const normalized = applyCookieDefaults(options)
+          cookieStore.set({ name, value: '', ...normalized })
         },
       },
     }

--- a/utils/supabase/actions.ts
+++ b/utils/supabase/actions.ts
@@ -4,8 +4,16 @@ import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import type { Database } from '@/lib/supabase';
 
+import {
+  getSupabaseCookieSecurityContext,
+  withSupabaseCookieDefaults,
+} from '@/utils/supabase/cookie-helpers';
+
 export async function createActionClient() {
   const cookieStore = cookies();
+  const securityContext = getSupabaseCookieSecurityContext();
+  const applyCookieDefaults = (options: CookieOptions) =>
+    withSupabaseCookieDefaults(options, securityContext);
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -16,10 +24,12 @@ export async function createActionClient() {
           return cookieStore.get(name)?.value;
         },
         set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options });
+          const normalized = applyCookieDefaults(options);
+          cookieStore.set({ name, value, ...normalized });
         },
         remove(name: string, options: CookieOptions) {
-          cookieStore.set({ name, value: '', ...options });
+          const normalized = applyCookieDefaults(options);
+          cookieStore.set({ name, value: '', ...normalized });
         },
       },
     }

--- a/utils/supabase/cookie-helpers.ts
+++ b/utils/supabase/cookie-helpers.ts
@@ -1,0 +1,258 @@
+import { type CookieOptions } from '@supabase/ssr'
+import { headers } from 'next/headers'
+
+const LOOPBACK_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '::1',
+  '0:0:0:0:0:0:0:1',
+])
+
+export interface CookieSecurityContext {
+  domain?: string
+  secure: boolean
+}
+
+export interface CookieSecurityInput {
+  allowInsecure?: boolean
+  defaultSecure?: boolean
+  envDomain?: string | null
+  forwardedHost?: string | null
+  host?: string | null
+  protocol?: string | null
+}
+
+export function getSupabaseCookieSecurityContext(): CookieSecurityContext {
+  const headerList = headers()
+  const forwardedHost = headerList.get('x-forwarded-host')
+  const host = headerList.get('host')
+  const protocol = headerList.get('x-forwarded-proto')
+
+  return computeCookieSecurityContext({
+    envDomain: process.env.SUPABASE_COOKIE_DOMAIN,
+    forwardedHost,
+    host,
+    protocol,
+    allowInsecure: process.env.SUPABASE_ALLOW_INSECURE_COOKIES === 'true',
+    defaultSecure: process.env.NODE_ENV !== 'development',
+  })
+}
+
+export function computeCookieSecurityContext(
+  input: CookieSecurityInput,
+): CookieSecurityContext {
+  const envDomain = sanitizeDomainInput(input.envDomain)
+  const hostCandidate = sanitizeHostname(
+    input.forwardedHost ? input.forwardedHost : input.host,
+  )
+  const hostname = envDomain ?? hostCandidate
+
+  const resolvedDomain = resolveDomain(envDomain, hostCandidate)
+  const secure = resolveSecureFlag({
+    allowInsecure: input.allowInsecure,
+    candidateHost: hostname,
+    defaultSecure: input.defaultSecure,
+    protocol: input.protocol,
+  })
+
+  return {
+    domain: resolvedDomain,
+    secure,
+  }
+}
+
+export function withSupabaseCookieDefaults(
+  options: CookieOptions,
+  context: CookieSecurityContext,
+): CookieOptions {
+  const normalizedSameSite = normalizeSameSite(options.sameSite)
+  const sanitizedDomain = resolveDomain(
+    context.domain,
+    sanitizeDomainInput(options.domain),
+  )
+
+  const normalized: CookieOptions = {
+    ...options,
+    httpOnly: true,
+    sameSite: normalizedSameSite,
+    secure: context.secure,
+  }
+
+  if (sanitizedDomain) {
+    normalized.domain = sanitizedDomain
+  } else {
+    delete normalized.domain
+  }
+
+  return normalized
+}
+
+function resolveDomain(
+  preferred: string | undefined,
+  fallback: string | undefined,
+): string | undefined {
+  if (preferred && !isLocalHost(preferred)) {
+    return preferred
+  }
+
+  if (fallback && !isLocalHost(fallback)) {
+    return fallback
+  }
+
+  return undefined
+}
+
+function resolveSecureFlag({
+  allowInsecure,
+  candidateHost,
+  defaultSecure,
+  protocol,
+}: {
+  allowInsecure?: boolean
+  candidateHost?: string
+  defaultSecure?: boolean
+  protocol?: string | null
+}): boolean {
+  if (allowInsecure) {
+    return false
+  }
+
+  const normalizedProtocol = normalizeProtocol(protocol)
+
+  if (normalizedProtocol) {
+    return normalizedProtocol === 'https'
+  }
+
+  if (candidateHost) {
+    return !isLocalHost(candidateHost)
+  }
+
+  return defaultSecure ?? true
+}
+
+function normalizeProtocol(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const first = value.split(',')[0]?.trim().toLowerCase()
+
+  if (!first) {
+    return undefined
+  }
+
+  return first.endsWith(':') ? first.slice(0, -1) : first
+}
+
+function normalizeSameSite(
+  sameSite: CookieOptions['sameSite'],
+): 'lax' | 'strict' {
+  if (typeof sameSite === 'string') {
+    const normalized = sameSite.toLowerCase()
+    if (normalized === 'strict') {
+      return 'strict'
+    }
+    if (normalized === 'lax') {
+      return 'lax'
+    }
+  }
+
+  return 'lax'
+}
+
+function sanitizeDomainInput(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return undefined
+  }
+
+  if (trimmed.startsWith('.')) {
+    return trimmed
+  }
+
+  if (trimmed.includes('://')) {
+    try {
+      return new URL(trimmed).hostname || undefined
+    } catch {
+      // fall through to manual parsing
+    }
+  }
+
+  if (trimmed.startsWith('[') && trimmed.includes(']')) {
+    return trimmed.slice(1, trimmed.indexOf(']'))
+  }
+
+  if (trimmed.includes(':') && trimmed.includes('.')) {
+    return trimmed.slice(0, trimmed.indexOf(':'))
+  }
+
+  return trimmed
+}
+
+function sanitizeHostname(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const first = value.split(',')[0]?.trim()
+
+  if (!first) {
+    return undefined
+  }
+
+  if (first.includes('://')) {
+    try {
+      return new URL(first).hostname || undefined
+    } catch {
+      // fall through to manual parsing
+    }
+  }
+
+  if (first.startsWith('[') && first.includes(']')) {
+    return first.slice(1, first.indexOf(']'))
+  }
+
+  if (first.startsWith('.')) {
+    return first
+  }
+
+  if (first.includes(':') && first.includes('.')) {
+    return first.slice(0, first.indexOf(':'))
+  }
+
+  return first
+}
+
+function isLocalHost(host?: string): boolean {
+  if (!host) {
+    return false
+  }
+
+  const normalized = host.startsWith('.') ? host.slice(1) : host
+  const lower = normalized.toLowerCase()
+
+  if (LOOPBACK_HOSTNAMES.has(lower)) {
+    return true
+  }
+
+  if (lower.endsWith('.local')) {
+    return true
+  }
+
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(lower)) {
+    return true
+  }
+
+  if (lower.includes(':') && !lower.includes('.')) {
+    // Treat bare IPv6 hosts as local/loopback to avoid invalid cookie domains
+    return true
+  }
+
+  return false
+}

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,8 +1,14 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import {
+  getSupabaseCookieSecurityContext,
+  withSupabaseCookieDefaults,
+} from '@/utils/supabase/cookie-helpers'
+
 export function createClient() {
   const cookieStore = cookies()
+  const securityContext = getSupabaseCookieSecurityContext()
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -14,7 +20,11 @@ export function createClient() {
         },
         set(name: string, value: string, options: CookieOptions) {
           try {
-            cookieStore.set({ name, value, ...options })
+            const normalized = withSupabaseCookieDefaults(
+              options,
+              securityContext,
+            )
+            cookieStore.set({ name, value, ...normalized })
           } catch (error) {
             // The `set` method was called from a Server Component.
             // This can be ignored if you have middleware refreshing
@@ -23,7 +33,11 @@ export function createClient() {
         },
         remove(name: string, options: CookieOptions) {
           try {
-            cookieStore.set({ name, value: '', ...options })
+            const normalized = withSupabaseCookieDefaults(
+              options,
+              securityContext,
+            )
+            cookieStore.set({ name, value: '', ...normalized })
           } catch (error) {
             // The `delete` method was called from a Server Component.
             // This can be ignored if you have middleware refreshing

--- a/utils/supaone.tsx
+++ b/utils/supaone.tsx
@@ -3,6 +3,11 @@ import { cookies } from "next/headers";
 import type { Database } from '@/lib/supabase'
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
 
+import {
+  getSupabaseCookieSecurityContext,
+  withSupabaseCookieDefaults,
+} from '@/utils/supabase/cookie-helpers'
+
 export async function createSupbaseServerClientReadOnly() {
 	const cookieStore = cookies();
 
@@ -20,23 +25,28 @@ export async function createSupbaseServerClientReadOnly() {
 }
 
 export async function createSupbaseServerClient() {
-	const cookieStore = cookies();
+        const cookieStore = cookies();
+        const securityContext = getSupabaseCookieSecurityContext();
+        const applyCookieDefaults = (options: CookieOptions) =>
+                withSupabaseCookieDefaults(options, securityContext);
 
-	return createServerClient<Database>(
-		process.env.NEXT_PUBLIC_SUPABASE_URL!,
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-		{
-			cookies: {
-				get(name: string) {
-					return cookieStore.get(name)?.value;
-				},
-				set(name: string, value: string, options: CookieOptions) {
-					cookieStore.set({ name, value, ...options });
-				},
-				remove(name: string, options: CookieOptions) {
-					cookieStore.set({ name, value: "", ...options });
-				},
-			},
-		}
-	);
+        return createServerClient<Database>(
+                process.env.NEXT_PUBLIC_SUPABASE_URL!,
+                process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+                {
+                        cookies: {
+                                get(name: string) {
+                                        return cookieStore.get(name)?.value;
+                                },
+                                set(name: string, value: string, options: CookieOptions) {
+                                        const normalized = applyCookieDefaults(options);
+                                        cookieStore.set({ name, value, ...normalized });
+                                },
+                                remove(name: string, options: CookieOptions) {
+                                        const normalized = applyCookieDefaults(options);
+                                        cookieStore.set({ name, value: "", ...normalized });
+                                },
+                        },
+                }
+        );
 }


### PR DESCRIPTION
## Summary
- wrap Supabase cookie adapters with a shared helper that enforces Secure, HttpOnly, SameSite, and domain defaults
- update middleware and server-side clients to apply the new cookie policies and document the environment overrides for development
- add Vitest coverage that asserts the helper produces the required cookie flags across production and local scenarios

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d1b631bdd8832897d87bd31036639f