### PR TITLE
Add undoable deletion flows for dashboard members and todos

### DIFF
--- a/app/dashboard/constants.ts
+++ b/app/dashboard/constants.ts
@@ -1,0 +1,1 @@
+export const DASHBOARD_UNDO_WINDOW_MS = 30_000

--- a/app/dashboard/members/actions/delete-member.ts
+++ b/app/dashboard/members/actions/delete-member.ts
@@ -1,0 +1,90 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { DASHBOARD_UNDO_WINDOW_MS } from "@/app/dashboard/constants"
+import type { Database } from "@/lib/supabase"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+import type { DashboardMember } from "../data"
+import { mapMemberRowToDashboard } from "../data"
+
+const ENTITY = "dashboard_members"
+
+type MemberRow = Database["public"]["Tables"]["dashboard_members"]["Row"]
+
+type DeletionEventInsert = Database["public"]["Tables"]["deletion_events"]["Insert"]
+
+function asDeletionEvent(
+  record: MemberRow,
+  recordId: string
+): DeletionEventInsert {
+  return {
+    entity: ENTITY,
+    record_id: recordId,
+    payload: record,
+    expires_at: new Date(Date.now() + DASHBOARD_UNDO_WINDOW_MS).toISOString(),
+  }
+}
+
+export async function deleteMember(id: string): Promise<DashboardMember> {
+  const supabase = await createSupbaseServerClient()
+
+  const { data: deleted, error } = await supabase
+    .from(ENTITY)
+    .delete()
+    .eq("id", id)
+    .select("*")
+    .single()
+
+  if (error || !deleted) {
+    throw new Error(error?.message ?? "Unable to delete member")
+  }
+
+  const { error: logError } = await supabase
+    .from("deletion_events")
+    .insert(asDeletionEvent(deleted, id))
+
+  if (logError) {
+    throw new Error(logError.message)
+  }
+
+  revalidatePath("/dashboard/members")
+  return mapMemberRowToDashboard(deleted)
+}
+
+export async function restoreMember(member: DashboardMember) {
+  const supabase = await createSupbaseServerClient()
+
+  const { data, error } = await supabase
+    .from(ENTITY)
+    .upsert(
+      {
+        id: member.id,
+        name: member.name,
+        role: member.role,
+        status: member.status,
+        created_at: member.createdAt,
+      },
+      { onConflict: "id" }
+    )
+    .select("*")
+    .single()
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Unable to restore member")
+  }
+
+  const { error: cleanupError } = await supabase
+    .from("deletion_events")
+    .delete()
+    .match({ entity: ENTITY, record_id: member.id })
+
+  if (cleanupError) {
+    throw new Error(cleanupError.message)
+  }
+
+  revalidatePath("/dashboard/members")
+
+  return mapMemberRowToDashboard(data)
+}

--- a/app/dashboard/members/actions/index.tsx
+++ b/app/dashboard/members/actions/index.tsx
@@ -1,23 +1,11 @@
-"use server";
+"use server"
 
-import { createSupbaseServerClient } from "@/utils/supaone";
-
-import { redirect } from "next/navigation";
-
-type formData = {
-    email: string;
-    password: string;
-    confirm: string;
-    username: string;
-    role: string;
-    status: string; 
-}
+export { deleteMember, restoreMember } from "./delete-member"
 
 export async function createMember() {
-	console.log("create member");
+  console.log("create member")
 }
 export async function updateMemberById(id: string) {
-	console.log("update member");
+  console.log("update member")
 }
-export async function deleteMemberById(id: string) {}
 export async function readMembers() {}

