### PR TITLE
Fix landing page markup to restore build

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import SmartLink from "@/components/navigation/SmartLink"
 import { buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
@@ -150,7 +151,7 @@ export default async function IndexPage() {
   const { data: userSession } = await readUserSession()
 
   if (userSession.session) {
-    return redirect("/dashboard")
+    redirect("/dashboard")
   }
 
   return (
@@ -413,14 +414,14 @@ export default async function IndexPage() {
                   intent="critical"
                 >
                   Start onboarding
-                </Link>
-                <Link
-
+                </SmartLink>
+                <SmartLink
                   href={siteConfig.links.contact}
                   className={cn(
                     buttonVariants({ variant: "outline", size: "lg" }),
                     "border-primary/40 bg-white/70 px-8 text-base font-semibold text-primary hover:border-primary hover:bg-white"
                   )}
+                  intent="passive"
                 >
                   Talk with us
                 </SmartLink>


### PR DESCRIPTION
## Summary
- import the SmartLink helper on the landing page and use it for the CTA buttons so tags are balanced
- update the dashboard redirect logic to call `redirect` directly per Next.js expectations

## Testing
- CI=1 pnpm build
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d20240cee0832892ca6ec9146a895b