### PR TITLE
Add locale-aware formatting utilities and tests

### DIFF
--- a/app/dashboard/(dashboard)/components/next-rent-card.tsx
+++ b/app/dashboard/(dashboard)/components/next-rent-card.tsx
@@ -1,20 +1,27 @@
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import SmartLink from "@/components/navigation/SmartLink"
-import { getRentSummary } from "../data"
 import { CalendarDays, Clock, RefreshCcw } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import SmartLink from "@/components/navigation/SmartLink"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getRentSummary } from "../data"
+import { formatCurrency } from "@/lib/payments/currency"
+import { formatDate } from "@/lib/utils"
+import { detectRequestLocale } from "@/lib/server/request-locale"
+import { resolveUserSettings } from "@/lib/user-settings"
 
 export async function NextRentCard() {
   const summary = await getRentSummary()
-  const formattedAmount = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(summary.amount)
-  const formattedBalance = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(summary.balance)
+  const locale = detectRequestLocale()
+  const userSettings = resolveUserSettings({ locale })
+  const formattedAmount = formatCurrency(summary.amount, {
+    currency: userSettings.currency,
+    locale: userSettings.locale,
+  })
+  const formattedBalance = formatCurrency(summary.balance, {
+    currency: userSettings.currency,
+    locale: userSettings.locale,
+  })
 
   const dueDate = new Date(summary.dueDate)
   const today = new Date()
@@ -29,6 +36,15 @@ export async function NextRentCard() {
         : diffInDays === 0
           ? "Due today"
           : `Overdue by ${Math.abs(diffInDays)} days`
+
+  const dueDateLabel = formatDate(dueDate, {
+    locale: userSettings.locale,
+    formatOptions: { month: "long", day: "numeric" },
+  })
+  const lastPaidLabel = formatDate(summary.lastPaymentDate, {
+    locale: userSettings.locale,
+    formatOptions: { month: "short", day: "numeric" },
+  })
 
   return (
     <Card className="h-full">
@@ -57,34 +73,28 @@ export async function NextRentCard() {
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2">
-          <div className="flex items-center gap-3 rounded-md border border-dashed border-border/60 p-3">
-            <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-              <CalendarDays className="size-5" />
+            <div className="flex items-center gap-3 rounded-md border border-dashed border-border/60 p-3">
+              <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <CalendarDays className="size-5" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">
+                  {dueDateLabel}
+                </p>
+                <p className="text-xs text-muted-foreground">{dueDescriptor}</p>
+              </div>
             </div>
-            <div>
-              <p className="text-sm font-medium">
-                {dueDate.toLocaleDateString(undefined, {
-                  month: "long",
-                  day: "numeric",
-                })}
-              </p>
-              <p className="text-xs text-muted-foreground">{dueDescriptor}</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-3 rounded-md border border-dashed border-border/60 p-3">
+            <div className="flex items-center gap-3 rounded-md border border-dashed border-border/60 p-3">
             <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
               <Clock className="size-5" />
             </div>
-            <div>
-              <p className="text-sm font-medium">
-                Last paid {new Date(summary.lastPaymentDate).toLocaleDateString(undefined, {
-                  month: "short",
-                  day: "numeric",
-                })}
-              </p>
-              <p className="text-xs text-muted-foreground">We’ll email receipts after processing</p>
+              <div>
+                <p className="text-sm font-medium">
+                  Last paid {lastPaidLabel}
+                </p>
+                <p className="text-xs text-muted-foreground">We’ll email receipts after processing</p>
+              </div>
             </div>
-          </div>
         </div>
 
         <SmartLink href="/payments" className="inline-flex" intent="critical">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from "next"
-import { Inter } from "next/font/google"
 import { Suspense } from "react"
 
 import { Analytics } from "@vercel/analytics/react"
@@ -7,19 +6,21 @@ import { SpeedInsights } from "@vercel/speed-insights/next"
 
 import "./globals.css"
 
+import { CookieButton } from "@/components/cookie-button"
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
-import { CookieButton } from "@/components/cookie-button"
+import { ReactQueryClientProvider } from "@/components/react-query-client-provider"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
-import { fontSans } from "@/lib/font"
-import { cn } from "@/lib/utils"
+import { UserSettingsProvider } from "@/components/user-settings-provider"
 import { siteConfig } from "@/config/site"
-import { ReactQueryClientProvider } from "@/components/react-query-client-provider"
-const inter = Inter({ subsets: ['latin'] })
+import { detectRequestLocale } from "@/lib/server/request-locale"
+import { fontSans } from "@/lib/font"
+import { resolveUserSettings } from "@/lib/user-settings"
+import { cn } from "@/lib/utils"
 
 export const metadata: Metadata = {
   title: {
@@ -27,40 +28,58 @@ export const metadata: Metadata = {
     template: `%s - ${siteConfig.name}`,
   },
   description: siteConfig.description,
-    manifest: '/manifest.json',
-  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || 'https://www.roomsily'),
+  manifest: "/manifest.json",
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://www.roomsily"),
   alternates: {
-    canonical: '/',
+    canonical: "/",
     languages: {
-      'en-US': '/en-US',
-      'de-DE': '/de-DE',
-      'es-ES': '/es-ES',
-      'fr-FR': '/fr-FR',
-      'jp-JP': '/jp-JP',
-      'ko-KO': '/ko-KP',
-      'zh-ZH': '/zh-ZH',
-      'pt-PT': '/pt-PT',
+      "en-US": "/en-US",
+      "de-DE": "/de-DE",
+      "es-ES": "/es-ES",
+      "fr-FR": "/fr-FR",
+      "jp-JP": "/jp-JP",
+      "ko-KO": "/ko-KP",
+      "zh-ZH": "/zh-ZH",
+      "pt-PT": "/pt-PT",
     },
   },
-  referrer: 'origin-when-cross-origin',
-  keywords: ['Roomsily', 'NextJS 14 TypeScript', 'Supabase SSR', 'TanStack React Query', 'co-living software', 'rent payment portal', 'shadcn/ui', 'Tailwind CSS', 'SaaS', 'NextJS Supabase Postgres Tailwind TanStack', 'NextJS CSP',
-             'PWA', 'NextJS SaaS PWA Template', 'CRUD ops', 'secure headers', 'NextJS templates with user authentication, RBAC, and CRUD ops', 'NextJS templates with data validation and database integration',
-            'Rust API runtime for vercel serverless functions', 'NextJS secure headers', 'NextJS NextMDX'],
-  authors: [{ name: 'Robert Mourey Jr' }],
-  creator: 'Robert Mourey Jr',
-  publisher: 'Robert Mourey Jr', 
+  referrer: "origin-when-cross-origin",
+  keywords: [
+    "Roomsily",
+    "NextJS 14 TypeScript",
+    "Supabase SSR",
+    "TanStack React Query",
+    "co-living software",
+    "rent payment portal",
+    "shadcn/ui",
+    "Tailwind CSS",
+    "SaaS",
+    "NextJS Supabase Postgres Tailwind TanStack",
+    "NextJS CSP",
+    "PWA",
+    "NextJS SaaS PWA Template",
+    "CRUD ops",
+    "secure headers",
+    "NextJS templates with user authentication, RBAC, and CRUD ops",
+    "NextJS templates with data validation and database integration",
+    "Rust API runtime for vercel serverless functions",
+    "NextJS secure headers",
+    "NextJS NextMDX",
+  ],
+  authors: [{ name: "Robert Mourey Jr" }],
+  creator: "Robert Mourey Jr",
+  publisher: "Robert Mourey Jr",
   formatDetection: {
     email: false,
     address: false,
     telephone: false,
   },
-  generator: 'NextJS',
+  generator: "NextJS",
   icons: {
     icon: "/favicon.svg",
     shortcut: "/favicon.svg",
     apple: "/favicon.svg",
   },
-
   robots: {
     index: false,
     follow: true,
@@ -69,9 +88,9 @@ export const metadata: Metadata = {
       index: true,
       follow: false,
       noimageindex: true,
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
     },
   },
   openGraph: {
@@ -81,87 +100,70 @@ export const metadata: Metadata = {
     url: "https://www.roomsily",
     images: [
       {
-        url: '/roomsily-og.svg',
+        url: "/roomsily-og.svg",
         width: 1200,
         height: 630,
-        alt: 'Roomsily — modern co-living hub',
+        alt: "Roomsily — modern co-living hub",
       },
     ],
-    locale: 'en_US',
-    type: 'website',
+    locale: "en_US",
+    type: "website",
   },
-    twitter: {
-         title: siteConfig.name,
-         description: siteConfig.description,
-         site: '@roomsily',
-         creator: '@roomsily',
-         images: ['/roomsily-og.svg'],
-   },
+  twitter: {
+    title: siteConfig.name,
+    description: siteConfig.description,
+    site: "@roomsily",
+    creator: "@roomsily",
+    images: ["/roomsily-og.svg"],
+  },
 }
-export const viewport: Viewport =  {
+
+export const viewport: Viewport = {
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "white" },
     { media: "(prefers-color-scheme: dark)", color: "black" },
   ],
-  width: 'device-width',
+  width: "device-width",
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
 }
 
 interface RootLayoutProps {
-  children: React.ReactNode
+  readonly children: React.ReactNode
 }
 
-
 export default function RootLayout({ children }: RootLayoutProps) {
+  const locale = detectRequestLocale()
+  const userSettings = resolveUserSettings({ locale })
+
   return (
     <ReactQueryClientProvider>
-    <html lang="en" suppressHydrationWarning>
-    <head></head>
-      <body className={cn(
-            "min-h-screen bg-background font-sans antialiased",
-            fontSans.variable
-          )}
+      <html lang={userSettings.locale} suppressHydrationWarning>
+        <head />
+        <body
+          className={cn("min-h-screen bg-background font-sans antialiased", fontSans.variable)}
         >
-<ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-             <div className="relative flex min-h-screen flex-col">
-              <SiteHeader />
-              <div className="flex-1">
-                <ErrorBoundary>
-                  <Suspense fallback={<RouteSkeleton />}>
-                    {children}
-                  </Suspense>
-                </ErrorBoundary>
-                <Toaster />
-                <Analytics />
-                <SpeedInsights />
+          <UserSettingsProvider value={userSettings}>
+            <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+              <div className="relative flex min-h-screen flex-col">
+                <SiteHeader />
+                <div className="flex-1">
+                  <ErrorBoundary>
+                    <Suspense fallback={<RouteSkeleton />}>{children}</Suspense>
+                  </ErrorBoundary>
+                  <Toaster />
+                  <Analytics />
+                  <SpeedInsights />
+                </div>
+                <SiteFooter />
               </div>
-
-   </div>
-<SiteFooter/>
-
-
-{/*
-enter your api info from termly.io or a provider of your choice
-<Script
-  type="text/javascript"
-  src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
-
- */}
-   <CookieButton />
-   <TailwindIndicator />
-          </ThemeProvider>
-
-
-
-</body>
-    </html>
+              <CookieButton />
+              <TailwindIndicator />
+            </ThemeProvider>
+          </UserSettingsProvider>
+        </body>
+      </html>
     </ReactQueryClientProvider>
   )
 }

--- a/app/payments/_components/catch-up-payment-card.tsx
+++ b/app/payments/_components/catch-up-payment-card.tsx
@@ -30,6 +30,7 @@ import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { Separator } from "@/components/ui/separator"
 import { toast } from "@/components/ui/use-toast"
+import { useUserSettings } from "@/components/user-settings-provider"
 import {
   allocatePaymentToCharges,
   applyAllocationsToCharges,
@@ -70,6 +71,7 @@ type QuickAmount = {
 }
 
 export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
+  const { locale } = useUserSettings()
   const schema = useMemo(() => createCatchUpFormSchema(balances), [balances])
   const form = useForm<CatchUpPaymentFormValues>({
     resolver: zodResolver(schema),
@@ -92,6 +94,9 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
     () => balances.find((balance) => balance.roommateId === selectedRoommateId),
     [balances, selectedRoommateId],
   )
+
+  const formatCurrencyForUser = (amount: number, currency: string) =>
+    formatCurrency(amount, { currency, locale })
 
   const handleRoommateChange = (roommateId: string) => {
     form.setValue("roommateId", roommateId, {
@@ -182,7 +187,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
     if (nextCharge) {
       amounts.push({
         key: "next",
-        label: `Next charge (${formatCurrency(nextCharge.outstandingAmount, selectedBalance.currency)})`,
+        label: `Next charge (${formatCurrencyForUser(nextCharge.outstandingAmount, selectedBalance.currency)})`,
         value: roundToCurrency(nextCharge.outstandingAmount),
       })
     }
@@ -191,14 +196,14 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
     if (half > 0) {
       amounts.push({
         key: "half",
-        label: `Half balance (${formatCurrency(half, selectedBalance.currency)})`,
+        label: `Half balance (${formatCurrencyForUser(half, selectedBalance.currency)})`,
         value: half,
       })
     }
 
     amounts.push({
       key: "full",
-      label: `Pay in full (${formatCurrency(outstandingBalance, selectedBalance.currency)})`,
+      label: `Pay in full (${formatCurrencyForUser(outstandingBalance, selectedBalance.currency)})`,
       value: roundToCurrency(outstandingBalance),
     })
 
@@ -239,7 +244,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
         setLastResult(result)
         toast({
           title: `Catch-up scheduled for ${result.roommateName}`,
-          description: `${formatCurrency(result.amount, result.currency)} applied • New balance ${formatCurrency(result.projectedBalance, result.currency)}`,
+          description: `${formatCurrencyForUser(result.amount, result.currency)} applied • New balance ${formatCurrencyForUser(result.projectedBalance, result.currency)}`,
         })
 
         form.setValue(
@@ -316,7 +321,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                   <span className="font-medium">Outstanding</span>
                   <span>
                     {selectedBalance
-                      ? formatCurrency(outstandingBalance, selectedBalance.currency)
+                      ? formatCurrencyForUser(outstandingBalance, selectedBalance.currency)
                       : "—"}
                   </span>
                 </div>
@@ -353,7 +358,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                     </FormControl>
                     <FormDescription>
                       {selectedBalance
-                        ? `${formatCurrency(outstandingBalance, selectedBalance.currency)} outstanding`
+                        ? `${formatCurrencyForUser(outstandingBalance, selectedBalance.currency)} outstanding`
                         : "Enter an amount to distribute across open charges."}
                     </FormDescription>
                     <FormMessage />
@@ -380,7 +385,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                   <span>Projected remaining</span>
                   <span>
                     {selectedBalance
-                      ? formatCurrency(projectedBalance, selectedBalance.currency)
+                      ? formatCurrencyForUser(projectedBalance, selectedBalance.currency)
                       : "—"}
                   </span>
                 </div>
@@ -432,15 +437,15 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                               {format(parseISO(charge.dueDate), "MMM d")}
                             </td>
                             <td className="py-2 pr-2 text-right">
-                              {formatCurrency(charge.outstandingAmount, selectedBalance.currency)}
+                              {formatCurrencyForUser(charge.outstandingAmount, selectedBalance.currency)}
                             </td>
                             <td className="py-2 pr-2 text-right text-emerald-600">
                               {applyingAmount > 0
-                                ? `-${formatCurrency(applyingAmount, selectedBalance.currency)}`
+                                ? `-${formatCurrencyForUser(applyingAmount, selectedBalance.currency)}`
                                 : "—"}
                             </td>
                             <td className="py-2 pr-4 text-right">
-                              {formatCurrency(remainingAmount, selectedBalance.currency)}
+                              {formatCurrencyForUser(remainingAmount, selectedBalance.currency)}
                             </td>
                           </tr>
                         )
@@ -527,11 +532,11 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                 </p>
               </div>
               <div className="text-sm font-semibold">
-                {formatCurrency(lastResult.amount, lastResult.currency)}
+                {formatCurrencyForUser(lastResult.amount, lastResult.currency)}
               </div>
             </div>
             <div className="flex w-full flex-wrap items-center gap-2 text-xs text-muted-foreground">
-              <span>Remaining balance {formatCurrency(lastResult.projectedBalance, lastResult.currency)}</span>
+              <span>Remaining balance {formatCurrencyForUser(lastResult.projectedBalance, lastResult.currency)}</span>
               <span aria-hidden="true">•</span>
               <span>
                 Allocated to {lastResult.allocations.length} charge{lastResult.allocations.length === 1 ? "" : "s"}
@@ -540,7 +545,7 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
             <div className="flex w-full flex-wrap gap-2">
               {lastResult.allocations.map((allocation) => (
                 <Badge key={allocation.chargeId} variant="outline">
-                  {allocation.description}: {formatCurrency(allocation.amount, lastResult.currency)}
+                  {allocation.description}: {formatCurrencyForUser(allocation.amount, lastResult.currency)}
                 </Badge>
               ))}
             </div>

--- a/app/payments/_components/roommate-ledger.tsx
+++ b/app/payments/_components/roommate-ledger.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { formatCurrency, roundToCurrency } from "@/lib/payments/currency"
+import { resolveUserSettings } from "@/lib/user-settings"
 import { cn } from "@/lib/utils"
 import type {
   LedgerActorRole,
@@ -20,6 +21,7 @@ import type {
 
 interface RoommateLedgerProps {
   ledgers: RoommateLedger[]
+  locale?: string
 }
 
 type LedgerRow = RoommateLedger["entries"][number] & { balanceAfter: number }
@@ -37,10 +39,14 @@ const actorRoleLabels: Record<LedgerActorRole, string> = {
   property_manager: "Property manager",
 }
 
-export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
+export function RoommateLedger({ ledgers, locale }: RoommateLedgerProps) {
   if (ledgers.length === 0) {
     return null
   }
+
+  const userSettings = resolveUserSettings({ locale })
+  const formatCurrencyForUser = (amount: number, currency: string) =>
+    formatCurrency(amount, { currency, locale: userSettings.locale })
 
   const derivedLedgers = ledgers.map((ledger) => {
     let running = roundToCurrency(ledger.startingBalance)
@@ -124,10 +130,10 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
                         Outstanding
                       </p>
                       <p className="text-sm font-semibold">
-                        {formatCurrency(currentOutstanding, ledger.currency)}
+                        {formatCurrencyForUser(currentOutstanding, ledger.currency)}
                       </p>
                       <p className="text-xs text-muted-foreground">
-                        Started at {formatCurrency(ledger.startingBalance, ledger.currency)}
+                        Started at {formatCurrencyForUser(ledger.startingBalance, ledger.currency)}
                       </p>
                     </div>
                   </div>
@@ -178,7 +184,7 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
                               </div>
                               <div className="flex flex-col items-end gap-1 text-right">
                                 <span className={cn("font-semibold", amountClass)}>
-                                  {formatLedgerChange(entry.amount, ledger.currency)}
+                                  {formatLedgerChange(entry.amount, ledger.currency, userSettings.locale)}
                                 </span>
                                 <Badge
                                   variant={entryTypeMeta.badgeVariant}
@@ -189,7 +195,7 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
                               </div>
                               <div className="text-right">
                                 <p className="font-semibold">
-                                  {formatCurrency(entry.balanceAfter, ledger.currency)}
+                                  {formatCurrencyForUser(entry.balanceAfter, ledger.currency)}
                                 </p>
                                 <p className="text-xs text-muted-foreground">
                                   Running balance
@@ -216,11 +222,11 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
   )
 }
 
-function formatLedgerChange(amount: number, currency: string): string {
+function formatLedgerChange(amount: number, currency: string, locale: string): string {
   if (amount === 0) {
-    return formatCurrency(0, currency)
+    return formatCurrency(0, { currency, locale })
   }
 
   const prefix = amount > 0 ? "+" : "-"
-  return `${prefix}${formatCurrency(Math.abs(amount), currency)}`
+  return `${prefix}${formatCurrency(Math.abs(amount), { currency, locale })}`
 }

--- a/app/payments/actions.ts
+++ b/app/payments/actions.ts
@@ -47,7 +47,7 @@ export async function submitCatchUpPayment(
   const outstanding = calculateOutstanding(balance.charges)
   if (amount > outstanding) {
     throw new Error(
-      `Catch-up amount exceeds outstanding balance of ${formatCurrency(outstanding, balance.currency)}.`,
+      `Catch-up amount exceeds outstanding balance of ${formatCurrency(outstanding, { currency: balance.currency })}.`,
     )
   }
 

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -17,6 +17,8 @@ import {
   getNextOutstandingCharge,
 } from "@/lib/payments/catch-up"
 import { formatCurrency } from "@/lib/payments/currency"
+import { detectRequestLocale } from "@/lib/server/request-locale"
+import { resolveUserSettings } from "@/lib/user-settings"
 import type { CatchUpBalance } from "@/types/payments"
 
 import { loadCatchUpBalances, loadRoommateLedgers } from "./loaders"
@@ -64,6 +66,9 @@ function formatFullDate(date: string) {
 }
 
 export default async function PaymentsPage() {
+  const locale = detectRequestLocale()
+  const userSettings = resolveUserSettings({ locale })
+
   const [catchUpBalances, roommateLedgers] = await Promise.all([
     loadCatchUpBalances(),
     loadRoommateLedgers(),
@@ -94,7 +99,10 @@ export default async function PaymentsPage() {
       ? Math.round((activeAutopays / catchUpBalances.length) * 100)
       : 0
 
-  const defaultCurrency = catchUpBalances[0]?.currency ?? "USD"
+  const defaultCurrency = catchUpBalances[0]?.currency ?? userSettings.currency
+
+  const formatCurrencyForUser = (amount: number, currency: string) =>
+    formatCurrency(amount, { currency, locale: userSettings.locale })
 
   const roommateSummaries = [...outstandingSummaries].sort(
     (a, b) => b.outstanding - a.outstanding,
@@ -137,7 +145,7 @@ export default async function PaymentsPage() {
                     Outstanding total
                   </dt>
                   <dd className="text-lg font-semibold">
-                    {formatCurrency(totalOutstanding, defaultCurrency)}
+                    {formatCurrencyForUser(totalOutstanding, defaultCurrency)}
                   </dd>
                   <p className="text-xs text-muted-foreground">
                     {catchUpBalances.length} roommates tracked
@@ -187,7 +195,7 @@ export default async function PaymentsPage() {
                       {balance.unitLabel} · {describeAutopayStatus(balance)}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      Last payment {formatFullDate(balance.lastPaymentDate)} · {formatCurrency(
+                      Last payment {formatFullDate(balance.lastPaymentDate)} · {formatCurrencyForUser(
                         balance.lastPaymentAmount,
                         balance.currency,
                       )}
@@ -195,7 +203,7 @@ export default async function PaymentsPage() {
                   </div>
                   <div className="text-right">
                     <p className="text-sm font-semibold">
-                      {formatCurrency(outstanding, balance.currency)}
+                      {formatCurrencyForUser(outstanding, balance.currency)}
                     </p>
                     {nextCharge ? (
                       <p className="text-xs text-muted-foreground">
@@ -221,7 +229,7 @@ export default async function PaymentsPage() {
         </div>
         <CatchUpPaymentCard balances={catchUpBalances} />
       </section>
-      <RoommateLedger ledgers={roommateLedgers} />
+      <RoommateLedger ledgers={roommateLedgers} locale={userSettings.locale} />
     </div>
   )
 }

--- a/components/emails/payment-receipt.tsx
+++ b/components/emails/payment-receipt.tsx
@@ -1,4 +1,7 @@
-import * as React from 'react';
+import * as React from "react"
+
+import { formatCurrency } from "@/lib/payments/currency"
+import { formatDate } from "@/lib/utils"
 
 export interface PaymentReceiptLineItem {
   description: string;
@@ -12,6 +15,7 @@ export interface PaymentReceiptEmailProps {
   paymentId: string;
   amountPaid: number;
   currency: string;
+  locale?: string;
   paymentDate: Date;
   items?: PaymentReceiptLineItem[];
   businessName?: string;
@@ -23,28 +27,10 @@ export interface PaymentReceiptEmailProps {
   discountAmount?: number;
 }
 
-const formatCurrency = (amount: number, currency: string) => {
-  try {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency,
-    }).format(amount);
-  } catch (error) {
-    const formattedAmount = amount.toFixed(2);
-    return `${formattedAmount} ${currency}`;
-  }
-};
-
-const formatDate = (date: Date) => {
-  return new Intl.DateTimeFormat('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(date);
-};
-
 const renderLineItems = (
   items: PaymentReceiptLineItem[] | undefined,
   currency: string,
+  locale?: string,
 ) => {
   if (!items?.length) return null;
 
@@ -66,14 +52,16 @@ const renderLineItems = (
               {item.quantity ?? '-'}
             </td>
             <td style={{ padding: '8px 0', textAlign: 'right', borderBottom: '1px solid #f1f5f9' }}>
-              {item.unitAmount != null ? formatCurrency(item.unitAmount, currency) : '—'}
+              {item.unitAmount != null
+                ? formatCurrency(item.unitAmount, { currency, locale })
+                : "—"}
             </td>
             <td style={{ padding: '8px 0', textAlign: 'right', borderBottom: '1px solid #f1f5f9' }}>
               {item.totalAmount != null
-                ? formatCurrency(item.totalAmount, currency)
+                ? formatCurrency(item.totalAmount, { currency, locale })
                 : item.unitAmount != null && item.quantity != null
-                  ? formatCurrency(item.unitAmount * item.quantity, currency)
-                  : '—'}
+                  ? formatCurrency(item.unitAmount * item.quantity, { currency, locale })
+                  : "—"}
             </td>
           </tr>
         ))}
@@ -85,18 +73,18 @@ const renderLineItems = (
 const renderTotals = (
   props: Pick<
     PaymentReceiptEmailProps,
-    'subtotalAmount' | 'taxAmount' | 'discountAmount' | 'amountPaid' | 'currency'
-  >,
+    "subtotalAmount" | "taxAmount" | "discountAmount" | "amountPaid" | "currency"
+  > & { locale?: string },
 ) => {
-  const { subtotalAmount, taxAmount, discountAmount, amountPaid, currency } = props;
+  const { subtotalAmount, taxAmount, discountAmount, amountPaid, currency, locale } = props;
 
   const hasAdjustments =
     subtotalAmount != null || taxAmount != null || discountAmount != null;
 
   if (!hasAdjustments) {
     return (
-      <p style={{ textAlign: 'right', fontWeight: 600, marginTop: '16px' }}>
-        Total: {formatCurrency(amountPaid, currency)}
+      <p style={{ textAlign: "right", fontWeight: 600, marginTop: "16px" }}>
+        Total: {formatCurrency(amountPaid, { currency, locale })}
       </p>
     );
   }
@@ -108,31 +96,31 @@ const renderTotals = (
           {subtotalAmount != null && (
             <tr>
               <td style={{ padding: '4px 0', textAlign: 'right', color: '#475569' }}>Subtotal</td>
-              <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 500 }}>
-                {formatCurrency(subtotalAmount, currency)}
+              <td style={{ padding: "4px 0", textAlign: "right", fontWeight: 500 }}>
+                {formatCurrency(subtotalAmount, { currency, locale })}
               </td>
             </tr>
           )}
           {taxAmount != null && (
             <tr>
               <td style={{ padding: '4px 0', textAlign: 'right', color: '#475569' }}>Tax</td>
-              <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 500 }}>
-                {formatCurrency(taxAmount, currency)}
+              <td style={{ padding: "4px 0", textAlign: "right", fontWeight: 500 }}>
+                {formatCurrency(taxAmount, { currency, locale })}
               </td>
             </tr>
           )}
           {discountAmount != null && (
             <tr>
               <td style={{ padding: '4px 0', textAlign: 'right', color: '#475569' }}>Discount</td>
-              <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 500 }}>
-                -{formatCurrency(discountAmount, currency)}
+              <td style={{ padding: "4px 0", textAlign: "right", fontWeight: 500 }}>
+                -{formatCurrency(discountAmount, { currency, locale })}
               </td>
             </tr>
           )}
           <tr>
             <td style={{ padding: '8px 0', textAlign: 'right', fontWeight: 600 }}>Total Paid</td>
-            <td style={{ padding: '8px 0', textAlign: 'right', fontWeight: 600 }}>
-              {formatCurrency(amountPaid, currency)}
+            <td style={{ padding: "8px 0", textAlign: "right", fontWeight: 600 }}>
+              {formatCurrency(amountPaid, { currency, locale })}
             </td>
           </tr>
         </tbody>
@@ -146,9 +134,10 @@ export const PaymentReceiptEmail: React.FC<Readonly<PaymentReceiptEmailProps>> =
   paymentId,
   amountPaid,
   currency,
+  locale,
   paymentDate,
   items,
-  businessName = 'Roomsily',
+  businessName = "Roomsily",
   supportEmail,
   billingAddress,
   notes,
@@ -156,6 +145,8 @@ export const PaymentReceiptEmail: React.FC<Readonly<PaymentReceiptEmailProps>> =
   taxAmount,
   discountAmount,
 }) => {
+  const formatCurrencyForUser = (value: number) => formatCurrency(value, { currency, locale })
+
   return (
     <div
       style={{
@@ -210,7 +201,10 @@ export const PaymentReceiptEmail: React.FC<Readonly<PaymentReceiptEmailProps>> =
                 Paid On
               </p>
               <p style={{ margin: '4px 0 0', color: '#0f172a', fontWeight: 600 }}>
-                {formatDate(paymentDate)}
+                {formatDate(paymentDate, {
+                  locale,
+                  formatOptions: { dateStyle: 'medium', timeStyle: 'short' },
+                })}
               </p>
             </div>
             <div>
@@ -218,12 +212,12 @@ export const PaymentReceiptEmail: React.FC<Readonly<PaymentReceiptEmailProps>> =
                 Amount Paid
               </p>
               <p style={{ margin: '4px 0 0', color: '#0f172a', fontWeight: 600 }}>
-                {formatCurrency(amountPaid, currency)}
+                {formatCurrencyForUser(amountPaid)}
               </p>
             </div>
           </div>
 
-          {renderLineItems(items, currency)}
+          {renderLineItems(items, currency, locale)}
 
           {renderTotals({
             subtotalAmount,
@@ -231,6 +225,7 @@ export const PaymentReceiptEmail: React.FC<Readonly<PaymentReceiptEmailProps>> =
             discountAmount,
             amountPaid,
             currency,
+            locale,
           })}
 
           {billingAddress && (

--- a/components/user-settings-provider.tsx
+++ b/components/user-settings-provider.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { createContext, useContext, useMemo, type ReactNode } from "react"
+
+import {
+  resolveUserSettings,
+  type UserSettings,
+  type UserSettingsOverrides,
+} from "@/lib/user-settings"
+
+const UserSettingsContext = createContext<UserSettings>(resolveUserSettings())
+
+interface UserSettingsProviderProps {
+  readonly value?: UserSettingsOverrides
+  readonly children: ReactNode
+}
+
+export function UserSettingsProvider({ value, children }: UserSettingsProviderProps) {
+  const settings = useMemo(() => resolveUserSettings(value), [value])
+
+  return <UserSettingsContext.Provider value={settings}>{children}</UserSettingsContext.Provider>
+}
+
+export function useUserSettings() {
+  return useContext(UserSettingsContext)
+}

--- a/config/user-settings.ts
+++ b/config/user-settings.ts
@@ -1,0 +1,19 @@
+export const supportedLocales = [
+  "en-US",
+  "de-DE",
+  "es-ES",
+  "fr-FR",
+  "ja-JP",
+  "ko-KR",
+  "zh-CN",
+  "pt-PT",
+] as const
+
+export type SupportedLocale = (typeof supportedLocales)[number]
+
+export const defaultUserSettings = {
+  locale: "en-US" as SupportedLocale,
+  currency: "USD",
+}
+
+export type DefaultUserSettings = typeof defaultUserSettings

--- a/lib/payments/currency.ts
+++ b/lib/payments/currency.ts
@@ -1,3 +1,5 @@
+import { resolveUserSettings } from "@/lib/user-settings"
+
 export function roundToCurrency(value: number): number {
   return Math.round(value * 100) / 100
 }
@@ -20,13 +22,39 @@ export function parseCurrencyInput(rawValue: string): number {
   return roundToCurrency(parsed)
 }
 
-export function formatCurrency(amount: number, currency: string): string {
+export interface FormatCurrencyOptions {
+  readonly currency?: string
+  readonly locale?: string
+  readonly minimumFractionDigits?: number
+  readonly maximumFractionDigits?: number
+}
+
+export function formatCurrency(amount: number, options?: FormatCurrencyOptions): string {
+  const { currency, locale } = resolveUserSettings({
+    currency: options?.currency,
+    locale: options?.locale,
+  })
+
+  const formatOptions: Intl.NumberFormatOptions = {
+    style: "currency",
+    currency,
+  }
+
+  if (options?.minimumFractionDigits != null) {
+    formatOptions.minimumFractionDigits = options.minimumFractionDigits
+  }
+
+  if (options?.maximumFractionDigits != null) {
+    formatOptions.maximumFractionDigits = options.maximumFractionDigits
+  }
+
   try {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency,
-    }).format(amount)
+    return new Intl.NumberFormat(locale, formatOptions).format(amount)
   } catch (error) {
-    return `${roundToCurrency(amount).toFixed(2)} ${currency.toUpperCase()}`
+    const digits =
+      options?.maximumFractionDigits ??
+      options?.minimumFractionDigits ??
+      2
+    return `${roundToCurrency(amount).toFixed(digits)} ${currency.toUpperCase()}`
   }
 }

--- a/lib/payments/schemas.ts
+++ b/lib/payments/schemas.ts
@@ -59,7 +59,7 @@ export const createCatchUpFormSchema = (balances: CatchUpBalance[]) =>
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["amount"],
-          message: `Amount exceeds outstanding balance of ${formatCurrency(outstanding, balance.currency)}`,
+          message: `Amount exceeds outstanding balance of ${formatCurrency(outstanding, { currency: balance.currency })}`,
         })
       }
     })

--- a/lib/server/request-locale.ts
+++ b/lib/server/request-locale.ts
@@ -1,0 +1,19 @@
+import { headers } from "next/headers"
+
+import { normalizeLocale } from "@/lib/user-settings"
+
+export function detectRequestLocale(): string | undefined {
+  const headerValue = headers().get("accept-language")
+
+  if (!headerValue) {
+    return undefined
+  }
+
+  const [primary] = headerValue.split(",")
+  if (!primary) {
+    return undefined
+  }
+
+  const [locale] = primary.split(";")
+  return normalizeLocale(locale)
+}

--- a/lib/user-settings.ts
+++ b/lib/user-settings.ts
@@ -1,0 +1,47 @@
+import { defaultUserSettings, type DefaultUserSettings } from "@/config/user-settings"
+
+export type UserSettings = DefaultUserSettings
+
+export type UserSettingsOverrides = Partial<Pick<UserSettings, "locale" | "currency">>
+
+export function resolveUserSettings(overrides?: UserSettingsOverrides): UserSettings {
+  return {
+    locale: overrides?.locale ?? defaultUserSettings.locale,
+    currency: overrides?.currency ?? defaultUserSettings.currency,
+  }
+}
+
+export function normalizeLocale(locale: string | null | undefined): string | undefined {
+  if (!locale) {
+    return undefined
+  }
+
+  return locale.trim() || undefined
+}
+
+export function deriveUserSettingsFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): UserSettingsOverrides {
+  if (!metadata) {
+    return {}
+  }
+
+  const localeValue =
+    typeof metadata.locale === "string"
+      ? metadata.locale
+      : typeof metadata.language === "string"
+        ? metadata.language
+        : undefined
+
+  const currencyValue =
+    typeof metadata.currency === "string"
+      ? metadata.currency
+      : typeof metadata.preferred_currency === "string"
+        ? metadata.preferred_currency
+        : undefined
+
+  return {
+    locale: normalizeLocale(localeValue),
+    currency: currencyValue?.trim() || undefined,
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,8 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+import { resolveUserSettings, type UserSettingsOverrides } from "@/lib/user-settings"
+
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -30,20 +32,40 @@ export async function fetcher<JSON = any>(
   return res.json()
 }
 
-export function formatDate(input: string | number | Date): string {
-  const date = new Date(input)
-  return date.toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric'
-  })
+export interface FormatDateOptions extends UserSettingsOverrides {
+  readonly formatOptions?: Intl.DateTimeFormatOptions
 }
 
-export const formatNumber = (value: number) =>
-  new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD'
-  }).format(value)
+export function formatDate(input: string | number | Date, options?: FormatDateOptions): string {
+  const date = new Date(input)
+  const { locale } = resolveUserSettings({ locale: options?.locale })
+  const formatOptions =
+    options?.formatOptions ?? ({ month: "long", day: "numeric", year: "numeric" } as const)
+
+  return new Intl.DateTimeFormat(locale, formatOptions).format(date)
+}
+
+export interface FormatNumberOptions extends UserSettingsOverrides {
+  readonly style?: Intl.NumberFormatOptions["style"]
+  readonly formatOptions?: Intl.NumberFormatOptions
+}
+
+export const formatNumber = (value: number, options?: FormatNumberOptions) => {
+  const { locale, currency } = resolveUserSettings({
+    locale: options?.locale,
+    currency: options?.currency,
+  })
+
+  const baseOptions: Intl.NumberFormatOptions = options?.formatOptions
+    ? { ...options.formatOptions }
+    : { style: options?.style ?? "currency" }
+
+  if (baseOptions.style === "currency" && !baseOptions.currency) {
+    baseOptions.currency = currency
+  }
+
+  return new Intl.NumberFormat(locale, baseOptions).format(value)
+}
 
 export const runAsyncFnWithoutBlocking = (
   fn: (...args: any) => Promise<any>

--- a/tests/lib/formatting.test.ts
+++ b/tests/lib/formatting.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { formatCurrency } from "@/lib/payments/currency"
+import { formatDate } from "@/lib/utils"
+
+describe("formatCurrency", () => {
+  it("uses default user settings when no overrides are provided", () => {
+    expect(formatCurrency(1234.5)).toBe("$1,234.50")
+  })
+
+  it("formats amounts according to the provided locale and currency", () => {
+    expect(formatCurrency(1234.5, { currency: "EUR", locale: "de-DE" })).toBe("1.234,50 €")
+  })
+})
+
+describe("formatDate", () => {
+  const sampleDate = new Date(Date.UTC(2024, 0, 15, 12, 0, 0))
+
+  it("returns a localized long date string by default", () => {
+    expect(formatDate(sampleDate)).toBe("January 15, 2024")
+  })
+
+  it("respects custom locales when provided", () => {
+    expect(formatDate(sampleDate, { locale: "fr-FR" })).toBe("15 janvier 2024")
+  })
+
+  it("supports custom format options including time styles", () => {
+    const formatted = formatDate(sampleDate, {
+      locale: "en-GB",
+      formatOptions: { dateStyle: "medium", timeStyle: "short", timeZone: "UTC" },
+    })
+
+    expect(formatted).toBe("15 Jan 2024, 12:00")
+  })
+})


### PR DESCRIPTION
## Summary
- add configuration, helpers, and a user-settings provider to expose locale and currency defaults and hydrate them from request headers
- extend currency/date formatting utilities to accept locale overrides and adopt them across payments, dashboard, and email surfaces
- add coverage ensuring formatting outputs change with different locales

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b61395548328a5281b5af035def5