### PR TITLE
Fix type errors in payments ledger

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import SmartLink from "@/components/navigation/SmartLink"
 import { buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -103,3 +103,32 @@ export interface PaymentReceiptHistoryEntry {
   lineItems: PaymentReceiptLineItem[]
 
 }
+
+export type LedgerActorRole = "roommate" | "property_manager"
+
+export interface LedgerActor {
+  id: string
+  name: string
+  role: LedgerActorRole
+}
+
+export type LedgerEntryType = "contribution" | "adjustment"
+
+export interface LedgerEntry {
+  id: string
+  date: string
+  description: string
+  note?: string
+  amount: number
+  type: LedgerEntryType
+  actor: LedgerActor
+}
+
+export interface RoommateLedger {
+  roommateId: string
+  roommateName: string
+  unitLabel: string
+  currency: string
+  startingBalance: number
+  entries: LedgerEntry[]
+}


### PR DESCRIPTION
## Summary
- remove the duplicate SmartLink import on the landing page that caused the Next.js build to fail
- define ledger-related TypeScript types so the roommate ledger component can compile cleanly

## Testing
- CI=1 pnpm run build
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d2045a00dc8328a827830d8c638f96