### PR TITLE
Fix duplicate Card import on messaging page

### DIFF
--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,6 +1,4 @@
 import ModerationControls from "@/components/messaging/moderation-controls"
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"


### PR DESCRIPTION
## Summary
- remove the redundant Card import on the messaging page to eliminate the duplicate symbol error during compilation

## Testing
- pnpm lint *(fails: Parsing error in app/page.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d1fd05fcd08328a874f8d51453b5d5