### PR TITLE
fix: harden web push payload handling

### DIFF
--- a/app/sw.js
+++ b/app/sw.js
@@ -1,21 +1,33 @@
-self.addEventListener('push', function (event) {
-    if (event.data) {
-      const data = event.data.json()
-      const options = {
-        body: data.body,
-        icon: data.icon || '/icon.png',
-        badge: '/badge.png',
-        vibrate: [100, 50, 100],
-        data: {
-          dateOfArrival: Date.now(),
-          primaryKey: '2',
-        },
-      }
-      event.waitUntil(self.registration.showNotification(data.title, options))
-    }
-  })
-   
-  self.addEventListener('notificationclick', function (event) {
-    event.notification.close()
-    event.waitUntil(clients.openWindow('<https://onyx-rho-pink.vercel.app>'))
-  })
+self.addEventListener('push', (event) => {
+  const payload = event.data?.json()
+
+  if (!payload) {
+    return
+  }
+
+  const scope = self.registration?.scope ?? '/'
+  const title = payload.title ?? 'Share House Portal'
+
+  const options = {
+    body: payload.body ?? '',
+    icon: payload.icon ?? '/images/touch/homescreen192.png',
+    badge: payload.badge ?? '/images/touch/homescreen48.png',
+    vibrate: payload.vibrate ?? [100, 50, 100],
+    data: {
+      dateOfArrival: Date.now(),
+      primaryKey: payload.data?.primaryKey ?? 'notification',
+      url: payload.url ?? payload.data?.url ?? scope,
+    },
+  }
+
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  const targetUrl =
+    event.notification?.data?.url ?? self.registration?.scope ?? '/'
+
+  event.waitUntil(clients.openWindow(targetUrl))
+})


### PR DESCRIPTION
## Summary
- guard the web push service worker against malformed payloads and missing notification metadata
- use existing manifest icons for notification imagery to prevent 404s in production
- default notification click targets to the registration scope instead of an invalid hard-coded URL

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f5a911048328a1016a0b8e6e8a51