### PR TITLE
Add Supabase query counters to data integration tests

### DIFF
--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -13,10 +13,13 @@ type QueryBuilder<T> = {
   gte: ReturnType<typeof vi.fn>;
   lte: ReturnType<typeof vi.fn>;
   then: (onFulfilled: (value: QueryResult<T>) => unknown) => Promise<unknown>;
+  getExecutions: () => number;
 };
 
 function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
-  const builder: Partial<QueryBuilder<T>> & {
+  let executions = 0;
+
+  const builder: (Partial<Omit<QueryBuilder<T>, 'getExecutions'>> & {
     select: ReturnType<typeof vi.fn>;
     order: ReturnType<typeof vi.fn>;
     or: ReturnType<typeof vi.fn>;
@@ -24,7 +27,7 @@ function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
     eq: ReturnType<typeof vi.fn>;
     gte: ReturnType<typeof vi.fn>;
     lte: ReturnType<typeof vi.fn>;
-  } = {
+  }) & { getExecutions?: () => number } = {
     select: vi.fn().mockImplementation(() => builder),
     order: vi.fn().mockImplementation(() => builder),
     or: vi.fn().mockImplementation(() => builder),
@@ -34,18 +37,26 @@ function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
     lte: vi.fn().mockImplementation(() => builder),
   };
 
-  (builder as QueryBuilder<T>).then = (onFulfilled) =>
-    Promise.resolve(onFulfilled(result));
+  (builder as QueryBuilder<T>).then = (onFulfilled) => {
+    executions += 1;
+    return Promise.resolve(onFulfilled(result));
+  };
+
+  (builder as QueryBuilder<T>).getExecutions = () => executions;
 
   return builder as QueryBuilder<T>;
 }
 
 function createSupabaseStub<T extends unknown[]>(query: QueryBuilder<T>) {
+  let fromCalls = 0;
+
   return {
     from: vi.fn((table: string) => {
+      fromCalls += 1;
       expect(table).toBe('documents');
       return query;
     }),
+    getQueryCount: () => fromCalls,
   };
 }
 
@@ -78,6 +89,9 @@ describe('fetchDocumentsList', () => {
     expect(query.eq).toHaveBeenCalledWith('unit_id', filters.unit_id);
     expect(query.gte).toHaveBeenCalledWith('created_at', filters.date_from);
     expect(query.lte).toHaveBeenCalledWith('created_at', filters.date_to);
+    // Guardrail: ensure we only execute a single Supabase query for the listing fetch.
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(query.getExecutions()).toBe(1);
   });
 
   it('skips scoping for property managers and admins', async () => {
@@ -91,6 +105,8 @@ describe('fetchDocumentsList', () => {
     });
 
     expect(query.or).not.toHaveBeenCalled();
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(query.getExecutions()).toBe(1);
   });
 
   it('throws when Supabase returns an error', async () => {
@@ -100,6 +116,8 @@ describe('fetchDocumentsList', () => {
     await expect(
       fetchDocumentsList({ client: supabase, userId: 'user-1', role: 'tenant' })
     ).rejects.toThrow(/Failed to fetch documents: boom/);
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(query.getExecutions()).toBe(1);
   });
 });
 