--- a/app/dashboard/members/components/LegacyMemberTable.tsx
+++ b/app/dashboard/members/components/LegacyMemberTable.tsx
@@ -5,27 +5,31 @@ import ListOfMembers from "./ListOfMembers"
 
 const LEGACY_MEMBERS: DashboardMember[] = [
         {
+                id: "legacy-admin-1",
                 name: "Admin Member",
                 role: "admin",
-                createdAt: new Date().toDateString(),
+                createdAt: new Date().toISOString(),
                 status: "active",
         },
         {
+                id: "legacy-user-1",
                 name: "Non Admin User",
                 role: "user",
-                createdAt: new Date().toDateString(),
+                createdAt: new Date().toISOString(),
                 status: "active",
         },
         {
+                id: "legacy-admin-2",
                 name: "Administrator",
                 role: "admin",
-                createdAt: new Date().toDateString(),
+                createdAt: new Date().toISOString(),
                 status: "resigned",
         },
         {
+                id: "legacy-user-2",
                 name: "Satoshi",
                 role: "user",
-                createdAt: new Date().toDateString(),
+                createdAt: new Date().toISOString(),
                 status: "active",
         },
 ]

--- a/app/dashboard/members/components/ListOfMembers.tsx
+++ b/app/dashboard/members/components/ListOfMembers.tsx
@@ -1,65 +1,232 @@
-import React from "react"
+"use client"
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from "react"
 
 import { Button } from "@/components/ui/button"
-import { TrashIcon } from "@radix-ui/react-icons"
+import { useToast } from "@/components/ui/use-toast"
+import { DASHBOARD_UNDO_WINDOW_MS } from "@/app/dashboard/constants"
+import { UndoQueue } from "@/lib/undo-queue"
 import { cn } from "@/lib/utils"
+import { TrashIcon } from "@radix-ui/react-icons"
 
-import { DashboardMember } from "../data"
+import { deleteMember, restoreMember } from "../actions"
+import type { DashboardMember } from "../data"
 import EditMember from "./edit/EditMember"
 
