### PR TITLE
Lazy load feature prism 3D showcase

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import {
   Wallet,
 } from "lucide-react"
 
+import { FeaturePrismLazy } from "@/components/feature-prism-lazy"
 import { readUserSession } from "@/utils/actions"
 import { siteConfig } from "@/config/site"
 import { Badge } from "@/components/ui/badge"
@@ -211,6 +212,21 @@ export default async function IndexPage() {
               </CardContent>
             </Card>
           ))}
+        </div>
+      </section>
+
+      <section className="border-y border-border/70 bg-muted/10 py-20 sm:py-24">
+        <div className="container mx-auto px-4">
+          <div className="mx-auto max-w-3xl space-y-4 text-center">
+            <h2 className="text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+              Explore the Roomsily feature prism
+            </h2>
+            <p className="text-muted-foreground">
+              Navigate our interactive 3D showcase to see how payments, bookings, messaging, and automations connect inside the
+              portal.
+            </p>
+          </div>
+          <FeaturePrismLazy className="mx-auto mt-12 max-w-6xl" />
         </div>
       </section>
 

--- a/components/feature-prism-lazy.tsx
+++ b/components/feature-prism-lazy.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import dynamic from "next/dynamic"
+import { useEffect, useRef, useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+const FeaturePrism = dynamic(() => import("./feature-prism"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full min-h-[480px] items-center justify-center rounded-3xl border border-dashed border-border/40 bg-muted/10 text-sm text-muted-foreground">
+      Loading interactive feature prism…
+    </div>
+  ),
+})
+
+interface FeaturePrismLazyProps {
+  className?: string
+  /**
+   * IntersectionObserver root margin.
+   * Allows the 3D bundle to start loading slightly before entering the viewport.
+   */
+  observeMargin?: string
+}
+
+export function FeaturePrismLazy({ className, observeMargin = "200px" }: FeaturePrismLazyProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [shouldRender, setShouldRender] = useState(false)
+
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node || shouldRender) {
+      return
+    }
+
+    if (typeof window !== "undefined" && !("IntersectionObserver" in window)) {
+      setShouldRender(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setShouldRender(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: observeMargin }
+    )
+
+    observer.observe(node)
+
+    return () => observer.disconnect()
+  }, [observeMargin, shouldRender])
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "relative min-h-[480px] overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-background via-background to-background shadow-lg shadow-primary/10",
+        className
+      )}
+    >
+      {shouldRender ? (
+        <FeaturePrism />
+      ) : (
+        <div className="flex h-full min-h-[inherit] items-center justify-center bg-background/80 text-sm text-muted-foreground">
+          Preparing interactive feature prism…
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a client-only wrapper that dynamically imports the 3D feature prism with an IntersectionObserver gate and graceful fallback
- embed the lazy 3D showcase section on the marketing landing page so the three.js bundle only loads when the section is visible

## Testing
- pnpm lint
- CI=1 pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68d1b62199e483289b5c285e84f47992