### PR TITLE
feat: add health check endpoints and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ Deploy to Vercel with the following environment variables configured in your Ver
 
 Review the [Performance & Availability Playbook](docs/perf/playbook.md) for service level objectives, monitoring dashboards, alert channels, and rollback procedures across Next.js, Supabase, and Stripe integrations.
 
+### Health Checks
+
+The portal exposes dedicated health endpoints for infrastructure probes and uptime monitoring:
+
+- `GET /api/health/liveness` returns process metrics (PID, uptime, RSS memory) and always responds with HTTP 200 when the runtime is reachable.
+- `GET /api/health/readiness` verifies Supabase connectivity, Stripe webhook configuration, Resend, Documenso, and Cal.com credentials. The endpoint responds with HTTP 200 for `pass`/`warn` states and HTTP 503 when any critical dependency fails.
+
+Both endpoints return a JSON payload with [`pass` | `warn` | `fail`] statuses per component. See [docs/engineering/health-checks.md](docs/engineering/health-checks.md) for the full schema and troubleshooting guidance.
+
+#### Deployment probe configuration
+
+| Platform | Liveness probe | Readiness probe | Notes |
+| --- | --- | --- | --- |
+| **Vercel** | `https://<deployment>/api/health/liveness` | `https://<deployment>/api/health/readiness` | Configure as [Uptime Monitors](https://vercel.com/docs/observability/monitors) or project health checks; readiness returning 503 will block traffic promotion. |
+| **Kubernetes** | `httpGet: { path: /api/health/liveness, port: 3000 }` | `httpGet: { path: /api/health/readiness, port: 3000 }` | Recommended probe thresholds: `initialDelaySeconds: 10`, `periodSeconds: 15`, `failureThreshold: 3`. |
+| **Docker Compose** | `healthcheck: ["CMD", "curl", "-f", "http://localhost:3000/api/health/liveness"]` | Use `curl http://localhost:3000/api/health/readiness` in orchestrator scripts before routing traffic. | Gate reverse-proxy enablement on a 200 response from readiness to avoid 503s during boot. |
+
 ## Project Structure
 
 ```

--- a/app/api/health/checks.ts
+++ b/app/api/health/checks.ts
@@ -1,0 +1,291 @@
+import { createClient } from "@supabase/supabase-js"
+import Stripe from "stripe"
+
+import type { Database } from "@/lib/supabase"
+
+export type HealthStatus = "pass" | "warn" | "fail"
+
+export interface HealthCheckResult {
+  status: HealthStatus
+  message?: string
+  meta?: Record<string, unknown>
+  checkedAt: string
+}
+
+export interface HealthResponse {
+  status: HealthStatus
+  timestamp: string
+  checks: Record<string, HealthCheckResult>
+}
+
+const SUPABASE_TIMEOUT_MS = 2000
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<T> {
+  let timeoutId: NodeJS.Timeout | undefined
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(timeoutMessage))
+    }, timeoutMs)
+  })
+
+  try {
+    return await Promise.race([promise, timeoutPromise])
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
+export async function checkSupabase(): Promise<HealthCheckResult> {
+  const start = Date.now()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim()
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim()
+
+  if (!supabaseUrl) {
+    return {
+      status: "fail",
+      message: "NEXT_PUBLIC_SUPABASE_URL is not configured",
+      meta: { environment: "NEXT_PUBLIC_SUPABASE_URL" },
+      checkedAt: nowIso(),
+    }
+  }
+
+  if (!serviceRoleKey) {
+    return {
+      status: "fail",
+      message: "SUPABASE_SERVICE_ROLE_KEY is not configured",
+      meta: { environment: "SUPABASE_SERVICE_ROLE_KEY" },
+      checkedAt: nowIso(),
+    }
+  }
+
+  try {
+    const supabase = createClient<Database>(supabaseUrl, serviceRoleKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    })
+
+    const { error, status } = await withTimeout(
+      supabase
+        .from("profiles")
+        .select("id", { head: true, count: "exact" })
+        .limit(1),
+      SUPABASE_TIMEOUT_MS,
+      "Supabase health check timed out"
+    )
+
+    if (error) {
+      return {
+        status: "fail",
+        message: `Supabase query failed: ${error.message}`,
+        meta: {
+          hint: error.hint,
+          details: error.details,
+          code: error.code,
+          httpStatus: status,
+          latencyMs: Date.now() - start,
+        },
+        checkedAt: nowIso(),
+      }
+    }
+
+    return {
+      status: "pass",
+      message: "Supabase connectivity verified",
+      meta: {
+        httpStatus: status,
+        latencyMs: Date.now() - start,
+      },
+      checkedAt: nowIso(),
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown Supabase connectivity error"
+
+    return {
+      status: "fail",
+      message,
+      meta: {
+        latencyMs: Date.now() - start,
+      },
+      checkedAt: nowIso(),
+    }
+  }
+}
+
+export async function checkStripeWebhook(): Promise<HealthCheckResult> {
+  const start = Date.now()
+  const secretKey = process.env.STRIPE_SECRET_KEY?.trim()
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET?.trim()
+
+  if (!secretKey) {
+    return {
+      status: "fail",
+      message: "STRIPE_SECRET_KEY is not configured",
+      meta: { environment: "STRIPE_SECRET_KEY" },
+      checkedAt: nowIso(),
+    }
+  }
+
+  if (!webhookSecret) {
+    return {
+      status: "fail",
+      message: "STRIPE_WEBHOOK_SECRET is not configured",
+      meta: { environment: "STRIPE_WEBHOOK_SECRET" },
+      checkedAt: nowIso(),
+    }
+  }
+
+  let status: HealthStatus = "pass"
+  const warnings: string[] = []
+
+  if (!/^sk_(live|test)_/.test(secretKey)) {
+    status = "warn"
+    warnings.push("STRIPE_SECRET_KEY does not match expected format")
+  }
+
+  if (!webhookSecret.startsWith("whsec_")) {
+    status = "warn"
+    warnings.push("STRIPE_WEBHOOK_SECRET should start with 'whsec_'")
+  }
+
+  try {
+    const stripe = new Stripe(secretKey, { apiVersion: "2024-06-20" })
+    const header = stripe.webhooks.generateTestHeaderString({
+      payload: "{}",
+      secret: webhookSecret,
+    })
+
+    return {
+      status,
+      message:
+        warnings.length > 0
+          ? warnings.join("; ")
+          : "Stripe webhook configuration verified",
+      meta: {
+        sampleSignature: header.split(",")[0],
+        latencyMs: Date.now() - start,
+      },
+      checkedAt: nowIso(),
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to initialize Stripe SDK"
+
+    return {
+      status: "fail",
+      message,
+      meta: {
+        latencyMs: Date.now() - start,
+      },
+      checkedAt: nowIso(),
+    }
+  }
+}
+
+export async function checkResend(): Promise<HealthCheckResult> {
+  const apiKey = process.env.RESEND_API_KEY?.trim()
+
+  if (!apiKey) {
+    return {
+      status: "warn",
+      message: "RESEND_API_KEY is not configured; transactional email will be disabled",
+      checkedAt: nowIso(),
+    }
+  }
+
+  return {
+    status: "pass",
+    message: "Resend API key detected",
+    meta: { keyPrefix: apiKey.slice(0, 6) },
+    checkedAt: nowIso(),
+  }
+}
+
+export async function checkDocumenso(): Promise<HealthCheckResult> {
+  const apiKey = process.env.DOCUMENSO_API_KEY?.trim()
+  const baseUrl = process.env.DOCUMENSO_BASE_URL?.trim()
+
+  if (!apiKey || !baseUrl) {
+    return {
+      status: "warn",
+      message: "Documenso credentials incomplete",
+      meta: {
+        hasApiKey: Boolean(apiKey),
+        hasBaseUrl: Boolean(baseUrl),
+      },
+      checkedAt: nowIso(),
+    }
+  }
+
+  return {
+    status: "pass",
+    message: "Documenso configuration detected",
+    meta: {
+      baseUrl,
+      keyPrefix: apiKey.slice(0, 6),
+    },
+    checkedAt: nowIso(),
+  }
+}
+
+export async function checkCalCom(): Promise<HealthCheckResult> {
+  const apiKey = process.env.CALCOM_API_KEY?.trim()
+  const baseUrl = process.env.CALCOM_BASE_URL?.trim()
+
+  if (!apiKey || !baseUrl) {
+    return {
+      status: "warn",
+      message: "Cal.com credentials incomplete",
+      meta: {
+        hasApiKey: Boolean(apiKey),
+        hasBaseUrl: Boolean(baseUrl),
+      },
+      checkedAt: nowIso(),
+    }
+  }
+
+  return {
+    status: "pass",
+    message: "Cal.com configuration detected",
+    meta: {
+      baseUrl,
+      keyPrefix: apiKey.slice(0, 6),
+    },
+    checkedAt: nowIso(),
+  }
+}
+
+export function aggregateStatus(checks: Record<string, HealthCheckResult>): HealthStatus {
+  if (Object.values(checks).some((check) => check.status === "fail")) {
+    return "fail"
+  }
+
+  if (Object.values(checks).some((check) => check.status === "warn")) {
+    return "warn"
+  }
+
+  return "pass"
+}
+
+export function buildHealthResponse(
+  checks: Record<string, HealthCheckResult>
+): HealthResponse {
+  return {
+    status: aggregateStatus(checks),
+    timestamp: nowIso(),
+    checks,
+  }
+}

--- a/app/api/health/liveness/route.ts
+++ b/app/api/health/liveness/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server"
+
+import { buildHealthResponse } from "../checks"
+
+export async function GET() {
+  const checks = {
+    process: {
+      status: "pass" as const,
+      message: "Process is running",
+      meta: {
+        uptimeSeconds: Number(process.uptime().toFixed(2)),
+        pid: process.pid,
+        memoryRssBytes: process.memoryUsage().rss,
+      },
+      checkedAt: new Date().toISOString(),
+    },
+  }
+
+  const response = buildHealthResponse(checks)
+
+  return NextResponse.json(response)
+}

--- a/app/api/health/readiness/route.ts
+++ b/app/api/health/readiness/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server"
+
+import {
+  buildHealthResponse,
+  checkCalCom,
+  checkDocumenso,
+  checkResend,
+  checkStripeWebhook,
+  checkSupabase,
+} from "../checks"
+
+export async function GET() {
+  const [supabase, stripeWebhook, resend, documenso, calCom] = await Promise.all([
+    checkSupabase(),
+    checkStripeWebhook(),
+    checkResend(),
+    checkDocumenso(),
+    checkCalCom(),
+  ])
+
+  const checks = {
+    supabase,
+    stripeWebhook,
+    resend,
+    documenso,
+    calCom,
+  }
+
+  const response = buildHealthResponse(checks)
+  const statusCode = response.status === "fail" ? 503 : 200
+
+  return NextResponse.json(response, { status: statusCode })
+}

--- a/docs/engineering/health-checks.md
+++ b/docs/engineering/health-checks.md
@@ -1,0 +1,117 @@
+# Health Check Endpoints
+
+Roomsily exposes dedicated health probes under `/api/health` to simplify orchestrator integrations, uptime monitoring, and on-call troubleshooting.
+
+## Endpoints
+
+| Path | Purpose | HTTP Status Contract |
+| --- | --- | --- |
+| `GET /api/health/liveness` | Confirms the process is running and able to serve requests. Includes uptime, PID, and RSS memory metrics. | Always returns `200 OK` with `status: "pass"` unless the runtime cannot be reached. |
+| `GET /api/health/readiness` | Validates external dependencies required for tenant workflows. | Returns `200 OK` for `pass` / `warn` states and `503 Service Unavailable` for `fail`. |
+
+All responses follow the [IETF Health Check](https://datatracker.ietf.org/doc/html/rfc9457) status vocabulary (`pass`, `warn`, `fail`) and expose a `checks` object keyed by dependency name.
+
+### Example readiness response
+
+```json
+{
+  "status": "fail",
+  "timestamp": "2024-07-12T16:42:10.221Z",
+  "checks": {
+    "supabase": {
+      "status": "fail",
+      "message": "Supabase query failed: Invalid API key",
+      "meta": {
+        "code": "401",
+        "httpStatus": 401,
+        "latencyMs": 187
+      },
+      "checkedAt": "2024-07-12T16:42:10.219Z"
+    },
+    "stripeWebhook": {
+      "status": "pass",
+      "message": "Stripe webhook configuration verified",
+      "meta": {
+        "sampleSignature": "t=1699870000",
+        "latencyMs": 12
+      },
+      "checkedAt": "2024-07-12T16:42:10.219Z"
+    },
+    "resend": {
+      "status": "warn",
+      "message": "RESEND_API_KEY is not configured; transactional email will be disabled",
+      "checkedAt": "2024-07-12T16:42:10.219Z"
+    }
+  }
+}
+```
+
+## Dependency coverage
+
+The readiness probe performs the following checks in parallel:
+
+- **Supabase** – Uses the service-role key to perform a lightweight `SELECT` against the `profiles` table. Timeouts and query errors surface as `fail` with diagnostic metadata.
+- **Stripe webhook configuration** – Ensures `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are present, validates expected prefixes, and exercises the Stripe SDK by generating a test webhook signature header.
+- **Resend** – Flags absence of `RESEND_API_KEY` as `warn` so deployments know transactional email is disabled.
+- **Documenso** – Confirms `DOCUMENSO_API_KEY` and `DOCUMENSO_BASE_URL` are configured. Missing values produce a `warn` status.
+- **Cal.com** – Confirms `CALCOM_API_KEY` and `CALCOM_BASE_URL` are configured. Missing values produce a `warn` status.
+
+Future dependencies can be added by extending `app/api/health/checks.ts` with an additional async check and including it in the readiness route.
+
+## Using the probes in deployments
+
+### Vercel
+
+1. Add both URLs (`/api/health/liveness` and `/api/health/readiness`) as [Monitors](https://vercel.com/docs/observability/monitors) to receive alerts on regression.
+2. Enable the project-level **Health Checks** feature and point it to `/api/health/readiness` so failed dependencies prevent traffic promotion during deployments.
+
+### Kubernetes
+
+Attach the following probes to the Next.js container:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /api/health/liveness
+    port: 3000
+  initialDelaySeconds: 10
+  periodSeconds: 15
+  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /api/health/readiness
+    port: 3000
+  initialDelaySeconds: 15
+  periodSeconds: 15
+  failureThreshold: 3
+```
+
+### Docker Compose / Swarm
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health/liveness"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    deploy:
+      update_config:
+        order: start-first
+      restart_policy:
+        condition: on-failure
+```
+
+Gate load balancer traffic by polling `/api/health/readiness` and waiting for a `pass`/`warn` response before announcing the container.
+
+## Troubleshooting
+
+- **Supabase failures** – Confirm `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set and that the service role has network access to the Supabase REST endpoint.
+- **Stripe warnings** – Validate the secret formats (`sk_live_` / `sk_test_` and `whsec_`). The readiness response includes a sample generated signature header prefix for debugging.
+- **Optional integrations** – `warn` statuses for Resend, Documenso, or Cal.com indicate missing API keys. Provision credentials before enabling features that rely on them.
+
+Use the `meta.latencyMs` values to spot unusual delays that might point to network issues.


### PR DESCRIPTION
## Summary
- add reusable health check helpers plus liveness and readiness API routes under `/api/health`
- surface Supabase, Stripe, Resend, Documenso, and Cal.com diagnostics with aggregated statuses
- document probe URLs and deployment usage in the README and a new health check runbook

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b61bbb748328ae63c1d7993145ee