-export default function ListOfMembers({ members }: { members: DashboardMember[] }) {
+type OptimisticAction =
+  | { type: "remove"; member: DashboardMember }
+  | { type: "restore"; member: DashboardMember }
+
+type PendingMap = Set<string>
+
+function reduceMembers(
+  state: DashboardMember[],
+  action: OptimisticAction
+): DashboardMember[] {
+  switch (action.type) {
+    case "remove":
+      return state.filter((member) => member.id !== action.member.id)
+    case "restore": {
+      const without = state.filter((member) => member.id !== action.member.id)
+      return [action.member, ...without]
+    }
+    default:
+      return state
+  }
+}
+
+export default function ListOfMembers({
+  members,
+}: {
+  members: DashboardMember[]
+}) {
+  const { toast, dismiss } = useToast()
+  const [pendingIds, setPendingIds] = useState<PendingMap>(() => new Set())
+  const [optimisticMembers, applyOptimisticMembers] = useOptimistic(
+    members,
+    reduceMembers
+  )
+  const [, startTransition] = useTransition()
+  const queueRef = useRef<UndoQueue<DashboardMember> | null>(null)
+
+  if (!queueRef.current) {
+    queueRef.current = new UndoQueue(DASHBOARD_UNDO_WINDOW_MS)
+  }
+
+  useEffect(() => {
+    return () => queueRef.current?.dispose()
+  }, [])
+
+  const setPendingFor = useCallback((id: string, value: boolean) => {
+    setPendingIds((previous) => {
+      const next = new Set(previous)
+      if (value) {
+        next.add(id)
+      } else {
+        next.delete(id)
+      }
+      return next
+    })
+  }, [])
+
+  const handleUndo = useCallback(
+    (memberId: string, toastId?: string) => {
+      const queue = queueRef.current
+      if (!queue) {
+        return
+      }
+      const restored = queue.undo(memberId)
+      if (!restored) {
+        toast({
+          variant: "destructive",
+          title: "Undo no longer available",
+          description: "The 30 second undo window has already expired.",
+        })
+        return
+      }
+
+      applyOptimisticMembers({ type: "restore", member: restored })
+      if (toastId) {
+        dismiss(toastId)
+      }
+
+      startTransition(async () => {
+        try {
+          await restoreMember(restored)
+        } catch (error) {
+          applyOptimisticMembers({ type: "remove", member: restored })
+          toast({
+            variant: "destructive",
+            title: "Failed to restore member",
+            description:
+              error instanceof Error
+                ? error.message
+                : "An unexpected error occurred while restoring the member.",
+          })
+        }
+      })
+    },
+    [applyOptimisticMembers, dismiss, startTransition, toast]
+  )
+
+  const handleDelete = useCallback(
+    (member: DashboardMember) => {
+      const queue = queueRef.current
+      if (!queue) {
+        return
+      }
+
+      setPendingFor(member.id, true)
+      applyOptimisticMembers({ type: "remove", member })
+
+      startTransition(async () => {
+        try {
+          const deleted = await deleteMember(member.id)
+          queue.enqueue(deleted)
+
+          let toastId: string | undefined
+          const undoToast = toast({
+            title: `${deleted.name} removed`,
+            description: "Undo within 30 seconds to restore this member.",
+            duration: DASHBOARD_UNDO_WINDOW_MS,
+            action: (
+              <Button
+                variant="outline"
+                onClick={() => handleUndo(deleted.id, toastId)}
+              >
+                Undo
+              </Button>
+            ),
+          })
+          toastId = undoToast.id
+        } catch (error) {
+          applyOptimisticMembers({ type: "restore", member })
+          toast({
+            variant: "destructive",
+            title: "Failed to delete member",
+            description:
+              error instanceof Error
+                ? error.message
+                : "An unexpected error occurred while deleting the member.",
+          })
+        } finally {
+          setPendingFor(member.id, false)
+        }
+      })
+    },
+    [applyOptimisticMembers, handleUndo, setPendingFor, startTransition, toast]
+  )
+
+  const renderMembers = useMemo(
+    () =>
+      optimisticMembers.map((member) => {
+        const pending = pendingIds.has(member.id)
+        const joinedDate = new Date(member.createdAt).toLocaleDateString()
+
         return (
-                <div className="mx-2 rounded-sm bg-white dark:bg-inherit">
-                        {members.map((member, index) => {
-                                return (
-                                        <div
-                                                className="grid grid-cols-5 rounded-sm p-3 align-middle font-normal"
-                                                key={member.name + index}
-                                        >
-                                                <h1>{member.name}</h1>
+          <div
+            className="grid grid-cols-5 rounded-sm p-3 align-middle font-normal"
+            key={member.id}
+          >
+            <h1>{member.name}</h1>
 
-                                                <div>
-                                                        <span
-                                                                className={cn(
-                                                                        "rounded-full border-[.5px] px-2 py-1 text-sm capitalize shadow dark:bg-zinc-800",
-                                                                        {
-                                                                                "border-green-500 bg-green-200 text-green-600":
-                                                                                        member.role === "admin",
-                                                                                "border-zinc-300 bg-yellow-50 px-4 text-yellow-700 dark:border-yellow-700 dark:text-yellow-300":
-                                                                                        member.role === "user",
-                                                                        },
-                                                                )}
-                                                        >
-                                                                {member.role}
-                                                        </span>
-                                                </div>
-                                                <h1>{member.createdAt}</h1>
-                                                <div>
-                                                        <span
-                                                                className={cn(
-                                                                        "rounded-full border border-zinc-300 px-2 py-1 text-sm capitalize dark:bg-zinc-800",
-                                                                        {
-                                                                                "bg-green-200 px-4 text-green-600 dark:border-green-400":
-                                                                                        member.status === "active",
-                                                                                "bg-red-100 text-red-500 dark:border-red-400 dark:text-red-300":
-                                                                                        member.status === "resigned",
-                                                                        },
-                                                                )}
-                                                        >
-                                                                {member.status}
-                                                        </span>
-                                                </div>
+            <div>
+              <span
+                className={cn(
+                  "rounded-full border-[.5px] px-2 py-1 text-sm capitalize shadow dark:bg-zinc-800",
+                  {
+                    "border-green-500 bg-green-200 text-green-600":
+                      member.role === "admin",
+                    "border-zinc-300 bg-yellow-50 px-4 text-yellow-700 dark:border-yellow-700 dark:text-yellow-300":
+                      member.role === "user",
+                  }
+                )}
+              >
+                {member.role}
+              </span>
+            </div>
+            <h1>{joinedDate}</h1>
+            <div>
+              <span
+                className={cn(
+                  "rounded-full border border-zinc-300 px-2 py-1 text-sm capitalize dark:bg-zinc-800",
+                  {
+                    "bg-green-200 px-4 text-green-600 dark:border-green-400":
+                      member.status === "active",
+                    "bg-red-100 text-red-500 dark:border-red-400 dark:text-red-300":
+                      member.status === "resigned",
+                  }
+                )}
+              >
+                {member.status}
+              </span>
+            </div>
 
-                                                <div className="flex items-center gap-2">
-                                                        <Button variant="outline" className="flex items-center gap-2">
-                                                                <TrashIcon />
-                                                                Delete
-                                                        </Button>
-                                                        <EditMember />
-                                                </div>
-                                        </div>
-                                )
-                        })}
-                </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                className="flex items-center gap-2"
+                onClick={() => handleDelete(member)}
+                disabled={pending}
+              >
+                <TrashIcon />
+                Delete
+              </Button>
+              <EditMember />
+            </div>
+          </div>
         )
+      }),
+    [handleDelete, optimisticMembers, pendingIds]
+  )
+
+  return <div className="mx-2 rounded-sm bg-white dark:bg-inherit">{renderMembers}</div>
 }

--- a/app/dashboard/members/data.ts
+++ b/app/dashboard/members/data.ts
@@ -2,43 +2,85 @@ import "server-only"
 
 import { cache } from "react"
 
+import type { Database } from "@/lib/supabase"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+
 export type DashboardMember = {
-        name: string
-        role: "admin" | "user"
-        createdAt: string
-        status: "active" | "resigned"
+  id: string
+  name: string
+  role: "admin" | "user"
+  createdAt: string
+  status: "active" | "resigned"
 }
 
-async function wait(ms: number) {
-        return new Promise((resolve) => setTimeout(resolve, ms))
+type MemberRow = Database["public"]["Tables"]["dashboard_members"]["Row"]
+
+const FALLBACK_MEMBERS: DashboardMember[] = [
+  {
+    id: "fallback-admin-1",
+    name: "Admin Member",
+    role: "admin",
+    createdAt: new Date().toISOString(),
+    status: "active",
+  },
+  {
+    id: "fallback-user-1",
+    name: "Non Admin User",
+    role: "user",
+    createdAt: new Date().toISOString(),
+    status: "active",
+  },
+  {
+    id: "fallback-admin-2",
+    name: "Administrator",
+    role: "admin",
+    createdAt: new Date().toISOString(),
+    status: "resigned",
+  },
+  {
+    id: "fallback-user-2",
+    name: "Satoshi",
+    role: "user",
+    createdAt: new Date().toISOString(),
+    status: "active",
+  },
+]
+
+export function mapMemberRowToDashboard(row: MemberRow): DashboardMember {
+  return {
+    id: row.id,
+    name: row.name,
+    role: row.role,
+    createdAt: row.created_at ?? new Date().toISOString(),
+    status: row.status,
+  }
 }
 
 export const getDashboardMembers = cache(async (): Promise<DashboardMember[]> => {
-        await wait(260)
-        return [
-                {
-                        name: "Admin Member",
-                        role: "admin",
-                        createdAt: new Date().toDateString(),
-                        status: "active",
-                },
-                {
-                        name: "Non Admin User",
-                        role: "user",
-                        createdAt: new Date().toDateString(),
-                        status: "active",
-                },
-                {
-                        name: "Administrator",
-                        role: "admin",
-                        createdAt: new Date().toDateString(),
-                        status: "resigned",
-                },
-                {
-                        name: "Satoshi",
-                        role: "user",
-                        createdAt: new Date().toDateString(),
-                        status: "active",
-                },
-        ]
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  ) {
+    return FALLBACK_MEMBERS
+  }
+
+  try {
+    const supabase = await createSupbaseServerClientReadOnly()
+    const { data, error } = await supabase
+      .from("dashboard_members")
+      .select("*")
+      .order("created_at", { ascending: false })
+
+    if (error || !data?.length) {
+      if (error) {
+        console.error("Failed to load dashboard members from Supabase", error)
+      }
+      return FALLBACK_MEMBERS
+    }
+
+    return data.map(mapMemberRowToDashboard)
+  } catch (error) {
+    console.error("Unexpected error loading dashboard members", error)
+    return FALLBACK_MEMBERS
+  }
 })

--- a/app/dashboard/todo/actions/delete-todo.ts
+++ b/app/dashboard/todo/actions/delete-todo.ts
@@ -1,0 +1,87 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { DASHBOARD_UNDO_WINDOW_MS } from "@/app/dashboard/constants"
+import type { Database } from "@/lib/supabase"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+import type { DashboardTodo } from "../data"
+import { mapTodoRowToDashboard } from "../data"
+
+const ENTITY = "dashboard_todos"
+
+type TodoRow = Database["public"]["Tables"]["dashboard_todos"]["Row"]
+
+type DeletionEventInsert = Database["public"]["Tables"]["deletion_events"]["Insert"]
+
+function asDeletionEvent(row: TodoRow, recordId: string): DeletionEventInsert {
+  return {
+    entity: ENTITY,
+    record_id: recordId,
+    payload: row,
+    expires_at: new Date(Date.now() + DASHBOARD_UNDO_WINDOW_MS).toISOString(),
+  }
+}
+
+export async function deleteTodo(id: string): Promise<DashboardTodo> {
+  const supabase = await createSupbaseServerClient()
+
+  const { data: deleted, error } = await supabase
+    .from(ENTITY)
+    .delete()
+    .eq("id", id)
+    .select("*")
+    .single()
+
+  if (error || !deleted) {
+    throw new Error(error?.message ?? "Unable to delete todo item")
+  }
+
+  const { error: logError } = await supabase
+    .from("deletion_events")
+    .insert(asDeletionEvent(deleted, id))
+
+  if (logError) {
+    throw new Error(logError.message)
+  }
+
+  revalidatePath("/dashboard/todo")
+  return mapTodoRowToDashboard(deleted)
+}
+
+export async function restoreTodo(todo: DashboardTodo) {
+  const supabase = await createSupbaseServerClient()
+
+  const { data, error } = await supabase
+    .from(ENTITY)
+    .upsert(
+      {
+        id: todo.id,
+        title: todo.title,
+        created_by: todo.createdBy,
+        completed: todo.completed,
+        created_at: todo.createdAt,
+      },
+      { onConflict: "id" }
+    )
+    .select("*")
+    .single()
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Unable to restore todo item")
+  }
+
+  const { error: cleanupError } = await supabase
+    .from("deletion_events")
+    .delete()
+    .match({ entity: ENTITY, record_id: todo.id })
+
+  if (cleanupError) {
+    throw new Error(cleanupError.message)
+  }
+
+  revalidatePath("/dashboard/todo")
+
+  return mapTodoRowToDashboard(data)
+}

