### PR TITLE
feat(logging): add structured logger and request correlation

### DIFF
--- a/app/account/loaders.ts
+++ b/app/account/loaders.ts
@@ -2,13 +2,14 @@
 
 import "server-only"
 
-import { cookies } from "next/headers"
+import { cookies, headers } from "next/headers"
 
 import type { User } from "@supabase/supabase-js"
 
 import type { Database } from "@/lib/supabase"
 
 import { createClient } from "@/utils/supa-server-actions"
+import { getLogger, withRequestContext } from "@/lib/logger"
 
 import type { AccountProfile } from "./types"
 
@@ -22,37 +23,46 @@ export interface AccountPageData {
   profile: AccountProfile | null
 }
 
+const log = getLogger({ module: "account.loaders" })
+
 export async function loadAccountPageData(): Promise<AccountPageData> {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)
+  const requestHeaders = headers()
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  return withRequestContext(
+    async () => {
+      const cookieStore = cookies()
+      const supabase = createClient(cookieStore)
 
-  if (!user) {
-    return { user: null, profile: null }
-  }
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
 
-  const { data, error } = await supabase
-    .from("profiles")
-    .select("full_name, username, website, avatar_url, email")
-    .eq("id", user.id)
-    .maybeSingle<ProfileRow>()
-
-  if (error) {
-    console.error("Failed to load account profile", error)
-  }
-
-  const profile: AccountProfile | null = data
-    ? {
-        fullName: data.full_name,
-        username: data.username,
-        website: data.website,
-        avatarUrl: data.avatar_url,
-        email: data.email,
+      if (!user) {
+        return { user: null, profile: null }
       }
-    : null
 
-  return { user, profile }
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("full_name, username, website, avatar_url, email")
+        .eq("id", user.id)
+        .maybeSingle<ProfileRow>()
+
+      if (error) {
+        log.error({ error }, "Failed to load account profile")
+      }
+
+      const profile: AccountProfile | null = data
+        ? {
+            fullName: data.full_name,
+            username: data.username,
+            website: data.website,
+            avatarUrl: data.avatar_url,
+            email: data.email,
+          }
+        : null
+
+      return { user, profile }
+    },
+    { headers: requestHeaders }
+  )
 }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -12,6 +12,9 @@ import {
 } from "@/lib/notifications"
 import type { Database } from "@/lib/supabase"
 import { createClient } from "@/utils/supa-server-actions"
+import { getLogger, withRequestContext } from "@/lib/logger"
+
+const log = getLogger({ module: "api.notifications" })
 
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 100
@@ -65,17 +68,24 @@ function getClientIp(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  return withRequestContext(
+    () => handleGetNotifications(request),
+    { headers: request.headers }
+  )
+}
+
+async function handleGetNotifications(request: NextRequest) {
   const rawParams = Object.fromEntries(request.nextUrl.searchParams.entries())
   const validation = notificationsQuerySchema.safeParse(rawParams)
   const ipAddress = getClientIp(request)
 
   if (!validation.success) {
-    console.warn("Notifications query validation failed", {
+    log.warn({
       ipAddress,
       userAgent: request.headers.get("user-agent") ?? "unknown",
       params: rawParams,
       issues: validation.error.issues,
-    })
+    }, "Notifications query validation failed")
 
     return NextResponse.json(
       {
@@ -100,11 +110,11 @@ export async function GET(request: NextRequest) {
   }
 
   if (startDate && startDate > normalizedEndDate) {
-    console.warn("Notifications query startDate after endDate", {
+    log.warn({
       ipAddress,
       userAgent: request.headers.get("user-agent") ?? "unknown",
       params: rawParams,
-    })
+    }, "Notifications query startDate after endDate")
 
     return NextResponse.json(
       { error: "startDate must be before or equal to endDate" },
@@ -170,12 +180,12 @@ export async function GET(request: NextRequest) {
   }
 
   if (suspiciousSignals.length > 0) {
-    console.warn("Notifications query parameters adjusted", {
+    log.warn({
       userId: user.id,
       ipAddress,
       userAgent: request.headers.get("user-agent") ?? "unknown",
       adjustments: suspiciousSignals,
-    })
+    }, "Notifications query parameters adjusted")
   }
 
   const from = (page - 1) * limit
@@ -191,11 +201,11 @@ export async function GET(request: NextRequest) {
     .range(from, to)
 
   if (error) {
-    console.error("Failed to fetch notifications", {
+    log.error({
+      err: error,
       userId: user.id,
       ipAddress,
-      error: error.message,
-    })
+    }, "Failed to fetch notifications")
 
     return NextResponse.json(
       { error: "Failed to fetch notifications" },
@@ -228,6 +238,13 @@ type NotificationRequest =
     }
 
 export async function POST(request: Request) {
+  return withRequestContext(
+    () => handlePostNotifications(request),
+    { headers: request.headers }
+  )
+}
+
+async function handlePostNotifications(request: Request) {
   try {
     const payload = (await request.json()) as NotificationRequest
 
@@ -258,7 +275,7 @@ export async function POST(request: Request) {
       }
     }
   } catch (error) {
-    console.error("Notification API error:", error)
+    log.error({ err: error }, "Notification API error")
     const message =
       error instanceof Error
         ? error.message

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,4 +1,3 @@
-import { headers } from "next/headers"
 import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 
 import {
@@ -7,13 +6,16 @@ import {
 } from "@/lib/notifications"
 import { getStripe } from "@/lib/stripe"
 import type { Database, TablesInsert } from "@/lib/supabase"
+import { getLogger, withRequestContext } from "@/lib/logger"
+
+const log = getLogger({ module: "api.stripe.webhook" })
 
 function createSupabaseAdminClient(): SupabaseClient<Database> | null {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (!supabaseUrl || !serviceRoleKey) {
-    console.error("Supabase admin credentials are not configured")
+    log.error("Supabase admin credentials are not configured")
     return null
   }
 
@@ -26,55 +28,60 @@ function createSupabaseAdminClient(): SupabaseClient<Database> | null {
 }
 
 export async function POST(req: Request) {
-  const stripe = getStripe()
-  const signature = (await headers()).get("stripe-signature")
-  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+  return withRequestContext(
+    async () => {
+      const stripe = getStripe()
+      const signature = req.headers.get("stripe-signature")
+      const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
 
-  if (!webhookSecret) {
-    return new Response("Webhook not configured", { status: 500 })
-  }
+      if (!webhookSecret) {
+        return new Response("Webhook not configured", { status: 500 })
+      }
 
-  const supabase = createSupabaseAdminClient()
-  if (!supabase) {
-    return new Response("Supabase client not configured", { status: 500 })
-  }
+      const supabase = createSupabaseAdminClient()
+      if (!supabase) {
+        return new Response("Supabase client not configured", { status: 500 })
+      }
 
-  const rawBody = await req.text()
+      const rawBody = await req.text()
 
-  try {
-    const event = stripe.webhooks.constructEvent(
-      rawBody,
-      signature ?? "",
-      webhookSecret
-    )
+      try {
+        const event = stripe.webhooks.constructEvent(
+          rawBody,
+          signature ?? "",
+          webhookSecret
+        )
 
-    switch (event.type) {
-      case "checkout.session.completed":
-        await handleCheckoutSessionCompleted(supabase, event.data.object)
-        break
-      case "invoice.payment_succeeded":
-        await handleInvoicePaymentSucceeded(supabase, event.data.object)
-        break
-      case "customer.subscription.created":
-        await handleSubscriptionCreated(supabase, event.data.object)
-        break
-      case "customer.subscription.updated":
-        await handleSubscriptionUpdated(supabase, event.data.object)
-        break
-      case "customer.subscription.deleted":
-        await handleSubscriptionDeleted(supabase, event.data.object)
-        break
-      default:
-        console.log(`Unhandled event type: ${event.type}`)
-        break
-    }
+        switch (event.type) {
+          case "checkout.session.completed":
+            await handleCheckoutSessionCompleted(supabase, event.data.object)
+            break
+          case "invoice.payment_succeeded":
+            await handleInvoicePaymentSucceeded(supabase, event.data.object)
+            break
+          case "customer.subscription.created":
+            await handleSubscriptionCreated(supabase, event.data.object)
+            break
+          case "customer.subscription.updated":
+            await handleSubscriptionUpdated(supabase, event.data.object)
+            break
+          case "customer.subscription.deleted":
+            await handleSubscriptionDeleted(supabase, event.data.object)
+            break
+          default:
+            log.info({ eventType: event.type }, "Unhandled Stripe event type")
+            break
+        }
 
-    return new Response("ok", { status: 200 })
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Invalid payload"
-    console.error("Webhook error:", message)
-    return new Response(`Webhook error: ${message}`, { status: 400 })
-  }
+        return new Response("ok", { status: 200 })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Invalid payload"
+        log.error({ err }, "Webhook error")
+        return new Response(`Webhook error: ${message}`, { status: 400 })
+      }
+    },
+    { headers: req.headers }
+  )
 }
 
 async function handleCheckoutSessionCompleted(
@@ -157,9 +164,9 @@ async function handleCheckoutSessionCompleted(
               })
             }
           } catch (notificationError) {
-            console.error(
-              "Failed to send payment notification:",
-              notificationError
+            log.error(
+              { err: notificationError, tenantId },
+              "Failed to send payment notification"
             )
             // Don't fail the webhook for notification errors
           }
@@ -170,7 +177,7 @@ async function handleCheckoutSessionCompleted(
     // For subscriptions, the subscription will be created separately
     // We might want to link the checkout session to the subscription here
   } catch (error) {
-    console.error("Error handling checkout session completed:", error)
+    log.error({ err: error }, "Error handling checkout session completed")
     throw error
   }
 }
@@ -243,7 +250,7 @@ async function handleInvoicePaymentSucceeded(
         .eq("stripe_subscription_id", subscription.id)
     }
   } catch (error) {
-    console.error("Error handling invoice payment succeeded:", error)
+    log.error({ err: error }, "Error handling invoice payment succeeded")
     throw error
   }
 }
@@ -278,7 +285,7 @@ async function handleSubscriptionCreated(
       },
     })
   } catch (error) {
-    console.error("Error handling subscription created:", error)
+    log.error({ err: error }, "Error handling subscription created")
     throw error
   }
 }
@@ -302,7 +309,7 @@ async function handleSubscriptionUpdated(
       })
       .eq("stripe_subscription_id", subscription.id)
   } catch (error) {
-    console.error("Error handling subscription updated:", error)
+    log.error({ err: error }, "Error handling subscription updated")
     throw error
   }
 }
