### PR TITLE
Add Supabase schema foundations and automated bootstrap

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -11,7 +11,7 @@ Error: Could not find the table 'public.documents' in the schema cache
 
 **Issue**: Your Supabase database is missing the required tables.
 
-**Solution**: You need to run the database migrations or create the tables manually.
+**Solution**: Apply the Supabase migrations via the CLI (`pnpm db:bootstrap`) so the schema defined in `supabase/migrations/` is created for you.
 
 ### 2. **DOCUMENSO API KEY**
 ```
@@ -117,30 +117,19 @@ RESEND_API_KEY="re_your_resend_api_key"
 
 ## 🗄️ **DATABASE SETUP**
 
-You also need to create the missing database tables in Supabase:
+All tables live in versioned SQL files under `supabase/migrations/`. After installing the [Supabase CLI](https://supabase.com/docs/guides/cli), run the project bootstrap script to apply every migration and load the demo seed data:
 
-```sql
--- Documents table
-CREATE TABLE public.documents (
-  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-  title TEXT NOT NULL,
-  description TEXT,
-  file_url TEXT,
-  file_type TEXT,
-  file_size INTEGER,
-  uploaded_by UUID REFERENCES auth.users(id),
-  uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-);
-
--- Add more tables as needed for your application
+```bash
+pnpm db:bootstrap
 ```
+
+This command executes `supabase db push` (optionally using `SUPABASE_DB_URL` if you need to target a remote instance) and then seeds from `supabase/demo/seed.sql`. Use `pnpm db:push` any time you want to re-run just the migrations without seeding.
 
 ## 🚀 **QUICK START**
 
 1. Copy this template to `.env.local`
 2. Fill in your actual API keys
