### PR TITLE
Remove GitHub login option

### DIFF
--- a/app/auth/actions/index.tsx
+++ b/app/auth/actions/index.tsx
@@ -170,35 +170,6 @@ export async function signInWithGoogle(): Promise<{ error?: string; url?: string
 
 */
 
-export async function signInWithGithub() {
-
-     const supabase = await createSupbaseServerClient();  
-
-supabase.auth.onAuthStateChange((event, session) => {
-  if (session && session.provider_token) {
-    window.localStorage.setItem('oauth_provider_token', session.provider_token)
-  }
-
-  if (session && session.provider_refresh_token) {
-    window.localStorage.setItem('oauth_provider_refresh_token', session.provider_refresh_token)
-  }
-
-  if (event === 'SIGNED_OUT') {
-    window.localStorage.removeItem('oauth_provider_token')
-    window.localStorage.removeItem('oauth_provider_refresh_token')
-  }
-})
-    const { data, error } = await supabase.auth.signInWithOAuth({
-    provider: 'github',
-    options: {
-       redirectTo: '/auth/callback',
-    },
-  })
-
-if (data.url) {
-  redirect(data.url)
- }
-}
 export async function signInWithTwitter() {
 
      const supabase = await createSupbaseServerClient();  

--- a/app/auth/components/user-auth-form.tsx
+++ b/app/auth/components/user-auth-form.tsx
@@ -2,62 +2,62 @@
 
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
-import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { loginWithEmailAndPassword, signInWithGithub } from "../actions"
 import { toast } from "@/components/ui/use-toast"
-import { AuthTokenResponse } from "@supabase/supabase-js"
+import { cn } from "@/lib/utils"
 import { zodResolver } from "@hookform/resolvers/zod"
+import { AuthTokenResponse } from "@supabase/supabase-js"
 import { useForm } from "react-hook-form"
-import { z } from "zod"
 import { AiOutlineLoading3Quarters } from "react-icons/ai"
+import { z } from "zod"
+
+import { loginWithEmailAndPassword } from "../actions"
 
 interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {}
 
+const LoginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1, { message: "Password can not be empty" }),
+})
+
 export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
-  const LoginSchema = z.object({
-    email: z.string().email(),
-    password: z.string().min(1, { message: "Password can not be empty" }),
-  });
-  
-    const [isGitHubLoading, setIsGitHubLoading] = React.useState<boolean>(false);
+  const [isLoading, setIsLoading] = React.useState<boolean>(false)
+  const [isPending, startTransition] = React.useTransition()
 
-const [isLoading, setIsLoading] = React.useState<boolean>(false)
-  const [isPending, startTransition] = React.useTransition();
-  
   const form = useForm<z.infer<typeof LoginSchema>>({
-		resolver: zodResolver(LoginSchema),
-		defaultValues: {
-			email: "",
-			password: "",
-		},
-	});
-  async function onSubmit(data: z.infer<typeof LoginSchema>) {
-    
-    setIsLoading(true)
-    startTransition(async () => {
-			const { error } = JSON.parse(
-				await loginWithEmailAndPassword(data)
-			) as AuthTokenResponse;
+    resolver: zodResolver(LoginSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  })
 
-			if (error) {
-				toast({
-					title: "Login failed!",
-					description: (
-						<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-							<code className="text-white">{error.message}</code>
-						</pre>
-					),
-				});
-			} else {
-				toast({
-					title: "Successful login 🎉",
-				});
-			}
-		});
+  async function onSubmit(data: z.infer<typeof LoginSchema>) {
+    setIsLoading(true)
+
+    startTransition(async () => {
+      const { error } = JSON.parse(
+        await loginWithEmailAndPassword(data),
+      ) as AuthTokenResponse
+
+      if (error) {
+        toast({
+          title: "Login failed!",
+          description: (
+            <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+              <code className="text-white">{error.message}</code>
+            </pre>
+          ),
+        })
+      } else {
+        toast({
+          title: "Successful login 🎉",
+        })
+      }
+    })
+
     setTimeout(() => {
       setIsLoading(false)
     }, 3000)
@@ -79,37 +79,34 @@ const [isLoading, setIsLoading] = React.useState<boolean>(false)
               autoComplete="email"
               autoCorrect="off"
               disabled={isLoading}
+              {...form.register("email")}
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label className="sr-only" htmlFor="password">
+              Password
+            </Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              disabled={isLoading}
+              {...form.register("password")}
             />
           </div>
           <Button
-				className="flex w-full items-center gap-2"
-				variant="outline"
-			>
-				Sign In{" "}
-				<AiOutlineLoading3Quarters
-					className={cn(" animate-spin", { hidden: !isPending })}
-				/>
-        </Button>
+            className="flex w-full items-center gap-2"
+            disabled={isLoading}
+            type="submit"
+            variant="outline"
+          >
+            Sign In{" "}
+            <AiOutlineLoading3Quarters
+              className={cn("animate-spin", { hidden: !isPending })}
+            />
+          </Button>
         </div>
       </form>
-      <div className="relative">
-        <div className="absolute inset-0 flex items-center">
-          <span className="w-full border-t" />
-        </div>
-        <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-background px-2 text-muted-foreground">
-            Or continue with
-          </span>
-        </div>
-      </div>
-      <Button variant="outline" type="button" disabled={isLoading}>
-        {isLoading ? (
-          <Icons.spinner className="mr-2 size-4 animate-spin" />
-        ) : (
-          <Icons.gitHub className="mr-2 size-4" />
-        )}{" "}
-        GitHub
-      </Button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove the GitHub OAuth helper from the auth server actions so the provider is no longer available
- simplify the user auth form to only render email/password inputs and the submit button

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b4832c508328a9b9600463a37989