### PR TITLE
Add dashboard first-run tour onboarding flow

### DIFF
--- a/app/dashboard/actions/tour.ts
+++ b/app/dashboard/actions/tour.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { createSupbaseServerClient } from "@/utils/supaone";
+
+type TourStatus = {
+        hasSeenTour: boolean;
+};
+
+async function withAuthenticatedClient() {
+        const supabase = await createSupbaseServerClient();
+        const {
+                data: { user },
+                error,
+        } = await supabase.auth.getUser();
+
+        if (error) {
+                throw new Error("Unable to determine the current session");
+        }
+
+        if (!user) {
+                throw new Error("No authenticated user found for dashboard tour updates");
+        }
+
+        return { supabase, userId: user.id } as const;
+}
+
+export async function getTourStatus(): Promise<TourStatus> {
+        const { supabase, userId } = await withAuthenticatedClient();
+        const { data, error } = await supabase
+                .from("profiles")
+                .select("has_seen_tour")
+                .eq("id", userId)
+                .maybeSingle();
+
+        if (error && error.code !== "PGRST116") {
+                throw new Error("Unable to read the dashboard tour status");
+        }
+
+        return {
+                hasSeenTour: data?.has_seen_tour ?? false,
+        };
+}
+
+export async function completeTour(): Promise<TourStatus> {
+        return updateTourState(true);
+}
+
+export async function requestTourReplay(): Promise<TourStatus> {
+        return updateTourState(false);
+}
+
+async function updateTourState(hasSeenTour: boolean): Promise<TourStatus> {
+        const { supabase, userId } = await withAuthenticatedClient();
+        const { data, error } = await supabase
+                .from("profiles")
+                .update({
+                        has_seen_tour: hasSeenTour,
+                        updated_at: new Date().toISOString(),
+                })
+                .eq("id", userId)
+                .select("has_seen_tour")
+                .maybeSingle();
+
+        if (error && error.code !== "PGRST116") {
+                throw new Error("Unable to update the dashboard tour preference");
+        }
+
+        return {
+                hasSeenTour: data?.has_seen_tour ?? hasSeenTour,
+        };
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,16 +1,18 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import React, { useCallback, useEffect, useState } from "react";
+import { PersonIcon, CrumpledPaperIcon, QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import SmartLink from "@/components/navigation/SmartLink";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
 import { createClient } from "@/utils/supabase-browser";
 import { fetchMemberRole } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { useFirstRunTourContext } from "@/components/onboarding/FirstRunTour";
 
 export default function NavLinks() {
-	const pathname = usePathname();
-	const [role, setRole] = useState<string | null>(null);
+        const pathname = usePathname();
+        const [role, setRole] = useState<string | null>(null);
+        const { replayTour, isPending: tourPending, isTourActive } = useFirstRunTourContext();
 
 	useEffect(() => {
 		const load = async () => {
@@ -53,11 +55,16 @@ export default function NavLinks() {
 			{ href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
 		];
 
-	return (
-		<div className="space-y-5">
-			{links.map((link, index) => {
-				const Icon = link.Icon;
-				return (
+        const handleReplayTour = useCallback(() => {
+                replayTour();
+                document.getElementById("sidebar-close")?.click();
+        }, [replayTour]);
+
+        return (
+                <div className="space-y-5">
+                        {links.map((link, index) => {
+                                const Icon = link.Icon;
+                                return (
                                         <SmartLink
                                                 onClick={() =>
                                                         document.getElementById("sidebar-close")?.click()
@@ -76,8 +83,23 @@ export default function NavLinks() {
                                                 <Icon />
                                                 {link.text}
                                         </SmartLink>
-				);
-			})}
-		</div>
-	);
+                                        );
+                        })}
+                        <button
+                                type="button"
+                                onClick={handleReplayTour}
+                                className={cn(
+                                        "flex w-full items-center gap-2 rounded-sm p-2 text-left transition hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-70 dark:hover:bg-gray-700",
+                                        {
+                                                "bg-gray-500 text-white dark:bg-gray-700": isTourActive,
+                                        },
+                                )}
+                                data-tour-id="dashboard-help"
+                                disabled={tourPending || isTourActive}
+                        >
+                                <QuestionMarkCircledIcon />
+                                Product tour
+                        </button>
+                </div>
+        );
 }

--- a/app/dashboard/components/SideNav.tsx
+++ b/app/dashboard/components/SideNav.tsx
@@ -11,15 +11,16 @@ export default function SideNav() {
 }
 
 export const SideBar = ({ className }: { className?: string }) => {
-	return (
-		<div className={className}>
-			<div
-				className={cn(
-					"flex size-full flex-col space-y-5 lg:w-96 lg:border-r lg:p-10 "
-				)}
-			>
-				<div className="flex-1 space-y-5">
-					<div className="flex flex-1 items-center gap-2">
+        return (
+                <div className={className}>
+                        <div
+                                className={cn(
+                                        "flex size-full flex-col space-y-5 lg:w-96 lg:border-r lg:p-10 "
+                                )}
+                                data-tour-id="dashboard-navigation"
+                        >
+                                <div className="flex-1 space-y-5">
+                                        <div className="flex flex-1 items-center gap-2">
                                         <div>
                                                 <h1 className="text-3xl font-semibold">Roomsily</h1>
                                                 <p className="text-sm text-muted-foreground">www.roomsily household hub</p>

--- a/app/dashboard/components/ToggleSidebar.tsx
+++ b/app/dashboard/components/ToggleSidebar.tsx
@@ -4,11 +4,12 @@ import React from "react";
 import { HamburgerMenuIcon } from "@radix-ui/react-icons";
 export default function ToggleSidebar() {
 	return (
-		<Button
-			variant="outline"
-			className="block lg:hidden"
-			onClick={() => document.getElementById("toggle-sidebar")?.click()}
-		>
+                <Button
+                        variant="outline"
+                        className="block lg:hidden"
+                        data-tour-id="dashboard-mobile-trigger"
+                        onClick={() => document.getElementById("toggle-sidebar")?.click()}
+                >
 			<HamburgerMenuIcon />
 		</Button>
 	);

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -3,8 +3,10 @@ import { Suspense, type ReactNode } from "react"
 import { redirect } from "next/navigation"
 
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
+import FirstRunTour from "@/components/onboarding/FirstRunTour"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
 import { readUserSession } from "@/utils/actions"
+import { createSupbaseServerClient } from "@/utils/supaone"
 import MobileSideNav from "./components/MobileSideNav"
 import SideNav from "./components/SideNav"
 import ToggleSidebar from "./components/ToggleSidebar"
@@ -15,21 +17,45 @@ export default async function Layout({ children }: { children: ReactNode }) {
 	if (!userSession.session) {
 		return redirect("/auth");
 	}
-	return (
-		<div className="flex w-full ">
-			<div className="flex h-screen flex-col">
-				<SideNav />
-				<MobileSideNav />
-			</div>
+        let initialHasSeenTour = false;
 
-                        <div className="w-full space-y-5 bg-gray-100 p-5 sm:flex-1 sm:p-10 dark:bg-inherit">
-                                <ToggleSidebar />
-                                <ErrorBoundary>
-                                        <Suspense fallback={<RouteSkeleton />}>
-                                                {children}
-                                        </Suspense>
-                                </ErrorBoundary>
+        try {
+                const supabase = await createSupbaseServerClient();
+                const { data, error } = await supabase
+                        .from("profiles")
+                        .select("has_seen_tour")
+                        .eq("id", userSession.session.user.id)
+                        .maybeSingle();
+
+                if (error && error.code !== "PGRST116") {
+                        console.error("Unable to resolve dashboard tour preference", error);
+                }
+
+                initialHasSeenTour = data?.has_seen_tour ?? false;
+        } catch (profileError) {
+                console.error("Failed to load dashboard tour state", profileError);
+        }
+
+        return (
+                <FirstRunTour initialHasSeenTour={initialHasSeenTour}>
+                        <div className="flex w-full">
+                                <div className="flex h-screen flex-col">
+                                        <SideNav />
+                                        <MobileSideNav />
+                                </div>
+
+                                <div
+                                        className="w-full space-y-5 bg-gray-100 p-5 sm:flex-1 sm:p-10 dark:bg-inherit"
+                                        data-tour-id="dashboard-workspace"
+                                >
+                                        <ToggleSidebar />
+                                        <ErrorBoundary>
+                                                <Suspense fallback={<RouteSkeleton />}>
+                                                        {children}
+                                                </Suspense>
+                                        </ErrorBoundary>
+                                </div>
                         </div>
-                </div>
+                </FirstRunTour>
         );
 }

--- a/app/tour-preview/TourPreviewScaffold.tsx
+++ b/app/tour-preview/TourPreviewScaffold.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+
+import { useFirstRunTourContext } from "@/components/onboarding/FirstRunTour";
+import { Button } from "@/components/ui/button";
+
+export default function TourPreviewScaffold() {
+        const { replayTour, isPending, isTourActive } = useFirstRunTourContext();
+
+        const previousOverrides = useMemo(() => {
+                if (typeof window === "undefined") {
+                        return { overrides: undefined, log: undefined } as const;
+                }
+
+                const overrides = window.__dashboardTourOverrides;
+                const log = window.__tourCallLog;
+
+                window.__tourCallLog = [];
+                window.__dashboardTourOverrides = {
+                        getStatus: async () => {
+                                window.__tourCallLog?.push?.("status");
+                                return { hasSeenTour: false };
+                        },
+                        markComplete: async () => {
+                                window.__tourCallLog?.push?.("complete");
+                                return { hasSeenTour: true };
+                        },
+                        replay: async () => {
+                                window.__tourCallLog?.push?.("replay");
+                                return { hasSeenTour: false };
+                        },
+                };
+
+                return { overrides, log } as const;
+        }, []);
+
+        useEffect(() => {
+                return () => {
+                        if (typeof window === "undefined") {
+                                return;
+                        }
+
+                        if (previousOverrides.overrides) {
+                                window.__dashboardTourOverrides = previousOverrides.overrides;
+                        } else {
+                                delete window.__dashboardTourOverrides;
+                        }
+
+                        if (previousOverrides.log) {
+                                window.__tourCallLog = previousOverrides.log;
+                        } else {
+                                delete window.__tourCallLog;
+                        }
+                };
+        }, [previousOverrides]);
+
+        return (
+                <div className="flex min-h-screen flex-col bg-slate-950 text-white">
+                        <div className="flex flex-1 flex-col lg:flex-row">
+                                <aside
+                                        data-tour-id="dashboard-navigation"
+                                        className="w-full max-w-xs space-y-4 border-b border-slate-800 bg-slate-900 p-6 lg:h-screen lg:border-b-0 lg:border-r"
+                                >
+                                        <div>
+                                                <h1 className="text-2xl font-semibold">Dashboard tour sandbox</h1>
+                                                <p className="mt-2 text-sm text-slate-300">
+                                                        Use this page to validate the first-run experience without signing in.
+                                                </p>
+                                        </div>
+                                        <Button
+                                                type="button"
+                                                variant="secondary"
+                                                onClick={replayTour}
+                                                data-tour-id="dashboard-help"
+                                                disabled={isPending || isTourActive}
+                                        >
+                                                Product tour
+                                        </Button>
+                                </aside>
+                                <main className="flex flex-1 flex-col gap-6 bg-white p-6 text-slate-900 dark:bg-slate-950 dark:text-white">
+                                        <div
+                                                data-tour-id="dashboard-mobile-trigger"
+                                                className="flex items-center justify-between rounded-lg border border-dashed border-slate-200 p-4 dark:border-slate-700"
+                                        >
+                                                <span className="text-sm text-muted-foreground">
+                                                        Mobile menu toggle placeholder
+                                                </span>
+                                                <Button variant="outline" type="button">
+                                                        Menu
+                                                </Button>
+                                        </div>
+                                        <section
+                                                data-tour-id="dashboard-workspace"
+                                                className="min-h-[320px] rounded-lg border border-dashed border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+                                        >
+                                                <h2 className="text-xl font-semibold">Workspace canvas</h2>
+                                                <p className="mt-2 text-muted-foreground">
+                                                        Drop dashboard widgets here to ensure the highlight overlay aligns with your
+                                                        layout.
+                                                </p>
+                                        </section>
+                                </main>
+                        </div>
+                </div>
+        );
+}

--- a/app/tour-preview/page.tsx
+++ b/app/tour-preview/page.tsx
@@ -1,0 +1,14 @@
+import FirstRunTour from "@/components/onboarding/FirstRunTour";
+import TourPreviewScaffold from "./TourPreviewScaffold";
+
+export const metadata = {
+        title: "Dashboard tour preview",
+};
+
+export default function TourPreviewPage() {
+        return (
+                <FirstRunTour initialHasSeenTour={false}>
+                        <TourPreviewScaffold />
+                </FirstRunTour>
+        );
+}

--- a/components/onboarding/FirstRunTour.tsx
+++ b/components/onboarding/FirstRunTour.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import {
+        createContext,
+        useContext,
+        useEffect,
+        useMemo,
+        useState,
+} from "react";
+
+import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
+
+import { Button } from "@/components/ui/button";
+import {
+        Dialog,
+        DialogContent,
+        DialogDescription,
+        DialogFooter,
+        DialogHeader,
+        DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { useDashboardTour } from "@/hooks/use-first-run-tour";
+
+type TourStep = {
+        id: string;
+        title: string;
+        description: string;
+        targetSelector?: string;
+};
+
+const DASHBOARD_TOUR_STEPS: TourStep[] = [
+        {
+                id: "navigation",
+                title: "Household navigation",
+                description:
+                        "Use the sidebar to jump between members, rent, documents, chores, and shared messages.",
+                targetSelector: '[data-tour-id="dashboard-navigation"]',
+        },
+        {
+                id: "mobile-menu",
+                title: "Mobile quick menu",
+                description:
+                        "On phones, open the dashboard menu from the toggle so you always have navigation within reach.",
+                targetSelector: '[data-tour-id="dashboard-mobile-trigger"]',
+        },
+        {
+                id: "workspace",
+                title: "Workspace canvas",
+                description:
+                        "Review payments, booking activity, and roommates updates in the main workspace area.",
+                targetSelector: '[data-tour-id="dashboard-workspace"]',
+        },
+        {
+                id: "help",
+                title: "Help & resources",
+                description:
+                        "Need a refresher later? Relaunch this walkthrough any time from the Help menu.",
+                targetSelector: '[data-tour-id="dashboard-help"]',
+        },
+];
+
+type HighlightRect = {
+        top: number;
+        left: number;
+        width: number;
+        height: number;
+};
+
+type FirstRunTourContextValue = {
+        hasSeenTour: boolean;
+        isTourActive: boolean;
+        isLoading: boolean;
+        isPending: boolean;
+        replayTour: () => void;
+};
+
+const FirstRunTourContext = createContext<FirstRunTourContextValue | null>(null);
+
+export function useFirstRunTourContext() {
+        const context = useContext(FirstRunTourContext);
+
+        if (!context) {
+                throw new Error("useFirstRunTourContext must be used within a FirstRunTour provider");
+        }
+
+        return context;
+}
+
+type FirstRunTourProps = {
+        children: React.ReactNode;
+        initialHasSeenTour?: boolean;
+};
+
+export default function FirstRunTour({ children, initialHasSeenTour }: FirstRunTourProps) {
+        const [isMounted, setIsMounted] = useState(false);
+        const {
+                hasSeenTour,
+                isOpen,
+                isLoading,
+                isPending,
+                currentStep,
+                goToNext,
+                goToPrevious,
+                skipTour,
+                handleOpenChange,
+                replayTour,
+        } = useDashboardTour(initialHasSeenTour, DASHBOARD_TOUR_STEPS.length);
+
+        useEffect(() => {
+                setIsMounted(true);
+        }, []);
+
+        const activeStep = DASHBOARD_TOUR_STEPS[currentStep];
+        const highlight = useHighlightRect(activeStep?.targetSelector, isOpen && isMounted);
+
+        const contextValue = useMemo<FirstRunTourContextValue>(
+                () => ({
+                        hasSeenTour,
+                        isTourActive: isOpen,
+                        isLoading,
+                        isPending,
+                        replayTour,
+                }),
+                [hasSeenTour, isOpen, isLoading, isPending, replayTour],
+        );
+
+        return (
+                <FirstRunTourContext.Provider value={contextValue}>
+                        {children}
+                        {isMounted && (
+                                <>
+                                        <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+                                                <DialogContent
+                                                        data-testid="dashboard-first-run-tour"
+                                                        className="max-w-xl space-y-4"
+                                                >
+                                                        <DialogHeader className="space-y-4 text-left">
+                                                                <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+                                                                        <span className="inline-flex size-6 items-center justify-center rounded-full bg-primary/10 font-semibold text-primary">
+                                                                                {currentStep + 1}
+                                                                        </span>
+                                                                        <span>
+                                                                                Step {currentStep + 1} of {DASHBOARD_TOUR_STEPS.length}
+                                                                        </span>
+                                                                </div>
+                                                                <DialogTitle className="text-xl font-semibold leading-tight">
+                                                                        {activeStep?.title}
+                                                                </DialogTitle>
+                                                                <DialogDescription className="text-base text-muted-foreground">
+                                                                        {activeStep?.description}
+                                                                </DialogDescription>
+                                                        </DialogHeader>
+
+                                                        <nav
+                                                                aria-label="Dashboard tour progress"
+                                                                className="flex flex-col gap-3"
+                                                        >
+                                                                <ol className="flex items-center gap-2" role="list">
+                                                                        {DASHBOARD_TOUR_STEPS.map((step, index) => (
+                                                                                <li
+                                                                                        key={step.id}
+                                                                                        className={cn(
+                                                                                                "h-2 flex-1 rounded-full",
+                                                                                                index <= currentStep
+                                                                                                        ? "bg-primary"
+                                                                                                        : "bg-muted",
+                                                                                        )}
+                                                                                        aria-hidden="true"
+                                                                                />
+                                                                        ))}
+                                                                </ol>
+                                                                <div className="grid gap-2 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
+                                                                        <p className="flex items-center gap-2 font-medium text-primary">
+                                                                                <QuestionMarkCircledIcon className="size-4" />
+                                                                                Tour steps
+                                                                        </p>
+                                                                        <ul className="grid gap-1 text-muted-foreground" role="list">
+                                                                                {DASHBOARD_TOUR_STEPS.map((step, index) => (
+                                                                                        <li
+                                                                                                key={step.id}
+                                                                                                className={cn(
+                                                                                                        "flex items-start gap-2 rounded-md px-2 py-1",
+                                                                                                        index === currentStep
+                                                                                                                ? "bg-primary/10 text-primary"
+                                                                                                                : "text-muted-foreground",
+                                                                                                )}
+                                                                                                aria-current={index === currentStep ? "step" : undefined}
+                                                                                        >
+                                                                                                <span className="mt-1 size-2 rounded-full bg-current" aria-hidden="true" />
+                                                                                                <span className="text-xs font-medium uppercase tracking-wide">
+                                                                                                        {step.title}
+                                                                                                </span>
+                                                                                        </li>
+                                                                                ))}
+                                                                        </ul>
+                                                                </div>
+                                                        </nav>
+
+                                                        <DialogFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                                                <Button
+                                                                        type="button"
+                                                                        variant="ghost"
+                                                                        className="justify-start px-0 text-sm font-medium text-muted-foreground hover:text-foreground"
+                                                                        onClick={skipTour}
+                                                                        disabled={isPending}
+                                                                >
+                                                                        Skip tour
+                                                                </Button>
+                                                                <div className="flex gap-2">
+                                                                        <Button
+                                                                                type="button"
+                                                                                variant="outline"
+                                                                                onClick={goToPrevious}
+                                                                                disabled={currentStep === 0 || isPending}
+                                                                        >
+                                                                                Back
+                                                                        </Button>
+                                                                        <Button
+                                                                                type="button"
+                                                                                onClick={goToNext}
+                                                                                disabled={isPending}
+                                                                        >
+                                                                                {currentStep === DASHBOARD_TOUR_STEPS.length - 1
+                                                                                        ? "Finish"
+                                                                                        : "Next"}
+                                                                        </Button>
+                                                                </div>
+                                                        </DialogFooter>
+                                                </DialogContent>
+                                        </Dialog>
+                                        {isOpen && highlight ? (
+                                                <div
+                                                        aria-hidden="true"
+                                                        className="pointer-events-none fixed z-[60] rounded-xl border-2 border-primary shadow-[0_0_0_9999px_rgba(9,9,11,0.55)] transition-[top,left,width,height] duration-300"
+                                                        style={{
+                                                                top: highlight.top,
+                                                                left: highlight.left,
+                                                                width: highlight.width,
+                                                                height: highlight.height,
+                                                        }}
+                                                />
+                                        ) : null}
+                                </>
+                        )}
+                </FirstRunTourContext.Provider>
+        );
+}
+
+function useHighlightRect(selector: string | undefined, active: boolean) {
+        const [rect, setRect] = useState<HighlightRect | null>(null);
+
+        useEffect(() => {
+                if (!active || !selector) {
+                        setRect(null);
+                        return;
+                }
+
+                const element = document.querySelector<HTMLElement>(selector);
+
+                if (!element) {
+                        setRect(null);
+                        return;
+                }
+
+                const update = () => {
+                        const elementRect = element.getBoundingClientRect();
+
+                        if (!elementRect || (elementRect.width === 0 && elementRect.height === 0)) {
+                                setRect(null);
+                                return;
+                        }
+
+                        setRect({
+                                top: Math.max(0, elementRect.top - 12),
+                                left: Math.max(0, elementRect.left - 12),
+                                width: elementRect.width + 24,
+                                height: elementRect.height + 24,
+                        });
+                };
+
+                update();
+
+                window.addEventListener("resize", update);
+                window.addEventListener("scroll", update, true);
+
+                let observer: ResizeObserver | null = null;
+
+                if ("ResizeObserver" in window) {
+                        observer = new ResizeObserver(update);
+                        observer.observe(element);
+                }
+
+                return () => {
+                        window.removeEventListener("resize", update);
+                        window.removeEventListener("scroll", update, true);
+                        observer?.disconnect();
+                };
+        }, [selector, active]);
+
+        return rect;
+}

--- a/hooks/use-first-run-tour.ts
+++ b/hooks/use-first-run-tour.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+
+import {
+        completeTour,
+        getTourStatus,
+        requestTourReplay,
+} from "@/app/dashboard/actions/tour";
+import { useToast } from "@/components/ui/use-toast";
+
+type TourStatus = {
+        hasSeenTour: boolean;
+};
+
+type TourAction = () => Promise<TourStatus>;
+
+type TourActionOverrides = {
+        getStatus?: TourAction;
+        markComplete?: TourAction;
+        replay?: TourAction;
+};
+
+declare global {
+        interface Window {
+                __dashboardTourOverrides?: TourActionOverrides;
+                __tourCallLog?: string[];
+        }
+}
+
+function resolveActions(): {
+        getStatus: TourAction;
+        markComplete: TourAction;
+        replay: TourAction;
+} {
+        if (typeof window !== "undefined") {
+                const overrides = window.__dashboardTourOverrides;
+
+                if (overrides) {
+                        return {
+                                getStatus: overrides.getStatus ?? getTourStatus,
+                                markComplete: overrides.markComplete ?? completeTour,
+                                replay: overrides.replay ?? requestTourReplay,
+                        };
+                }
+        }
+
+        return {
+                getStatus: getTourStatus,
+                markComplete: completeTour,
+                replay: requestTourReplay,
+        };
+}
+
+type DashboardTourState = {
+        hasSeenTour: boolean;
+        isOpen: boolean;
+        isLoading: boolean;
+        isPending: boolean;
+        currentStep: number;
+        goToNext: () => void;
+        goToPrevious: () => void;
+        skipTour: () => void;
+        handleOpenChange: (nextOpen: boolean) => void;
+        replayTour: () => void;
+};
+
+export function useDashboardTour(initialHasSeenTour: boolean | undefined, totalSteps: number): DashboardTourState {
+        const { toast } = useToast();
+        const [hasSeenTour, setHasSeenTour] = useState(initialHasSeenTour ?? false);
+        const [isOpen, setIsOpen] = useState(!(initialHasSeenTour ?? false));
+        const [currentStep, setCurrentStep] = useState(0);
+        const [isLoading, setIsLoading] = useState(true);
+        const [isPending, startTransition] = useTransition();
+        const isFinalizingRef = useRef(false);
+
+        useEffect(() => {
+                setHasSeenTour(initialHasSeenTour ?? false);
+                setIsOpen(!(initialHasSeenTour ?? false));
+        }, [initialHasSeenTour]);
+
+        useEffect(() => {
+                let active = true;
+
+                const fetchStatus = async () => {
+                        try {
+                                const { getStatus } = resolveActions();
+                                const status = await getStatus();
+
+                                if (!active) {
+                                        return;
+                                }
+
+                                setHasSeenTour(status.hasSeenTour);
+                                setIsOpen(!status.hasSeenTour);
+                        } catch (error) {
+                                if (!active) {
+                                        return;
+                                }
+
+                                console.error("Failed to load dashboard tour status", error);
+                                setHasSeenTour(true);
+                                setIsOpen(false);
+                        } finally {
+                                if (active) {
+                                        setIsLoading(false);
+                                }
+                        }
+                };
+
+                fetchStatus();
+
+                return () => {
+                        active = false;
+                };
+        }, []);
+
+        const finalizeTour = useCallback(() => {
+                if (isFinalizingRef.current) {
+                        return;
+                }
+
+                isFinalizingRef.current = true;
+                setIsOpen(false);
+                setCurrentStep(0);
+
+                startTransition(async () => {
+                        try {
+                                const { markComplete } = resolveActions();
+                                const status = await markComplete();
+                                setHasSeenTour(status.hasSeenTour);
+                        } catch (error) {
+                                console.error("Unable to update tour completion", error);
+                                toast({
+                                        title: "We couldn't save your tour progress",
+                                        description: "Please try again. Your dashboard is still available in the background.",
+                                        variant: "destructive",
+                                });
+                        } finally {
+                                isFinalizingRef.current = false;
+                        }
+                });
+        }, [startTransition, toast]);
+
+        const goToNext = useCallback(() => {
+                setCurrentStep((previous) => {
+                        if (previous >= totalSteps - 1) {
+                                finalizeTour();
+                                return previous;
+                        }
+
+                        return previous + 1;
+                });
+        }, [finalizeTour, totalSteps]);
+
+        const goToPrevious = useCallback(() => {
+                setCurrentStep((previous) => Math.max(previous - 1, 0));
+        }, []);
+
+        const skipTour = useCallback(() => {
+                finalizeTour();
+        }, [finalizeTour]);
+
+        const handleOpenChange = useCallback(
+                (nextOpen: boolean) => {
+                        if (!nextOpen) {
+                                finalizeTour();
+                        }
+                },
+                [finalizeTour],
+        );
+
+        const replayTour = useCallback(() => {
+                setCurrentStep(0);
+                setHasSeenTour(false);
+                setIsOpen(true);
+
+                startTransition(async () => {
+                        try {
+                                const { replay } = resolveActions();
+                                const status = await replay();
+                                setHasSeenTour(status.hasSeenTour);
+                                if (status.hasSeenTour) {
+                                        setIsOpen(false);
+                                }
+                        } catch (error) {
+                                console.error("Unable to relaunch the dashboard tour", error);
+                                setIsOpen(false);
+                                toast({
+                                        title: "We couldn't relaunch the tour",
+                                        description: "Refresh and try again, or contact support if the issue continues.",
+                                        variant: "destructive",
+                                });
+                        }
+                });
+        }, [startTransition, toast]);
+
+        return useMemo(
+                () => ({
+                        hasSeenTour,
+                        isOpen,
+                        isLoading,
+                        isPending,
+                        currentStep,
+                        goToNext,
+                        goToPrevious,
+                        skipTour,
+                        handleOpenChange,
+                        replayTour,
+                }),
+                [
+                        currentStep,
+                        goToNext,
+                        goToPrevious,
+                        handleOpenChange,
+                        hasSeenTour,
+                        isLoading,
+                        isOpen,
+                        isPending,
+                        replayTour,
+                        skipTour,
+                ],
+        );
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -45,6 +45,7 @@ export type Database = {
         stripe_customer_id: string | null
         rent_share: number | null
         metadata: Json | null
+        has_seen_tour: boolean
       }>
       documents: SupabaseTable<{
         id: string

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "css:purge": "node scripts/check-css-size.mjs"
   },
   "dependencies": {
@@ -78,6 +79,7 @@
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@playwright/test": "^1.41.2",
     "@typescript-eslint/parser": "^7.16.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
+
+export default defineConfig({
+        testDir: "./tests/e2e",
+        timeout: 30 * 1000,
+        expect: {
+                timeout: 10 * 1000,
+        },
+        fullyParallel: false,
+        forbidOnly: !!process.env.CI,
+        retries: process.env.CI ? 2 : 0,
+        reporter: "list",
+        use: {
+                baseURL,
+                trace: "on-first-retry",
+                video: "on-first-retry",
+        },
+        projects: [
+                {
+                        name: "chromium",
+                        use: { ...devices["Desktop Chrome"] },
+                },
+        ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,10 +103,10 @@ importers:
         version: 2.0.13
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+        version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -139,13 +139,13 @@ importers:
         version: 0.302.0(react@18.2.0)
       next:
         specifier: 14.2.4
-        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -192,6 +192,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@playwright/test':
+        specifier: ^1.41.2
+        version: 1.55.0
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -754,6 +757,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -2812,6 +2820,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3734,6 +3747,16 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -5222,6 +5245,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
+
   '@radix-ui/number@1.0.1':
     dependencies:
       '@babel/runtime': 7.23.9
@@ -6390,16 +6417,16 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.2.0
 
-  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.3.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))':
     optionalDependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       svelte: 4.2.18
       vue: 3.4.35(typescript@5.5.4)
@@ -7604,6 +7631,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8568,13 +8598,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -8596,6 +8626,7 @@ snapshots:
       '@next/swc-win32-ia32-msvc': 14.2.4
       '@next/swc-win32-x64-msvc': 14.2.4
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.55.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -8751,6 +8782,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.4.32):
     dependencies:

--- a/supabase/migrations/20250305_dashboard_tour_flag.sql
+++ b/supabase/migrations/20250305_dashboard_tour_flag.sql
@@ -1,0 +1,21 @@
+-- Track whether residents have completed the dashboard first-run tour.
+
+DO $$
+BEGIN
+  IF to_regclass('public.profiles') IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'profiles'
+        AND column_name = 'has_seen_tour'
+    ) THEN
+      EXECUTE 'ALTER TABLE public.profiles ADD COLUMN has_seen_tour boolean DEFAULT false';
+    END IF;
+
+    EXECUTE 'UPDATE public.profiles SET has_seen_tour = COALESCE(has_seen_tour, false)';
+    EXECUTE 'ALTER TABLE public.profiles ALTER COLUMN has_seen_tour SET DEFAULT false';
+    EXECUTE 'ALTER TABLE public.profiles ALTER COLUMN has_seen_tour SET NOT NULL';
+    EXECUTE $$COMMENT ON COLUMN public.profiles.has_seen_tour IS ''Tracks whether the dashboard onboarding tour has been completed.''$$;
+  END IF;
+END $$;

--- a/tests/e2e/dashboard-tour.spec.ts
+++ b/tests/e2e/dashboard-tour.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+        await page.addInitScript(() => {
+                window.__tourCallLog = [];
+                window.__dashboardTourOverrides = {
+                        getStatus: async () => {
+                                window.__tourCallLog?.push?.("status");
+                                return { hasSeenTour: false };
+                        },
+                        markComplete: async () => {
+                                window.__tourCallLog?.push?.("complete");
+                                return { hasSeenTour: true };
+                        },
+                        replay: async () => {
+                                window.__tourCallLog?.push?.("replay");
+                                return { hasSeenTour: false };
+                        },
+                };
+        });
+});
+
+test("allows residents to skip the dashboard tour", async ({ page }) => {
+        await page.goto("/tour-preview");
+
+        const dialog = page.getByTestId("dashboard-first-run-tour");
+        await expect(dialog).toBeVisible();
+
+        await page.getByRole("button", { name: /Skip tour/i }).click();
+
+        await expect(dialog).toHaveCount(0);
+
+        const callLog = await page.evaluate(() => window.__tourCallLog ?? []);
+        expect(callLog).toContain("complete");
+});
+
+test("walks through the entire tour flow", async ({ page }) => {
+        await page.goto("/tour-preview");
+
+        const dialog = page.getByTestId("dashboard-first-run-tour");
+        await expect(dialog).toBeVisible();
+
+        const stepTitles = [
+                "Household navigation",
+                "Mobile quick menu",
+                "Workspace canvas",
+                "Help & resources",
+        ];
+
+        for (let index = 0; index < stepTitles.length; index += 1) {
+                await expect(page.getByText(stepTitles[index], { exact: false })).toBeVisible();
+                const isLastStep = index === stepTitles.length - 1;
+                const actionLabel = isLastStep ? /Finish/i : /Next/i;
+                await page.getByRole("button", { name: actionLabel }).click();
+        }
+
+        await expect(dialog).toHaveCount(0);
+
+        const callLog = await page.evaluate(() => window.__tourCallLog ?? []);
+        const completeCount = callLog.filter((entry: string) => entry === "complete").length;
+        expect(completeCount).toBeGreaterThan(0);
+});
+
+test("relaunches the tour from the help entry", async ({ page }) => {
+        await page.goto("/tour-preview");
+
+        const dialog = page.getByTestId("dashboard-first-run-tour");
+        await expect(dialog).toBeVisible();
+
+        await page.getByRole("button", { name: /Skip tour/i }).click();
+        await expect(dialog).toHaveCount(0);
+
+        await page.getByRole("button", { name: /Product tour/i }).click();
+        await expect(dialog).toBeVisible();
+
+        const callLog = await page.evaluate(() => window.__tourCallLog ?? []);
+        expect(callLog).toContain("replay");
+});


### PR DESCRIPTION
## Summary
- add a reusable first-run tour provider with highlight overlays and Supabase-backed state
- persist completion and replay via new dashboard tour server actions and migration, wiring the provider into the dashboard shell and help menu
- add a preview harness, Playwright e2e coverage, and supporting configuration updates

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d20b621c3c8328b2ca3ba5051d1c5b