### PR TITLE
Protect payment API routes with Supabase role checks

### DIFF
--- a/app/api/payments/receipt/route.ts
+++ b/app/api/payments/receipt/route.ts
@@ -1,4 +1,5 @@
 import { PaymentReceiptEmail } from '@/components/emails/payment-receipt';
+import { authenticatePaymentRequest } from '@/lib/payments/permissions';
 import { Resend } from 'resend';
 import { z } from 'zod';
 
@@ -28,6 +29,11 @@ const paymentReceiptSchema = z.object({
 });
 
 export async function POST(request: Request) {
+  const authResult = await authenticatePaymentRequest()
+  if (!authResult.success) {
+    return authResult.response
+  }
+
   const resendApiKey = process.env.RESEND_API_KEY;
   if (!resendApiKey) {
     return Response.json(

--- a/app/api/stripe/billing-portal/route.ts
+++ b/app/api/stripe/billing-portal/route.ts
@@ -1,8 +1,15 @@
 import { NextRequest } from "next/server"
+
+import { authenticatePaymentRequest } from "@/lib/payments/permissions"
 import { getStripe, getAppBaseUrl } from "@/lib/stripe"
 
 export async function POST(req: NextRequest) {
   try {
+    const authResult = await authenticatePaymentRequest()
+    if (!authResult.success) {
+      return authResult.response
+    }
+
     const stripe = getStripe()
     const { customerId } = await req.json()
     if (!customerId || typeof customerId !== "string") {

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -1,10 +1,23 @@
 import { NextRequest } from "next/server"
+
+import { authenticatePaymentRequest } from "@/lib/payments/permissions"
 import { getStripe, getAppBaseUrl } from "@/lib/stripe"
 
 export async function POST(req: NextRequest) {
   try {
+    const authResult = await authenticatePaymentRequest()
+    if (!authResult.success) {
+      return authResult.response
+    }
+
     const stripe = getStripe()
-    const { priceId, quantity = 1, mode = "payment", metadata } = await req.json()
+    const body = await req.json()
+    const {
+      priceId,
+      quantity = 1,
+      mode = "payment",
+      metadata,
+    } = body ?? {}
 
     if (!priceId || typeof priceId !== "string") {
       return Response.json({ error: "priceId is required" }, { status: 400 })

--- a/lib/payments/permissions.ts
+++ b/lib/payments/permissions.ts
@@ -1,0 +1,70 @@
+import type { User } from "@supabase/supabase-js"
+
+import { fetchMemberRole, type MemberRole } from "@/lib/data/members"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+import { createClient } from "@/utils/supabase/server"
+
+export const DEFAULT_PAYMENT_ALLOWED_ROLES: MemberRole[] = [
+  "tenant",
+  "roommate",
+  "property_manager",
+  "admin",
+]
+
+type AuthSuccess = {
+  success: true
+  user: User
+  role: MemberRole
+}
+
+type AuthFailure = {
+  success: false
+  response: Response
+}
+
+export async function authenticatePaymentRequest(
+  allowedRoles: MemberRole[] = DEFAULT_PAYMENT_ALLOWED_ROLES,
+): Promise<AuthSuccess | AuthFailure> {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return {
+      success: false,
+      response: Response.json({ error: "Unauthorized" }, { status: 401 }),
+    }
+  }
+
+  let role: MemberRole | null = null
+  try {
+    role = await fetchMemberRole(
+      supabase as unknown as TypedSupabaseClient,
+      user.id,
+    )
+  } catch (error) {
+    console.error("Failed to resolve member role", error)
+    return {
+      success: false,
+      response: Response.json(
+        { error: "Unable to verify permissions" },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!role || !allowedRoles.includes(role)) {
+    return {
+      success: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    }
+  }
+
+  return {
+    success: true,
+    user,
+    role,
+  }
+}

--- a/tests/app/api/payments/guards.test.ts
+++ b/tests/app/api/payments/guards.test.ts
@@ -1,0 +1,119 @@
+import type { NextRequest } from "next/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  authenticatePaymentRequestMock,
+  stripeCheckoutCreateMock,
+  stripeBillingPortalCreateMock,
+  getStripeMock,
+  getAppBaseUrlMock,
+} = vi.hoisted(() => {
+  const authenticatePaymentRequestMock = vi.fn()
+  const stripeCheckoutCreateMock = vi.fn()
+  const stripeBillingPortalCreateMock = vi.fn()
+  const getStripeMock = vi.fn(() => ({
+    checkout: { sessions: { create: stripeCheckoutCreateMock } },
+    billingPortal: { sessions: { create: stripeBillingPortalCreateMock } },
+  }))
+  const getAppBaseUrlMock = vi.fn(() => "http://localhost:3000")
+
+  return {
+    authenticatePaymentRequestMock,
+    stripeCheckoutCreateMock,
+    stripeBillingPortalCreateMock,
+    getStripeMock,
+    getAppBaseUrlMock,
+  }
+})
+
+vi.mock("@/lib/payments/permissions", () => ({
+  authenticatePaymentRequest: authenticatePaymentRequestMock,
+}))
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: getStripeMock,
+  getAppBaseUrl: getAppBaseUrlMock,
+}))
+
+import { POST as checkoutPost } from "@/app/api/stripe/checkout/route"
+import { POST as billingPortalPost } from "@/app/api/stripe/billing-portal/route"
+import { POST as receiptPost } from "@/app/api/payments/receipt/route"
+
+describe("payment API guards", () => {
+  beforeEach(() => {
+    authenticatePaymentRequestMock.mockReset()
+    stripeCheckoutCreateMock.mockReset()
+    stripeBillingPortalCreateMock.mockReset()
+    getStripeMock.mockClear()
+    getAppBaseUrlMock.mockClear()
+  })
+
+  it("propagates unauthorized responses from the checkout guard", async () => {
+    const unauthorizedResponse = Response.json({ error: "Unauthorized" }, {
+      status: 401,
+    })
+    authenticatePaymentRequestMock.mockResolvedValueOnce({
+      success: false,
+      response: unauthorizedResponse,
+    })
+
+    const jsonMock = vi.fn()
+    const request = { json: jsonMock } as unknown as NextRequest
+    const response = await checkoutPost(request)
+
+    expect(response).toBe(unauthorizedResponse)
+    expect(getStripeMock).not.toHaveBeenCalled()
+    expect(jsonMock).not.toHaveBeenCalled()
+  })
+
+  it("propagates forbidden responses from the checkout guard", async () => {
+    const forbiddenResponse = Response.json({ error: "Forbidden" }, { status: 403 })
+    authenticatePaymentRequestMock.mockResolvedValueOnce({
+      success: false,
+      response: forbiddenResponse,
+    })
+
+    const jsonMock = vi.fn()
+    const request = { json: jsonMock } as unknown as NextRequest
+    const response = await checkoutPost(request)
+
+    expect(response).toBe(forbiddenResponse)
+    expect(getStripeMock).not.toHaveBeenCalled()
+    expect(jsonMock).not.toHaveBeenCalled()
+  })
+
+  it("prevents billing portal access when authentication fails", async () => {
+    const unauthorizedResponse = Response.json({ error: "Unauthorized" }, {
+      status: 401,
+    })
+    authenticatePaymentRequestMock.mockResolvedValueOnce({
+      success: false,
+      response: unauthorizedResponse,
+    })
+
+    const jsonMock = vi.fn()
+    const request = { json: jsonMock } as unknown as NextRequest
+    const response = await billingPortalPost(request)
+
+    expect(response).toBe(unauthorizedResponse)
+    expect(getStripeMock).not.toHaveBeenCalled()
+    expect(jsonMock).not.toHaveBeenCalled()
+  })
+
+  it("prevents receipt generation when authentication fails", async () => {
+    const unauthorizedResponse = Response.json({ error: "Unauthorized" }, {
+      status: 401,
+    })
+    authenticatePaymentRequestMock.mockResolvedValueOnce({
+      success: false,
+      response: unauthorizedResponse,
+    })
+
+    const jsonMock = vi.fn()
+    const request = { json: jsonMock } as unknown as Request
+    const response = await receiptPost(request)
+
+    expect(response).toBe(unauthorizedResponse)
+    expect(jsonMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/payments/permissions.test.ts
+++ b/tests/lib/payments/permissions.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  getUserMock,
+  supabaseMock,
+  createClientMock,
+  fetchMemberRoleMock,
+} = vi.hoisted(() => {
+  const getUserMock = vi.fn()
+  const supabaseMock = {
+    auth: {
+      getUser: getUserMock,
+    },
+  }
+
+  const createClientMock = vi.fn(() => supabaseMock)
+  const fetchMemberRoleMock = vi.fn()
+
+  return { getUserMock, supabaseMock, createClientMock, fetchMemberRoleMock }
+})
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: createClientMock,
+}))
+
+vi.mock("@/lib/data/members", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/data/members")
+  >("@/lib/data/members")
+  return {
+    ...actual,
+    fetchMemberRole: fetchMemberRoleMock,
+  }
+})
+
+import { authenticatePaymentRequest } from "@/lib/payments/permissions"
+
+describe("authenticatePaymentRequest", () => {
+  beforeEach(() => {
+    getUserMock.mockReset()
+    fetchMemberRoleMock.mockReset()
+    createClientMock.mockClear()
+  })
+
+  it("returns 401 when no authenticated user is found", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null })
+
+    const result = await authenticatePaymentRequest()
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.response.status).toBe(401)
+      expect(await result.response.json()).toEqual({ error: "Unauthorized" })
+    }
+    expect(fetchMemberRoleMock).not.toHaveBeenCalled()
+  })
+
+  it("returns 403 when the member role is not permitted", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    })
+    fetchMemberRoleMock.mockResolvedValueOnce("user")
+
+    const result = await authenticatePaymentRequest()
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.response.status).toBe(403)
+      expect(await result.response.json()).toEqual({ error: "Forbidden" })
+    }
+  })
+
+  it("returns 500 when role resolution fails", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "user-456" } },
+      error: null,
+    })
+    const error = new Error("Database offline")
+    fetchMemberRoleMock.mockRejectedValueOnce(error)
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {})
+
+    const result = await authenticatePaymentRequest()
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.response.status).toBe(500)
+      expect(await result.response.json()).toEqual({
+        error: "Unable to verify permissions",
+      })
+    }
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to resolve member role",
+      error,
+    )
+    consoleErrorSpy.mockRestore()
+  })
+
+  it("returns the authenticated user and role when authorized", async () => {
+    const user = { id: "user-789" }
+    getUserMock.mockResolvedValue({
+      data: { user },
+      error: null,
+    })
+    fetchMemberRoleMock.mockResolvedValueOnce("tenant")
+
+    const result = await authenticatePaymentRequest()
+
+    expect(result).toEqual({
+      success: true,
+      user,
+      role: "tenant",
+    })
+    expect(fetchMemberRoleMock).toHaveBeenCalledWith(supabaseMock, user.id)
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared payment authorization helper that loads the Supabase user and validates allowed roles
- gate the Stripe checkout, billing portal, and payment receipt APIs behind the new guard
- cover unauthorized paths with unit tests for the helper and API handlers

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b62e7f688328a87565e37460143c