### PR TITLE
Add competitor analysis for roommate platforms

### DIFF
--- a/docs/design/all-in-one-roommate-management-platforms.md
+++ b/docs/design/all-in-one-roommate-management-platforms.md
@@ -1,0 +1,25 @@
+# All-in-One Roommate Management Platforms
+
+## Overview
+All-in-one roommate portals aim to centralize every shared living task—rent collection, expense tracking, chore management, and maintenance—into a single workflow. Studying previous attempts highlights which feature bundles resonate with roommates and where modern implementations like Roomsily can differentiate.
+
+## Platform snapshots
+
+| Platform | Launch | Core positioning | Notable capabilities | Lessons
+| --- | --- | --- | --- | --- |
+| **Zently** | 2017 | Renter-focused finance and maintenance companion | - Electronic rent payments with optional landlord check mailing<br>- In-app maintenance flagging that notifies the landlord<br>- Automated expense reconciliation by connecting to roommates' bank accounts and calculating IOUs<br>- Enabled master tenant to collect rent shares directly in the app | Household finances are sticky when rent, reimbursements, and upkeep live together. Automations around payment distribution are critical for adoption.
+| **HomeSlice** | ~2014 | "Command center" for new roommates | - Dedicated sections for chores, supplies, and bills<br>- Transparent accountability instead of ad-hoc notes<br>- Roadmap included in-app bill pay and gamified rewards | Early demand for structured accountability shows value in separating responsibilities while maintaining a shared dashboard and incentive loops.
+| **Bungalow/Common resident apps** | Mid-2010s | Co-living company resident experience | - Individual rent share payments handled in-app<br>- Centralized announcements, events, and chat for the household<br>- Support for maintenance and service requests<br>- Lease details managed alongside community features | Integrating communication, billing, and service management keeps managed co-living frictionless and builds community through events and messaging.
+
+## Opportunity areas for Roomsily
+- **Unified financial spine:** Combine Zently-style rent, bill splitting, and IOU automation with Stripe subscriptions so master tenants never manually chase payments.
+- **Transparent chore and supply loops:** Mirror HomeSlice's chore assignment clarity while layering in Roomsily automations (e.g., reminders, rotating schedules, completion streaks).
+- **Community plus service channel:** Adopt Common's blend of announcements, chats, and maintenance tracking to keep every roommate informed without juggling third-party apps.
+- **Trustworthy data connections:** Provide safe bank-linking flows (e.g., via Plaid) and detailed activity logs to convince roommates to centralize finances and communications in Roomsily.
+- **Incentivized good behavior:** Experiment with recognition systems or perks, evolving HomeSlice's gamification vision into modern reward streaks or rent-credit bonuses managed through the portal.
+
+## Implementation considerations
+1. **Payment orchestration:** Use Stripe Billing for base rent, while a ledger service tracks reimbursements to avoid double-charging and maintain visibility into outstanding balances.
+2. **Automation and notifications:** Tie Cal.com bookings, maintenance tickets, and visitor logs into the messaging feed so households receive real-time updates without app switching.
+3. **Role-aware experiences:** Deliver master tenant tools for rent aggregation, while other roommates see simplified obligations and shared progress dashboards.
+4. **Compliance and trust:** Maintain audit trails for every payment, chore completion, and maintenance request to reassure roommates and property managers.


### PR DESCRIPTION
## Summary
- add a design research note summarizing legacy all-in-one roommate management platforms
- capture differentiators from Zently, HomeSlice, and Bungalow/Common resident apps
- outline opportunity areas and implementation considerations for Roomsily

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d20ac7915c8328b80ca979de1b96f5