### PR TITLE
Add Supabase seed script and preview automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Roomsily (www.roomsily) is a comprehensive co-living portal that helps roommates
 - Node.js 18+
 - npm/yarn/pnpm
 - Supabase account
+- PostgreSQL CLI (`psql`) or Supabase CLI (for database seeding)
 - Stripe account
 - Vercel account (for deployment)
 
@@ -65,6 +66,7 @@ NEXT_PUBLIC_SUPABASE_URL="your_supabase_project_url"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="your_supabase_anon_key"
 SUPABASE_SERVICE_ROLE_KEY="your_supabase_service_role_key"
 SUPABASE_JWT_SECRET="your_jwt_secret"
+SUPABASE_DB_URL="postgresql://username:password@db.host:5432/postgres?sslmode=require"
 
 # Stripe
 STRIPE_SECRET_KEY="your_stripe_secret_key"
@@ -88,6 +90,22 @@ Run the Supabase migrations to set up the required database tables:
 # Apply database migrations (requires Supabase CLI)
 supabase db push
 ```
+
+### Demo Data Seeding
+
+The repository includes an idempotent seed (`supabase/demo/seed.sql`) that keeps development and preview environments populated
+with realistic households and chore data.
+
+1. Ensure the `psql` CLI (or Supabase CLI, which bundles `psql`) is installed locally.
+2. Provide a Postgres connection string via `SUPABASE_DB_URL` (or `DATABASE_URL`) in `.env.local`.
+3. Load the seed with:
+
+```bash
+npm run dev:seed
+```
+
+The script wraps the seed in a single transaction and uses `ON CONFLICT`/`WHERE NOT EXISTS` guards so it is safe to re-run whenever
+sample data needs to be refreshed.
 
 ### Development
 
@@ -114,6 +132,9 @@ Deploy to Vercel with the following environment variables configured in your Ver
 - All Supabase environment variables
 - Stripe keys (use live keys for production)
 - Document and calendar service URLs/keys
+
+Preview deployments automatically execute `npm run dev:seed` (via the `vercel-build` script) when `SUPABASE_DB_URL` is present so
+shared demo data stays up-to-date. Update `supabase/demo/seed.sql` whenever sample records change to keep environments in sync.
 
 ## Operations & Reliability
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "css:purge": "node scripts/check-css-size.mjs"
+    "css:purge": "node scripts/check-css-size.mjs",
+    "dev:seed": "node scripts/dev-seed.cjs",
+    "vercel-build": "node scripts/vercel-build.cjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/scripts/dev-seed.cjs
+++ b/scripts/dev-seed.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const seedPath = path.resolve(__dirname, '..', 'supabase', 'demo', 'seed.sql');
+
+if (!fs.existsSync(seedPath)) {
+  console.error('Unable to find Supabase seed file at', seedPath);
+  process.exit(1);
+}
+
+const connectionUrl = process.env.SUPABASE_DB_URL || process.env.DATABASE_URL;
+
+if (!connectionUrl) {
+  console.error(
+    'Missing required environment variable. Set SUPABASE_DB_URL (or DATABASE_URL) to a valid Postgres connection string.'
+  );
+  process.exit(1);
+}
+
+const versionCheck = spawnSync('psql', ['--version'], { stdio: 'ignore' });
+
+if (versionCheck.status !== 0) {
+  console.error(
+    'The `psql` CLI is required to run the seed. Install PostgreSQL locally or use the Supabase CLI to expose `psql`.'
+  );
+  process.exit(versionCheck.status || 1);
+}
+
+let databaseLabel = 'Supabase database';
+
+try {
+  const parsed = new URL(connectionUrl);
+  const dbName = parsed.pathname ? parsed.pathname.replace(/^\//, '') : '';
+  const user = parsed.username ? `${parsed.username}@` : '';
+  databaseLabel = `${user}${parsed.hostname}${dbName ? `/${dbName}` : ''}`;
+} catch (error) {
+  // Ignore parsing issues and fall back to the generic label above.
+}
+
+console.log(`Seeding ${databaseLabel} using ${seedPath}`);
+
+const result = spawnSync(
+  'psql',
+  [connectionUrl, '--single-transaction', '-v', 'ON_ERROR_STOP=1', '-f', seedPath],
+  { stdio: 'inherit' }
+);
+
+if (result.error) {
+  console.error('Failed to execute seed via psql:', result.error.message);
+  process.exit(result.status || 1);
+}
+
+if (result.status !== 0) {
+  console.error('Supabase seed exited with a non-zero status code.');
+  process.exit(result.status);
+}
+
+console.log('Seed data loaded successfully.');

--- a/scripts/vercel-build.cjs
+++ b/scripts/vercel-build.cjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const hasConnectionString = Boolean(process.env.SUPABASE_DB_URL || process.env.DATABASE_URL);
+
+function runStep(command, args, message) {
+  if (message) {
+    console.log(message);
+  }
+
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  if (result.error) {
+    console.error(`Failed to execute ${command}:`, result.error.message);
+    process.exit(result.status || 1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+if (process.env.VERCEL_ENV === 'preview') {
+  if (hasConnectionString) {
+    runStep(npmCommand, ['run', 'dev:seed'], 'Running preview seed (npm run dev:seed) before build');
+  } else {
+    console.warn(
+      'Preview seed skipped because SUPABASE_DB_URL (or DATABASE_URL) is not configured. '
+        + 'Provide a connection string to load demo data during preview builds.'
+    );
+  }
+} else {
+  console.log(
+    `Skipping preview seed because VERCEL_ENV=${process.env.VERCEL_ENV || 'undefined'}.` +
+      ' The build will continue without loading demo data.'
+  );
+}
+
+runStep(npmCommand, ['run', 'build'], 'Starting Next.js build');

--- a/supabase/demo/seed.sql
+++ b/supabase/demo/seed.sql
@@ -1,5 +1,6 @@
 -- Demo seed script for validating household chore relationships
 -- Inserts sample households and related chores for local development/testing
+-- NOTE: Keep statements idempotent (use ON CONFLICT/WHERE NOT EXISTS guards) so the seed can run repeatedly in preview builds.
 
 -- Ensure demo households exist
 INSERT INTO public.households (id, name)


### PR DESCRIPTION
## Summary
- add a reusable `npm run dev:seed` helper that replays `supabase/demo/seed.sql` through psql
- hook the new seeding command into Vercel preview builds while keeping production deploys unchanged
- document demo data setup steps and required environment variables in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b6259d2c8328be4c3a2e59cd833e