@@ -322,7 +329,7 @@ async function handleSubscriptionDeleted(
       })
       .eq("stripe_subscription_id", subscription.id)
   } catch (error) {
-    console.error("Error handling subscription deleted:", error)
+    log.error({ err: error }, "Error handling subscription deleted")
     throw error
   }
 }

--- a/app/contact/actions/index.tsx
+++ b/app/contact/actions/index.tsx
@@ -1,8 +1,9 @@
 "use server"
 
 import { revalidatePath } from "next/cache"
-import { cookies } from "next/headers"
+import { cookies, headers } from "next/headers"
 import { createClient } from "@/utils/supa-server-actions"
+import { getLogger, withRequestContext } from "@/lib/logger"
 
 type formData = {
   name: string
@@ -11,27 +12,35 @@ type formData = {
 }
 
 export async function submitInquiry(data: formData) {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)
+  const requestHeaders = headers()
+  const log = getLogger({ module: "contact.submitInquiry" })
 
-  try {
-    const { error } = await supabase.from("inquiries").insert([
-      {
-        name: data.name,
-        email: data.email,
-        message: data.message,
-      },
-    ])
+  return withRequestContext(
+    async () => {
+      const cookieStore = cookies()
+      const supabase = createClient(cookieStore)
 
-    if (error) throw error
+      try {
+        const { error } = await supabase.from("inquiries").insert([
+          {
+            name: data.name,
+            email: data.email,
+            message: data.message,
+          },
+        ])
 
-    revalidatePath("/contact")
-    return { success: true, message: "Message sent successfully!" }
-  } catch (error) {
-    console.error("Error submitting inquiry:", error)
-    return {
-      success: false,
-      message: "Error sending message. Please try again.",
-    }
-  }
+        if (error) throw error
+
+        revalidatePath("/contact")
+        return { success: true, message: "Message sent successfully!" }
+      } catch (error) {
+        log.error({ err: error, inquiry: data }, "Error submitting inquiry")
+        return {
+          success: false,
+          message: "Error sending message. Please try again.",
+        }
+      }
+    },
+    { headers: requestHeaders }
+  )
 }

--- a/app/dashboard/members/actions/index.tsx
+++ b/app/dashboard/members/actions/index.tsx
@@ -1,8 +1,10 @@
 "use server";
 
+import { headers } from "next/headers";
 import { createSupbaseServerClient } from "@/utils/supaone";
 
 import { redirect } from "next/navigation";
