### PR TITLE
Defer analytics scripts to avoid blocking main thread

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,9 +2,6 @@ import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
 import { Suspense } from "react"
 
-import { Analytics } from "@vercel/analytics/react"
-import { SpeedInsights } from "@vercel/speed-insights/next"
-
 import "./globals.css"
 
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
@@ -19,6 +16,7 @@ import { fontSans } from "@/lib/font"
 import { cn } from "@/lib/utils"
 import { siteConfig } from "@/config/site"
 import { ReactQueryClientProvider } from "@/components/react-query-client-provider"
+import { DeferredAnalytics } from "@/components/deferred-analytics"
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
@@ -139,8 +137,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
                   </Suspense>
                 </ErrorBoundary>
                 <Toaster />
-                <Analytics />
-                <SpeedInsights />
+                <DeferredAnalytics />
               </div>
 
    </div>

--- a/components/deferred-analytics.tsx
+++ b/components/deferred-analytics.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import dynamic from "next/dynamic"
+import { useEffect, useState } from "react"
+
+const VercelAnalytics = dynamic(
+  () => import("@vercel/analytics/react").then((mod) => mod.Analytics),
+  { ssr: false }
+)
+
+const VercelSpeedInsights = dynamic(
+  () => import("@vercel/speed-insights/next").then((mod) => mod.SpeedInsights),
+  { ssr: false }
+)
+
+type ExtendedWindow = Window & {
+  requestIdleCallback?: (callback: IdleRequestCallback) => number
+  cancelIdleCallback?: (handle: number) => void
+}
+
+export function DeferredAnalytics() {
+  const [shouldRender, setShouldRender] = useState(false)
+
+  useEffect(() => {
+    const extendedWindow = window as ExtendedWindow
+
+    if (extendedWindow.requestIdleCallback) {
+      const idleHandle = extendedWindow.requestIdleCallback(() => {
+        setShouldRender(true)
+      })
+
+      return () => {
+        extendedWindow.cancelIdleCallback?.(idleHandle)
+      }
+    }
+
+    const timeout = window.setTimeout(() => {
+      setShouldRender(true)
+    }, 1)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [])
+
+  if (!shouldRender) {
+    return null
+  }
+
+  return (
+    <>
+      <VercelAnalytics />
+      <VercelSpeedInsights />
+    </>
+  )
+}

--- a/docs/perf/playbook.md
+++ b/docs/perf/playbook.md
@@ -25,6 +25,11 @@ This playbook documents how Roomsily measures and protects critical experience-l
 | Stripe Payments Overview | Checkout conversion, webhook failures | <https://dashboard.stripe.com/live/payments>
 | Statuspage (Public) | External communication for incidents | <https://status.roomsily.com>
 
+## Third-party Analytics Loading
+
+- Vercel Analytics and Speed Insights are injected via a deferred client component that waits for hydration (and browser idle time when supported) before dynamically importing the libraries. This keeps their script evaluation off the initial navigation path and preserves first-load responsiveness.
+- Any new observability or marketing pixels must follow the same pattern: load them with `next/script` using `strategy="lazyOnload"` or gate them behind a post-hydration dynamic import so they do not block the main thread.
+
 ## Alert Channels
 | Trigger | Channel | Notes |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary
- introduce a DeferredAnalytics client component that dynamically imports the Vercel Analytics and Speed Insights bundles after hydration/idle time
- swap the root layout to render the deferred analytics wrapper instead of directly including the analytics components
- update the performance playbook with guidance on loading analytics and other third-party scripts lazily

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b6237e148328a1bc02199d944574