### PR TITLE
Add recent activity tracking and resume CTA

### DIFF
--- a/app/dashboard/(dashboard)/components/recent-activity-panel.tsx
+++ b/app/dashboard/(dashboard)/components/recent-activity-panel.tsx
@@ -1,0 +1,27 @@
+import RecentActivityPanel from "@/components/navigation/RecentActivityPanel"
+import { fetchRecentActivity } from "@/lib/data/recent-activity"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+export default async function DashboardRecentActivityPanel() {
+  const supabase = (await createSupbaseServerClientReadOnly()) as TypedSupabaseClient
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return null
+  }
+
+  try {
+    const { items, lastRoute } = await fetchRecentActivity({
+      client: supabase,
+      userId: user.id,
+    })
+
+    return <RecentActivityPanel items={items} lastRoute={lastRoute} />
+  } catch (error) {
+    console.error("Unable to load recent activity", error)
+    return <RecentActivityPanel items={[]} lastRoute={null} />
+  }
+}

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "./components/skeletons"
 
 import InsightsPanel from "./components/insights-panel"
+import DashboardRecentActivityPanel from "./components/recent-activity-panel"
 
 export default function DashboardPage() {
   return (
@@ -57,6 +58,9 @@ export default function DashboardPage() {
 
 
         <div className="space-y-4">
+          <Suspense fallback={<DashboardCardSkeleton />}>
+            <DashboardRecentActivityPanel />
+          </Suspense>
           <Suspense fallback={<DashboardCardSkeleton />}>
             <UpcomingBookingsCard />
           </Suspense>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,10 @@ import { fontSans } from "@/lib/font"
 import { cn } from "@/lib/utils"
 import { siteConfig } from "@/config/site"
 import { ReactQueryClientProvider } from "@/components/react-query-client-provider"
+import ResumeActivityBanner from "@/components/navigation/ResumeActivityBanner"
+import { fetchRecentActivity } from "@/lib/data/recent-activity"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
@@ -114,6 +118,47 @@ interface RootLayoutProps {
 }
 
 
+async function ResumeLastRouteCTA() {
+  const supabase = (await createSupbaseServerClientReadOnly()) as TypedSupabaseClient
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return null
+  }
+
+  try {
+    const { items, lastRoute } = await fetchRecentActivity({
+      client: supabase,
+      userId: user.id,
+    })
+
+    if (!lastRoute || items.length === 0) {
+      return null
+    }
+
+    const latest = items[0]
+
+    return (
+      <div className="border-b border-border/70 bg-muted/30">
+        <div className="container mx-auto px-4 py-3">
+          <ResumeActivityBanner
+            href={lastRoute}
+            label={latest.label}
+            entityType={latest.entity_type}
+            entityId={latest.entity_id}
+          />
+        </div>
+      </div>
+    )
+  } catch (error) {
+    console.error("Failed to load resume activity CTA", error)
+    return null
+  }
+}
+
+
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <ReactQueryClientProvider>
@@ -132,6 +177,9 @@ export default function RootLayout({ children }: RootLayoutProps) {
           >
              <div className="relative flex min-h-screen flex-col">
               <SiteHeader />
+              <Suspense fallback={null}>
+                <ResumeLastRouteCTA />
+              </Suspense>
               <div className="flex-1">
                 <ErrorBoundary>
                   <Suspense fallback={<RouteSkeleton />}>

--- a/components/navigation/RecentActivityPanel.tsx
+++ b/components/navigation/RecentActivityPanel.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import * as React from "react"
+import { ArrowUpRight, Clock } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import SmartLink from "@/components/navigation/SmartLink"
+import type { Tables } from "@/lib/supabase"
+
+type RecentActivityItem = Tables<"user_recent_items">
+
+type RecentActivityPanelProps = {
+  items: RecentActivityItem[]
+  lastRoute: string | null
+}
+
+function formatEntityType(entityType: string) {
+  return entityType
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ")
+}
+
+function formatVisitedAt(timestamp: string | null | undefined) {
+  if (!timestamp) {
+    return "Just now"
+  }
+
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return "Just now"
+  }
+
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+export function RecentActivityPanel({ items, lastRoute }: RecentActivityPanelProps) {
+  const resumeTarget = React.useMemo(() => items[0], [items])
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="pb-4">
+        <div className="space-y-1">
+          <CardTitle>Recent activity</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Jump back into the documents, payments, and tasks you opened most recently.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {items.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+            We’ll keep track of the pages you visit most so you can resume work without hunting for links.
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {items.map((item) => {
+              const visitedAt = item.visited_at ?? item.updated_at ?? item.created_at
+              const href = item.last_visited_route || "#"
+
+              return (
+                <li key={`${item.entity_type}:${item.entity_id}`}>
+                  <SmartLink
+                    href={href}
+                    intent="navigation"
+                    recentActivity={{
+                      entityType: item.entity_type,
+                      entityId: item.entity_id,
+                      label: item.label,
+                      route: href,
+                    }}
+                    className="group flex items-center justify-between gap-3 rounded-md border border-transparent px-3 py-2 transition-colors hover:border-border"
+                  >
+                    <div className="space-y-1 text-left">
+                      <p className="text-sm font-medium text-foreground transition-colors group-hover:text-primary">
+                        {item.label}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatEntityType(item.entity_type)} · {formatVisitedAt(visitedAt)}
+                      </p>
+                    </div>
+                    <Clock className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-primary" />
+                  </SmartLink>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+
+        {lastRoute && resumeTarget ? (
+          <SmartLink
+            href={lastRoute}
+            intent="navigation"
+            recentActivity={{
+              entityType: resumeTarget.entity_type,
+              entityId: resumeTarget.entity_id,
+              label: resumeTarget.label,
+              route: lastRoute,
+            }}
+            className="inline-flex w-full"
+          >
+            <Button variant="outline" className="w-full items-center justify-center gap-2 text-sm">
+              Resume {resumeTarget.label}
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+          </SmartLink>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default RecentActivityPanel

--- a/components/navigation/ResumeActivityBanner.tsx
+++ b/components/navigation/ResumeActivityBanner.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { ArrowRight } from "lucide-react"
+
+import SmartLink from "@/components/navigation/SmartLink"
+import { cn } from "@/lib/utils"
+
+export type ResumeActivityBannerProps = {
+  href: string
+  label: string
+  entityType: string
+  entityId: string
+  className?: string
+}
+
+export default function ResumeActivityBanner({
+  href,
+  label,
+  entityType,
+  entityId,
+  className,
+}: ResumeActivityBannerProps) {
+  return (
+    <SmartLink
+      href={href}
+      intent="navigation"
+      recentActivity={{
+        entityType,
+        entityId,
+        label,
+        route: href,
+      }}
+      className={cn(
+        "group flex items-center justify-between gap-3 rounded-md border border-border bg-background px-4 py-3 text-sm",
+        "transition-colors hover:bg-muted",
+        className,
+      )}
+    >
+      <div className="space-y-0.5">
+        <p className="font-medium text-foreground">Resume where you left off</p>
+        <p className="text-xs text-muted-foreground">{label}</p>
+      </div>
+      <ArrowRight className="h-4 w-4 text-muted-foreground transition-all group-hover:translate-x-0.5 group-hover:text-primary" />
+    </SmartLink>
+  )
+}

--- a/components/navigation/SmartLink.tsx
+++ b/components/navigation/SmartLink.tsx
@@ -4,6 +4,9 @@ import * as React from "react"
 import NextLink from "next/link"
 import { useRouter } from "next/navigation"
 
+import { recordRecentItemVisit } from "@/lib/data/recent-activity"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
 export type SmartLinkIntent = "standard" | "critical" | "passive" | "navigation"
 
 export interface SmartLinkProps
@@ -20,6 +23,15 @@ export interface SmartLinkProps
    * Custom root margin applied to the IntersectionObserver used for viewport based prefetching.
    */
   viewportMargin?: string
+  /**
+   * Optional metadata for persisting navigation history.
+   */
+  recentActivity?: {
+    entityType: string
+    entityId: string
+    label: string
+    route?: string
+  }
 }
 
 type PrefetchHint = "never" | "hover" | "viewport" | "immediate"
@@ -34,11 +46,33 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       prefetch: prefetchProp,
       onPointerEnter,
       onFocus,
+      onClick,
       href,
+      recentActivity,
       ...rest
     } = props
 
     const router = useRouter()
+    const supabase = useSupabaseBrowser()
+    const resolvedUserIdRef = React.useRef<string | null | undefined>(undefined)
+
+    const resolveUserId = React.useCallback(async () => {
+      if (resolvedUserIdRef.current !== undefined) {
+        return resolvedUserIdRef.current
+      }
+
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
+        resolvedUserIdRef.current = user?.id ?? null
+        return resolvedUserIdRef.current
+      } catch (error) {
+        resolvedUserIdRef.current = null
+        throw error
+      }
+    }, [supabase])
+
     const innerRef = React.useRef<HTMLAnchorElement | null>(null)
     const combinedRef = React.useCallback(
       (node: AnchorRef) => {
@@ -186,6 +220,49 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       [onFocus, prefetchHint, triggerPrefetch]
     )
 
+    const handleClick = React.useCallback(
+      (event: React.MouseEvent<HTMLAnchorElement>) => {
+        onClick?.(event)
+        if (event.defaultPrevented) {
+          return
+        }
+
+        if (!recentActivity) {
+          return
+        }
+
+        const candidateRoute =
+          recentActivity.route ?? (typeof href === "string" ? href : undefined)
+        const shouldRecord =
+          !!candidateRoute && typeof candidateRoute === "string" && candidateRoute.startsWith("/")
+
+        if (!isInternalHref || !shouldRecord) {
+          return
+        }
+
+        void (async () => {
+          try {
+            const userId = await resolveUserId()
+            if (!userId) {
+              return
+            }
+
+            await recordRecentItemVisit({
+              client: supabase,
+              userId,
+              entityType: recentActivity.entityType,
+              entityId: recentActivity.entityId,
+              label: recentActivity.label,
+              lastVisitedRoute: candidateRoute,
+            })
+          } catch (error) {
+            console.error("Failed to record recent navigation", error)
+          }
+        })()
+      },
+      [href, isInternalHref, onClick, recentActivity, resolveUserId, supabase]
+    )
+
     const shouldPrefetch = React.useMemo(() => {
       if (!isInternalHref) {
         return false
@@ -210,6 +287,7 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
         prefetch={shouldPrefetch}
         onPointerEnter={handlePointerEnter}
         onFocus={handleFocus}
+        onClick={handleClick}
         {...rest}
       />
     )

--- a/lib/data/recent-activity.ts
+++ b/lib/data/recent-activity.ts
@@ -1,0 +1,108 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+import type { Database } from '@/lib/supabase';
+
+const TABLE_NAME = 'user_recent_items';
+
+type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
+
+type RecentActivityRow = Database['public']['Tables']['user_recent_items']['Row'];
+
+type RecordRecentItemParams = {
+  client: SupabaseClientLike;
+  userId: string | null | undefined;
+  entityType: string | null | undefined;
+  entityId: string | null | undefined;
+  label: string | null | undefined;
+  lastVisitedRoute: string | null | undefined;
+};
+
+type FetchRecentActivityParams = {
+  client: SupabaseClientLike;
+  userId: string | null | undefined;
+};
+
+export type RecentActivityResult = {
+  items: RecentActivityRow[];
+  lastRoute: string | null;
+};
+
+function normalizeRoute(route: string | null | undefined): string | null {
+  if (!route) {
+    return null;
+  }
+
+  try {
+    const trimmed = route.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    if (trimmed.startsWith('/')) {
+      return trimmed;
+    }
+
+    const url = new URL(trimmed, 'http://localhost');
+    return url.pathname + url.search + url.hash;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export async function recordRecentItemVisit({
+  client,
+  userId,
+  entityType,
+  entityId,
+  label,
+  lastVisitedRoute,
+}: RecordRecentItemParams): Promise<void> {
+  const normalizedRoute = normalizeRoute(lastVisitedRoute);
+  if (!client || !userId || !entityType || !entityId || !label || !normalizedRoute) {
+    return;
+  }
+
+  const payload = {
+    user_id: userId,
+    entity_type: entityType,
+    entity_id: entityId,
+    label,
+    last_visited_route: normalizedRoute,
+    visited_at: new Date().toISOString(),
+  };
+
+  const { error } = await client
+    .from(TABLE_NAME)
+    .upsert(payload, { onConflict: 'user_id,entity_type,entity_id' });
+
+  if (error) {
+    throw new Error(`Failed to record recent activity: ${error.message}`);
+  }
+}
+
+export async function fetchRecentActivity({
+  client,
+  userId,
+}: FetchRecentActivityParams): Promise<RecentActivityResult> {
+  if (!client || !userId) {
+    return { items: [], lastRoute: null };
+  }
+
+  const { data, error } = await client
+    .from(TABLE_NAME)
+    .select('*')
+    .eq('user_id', userId)
+    .order('visited_at', { ascending: false })
+    .limit(5);
+
+  if (error) {
+    throw new Error(`Failed to fetch recent activity: ${error.message}`);
+  }
+
+  const items = (data ?? []) as RecentActivityRow[];
+  const lastRoute = items[0]?.last_visited_route ?? null;
+
+  return {
+    items,
+    lastRoute,
+  };
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -213,6 +213,17 @@ export type Database = {
         created_at: string | null
         updated_at: string | null
       }>
+      user_recent_items: SupabaseTable<{
+        id: string
+        user_id: string
+        entity_type: string
+        entity_id: string
+        label: string
+        last_visited_route: string
+        visited_at: string
+        created_at: string | null
+        updated_at: string | null
+      }>
       email_notifications: SupabaseTable<{
         id: string
         user_id: string | null

--- a/supabase/migrations/20250220_user_recent_items.sql
+++ b/supabase/migrations/20250220_user_recent_items.sql
@@ -1,0 +1,34 @@
+-- Track recently visited entities per user
+CREATE TABLE public.user_recent_items (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  label TEXT NOT NULL,
+  last_visited_route TEXT NOT NULL,
+  visited_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CONSTRAINT user_recent_items_unique_visit UNIQUE (user_id, entity_type, entity_id)
+);
+
+CREATE INDEX idx_user_recent_items_user_id ON public.user_recent_items(user_id);
+CREATE INDEX idx_user_recent_items_visited_at ON public.user_recent_items(visited_at DESC);
+
+ALTER TABLE public.user_recent_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their recent items" ON public.user_recent_items
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their recent items" ON public.user_recent_items
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their recent items" ON public.user_recent_items
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their recent items" ON public.user_recent_items
+  FOR DELETE USING (auth.uid() = user_id);
+
+CREATE TRIGGER update_user_recent_items_updated_at
+  BEFORE UPDATE ON public.user_recent_items
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/tests/lib/data/recent-activity.test.ts
+++ b/tests/lib/data/recent-activity.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchRecentActivity, recordRecentItemVisit } from '@/lib/data/recent-activity';
+import type { Database } from '@/lib/supabase';
+
+type RecentActivityRow = Database['public']['Tables']['user_recent_items']['Row'];
+
+type RecentActivityStore = Map<string, RecentActivityRow>;
+
+type UpsertPayload = Partial<RecentActivityRow> | Partial<RecentActivityRow>[];
+
+class RecentActivityQueryBuilder {
+  private result: RecentActivityRow[] = [];
+
+  constructor(private readonly store: RecentActivityStore) {}
+
+  upsert(payload: UpsertPayload) {
+    const entries = Array.isArray(payload) ? payload : [payload];
+
+    for (const entry of entries) {
+      if (!entry.user_id || !entry.entity_type || !entry.entity_id) {
+        continue;
+      }
+
+      const key = `${entry.user_id}:${entry.entity_type}:${entry.entity_id}`;
+      const existing = this.store.get(key);
+      const timestamp = entry.visited_at ?? new Date().toISOString();
+
+      const record: RecentActivityRow = {
+        id: existing?.id ?? `mock-${this.store.size + 1}`,
+        user_id: entry.user_id,
+        entity_type: entry.entity_type,
+        entity_id: entry.entity_id,
+        label: entry.label ?? existing?.label ?? '',
+        last_visited_route: entry.last_visited_route ?? existing?.last_visited_route ?? '',
+        visited_at: timestamp,
+        created_at: existing?.created_at ?? timestamp,
+        updated_at: timestamp,
+      };
+
+      this.store.set(key, record);
+    }
+
+    return Promise.resolve({ data: null, error: null });
+  }
+
+  select() {
+    this.result = Array.from(this.store.values());
+    return this;
+  }
+
+  eq(column: keyof RecentActivityRow, value: string) {
+    this.result = this.result.filter((row) => row[column] === value);
+    return this;
+  }
+
+  order(column: keyof RecentActivityRow, { ascending }: { ascending: boolean }) {
+    const factor = ascending ? 1 : -1;
+    this.result.sort((a, b) => {
+      const first = a[column] ?? '';
+      const second = b[column] ?? '';
+      const firstTime = typeof first === 'string' ? new Date(first).getTime() : 0;
+      const secondTime = typeof second === 'string' ? new Date(second).getTime() : 0;
+      return (firstTime - secondTime) * factor;
+    });
+    return this;
+  }
+
+  limit(count: number) {
+    return Promise.resolve({ data: this.result.slice(0, count), error: null });
+  }
+}
+
+function createRecentActivityClient(store: RecentActivityStore = new Map()) {
+  return {
+    client: {
+      from: (table: string) => {
+        if (table !== 'user_recent_items') {
+          throw new Error(`Unexpected table requested: ${table}`);
+        }
+        return new RecentActivityQueryBuilder(store);
+      },
+    } as unknown as { from: (table: string) => RecentActivityQueryBuilder },
+    store,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('recent activity persistence', () => {
+  it('persists visits across client sessions', async () => {
+    vi.useFakeTimers();
+    const { client, store } = createRecentActivityClient();
+
+    vi.setSystemTime(new Date('2024-01-01T09:00:00Z'));
+    await recordRecentItemVisit({
+      client,
+      userId: 'user-1',
+      entityType: 'document',
+      entityId: 'lease-1',
+      label: 'Lease agreement',
+      lastVisitedRoute: '/documents/lease-1',
+    });
+
+    const { client: newSession } = createRecentActivityClient(store);
+
+    vi.setSystemTime(new Date('2024-01-03T12:00:00Z'));
+    await recordRecentItemVisit({
+      client: newSession,
+      userId: 'user-1',
+      entityType: 'payment',
+      entityId: 'rent-jan',
+      label: 'January rent',
+      lastVisitedRoute: '/payments/history',
+    });
+
+    const { items } = await fetchRecentActivity({ client: newSession, userId: 'user-1' });
+
+    expect(items).toHaveLength(2);
+    expect(items[0].entity_id).toBe('rent-jan');
+    expect(items[1].entity_id).toBe('lease-1');
+  });
+
+  it('restores the most recent route for returning sessions', async () => {
+    vi.useFakeTimers();
+    const { client } = createRecentActivityClient();
+
+    vi.setSystemTime(new Date('2024-02-10T08:15:00Z'));
+    await recordRecentItemVisit({
+      client,
+      userId: 'user-42',
+      entityType: 'payment',
+      entityId: 'rent-feb',
+      label: 'February rent',
+      lastVisitedRoute: '/payments',
+    });
+
+    vi.setSystemTime(new Date('2024-02-11T18:45:00Z'));
+    await recordRecentItemVisit({
+      client,
+      userId: 'user-42',
+      entityType: 'document',
+      entityId: 'lease-update',
+      label: 'Lease addendum',
+      lastVisitedRoute: '/documents/lease-update',
+    });
+
+    const activity = await fetchRecentActivity({ client, userId: 'user-42' });
+
+    expect(activity.items[0].last_visited_route).toBe('/documents/lease-update');
+    expect(activity.lastRoute).toBe('/documents/lease-update');
+  });
+});


### PR DESCRIPTION
## Summary
- add a `user_recent_items` table and typed utilities for recording and reading recent navigation
- surface a recent activity panel on the dashboard and a resume banner in the global layout
- extend SmartLink to track visits and cover the new flows with integration tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b6355e88328848cc13ad5cf272c