+import { getLogger, withRequestContext } from "@/lib/logger";
 
 type formData = {
     email: string;
@@ -13,11 +15,41 @@ type formData = {
     status: string; 
 }
 
+const log = getLogger({ module: "dashboard.members.actions" });
+
 export async function createMember() {
-	console.log("create member");
+  const requestHeaders = headers();
+  return withRequestContext(
+    async () => {
+      log.info("createMember invoked");
+    },
+    { headers: requestHeaders }
+  );
 }
 export async function updateMemberById(id: string) {
-	console.log("update member");
+  const requestHeaders = headers();
+  return withRequestContext(
+    async () => {
+      log.info({ id }, "updateMemberById invoked");
+    },
+    { headers: requestHeaders }
+  );
 }
-export async function deleteMemberById(id: string) {}
-export async function readMembers() {}
+export async function deleteMemberById(id: string) {
+  const requestHeaders = headers();
+  return withRequestContext(
+    async () => {
+      log.info({ id }, "deleteMemberById invoked");
+    },
+    { headers: requestHeaders }
+  );
+}
+export async function readMembers() {
+  const requestHeaders = headers();
+  return withRequestContext(
+    async () => {
+      log.info("readMembers invoked");
+    },
+    { headers: requestHeaders }
+  );
+}

--- a/app/dashboard/todo/actions/index.ts
+++ b/app/dashboard/todo/actions/index.ts
@@ -1,9 +1,46 @@
 // "use server";
+import { headers } from 'next/headers'
+
+import { getLogger, withRequestContext } from '@/lib/logger'
+
+const log = getLogger({ module: 'dashboard.todo.actions' })
+
 export async function createTodo() {
-	console.log("create todo");
+  const requestHeaders = headers()
+  return withRequestContext(
+    async () => {
+      log.info('createTodo invoked')
+    },
+    { headers: requestHeaders }
+  )
 }
+
 export async function updateTodoById(id: string) {
-	console.log("update todo");
+  const requestHeaders = headers()
+  return withRequestContext(
+    async () => {
+      log.info({ id }, 'updateTodoById invoked')
+    },
+    { headers: requestHeaders }
+  )
 }
-export async function deleteTodoById(id: string) {}
-export async function readTodos() {}
+
+export async function deleteTodoById(id: string) {
+  const requestHeaders = headers()
+  return withRequestContext(
+    async () => {
+      log.info({ id }, 'deleteTodoById invoked')
+    },
+    { headers: requestHeaders }
+  )
+}
+
+export async function readTodos() {
+  const requestHeaders = headers()
+  return withRequestContext(
+    async () => {
+      log.info('readTodos invoked')
+    },
+    { headers: requestHeaders }
+  )
+}

--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -2,12 +2,13 @@
 
 import { createClient } from '@/utils/supa-server-actions';
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
 import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+import { getLogger, withRequestContext } from '@/lib/logger';
 import {
   Document,
   DocumentWithLease,
@@ -53,345 +54,363 @@ interface ActionResult<T = any> {
   message?: string;
 }
 
+const log = getLogger({ module: 'documents.actions' });
+
+function runDocumentAction<T>(fn: () => Promise<T>) {
+  const requestHeaders = headers();
+  return withRequestContext(fn, { headers: requestHeaders });
+}
+
 // Get documents with optional filters
 export async function getDocumentsAction(
   filters?: DocumentListFilters
 ): Promise<ActionResult<DocumentWithLease[]>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
-  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  return runDocumentAction(async () => {
+    const cookieStore = cookies();
+    const supabase = createClient(cookieStore);
+    const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to view documents.' };
-    }
-
-    // Validate filters
-    const validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
-    let role: Awaited<ReturnType<typeof fetchMemberRole>>;
     try {
-      role = await fetchMemberRole(typedSupabase, user.id);
-    } catch (roleError) {
-      console.error('Error resolving member role:', roleError);
-      return { success: false, error: 'Failed to fetch documents.' };
-    }
+      // Check authentication
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        return { success: false, error: 'You must be logged in to view documents.' };
+      }
 
-    let documents: DocumentWithLease[];
-    try {
-      documents = await fetchDocumentsList({
-        client: typedSupabase,
-        userId: user.id,
-        role,
-        filters: validatedFilters,
-      });
-    } catch (documentsError) {
-      console.error('Error fetching documents:', documentsError);
-      return { success: false, error: 'Failed to fetch documents.' };
-    }
+      // Validate filters
+      const validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
+      let role: Awaited<ReturnType<typeof fetchMemberRole>>;
+      try {
+        role = await fetchMemberRole(typedSupabase, user.id);
+      } catch (roleError) {
+        log.error({ roleError }, 'Error resolving member role');
+        return { success: false, error: 'Failed to fetch documents.' };
+      }
 
-    // Log access
-    for (const doc of documents) {
-      await (supabase as any).rpc('log_document_access', {
-        p_document_id: doc.id,
-        p_action: 'view',
-        p_metadata: { source: 'documents_page' }
-      });
-    }
+      let documents: DocumentWithLease[];
+      try {
+        documents = await fetchDocumentsList({
+          client: typedSupabase,
+          userId: user.id,
+          role,
+          filters: validatedFilters,
+        });
+      } catch (documentsError) {
+        log.error({ documentsError }, 'Error fetching documents list');
+        return { success: false, error: 'Failed to fetch documents.' };
+      }
 
-    return { success: true, data: documents };
-  } catch (error) {
-    console.error('Unexpected error in getDocumentsAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
+      // Log access
+      for (const doc of documents) {
+        await (supabase as any).rpc('log_document_access', {
+          p_document_id: doc.id,
+          p_action: 'view',
+          p_metadata: { source: 'documents_page' }
+        });
+      }
+
+      return { success: true, data: documents };
+    } catch (error) {
+      log.error({ err: error }, 'Unexpected error in getDocumentsAction');
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+      };
+    }
+  });
 }
 
 // Upload and create a new document
 export async function uploadDocumentAction(
   formData: FormData
 ): Promise<ActionResult<Document>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  return runDocumentAction(async () => {
+    const cookieStore = cookies();
+    const supabase = createClient(cookieStore);
 
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to upload documents.' };
+    try {
+      // Check authentication
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        return { success: false, error: 'You must be logged in to upload documents.' };
+      }
+
+      // Get file from form data
+      const file = formData.get('file') as File;
+      if (!file) {
+        return { success: false, error: 'No file provided.' };
+      }
+
+      // Validate other form data
+      const rawData = {
+        title: formData.get('title'),
+        description: formData.get('description'),
+        document_type: formData.get('document_type'),
+        tenant_id: formData.get('tenant_id'),
+        unit_id: formData.get('unit_id'),
+        requires_signature: formData.get('requires_signature') === 'true',
+        expires_at: formData.get('expires_at'),
+      };
+
+      const validationResult = documentUploadSchema.safeParse(rawData);
+      if (!validationResult.success) {
+        const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
+          .map(errors => errors?.join('. '))
+          .filter(Boolean)
+          .join(' ');
+        return { success: false, error: errorMessages || 'Invalid form data provided.' };
+      }
+
+      const validatedData = validationResult.data;
+
+      // Upload file to Supabase Storage
+      const fileExt = file.name.split('.').pop();
+      const fileName = `${Date.now()}-${Math.random().toString(36).substring(2)}.${fileExt}`;
+      const filePath = `documents/${fileName}`;
+
+      const { data: uploadData, error: uploadError } = await supabase.storage
+        .from('documents')
+        .upload(filePath, file);
+
+      if (uploadError) {
+        log.error({ uploadError }, 'Error uploading file to storage');
+        return { success: false, error: 'Failed to upload file.' };
+      }
+
+      // Get public URL
+      const { data: { publicUrl } } = supabase.storage
+        .from('documents')
+        .getPublicUrl(filePath);
+
+      // Create document record
+      const { data: document, error: dbError } = await (supabase as any)
+        .from('documents')
+        .insert({
+          title: validatedData.title,
+          description: validatedData.description,
+          document_type: validatedData.document_type,
+          file_url: publicUrl,
+          tenant_id: validatedData.tenant_id,
+          unit_id: validatedData.unit_id,
+          requires_signature: validatedData.requires_signature,
+          expires_at: validatedData.expires_at,
+          created_by: user.id,
+        })
+        .select()
+        .single();
+
+      if (dbError) {
+        log.error({ dbError }, 'Error creating document record');
+        // Clean up uploaded file if document creation fails
+        await supabase.storage.from('documents').remove([filePath]);
+        return { success: false, error: 'Failed to create document record.' };
+      }
+
+      // Log document creation
+      await (supabase as any).rpc('log_document_access', {
+        p_document_id: document.id,
+        p_action: 'upload',
+        p_metadata: { file_name: file.name, file_size: file.size }
+      });
+
+      revalidatePath('/documents');
+      return { success: true, data: document, message: 'Document uploaded successfully.' };
+    } catch (error) {
+      log.error({ err: error }, 'Unexpected error in uploadDocumentAction');
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+      };
     }
-
-    // Get file from form data
-    const file = formData.get('file') as File;
-    if (!file) {
-      return { success: false, error: 'No file provided.' };
-    }
-
-    // Validate other form data
-    const rawData = {
-      title: formData.get('title'),
-      description: formData.get('description'),
-      document_type: formData.get('document_type'),
-      tenant_id: formData.get('tenant_id'),
-      unit_id: formData.get('unit_id'),
-      requires_signature: formData.get('requires_signature') === 'true',
-      expires_at: formData.get('expires_at'),
-    };
-
-    const validationResult = documentUploadSchema.safeParse(rawData);
-    if (!validationResult.success) {
-      const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
-        .map(errors => errors?.join('. '))
-        .filter(Boolean)
-        .join(' ');
-      return { success: false, error: errorMessages || 'Invalid form data provided.' };
-    }
-
-    const validatedData = validationResult.data;
-
-    // Upload file to Supabase Storage
-    const fileExt = file.name.split('.').pop();
-    const fileName = `${Date.now()}-${Math.random().toString(36).substring(2)}.${fileExt}`;
-    const filePath = `documents/${fileName}`;
-
-    const { data: uploadData, error: uploadError } = await supabase.storage
-      .from('documents')
-      .upload(filePath, file);
-
-    if (uploadError) {
-      console.error('Error uploading file:', uploadError);
-      return { success: false, error: 'Failed to upload file.' };
-    }
-
-    // Get public URL
-    const { data: { publicUrl } } = supabase.storage
-      .from('documents')
-      .getPublicUrl(filePath);
-
-    // Create document record
-    const { data: document, error: dbError } = await (supabase as any)
-      .from('documents')
-      .insert({
-        title: validatedData.title,
-        description: validatedData.description,
-        document_type: validatedData.document_type,
-        file_url: publicUrl,
-        tenant_id: validatedData.tenant_id,
-        unit_id: validatedData.unit_id,
-        requires_signature: validatedData.requires_signature,
-        expires_at: validatedData.expires_at,
-        created_by: user.id,
-      })
-      .select()
-      .single();
-
-    if (dbError) {
-      console.error('Error creating document:', dbError);
-      // Clean up uploaded file if document creation fails
-      await supabase.storage.from('documents').remove([filePath]);
-      return { success: false, error: 'Failed to create document record.' };
-    }
-
-    // Log document creation
-    await (supabase as any).rpc('log_document_access', {
-      p_document_id: document.id,
-      p_action: 'upload',
-      p_metadata: { file_name: file.name, file_size: file.size }
-    });
-
-    revalidatePath('/documents');
-    return { success: true, data: document, message: 'Document uploaded successfully.' };
-  } catch (error) {
-    console.error('Unexpected error in uploadDocumentAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
+  });
 }
 
 // Create a signing request for a document
 export async function createSigningRequestAction(
   formData: FormData
 ): Promise<ActionResult<{ signing_url?: string; envelope_id?: string }>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