-3. Run database migrations or create tables manually in Supabase
+3. Run `pnpm db:bootstrap` to apply the Supabase migrations
 4. Restart your development server: `npm run dev`
 
 ## ⚠️ **SECURITY NOTES**

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -17,6 +17,20 @@ type SupabaseTable<Row extends Record<string, unknown>> = {
 export type Database = {
   public: {
     Tables: {
+      units: SupabaseTable<{
+        id: string
+        created_at: string | null
+        updated_at: string | null
+        building_id: string | null
+        unit_number: string
+        name: string | null
+        description: string | null
+        bedrooms: number | null
+        bathrooms: number | null
+        square_feet: number | null
+        rent_cents: number | null
+        metadata: Json | null
+      }>,
       profiles: SupabaseTable<{
         id: string
         created_at: string | null
@@ -33,7 +47,36 @@ export type Database = {
         stripe_customer_id: string | null
         rent_share: number | null
         metadata: Json | null
-      }>
+      }>,
+      amenities: SupabaseTable<{
+        id: string
+        created_at: string | null
+        updated_at: string | null
+        unit_id: string | null
+        building_id: string | null
+        name: string
+        description: string | null
+        location: string | null
+        capacity: number | null
+        requires_approval: boolean
+        metadata: Json | null
+      }>,
+      bookings: SupabaseTable<{
+        id: string
+        created_at: string | null
+        updated_at: string | null
+        amenity_id: string
+        unit_id: string | null
+        building_id: string | null
+        start_time: string
+        end_time: string
+        status: 'pending' | 'approved' | 'rejected' | 'cancelled' | 'completed'
+        created_by: string
+        approved_by: string | null
+        notes: string | null
+        recurrence_rule: string | null
+        metadata: Json | null
+      }>,
       documents: SupabaseTable<{
         id: string
         created_at: string | null
@@ -198,7 +241,29 @@ export type Database = {
         read: boolean | null
         created_at: string | null
         updated_at: string | null
-      }>
+      }>,
+      threads: SupabaseTable<{
+        id: string
+        created_at: string | null
+        updated_at: string | null
+        unit_id: string | null
+        title: string
+        created_by: string
+        status: 'open' | 'locked' | 'archived'
+        pinned: boolean
+        metadata: Json | null
+      }>,
+      messages: SupabaseTable<{
+        id: string
+        created_at: string | null
+        updated_at: string | null
+        thread_id: string
+        sender_id: string
+        content: string
+        message_type: 'message' | 'announcement' | 'system'
+        attachments: Json | null
+        metadata: Json | null
+      }>,
       email_notifications: SupabaseTable<{
         id: string
         user_id: string | null
@@ -209,7 +274,30 @@ export type Database = {
         sent_at: string | null
         error_message: string | null
         metadata: Json | null
-      }>
+      }>,
+      floorplans: SupabaseTable<{
+        id: string
+        created_at: string | null
+        updated_at: string | null
+        unit_id: string | null
+        name: string
+        description: string | null
+        svg_url: string
+        created_by: string | null
+        metadata: Json | null
+      }>,
+      floorplan_annotations: SupabaseTable<{
+        id: string
+        created_at: string | null
+        updated_at: string | null
+        floorplan_id: string
+        created_by: string
+        label: string
+        description: string | null
+        coordinates: Json
+        color: string | null
+        metadata: Json | null
+      }>,
       meetings: SupabaseTable<{
         id: string
         user_id: string

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "css:purge": "node scripts/check-css-size.mjs"
+    "css:purge": "node scripts/check-css-size.mjs",
+    "db:push": "supabase db push",
+    "db:bootstrap": "node scripts/bootstrap-supabase.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/scripts/bootstrap-supabase.mjs
+++ b/scripts/bootstrap-supabase.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const supabaseCli = process.env.SUPABASE_CLI_PATH || 'supabase';
+const dbUrl = process.env.SUPABASE_DB_URL;
+const shouldSeed = process.env.SUPABASE_SKIP_SEED !== 'true';
+const seedFile = resolve(process.cwd(), process.env.SUPABASE_SEED_FILE ?? 'supabase/demo/seed.sql');
+
+function runSupabaseCommand(args) {
+  const result = spawnSync(supabaseCli, args, {
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      console.error(`Supabase CLI not found at \"${supabaseCli}\". Install it from https://supabase.com/docs/guides/cli.`);
+      process.exit(1);
+    }
+
+    console.error(result.error);
+    process.exit(1);
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+const pushArgs = ['db', 'push'];
+if (dbUrl) {
+  pushArgs.push('--db-url', dbUrl);
+}
+
+console.log('Applying Supabase migrations...');
+runSupabaseCommand(pushArgs);
+
+if (shouldSeed && existsSync(seedFile)) {
+  console.log(`Seeding database with ${seedFile}...`);
+  runSupabaseCommand(['db', 'seed', '--file', seedFile]);
+} else if (shouldSeed) {
+  console.warn(`Seed file not found at ${seedFile}. Skipping seeding step.`);
+} else {
+  console.log('Skipping seeding step because SUPABASE_SKIP_SEED is set to true.');
+}

--- a/supabase/migrations/20240101_core_foundations.sql
+++ b/supabase/migrations/20240101_core_foundations.sql
@@ -1,0 +1,911 @@
+-- Core schema foundations for Roomsily domain objects.
+-- This migration runs before other feature-specific migrations so later files
+-- can safely reference these tables, policies, and helper functions.
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY INVOKER;
+
+-- ------------------------------------------------------------
+-- Households keep shared chores scoped to a group of roommates.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.households (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.households ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'households'
+      AND policyname = 'Authenticated users can view households'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Authenticated users can view households"
+      ON public.households
+      FOR SELECT
+      USING (auth.uid() IS NOT NULL);$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_households_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_households_updated_at
+      BEFORE UPDATE ON public.households
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------
+-- Units represent an individual rentable space inside a building.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.units (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  building_id UUID,
+  unit_number TEXT NOT NULL,
+  name TEXT,
+  description TEXT,
+  bedrooms SMALLINT,
+  bathrooms SMALLINT,
+  square_feet INTEGER,
+  rent_cents INTEGER,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.units ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_units_building_id ON public.units(building_id);
+CREATE INDEX IF NOT EXISTS idx_units_unit_number ON public.units(unit_number);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_units_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_units_updated_at
+      BEFORE UPDATE ON public.units
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------
+-- Profiles extend auth.users with tenant specific metadata.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  email TEXT UNIQUE,
+  full_name TEXT,
+  username TEXT UNIQUE,
+  website TEXT,
+  avatar_url TEXT,
+  role TEXT NOT NULL DEFAULT 'tenant' CHECK (role IN ('tenant', 'roommate', 'property_manager', 'admin', 'user')),
+  unit_id UUID REFERENCES public.units(id) ON DELETE SET NULL,
+  phone TEXT,
+  language TEXT,
+  stripe_customer_id TEXT,
+  rent_share NUMERIC(5,2),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profiles'
+      AND policyname = 'Users can view their profile'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Users can view their profile"
+      ON public.profiles
+      FOR SELECT
+      USING (auth.uid() = id OR EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profiles'
+      AND policyname = 'Users can modify their profile'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Users can modify their profile"
+      ON public.profiles
+      FOR INSERT
+      WITH CHECK (auth.uid() = id);$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profiles'
+      AND policyname = 'Users can update their profile'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Users can update their profile"
+      ON public.profiles
+      FOR UPDATE
+      USING (auth.uid() = id)
+      WITH CHECK (auth.uid() = id);$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profiles'
+      AND policyname = 'Property staff manage profiles'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff manage profiles"
+      ON public.profiles
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS idx_profiles_unit_id ON public.profiles(unit_id);
+CREATE INDEX IF NOT EXISTS idx_profiles_unit_role ON public.profiles(unit_id, role);
+CREATE INDEX IF NOT EXISTS idx_profiles_email ON public.profiles(email);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_profiles_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_profiles_updated_at
+      BEFORE UPDATE ON public.profiles
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+-- Policies that rely on profiles for household and unit access
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'households'
+      AND policyname = 'Property staff manage households'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff manage households"
+      ON public.households
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'units'
+      AND policyname = 'Members can view their unit'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can view their unit"
+      ON public.units
+      FOR SELECT
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND (p.role IN ('property_manager', 'admin') OR p.unit_id = units.id)
+      ));$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'units'
+      AND policyname = 'Property staff manage units'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff manage units"
+      ON public.units
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------
+-- Amenities and bookings orchestrate shared resource usage.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.amenities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  unit_id UUID REFERENCES public.units(id) ON DELETE SET NULL,
+  building_id UUID,
+  name TEXT NOT NULL,
+  description TEXT,
+  location TEXT,
+  capacity INTEGER,
+  requires_approval BOOLEAN NOT NULL DEFAULT FALSE,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.amenities ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_amenities_unit_id ON public.amenities(unit_id);
+CREATE INDEX IF NOT EXISTS idx_amenities_building_id ON public.amenities(building_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_amenities_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_amenities_updated_at
+      BEFORE UPDATE ON public.amenities
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'amenities'
+      AND policyname = 'Members can view amenities'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can view amenities"
+      ON public.amenities
+      FOR SELECT
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND (p.role IN ('property_manager', 'admin') OR p.unit_id = amenities.unit_id)
+      ));$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'amenities'
+      AND policyname = 'Property staff manage amenities'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff manage amenities"
+      ON public.amenities
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS public.bookings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  amenity_id UUID NOT NULL REFERENCES public.amenities(id) ON DELETE CASCADE,
+  unit_id UUID REFERENCES public.units(id) ON DELETE SET NULL,
+  building_id UUID,
+  start_time TIMESTAMPTZ NOT NULL,
+  end_time TIMESTAMPTZ NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled', 'completed')),
+  created_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  approved_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  notes TEXT,
+  recurrence_rule TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.bookings ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_bookings_building_start_time ON public.bookings(building_id, start_time DESC);
+CREATE INDEX IF NOT EXISTS idx_bookings_amenity_time_window ON public.bookings(amenity_id, start_time DESC);
+CREATE INDEX IF NOT EXISTS idx_bookings_creator_status ON public.bookings(created_by, status, start_time DESC);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_bookings_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_bookings_updated_at
+      BEFORE UPDATE ON public.bookings
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'bookings'
+      AND policyname = 'Members can view bookings they are involved with'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can view bookings they are involved with"
+      ON public.bookings
+      FOR SELECT
+      USING (
+        auth.uid() = created_by
+        OR EXISTS (
+          SELECT 1 FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND (p.role IN ('property_manager', 'admin') OR p.unit_id = bookings.unit_id)
+        )
+      );$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'bookings'
+      AND policyname = 'Members can create bookings'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can create bookings"
+      ON public.bookings
+      FOR INSERT
+      WITH CHECK (auth.uid() = created_by);$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'bookings'
+      AND policyname = 'Members can update their bookings'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can update their bookings"
+      ON public.bookings
+      FOR UPDATE
+      USING (auth.uid() = created_by)
+      WITH CHECK (auth.uid() = created_by);$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'bookings'
+      AND policyname = 'Property staff manage bookings'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff manage bookings"
+      ON public.bookings
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------
+-- Messaging system for roommate collaboration.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.threads (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  unit_id UUID REFERENCES public.units(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  created_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'locked', 'archived')),
+  pinned BOOLEAN NOT NULL DEFAULT FALSE,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.threads ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_threads_unit_id ON public.threads(unit_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_threads_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_threads_updated_at
+      BEFORE UPDATE ON public.threads
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'threads'
+      AND policyname = 'Members can view unit threads'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can view unit threads"
+      ON public.threads
+      FOR SELECT
+      USING (
+        EXISTS (
+          SELECT 1 FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND (p.role IN ('property_manager', 'admin') OR p.unit_id = threads.unit_id)
+        )
+      );$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'threads'
+      AND policyname = 'Members can create threads'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can create threads"
+      ON public.threads
+      FOR INSERT
+      WITH CHECK (
+        auth.uid() = created_by
+        AND EXISTS (
+          SELECT 1 FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND (p.role IN ('property_manager', 'admin') OR p.unit_id = threads.unit_id)
+        )
+      );$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'threads'
+      AND policyname = 'Members can update their threads'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can update their threads"
+      ON public.threads
+      FOR UPDATE
+      USING (auth.uid() = created_by)
+      WITH CHECK (auth.uid() = created_by);$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'threads'
+      AND policyname = 'Property staff manage threads'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff manage threads"
+      ON public.threads
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS public.messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  thread_id UUID NOT NULL REFERENCES public.threads(id) ON DELETE CASCADE,
+  sender_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  message_type TEXT NOT NULL DEFAULT 'message' CHECK (message_type IN ('message', 'announcement', 'system')),
+  attachments JSONB NOT NULL DEFAULT '[]'::jsonb,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.messages ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_messages_thread_id_created_at ON public.messages(thread_id, created_at);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_messages_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_messages_updated_at
+      BEFORE UPDATE ON public.messages
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'messages'
+      AND policyname = 'Members can view thread messages'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can view thread messages"
+      ON public.messages
+      FOR SELECT
+      USING (EXISTS (
+        SELECT 1
+        FROM public.threads t
+        JOIN public.profiles p ON p.id = auth.uid()
+        WHERE t.id = messages.thread_id
+          AND (p.role IN ('property_manager', 'admin') OR p.unit_id = t.unit_id)
+      ));$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'messages'
+      AND policyname = 'Members can post messages'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can post messages"
+      ON public.messages
+      FOR INSERT
+      WITH CHECK (
+        auth.uid() = sender_id AND EXISTS (
+          SELECT 1
+          FROM public.threads t
+          JOIN public.profiles p ON p.id = auth.uid()
+          WHERE t.id = messages.thread_id
+            AND (p.role IN ('property_manager', 'admin') OR p.unit_id = t.unit_id)
+        )
+      );$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'messages'
+      AND policyname = 'Members can edit their messages'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can edit their messages"
+      ON public.messages
+      FOR UPDATE
+      USING (auth.uid() = sender_id)
+      WITH CHECK (auth.uid() = sender_id);$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'messages'
+      AND policyname = 'Property staff moderate messages'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff moderate messages"
+      ON public.messages
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------
+-- Floorplans with roommate-specific annotations.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.floorplans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  unit_id UUID REFERENCES public.units(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  svg_url TEXT NOT NULL,
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.floorplans ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_floorplans_unit_id ON public.floorplans(unit_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_floorplans_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_floorplans_updated_at
+      BEFORE UPDATE ON public.floorplans
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'floorplans'
+      AND policyname = 'Members can view floorplans'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can view floorplans"
+      ON public.floorplans
+      FOR SELECT
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND (p.role IN ('property_manager', 'admin') OR p.unit_id = floorplans.unit_id)
+      ));$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'floorplans'
+      AND policyname = 'Property staff manage floorplans'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff manage floorplans"
+      ON public.floorplans
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS public.floorplan_annotations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  floorplan_id UUID NOT NULL REFERENCES public.floorplans(id) ON DELETE CASCADE,
+  created_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  description TEXT,
+  coordinates JSONB NOT NULL,
+  color TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.floorplan_annotations ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_floorplan_annotations_floorplan_id ON public.floorplan_annotations(floorplan_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_floorplan_annotations_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_floorplan_annotations_updated_at
+      BEFORE UPDATE ON public.floorplan_annotations
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'floorplan_annotations'
+      AND policyname = 'Members can view floorplan annotations'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can view floorplan annotations"
+      ON public.floorplan_annotations
+      FOR SELECT
+      USING (EXISTS (
+        SELECT 1
+        FROM public.floorplans f
+        JOIN public.profiles p ON p.id = auth.uid()
+        WHERE f.id = floorplan_annotations.floorplan_id
+          AND (p.role IN ('property_manager', 'admin') OR p.unit_id = f.unit_id)
+      ));$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'floorplan_annotations'
+      AND policyname = 'Members can manage their annotations'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Members can manage their annotations"
+      ON public.floorplan_annotations
+      FOR ALL
+      USING (auth.uid() = created_by)
+      WITH CHECK (auth.uid() = created_by);$$;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'floorplan_annotations'
+      AND policyname = 'Property staff manage annotations'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Property staff manage annotations"
+      ON public.floorplan_annotations
+      FOR ALL
+      USING (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid()
+          AND p.role IN ('property_manager', 'admin')
+      ));$$;
+  END IF;
+END$$;
+
+-- ------------------------------------------------------------
+-- Meetings and user tokens support integrations with external APIs.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.meetings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  start_time TIMESTAMPTZ NOT NULL,
+  end_time TIMESTAMPTZ NOT NULL,
+  google_event_id TEXT,
+  summary TEXT,
+  description TEXT,
+  google_event_link TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.meetings ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'meetings'
+      AND policyname = 'Users manage their meetings'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Users manage their meetings"
+      ON public.meetings
+      FOR ALL
+      USING (auth.uid() = user_id)
+      WITH CHECK (auth.uid() = user_id);$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_meetings_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_meetings_updated_at
+      BEFORE UPDATE ON public.meetings
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS public.user_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  refresh_token TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id)
+);
+
+ALTER TABLE public.user_tokens ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_tokens'
+      AND policyname = 'Users manage their tokens'
+  ) THEN
+    EXECUTE $$CREATE POLICY "Users manage their tokens"
+      ON public.user_tokens
+      FOR ALL
+      USING (auth.uid() = user_id)
+      WITH CHECK (auth.uid() = user_id);$$;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_user_tokens_updated_at'
+  ) THEN
+    EXECUTE $$CREATE TRIGGER update_user_tokens_updated_at
+      BEFORE UPDATE ON public.user_tokens
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();$$;
+  END IF;
+END$$;

--- a/supabase/migrations/20250308_rent_payments_alignment.sql
+++ b/supabase/migrations/20250308_rent_payments_alignment.sql
@@ -1,0 +1,32 @@
+-- Align rent payment records with the fields used throughout the application.
+
+ALTER TABLE public.rent_payments
+  ADD COLUMN IF NOT EXISTS stripe_charge_id TEXT,
+  ADD COLUMN IF NOT EXISTS stripe_subscription_id TEXT,
+  ADD COLUMN IF NOT EXISTS payment_method_type TEXT,
+  ADD COLUMN IF NOT EXISTS tenant_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS unit_id UUID REFERENCES public.units(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS processed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS billing_period_start TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS billing_period_end TIMESTAMPTZ;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.constraint_column_usage
+    WHERE table_schema = 'public'
+      AND table_name = 'rent_payments'
+      AND constraint_name = 'rent_payments_status_check'
+  ) THEN
+    ALTER TABLE public.rent_payments DROP CONSTRAINT rent_payments_status_check;
+  END IF;
+END$$;
+
+ALTER TABLE public.rent_payments
+  ADD CONSTRAINT rent_payments_status_check
+  CHECK (status IN ('pending', 'succeeded', 'failed', 'cancelled', 'completed'));
+
+CREATE INDEX IF NOT EXISTS idx_rent_payments_tenant_id ON public.rent_payments(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_rent_payments_unit_id ON public.rent_payments(unit_id);
+CREATE INDEX IF NOT EXISTS idx_rent_payments_processed_at ON public.rent_payments(processed_at DESC);


### PR DESCRIPTION
## Summary
- add a foundational Supabase migration that seeds shared domain tables (households, units, profiles, amenities, bookings, messaging, floorplans, meetings, user tokens) with RLS policies and updated-at triggers
- align the rent_payments table with the typed client expectations and add supporting indexes
- automate schema bootstrapping via a reusable script, package.json commands, and documentation updates that direct developers to supabase/migrations

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b62a803083288bd7ba21af85f9b5