### PR TITLE
Fix landing page CTA SmartLink markup

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,8 @@ import dynamic from "next/dynamic"
 import Image from "next/image"
 import Link from "next/link"
 
+import SmartLink from "@/components/navigation/SmartLink"
+
 import { redirect } from "next/navigation"
 import {
   CalendarClock,
@@ -413,9 +415,8 @@ export default async function IndexPage() {
                   intent="critical"
                 >
                   Start onboarding
-                </Link>
-                <Link
-
+                </SmartLink>
+                <SmartLink
                   href={siteConfig.links.contact}
                   className={cn(
                     buttonVariants({ variant: "outline", size: "lg" }),


### PR DESCRIPTION
## Summary
- import the SmartLink component on the landing page and fix the CTA markup so both buttons use the correct component

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ffc84a7c83288cf604db2d41b825