--- a/app/dashboard/todo/actions/index.ts
+++ b/app/dashboard/todo/actions/index.ts
@@ -1,9 +1,10 @@
 // "use server";
+export { deleteTodo, restoreTodo } from "./delete-todo"
+
 export async function createTodo() {
-	console.log("create todo");
+        console.log("create todo");
 }
 export async function updateTodoById(id: string) {
-	console.log("update todo");
+        console.log("update todo");
 }
-export async function deleteTodoById(id: string) {}
 export async function readTodos() {}

--- a/app/dashboard/todo/components/TodoItems.tsx
+++ b/app/dashboard/todo/components/TodoItems.tsx
@@ -1,26 +1,8 @@
-import { Button } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
-
 import { getDashboardTodos } from "../data"
+import { TodoList } from "./TodoList"
 
 export async function TodoItems() {
         const todos = await getDashboardTodos()
 
-        return (
-                <div className="space-y-4">
-                        {todos.map((todo) => (
-                                <div key={todo.id} className="flex items-center gap-6">
-                                        <h1
-                                                className={cn({
-                                                        "line-through": todo.completed,
-                                                })}
-                                        >
-                                                {todo.title}
-                                        </h1>
-                                        <Button variant="outline">Delete</Button>
-                                        <Button>Update</Button>
-                                </div>
-                        ))}
-                </div>
-        )
+        return <TodoList todos={todos} />
 }