-  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  return runDocumentAction(async () => {
+    const cookieStore = cookies();
+    const supabase = createClient(cookieStore);
+    const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to create signing requests.' };
-    }
-
-    // Validate form data
-    const rawData = {
-      document_id: formData.get('document_id'),
-      signer_email: formData.get('signer_email'),
-      signer_name: formData.get('signer_name'),
-      message: formData.get('message'),
-      expires_in_days: formData.get('expires_in_days') ? parseInt(formData.get('expires_in_days') as string) : undefined,
-    };
-
-    const validationResult = documentSigningSchema.safeParse(rawData);
-    if (!validationResult.success) {
-      const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
-        .map(errors => errors?.join('. '))
-        .filter(Boolean)
-        .join(' ');
-      return { success: false, error: errorMessages || 'Invalid form data provided.' };
-    }
-
-    const validatedData = validationResult.data;
-
-    // Get document details
-    const { data: document, error: docError } = await (supabase as any)
-      .from('documents')
-      .select('*')
-      .eq('id', validatedData.document_id)
-      .single();
-
-    if (docError || !document) {
-      return { success: false, error: 'Document not found.' };
-    }
-
-    // Check permissions (user must be property manager or admin, or document owner)
-    let role: Awaited<ReturnType<typeof fetchMemberRole>>;
     try {
-      role = await fetchMemberRole(typedSupabase, user.id);
-    } catch (roleError) {
-      console.error('Error resolving member role for signing request:', roleError);
-      return { success: false, error: 'You do not have permission to create signing requests for this document.' };
-    }
+      // Check authentication
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        return { success: false, error: 'You must be logged in to create signing requests.' };
+      }
 
-    if (role !== 'property_manager' && role !== 'admin' && document.tenant_id !== user.id) {
-      return { success: false, error: 'You do not have permission to create signing requests for this document.' };
-    }
+      // Validate form data
+      const rawData = {
+        document_id: formData.get('document_id'),
+        signer_email: formData.get('signer_email'),
+        signer_name: formData.get('signer_name'),
+        message: formData.get('message'),
+        expires_in_days: formData.get('expires_in_days')
+          ? parseInt(formData.get('expires_in_days') as string)
+          : undefined,
+      };
 
-    // Download file from Supabase Storage
-    const fileResponse = await fetch(document.file_url!);
-    if (!fileResponse.ok) {
-      return { success: false, error: 'Failed to download document file.' };
-    }
+      const validationResult = documentSigningSchema.safeParse(rawData);
+      if (!validationResult.success) {
+        const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
+          .map(errors => errors?.join('. '))
+          .filter(Boolean)
+          .join(' ');
+        return { success: false, error: errorMessages || 'Invalid form data provided.' };
+      }
 
-    const fileBlob = await fileResponse.blob();
-    const file = new File([fileBlob], `${document.title}.pdf`, { type: 'application/pdf' });
+      const validatedData = validationResult.data;
 
-    // Upload file to Documenso to obtain documentDataId
-    const uploadResult = await documensoService.uploadDocument(file);
-
-    // Get tenant emails for lease documents
-    let tenantEmails = [validatedData.signer_email];
-    let tenantNames = [validatedData.signer_name];
-    let tenantProfiles: { id: string; email: string | null; full_name: string | null }[] = [];
-
-    if (document.document_type === 'lease') {
-      const { data: lease } = await (supabase as any)
-        .from('leases')
-        .select('tenant_ids')
-        .eq('document_id', document.id)
+      // Get document details
+      const { data: document, error: docError } = await (supabase as any)
+        .from('documents')
+        .select('*')
+        .eq('id', validatedData.document_id)
         .single();
 
-      if (lease) {
-        const { data: profiles } = await supabase
+      if (docError || !document) {
+        return { success: false, error: 'Document not found.' };
+      }
+
+      // Check permissions (user must be property manager or admin, or document owner)
+      let role: Awaited<ReturnType<typeof fetchMemberRole>>;
+      try {
+        role = await fetchMemberRole(typedSupabase, user.id);
+      } catch (roleError) {
+        log.error({ roleError }, 'Error resolving member role for signing request');
+        return {
+          success: false,
+          error: 'You do not have permission to create signing requests for this document.',
+        };
+      }
+
+      if (role !== 'property_manager' && role !== 'admin' && document.tenant_id !== user.id) {
+        return { success: false, error: 'You do not have permission to create signing requests for this document.' };
+      }
+
+      // Download file from Supabase Storage
+      const fileResponse = await fetch(document.file_url!);
+      if (!fileResponse.ok) {
+        return { success: false, error: 'Failed to download document file.' };
+      }
+
+      const fileBlob = await fileResponse.blob();
+      const file = new File([fileBlob], `${document.title}.pdf`, { type: 'application/pdf' });
+
+      // Upload file to Documenso to obtain documentDataId
+      const uploadResult = await documensoService.uploadDocument(file);
+
+      // Get tenant emails for lease documents
+      let tenantEmails = [validatedData.signer_email];
+      let tenantNames = [validatedData.signer_name];
+      let tenantProfiles: { id: string; email: string | null; full_name: string | null }[] = [];
+
+      if (document.document_type === 'lease') {
+        const { data: lease } = await (supabase as any)
+          .from('leases')
+          .select('tenant_ids')
+          .eq('document_id', document.id)
+          .single();
+
+        if (lease) {
+          const { data: profiles } = await supabase
+            .from('profiles')
+            .select('id, email, full_name')
+            .in('id', lease.tenant_ids);
+
+          tenantProfiles = profiles || [];
+          tenantEmails = tenantProfiles.map(p => p.email || '').filter(Boolean);
+          tenantNames = tenantProfiles.map(p => p.full_name || '');
+        }
+      }
+
+      // Create signing request via Documenso
+      const signingResult = await documensoService.createDocumentSigningEnvelope({
+        title: document.title,
+        documentDataId: uploadResult.documentDataId,
+        recipients: tenantEmails.map((email, index) => ({
+          email,
+          name: tenantNames[index] || email.split('@')[0],
+          role: 'SIGNER' as const,
+          signingOrder: index + 1,
+        })),
+        message: validatedData.message,
+        expiresAt: validatedData.expires_in_days
+          ? new Date(Date.now() + validatedData.expires_in_days * 24 * 60 * 60 * 1000).toISOString()
+          : undefined,
+      });
+
+      if (!signingResult) {
+        return { success: false, error: 'Failed to create signing request.' };
+      }
+
+      // Update document with Documenso envelope ID
+      await (supabase as any)
+        .from('documents')
+        .update({
+          documenso_envelope_id: signingResult.id,
+          status: 'pending_signature'
+        })
+        .eq('id', document.id);
+
+      // Create signature records with signer_id mapping
+      const emailToProfileId = new Map<string, string>();
+      if (tenantProfiles.length === 0) {
+        // Fallback: try to resolve signer from provided email
+        const { data: maybeProfile } = await supabase
           .from('profiles')
-          .select('id, email, full_name')
-          .in('id', lease.tenant_ids);
-
-        tenantProfiles = profiles || [];
-        tenantEmails = tenantProfiles.map(p => p.email || '').filter(Boolean);
-        tenantNames = tenantProfiles.map(p => p.full_name || '');
+          .select('id, email')
+          .eq('email', validatedData.signer_email)
+          .single();
+        if (maybeProfile?.id && maybeProfile.email) {
+          emailToProfileId.set(maybeProfile.email, maybeProfile.id);
+        }
+      } else {
+        for (const p of tenantProfiles) {
+          if (p.email && p.id) emailToProfileId.set(p.email, p.id);
+        }
       }
-    }
 
-    // Create signing request via Documenso
-    const signingResult = await documensoService.createDocumentSigningEnvelope({
-      title: document.title,
-      documentDataId: uploadResult.documentDataId,
-      recipients: tenantEmails.map((email, index) => ({
-        email,
-        name: tenantNames[index] || email.split('@')[0],
-        role: 'SIGNER' as const,
-        signingOrder: index + 1,
-      })),
-      message: validatedData.message,
-      expiresAt: validatedData.expires_in_days
-        ? new Date(Date.now() + validatedData.expires_in_days * 24 * 60 * 60 * 1000).toISOString()
-        : undefined,
-    });
-
-    if (!signingResult) {
-      return { success: false, error: 'Failed to create signing request.' };
-    }
-
-    // Update document with Documenso envelope ID
-    await (supabase as any)
-      .from('documents')
-      .update({
-        documenso_envelope_id: signingResult.id,
-        status: 'pending_signature'
-      })
-      .eq('id', document.id);
-
-    // Create signature records with signer_id mapping
-    const emailToProfileId = new Map<string, string>();
-    if (tenantProfiles.length === 0) {
-      // Fallback: try to resolve signer from provided email
-      const { data: maybeProfile } = await supabase
-        .from('profiles')
-        .select('id, email')
-        .eq('email', validatedData.signer_email)
-        .single();
-      if (maybeProfile?.id && maybeProfile.email) {
-        emailToProfileId.set(maybeProfile.email, maybeProfile.id);
+      for (const recipient of signingResult.recipients) {
+        const signerId = emailToProfileId.get(recipient.email);
+        if (!signerId) {
+          continue; // skip recipients we cannot map to a user
+        }
+        await supabase
+          .from('document_signatures')
+          .insert({
+            document_id: document.id,
+            signer_id: signerId,
+            signer_email: recipient.email,
+            signer_name: recipient.name || null,
+            status: 'pending',
+            documenso_signature_id: recipient.id,
+          });
       }
-    } else {
-      for (const p of tenantProfiles) {
-        if (p.email && p.id) emailToProfileId.set(p.email, p.id);
-      }
+
+      // Log signing request creation
+      await supabase.rpc('log_document_access', {
+        p_document_id: document.id,
+        p_action: 'signing_request_created',
+        p_metadata: { envelope_id: signingResult.id, recipients: tenantEmails }
+      });
+
+      revalidatePath('/documents');
+      return {
+        success: true,
+        data: { envelope_id: signingResult.id },
+        message: 'Signing request created successfully.'
+      };
+    } catch (error) {
+      log.error({ err: error }, 'Unexpected error in createSigningRequestAction');
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+      };
     }
-
-    for (const recipient of signingResult.recipients) {
-      const signerId = emailToProfileId.get(recipient.email);
-      if (!signerId) {
-        continue; // skip recipients we cannot map to a user
-      }
-      await supabase
-        .from('document_signatures')
-        .insert({
-          document_id: document.id,
-          signer_id: signerId,
-          signer_email: recipient.email,
-          signer_name: recipient.name || null,
-          status: 'pending',
-          documenso_signature_id: recipient.id,
-        });
-    }
-
-    // Log signing request creation
-    await supabase.rpc('log_document_access', {
-      p_document_id: document.id,
-      p_action: 'signing_request_created',
-      p_metadata: { envelope_id: signingResult.id, recipients: tenantEmails }
-    });
-
-    revalidatePath('/documents');
-    return {
-      success: true,
-      data: { envelope_id: signingResult.id },
-      message: 'Signing request created successfully.'
-    };
-  } catch (error) {
-    console.error('Unexpected error in createSigningRequestAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
+  });
 }
 
 // Sign a document (mark as signed)
