### PR TITLE
Add favorites system with Supabase storage and UI

### DIFF
--- a/app/api/favorites/route.ts
+++ b/app/api/favorites/route.ts
@@ -1,0 +1,275 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import type { Database, Json } from "@/lib/supabase"
+import createSupabaseServer from "@/utils/supabase-server"
+
+type FavoriteRow = Database["public"]["Tables"]["user_favorites"]["Row"]
+
+export type FavoriteMetadata = Record<string, string>
+
+export type FavoriteResponse = {
+  id: string
+  entityType: string
+  entityId: string
+  sortOrder: number
+  pinnedAt: string | null
+  metadata?: FavoriteMetadata
+}
+
+function serializeFavorite(row: FavoriteRow): FavoriteResponse {
+  return {
+    id: row.id,
+    entityType: row.entity_type,
+    entityId: row.entity_id,
+    sortOrder: row.sort_order,
+    pinnedAt: row.pinned_at,
+    metadata: normalizeMetadata(row.metadata),
+  }
+}
+
+function normalizeMetadata(metadata: FavoriteRow["metadata"]): FavoriteMetadata | undefined {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined
+  }
+
+  const entries = Object.entries(metadata).reduce<FavoriteMetadata>((acc, [key, value]) => {
+    if (typeof value === "string") {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+
+  return Object.keys(entries).length > 0 ? entries : undefined
+}
+
+function sanitizeMetadata(metadata: unknown): Json | undefined {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined
+  }
+
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value === "string") {
+      result[key] = value
+    }
+  }
+
+  return Object.keys(result).length > 0 ? (result as Json) : undefined
+}
+
+async function getAuthenticatedUserId() {
+  const cookieStore = cookies()
+  const supabase = createSupabaseServer(cookieStore)
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    return { supabase, userId: null as const }
+  }
+
+  return { supabase, userId: user.id }
+}
+
+async function fetchUserFavorites(
+  supabase: ReturnType<typeof createSupabaseServer>,
+  userId: string,
+) {
+  const { data, error } = await supabase
+    .from("user_favorites")
+    .select("*")
+    .eq("user_id", userId)
+    .order("sort_order", { ascending: true })
+    .order("pinned_at", { ascending: false })
+
+  if (error) {
+    throw error
+  }
+
+  return data ?? []
+}
+
+async function buildFavoritesResponse(
+  supabase: ReturnType<typeof createSupabaseServer>,
+  userId: string,
+  status = 200,
+) {
+  const favorites = await fetchUserFavorites(supabase, userId)
+  return NextResponse.json(
+    {
+      favorites: favorites.map(serializeFavorite),
+    },
+    { status },
+  )
+}
+
+export async function GET() {
+  const { supabase, userId } = await getAuthenticatedUserId()
+
+  if (!userId) {
+    return NextResponse.json({ favorites: [] }, { status: 401 })
+  }
+
+  try {
+    return await buildFavoritesResponse(supabase, userId)
+  } catch (error) {
+    console.error("Failed to load favorites", error)
+    return NextResponse.json({ error: "Unable to fetch favorites" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  const { supabase, userId } = await getAuthenticatedUserId()
+
+  if (!userId) {
+    return NextResponse.json({ favorites: [] }, { status: 401 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const { entityType, entityId, metadata } = (payload || {}) as {
+    entityType?: string
+    entityId?: string
+    metadata?: unknown
+  }
+
+  if (!entityType || !entityId) {
+    return NextResponse.json(
+      { error: "Missing entityType or entityId" },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const existing = await supabase
+      .from("user_favorites")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("entity_type", entityType)
+      .eq("entity_id", entityId)
+      .maybeSingle()
+
+    if (existing.data?.id) {
+      const { error } = await supabase
+        .from("user_favorites")
+        .delete()
+        .eq("id", existing.data.id)
+        .eq("user_id", userId)
+
+      if (error) {
+        throw error
+      }
+    } else {
+      const { data: maxSortRow, error: sortError } = await supabase
+        .from("user_favorites")
+        .select("sort_order")
+        .eq("user_id", userId)
+        .order("sort_order", { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+      if (sortError && sortError.code !== "PGRST116") {
+        throw sortError
+      }
+
+      const nextSortOrder = (maxSortRow?.sort_order ?? 0) + 1
+      const insertPayload = {
+        user_id: userId,
+        entity_type: entityType,
+        entity_id: entityId,
+        metadata: sanitizeMetadata(metadata),
+        sort_order: nextSortOrder,
+        pinned_at: new Date().toISOString(),
+      }
+
+      const { error: insertError } = await supabase
+        .from("user_favorites")
+        .insert(insertPayload)
+
+      if (insertError) {
+        throw insertError
+      }
+    }
+
+    return await buildFavoritesResponse(supabase, userId)
+  } catch (error) {
+    console.error("Failed to toggle favorite", error)
+    return NextResponse.json({ error: "Unable to update favorite" }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: Request) {
+  const { supabase, userId } = await getAuthenticatedUserId()
+
+  if (!userId) {
+    return NextResponse.json({ favorites: [] }, { status: 401 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const { orderedIds } = (payload || {}) as { orderedIds?: unknown }
+
+  if (!Array.isArray(orderedIds)) {
+    return NextResponse.json(
+      { error: "orderedIds must be an array" },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const favorites = await fetchUserFavorites(supabase, userId)
+    const orderLookup = new Set(orderedIds)
+    const now = new Date().toISOString()
+
+    let position = 0
+    const applyUpdate = async (id: string) => {
+      position += 1
+      const { error } = await supabase
+        .from("user_favorites")
+        .update({ sort_order: position, updated_at: now })
+        .eq("id", id)
+        .eq("user_id", userId)
+
+      if (error) {
+        throw error
+      }
+    }
+
+    for (const id of orderedIds) {
+      if (typeof id !== "string") {
+        continue
+      }
+
+      if (!favorites.some((favorite) => favorite.id === id)) {
+        continue
+      }
+
+      await applyUpdate(id)
+    }
+
+    for (const favorite of favorites) {
+      if (orderLookup.has(favorite.id)) {
+        continue
+      }
+
+      await applyUpdate(favorite.id)
+    }
+
+    return await buildFavoritesResponse(supabase, userId)
+  } catch (error) {
+    console.error("Failed to reorder favorites", error)
+    return NextResponse.json({ error: "Unable to reorder favorites" }, { status: 500 })
+  }
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,83 +1,161 @@
-"use client";
-import React, { useEffect, useState } from "react";
-import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
-import SmartLink from "@/components/navigation/SmartLink";
-import { cn } from "@/lib/utils";
-import { usePathname } from "next/navigation";
-import { createClient } from "@/utils/supabase-browser";
-import { fetchMemberRole } from "@/lib/data/members";
-import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+"use client"
+
+import * as React from "react"
+import { CrumpledPaperIcon, PersonIcon } from "@radix-ui/react-icons"
+import { usePathname } from "next/navigation"
+
+import SmartLink from "@/components/navigation/SmartLink"
+import { useFavorites } from "@/components/navigation/FavoritesPanel"
+import { fetchMemberRole } from "@/lib/data/members"
+import { cn } from "@/lib/utils"
+import { createClient } from "@/utils/supabase-browser"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+type NavLinkEntry = {
+  href: string
+  text: string
+  Icon: typeof PersonIcon
+}
 
 export default function NavLinks() {
-	const pathname = usePathname();
-	const [role, setRole] = useState<string | null>(null);
+  const pathname = usePathname()
+  const { favorites } = useFavorites()
+  const [role, setRole] = React.useState<string | null>(null)
 
-	useEffect(() => {
-		const load = async () => {
-			try {
-				const supabase = createClient();
-                                const { data: { user } } = await supabase.auth.getUser();
-                                if (!user) {
-                                        setRole(null);
-                                        return;
-                                }
-                                const typedSupabase = supabase as unknown as TypedSupabaseClient;
-                                try {
-                                        const resolvedRole = await fetchMemberRole(typedSupabase, user.id);
-                                        setRole(resolvedRole || null);
-                                } catch (memberError) {
-                                        console.error("Error loading member role", memberError);
-                                        setRole(null);
-                                }
-                        } catch (e) {
-                                setRole(null);
-                        }
-		};
-		load();
-	}, []);
+  React.useEffect(() => {
+    const loadRole = async () => {
+      try {
+        const supabase = createClient() as unknown as TypedSupabaseClient
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
 
-	const isLandlord = role === 'property_manager' || role === 'admin' || role === 'landlord';
+        if (!user) {
+          setRole(null)
+          return
+        }
 
-	const links = isLandlord
-		? [
-			{ href: "/dashboard/members", text: "Members", Icon: PersonIcon },
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-		]
-		: [
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-			{ href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
-			{ href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
-		];
+        try {
+          const resolvedRole = await fetchMemberRole(supabase, user.id)
+          setRole(resolvedRole || null)
+        } catch (memberError) {
+          console.error("Error loading member role", memberError)
+          setRole(null)
+        }
+      } catch (error) {
+        console.error("Unable to load Supabase user", error)
+        setRole(null)
+      }
+    }
 
-	return (
-		<div className="space-y-5">
-			{links.map((link, index) => {
-				const Icon = link.Icon;
-				return (
-                                        <SmartLink
-                                                onClick={() =>
-                                                        document.getElementById("sidebar-close")?.click()
-                                                }
-                                                href={link.href}
-                                                key={index}
-                                                className={cn(
-                                                        "flex items-center gap-2 rounded-sm p-2",
-                                                        {
-                                                                " bg-gray-500 dark:bg-gray-700 text-white ":
-                                                                        pathname === link.href,
-                                                        }
-                                                )}
-                                                intent="navigation"
-                                        >
-                                                <Icon />
-                                                {link.text}
-                                        </SmartLink>
-				);
-			})}
-		</div>
-	);
+    void loadRole()
+  }, [])
+
+  const isLandlord =
+    role === "property_manager" || role === "admin" || role === "landlord"
+
+  const baseLinks: NavLinkEntry[] = React.useMemo(
+    () =>
+      isLandlord
+        ? [
+            { href: "/dashboard/members", text: "Members", Icon: PersonIcon },
+            { href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
+            { href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
+            { href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
+          ]
+        : [
+            { href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
+            { href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
+            { href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
+            { href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
+            { href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
+          ],
+    [isLandlord],
+  )
+
+  const navigationFavorites = React.useMemo(
+    () =>
+      favorites.filter(
+        (favorite) =>
+          favorite.entityType === "navigation" &&
+          Boolean(favorite.metadata?.href ?? favorite.entityId),
+      ),
+    [favorites],
+  )
+
+  const pinnedHrefs = React.useMemo(() => {
+    const hrefs = navigationFavorites
+      .map((favorite) => favorite.metadata?.href ?? favorite.entityId)
+      .filter((href): href is string => Boolean(href))
+    return new Set(hrefs)
+  }, [navigationFavorites])
+
+  const linksToRender = React.useMemo(
+    () => baseLinks.filter((link) => !pinnedHrefs.has(link.href)),
+    [baseLinks, pinnedHrefs],
+  )
+
+  return (
+    <div className="space-y-6">
+      {navigationFavorites.length > 0 && (
+        <section className="space-y-2">
+          <p className="px-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Favorites
+          </p>
+          <div className="space-y-2">
+            {navigationFavorites.map((favorite) => {
+              const href = favorite.metadata?.href ?? favorite.entityId
+
+              return (
+                <SmartLink
+                  key={`favorite-${favorite.id}`}
+                  href={href}
+                  onClick={() => document.getElementById("sidebar-close")?.click()}
+                  className={cn(
+                    "flex items-center gap-2 rounded-sm p-2",
+                    pathname === href
+                      ? "bg-gray-500 text-white dark:bg-gray-700"
+                      : undefined,
+                  )}
+                  intent="navigation"
+                  favorite={{
+                    entityType: favorite.entityType,
+                    entityId: favorite.entityId,
+                    metadata: favorite.metadata,
+                  }}
+                >
+                  {favorite.metadata?.label ?? favorite.entityId}
+                </SmartLink>
+              )
+            })}
+          </div>
+        </section>
+      )}
+
+      <div className="space-y-3">
+        {linksToRender.map((link) => (
+          <SmartLink
+            key={link.href}
+            onClick={() => document.getElementById("sidebar-close")?.click()}
+            href={link.href}
+            className={cn(
+              "flex items-center gap-2 rounded-sm p-2",
+              pathname === link.href
+                ? " bg-gray-500 text-white dark:bg-gray-700"
+                : undefined,
+            )}
+            intent="navigation"
+            favorite={{
+              entityType: "navigation",
+              entityId: link.href,
+              metadata: { label: link.text, href: link.href },
+            }}
+          >
+            <link.Icon />
+            {link.text}
+          </SmartLink>
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import "./globals.css"
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
 import { CookieButton } from "@/components/cookie-button"
+import { FavoritesPanel, FavoritesProvider } from "@/components/navigation/FavoritesPanel"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
@@ -119,18 +120,20 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <ReactQueryClientProvider>
     <html lang="en" suppressHydrationWarning>
     <head></head>
-      <body className={cn(
-            "min-h-screen bg-background font-sans antialiased",
-            fontSans.variable
-          )}
+      <body
+        className={cn(
+          "min-h-screen bg-background font-sans antialiased",
+          fontSans.variable,
+        )}
+      >
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
         >
-<ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-             <div className="relative flex min-h-screen flex-col">
+          <FavoritesProvider>
+            <div className="relative flex min-h-screen flex-col">
               <SiteHeader />
               <div className="flex-1">
                 <ErrorBoundary>
@@ -142,25 +145,22 @@ export default function RootLayout({ children }: RootLayoutProps) {
                 <Analytics />
                 <SpeedInsights />
               </div>
+            </div>
+            <SiteFooter />
+            <FavoritesPanel />
+          </FavoritesProvider>
 
-   </div>
-<SiteFooter/>
+          {/*
+          enter your api info from termly.io or a provider of your choice
+          <Script
+            type="text/javascript"
+            src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
 
-
-{/*
-enter your api info from termly.io or a provider of your choice
-<Script
-  type="text/javascript"
-  src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
-
- */}
-   <CookieButton />
-   <TailwindIndicator />
-          </ThemeProvider>
-
-
-
-</body>
+           */}
+          <CookieButton />
+          <TailwindIndicator />
+        </ThemeProvider>
+      </body>
     </html>
     </ReactQueryClientProvider>
   )

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation"
 import { docsConfig } from "@/config/docs"
 import { siteConfig } from "@/config/site"
 import { cn } from "@/lib/utils"
+import { useFavorites } from "@/components/navigation/FavoritesPanel"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
@@ -19,6 +20,17 @@ interface MobileNavProps {
 
 export function MobileNav({ isAuthenticated }: MobileNavProps) {
   const [open, setOpen] = React.useState(false)
+  const { favorites } = useFavorites()
+
+  const navigationFavorites = React.useMemo(
+    () =>
+      favorites.filter(
+        (favorite) =>
+          favorite.entityType === "navigation" &&
+          Boolean(favorite.metadata?.href ?? favorite.entityId),
+      ),
+    [favorites],
+  )
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -90,6 +102,32 @@ export function MobileNav({ isAuthenticated }: MobileNavProps) {
           )}
         </div>
         <ScrollArea className="my-4 h-[calc(100vh-8rem)] pb-10 pl-6">
+          {navigationFavorites.length > 0 && (
+            <div className="mb-6 flex flex-col space-y-2">
+              <h4 className="px-0 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Favorites
+              </h4>
+              <div className="flex flex-col space-y-2">
+                {navigationFavorites.map((favorite) => {
+                  const href = favorite.metadata?.href ?? favorite.entityId
+                  return (
+                    <MobileLink
+                      key={`favorite-${favorite.id}`}
+                      href={href}
+                      onOpenChange={setOpen}
+                      favorite={{
+                        entityType: favorite.entityType,
+                        entityId: favorite.entityId,
+                        metadata: favorite.metadata,
+                      }}
+                    >
+                      {favorite.metadata?.label ?? favorite.entityId}
+                    </MobileLink>
+                  )
+                })}
+              </div>
+            </div>
+          )}
           <div className="flex flex-col space-y-3">
             {docsConfig.mainNav?.map(
               (item) =>

--- a/components/navigation/FavoritesPanel.tsx
+++ b/components/navigation/FavoritesPanel.tsx
@@ -1,0 +1,414 @@
+"use client"
+
+import * as React from "react"
+import Link from "next/link"
+import { ArrowDown, ArrowUp, Loader2, Pin, PinOff } from "lucide-react"
+
+import type { FavoriteMetadata, FavoriteResponse } from "@/app/api/favorites/route"
+import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { cn } from "@/lib/utils"
+
+export type FavoriteToggleInput = {
+  entityType: string
+  entityId: string
+  metadata?: FavoriteMetadata
+}
+
+type FavoritesContextValue = {
+  favorites: FavoriteResponse[]
+  isReady: boolean
+  isReadOnly: boolean
+  panelOpen: boolean
+  openPanel: () => void
+  closePanel: () => void
+  toggleFavorite: (input: FavoriteToggleInput) => Promise<void>
+  reorderFavorites: (orderedIds: string[]) => Promise<void>
+  isFavorited: (entityType: string, entityId: string) => boolean
+  isProcessing: (entityType: string, entityId: string) => boolean
+}
+
+const FavoritesContext = React.createContext<FavoritesContextValue | undefined>(
+  undefined,
+)
+
+type FavoritesPayload = {
+  favorites: FavoriteResponse[]
+}
+
+const FAVORITES_API = "/api/favorites"
+
+const mapFavorite = (favorite: FavoriteResponse): FavoriteResponse => ({
+  ...favorite,
+  metadata: favorite.metadata,
+})
+
+const makeKey = (entityType: string, entityId: string) => `${entityType}::${entityId}`
+
+export function FavoritesProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [favorites, setFavorites] = React.useState<FavoriteResponse[]>([])
+  const [panelOpen, setPanelOpen] = React.useState(false)
+  const [isReady, setIsReady] = React.useState(false)
+  const [isReadOnly, setIsReadOnly] = React.useState(false)
+  const [pendingKeys, setPendingKeys] = React.useState<Set<string>>(new Set())
+
+  const fetchFavorites = React.useCallback(async () => {
+    try {
+      const response = await fetch(FAVORITES_API)
+
+      if (response.status === 401) {
+        setFavorites([])
+        setIsReadOnly(true)
+        setIsReady(true)
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch favorites: ${response.status}`)
+      }
+
+      const payload = (await response.json()) as FavoritesPayload
+      setFavorites(payload.favorites.map(mapFavorite))
+      setIsReadOnly(false)
+    } catch (error) {
+      console.error("Unable to hydrate favorites", error)
+    } finally {
+      setIsReady(true)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    void fetchFavorites()
+  }, [fetchFavorites])
+
+  const updatePending = React.useCallback((key: string, next: boolean) => {
+    setPendingKeys((prev) => {
+      const nextKeys = new Set(prev)
+      if (next) {
+        nextKeys.add(key)
+      } else {
+        nextKeys.delete(key)
+      }
+      return nextKeys
+    })
+  }, [])
+
+  const toggleFavorite = React.useCallback(
+    async ({ entityType, entityId, metadata }: FavoriteToggleInput) => {
+      if (isReadOnly) {
+        return
+      }
+
+      const key = makeKey(entityType, entityId)
+      updatePending(key, true)
+
+      try {
+        const response = await fetch(FAVORITES_API, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ entityType, entityId, metadata }),
+        })
+
+        if (response.status === 401) {
+          setIsReadOnly(true)
+          return
+        }
+
+        if (!response.ok) {
+          throw new Error(`Failed to toggle favorite: ${response.status}`)
+        }
+
+        const payload = (await response.json()) as FavoritesPayload
+        setFavorites(payload.favorites.map(mapFavorite))
+      } catch (error) {
+        console.error("Unable to toggle favorite", error)
+        await fetchFavorites()
+      } finally {
+        updatePending(key, false)
+      }
+    },
+    [fetchFavorites, isReadOnly, updatePending],
+  )
+
+  const reorderFavorites = React.useCallback(
+    async (orderedIds: string[]) => {
+      if (isReadOnly) {
+        return
+      }
+
+      if (!orderedIds.length) {
+        return
+      }
+
+      try {
+        const response = await fetch(FAVORITES_API, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ orderedIds }),
+        })
+
+        if (response.status === 401) {
+          setIsReadOnly(true)
+          return
+        }
+
+        if (!response.ok) {
+          throw new Error(`Failed to reorder favorites: ${response.status}`)
+        }
+
+        const payload = (await response.json()) as FavoritesPayload
+        setFavorites(payload.favorites.map(mapFavorite))
+      } catch (error) {
+        console.error("Unable to reorder favorites", error)
+        await fetchFavorites()
+      }
+    },
+    [fetchFavorites, isReadOnly],
+  )
+
+  const openPanel = React.useCallback(() => setPanelOpen(true), [])
+  const closePanel = React.useCallback(() => setPanelOpen(false), [])
+
+  const isFavorited = React.useCallback(
+    (entityType: string, entityId: string) =>
+      favorites.some(
+        (favorite) =>
+          favorite.entityType === entityType && favorite.entityId === entityId,
+      ),
+    [favorites],
+  )
+
+  const isProcessing = React.useCallback(
+    (entityType: string, entityId: string) =>
+      pendingKeys.has(makeKey(entityType, entityId)),
+    [pendingKeys],
+  )
+
+  const value = React.useMemo<FavoritesContextValue>(
+    () => ({
+      favorites,
+      isReady,
+      isReadOnly,
+      panelOpen,
+      openPanel,
+      closePanel,
+      toggleFavorite,
+      reorderFavorites,
+      isFavorited,
+      isProcessing,
+    }),
+    [
+      favorites,
+      isReady,
+      isReadOnly,
+      panelOpen,
+      openPanel,
+      closePanel,
+      toggleFavorite,
+      reorderFavorites,
+      isFavorited,
+      isProcessing,
+    ],
+  )
+
+  return (
+    <FavoritesContext.Provider value={value}>{children}</FavoritesContext.Provider>
+  )
+}
+
+export function useFavorites() {
+  const context = React.useContext(FavoritesContext)
+  if (!context) {
+    throw new Error("useFavorites must be used within a FavoritesProvider")
+  }
+  return context
+}
+
+export function FavoritesPanel() {
+  const {
+    favorites,
+    panelOpen,
+    closePanel,
+    openPanel,
+    reorderFavorites,
+    toggleFavorite,
+    isProcessing,
+    isReadOnly,
+    isReady,
+  } = useFavorites()
+
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (open) {
+        openPanel()
+      } else {
+        closePanel()
+      }
+    },
+    [closePanel, openPanel],
+  )
+
+  const handleMove = React.useCallback(
+    (id: string, direction: "up" | "down") => {
+      const ids = favorites.map((favorite) => favorite.id)
+      const currentIndex = ids.indexOf(id)
+      if (currentIndex === -1) {
+        return
+      }
+
+      const targetIndex =
+        direction === "up" ? currentIndex - 1 : currentIndex + 1
+
+      if (targetIndex < 0 || targetIndex >= ids.length) {
+        return
+      }
+
+      const nextOrder = [...ids]
+      const [removed] = nextOrder.splice(currentIndex, 1)
+      nextOrder.splice(targetIndex, 0, removed)
+
+      void reorderFavorites(nextOrder)
+    },
+    [favorites, reorderFavorites],
+  )
+
+  const renderFavoriteLabel = React.useCallback(
+    (favorite: FavoriteResponse) => {
+      const label = favorite.metadata?.label ?? favorite.entityId
+      const href = favorite.metadata?.href
+
+      if (href) {
+        return (
+          <Link
+            href={href}
+            className="truncate text-sm font-medium text-primary underline-offset-2 hover:underline"
+            onClick={closePanel}
+          >
+            {label}
+          </Link>
+        )
+      }
+
+      return <p className="truncate text-sm font-medium">{label}</p>
+    },
+    [closePanel],
+  )
+
+  return (
+    <Sheet open={panelOpen} onOpenChange={handleOpenChange}>
+      <SheetTrigger asChild>
+        <Button
+          variant="secondary"
+          size="icon"
+          className={cn(
+            "fixed bottom-4 right-4 z-50 h-12 w-12 rounded-full shadow-lg",
+            "border border-border bg-background/90 backdrop-blur",
+          )}
+          aria-label="Toggle favorites drawer"
+        >
+          <Pin className="size-5" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="flex w-full max-w-sm flex-col gap-6">
+        <SheetHeader>
+          <SheetTitle>Favorites</SheetTitle>
+          <SheetDescription>
+            Pin navigation items and documents to jump back to them quickly.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto">
+          {!isReady ? (
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={`favorite-skeleton-${index}`}
+                  className="h-12 animate-pulse rounded-md bg-muted"
+                />
+              ))}
+            </div>
+          ) : favorites.length === 0 ? (
+            <div className="rounded-md border border-dashed border-muted-foreground/40 p-4 text-sm text-muted-foreground">
+              {isReadOnly
+                ? "Sign in to start pinning your go-to destinations."
+                : "Use the pin icon on navigation links to save them here."}
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {favorites.map((favorite, index) => {
+                const pending = isProcessing(
+                  favorite.entityType,
+                  favorite.entityId,
+                )
+
+                return (
+                  <li
+                    key={favorite.id}
+                    className="flex items-center justify-between gap-3 rounded-md border bg-card px-3 py-2"
+                  >
+                    <div className="min-w-0 flex-1">
+                      {renderFavoriteLabel(favorite)}
+                      <p className="truncate text-xs text-muted-foreground">
+                        {favorite.metadata?.href ?? favorite.entityType}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        aria-label="Move favorite up"
+                        onClick={() => handleMove(favorite.id, "up")}
+                        disabled={index === 0 || pending}
+                      >
+                        <ArrowUp className="size-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        aria-label="Move favorite down"
+                        onClick={() => handleMove(favorite.id, "down")}
+                        disabled={index === favorites.length - 1 || pending}
+                      >
+                        <ArrowDown className="size-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        aria-label="Remove from favorites"
+                        onClick={() =>
+                          toggleFavorite({
+                            entityType: favorite.entityType,
+                            entityId: favorite.entityId,
+                            metadata: favorite.metadata,
+                          })
+                        }
+                        disabled={pending}
+                      >
+                        {pending ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <PinOff className="size-4" />
+                        )}
+                      </Button>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/navigation/SmartLink.tsx
+++ b/components/navigation/SmartLink.tsx
@@ -3,6 +3,11 @@
 import * as React from "react"
 import NextLink from "next/link"
 import { useRouter } from "next/navigation"
+import { Loader2, Pin, PinOff } from "lucide-react"
+
+import type { FavoriteMetadata } from "@/app/api/favorites/route"
+
+import { useFavorites } from "./FavoritesPanel"
 
 export type SmartLinkIntent = "standard" | "critical" | "passive" | "navigation"
 
@@ -20,6 +25,16 @@ export interface SmartLinkProps
    * Custom root margin applied to the IntersectionObserver used for viewport based prefetching.
    */
   viewportMargin?: string
+  /**
+   * Optional configuration to show a favorite pin toggle inline with the link.
+   */
+  favorite?: FavoriteToggleConfig
+}
+
+export interface FavoriteToggleConfig {
+  entityType: string
+  entityId: string
+  metadata?: FavoriteMetadata
 }
 
 type PrefetchHint = "never" | "hover" | "viewport" | "immediate"
@@ -35,6 +50,8 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       onPointerEnter,
       onFocus,
       href,
+      favorite,
+      children,
       ...rest
     } = props
 
@@ -203,6 +220,15 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       }
     }, [isInternalHref, isVisible, prefetchHint])
 
+    const content = favorite ? (
+      <span className="inline-flex w-full items-center gap-2">
+        <span className="min-w-0 flex-1 truncate">{children}</span>
+        <FavoriteToggleButton config={favorite} />
+      </span>
+    ) : (
+      children ?? null
+    )
+
     return (
       <NextLink
         ref={combinedRef}
@@ -211,7 +237,9 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
         onPointerEnter={handlePointerEnter}
         onFocus={handleFocus}
         {...rest}
-      />
+      >
+        {content}
+      </NextLink>
     )
   }
 )
@@ -219,3 +247,46 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
 SmartLink.displayName = "SmartLink"
 
 export default SmartLink
+
+const FavoriteToggleButton = ({
+  config,
+}: {
+  config: FavoriteToggleConfig
+}) => {
+  const { toggleFavorite, isFavorited, isProcessing, isReadOnly } = useFavorites()
+  const isPinned = isFavorited(config.entityType, config.entityId)
+  const pending = isProcessing(config.entityType, config.entityId)
+
+  const handleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      if (pending || isReadOnly) {
+        return
+      }
+
+      void toggleFavorite(config)
+    },
+    [config, isReadOnly, pending, toggleFavorite],
+  )
+
+  const ariaLabel = isPinned ? "Unpin from favorites" : "Pin to favorites"
+
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
+      onClick={handleClick}
+      disabled={pending || isReadOnly}
+    >
+      {pending ? (
+        <Loader2 className="size-4 animate-spin" />
+      ) : isPinned ? (
+        <PinOff className="size-4" />
+      ) : (
+        <Pin className="size-4" />
+      )}
+    </button>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -243,6 +243,17 @@ export type Database = {
         created_at: string | null
         updated_at: string | null
       }>
+      user_favorites: SupabaseTable<{
+        id: string
+        user_id: string
+        entity_type: string
+        entity_id: string
+        metadata: Json | null
+        sort_order: number
+        pinned_at: string | null
+        created_at: string | null
+        updated_at: string | null
+      }>
       chores: SupabaseTable<{
         id: string
         household_id: string

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.3.1",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
@@ -85,6 +87,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,12 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@testing-library/jest-dom':
+        specifier: ^6.4.2
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -225,6 +231,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,13 +245,16 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -255,6 +267,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@4.0.4':
+    resolution: {integrity: sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==}
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    resolution: {integrity: sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +392,40 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1628,11 +1683,29 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@testing-library/dom@9.3.4':
+    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+    engines: {node: '>=14'}
+
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@14.3.1':
+    resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2012,6 +2085,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2032,6 +2109,9 @@ packages:
   aria-hidden@1.2.3:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
+
+  aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2206,6 +2286,10 @@ packages:
   call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
 
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -2350,16 +2434,31 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2390,6 +2489,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
@@ -2400,6 +2502,10 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-equal@2.2.3:
+    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
+    engines: {node: '>= 0.4'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2414,6 +2520,10 @@ packages:
 
   define-data-property@1.1.1:
     resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
+    engines: {node: '>= 0.4'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
   define-properties@1.2.1:
@@ -2454,6 +2564,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2507,6 +2623,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   es-abstract@1.22.3:
     resolution: {integrity: sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==}
     engines: {node: '>= 0.4'}
@@ -2518,6 +2638,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
@@ -2950,6 +3073,9 @@ packages:
   has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
     engines: {node: '>= 0.4'}
@@ -2964,6 +3090,10 @@ packages:
 
   has-tostringtag@1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.0:
@@ -2983,6 +3113,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3124,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3008,6 +3150,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3029,6 +3175,10 @@ packages:
     resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
     engines: {node: '>= 0.4'}
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -3037,6 +3187,10 @@ packages:
 
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
@@ -3117,6 +3271,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
@@ -3201,6 +3358,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3483,10 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3324,6 +3494,10 @@ packages:
     resolution: {integrity: sha512-JZX+1fjpqxvQmEgItvPOAwRlqf0Eg9dSZMxljA2/V2M6dluOhQCPBhewIlSJWgkNu0M36kViOgmTAMnDaAMOFw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -3374,6 +3548,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
@@ -3493,6 +3670,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3623,6 +3804,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -3671,6 +3856,9 @@ packages:
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -3712,9 +3900,6 @@ packages:
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3806,6 +3991,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3868,6 +4057,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
@@ -3945,6 +4137,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
     engines: {node: '>= 0.4'}
@@ -4001,6 +4197,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4212,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4048,6 +4254,10 @@ packages:
 
   set-function-length@1.1.1:
     resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
+    engines: {node: '>= 0.4'}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
 
   set-function-name@2.0.1:
@@ -4152,6 +4362,10 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -4197,6 +4411,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -4261,6 +4479,9 @@ packages:
   svelte@4.2.18:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
@@ -4361,6 +4582,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4369,8 +4597,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4622,6 +4858,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4634,6 +4874,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4892,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4955,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4732,6 +5007,8 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.2.1':
@@ -4744,6 +5021,23 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@4.0.4':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.1
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5193,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.4.32)':
+    dependencies:
+      postcss: 8.4.32
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -6195,11 +6513,41 @@ snapshots:
       '@tanstack/query-core': 5.51.9
       react: 18.2.0
 
+  '@testing-library/dom@9.3.4':
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/runtime': 7.23.9
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@14.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@testing-library/dom': 9.3.4
+      '@types/react-dom': 18.3.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.5
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -6644,6 +6992,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -6660,6 +7010,10 @@ snapshots:
   aria-hidden@1.2.3:
     dependencies:
       tslib: 2.6.2
+
+  aria-query@5.1.3:
+    dependencies:
+      deep-equal: 2.2.3
 
   aria-query@5.3.2: {}
 
@@ -6869,6 +7223,13 @@ snapshots:
       get-intrinsic: 1.2.2
       set-function-length: 1.1.1
 
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7012,11 +7373,31 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.1(postcss@8.4.32):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.4
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.4.32)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   date-fns@3.3.1: {}
 
@@ -7032,6 +7413,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   decode-named-character-reference@1.0.2:
     dependencies:
       character-entities: 2.0.2
@@ -7041,6 +7424,27 @@ snapshots:
       mimic-response: 3.1.0
 
   deep-eql@5.0.2: {}
+
+  deep-equal@2.2.3:
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      call-bind: 1.0.5
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.3.0
+      is-arguments: 1.2.0
+      is-array-buffer: 3.0.2
+      is-date-object: 1.0.5
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      isarray: 2.0.5
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      object.assign: 4.1.5
+      regexp.prototype.flags: 1.5.1
+      side-channel: 1.1.0
+      which-boxed-primitive: 1.0.2
+      which-collection: 1.0.1
+      which-typed-array: 1.1.13
 
   deep-extend@0.6.0: {}
 
@@ -7053,6 +7457,12 @@ snapshots:
       get-intrinsic: 1.2.2
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   define-properties@1.2.1:
     dependencies:
@@ -7089,6 +7499,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -7143,6 +7557,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   es-abstract@1.22.3:
     dependencies:
       array-buffer-byte-length: 1.0.0
@@ -7188,6 +7604,18 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.5
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.2
+      is-set: 2.0.2
+      is-string: 1.0.7
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
 
   es-iterator-helpers@1.0.15:
     dependencies:
@@ -7788,6 +8216,10 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.2
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
   has-proto@1.0.1: {}
 
   has-symbols@1.0.3: {}
@@ -7797,6 +8229,10 @@ snapshots:
   has-tostringtag@1.0.0:
     dependencies:
       has-symbols: 1.0.3
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.0:
     dependencies:
@@ -7851,6 +8287,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8306,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7883,6 +8334,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -7903,6 +8356,12 @@ snapshots:
       hasown: 2.0.0
       side-channel: 1.0.4
 
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -7913,6 +8372,11 @@ snapshots:
     dependencies:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.2:
     dependencies:
@@ -7982,6 +8446,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-reference@3.0.2:
     dependencies:
@@ -8072,6 +8538,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.5
+      cssstyle: 5.3.1(postcss@8.4.32)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8167,6 +8661,8 @@ snapshots:
 
   lru-cache@10.1.0: {}
 
+  lru-cache@11.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -8174,6 +8670,8 @@ snapshots:
   lucide-react@0.302.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.176.0)(three@0.160.0):
     dependencies:
@@ -8294,6 +8792,8 @@ snapshots:
 
   mdn-data@2.0.30:
     optional: true
+
+  mdn-data@2.12.2: {}
 
   merge-anything@5.1.7:
     dependencies:
@@ -8496,7 +8996,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8527,6 +9027,8 @@ snapshots:
       mime-db: 1.52.0
 
   mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -8631,6 +9133,11 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+
   object-keys@1.1.1: {}
 
   object.assign@4.1.5:
@@ -8706,6 +9213,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -8739,8 +9250,6 @@ snapshots:
       is-reference: 3.0.2
 
   picocolors@1.0.0: {}
-
-  picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -8786,7 +9295,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -8823,6 +9332,12 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.6.2: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prop-types@15.8.1:
     dependencies:
@@ -8885,6 +9400,8 @@ snapshots:
       react: 18.2.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-merge-refs@1.1.0: {}
 
@@ -8960,6 +9477,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.4:
     dependencies:
@@ -9061,6 +9583,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9079,6 +9603,12 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9121,6 +9651,15 @@ snapshots:
       get-intrinsic: 1.2.2
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   set-function-name@2.0.1:
     dependencies:
@@ -9230,6 +9769,11 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
   streamsearch@1.1.0: {}
 
   streamx@2.18.0:
@@ -9300,6 +9844,10 @@ snapshots:
       ansi-regex: 6.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 
@@ -9374,6 +9922,8 @@ snapshots:
       magic-string: 0.30.19
       periscopic: 3.1.0
     optional: true
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.2.0:
     dependencies:
@@ -9502,13 +10052,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9644,13 +10208,13 @@ snapshots:
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.0(browserslist@4.23.2):
     dependencies:
       browserslist: 4.23.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
@@ -9736,7 +10300,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10328,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,6 +10354,10 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -9799,6 +10368,8 @@ snapshots:
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9832,6 +10403,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9903,6 +10485,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/supabase/migrations/20250309_user_favorites.sql
+++ b/supabase/migrations/20250309_user_favorites.sql
@@ -1,0 +1,36 @@
+-- Create user_favorites table for storing pinned entities per user
+CREATE TABLE public.user_favorites (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  pinned_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Prevent duplicate favorites per user and entity
+CREATE UNIQUE INDEX user_favorites_user_entity_unique
+  ON public.user_favorites (user_id, entity_type, entity_id);
+
+-- Index for retrieving a user's favorites ordered by sort metadata
+CREATE INDEX user_favorites_user_order_idx
+  ON public.user_favorites (user_id, sort_order, pinned_at DESC);
+
+-- Enable row level security
+ALTER TABLE public.user_favorites ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies to ensure users may only manage their own favorites
+CREATE POLICY "Users can view their favorites" ON public.user_favorites
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their favorites" ON public.user_favorites
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their favorites" ON public.user_favorites
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their favorites" ON public.user_favorites
+  FOR DELETE USING (auth.uid() = user_id);

--- a/tests/favorites-toggle.test.tsx
+++ b/tests/favorites-toggle.test.tsx
@@ -1,0 +1,199 @@
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+
+import SmartLink from "@/components/navigation/SmartLink"
+import { FavoritesProvider, useFavorites } from "@/components/navigation/FavoritesPanel"
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    prefetch: vi.fn(),
+  }),
+}))
+
+type FavoriteResponse = {
+  id: string
+  entityType: string
+  entityId: string
+  sortOrder: number
+  pinnedAt: string | null
+  metadata?: { label?: string; href?: string }
+}
+
+type FavoritesPayload = {
+  favorites: FavoriteResponse[]
+}
+
+const originalFetch = globalThis.fetch
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function ToggleHarness() {
+  const { favorites } = useFavorites()
+
+  return (
+    <div>
+      <SmartLink
+        href="/payments"
+        favorite={{
+          entityType: "navigation",
+          entityId: "/payments",
+          metadata: { label: "Payments", href: "/payments" },
+        }}
+      >
+        Payments
+      </SmartLink>
+      <ul data-testid="favorites-list">
+        {favorites.map((favorite) => (
+          <li key={favorite.id}>{favorite.metadata?.label ?? favorite.entityId}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function ReorderHarness() {
+  const { favorites, reorderFavorites } = useFavorites()
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          reorderFavorites(
+            favorites
+              .map((favorite) => favorite.id)
+              .slice()
+              .reverse(),
+          )
+        }
+      >
+        Reverse order
+      </button>
+      <ol data-testid="favorites-order">
+        {favorites.map((favorite) => (
+          <li key={favorite.id}>{favorite.metadata?.label ?? favorite.entityId}</li>
+        ))}
+      </ol>
+    </div>
+  )
+}
+
+describe("favorites toggling", () => {
+  it("adds a navigation link to favorites when pinned", async () => {
+    const togglePayload: FavoritesPayload = {
+      favorites: [
+        {
+          id: "fav-1",
+          entityType: "navigation",
+          entityId: "/payments",
+          sortOrder: 1,
+          pinnedAt: "2024-01-01T00:00:00.000Z",
+          metadata: { label: "Payments", href: "/payments" },
+        },
+      ],
+    }
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ favorites: [] as FavoriteResponse[] }), {
+        status: 200,
+      }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(togglePayload), { status: 200 }),
+    )
+
+    render(
+      <FavoritesProvider>
+        <ToggleHarness />
+      </FavoritesProvider>,
+    )
+
+    const pinButton = await screen.findByRole("button", {
+      name: /pin to favorites/i,
+    })
+
+    fireEvent.click(pinButton)
+
+    const list = screen.getByTestId("favorites-list")
+    await waitFor(() => {
+      expect(within(list).getByText("Payments")).toBeInTheDocument()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("reorders favorites and persists the new order", async () => {
+    const initialFavorites: FavoritesPayload = {
+      favorites: [
+        {
+          id: "fav-a",
+          entityType: "navigation",
+          entityId: "/alpha",
+          sortOrder: 1,
+          pinnedAt: "2024-01-01T00:00:00.000Z",
+          metadata: { label: "Alpha", href: "/alpha" },
+        },
+        {
+          id: "fav-b",
+          entityType: "navigation",
+          entityId: "/beta",
+          sortOrder: 2,
+          pinnedAt: "2024-01-02T00:00:00.000Z",
+          metadata: { label: "Beta", href: "/beta" },
+        },
+      ],
+    }
+
+    const reorderedFavorites: FavoritesPayload = {
+      favorites: [
+        {
+          ...initialFavorites.favorites[1],
+          sortOrder: 1,
+        },
+        {
+          ...initialFavorites.favorites[0],
+          sortOrder: 2,
+        },
+      ],
+    }
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(initialFavorites), { status: 200 }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(reorderedFavorites), { status: 200 }),
+    )
+
+    render(
+      <FavoritesProvider>
+        <ReorderHarness />
+      </FavoritesProvider>,
+    )
+
+    const order = await screen.findByTestId("favorites-order")
+    const initialOrder = within(order)
+      .getAllByRole("listitem")
+      .map((item) => item.textContent)
+    expect(initialOrder).toEqual(["Alpha", "Beta"])
+
+    fireEvent.click(screen.getByRole("button", { name: /reverse order/i }))
+
+    await waitFor(() => {
+      const updatedOrder = within(order)
+        .getAllByRole("listitem")
+        .map((item) => item.textContent)
+      expect(updatedOrder).toEqual(["Beta", "Alpha"])
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,9 @@ import path from "path"
 
 export default defineConfig({
   test: {
-    environment: "node",
-    include: ["tests/**/*.test.ts"],
+    environment: "jsdom",
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+    setupFiles: ["./tests/setup.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a Supabase migration and typed metadata for storing per-user favorites
- create a favorites API route, provider, and drawer with pin and reorder UX wired through SmartLink
- surface pinned navigation entries across dashboard and mobile menus and cover toggling with RTL tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b643f88832884ed5827f992613d