### PR TITLE
Configure caching headers and document invalidation procedures

### DIFF
--- a/docs/perf/playbook.md
+++ b/docs/perf/playbook.md
@@ -48,6 +48,14 @@ This playbook documents how Roomsily measures and protects critical experience-l
 3. Verify the rollback by re-running the synthetic check suite (`npm run test:e2e:smoke` in GitHub Actions or manually via Checkly) and confirming green results in the Vercel analytics dashboard.
 4. Re-enable auto-deploys and communicate completion in Slack `#incidents`.
 
+### CDN Cache Invalidation (Next.js on Vercel)
+- **Routine deploys:** Each production deploy emits fingerprinted bundles under `/_next/static` with `Cache-Control: public, max-age=31536000, immutable`. Publishing a new commit automatically shifts HTML to reference the new asset hashes, so no manual purge is needed.
+- **Hotfixing public assets or stale HTML/API payloads:**
+  1. Navigate to the Vercel project → **Deployments → Production** and open the latest deployment.
+  2. Use the **⋯ → Purge Cache** action. Prefer **Purge Specific Paths** (e.g., `/favicon.ico`, `/_next/data/*`, `/api/stripe/*`) before opting for **Purge Entire Project** to limit blast radius.
+  3. Announce the purge in Slack `#incidents` and monitor until the dashboard shows the purge completed.
+- **Verification:** From your workstation (or in CI), run `curl -I https://portal.roomsily.com -H 'Accept: text/html'` to confirm HTML responses advertise `Cache-Control: public, max-age=0, s-maxage=60, stale-while-revalidate=86400`. Spot-check an API (`curl -I https://portal.roomsily.com/api/health`) for the SWR policy and a static asset (`curl -I https://portal.roomsily.com/_next/static/...`) for the immutable directive. Capture the headers in the deployment checklist before calling the release done.
+
 ### Supabase Migrations
 1. Identify the offending migration in `supabase/migrations` (timestamps map to deploy order). Confirm via `supabase migration list --status applied`.
 2. Run `supabase db remote commit` to snapshot the current production state before touching schema.

--- a/next.config.js
+++ b/next.config.js
@@ -62,6 +62,12 @@ const securityHeaders = [
   },
 ]
 
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable'
+const HTML_SWR_CACHE_CONTROL =
+  'public, max-age=0, s-maxage=60, stale-while-revalidate=86400'
+const API_SWR_CACHE_CONTROL =
+  'public, max-age=0, s-maxage=30, stale-while-revalidate=300'
+
 const nextConfig = {
   webpack: config => {
     config.externals.push('pino-pretty', 'lokijs', 'encoding')
@@ -121,6 +127,50 @@ const nextConfig = {
   },
    async headers() {
       return [
+        {
+          source: '/_next/static/(.*)',
+          headers: [
+            {
+              key: 'Cache-Control',
+              value: IMMUTABLE_CACHE_CONTROL,
+            },
+          ],
+        },
+        {
+          source:
+            '/(.*\\.(?:js|css|svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|otf))',
+          headers: [
+            {
+              key: 'Cache-Control',
+              value: IMMUTABLE_CACHE_CONTROL,
+            },
+          ],
+        },
+        {
+          source: '/api/:path*',
+          headers: [
+            {
+              key: 'Cache-Control',
+              value: API_SWR_CACHE_CONTROL,
+            },
+          ],
+        },
+        {
+          source: '/:path*',
+          has: [
+            {
+              type: 'header',
+              key: 'accept',
+              value: 'text/html.*',
+            },
+          ],
+          headers: [
+            {
+              key: 'Cache-Control',
+              value: HTML_SWR_CACHE_CONTROL,
+            },
+          ],
+        },
         {
           source: '/(.*)',
           headers: securityHeaders,


### PR DESCRIPTION
## Summary
- add explicit Cache-Control policies for immutable assets, HTML, and API responses via Next.js headers
- document the CDN cache purge workflow and verification commands in the performance playbook

## Testing
- npm run lint
- npm run build
- curl -I -H 'Accept: text/html' http://localhost:3000/
- curl -I -X POST http://localhost:3000/api/send
- curl -I http://localhost:3000/favicon.ico

------
https://chatgpt.com/codex/tasks/task_e_68d1b62084bc8328ab5a999bcf27d9f4