--- a/app/dashboard/todo/components/TodoList.tsx
+++ b/app/dashboard/todo/components/TodoList.tsx
@@ -1,0 +1,197 @@
+"use client"
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from "react"
+
+import { Button } from "@/components/ui/button"
+import { useToast } from "@/components/ui/use-toast"
+import { DASHBOARD_UNDO_WINDOW_MS } from "@/app/dashboard/constants"
+import { UndoQueue } from "@/lib/undo-queue"
+import { cn } from "@/lib/utils"
+import { TrashIcon } from "@radix-ui/react-icons"
+
+import { deleteTodo, restoreTodo } from "../actions"
+import type { DashboardTodo } from "../data"
+
+export type TodoListProps = {
+  todos: DashboardTodo[]
+}
+
+type OptimisticAction =
+  | { type: "remove"; todo: DashboardTodo }
+  | { type: "restore"; todo: DashboardTodo }
+
+type PendingSet = Set<string>
+
+function reduceTodos(
+  state: DashboardTodo[],
+  action: OptimisticAction
+): DashboardTodo[] {
+  switch (action.type) {
+    case "remove":
+      return state.filter((todo) => todo.id !== action.todo.id)
+    case "restore": {
+      const without = state.filter((todo) => todo.id !== action.todo.id)
+      return [action.todo, ...without]
+    }
+    default:
+      return state
+  }
+}
+
+export function TodoList({ todos }: TodoListProps) {
+  const { toast, dismiss } = useToast()
+  const [pending, setPending] = useState<PendingSet>(() => new Set())
+  const [optimisticTodos, applyOptimisticTodos] = useOptimistic(
+    todos,
+    reduceTodos
+  )
+  const [, startTransition] = useTransition()
+  const queueRef = useRef<UndoQueue<DashboardTodo> | null>(null)
+
+  if (!queueRef.current) {
+    queueRef.current = new UndoQueue(DASHBOARD_UNDO_WINDOW_MS)
+  }
+
+  useEffect(() => {
+    return () => queueRef.current?.dispose()
+  }, [])
+
+  const setPendingFor = useCallback((id: string, value: boolean) => {
+    setPending((previous) => {
+      const next = new Set(previous)
+      if (value) {
+        next.add(id)
+      } else {
+        next.delete(id)
+      }
+      return next
+    })
+  }, [])
+
+  const handleUndo = useCallback(
+    (todoId: string, toastId?: string) => {
+      const queue = queueRef.current
+      if (!queue) {
+        return
+      }
+      const restored = queue.undo(todoId)
+      if (!restored) {
+        toast({
+          variant: "destructive",
+          title: "Undo no longer available",
+          description: "The deletion has already been finalized.",
+        })
+        return
+      }
+
+      applyOptimisticTodos({ type: "restore", todo: restored })
+      if (toastId) {
+        dismiss(toastId)
+      }
+
+      startTransition(async () => {
+        try {
+          await restoreTodo(restored)
+        } catch (error) {
+          applyOptimisticTodos({ type: "remove", todo: restored })
+          toast({
+            variant: "destructive",
+            title: "Failed to restore todo",
+            description:
+              error instanceof Error
+                ? error.message
+                : "An unexpected error occurred while restoring the todo.",
+          })
+        }
+      })
+    },
+    [applyOptimisticTodos, dismiss, startTransition, toast]
+  )
+
+  const handleDelete = useCallback(
+    (todo: DashboardTodo) => {
+      const queue = queueRef.current
+      if (!queue) {
+        return
+      }
+
+      setPendingFor(todo.id, true)
+      applyOptimisticTodos({ type: "remove", todo })
+
+      startTransition(async () => {
+        try {
+          const deleted = await deleteTodo(todo.id)
+          queue.enqueue(deleted)
+
+          let toastId: string | undefined
+          const undoToast = toast({
+            title: `Task \"${deleted.title}\" removed`,
+            description: "Undo within 30 seconds to restore this task.",
+            duration: DASHBOARD_UNDO_WINDOW_MS,
+            action: (
+              <Button
+                variant="outline"
+                onClick={() => handleUndo(deleted.id, toastId)}
+              >
+                Undo
+              </Button>
+            ),
+          })
+          toastId = undoToast.id
+        } catch (error) {
+          applyOptimisticTodos({ type: "restore", todo })
+          toast({
+            variant: "destructive",
+            title: "Failed to delete todo",
+            description:
+              error instanceof Error
+                ? error.message
+                : "An unexpected error occurred while deleting the todo.",
+          })
+        } finally {
+          setPendingFor(todo.id, false)
+        }
+      })
+    },
+    [applyOptimisticTodos, handleUndo, setPendingFor, startTransition, toast]
+  )
+
+  const content = useMemo(
+    () =>
+      optimisticTodos.map((todo) => {
+        const pendingDeletion = pending.has(todo.id)
+        const createdAt = new Date(todo.createdAt).toLocaleString()
+
+        return (
+          <div key={todo.id} className="flex items-center justify-between gap-4">
+            <div className="flex flex-1 flex-col">
+              <h1 className={cn({ "line-through": todo.completed })}>{todo.title}</h1>
+              <p className="text-xs text-muted-foreground">
+                Created {createdAt} by {todo.createdBy}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              className="flex items-center gap-2"
+              onClick={() => handleDelete(todo)}
+              disabled={pendingDeletion}
+            >
+              <TrashIcon />
+              Delete
+            </Button>
+          </div>
+        )
+      }),
+    [handleDelete, optimisticTodos, pending]
+  )
+
+  return <div className="space-y-4">{content}</div>
+}