@@ -399,166 +418,172 @@ export async function signDocumentAction(
   documentId: string,
   signatureData?: Record<string, any>
 ): Promise<ActionResult> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  return runDocumentAction(async () => {
+    const cookieStore = cookies();
+    const supabase = createClient(cookieStore);
 
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to sign documents.' };
-    }
+    try {
+      // Check authentication
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        return { success: false, error: 'You must be logged in to sign documents.' };
+      }
 
-    // Get signature record
-    const { data: signature, error: sigError } = await supabase
-      .from('document_signatures')
-      .select('*')
-      .eq('document_id', documentId)
-      .eq('signer_id', user.id)
-      .single();
+      // Get signature record
+      const { data: signature, error: sigError } = await supabase
+        .from('document_signatures')
+        .select('*')
+        .eq('document_id', documentId)
+        .eq('signer_id', user.id)
+        .single();
 
-    if (sigError || !signature) {
-      return { success: false, error: 'Signature record not found.' };
-    }
+      if (sigError || !signature) {
+        return { success: false, error: 'Signature record not found.' };
+      }
 
-    // Update signature
-    await supabase
-      .from('document_signatures')
-      .update({
-        status: 'signed',
-        signed_at: new Date().toISOString(),
-        signature_data: signatureData,
-      })
-      .eq('id', signature.id);
-
-    // Check if all signatures are complete
-    const { data: allSignatures } = await supabase
-      .from('document_signatures')
-      .select('status')
-      .eq('document_id', documentId);
-
-    const allSigned = allSignatures?.every(sig => sig.status === 'signed');
-
-    if (allSigned) {
-      // Update document status
+      // Update signature
       await supabase
-        .from('documents')
+        .from('document_signatures')
         .update({
           status: 'signed',
           signed_at: new Date().toISOString(),
+          signature_data: signatureData,
         })
-        .eq('id', documentId);
+        .eq('id', signature.id);
+
+      // Check if all signatures are complete
+      const { data: allSignatures } = await supabase
+        .from('document_signatures')
+        .select('status')
+        .eq('document_id', documentId);
+
+      const allSigned = allSignatures?.every(sig => sig.status === 'signed');
+
+      if (allSigned) {
+        // Update document status
+        await supabase
+          .from('documents')
+          .update({
+            status: 'signed',
+            signed_at: new Date().toISOString(),
+          })
+          .eq('id', documentId);
+      }
+
+      // Log signing action
+      await supabase.rpc('log_document_access', {
+        p_document_id: documentId,
+        p_action: 'signed',
+        p_metadata: signatureData
+      });
+
+      revalidatePath('/documents');
+      return { success: true, message: 'Document signed successfully.' };
+    } catch (error) {
+      log.error({ err: error }, 'Unexpected error in signDocumentAction');
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+      };
     }
-
-    // Log signing action
-    await supabase.rpc('log_document_access', {
-      p_document_id: documentId,
-      p_action: 'signed',
-      p_metadata: signatureData
-    });
-
-    revalidatePath('/documents');
-    return { success: true, message: 'Document signed successfully.' };
-  } catch (error) {
-    console.error('Unexpected error in signDocumentAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
+  });
 }
 
 // Get Documenso signing URL for the current user for a document
 export async function getSigningUrlAction(
   documentId: string
 ): Promise<ActionResult<{ signing_url: string }>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
+  return runDocumentAction(async () => {
+    const cookieStore = cookies();
+    const supabase = createClient(cookieStore);
 
-  try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to sign documents.' };
+    try {
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        return { success: false, error: 'You must be logged in to sign documents.' };
+      }
+
+      // Get document with envelope id
+      const { data: document } = await supabase
+        .from('documents')
+        .select('id, documenso_envelope_id')
+        .eq('id', documentId)
+        .single();
+
+      if (!document?.documenso_envelope_id) {
+        return { success: false, error: 'Signing session is not available for this document.' };
+      }
+
+      // Find the signature record for this user
+      const { data: signature } = await supabase
+        .from('document_signatures')
+        .select('id, documenso_signature_id')
+        .eq('document_id', documentId)
+        .eq('signer_id', user.id)
+        .single();
+
+      if (!signature?.documenso_signature_id) {
+        return { success: false, error: 'No signing request found for your account.' };
+      }
+
+      // Get signing URL from Documenso
+      const url = await documensoService.getSigningUrl(
+        document.documenso_envelope_id,
+        signature.documenso_signature_id
+      );
+
+      return { success: true, data: { signing_url: url } };
+    } catch (error) {
+      log.error({ err: error }, 'Unexpected error in getSigningUrlAction');
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+      };
     }
