### PR TITLE
Add notification job queue infrastructure

### DIFF
--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -4,9 +4,11 @@ import type { SupabaseClient } from "@supabase/supabase-js"
 import { z } from "zod"
 
 import {
-  sendBulkNotifications,
-  sendEmailNotification,
-  sendInAppNotification,
+  enqueueBulkNotifications,
+  enqueueEmailNotification,
+  enqueueInAppNotification,
+} from "@/lib/notification-queue"
+import {
   type InAppNotification,
   type NotificationData,
 } from "@/lib/notifications"
@@ -230,24 +232,59 @@ type NotificationRequest =
 export async function POST(request: Request) {
   try {
     const payload = (await request.json()) as NotificationRequest
+    const requestId =
+      request.headers.get("x-request-id") ?? crypto.randomUUID()
 
     switch (payload.type) {
       case "email": {
-        const result = await sendEmailNotification(payload.notification)
-        const status = result.success ? 200 : 400
-        return NextResponse.json(result, { status })
+        const { jobId } = await enqueueEmailNotification(payload.notification, {
+          correlationId: requestId,
+        })
+        console.info("Enqueued email notification", {
+          jobId,
+          correlationId: requestId,
+          template: payload.notification.template,
+          recipient: payload.notification.to,
+        })
+        return NextResponse.json(
+          { success: true, jobId, correlationId: requestId },
+          { status: 202 }
+        )
       }
       case "in-app": {
-        const result = await sendInAppNotification(payload.notification)
-        const status = result.success ? 200 : 400
-        return NextResponse.json(result, { status })
+        const { jobId } = await enqueueInAppNotification(
+          payload.notification,
+          { correlationId: requestId }
+        )
+        console.info("Enqueued in-app notification", {
+          jobId,
+          correlationId: requestId,
+          userId: payload.notification.userId,
+          type: payload.notification.type,
+        })
+        return NextResponse.json(
+          { success: true, jobId, correlationId: requestId },
+          { status: 202 }
+        )
       }
       case "bulk": {
-        const results = await sendBulkNotifications(payload.notifications)
-        const success = results.every((entry) => entry.success)
+        const { jobId } = await enqueueBulkNotifications(
+          payload.notifications,
+          { correlationId: requestId }
+        )
+        console.info("Enqueued bulk notification job", {
+          jobId,
+          correlationId: requestId,
+          totalNotifications: payload.notifications.length,
+        })
         return NextResponse.json(
-          { success, results },
-          { status: success ? 200 : 400 }
+          {
+            success: true,
+            jobId,
+            correlationId: requestId,
+            totalNotifications: payload.notifications.length,
+          },
+          { status: 202 }
         )
       }
       default: {

--- a/app/api/payments/receipt/route.ts
+++ b/app/api/payments/receipt/route.ts
@@ -1,31 +1,5 @@
-import { PaymentReceiptEmail } from '@/components/emails/payment-receipt';
-import { Resend } from 'resend';
-import { z } from 'zod';
-
-const lineItemSchema = z.object({
-  description: z.string().min(1, "Line item description is required."),
-  quantity: z.number().positive().optional(),
-  unitAmount: z.number().nonnegative().optional(),
-  totalAmount: z.number().nonnegative().optional(),
-});
-
-const paymentReceiptSchema = z.object({
-  customerEmail: z.string().email(),
-  customerName: z.string().min(1),
-  paymentId: z.string().min(1),
-  amountPaid: z.number().positive(),
-  currency: z.string().min(3).max(10),
-  paymentDate: z.coerce.date().optional(),
-  items: z.array(lineItemSchema).optional(),
-  businessName: z.string().optional(),
-  supportEmail: z.string().email().optional(),
-  billingAddress: z.string().optional(),
-  notes: z.string().optional(),
-  subtotalAmount: z.number().nonnegative().optional(),
-  taxAmount: z.number().nonnegative().optional(),
-  discountAmount: z.number().nonnegative().optional(),
-  sendCopyTo: z.array(z.string().email()).optional(),
-});
+import { enqueuePaymentReceiptEmail } from "@/lib/notification-queue";
+import { paymentReceiptSchema } from "@/lib/payment-receipt";
 
 export async function POST(request: Request) {
   const resendApiKey = process.env.RESEND_API_KEY;
@@ -58,57 +32,27 @@ export async function POST(request: Request) {
     );
   }
 
-  const {
-    customerEmail,
-    customerName,
-    paymentId,
-    amountPaid,
-    currency,
-    paymentDate,
-    items,
-    businessName,
-    supportEmail,
-    billingAddress,
-    notes,
-    subtotalAmount,
-    taxAmount,
-    discountAmount,
-    sendCopyTo,
-  } = parsed.data;
-
-  const resend = new Resend(resendApiKey);
-
-  const fromAddress = process.env.RESEND_RECEIPTS_FROM ?? 'Roomsily Receipts <receipts@resend.dev>';
-  const emailRecipients = [customerEmail, ...(sendCopyTo ?? [])];
+  const correlationId =
+    request.headers.get("x-request-id") ??
+    `payment-receipt:${parsed.data.paymentId}`;
 
   try {
-    const { data, error } = await resend.emails.send({
-      from: fromAddress,
-      to: emailRecipients,
-      subject: `Receipt for payment ${paymentId}`,
-      react: PaymentReceiptEmail({
-        customerName,
-        paymentId,
-        amountPaid,
-        currency,
-        paymentDate: paymentDate ?? new Date(),
-        items,
-        businessName,
-        supportEmail,
-        billingAddress,
-        notes,
-        subtotalAmount,
-        taxAmount,
-        discountAmount,
-      }),
+    const { jobId } = await enqueuePaymentReceiptEmail(parsed.data, {
+      correlationId,
+      maxAttempts: 5,
     });
 
-    if (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return Response.json({ error: message }, { status: 502 });
-    }
+    console.info("Enqueued payment receipt email job", {
+      jobId,
+      correlationId,
+      paymentId: parsed.data.paymentId,
+      customerEmail: parsed.data.customerEmail,
+    });
 
-    return Response.json({ id: data?.id ?? null });
+    return Response.json(
+      { success: true, jobId, correlationId },
+      { status: 202 },
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return Response.json({ error: message }, { status: 500 });

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,29 +1,13 @@
 import { headers } from "next/headers"
-import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import type { SupabaseClient } from "@supabase/supabase-js"
 
 import {
-  sendEmailNotification,
-  sendInAppNotification,
-} from "@/lib/notifications"
+  enqueueEmailNotification,
+  enqueueInAppNotification,
+} from "@/lib/notification-queue"
 import { getStripe } from "@/lib/stripe"
 import type { Database, TablesInsert } from "@/lib/supabase"
-
-function createSupabaseAdminClient(): SupabaseClient<Database> | null {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-
-  if (!supabaseUrl || !serviceRoleKey) {
-    console.error("Supabase admin credentials are not configured")
-    return null
-  }
-
-  return createClient<Database>(supabaseUrl, serviceRoleKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  })
-}
+import { getSupabaseServiceRoleClient } from "@/lib/supabase-admin"
 
 export async function POST(req: Request) {
   const stripe = getStripe()
@@ -34,8 +18,11 @@ export async function POST(req: Request) {
     return new Response("Webhook not configured", { status: 500 })
   }
 
-  const supabase = createSupabaseAdminClient()
-  if (!supabase) {
+  let supabase: SupabaseClient<Database>
+  try {
+    supabase = getSupabaseServiceRoleClient()
+  } catch (error) {
+    console.error("Supabase admin credentials are not configured", error)
     return new Response("Supabase client not configured", { status: 500 })
   }
 
@@ -132,28 +119,47 @@ async function handleCheckoutSessionCompleted(
               .single()
 
             if (tenantProfile?.email) {
-              await sendEmailNotification({
-                to: tenantProfile.email,
-                subject: `Payment Receipt - $${paymentData.amount}`,
-                template: "payment-receipt",
-                data: {
-                  tenantName: tenantProfile.full_name || tenantProfile.email,
-                  amount: `$${paymentData.amount}`,
-                  description: paymentData.description,
-                  date: new Date(
-                    paymentData.processed_at ?? new Date().toISOString()
-                  ).toLocaleDateString(),
+              const correlationId = `stripe-session:${session.id}`
+              const { jobId: emailJobId } = await enqueueEmailNotification(
+                {
+                  to: tenantProfile.email,
+                  subject: `Payment Receipt - $${paymentData.amount}`,
+                  template: "payment-receipt",
+                  data: {
+                    tenantName:
+                      tenantProfile.full_name || tenantProfile.email,
+                    amount: `$${paymentData.amount}`,
+                    description: paymentData.description,
+                    date: new Date(
+                      paymentData.processed_at ?? new Date().toISOString()
+                    ).toLocaleDateString(),
+                  },
+                  userId: tenantId,
                 },
-                userId: tenantId,
+                { correlationId }
+              )
+
+              console.info("Enqueued payment receipt email job", {
+                jobId: emailJobId,
+                correlationId,
+                tenantId,
               })
 
-              // Also send in-app notification
-              await sendInAppNotification({
-                userId: tenantId,
-                title: "Payment Successful",
-                message: `Your payment of $${paymentData.amount} has been processed successfully.`,
-                type: "success",
-                actionUrl: "/payments",
+              const { jobId: inAppJobId } = await enqueueInAppNotification(
+                {
+                  userId: tenantId,
+                  title: "Payment Successful",
+                  message: `Your payment of $${paymentData.amount} has been processed successfully.`,
+                  type: "success",
+                  actionUrl: "/payments",
+                },
+                { correlationId }
+              )
+
+              console.info("Enqueued payment success in-app notification", {
+                jobId: inAppJobId,
+                correlationId,
+                tenantId,
               })
             }
           } catch (notificationError) {

--- a/lib/notification-queue.ts
+++ b/lib/notification-queue.ts
@@ -1,0 +1,284 @@
+import { z } from "zod"
+
+import {
+  sendBulkNotifications,
+  sendEmailNotification,
+  sendInAppNotification,
+  type InAppNotification,
+  type NotificationData,
+} from "@/lib/notifications"
+import {
+  paymentReceiptSchema,
+  sendPaymentReceiptEmail,
+  type PaymentReceiptPayload,
+} from "@/lib/payment-receipt"
+import type { Database } from "@/lib/supabase"
+import { getSupabaseServiceRoleClient } from "@/lib/supabase-admin"
+
+const DEFAULT_MAX_ATTEMPTS = 5
+const BASE_RETRY_DELAY_MS = 2_000
+const MAX_RETRY_DELAY_MS = 60_000
+
+const jobPayloadSchemas = {
+  email: z.object({ notification: z.custom<NotificationData>() }),
+  in_app: z.object({ notification: z.custom<InAppNotification>() }),
+  bulk: z.object({
+    notifications: z
+      .array(z.custom<NotificationData | InAppNotification>())
+      .min(1),
+  }),
+  payment_receipt: z.object({ payload: paymentReceiptSchema }),
+} as const
+
+type NotificationJobType = keyof typeof jobPayloadSchemas
+
+type NotificationJobRecord = Database["public"]["Tables"]["notification_jobs"]["Row"]
+type NotificationJobInsert = Database["public"]["Tables"]["notification_jobs"]["Insert"]
+
+interface EnqueueOptions {
+  maxAttempts?: number
+  scheduledAt?: Date
+  correlationId?: string
+}
+
+interface JobResult {
+  jobId: string
+  status: "completed" | "retry-scheduled" | "dead-letter"
+  attempts: number
+  error?: string
+}
+
+export async function enqueueNotificationJob(
+  jobType: NotificationJobType,
+  payload: Record<string, unknown>,
+  options: EnqueueOptions = {}
+) {
+  const supabase = getSupabaseServiceRoleClient()
+  const insertPayload: NotificationJobInsert = {
+    job_type: jobType,
+    payload: payload as NotificationJobInsert["payload"],
+    max_attempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    scheduled_at: (options.scheduledAt ?? new Date()).toISOString(),
+    correlation_id: options.correlationId ?? null,
+  }
+
+  const { data, error } = await supabase
+    .from("notification_jobs")
+    .insert(insertPayload)
+    .select("id")
+    .single()
+
+  if (error) {
+    throw new Error(`Failed to enqueue ${jobType} job: ${error.message}`)
+  }
+
+  return { jobId: data.id }
+}
+
+export async function enqueueEmailNotification(
+  notification: NotificationData,
+  options?: EnqueueOptions
+) {
+  return enqueueNotificationJob("email", { notification }, options)
+}
+
+export async function enqueueInAppNotification(
+  notification: InAppNotification,
+  options?: EnqueueOptions
+) {
+  return enqueueNotificationJob("in_app", { notification }, options)
+}
+
+export async function enqueueBulkNotifications(
+  notifications: (NotificationData | InAppNotification)[],
+  options?: EnqueueOptions
+) {
+  return enqueueNotificationJob("bulk", { notifications }, options)
+}
+
+export async function enqueuePaymentReceiptEmail(
+  payload: PaymentReceiptPayload,
+  options?: EnqueueOptions
+) {
+  return enqueueNotificationJob("payment_receipt", { payload }, options)
+}
+
+export async function processNotificationJobs({
+  limit = 10,
+}: { limit?: number } = {}) {
+  const supabase = getSupabaseServiceRoleClient()
+  const nowIso = new Date().toISOString()
+
+  const { data: jobs, error } = await supabase
+    .from("notification_jobs")
+    .select("*")
+    .eq("status", "pending")
+    .lte("scheduled_at", nowIso)
+    .order("scheduled_at", { ascending: true })
+    .limit(limit)
+
+  if (error) {
+    throw new Error(`Failed to load pending jobs: ${error.message}`)
+  }
+
+  const results: JobResult[] = []
+
+  for (const job of jobs ?? []) {
+    const lockResult = await supabase
+      .from("notification_jobs")
+      .update({
+        status: "processing",
+        attempts: job.attempts + 1,
+        locked_at: new Date().toISOString(),
+        last_error: null,
+      })
+      .eq("id", job.id)
+      .eq("status", "pending")
+      .select("*")
+      .single()
+
+    if (lockResult.error || !lockResult.data) {
+      if (lockResult.error) {
+        console.error("Failed to lock job", {
+          jobId: job.id,
+          error: lockResult.error.message,
+        })
+      }
+      continue
+    }
+
+    const lockedJob = lockResult.data
+
+    try {
+      await executeJob(lockedJob)
+
+      await supabase
+        .from("notification_jobs")
+        .update({
+          status: "completed",
+          completed_at: new Date().toISOString(),
+          last_error: null,
+        })
+        .eq("id", lockedJob.id)
+
+      results.push({
+        jobId: lockedJob.id,
+        status: "completed",
+        attempts: lockedJob.attempts,
+      })
+    } catch (jobError) {
+      const message =
+        jobError instanceof Error ? jobError.message : String(jobError)
+      const attempts = lockedJob.attempts
+      const maxAttempts = lockedJob.max_attempts ?? DEFAULT_MAX_ATTEMPTS
+
+      if (attempts >= maxAttempts) {
+        await moveToDeadLetterQueue(lockedJob, message)
+        results.push({
+          jobId: lockedJob.id,
+          status: "dead-letter",
+          attempts,
+          error: message,
+        })
+      } else {
+        const delay = Math.min(
+          BASE_RETRY_DELAY_MS * 2 ** (attempts - 1),
+          MAX_RETRY_DELAY_MS
+        )
+        const nextScheduled = new Date(Date.now() + delay)
+
+        await supabase
+          .from("notification_jobs")
+          .update({
+            status: "pending",
+            scheduled_at: nextScheduled.toISOString(),
+            last_error: message,
+          })
+          .eq("id", lockedJob.id)
+
+        results.push({
+          jobId: lockedJob.id,
+          status: "retry-scheduled",
+          attempts,
+          error: message,
+        })
+      }
+    }
+  }
+
+  return { processed: results.length, results }
+}
+
+async function executeJob(job: NotificationJobRecord) {
+  const schema = jobPayloadSchemas[job.job_type as NotificationJobType]
+
+  if (!schema) {
+    throw new Error(`Unsupported job type: ${job.job_type}`)
+  }
+
+  const validation = schema.safeParse(job.payload)
+
+  if (!validation.success) {
+    throw new Error(
+      `Invalid payload for job ${job.id}: ${validation.error.message}`
+    )
+  }
+
+  switch (job.job_type as NotificationJobType) {
+    case "email": {
+      const result = await sendEmailNotification(validation.data.notification, {
+        jobId: job.id,
+      })
+
+      if (!result.success) {
+        throw new Error(result.error ?? "Email delivery failed")
+      }
+      break
+    }
+    case "in_app": {
+      const result = await sendInAppNotification(validation.data.notification, {
+        jobId: job.id,
+      })
+
+      if (!result.success) {
+        throw new Error(result.error ?? "In-app notification failed")
+      }
+      break
+    }
+    case "bulk": {
+      const results = await sendBulkNotifications(
+        validation.data.notifications
+      )
+
+      const failed = results.filter((entry) => !entry.success)
+
+      if (failed.length > 0) {
+        throw new Error(
+          `Bulk notification failed for ${failed.length} of ${results.length} entries`
+        )
+      }
+      break
+    }
+    case "payment_receipt": {
+      await sendPaymentReceiptEmail(validation.data.payload)
+      break
+    }
+    default:
+      throw new Error(`Unhandled job type: ${job.job_type}`)
+  }
+}
+
+async function moveToDeadLetterQueue(job: NotificationJobRecord, error: string) {
+  const supabase = getSupabaseServiceRoleClient()
+
+  await supabase.from("notification_dead_letters").insert({
+    id: job.id,
+    job_type: job.job_type,
+    payload: job.payload,
+    attempts: job.attempts,
+    error,
+    correlation_id: job.correlation_id,
+  })
+
+  await supabase.from("notification_jobs").delete().eq("id", job.id)
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,7 +1,10 @@
 "use server"
 
-import { createSupbaseServerClient } from "@/utils/supaone"
+import type { SupabaseClient } from "@supabase/supabase-js"
 import { Resend } from "resend"
+
+import type { Database } from "@/lib/supabase"
+import { getSupabaseServiceRoleClient } from "@/lib/supabase-admin"
 
 export interface NotificationData {
   to: string | string[]
@@ -22,6 +25,7 @@ export interface InAppNotification {
 
 class NotificationService {
   private resend: Resend | null = null
+  private supabase: SupabaseClient<Database> | null = null
 
   constructor() {
     const apiKey = process.env.RESEND_API_KEY
@@ -30,7 +34,20 @@ class NotificationService {
     }
   }
 
-  async sendEmail(notification: NotificationData) {
+  private getSupabaseClient() {
+    if (!this.supabase) {
+      try {
+        this.supabase = getSupabaseServiceRoleClient()
+      } catch (error) {
+        console.error("Supabase service role client unavailable", error)
+        return null
+      }
+    }
+
+    return this.supabase
+  }
+
+  async sendEmail(notification: NotificationData, context?: { jobId?: string }) {
     if (!this.resend) {
       console.warn(
         "Resend API key not configured. Skipping email notification."
@@ -73,7 +90,7 @@ class NotificationService {
 
       // Store email notification in database for tracking
       if (notification.userId) {
-        await this.storeEmailNotification(notification)
+        await this.storeEmailNotification(notification, context)
       }
 
       return { success: true, data }
@@ -86,11 +103,17 @@ class NotificationService {
     }
   }
 
-  async sendInAppNotification(notification: InAppNotification) {
+  async sendInAppNotification(
+    notification: InAppNotification,
+    context?: { jobId?: string }
+  ) {
     try {
-      const supabase = await createSupbaseServerClient()
+      const supabase = this.getSupabaseClient()
+      if (!supabase) {
+        throw new Error("Supabase client is not configured")
+      }
 
-      const { data, error } = await (supabase as any)
+      const { data, error } = await supabase
         .from("notifications")
         .insert({
           user_id: notification.userId,
@@ -98,7 +121,13 @@ class NotificationService {
           message: notification.message,
           type: notification.type,
           action_url: notification.actionUrl,
-          metadata: notification.metadata,
+          metadata:
+            notification.metadata || context?.jobId
+              ? {
+                  ...(notification.metadata ?? {}),
+                  ...(context?.jobId ? { jobId: context.jobId } : {}),
+                }
+              : null,
           read: false,
           created_at: new Date().toISOString(),
         })
@@ -138,11 +167,17 @@ class NotificationService {
     }))
   }
 
-  private async storeEmailNotification(notification: NotificationData) {
+  private async storeEmailNotification(
+    notification: NotificationData,
+    context?: { jobId?: string }
+  ) {
     try {
-      const supabase = await createSupbaseServerClient()
+      const supabase = this.getSupabaseClient()
+      if (!supabase) {
+        throw new Error("Supabase client is not configured")
+      }
 
-      await (supabase as any).from("email_notifications").insert({
+      await supabase.from("email_notifications").insert({
         user_id: notification.userId,
         recipient: Array.isArray(notification.to)
           ? notification.to.join(", ")
@@ -151,6 +186,13 @@ class NotificationService {
         template: notification.template,
         status: "sent",
         sent_at: new Date().toISOString(),
+        metadata:
+          notification.data || context?.jobId
+            ? {
+                ...(notification.data ?? {}),
+                ...(context?.jobId ? { jobId: context.jobId } : {}),
+              }
+            : null,
       })
     } catch (error) {
       console.error("Failed to store email notification:", error)
@@ -249,12 +291,18 @@ class NotificationService {
 
 const notificationService = new NotificationService()
 
-export async function sendEmailNotification(notification: NotificationData) {
-  return notificationService.sendEmail(notification)
+export async function sendEmailNotification(
+  notification: NotificationData,
+  context?: { jobId?: string }
+) {
+  return notificationService.sendEmail(notification, context)
 }
 
-export async function sendInAppNotification(notification: InAppNotification) {
-  return notificationService.sendInAppNotification(notification)
+export async function sendInAppNotification(
+  notification: InAppNotification,
+  context?: { jobId?: string }
+) {
+  return notificationService.sendInAppNotification(notification, context)
 }
 
 export async function sendBulkNotifications(

--- a/lib/payment-receipt.ts
+++ b/lib/payment-receipt.ts
@@ -1,0 +1,73 @@
+import { PaymentReceiptEmail } from "@/components/emails/payment-receipt"
+import { Resend } from "resend"
+import { z } from "zod"
+
+export const lineItemSchema = z.object({
+  description: z.string().min(1, "Line item description is required."),
+  quantity: z.number().positive().optional(),
+  unitAmount: z.number().nonnegative().optional(),
+  totalAmount: z.number().nonnegative().optional(),
+})
+
+export const paymentReceiptSchema = z.object({
+  customerEmail: z.string().email(),
+  customerName: z.string().min(1),
+  paymentId: z.string().min(1),
+  amountPaid: z.number().positive(),
+  currency: z.string().min(3).max(10),
+  paymentDate: z.coerce.date().optional(),
+  items: z.array(lineItemSchema).optional(),
+  businessName: z.string().optional(),
+  supportEmail: z.string().email().optional(),
+  billingAddress: z.string().optional(),
+  notes: z.string().optional(),
+  subtotalAmount: z.number().nonnegative().optional(),
+  taxAmount: z.number().nonnegative().optional(),
+  discountAmount: z.number().nonnegative().optional(),
+  sendCopyTo: z.array(z.string().email()).optional(),
+})
+
+export type PaymentReceiptPayload = z.infer<typeof paymentReceiptSchema>
+
+export async function sendPaymentReceiptEmail(payload: PaymentReceiptPayload) {
+  const resendApiKey = process.env.RESEND_API_KEY
+  if (!resendApiKey) {
+    throw new Error("Resend API key is not configured.")
+  }
+
+  const resend = new Resend(resendApiKey)
+  const fromAddress =
+    process.env.RESEND_RECEIPTS_FROM ?? "Roomsily Receipts <receipts@resend.dev>"
+  const emailRecipients = [
+    payload.customerEmail,
+    ...(payload.sendCopyTo ?? []),
+  ]
+
+  const { data, error } = await resend.emails.send({
+    from: fromAddress,
+    to: emailRecipients,
+    subject: `Receipt for payment ${payload.paymentId}`,
+    react: PaymentReceiptEmail({
+      customerName: payload.customerName,
+      paymentId: payload.paymentId,
+      amountPaid: payload.amountPaid,
+      currency: payload.currency,
+      paymentDate: payload.paymentDate ?? new Date(),
+      items: payload.items,
+      businessName: payload.businessName,
+      supportEmail: payload.supportEmail,
+      billingAddress: payload.billingAddress,
+      notes: payload.notes,
+      subtotalAmount: payload.subtotalAmount,
+      taxAmount: payload.taxAmount,
+      discountAmount: payload.discountAmount,
+    }),
+  })
+
+  if (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(message)
+  }
+
+  return data
+}

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,0 +1,28 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+let cachedClient: SupabaseClient<Database> | null = null
+
+function createServiceRoleClient(): SupabaseClient<Database> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Supabase service role credentials are not configured")
+  }
+
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}
+
+export function getSupabaseServiceRoleClient(): SupabaseClient<Database> {
+  if (!cachedClient) {
+    cachedClient = createServiceRoleClient()
+  }
+  return cachedClient
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -210,6 +210,30 @@ export type Database = {
         error_message: string | null
         metadata: Json | null
       }>
+      notification_jobs: SupabaseTable<{
+        id: string
+        job_type: 'email' | 'in_app' | 'bulk' | 'payment_receipt'
+        payload: Json
+        status: 'pending' | 'processing' | 'completed' | 'failed'
+        attempts: number
+        max_attempts: number
+        scheduled_at: string
+        locked_at: string | null
+        completed_at: string | null
+        last_error: string | null
+        correlation_id: string | null
+        created_at: string | null
+        updated_at: string | null
+      }>
+      notification_dead_letters: SupabaseTable<{
+        id: string
+        job_type: string
+        payload: Json
+        attempts: number
+        error: string | null
+        correlation_id: string | null
+        failed_at: string | null
+      }>
       meetings: SupabaseTable<{
         id: string
         user_id: string

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "css:purge": "node scripts/check-css-size.mjs"
+    "css:purge": "node scripts/check-css-size.mjs",
+    "queue:process": "tsx scripts/process-notification-jobs.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -87,6 +88,7 @@
     "eslint-plugin-tailwindcss": "^3.14.2",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
+    "tsx": "^4.7.0",
     "typescript": "^5.5.4",
     "vitest": "^3.2.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,12 +231,15 @@ importers:
       tailwindcss:
         specifier: ^3.4.0
         version: 3.4.0
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.5
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5)
 
 packages:
 
@@ -2858,6 +2861,9 @@ packages:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   get-tsconfig@4.7.2:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
 
@@ -4414,6 +4420,11 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -6412,13 +6423,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0))':
+  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7671,6 +7682,10 @@ snapshots:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
+
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@4.7.2:
     dependencies:
@@ -9550,6 +9565,13 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.5.4
 
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -9701,13 +9723,13 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vite-node@3.2.4(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9722,7 +9744,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9735,12 +9757,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.0
       terser: 5.44.0
+      tsx: 4.20.5
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9758,8 +9781,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
-      vite-node: 3.2.4(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+      vite: 7.1.6(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5)
+      vite-node: 3.2.4(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)(tsx@4.20.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/scripts/process-notification-jobs.ts
+++ b/scripts/process-notification-jobs.ts
@@ -1,0 +1,38 @@
+import { processNotificationJobs } from "@/lib/notification-queue"
+
+function parseBatchSize() {
+  const raw = process.env.NOTIFICATION_JOB_BATCH_SIZE
+  if (!raw) return undefined
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+async function main() {
+  const limit = parseBatchSize()
+  const start = Date.now()
+  const result = await processNotificationJobs({ limit })
+  const durationMs = Date.now() - start
+
+  console.info("Notification worker completed", {
+    processed: result.processed,
+    durationMs,
+    retries: result.results.filter((entry) => entry.status === "retry-scheduled")
+      .length,
+    deadLetters: result.results.filter((entry) => entry.status === "dead-letter")
+      .length,
+  })
+
+  const deadLetterJobs = result.results.filter(
+    (entry) => entry.status === "dead-letter"
+  )
+
+  if (deadLetterJobs.length > 0) {
+    console.error("Jobs moved to dead-letter queue", deadLetterJobs)
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error("Notification worker failed", error)
+  process.exit(1)
+})

--- a/supabase/migrations/20250305_notification_jobs_queue.sql
+++ b/supabase/migrations/20250305_notification_jobs_queue.sql
@@ -1,0 +1,52 @@
+-- Notification job queue infrastructure for asynchronous notification processing
+CREATE TABLE public.notification_jobs (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  job_type TEXT NOT NULL CHECK (job_type IN ('email', 'in_app', 'bulk', 'payment_receipt')),
+  payload JSONB NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  max_attempts INTEGER NOT NULL DEFAULT 5 CHECK (max_attempts > 0),
+  scheduled_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  locked_at TIMESTAMP WITH TIME ZONE,
+  completed_at TIMESTAMP WITH TIME ZONE,
+  last_error TEXT,
+  correlation_id TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX notification_jobs_status_scheduled_idx
+  ON public.notification_jobs (status, scheduled_at);
+
+CREATE INDEX notification_jobs_scheduled_idx
+  ON public.notification_jobs (scheduled_at);
+
+CREATE TABLE public.notification_dead_letters (
+  id UUID PRIMARY KEY,
+  job_type TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  attempts INTEGER NOT NULL,
+  error TEXT,
+  correlation_id TEXT,
+  failed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.notification_jobs
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.notification_dead_letters
+  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role can manage notification jobs" ON public.notification_jobs
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "Service role can manage notification dead letters" ON public.notification_dead_letters
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE TRIGGER update_notification_jobs_updated_at
+  BEFORE UPDATE ON public.notification_jobs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- introduce a Supabase-backed notification job queue with retry scheduling and a dead-letter table
- refactor notification helpers and API routes to enqueue jobs, log correlation IDs, and store metadata with job IDs
- queue payment receipt emails, add a reusable worker script, and expose new Supabase types/migrations

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b61fc5848328896868f0d9494a67