--- a/app/dashboard/todo/data.ts
+++ b/app/dashboard/todo/data.ts
@@ -2,25 +2,64 @@ import "server-only"
 
 import { cache } from "react"
 
+import type { Database } from "@/lib/supabase"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+
 export type DashboardTodo = {
-        id: string
-        title: string
-        createdBy: string
-        completed: boolean
+  id: string
+  title: string
+  createdBy: string
+  completed: boolean
+  createdAt: string
 }
 
-async function wait(ms: number) {
-        return new Promise((resolve) => setTimeout(resolve, ms))
+type TodoRow = Database["public"]["Tables"]["dashboard_todos"]["Row"]
+
+const FALLBACK_TODOS: DashboardTodo[] = [
+  {
+    id: "fallback-todo-1",
+    title: "Subscribe",
+    createdBy: "091832901830",
+    completed: false,
+    createdAt: new Date().toISOString(),
+  },
+]
+
+export function mapTodoRowToDashboard(row: TodoRow): DashboardTodo {
+  return {
+    id: row.id,
+    title: row.title,
+    createdBy: row.created_by,
+    completed: row.completed,
+    createdAt: row.created_at ?? new Date().toISOString(),
+  }
 }
 
 export const getDashboardTodos = cache(async (): Promise<DashboardTodo[]> => {
-        await wait(200)
-        return [
-                {
-                        title: "Subscribe",
-                        createdBy: "091832901830",
-                        id: "101981908",
-                        completed: false,
-                },
-        ]
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  ) {
+    return FALLBACK_TODOS
+  }
+
+  try {
+    const supabase = await createSupbaseServerClientReadOnly()
+    const { data, error } = await supabase
+      .from("dashboard_todos")
+      .select("*")
+      .order("created_at", { ascending: false })
+
+    if (error || !data?.length) {
+      if (error) {
+        console.error("Failed to load dashboard todos from Supabase", error)
+      }
+      return FALLBACK_TODOS
+    }
+
+    return data.map(mapTodoRowToDashboard)
+  } catch (error) {
+    console.error("Unexpected error loading dashboard todos", error)
+    return FALLBACK_TODOS
+  }
 })

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -29,6 +29,28 @@ export type Database = {
         updated_at: string | null
         metadata: Json | null
       }>