-
-    // Get document with envelope id
-    const { data: document } = await supabase
-      .from('documents')
-      .select('id, documenso_envelope_id')
-      .eq('id', documentId)
-      .single();
-
-    if (!document?.documenso_envelope_id) {
-      return { success: false, error: 'Signing session is not available for this document.' };
-    }
-
-    // Find the signature record for this user
-    const { data: signature } = await supabase
-      .from('document_signatures')
-      .select('id, documenso_signature_id')
-      .eq('document_id', documentId)
-      .eq('signer_id', user.id)
-      .single();
-
-    if (!signature?.documenso_signature_id) {
-      return { success: false, error: 'No signing request found for your account.' };
-    }
-
-    // Get signing URL from Documenso
-    const url = await documensoService.getSigningUrl(
-      document.documenso_envelope_id,
-      signature.documenso_signature_id
-    );
-
-    return { success: true, data: { signing_url: url } };
-  } catch (error) {
-    console.error('Unexpected error in getSigningUrlAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
+  });
 }
 
 // Get document statistics
 export async function getDocumentStatsAction(): Promise<ActionResult<DocumentStats>> {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
-  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  return runDocumentAction(async () => {
+    const cookieStore = cookies();
+    const supabase = createClient(cookieStore);
+    const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
-  try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to view document statistics.' };
-    }
-
-    let role: Awaited<ReturnType<typeof fetchMemberRole>>;
     try {
-      role = await fetchMemberRole(typedSupabase, user.id);
-    } catch (roleError) {
-      console.error('Error resolving member role for stats:', roleError);
-      return { success: false, error: 'Failed to fetch document statistics.' };
-    }
+      // Check authentication
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        return { success: false, error: 'You must be logged in to view document statistics.' };
+      }
 
-    let stats: DocumentStats;
-    try {
-      stats = await fetchDocumentStats({
-        client: typedSupabase,
-        userId: user.id,
-        role,
-      });
-    } catch (statsError) {
-      console.error('Error fetching document stats:', statsError);
-      return { success: false, error: 'Failed to fetch document statistics.' };
-    }
+      let role: Awaited<ReturnType<typeof fetchMemberRole>>;
+      try {
+        role = await fetchMemberRole(typedSupabase, user.id);
+      } catch (roleError) {
+        log.error({ roleError }, 'Error resolving member role for stats');
+        return { success: false, error: 'Failed to fetch document statistics.' };
+      }
 
-    return { success: true, data: stats };
-  } catch (error) {
-    console.error('Unexpected error in getDocumentStatsAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
-  }
+      let stats: DocumentStats;
+      try {
+        stats = await fetchDocumentStats({
+          client: typedSupabase,
+          userId: user.id,
+          role,
+        });
+      } catch (statsError) {
+        log.error({ statsError }, 'Error fetching document stats');
+        return { success: false, error: 'Failed to fetch document statistics.' };
+      }
+
+      return { success: true, data: stats };
+    } catch (error) {
+      log.error({ err: error }, 'Unexpected error in getDocumentStatsAction');
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+      };
+    }
+  });
 }

--- a/app/schedule/actions/index.tsx
+++ b/app/schedule/actions/index.tsx
@@ -5,8 +5,11 @@ import { createGoogleCalendarEvent } from '@/lib/calendar-service';
 import { revalidatePath } from 'next/cache';
 import type { Database } from '@/lib/supabase';
 import { z } from 'zod';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { formatISO, isPast } from 'date-fns'; // Import formatISO here
