### PR TITLE
feat: add shared empty state experience

### DIFF
--- a/app/dashboard/members/components/ListOfMembers.tsx
+++ b/app/dashboard/members/components/ListOfMembers.tsx
@@ -1,13 +1,38 @@
 import React from "react"
 
 import { Button } from "@/components/ui/button"
-import { TrashIcon } from "@radix-ui/react-icons"
+import { EmptyState } from "@/components/empty-states/EmptyState"
+import {
+        MEMBERS_EMPTY_STATE_ROUTE,
+        MEMBERS_EMPTY_STATE_SAMPLES,
+} from "@/components/empty-states/presets"
 import { cn } from "@/lib/utils"
+import { TrashIcon } from "@radix-ui/react-icons"
+import { Users } from "lucide-react"
 
 import { DashboardMember } from "../data"
 import EditMember from "./edit/EditMember"
 
 export default function ListOfMembers({ members }: { members: DashboardMember[] }) {
+        if (members.length === 0) {
+                return (
+                        <div className="px-5 pb-8">
+                                <EmptyState
+                                        surface="dashboard:members"
+                                        className="w-full"
+                                        title="Invite your first household member"
+                                        description="Track roles, onboarding progress, and payment permissions by adding roommates and managers."
+                                        illustration={<Users className="size-12 text-muted-foreground" />}
+                                        sampleItems={MEMBERS_EMPTY_STATE_SAMPLES}
+                                        primaryAction={{
+                                                href: MEMBERS_EMPTY_STATE_ROUTE,
+                                                label: "Create",
+                                        }}
+                                />
+                        </div>
+                )
+        }
+
         return (
                 <div className="mx-2 rounded-sm bg-white dark:bg-inherit">
                         {members.map((member, index) => {

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -4,6 +4,11 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/empty-states/EmptyState";
+import {
+  DOCUMENTS_EMPTY_STATE_ROUTE,
+  DOCUMENTS_EMPTY_STATE_SAMPLES,
+} from "@/components/empty-states/presets";
 import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
 import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
@@ -79,6 +84,8 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     }
   };
 
+  const hasFilters = Object.keys(filter).length > 0;
+
   if (loading) {
     return (
       <div className="space-y-4">
@@ -128,17 +135,24 @@ export function DocumentsList({ filter }: DocumentsListProps) {
 
   if (documents.length === 0) {
     return (
-      <Card className="p-12">
-        <div className="text-center">
-          <FileText className="mx-auto mb-4 size-12 text-muted-foreground" />
-          <h3 className="mb-2 text-lg font-medium">No documents found</h3>
-          <p className="text-sm text-muted-foreground">
-            {Object.keys(filter).length > 0
-              ? "No documents match your current filters."
-              : "Get started by uploading your first document."}
-          </p>
-        </div>
-      </Card>
+      <EmptyState
+        surface="documents:list"
+        title={hasFilters ? "No matching documents" : "Bring your first document online"}
+        description={
+          hasFilters
+            ? "Try adjusting your filters or create a new document packet for your roommates."
+            : "Import lease packets from Documenso or upload roommate paperwork to keep everyone aligned."
+        }
+        illustration={<FileText className="size-12 text-muted-foreground" />}
+        sampleItems={DOCUMENTS_EMPTY_STATE_SAMPLES}
+        primaryAction={{
+          href: DOCUMENTS_EMPTY_STATE_ROUTE,
+          label: "Create",
+          analyticsMetadata: {
+            filtersApplied: hasFilters,
+          },
+        }}
+      />
     );
   }
 

--- a/app/payments/_components/roommate-ledger.tsx
+++ b/app/payments/_components/roommate-ledger.tsx
@@ -2,6 +2,11 @@ import { Fragment } from "react"
 import { format, parseISO } from "date-fns"
 
 import { Badge, type BadgeProps } from "@/components/ui/badge"
+import { EmptyState } from "@/components/empty-states/EmptyState"
+import {
+  ROOMMATE_LEDGER_EMPTY_STATE_ROUTE,
+  ROOMMATE_LEDGER_EMPTY_STATE_SAMPLES,
+} from "@/components/empty-states/presets"
 import {
   Card,
   CardContent,
@@ -17,6 +22,7 @@ import type {
   LedgerEntryType,
   RoommateLedger,
 } from "@/types/payments"
+import { PiggyBank } from "lucide-react"
 
 interface RoommateLedgerProps {
   ledgers: RoommateLedger[]
@@ -39,7 +45,20 @@ const actorRoleLabels: Record<LedgerActorRole, string> = {
 
 export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
   if (ledgers.length === 0) {
-    return null
+    return (
+      <EmptyState
+        surface="payments:roommate-ledger"
+        className="w-full"
+        title="Start tracking roommate balances"
+        description="Log contributions and adjustments so every roommate sees the same running total."
+        illustration={<PiggyBank className="size-12 text-muted-foreground" />}
+        sampleItems={ROOMMATE_LEDGER_EMPTY_STATE_SAMPLES}
+        primaryAction={{
+          href: ROOMMATE_LEDGER_EMPTY_STATE_ROUTE,
+          label: "Create",
+        }}
+      />
+    )
   }
 
   const derivedLedgers = ledgers.map((ledger) => {

--- a/components/empty-states/EmptyState.tsx
+++ b/components/empty-states/EmptyState.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React from "react";
+import type { MouseEvent, ReactNode } from "react";
+import Link from "next/link";
+
+import { buttonVariants } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { cn, logEmptyStateConversion } from "@/lib/utils";
+
+export interface EmptyStateSampleItem {
+  title: string;
+  description?: string;
+  metadata?: string;
+}
+
+export interface EmptyStateProps {
+  surface: string;
+  title: string;
+  description: string;
+  illustration: ReactNode;
+  sampleItems?: EmptyStateSampleItem[];
+  primaryAction: {
+    href: string;
+    label?: string;
+    onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+    analyticsMetadata?: Record<string, unknown>;
+  };
+  className?: string;
+}
+
+export function EmptyState({
+  surface,
+  title,
+  description,
+  illustration,
+  sampleItems,
+  primaryAction,
+  className,
+}: EmptyStateProps) {
+  const { href, label = "Create", onClick, analyticsMetadata } = primaryAction;
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+
+    if (!event.defaultPrevented) {
+      logEmptyStateConversion(surface, href, {
+        sampleCount: sampleItems?.length ?? 0,
+        ...analyticsMetadata,
+      });
+    }
+  };
+
+  return (
+    <Card className={cn("flex flex-col items-center gap-8 p-10 text-center sm:p-12", className)}>
+      <div
+        aria-hidden="true"
+        className="flex h-20 w-20 items-center justify-center rounded-full bg-muted"
+      >
+        {illustration}
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold">{title}</h3>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      {sampleItems && sampleItems.length > 0 ? (
+        <div className="w-full max-w-md rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 p-5 text-left">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Example entries
+          </p>
+          <ul className="mt-4 space-y-4">
+            {sampleItems.map((item, index) => (
+              <li key={`${item.title}-${index}`} className="space-y-1">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-sm font-medium text-foreground">{item.title}</p>
+                  {item.metadata ? (
+                    <span className="text-xs font-medium uppercase text-muted-foreground">
+                      {item.metadata}
+                    </span>
+                  ) : null}
+                </div>
+                {item.description ? (
+                  <p className="text-xs text-muted-foreground">{item.description}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      <Link
+        href={href}
+        aria-label={`${label} ${title.toLowerCase()}`}
+        onClick={handleClick}
+        className={cn(buttonVariants({ variant: "default" }), "px-6")}
+      >
+        {label}
+      </Link>
+    </Card>
+  );
+}

--- a/components/empty-states/presets.ts
+++ b/components/empty-states/presets.ts
@@ -1,0 +1,61 @@
+import type { EmptyStateSampleItem } from "./EmptyState"
+
+export const DOCUMENTS_EMPTY_STATE_ROUTE = "/documents/upload";
+
+export const DOCUMENTS_EMPTY_STATE_SAMPLES: EmptyStateSampleItem[] = [
+  {
+    title: "Lease agreement — Unit 2A",
+    description: "Documenso template for the primary roommate lease this season.",
+    metadata: "Pending signatures",
+  },
+  {
+    title: "Pet policy addendum",
+    description: "Tracks approvals for roommates bringing new pets into the unit.",
+    metadata: "Awaiting review",
+  },
+  {
+    title: "Move-in checklist",
+    description: "Shared acknowledgment of keys, parking passes, and storage lockers.",
+    metadata: "Signed",
+  },
+];
+
+export const MEMBERS_EMPTY_STATE_ROUTE = "/dashboard/members/create";
+
+export const MEMBERS_EMPTY_STATE_SAMPLES: EmptyStateSampleItem[] = [
+  {
+    title: "Avery Johnson",
+    description: "Property manager overseeing billing, documents, and messaging.",
+    metadata: "Role · admin",
+  },
+  {
+    title: "Skylar Chen",
+    description: "Roommate contributing $950 monthly via autopay.",
+    metadata: "Status · active",
+  },
+  {
+    title: "Jordan Patel",
+    description: "Invited roommate awaiting onboarding tasks.",
+    metadata: "Status · invited",
+  },
+];
+
+export const ROOMMATE_LEDGER_EMPTY_STATE_ROUTE = "/payments/catch-up";
+
+export const ROOMMATE_LEDGER_EMPTY_STATE_SAMPLES: EmptyStateSampleItem[] = [
+  {
+    title: "Jamie Rivera",
+    description: "Autopay posted $950 for July rent and utilities.",
+    metadata: "Balance · $120 due",
+  },
+  {
+    title: "Morgan Lee",
+    description: "Property manager logged a $45 internet reimbursement.",
+    metadata: "Balance · $0",
+  },
+  {
+    title: "Priya Desai",
+    description: "Manual catch-up payment scheduled for the 15th.",
+    metadata: "Balance · $340 due",
+  },
+];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -240,3 +240,60 @@ export const getMessageFromCode = (resultCode: string) => {
       return 'Logged in!'
   }
 }
+
+export interface EmptyStateConversionEvent {
+  surface: string
+  href: string
+  timestamp: number
+  metadata?: Record<string, unknown>
+}
+
+const emptyStateConversionBuffer: EmptyStateConversionEvent[] = []
+
+const dispatchEmptyStateEvent = (event: EmptyStateConversionEvent) => {
+  if (typeof window === "undefined" || typeof window.dispatchEvent !== "function") {
+    return
+  }
+
+  const CustomEventCtor: typeof CustomEvent | undefined =
+    typeof window.CustomEvent === "function" ? window.CustomEvent : undefined
+
+  if (!CustomEventCtor) {
+    return
+  }
+
+  try {
+    window.dispatchEvent(new CustomEventCtor("roomsily:empty-state-conversion", { detail: event }))
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("empty-state conversion dispatch failed", error)
+    }
+  }
+}
+
+export const logEmptyStateConversion = (
+  surface: string,
+  href: string,
+  metadata?: Record<string, unknown>,
+): EmptyStateConversionEvent => {
+  const event: EmptyStateConversionEvent = {
+    surface,
+    href,
+    timestamp: Date.now(),
+    ...(metadata && Object.keys(metadata).length > 0 ? { metadata } : {}),
+  }
+
+  emptyStateConversionBuffer.push(event)
+
+  if (process.env.NODE_ENV !== "production") {
+    console.info("[analytics] empty-state conversion", event)
+  }
+
+  dispatchEmptyStateEvent(event)
+
+  return event
+}
+
+export const getEmptyStateConversions = (): EmptyStateConversionEvent[] => {
+  return [...emptyStateConversionBuffer]
+}

--- a/tests/components/empty-state.test.tsx
+++ b/tests/components/empty-state.test.tsx
@@ -1,0 +1,84 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("next/link", () => {
+  return {
+    __esModule: true,
+    default: React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>(
+      ({ children, ...props }, ref) => (
+        <a ref={ref} {...props}>
+          {children}
+        </a>
+      ),
+    ),
+  }
+})
+
+import { renderToStaticMarkup } from "react-dom/server"
+import { FileText, PiggyBank, Users } from "lucide-react"
+
+import { EmptyState } from "@/components/empty-states/EmptyState"
+import {
+  DOCUMENTS_EMPTY_STATE_ROUTE,
+  DOCUMENTS_EMPTY_STATE_SAMPLES,
+  MEMBERS_EMPTY_STATE_ROUTE,
+  MEMBERS_EMPTY_STATE_SAMPLES,
+  ROOMMATE_LEDGER_EMPTY_STATE_ROUTE,
+  ROOMMATE_LEDGER_EMPTY_STATE_SAMPLES,
+} from "@/components/empty-states/presets"
+
+describe("EmptyState snapshots", () => {
+  it("renders documents empty state with sample entries", () => {
+    const markup = renderToStaticMarkup(
+      <EmptyState
+        surface="documents:list"
+        title="Bring your first document online"
+        description="Import lease packets from Documenso or upload roommate paperwork to keep everyone aligned."
+        illustration={<FileText className="size-12 text-muted-foreground" />}
+        sampleItems={DOCUMENTS_EMPTY_STATE_SAMPLES}
+        primaryAction={{
+          href: DOCUMENTS_EMPTY_STATE_ROUTE,
+          label: "Create",
+        }}
+      />,
+    )
+
+    expect(markup).toMatchInlineSnapshot(`"<div class="rounded-xl border bg-card text-card-foreground shadow flex flex-col items-center gap-8 p-10 text-center sm:p-12"><div aria-hidden="true" class="flex h-20 w-20 items-center justify-center rounded-full bg-muted"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-text size-12 text-muted-foreground"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" x2="8" y1="13" y2="13"></line><line x1="16" x2="8" y1="17" y2="17"></line><line x1="10" x2="8" y1="9" y2="9"></line></svg></div><div class="space-y-2"><h3 class="text-xl font-semibold">Bring your first document online</h3><p class="text-sm text-muted-foreground">Import lease packets from Documenso or upload roommate paperwork to keep everyone aligned.</p></div><div class="w-full max-w-md rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 p-5 text-left"><p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Example entries</p><ul class="mt-4 space-y-4"><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Lease agreement — Unit 2A</p><span class="text-xs font-medium uppercase text-muted-foreground">Pending signatures</span></div><p class="text-xs text-muted-foreground">Documenso template for the primary roommate lease this season.</p></li><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Pet policy addendum</p><span class="text-xs font-medium uppercase text-muted-foreground">Awaiting review</span></div><p class="text-xs text-muted-foreground">Tracks approvals for roommates bringing new pets into the unit.</p></li><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Move-in checklist</p><span class="text-xs font-medium uppercase text-muted-foreground">Signed</span></div><p class="text-xs text-muted-foreground">Shared acknowledgment of keys, parking passes, and storage lockers.</p></li></ul></div><a href="/documents/upload" aria-label="Create bring your first document online" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:translate-y-px motion-safe:active:scale-[0.97] motion-reduce:transform-none motion-reduce:transition-none bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 py-2 px-6">Create</a></div>"`)
+  })
+
+  it("renders members empty state with invite guidance", () => {
+    const markup = renderToStaticMarkup(
+      <EmptyState
+        surface="dashboard:members"
+        title="Invite your first household member"
+        description="Track roles, onboarding progress, and payment permissions by adding roommates and managers."
+        illustration={<Users className="size-12 text-muted-foreground" />}
+        sampleItems={MEMBERS_EMPTY_STATE_SAMPLES}
+        primaryAction={{
+          href: MEMBERS_EMPTY_STATE_ROUTE,
+          label: "Create",
+        }}
+      />,
+    )
+
+    expect(markup).toMatchInlineSnapshot(`"<div class="rounded-xl border bg-card text-card-foreground shadow flex flex-col items-center gap-8 p-10 text-center sm:p-12"><div aria-hidden="true" class="flex h-20 w-20 items-center justify-center rounded-full bg-muted"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-users size-12 text-muted-foreground"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M22 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg></div><div class="space-y-2"><h3 class="text-xl font-semibold">Invite your first household member</h3><p class="text-sm text-muted-foreground">Track roles, onboarding progress, and payment permissions by adding roommates and managers.</p></div><div class="w-full max-w-md rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 p-5 text-left"><p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Example entries</p><ul class="mt-4 space-y-4"><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Avery Johnson</p><span class="text-xs font-medium uppercase text-muted-foreground">Role · admin</span></div><p class="text-xs text-muted-foreground">Property manager overseeing billing, documents, and messaging.</p></li><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Skylar Chen</p><span class="text-xs font-medium uppercase text-muted-foreground">Status · active</span></div><p class="text-xs text-muted-foreground">Roommate contributing $950 monthly via autopay.</p></li><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Jordan Patel</p><span class="text-xs font-medium uppercase text-muted-foreground">Status · invited</span></div><p class="text-xs text-muted-foreground">Invited roommate awaiting onboarding tasks.</p></li></ul></div><a href="/dashboard/members/create" aria-label="Create invite your first household member" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:translate-y-px motion-safe:active:scale-[0.97] motion-reduce:transform-none motion-reduce:transition-none bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 py-2 px-6">Create</a></div>"`)
+  })
+
+  it("renders roommate ledger empty state with ledger examples", () => {
+    const markup = renderToStaticMarkup(
+      <EmptyState
+        surface="payments:roommate-ledger"
+        title="Start tracking roommate balances"
+        description="Log contributions and adjustments so every roommate sees the same running total."
+        illustration={<PiggyBank className="size-12 text-muted-foreground" />}
+        sampleItems={ROOMMATE_LEDGER_EMPTY_STATE_SAMPLES}
+        primaryAction={{
+          href: ROOMMATE_LEDGER_EMPTY_STATE_ROUTE,
+          label: "Create",
+        }}
+      />,
+    )
+
+    expect(markup).toMatchInlineSnapshot(`"<div class="rounded-xl border bg-card text-card-foreground shadow flex flex-col items-center gap-8 p-10 text-center sm:p-12"><div aria-hidden="true" class="flex h-20 w-20 items-center justify-center rounded-full bg-muted"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-piggy-bank size-12 text-muted-foreground"><path d="M19 5c-1.5 0-2.8 1.4-3 2-3.5-1.5-11-.3-11 5 0 1.8 0 3 2 4.5V20h4v-2h3v2h4v-4c1-.5 1.7-1 2-2h2v-4h-2c0-1-.5-1.5-1-2h0V5z"></path><path d="M2 9v1c0 1.1.9 2 2 2h1"></path><path d="M16 11h0"></path></svg></div><div class="space-y-2"><h3 class="text-xl font-semibold">Start tracking roommate balances</h3><p class="text-sm text-muted-foreground">Log contributions and adjustments so every roommate sees the same running total.</p></div><div class="w-full max-w-md rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 p-5 text-left"><p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Example entries</p><ul class="mt-4 space-y-4"><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Jamie Rivera</p><span class="text-xs font-medium uppercase text-muted-foreground">Balance · $120 due</span></div><p class="text-xs text-muted-foreground">Autopay posted $950 for July rent and utilities.</p></li><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Morgan Lee</p><span class="text-xs font-medium uppercase text-muted-foreground">Balance · $0</span></div><p class="text-xs text-muted-foreground">Property manager logged a $45 internet reimbursement.</p></li><li class="space-y-1"><div class="flex items-start justify-between gap-3"><p class="text-sm font-medium text-foreground">Priya Desai</p><span class="text-xs font-medium uppercase text-muted-foreground">Balance · $340 due</span></div><p class="text-xs text-muted-foreground">Manual catch-up payment scheduled for the 15th.</p></li></ul></div><a href="/payments/catch-up" aria-label="Create start tracking roommate balances" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:translate-y-px motion-safe:active:scale-[0.97] motion-reduce:transform-none motion-reduce:transition-none bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 py-2 px-6">Create</a></div>"`)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a reusable empty state component with analytics logging helpers and shared sample presets
- update document, member, and roommate ledger views to render the new empty state with contextual content and create CTAs
- cover the empty states with Vitest snapshots and enable tsx test discovery

## Testing
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d20b648f288328867a63e070f96689