+      dashboard_members: SupabaseTable<{
+        id: string
+        name: string
+        role: 'admin' | 'user'
+        status: 'active' | 'resigned'
+        created_at: string | null
+      }>
+      dashboard_todos: SupabaseTable<{
+        id: string
+        title: string
+        created_by: string
+        completed: boolean
+        created_at: string | null
+      }>
+      deletion_events: SupabaseTable<{
+        id: string
+        entity: string
+        record_id: string
+        payload: Json
+        expires_at: string
+        created_at: string | null
+      }>
       profiles: SupabaseTable<{
         id: string
         created_at: string | null

--- a/lib/undo-queue.ts
+++ b/lib/undo-queue.ts
@@ -1,0 +1,47 @@
+export type UndoRecord<T extends { id: string }> = {
+  record: T
+  timeout: ReturnType<typeof setTimeout>
+}
+
+export class UndoQueue<T extends { id: string }> {
+  private pending = new Map<string, UndoRecord<T>>()
+
+  constructor(private readonly delayMs: number) {}
+
+  enqueue(record: T) {
+    this.cancel(record.id)
+    const timeout = setTimeout(() => {
+      this.pending.delete(record.id)
+    }, this.delayMs)
+
+    this.pending.set(record.id, { record, timeout })
+  }
+
+  undo(id: string) {
+    const entry = this.pending.get(id)
+    if (!entry) {
+      return null
+    }
+
+    clearTimeout(entry.timeout)
+    this.pending.delete(id)
+    return entry.record
+  }
+
+  cancel(id: string) {
+    const entry = this.pending.get(id)
+    if (!entry) {
+      return
+    }
+
+    clearTimeout(entry.timeout)
+    this.pending.delete(id)
+  }
+
+  dispose() {
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timeout)
+    }
+    this.pending.clear()
+  }
+}