+import { getLogger, withRequestContext } from '@/lib/logger';
+
+const log = getLogger({ module: 'schedule.actions' });
 
 // --- Updated Zod Schema for Server Action ---
 const scheduleSchema = z.object({
@@ -47,16 +50,27 @@ export async function scheduleMeetingAction(
   prevState: ActionResult,
   formData: FormData
 ): Promise<ActionResult> {
+  const requestHeaders = headers();
 
- const cookieStore = cookies();
- const supabase = createClient(cookieStore);
+  return withRequestContext(
+    async () => {
+      const cookieStore = cookies();
+      const supabase = createClient(cookieStore);
 
-  // 1. Check Authentication
-  const { data: { user }, error: authError } = await supabase.auth.getUser();
-  if (authError || !user) {
-    console.error('Authentication error in server action:', authError);
-    return { success: false, message: null, error: 'You must be logged in to schedule a meeting.', googleEventLink: null };
-  }
+      // 1. Check Authentication
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
+      if (authError || !user) {
+        log.error({ authError }, 'Authentication error in scheduleMeetingAction');
+        return {
+          success: false,
+          message: null,
+          error: 'You must be logged in to schedule a meeting.',
+          googleEventLink: null,
+        };
+      }
 
    // 2. Validate Form Data (using the updated schema with coerce)
    const rawData = {
@@ -73,7 +87,10 @@ export async function scheduleMeetingAction(
    const validationResult = scheduleSchema.safeParse(rawData);
 
    if (!validationResult.success) {
-       console.error("Server validation failed:", validationResult.error.flatten());
+       log.warn(
+         { validationErrors: validationResult.error.flatten() },
+         "Server validation failed"
+       );
        // Combine Zod error messages
        const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
            .map(errors => errors?.join('. '))
@@ -87,7 +104,13 @@ export async function scheduleMeetingAction(
 
    // 3. Basic check: User email from form should match logged-in user
    if (validatedData.userEmail !== user.email) {
-       console.error(`Security Alert: Form email (${validatedData.userEmail}) does not match authenticated user (${user.email})`);
+       log.warn(
+         {
+           formEmail: validatedData.userEmail,
+           authenticatedEmail: user.email,
+         },
+         'Security alert: user email mismatch in scheduleMeetingAction'
+       );
        return { success: false, message: null, error: 'User email mismatch.', googleEventLink: null };
    }
 
@@ -105,13 +128,22 @@ export async function scheduleMeetingAction(
     });
 
     if (!calendarResult.success || !calendarResult.eventId) {
-      console.error("Failed to create Google Calendar event:", calendarResult.error);
+      log.error(
+        { calendarError: calendarResult.error },
+        "Failed to create Google Calendar event"
+      );
       // Pass specific Google error back if available
       const errorMessage = calendarResult.error || 'Failed to create Google Calendar event.';
       return { success: false, message: null, error: errorMessage, googleEventLink: null };
     }
 
-    console.log(`Google Event created: ${calendarResult.eventId}, Link: ${calendarResult.link}`);
+    log.info(
+      {
+        eventId: calendarResult.eventId,
+        eventLink: calendarResult.link,
+      },
+      'Google Calendar event created'
+    );
 
     // 5. Store meeting info in Supabase DB
     //    Pass the validated Date objects directly to the Supabase client.
@@ -128,11 +160,11 @@ export async function scheduleMeetingAction(
 
     if (dbError) {
       // Log the error, but don't necessarily fail if calendar event succeeded
-      console.error('Error saving meeting to database:', dbError);
+      log.error({ dbError }, 'Error saving meeting to database');
       // Optional: Return a partial success message or specific DB error
       // return { success: false, message: null, error: 'Meeting scheduled, but failed to save record.', googleEventLink: calendarResult.link };
     } else {
-       console.log("Meeting details saved to database.");
+       log.info('Meeting details saved to database');
     }
 
     // 6. Revalidate the path if needed
@@ -147,11 +179,14 @@ export async function scheduleMeetingAction(
     };
 
   } catch (error) {
-    console.error('Unexpected error in scheduleMeetingAction:', error);
+    log.error({ err: error }, 'Unexpected error in scheduleMeetingAction');
      let errorMessage = 'An unexpected error occurred while scheduling.';
      if (error instanceof Error) {
          errorMessage = error.message;
      }
     return { success: false, message: null, error: errorMessage, googleEventLink: null };
   }
+    },
+    { headers: requestHeaders }
+  );
 }

--- a/lib/calcom-service.ts
+++ b/lib/calcom-service.ts
@@ -1,3 +1,5 @@
+import { getLogger } from '@/lib/logger';
+
 interface CalComCreateBookingRequest {
   start: string;
   end: string;
@@ -25,6 +27,8 @@ interface CalComEventType {
   slug: string;
   hidden: boolean;
 }
+
+const log = getLogger({ module: 'calcom-service' });
 
 class CalComService {
   private baseUrl: string;
@@ -58,7 +62,7 @@ class CalComService {
       const data = await response.json();
       return data.eventTypes || [];
     } catch (error) {
-      console.error('Error fetching Cal.com event types:', error);
+      log.error({ err: error }, 'Error fetching Cal.com event types');
       return [];
     }
   }
@@ -106,7 +110,7 @@ class CalComService {
         bookingUrl: data.booking?.url,
       };
     } catch (error) {
-      console.error('Error creating Cal.com booking:', error);
+      log.error({ err: error }, 'Error creating Cal.com booking');
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to create booking',
@@ -132,7 +136,7 @@ class CalComService {
 
       return response.ok;
     } catch (error) {
-      console.error('Error canceling Cal.com booking:', error);
+      log.error({ err: error, bookingId }, 'Error canceling Cal.com booking');
       return false;
     }
   }
@@ -158,7 +162,7 @@ class CalComService {
 
       return await response.json();
     } catch (error) {
-      console.error('Error fetching Cal.com booking:', error);
+      log.error({ err: error, bookingId }, 'Error fetching Cal.com booking');
       return null;
     }
   }
@@ -193,7 +197,7 @@ class CalComService {
       const data = await response.json();
       return data.bookings || [];
     } catch (error) {
-      console.error('Error fetching Cal.com user bookings:', error);
+      log.error({ err: error, userEmail }, 'Error fetching Cal.com user bookings');
       return [];
     }
   }
@@ -204,7 +208,7 @@ const CALCOM_BASE_URL = process.env.CALCOM_BASE_URL || 'https://api.cal.com';
 const CALCOM_API_KEY = process.env.CALCOM_API_KEY || '';
 
 if (!CALCOM_API_KEY) {
-  console.warn('CALCOM_API_KEY is not configured');
+  log.warn('CALCOM_API_KEY is not configured');
 }
 
 export const calComService = new CalComService(CALCOM_BASE_URL, CALCOM_API_KEY);

--- a/lib/calendar-service.ts
+++ b/lib/calendar-service.ts
@@ -1,6 +1,8 @@
 import { google } from 'googleapis';
 import { GaxiosError } from 'gaxios'; // Part of googleapis
 
+import { getLogger } from '@/lib/logger';
+
 // Configure the Google OAuth2 client
 const oauth2Client = new google.auth.OAuth2(
   process.env.GOOGLE_CLIENT_ID,
@@ -29,6 +31,8 @@ interface CreateEventOptions {
   attendeeName?: string; // Optional name of the user
 }
 
+const log = getLogger({ module: 'calendar-service' });
+
 /**
  * Creates an event on the app owner's Google Calendar.
  */
@@ -40,7 +44,10 @@ export async function createGoogleCalendarEvent({
   attendeeEmail,
   attendeeName,
 }: CreateEventOptions) {
-  console.log(`Attempting to create event for ${attendeeEmail} from ${startTime} to ${endTime}`);
+  log.info(
+    { attendeeEmail, startTime, endTime },
+    'Attempting to create Google Calendar event'
+  );
 
   try {
     const event = {
@@ -78,31 +85,48 @@ export async function createGoogleCalendarEvent({
       // conferenceDataVersion: 1, // Required if adding conferenceData
     });
 
-    console.log('Google Calendar Event created: %s', response.data.htmlLink);
+    log.info(
+      { eventId: response.data.id, htmlLink: response.data.htmlLink },
+      'Google Calendar event created'
+    );
     return { success: true, eventId: response.data.id, link: response.data.htmlLink };
 
   } catch (error: unknown) {
-    console.error('Error creating Google Calendar event:');
     if (error instanceof GaxiosError) {
-        console.error('Gaxios Error:', error.response?.status, error.response?.data);
-    } else if (error instanceof Error) {
-         console.error(error.message);
-    } else {
-        console.error('An unknown error occurred', error);
-    }
+      log.error(
+        {
+          status: error.response?.status,
+          data: error.response?.data,
+        },
+        'Error creating Google Calendar event via Google API'
+      );
 
-    // More specific error handling
-    if (error instanceof GaxiosError && error.response?.status === 401) {
-       console.error('Authentication error: Check Google credentials (Refresh Token might be expired or invalid).');
-       return { success: false, error: 'Authentication error with Google Calendar.' };
-    }
-     if (error instanceof GaxiosError && error.response?.status === 403) {
-        console.error('Permission error: Ensure the Calendar API is enabled and the refresh token has the correct scope (calendar.events).');
-       return { success: false, error: 'Permission error with Google Calendar.' };
-    }
-    if (error instanceof GaxiosError && error.response?.status === 400) {
-        console.error('Bad Request: Check event data format (dates, emails etc).', error.response?.data?.error?.errors);
-       return { success: false, error: `Invalid meeting data: ${error.response?.data?.error?.message || 'Check input format.'}` };
+      if (error.response?.status === 401) {
+        log.error('Authentication error with Google Calendar credentials');
+        return { success: false, error: 'Authentication error with Google Calendar.' };
+      }
+
+      if (error.response?.status === 403) {
+        log.error('Permission error accessing Google Calendar API');
+        return { success: false, error: 'Permission error with Google Calendar.' };
+      }
+
+      if (error.response?.status === 400) {
+        log.error(
+          { details: error.response?.data?.error?.errors },
+          'Bad request when creating Google Calendar event'
+        );
+        return {
+          success: false,
+          error: `Invalid meeting data: ${
+            error.response?.data?.error?.message || 'Check input format.'
+          }`,
+        };
+      }
+    } else if (error instanceof Error) {
+      log.error({ err: error }, 'Error creating Google Calendar event');
+    } else {
+      log.error({ error }, 'Unknown error creating Google Calendar event');
     }
 
     return { success: false, error: 'Failed to create Google Calendar event.' };

--- a/lib/constants/logging.ts
+++ b/lib/constants/logging.ts
@@ -1,0 +1,1 @@
+export const CORRELATION_ID_HEADER = 'x-correlation-id'

--- a/lib/documenso.ts
+++ b/lib/documenso.ts
@@ -1,10 +1,14 @@
 import { DocumentSigningRequest, DocumentSigningResponse } from '@/types/documents';
 
+import { getLogger } from '@/lib/logger';
+
 const DOCUMENSO_BASE_URL = process.env.DOCUMENSO_BASE_URL || 'https://app.documenso.com';
 const DOCUMENSO_API_KEY = process.env.DOCUMENSO_API_KEY;
 
+const log = getLogger({ module: 'documenso-service' });
+
 if (!DOCUMENSO_API_KEY) {
-  console.warn('DOCUMENSO_API_KEY is not configured');
+  log.warn('DOCUMENSO_API_KEY is not configured');
 }
 
 const getAuthHeaders = (): Record<string, string> => ({
@@ -261,7 +265,7 @@ export async function createLeaseSigningRequest(
       signing_url: signingUrl,
     };
   } catch (error) {
-    console.error('Error creating lease signing request:', error);
+    log.error({ err: error }, 'Error creating lease signing request');
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,123 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { randomUUID } from 'node:crypto'
+
+import pino from 'pino'
+
+import { CORRELATION_ID_HEADER } from './constants/logging'
+
+type RequestContext = {
+  correlationId: string
+}
+
+type HeaderRecord = Record<string, string | string[] | undefined>
+type HeaderGetter = {
+  get(name: string): string | null | undefined
+}
+
+type HeaderSource = HeaderGetter | HeaderRecord | null | undefined
+
+const requestContext = new AsyncLocalStorage<RequestContext>()
+
+function resolveHeaderValue(
+  value: string | string[] | null | undefined
+): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  return Array.isArray(value) ? value[0] : value
+}
+
+function isHeaderGetter(value: unknown): value is HeaderGetter {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'get' in value &&
+    typeof (value as HeaderGetter).get === 'function'
+  )
+}
+
+function getFromRecord(record: HeaderRecord | null | undefined): string | undefined {
+  if (!record) {
+    return undefined
+  }
+
+  const direct =
+    record[CORRELATION_ID_HEADER] ??
+    record[CORRELATION_ID_HEADER.toLowerCase()] ??
+    record[CORRELATION_ID_HEADER.toUpperCase()]
+
+  return resolveHeaderValue(direct)
+}
+
+function readCorrelationIdFromHeaders(source: HeaderSource): string | undefined {
+  if (!source) {
+    return undefined
+  }
+
+  if (isHeaderGetter(source)) {
+    return resolveHeaderValue(source.get(CORRELATION_ID_HEADER))
+  }
+
+  return getFromRecord(source)
+}
+
+function createCorrelationId(): string {
+  return randomUUID()
+}
+
+const baseLogger = pino({
+  base: undefined,
+  level: process.env.LOG_LEVEL ?? 'info',
+  messageKey: 'message',
+  mixin() {
+    const correlationId = getCorrelationId()
+    return correlationId ? { correlationId } : {}
+  },
+  serializers: {
+    err: pino.stdSerializers.err,
+  },
+})
+
+export const logger = baseLogger
+
+export function getLogger(bindings?: pino.Bindings) {
+  return bindings ? baseLogger.child(bindings) : baseLogger
+}
+
+export function getCorrelationId(): string | undefined {
+  return requestContext.getStore()?.correlationId
+}
+
+export function initializeRequestContext(
+  options: { headers?: HeaderSource; correlationId?: string } = {}
+): string {
+  const correlationId =
+    options.correlationId ??
+    readCorrelationIdFromHeaders(options.headers ?? null) ??
+    createCorrelationId()
+
+  requestContext.enterWith({ correlationId })
+
+  return correlationId
+}
+
+export function withRequestContext<T>(
+  fn: () => T,
+  options: { headers?: HeaderSource; correlationId?: string } = {}
+): T {
+  const correlationId =
+    options.correlationId ??
+    readCorrelationIdFromHeaders(options.headers ?? null) ??
+    createCorrelationId()
+
+  return requestContext.run({ correlationId }, fn)
+}
+
+export function getCorrelationIdFromHeaders(
+  headers: HeaderSource
+): string | undefined {
+  return readCorrelationIdFromHeaders(headers)
+}
+
+export type { HeaderSource }

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -2,6 +2,7 @@
 
 import { createSupbaseServerClient } from "@/utils/supaone"
 import { Resend } from "resend"
+import { getLogger } from "@/lib/logger"
 
 export interface NotificationData {
   to: string | string[]
@@ -22,6 +23,7 @@ export interface InAppNotification {
 
 class NotificationService {
   private resend: Resend | null = null
+  private log = getLogger({ module: "notifications" })
 
   constructor() {
     const apiKey = process.env.RESEND_API_KEY
@@ -32,7 +34,7 @@ class NotificationService {
 
   async sendEmail(notification: NotificationData) {
     if (!this.resend) {
-      console.warn(
+      this.log.warn(
         "Resend API key not configured. Skipping email notification."
       )
       return { success: false, error: "Email service not configured" }
@@ -67,7 +69,7 @@ class NotificationService {
       })
 
       if (error) {
-        console.error("Failed to send email:", error)
+        this.log.error({ err: error, template: notification.template }, "Failed to send email notification")
         return { success: false, error: error.message }
       }
 
@@ -78,7 +80,7 @@ class NotificationService {
 
       return { success: true, data }
     } catch (error) {
-      console.error("Email sending error:", error)
+      this.log.error({ err: error, template: notification.template }, "Email sending error")
       return {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",
@@ -104,13 +106,13 @@ class NotificationService {
         })
 
       if (error) {
-        console.error("Failed to create in-app notification:", error)
+        this.log.error({ err: error, notification }, "Failed to create in-app notification")
         return { success: false, error: error.message }
       }
 
       return { success: true, data }
     } catch (error) {
-      console.error("In-app notification error:", error)
+      this.log.error({ err: error, notification }, "In-app notification error")
       return {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",
@@ -153,7 +155,7 @@ class NotificationService {
         sent_at: new Date().toISOString(),
       })
     } catch (error) {
-      console.error("Failed to store email notification:", error)
+      this.log.error({ err: error, notification }, "Failed to store email notification")
     }
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,12 +3,26 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
+import { CORRELATION_ID_HEADER } from '@/lib/constants/logging'
+
 export async function middleware(request: NextRequest) {
-  let response = NextResponse.next({
-    request: {
-      headers: request.headers,
-    },
-  })
+  const requestHeaders = new Headers(request.headers)
+  const incomingCorrelationId =
+    requestHeaders.get(CORRELATION_ID_HEADER) ?? crypto.randomUUID()
+  requestHeaders.set(CORRELATION_ID_HEADER, incomingCorrelationId)
+
+  const applyCorrelationHeader = (res: NextResponse) => {
+    res.headers.set(CORRELATION_ID_HEADER, incomingCorrelationId)
+    return res
+  }
+
+  let response = applyCorrelationHeader(
+    NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    })
+  )
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL || '',
@@ -24,11 +38,13 @@ export async function middleware(request: NextRequest) {
             value,
             ...options,
           })
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          })
+          response = applyCorrelationHeader(
+            NextResponse.next({
+              request: {
+                headers: requestHeaders,
+              },
+            })
+          )
           response.cookies.set({
             name,
             value,
@@ -41,11 +57,13 @@ export async function middleware(request: NextRequest) {
             value: '',
             ...options,
           })
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          })
+          response = applyCorrelationHeader(
+            NextResponse.next({
+              request: {
+                headers: requestHeaders,
+              },
+            })
+          )
           response.cookies.set({
             name,
             value: '',

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "next": "14.2.4",
     "next-compose-plugins": "^2.2.1",
     "next-themes": "^0.2.1",
+    "pino": "^9.11.0",
     "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-day-picker": "^8.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      pino:
+        specifier: ^9.11.0
+        version: 9.11.0
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -2081,6 +2084,10 @@ packages:
   asynciterator.prototype@1.0.0:
     resolution: {integrity: sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   autoprefixer@10.4.16:
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2740,6 +2747,10 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-redact@3.5.0:
+    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
+    engines: {node: '>=6'}
 
   fast-uri@3.0.1:
     resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
@@ -3649,6 +3660,10 @@ packages:
     resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
     engines: {node: '>= 0.4'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3731,6 +3746,16 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+
+  pino@9.11.0:
+    resolution: {integrity: sha512-+YIodBB9sxcWeR8PrXC2K3gEDyfkUuVEITOcbqrfcj+z5QW4ioIcqZfYFbrLTYLsmAwunbS7nfU/dpBB6PZc1g==}
+    hasBin: true
+
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
@@ -3806,6 +3831,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3828,6 +3856,9 @@ packages:
 
   queue-tick@1.0.1:
     resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   ramda@0.29.1:
     resolution: {integrity: sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==}
@@ -3945,6 +3976,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   reflect.getprototypeof@1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
     engines: {node: '>= 0.4'}
@@ -4013,6 +4048,10 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4105,6 +4144,9 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+
   sonner@1.5.0:
     resolution: {integrity: sha512-FBjhG/gnnbN6FY0jaNnqZOMmB73R+5IiyYAw8yBj7L54ER7HB3fOSE5OFiQiE2iXWxeXKvg6fIP4LtVppHEdJA==}
     peerDependencies:
@@ -4136,6 +4178,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4325,6 +4371,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   three-mesh-bvh@0.6.8:
     resolution: {integrity: sha512-EGebF9DZx1S8+7OZYNNTT80GXJZVf+UYXD/HyTg/e2kR/ApofIFfUS4ZzIHNnUVIadpnLSzM4n96wX+l7GMbnQ==}
@@ -6728,6 +6777,8 @@ snapshots:
     dependencies:
       has-symbols: 1.0.3
 
+  atomic-sleep@1.0.0: {}
+
   autoprefixer@10.4.16(postcss@8.4.32):
     dependencies:
       browserslist: 4.22.2
@@ -7543,6 +7594,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-redact@3.5.0: {}
 
   fast-uri@3.0.1: {}
 
@@ -8670,6 +8723,8 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.22.3
 
+  on-exit-leak-free@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -8750,6 +8805,26 @@ snapshots:
 
   pify@2.3.0: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.0.0: {}
+
+  pino@9.11.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
   pirates@4.0.6: {}
 
   postcss-import@15.1.0(postcss@8.4.32):
@@ -8824,6 +8899,8 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  process-warning@5.0.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8846,6 +8923,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   queue-tick@1.0.1: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   ramda@0.29.1: {}
 
@@ -8960,6 +9039,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  real-require@0.2.0: {}
 
   reflect.getprototypeof@1.0.4:
     dependencies:
@@ -9080,6 +9161,8 @@ snapshots:
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
 
+  safe-stable-stringify@2.5.0: {}
+
   scheduler@0.21.0:
     dependencies:
       loose-envify: 1.4.0
@@ -9197,6 +9280,10 @@ snapshots:
 
   slash@3.0.0: {}
 
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   sonner@1.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -9218,6 +9305,8 @@ snapshots:
   source-map@0.7.4: {}
 
   space-separated-tokens@2.0.2: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -9470,6 +9559,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   three-mesh-bvh@0.6.8(three@0.160.0):
     dependencies:


### PR DESCRIPTION
## Summary
- add a Pino-based logger with request correlation utilities and header constant
- ensure middleware stamps requests with correlation IDs
- refactor server actions, API routes, and services to replace console usage with contextual logger calls

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b61206cc83288d9ddb550c8e9b6a