### PR TITLE
docs: summarize co-living community platforms

### DIFF
--- a/docs/design/co-living-tenant-community-platforms.md
+++ b/docs/design/co-living-tenant-community-platforms.md
@@ -1,0 +1,60 @@
+# Co-Living & Tenant Community Platforms
+
+This research roundup catalogs the co-living and tenant experience suites that most closely mirror the Share House Portal vision. Each product below blends rent operations, amenity coordination, and resident engagement into a single branded portal, offering a useful benchmark for our own roadmap and UX decisions.
+
+## Platform Snapshots
+
+### TheHouseMonk
+- White-label tenant portals that property teams can skin per house while relying on a shared automation layer.
+- Resident app bundles in-app rent payments, maintenance ticketing, parcel and visitor logs, and digital document storage to keep roommates and managers aligned.
+- Community feed supports announcements and messaging while shared amenity booking ensures kitchens, lounges, or other facilities avoid conflicts.
+- Real-time ledgers and rule-enforcement tooling provide transparency on balances, late fees, and house policies.
+
+### Spaceflow
+- Tenant experience platform focused on co-living and modern multifamily buildings with a resident mobile app at its core.
+- Integrates access control, smart amenity reservations, and visitor sign-ins so roommates can coordinate shared resources and arrivals.
+- Supports issue reporting, event updates, and payment processing for amenity fees or shared costs.
+- Community features such as polls and a social news feed keep residents engaged beyond transactional tasks.
+
+### MonBuilding
+- All-in-one community app used across residential buildings and co-living hubs, spanning resident and manager tooling.
+- Tenants can make amenity reservations, submit in-app payments, and participate in a message board for household coordination.
+- Management side handles onboarding with e-signature leases and contracts, stores documents, and tracks service tickets.
+- Digital document storage and electronic lease signing keep agreements searchable and enforceable inside the portal.
+
+### District Tech
+- Communications-first platform oriented around shared living environments and large community operations.
+- Offers an events calendar, newsfeed, and in-app chat to streamline announcements and roommate discussions.
+- Integrates building services with concierge workflows, covering visitor management, service requests, and content updates.
+- Includes payment collection, event RSVPs, and content management features that align with a house portal’s transparency goals.
+
+## Feature Comparison Checklist
+
+| Capability | TheHouseMonk | Spaceflow | MonBuilding | District Tech |
+| --- | --- | --- | --- | --- |
+| In-app rent or fee payments | ✓ | ✓ | ✓ | ✓ |
+| Community feed / messaging | ✓ | ✓ | ✓ | ✓ |
+| Shared amenity bookings | ✓ | ✓ | ✓ | ✓ |
+| Visitor / parcel management | ✓ | ✓ | ✓ | ✓ |
+| Digital document storage & e-signatures | ✓ | – (focus on access + updates) | ✓ | ✓ |
+| Events & polls | ✓ (announcements) | ✓ | ✓ | ✓ |
+| Manager automation / rule enforcement | ✓ | ✓ | ✓ | ✓ |
+
+*Spaceflow focuses on real-time updates and access integrations more than document workflows, but partners can extend storage via connected services.*
+
+## Takeaways for Share House Portal
+
+- **Lean on modular white-labeling:** Mirror the ability to customize branding per property while keeping consistent automation and policy enforcement underneath.
+- **Surface a transparent ledger:** Follow TheHouseMonk’s real-time balances paired with notifications so every roommate understands obligations and receipts.
+- **Bundle access, bookings, and visitor flows:** Combine Cal.com scheduling, visitor registration, and access control integrations the way Spaceflow and District Tech do to limit friction at shared spaces.
+- **Keep messaging contextual:** Deliver a threaded feed with polls and event RSVPs inspired by Spaceflow, MonBuilding, and District Tech to maintain community engagement.
+- **Centralize documents and signatures:** Use Documenso-driven workflows to match MonBuilding’s e-signatures and searchable storage for leases and house rules.
+- **Provide manager dashboards for onboarding:** Echo MonBuilding’s admin views to monitor onboarding, service tickets, and policy compliance.
+
+## Reference Links
+
+- <https://www.consciouscoliving.com>
+- <https://www.thehousemonk.com>
+- <https://www.spaceflow.io>
+- <https://www.monbuilding.com>
+- <https://www.district-tech.com>


### PR DESCRIPTION
## Summary
- document key co-living and tenant community platforms that mirror the Share House Portal vision
- capture feature checklists and product takeaways across TheHouseMonk, Spaceflow, MonBuilding, and District Tech
- include reference links for follow-up product research

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d20b572bec8328becd83876b46ae75