--- a/supabase/migrations/20250309_dashboard_undo.sql
+++ b/supabase/migrations/20250309_dashboard_undo.sql
@@ -1,0 +1,27 @@
+create table if not exists public.dashboard_members (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  role text not null check (role in ('admin', 'user')),
+  status text not null check (status in ('active', 'resigned')),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.dashboard_todos (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  created_by text not null,
+  completed boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.deletion_events (
+  id uuid primary key default gen_random_uuid(),
+  entity text not null,
+  record_id text not null,
+  payload jsonb not null,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists deletion_events_entity_idx on public.deletion_events(entity, record_id);
+create index if not exists deletion_events_expires_at_idx on public.deletion_events(expires_at);

--- a/tests/undo-queue.test.ts
+++ b/tests/undo-queue.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { UndoQueue } from "@/lib/undo-queue"
+
+describe("undo queue", () => {
+  it("restores the record when undo is triggered before the timer expires", () => {
+    vi.useFakeTimers()
+
+    const queue = new UndoQueue<{ id: string; name: string }>(30_000)
+    const initial = [
+      { id: "member-1", name: "Alice" },
+      { id: "member-2", name: "Bob" },
+    ]
+
+    let optimisticState = [...initial]
+    const target = initial[0]
+
+    optimisticState = optimisticState.filter((item) => item.id !== target.id)
+    expect(optimisticState).not.toContainEqual(target)
+
+    queue.enqueue(target)
+    vi.advanceTimersByTime(15_000)
+
+    const restored = queue.undo(target.id)
+    expect(restored).toEqual(target)
+
+    if (restored) {
+      optimisticState = [restored, ...optimisticState]
+    }
+
+    expect(optimisticState).toContainEqual(target)
+
+    queue.dispose()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- implement Supabase-backed delete and restore server actions for members and todos while logging `deletion_events`
- wrap dashboard lists in optimistic client experiences with Undo toasts powered by a shared undo queue utility
- add database tables, fallbacks, and Vitest coverage to guarantee undo timers restore records when cancellation occurs

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b6bf0888328a430c3bb0c14ffa4