### PR TITLE
Refine document upload validation and add form tests

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -16,18 +16,9 @@ import {
   DocumentSigningRequest,
   DocumentStats
 } from '@/types/documents';
+import { documentUploadSchema } from './schemas';
 
 // Validation schemas
-const documentUploadSchema = z.object({
-  title: z.string().min(1, 'Title is required'),
-  description: z.string().optional(),
-  document_type: z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other']),
-  tenant_id: z.string().uuid().optional(),
-  unit_id: z.string().optional(),
-  requires_signature: z.boolean().default(false),
-  expires_at: z.string().datetime().optional(),
-});
-
 const documentSigningSchema = z.object({
   document_id: z.string().uuid(),
   signer_email: z.string().email(),
@@ -51,6 +42,7 @@ interface ActionResult<T = any> {
   data?: T;
   error?: string;
   message?: string;
+  fieldErrors?: Record<string, string[]>;
 }
 
 // Get documents with optional filters
@@ -125,32 +117,28 @@ export async function uploadDocumentAction(
     }
 
     // Get file from form data
-    const file = formData.get('file') as File;
-    if (!file) {
-      return { success: false, error: 'No file provided.' };
-    }
-
-    // Validate other form data
-    const rawData = {
+    const validationResult = documentUploadSchema.safeParse({
+      file: formData.get('file'),
       title: formData.get('title'),
       description: formData.get('description'),
       document_type: formData.get('document_type'),
       tenant_id: formData.get('tenant_id'),
       unit_id: formData.get('unit_id'),
-      requires_signature: formData.get('requires_signature') === 'true',
+      requires_signature: formData.get('requires_signature'),
       expires_at: formData.get('expires_at'),
-    };
-
-    const validationResult = documentUploadSchema.safeParse(rawData);
+    });
     if (!validationResult.success) {
-      const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
-        .map(errors => errors?.join('. '))
-        .filter(Boolean)
-        .join(' ');
-      return { success: false, error: errorMessages || 'Invalid form data provided.' };
+      const { fieldErrors, formErrors } = validationResult.error.flatten();
+      const combinedErrors = [...formErrors, ...Object.values(fieldErrors).flat()].filter(Boolean);
+      return {
+        success: false,
+        error: combinedErrors[0] || 'Please correct the highlighted fields and try again.',
+        fieldErrors,
+      };
     }
 
     const validatedData = validationResult.data;
+    const { file, ...metadata } = validatedData;
 
     // Upload file to Supabase Storage
     const fileExt = file.name.split('.').pop();
@@ -175,14 +163,14 @@ export async function uploadDocumentAction(
     const { data: document, error: dbError } = await (supabase as any)
       .from('documents')
       .insert({
-        title: validatedData.title,
-        description: validatedData.description,
-        document_type: validatedData.document_type,
+        title: metadata.title,
+        description: metadata.description,
+        document_type: metadata.document_type,
         file_url: publicUrl,
-        tenant_id: validatedData.tenant_id,
-        unit_id: validatedData.unit_id,
-        requires_signature: validatedData.requires_signature,
-        expires_at: validatedData.expires_at,
+        tenant_id: metadata.tenant_id,
+        unit_id: metadata.unit_id,
+        requires_signature: metadata.requires_signature,
+        expires_at: metadata.expires_at,
         created_by: user.id,
       })
       .select()
@@ -239,11 +227,13 @@ export async function createSigningRequestAction(
 
     const validationResult = documentSigningSchema.safeParse(rawData);
     if (!validationResult.success) {
-      const errorMessages = Object.values(validationResult.error.flatten().fieldErrors)
-        .map(errors => errors?.join('. '))
-        .filter(Boolean)
-        .join(' ');
-      return { success: false, error: errorMessages || 'Invalid form data provided.' };
+      const { fieldErrors, formErrors } = validationResult.error.flatten();
+      const combinedErrors = [...formErrors, ...Object.values(fieldErrors).flat()].filter(Boolean);
+      return {
+        success: false,
+        error: combinedErrors[0] || 'Please correct the highlighted fields and try again.',
+        fieldErrors,
+      };
     }
 
     const validatedData = validationResult.data;

--- a/app/documents/actions/schemas.ts
+++ b/app/documents/actions/schemas.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+export const DOCUMENT_ALLOWED_MIME_TYPES = [
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
+
+export const MAX_DOCUMENT_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+const optionalTrimmedString = (maxMessage?: string, maxLength?: number) =>
+  z.preprocess(
+    (value) => {
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        return trimmed === "" ? undefined : trimmed;
+      }
+      return value ?? undefined;
+    },
+    maxLength
+      ? z
+          .string()
+          .max(maxLength, maxMessage ?? `Must be ${maxLength} characters or fewer.`)
+          .optional()
+      : z.string().optional(),
+  );
+
+const optionalUuidString = z.preprocess(
+  (value) => {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed === "" ? undefined : trimmed;
+    }
+    return value ?? undefined;
+  },
+  z.string().uuid("Select a valid tenant.").optional(),
+);
+
+const optionalDateInput = z.preprocess(
+  (value) => {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed === "" ? undefined : trimmed;
+    }
+    return undefined;
+  },
+  z
+    .string()
+    .refine((val) => !Number.isNaN(new Date(val).getTime()), {
+      message: "Enter a valid expiration date.",
+    })
+    .optional(),
+);
+
+export const documentUploadSchema = z.object({
+  file: z
+    .any()
+    .refine((file): file is File => file instanceof File, {
+      message: "Add a file before uploading.",
+    })
+    .refine(
+      (file) =>
+        !(file instanceof File) || DOCUMENT_ALLOWED_MIME_TYPES.includes(file.type),
+      {
+        message: "Please upload a PDF, Word, or image file.",
+      },
+    )
+    .refine((file) => !(file instanceof File) || file.size <= MAX_DOCUMENT_FILE_SIZE, {
+      message: "File size must be 10MB or less.",
+    }),
+  title: z
+    .string({ required_error: "Give your document a title." })
+    .trim()
+    .min(1, "Give your document a title."),
+  description: optionalTrimmedString("Description must be 1000 characters or fewer.", 1000),
+  document_type: z.enum(["lease", "addendum", "insurance", "maintenance", "other"], {
+    required_error: "Choose a document type.",
+  }),
+  tenant_id: optionalUuidString,
+  unit_id: optionalTrimmedString(),
+  requires_signature: z.preprocess(
+    (value) => {
+      if (typeof value === "string") {
+        return value === "true";
+      }
+      if (typeof value === "boolean") {
+        return value;
+      }
+      return false;
+    },
+    z.boolean(),
+  ),
+  expires_at: optionalDateInput,
+});
+
+export type DocumentUploadFormValues = z.infer<typeof documentUploadSchema>;

--- a/app/documents/components/upload-document-dialog.tsx
+++ b/app/documents/components/upload-document-dialog.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,8 +14,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -27,110 +29,101 @@ import { uploadDocumentAction } from '../actions';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
 import { Upload, FileText } from 'lucide-react';
 import { toast } from 'sonner';
+import { documentUploadSchema, type DocumentUploadFormValues } from '../actions/schemas';
 
 export function UploadDocumentDialog() {
   const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [formData, setFormData] = useState({
-    title: '',
-    description: '',
-    document_type: 'other' as const,
-    tenant_id: '',
-    unit_id: '',
-    requires_signature: false,
-    expires_at: '',
-  });
-  const [file, setFile] = useState<File | null>(null);
   const router = useRouter();
   const permissions = useDocumentPermissions();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const defaultValues: Partial<DocumentUploadFormValues> = {
+    title: '',
+    description: '',
+    document_type: 'other',
+    tenant_id: undefined,
+    unit_id: undefined,
+    requires_signature: false,
+    expires_at: '',
+  };
+
+  const form = useForm<DocumentUploadFormValues>({
+    resolver: zodResolver(documentUploadSchema),
+    defaultValues,
+  });
+
+  const { isSubmitting } = form.formState;
+
+  const resetFormState = () => {
+    form.reset({
+      ...defaultValues,
+      file: undefined as unknown as DocumentUploadFormValues['file'],
+    });
+    form.clearErrors();
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
 
   // Don't render upload button if user doesn't have permission
   if (!permissions.canUploadDocuments) {
     return null;
   }
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFile = e.target.files?.[0];
-    if (selectedFile) {
-      // Validate file type
-      const allowedTypes = [
-        'application/pdf',
-        'image/jpeg',
-        'image/png',
-        'image/gif',
-        'application/msword',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-      ];
-
-      if (!allowedTypes.includes(selectedFile.type)) {
-        toast.error('Please select a valid file type (PDF, Word, or image)');
-        return;
-      }
-
-      // Validate file size (10MB max)
-      if (selectedFile.size > 10 * 1024 * 1024) {
-        toast.error('File size must be less than 10MB');
-        return;
-      }
-
-      setFile(selectedFile);
+  const handleDialogChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      resetFormState();
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!file) {
-      toast.error('Please select a file to upload');
-      return;
-    }
-
-    if (!formData.title.trim()) {
-      toast.error('Please enter a document title');
-      return;
-    }
-
-    setLoading(true);
+  const onSubmit = async (values: DocumentUploadFormValues) => {
     try {
       const submitData = new FormData();
-      submitData.append('file', file);
-      submitData.append('title', formData.title);
-      submitData.append('description', formData.description);
-      submitData.append('document_type', formData.document_type);
-      submitData.append('tenant_id', formData.tenant_id);
-      submitData.append('unit_id', formData.unit_id);
-      submitData.append('requires_signature', formData.requires_signature.toString());
-      submitData.append('expires_at', formData.expires_at);
+      submitData.append('file', values.file);
+      submitData.append('title', values.title);
+      if (values.description) {
+        submitData.append('description', values.description);
+      }
+      submitData.append('document_type', values.document_type);
+      if (values.tenant_id) {
+        submitData.append('tenant_id', values.tenant_id);
+      }
+      if (values.unit_id) {
+        submitData.append('unit_id', values.unit_id);
+      }
+      submitData.append('requires_signature', values.requires_signature ? 'true' : 'false');
+      if (values.expires_at) {
+        submitData.append('expires_at', values.expires_at);
+      }
 
       const result = await uploadDocumentAction(submitData);
 
       if (result.success) {
         toast.success('Document uploaded successfully');
         setOpen(false);
-        setFormData({
-          title: '',
-          description: '',
-          document_type: 'other',
-          tenant_id: '',
-          unit_id: '',
-          requires_signature: false,
-          expires_at: '',
-        });
-        setFile(null);
+        resetFormState();
         router.refresh();
       } else {
+        if (result.fieldErrors) {
+          (Object.entries(result.fieldErrors) as [keyof DocumentUploadFormValues, string[] | undefined][])
+            .forEach(([field, messages]) => {
+              const message = messages?.[0];
+              if (message) {
+                form.setError(field, { type: 'server', message });
+              }
+            });
+        }
         toast.error(result.error || 'Failed to upload document');
       }
     } catch (error) {
       console.error('Error uploading document:', error);
       toast.error('An unexpected error occurred');
-    } finally {
-      setLoading(false);
     }
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleDialogChange}>
       <DialogTrigger asChild>
         <Button>
           <Upload className="mr-2 size-4" />
@@ -145,118 +138,169 @@ export function UploadDocumentDialog() {
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* File Upload */}
-          <div className="space-y-2">
-            <Label htmlFor="file">Document File</Label>
-            <div className="rounded-lg border-2 border-dashed border-muted-foreground/25 p-6 text-center">
-              <input
-                id="file"
-                type="file"
-                onChange={handleFileChange}
-                accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif"
-                className="hidden"
-              />
-              <label htmlFor="file" className="cursor-pointer">
-                <FileText className="mx-auto mb-2 size-12 text-muted-foreground" />
-                <div className="text-sm text-muted-foreground">
-                  {file ? (
-                    <span className="font-medium text-foreground">{file.name}</span>
-                  ) : (
-                    <>
-                      Click to select a file or drag and drop
-                      <br />
-                      <span className="text-xs">PDF, Word, or image files up to 10MB</span>
-                    </>
-                  )}
-                </div>
-              </label>
-            </div>
-          </div>
-
-          {/* Title */}
-          <div className="space-y-2">
-            <Label htmlFor="title">Document Title *</Label>
-            <Input
-              id="title"
-              value={formData.title}
-              onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
-              placeholder="e.g., Lease Agreement - Unit 2A"
-              required
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="file"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="document-file">Document File *</FormLabel>
+                  <FormControl>
+                    <div className="rounded-lg border-2 border-dashed border-muted-foreground/25 p-6 text-center">
+                      <input
+                        id="document-file"
+                        type="file"
+                        accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif"
+                        className="hidden"
+                        ref={(node) => {
+                          field.ref(node);
+                          fileInputRef.current = node;
+                        }}
+                        onBlur={field.onBlur}
+                        onChange={(event) => {
+                          const selectedFile = event.target.files?.[0];
+                          field.onChange(selectedFile);
+                        }}
+                      />
+                      <label htmlFor="document-file" className="cursor-pointer">
+                        <FileText className="mx-auto mb-2 size-12 text-muted-foreground" />
+                        <div className="text-sm text-muted-foreground">
+                          {field.value instanceof File ? (
+                            <span className="font-medium text-foreground">{field.value.name}</span>
+                          ) : (
+                            <>
+                              Click to select a file or drag and drop
+                              <br />
+                              <span className="text-xs">PDF, Word, or image files up to 10MB</span>
+                            </>
+                          )}
+                        </div>
+                      </label>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
 
-          {/* Description */}
-          <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
-            <Textarea
-              id="description"
-              value={formData.description}
-              onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
-              placeholder="Optional description of the document"
-              rows={2}
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Document Title *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g., Lease Agreement - Unit 2A"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
 
-          {/* Document Type */}
-          <div className="space-y-2">
-            <Label htmlFor="document_type">Document Type</Label>
-            <Select
-              value={formData.document_type}
-              onValueChange={(value: any) => setFormData(prev => ({ ...prev, document_type: value }))}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="lease">Lease Agreement</SelectItem>
-                <SelectItem value="addendum">Addendum</SelectItem>
-                <SelectItem value="insurance">Insurance</SelectItem>
-                <SelectItem value="maintenance">Maintenance</SelectItem>
-                <SelectItem value="other">Other</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Signature Required */}
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="requires_signature"
-              checked={formData.requires_signature}
-              onCheckedChange={(checked) =>
-                setFormData(prev => ({ ...prev, requires_signature: checked as boolean }))
-              }
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description (Optional)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={2}
+                      placeholder="Optional description of the document"
+                      {...field}
+                      value={field.value ?? ''}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            <Label htmlFor="requires_signature" className="text-sm">
-              Requires signature
-            </Label>
-          </div>
 
-          {/* Expiry Date */}
-          <div className="space-y-2">
-            <Label htmlFor="expires_at">Expiry Date (Optional)</Label>
-            <Input
-              id="expires_at"
-              type="datetime-local"
-              value={formData.expires_at}
-              onChange={(e) => setFormData(prev => ({ ...prev, expires_at: e.target.value }))}
+            <FormField
+              control={form.control}
+              name="document_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Document Type</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="lease">Lease Agreement</SelectItem>
+                      <SelectItem value="addendum">Addendum</SelectItem>
+                      <SelectItem value="insurance">Insurance</SelectItem>
+                      <SelectItem value="maintenance">Maintenance</SelectItem>
+                      <SelectItem value="other">Other</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setOpen(false)}
-              disabled={loading}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={loading || !file}>
-              {loading ? 'Uploading...' : 'Upload Document'}
-            </Button>
-          </DialogFooter>
-        </form>
+            <FormField
+              control={form.control}
+              name="requires_signature"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center space-x-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      id="requires_signature"
+                      checked={field.value}
+                      onCheckedChange={(checked) => field.onChange(Boolean(checked))}
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel htmlFor="requires_signature" className="text-sm">
+                      Requires signature
+                    </FormLabel>
+                    <FormMessage />
+                  </div>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="expires_at"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Expiry Date (Optional)</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="datetime-local"
+                      value={field.value ?? ''}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleDialogChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Uploading...' : 'Upload Document'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -16,10 +16,12 @@ import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
-const maintenanceRequestSchema = z.object({
+export const maintenanceRequestSchema = z.object({
   title: z.string().min(5, "Title must be at least 5 characters"),
   description: z.string().min(20, "Description must be at least 20 characters"),
-  priority: z.enum(["low", "normal", "high", "urgent"]),
+  priority: z.enum(["low", "normal", "high", "urgent"], {
+    errorMap: () => ({ message: "Please choose a priority level." }),
+  }),
   category: z.string().optional(),
   location: z.string().optional(),
 });

--- a/components/schedule-form.tsx
+++ b/components/schedule-form.tsx
@@ -23,7 +23,7 @@ import {
 // --- Zod Schema for Client-Side Validation ---
 // This schema validates the data *after* the user has made selections
 // and we've constructed the initial Date objects.
-const clientScheduleSchema = z.object({
+export const clientScheduleSchema = z.object({
     startDateTime: z.date({
         // Error if we somehow fail to create a valid Date object
         invalid_type_error: "Invalid date or time selected.",

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -21,7 +21,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
-const visitorBookingSchema = z.object({
+export const visitorBookingSchema = z.object({
   guestName: z.string().min(2, "Guest name must be at least 2 characters"),
   guestEmail: z.string().email("Please enter a valid email address"),
   guestPhone: z.string().optional(),

--- a/tests/forms/document-upload-form.test.ts
+++ b/tests/forms/document-upload-form.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  documentUploadSchema,
+  MAX_DOCUMENT_FILE_SIZE,
+} from "@/app/documents/actions/schemas";
+
+const basePayload = {
+  title: "Lease Agreement",
+  document_type: "lease" as const,
+  requires_signature: false,
+};
+
+const createFile = (size: number, type: string) =>
+  new File([new Uint8Array(size)], "lease-file", { type });
+
+describe("document upload form validation", () => {
+  it("requires a document file before submission", () => {
+    const result = documentUploadSchema.safeParse({
+      ...basePayload,
+      file: undefined,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.file).toContain(
+      "Add a file before uploading.",
+    );
+  });
+
+  it("rejects unsupported file types", () => {
+    const result = documentUploadSchema.safeParse({
+      ...basePayload,
+      file: createFile(1024, "text/plain"),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.file).toContain(
+      "Please upload a PDF, Word, or image file.",
+    );
+  });
+
+  it("rejects files larger than 10MB", () => {
+    const result = documentUploadSchema.safeParse({
+      ...basePayload,
+      file: createFile(MAX_DOCUMENT_FILE_SIZE + 1, "application/pdf"),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.file).toContain(
+      "File size must be 10MB or less.",
+    );
+  });
+
+  it("requires a short, plain-language title", () => {
+    const result = documentUploadSchema.safeParse({
+      ...basePayload,
+      file: createFile(1024, "application/pdf"),
+      title: "",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.title).toContain(
+      "Give your document a title.",
+    );
+  });
+
+  it("validates expiration dates", () => {
+    const result = documentUploadSchema.safeParse({
+      ...basePayload,
+      file: createFile(1024, "application/pdf"),
+      expires_at: "not-a-date",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.expires_at).toContain(
+      "Enter a valid expiration date.",
+    );
+  });
+});

--- a/tests/forms/maintenance-request-form.test.ts
+++ b/tests/forms/maintenance-request-form.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { maintenanceRequestSchema } from "@/components/maintenance/maintenance-request-form";
+
+const basePayload = {
+  title: "Broken kitchen sink",
+  description: "Water has been leaking continuously for two days causing puddles.",
+  priority: "normal" as const,
+};
+
+describe("maintenance request form validation", () => {
+  it("requires a descriptive title", () => {
+    const result = maintenanceRequestSchema.safeParse({
+      ...basePayload,
+      title: "Drip",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.title).toContain(
+      "Title must be at least 5 characters",
+    );
+  });
+
+  it("requires a detailed description", () => {
+    const result = maintenanceRequestSchema.safeParse({
+      ...basePayload,
+      description: "Leaking pipe",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.description).toContain(
+      "Description must be at least 20 characters",
+    );
+  });
+
+  it("rejects unsupported priorities", () => {
+    const result = maintenanceRequestSchema.safeParse({
+      ...basePayload,
+      priority: "impossible" as any,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.priority).toContain(
+      "Please choose a priority level.",
+    );
+  });
+});

--- a/tests/forms/schedule-form.test.ts
+++ b/tests/forms/schedule-form.test.ts
@@ -1,0 +1,34 @@
+import { addHours } from "date-fns";
+import { describe, expect, it } from "vitest";
+
+import { clientScheduleSchema } from "@/components/schedule-form";
+
+describe("schedule form validation", () => {
+  it("requires both a date and time selection", () => {
+    const result = clientScheduleSchema.safeParse({});
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.startDateTime).toContain(
+      "Please select both a date and a time slot.",
+    );
+  });
+
+  it("prevents booking past time slots", () => {
+    const result = clientScheduleSchema.safeParse({
+      startDateTime: addHours(new Date(), -1),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.startDateTime).toContain(
+      "The selected time slot has already passed. Please select a future time.",
+    );
+  });
+
+  it("accepts future selections", () => {
+    const result = clientScheduleSchema.safeParse({
+      startDateTime: addHours(new Date(), 2),
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/forms/visitor-booking-form.test.ts
+++ b/tests/forms/visitor-booking-form.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { visitorBookingSchema } from "@/components/visitors/visitor-booking-form";
+
+const basePayload = {
+  guestName: "Alex Guest",
+  guestEmail: "alex@example.com",
+  guestPhone: "",
+  checkInDate: new Date("2024-07-01"),
+  checkOutDate: new Date("2024-07-03"),
+  purpose: "Catching up with family over the long weekend.",
+};
+
+describe("visitor booking form validation", () => {
+  it("requires a guest name", () => {
+    const result = visitorBookingSchema.safeParse({
+      ...basePayload,
+      guestName: "A",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.guestName).toContain(
+      "Guest name must be at least 2 characters",
+    );
+  });
+
+  it("validates the guest email", () => {
+    const result = visitorBookingSchema.safeParse({
+      ...basePayload,
+      guestEmail: "not-an-email",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.guestEmail).toContain(
+      "Please enter a valid email address",
+    );
+  });
+
+  it("requires a check-in date", () => {
+    const { checkInDate, ...withoutCheckIn } = basePayload;
+    const result = visitorBookingSchema.safeParse({
+      ...withoutCheckIn,
+    } as any);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.checkInDate).toContain(
+      "Check-in date is required",
+    );
+  });
+
+  it("asks for more detail on the purpose field", () => {
+    const result = visitorBookingSchema.safeParse({
+      ...basePayload,
+      purpose: "Hangout",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.purpose).toContain(
+      "Please provide more details about the visit",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the document upload dialog to use react-hook-form with shared zod validation and inline field errors
- share document upload validation in a reusable schema and return field-level issues from server actions
- export schemas for other resident forms and add unit tests that assert friendly validation messaging

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b66795c83288e12c26fb956dd8b