@@ -129,6 +147,8 @@ describe('fetchDocumentStats', () => {
       expired_documents: 0,
       draft_documents: 1,
     });
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(query.getExecutions()).toBe(1);
   });
 
   it('omits tenant filter for admins', async () => {
@@ -138,6 +158,8 @@ describe('fetchDocumentStats', () => {
     await fetchDocumentStats({ client: supabase, userId: 'admin-1', role: 'admin' });
 
     expect(query.eq).not.toHaveBeenCalled();
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(query.getExecutions()).toBe(1);
   });
 
   it('throws when Supabase returns an error', async () => {
@@ -147,5 +169,7 @@ describe('fetchDocumentStats', () => {
     await expect(
       fetchDocumentStats({ client: supabase, userId: 'user-1', role: 'tenant' })
     ).rejects.toThrow(/Failed to fetch document statistics: stats failed/);
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(query.getExecutions()).toBe(1);
   });
 });

--- a/tests/lib/data/members.test.ts
+++ b/tests/lib/data/members.test.ts
@@ -7,14 +7,23 @@ type SingleBuilder<T> = {
   select: ReturnType<typeof vi.fn>;
   eq: ReturnType<typeof vi.fn>;
   maybeSingle: () => Promise<SingleResult<T>>;
+  getExecutions: () => number;
 };
 
 function createSingleBuilder<T>(result: SingleResult<T>): SingleBuilder<T> {
-  return {
+  let executions = 0;
+
+  const builder = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
-    maybeSingle: vi.fn().mockResolvedValue(result),
-  } as unknown as SingleBuilder<T>;
+    maybeSingle: vi.fn().mockImplementation(() => {
+      executions += 1;
+      return Promise.resolve(result);
+    }),
+    getExecutions: () => executions,
+  } satisfies SingleBuilder<T>;
+
+  return builder;
 }
 
 type MultiResult<T> = { data: T; error: { message: string } | null };
@@ -25,33 +34,44 @@ type MultiBuilder<T> = {
   neq: ReturnType<typeof vi.fn>;
   in: ReturnType<typeof vi.fn>;
   then: (onFulfilled: (value: MultiResult<T>) => unknown) => Promise<unknown>;
+  getExecutions: () => number;
 };
 
 function createMultiBuilder<T>(result: MultiResult<T>): MultiBuilder<T> {
-  const builder: Partial<MultiBuilder<T>> & {
+  let executions = 0;
+
+  const builder: (Partial<Omit<MultiBuilder<T>, 'getExecutions'>> & {
     select: ReturnType<typeof vi.fn>;
     eq: ReturnType<typeof vi.fn>;
     neq: ReturnType<typeof vi.fn>;
     in: ReturnType<typeof vi.fn>;
-  } = {
+  }) & { getExecutions?: () => number } = {
     select: vi.fn().mockImplementation(() => builder),
     eq: vi.fn().mockImplementation(() => builder),
     neq: vi.fn().mockImplementation(() => builder),
     in: vi.fn().mockImplementation(() => builder),
   };
 
-  (builder as MultiBuilder<T>).then = (onFulfilled) =>
-    Promise.resolve(onFulfilled(result));
+  (builder as MultiBuilder<T>).then = (onFulfilled) => {
+    executions += 1;
+    return Promise.resolve(onFulfilled(result));
+  };
+
+  (builder as MultiBuilder<T>).getExecutions = () => executions;
 
   return builder as MultiBuilder<T>;
 }
 
 function createProfilesStub<T>(builder: unknown) {
+  let fromCalls = 0;
+
   return {
     from: vi.fn((table: string) => {
+      fromCalls += 1;
       expect(table).toBe('profiles');
       return builder;
     }),
+    getQueryCount: () => fromCalls,
   };
 }
 
@@ -65,6 +85,8 @@ describe('fetchMemberRole', () => {
     expect(builder.select).toHaveBeenCalledWith('role');
     expect(builder.eq).toHaveBeenCalledWith('id', 'user-1');
     expect(role).toBe('tenant');
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(builder.getExecutions()).toBe(1);
   });
 
   it('throws when supabase returns an error', async () => {
@@ -74,6 +96,8 @@ describe('fetchMemberRole', () => {
     await expect(fetchMemberRole(supabase as any, 'user-1')).rejects.toThrow(
       /Failed to load member role: role failed/
     );
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(builder.getExecutions()).toBe(1);
   });
 });
 
@@ -94,6 +118,8 @@ describe('fetchMemberProfile', () => {
     expect(builder.select).toHaveBeenCalledWith('id, email, full_name, role, unit_id');
     expect(builder.eq).toHaveBeenCalledWith('id', 'user-1');
     expect(result).toEqual(profile);
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(builder.getExecutions()).toBe(1);
   });
 
   it('throws when supabase reports an error', async () => {
@@ -103,6 +129,8 @@ describe('fetchMemberProfile', () => {
     await expect(fetchMemberProfile(supabase as any, 'user-1')).rejects.toThrow(
       /Failed to load member profile: profile boom/
     );
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(builder.getExecutions()).toBe(1);
   });
 });
 
@@ -125,6 +153,9 @@ describe('fetchMembersByUnit', () => {
     expect(builder.neq).toHaveBeenCalledWith('id', 'user-2');
     expect(builder.in).toHaveBeenCalledWith('role', ['tenant']);
     expect(result).toEqual(members);
+    // Guardrail: ensure the unit lookup only performs one PostgREST round-trip.
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(builder.getExecutions()).toBe(1);
   });
 
   it('throws when supabase returns an error', async () => {
@@ -134,5 +165,7 @@ describe('fetchMembersByUnit', () => {
     await expect(
       fetchMembersByUnit(supabase as any, 'unit-1')
     ).rejects.toThrow(/Failed to load members for unit: unit failed/);
+    expect(supabase.getQueryCount()).toBe(1);
+    expect(builder.getExecutions()).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- instrument the documents data test stub to record Supabase query executions
- extend documents and member integration tests to assert single query invocations and document the guardrail pattern

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b626324c8328be28f0aa979b0f27