### PR TITLE
feat(documents): sync filters with URL and saved views

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -5,7 +5,12 @@ import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
-import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import {
+  fetchDocumentStats,
+  fetchDocumentsList,
+  saveDocumentView,
+  type SavedDocumentView,
+} from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import {
@@ -43,6 +48,11 @@ const documentListFiltersSchema = z.object({
   unit_id: z.string().optional(),
   date_from: z.string().datetime().optional(),
   date_to: z.string().datetime().optional(),
+});
+
+const saveViewSchema = z.object({
+  name: z.string().min(1).max(80),
+  filters: documentListFiltersSchema.default({}),
 });
 
 // Action result interface
@@ -210,6 +220,43 @@ export async function uploadDocumentAction(
       success: false,
       error: error instanceof Error ? error.message : 'An unexpected error occurred.'
     };
+  }
+}
+
+export async function saveDocumentViewAction(
+  input: z.infer<typeof saveViewSchema>
+): Promise<ActionResult<SavedDocumentView>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  const validation = saveViewSchema.safeParse(input);
+  if (!validation.success) {
+    const message = validation.error.errors.map(error => error.message).join('. ');
+    return { success: false, error: message || 'Invalid saved view payload.' };
+  }
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to save views.' };
+    }
+
+    const savedView = await saveDocumentView({
+      client: typedSupabase,
+      userId: user.id,
+      name: validation.data.name,
+      filters: validation.data.filters,
+    });
+
+    return {
+      success: true,
+      data: savedView,
+      message: 'View saved successfully.',
+    };
+  } catch (error) {
+    console.error('Error saving document view:', error);
+    return { success: false, error: 'Failed to save view.' };
   }
 }
 

--- a/app/documents/components/documents-filters.tsx
+++ b/app/documents/components/documents-filters.tsx
@@ -1,87 +1,285 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuCheckboxItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
 import { DocumentListFilters, DocumentStatus, DocumentType } from '@/types/documents';
-import { Filter, X } from 'lucide-react';
+import { Filter, Save, Share2, X } from 'lucide-react';
+import {
+  areDocumentFiltersEqual,
+  documentFiltersToSearchParams,
+  isDocumentFilterEmpty,
+  normalizeDocumentFilters,
+  parseDocumentFiltersFromSearchParams,
+} from '@/lib/document-filter-params';
+import { useCopyToClipboard } from '@/lib/hooks/use-copy-to-clipboard';
+import { saveDocumentViewAction } from '../actions';
+
+type SavedViewState = {
+  slug: string;
+  filters: DocumentListFilters;
+  name?: string;
+};
 
 interface DocumentsFiltersProps {
   onFiltersChange?: (filters: DocumentListFilters) => void;
+  initialFilters?: DocumentListFilters;
+  initialSavedView?: SavedViewState | null;
 }
 
-export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
-  const [filters, setFilters] = useState<DocumentListFilters>({});
+export function DocumentsFilters({
+  onFiltersChange,
+  initialFilters,
+  initialSavedView,
+}: DocumentsFiltersProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const [isPending, startTransition] = useTransition();
+  const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 1500 });
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const statusOptions: { value: DocumentStatus; label: string }[] = [
-    { value: 'draft', label: 'Draft' },
-    { value: 'pending_signature', label: 'Pending Signature' },
-    { value: 'signed', label: 'Signed' },
-    { value: 'expired', label: 'Expired' },
-    { value: 'cancelled', label: 'Cancelled' },
-  ];
+  const [savedViews, setSavedViews] = useState<Record<string, SavedViewState>>(() => {
+    if (initialSavedView?.slug) {
+      return {
+        [initialSavedView.slug]: {
+          ...initialSavedView,
+          filters: normalizeDocumentFilters(initialSavedView.filters),
+        },
+      };
+    }
+    return {};
+  });
 
-  const typeOptions: { value: DocumentType; label: string }[] = [
-    { value: 'lease', label: 'Lease' },
-    { value: 'addendum', label: 'Addendum' },
-    { value: 'insurance', label: 'Insurance' },
-    { value: 'maintenance', label: 'Maintenance' },
-    { value: 'other', label: 'Other' },
-  ];
+  const [filters, setFilters] = useState<DocumentListFilters>(() => {
+    const fromParams = parseDocumentFiltersFromSearchParams(searchParams);
+    if (!isDocumentFilterEmpty(fromParams)) {
+      return fromParams;
+    }
+    if (initialFilters && !isDocumentFilterEmpty(initialFilters)) {
+      return normalizeDocumentFilters(initialFilters);
+    }
+    return {};
+  });
 
-  const updateFilters = (newFilters: DocumentListFilters) => {
-    setFilters(newFilters);
-    onFiltersChange?.(newFilters);
-  };
+  useEffect(() => {
+    if (initialSavedView?.slug) {
+      setSavedViews(prev => {
+        if (prev[initialSavedView.slug]) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [initialSavedView.slug]: {
+            ...initialSavedView,
+            filters: normalizeDocumentFilters(initialSavedView.filters),
+          },
+        };
+      });
+    }
+  }, [initialSavedView]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParamsString);
+    const slug = params.get('view') ?? undefined;
+    const paramsFilters = parseDocumentFiltersFromSearchParams(params);
+
+    if (slug && isDocumentFilterEmpty(paramsFilters)) {
+      const cached = slug ? savedViews[slug] : undefined;
+      if (cached && !areDocumentFiltersEqual(filters, cached.filters)) {
+        setFilters(cached.filters);
+        onFiltersChange?.(cached.filters);
+      }
+      return;
+    }
+
+    if (!areDocumentFiltersEqual(filters, paramsFilters)) {
+      setFilters(paramsFilters);
+      onFiltersChange?.(paramsFilters);
+    }
+  }, [filters, onFiltersChange, savedViews, searchParamsString]);
+
+  const updateUrl = useCallback(
+    (nextFilters: DocumentListFilters, options?: { viewSlug?: string }) => {
+      const params = documentFiltersToSearchParams(
+        nextFilters,
+        new URLSearchParams(searchParamsString)
+      );
+      if (options?.viewSlug) {
+        params.set('view', options.viewSlug);
+      } else {
+        params.delete('view');
+      }
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    },
+    [pathname, router, searchParamsString]
+  );
+
+  const applyFilters = useCallback(
+    (next: DocumentListFilters, options?: { viewSlug?: string }) => {
+      const normalized = normalizeDocumentFilters(next);
+      setFilters(normalized);
+      onFiltersChange?.(normalized);
+      setMessage(null);
+      setError(null);
+      updateUrl(normalized, { viewSlug: options?.viewSlug });
+    },
+    [onFiltersChange, updateUrl]
+  );
+
+  const statusOptions: { value: DocumentStatus; label: string }[] = useMemo(
+    () => [
+      { value: 'draft', label: 'Draft' },
+      { value: 'pending_signature', label: 'Pending Signature' },
+      { value: 'signed', label: 'Signed' },
+      { value: 'expired', label: 'Expired' },
+      { value: 'cancelled', label: 'Cancelled' },
+    ],
+    []
+  );
+
+  const typeOptions: { value: DocumentType; label: string }[] = useMemo(
+    () => [
+      { value: 'lease', label: 'Lease' },
+      { value: 'addendum', label: 'Addendum' },
+      { value: 'insurance', label: 'Insurance' },
+      { value: 'maintenance', label: 'Maintenance' },
+      { value: 'other', label: 'Other' },
+    ],
+    []
+  );
 
   const toggleStatusFilter = (status: DocumentStatus, checked: boolean) => {
-    const currentStatuses = filters.status || [];
-    const newStatuses = checked
-      ? [...currentStatuses, status]
-      : currentStatuses.filter(s => s !== status);
+    const current = filters.status ?? [];
+    const nextStatuses = checked
+      ? Array.from(new Set([...current, status]))
+      : current.filter(s => s !== status);
 
-    updateFilters({
+    const nextFilters = {
       ...filters,
-      status: newStatuses.length > 0 ? newStatuses : undefined,
-    });
+      status: nextStatuses.length ? nextStatuses : undefined,
+    };
+
+    applyFilters(nextFilters);
   };
 
   const toggleTypeFilter = (type: DocumentType, checked: boolean) => {
-    const currentTypes = filters.type || [];
-    const newTypes = checked
-      ? [...currentTypes, type]
-      : currentTypes.filter(t => t !== type);
+    const current = filters.type ?? [];
+    const nextTypes = checked
+      ? Array.from(new Set([...current, type]))
+      : current.filter(t => t !== type);
 
-    updateFilters({
+    const nextFilters = {
       ...filters,
-      type: newTypes.length > 0 ? newTypes : undefined,
-    });
+      type: nextTypes.length ? nextTypes : undefined,
+    };
+
+    applyFilters(nextFilters);
   };
 
   const clearFilters = () => {
-    setFilters({});
-    onFiltersChange?.({});
+    applyFilters({});
+  };
+
+  const handleShare = () => {
+    const params = documentFiltersToSearchParams(filters);
+    const viewSlug = searchParams.get('view');
+
+    if (viewSlug) {
+      params.set('view', viewSlug);
+    } else {
+      const matchingSavedView = Object.values(savedViews).find(savedView =>
+        areDocumentFiltersEqual(savedView.filters, filters)
+      );
+      if (matchingSavedView) {
+        params.set('view', matchingSavedView.slug);
+      }
+    }
+
+    const query = params.toString();
+    const base = typeof window !== 'undefined' ? window.location.origin : '';
+    const url = `${base}${pathname}${query ? `?${query}` : ''}`;
+
+    copyToClipboard(url);
+    setMessage('Link copied to clipboard.');
+    setError(null);
+  };
+
+  const handleSaveView = () => {
+    if (isDocumentFilterEmpty(filters)) {
+      setError('Add at least one filter before saving a view.');
+      setMessage(null);
+      return;
+    }
+
+    const suggestedName = searchParams.get('view') && savedViews[searchParams.get('view') ?? '']
+      ? savedViews[searchParams.get('view') ?? ''].name
+      : undefined;
+    const name = window.prompt('Name this view', suggestedName ?? '');
+    if (!name) {
+      return;
+    }
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError('Name cannot be empty.');
+      setMessage(null);
+      return;
+    }
+
+    setError(null);
+    setMessage(null);
+
+    startTransition(async () => {
+      const result = await saveDocumentViewAction({
+        name: trimmedName,
+        filters,
+      });
+
+      if (!result.success || !result.data) {
+        setError(result.error ?? 'Failed to save view.');
+        return;
+      }
+
+      const normalizedFilters = normalizeDocumentFilters(result.data.filters);
+      setSavedViews(prev => ({
+        ...prev,
+        [result.data.slug]: {
+          slug: result.data.slug,
+          name: result.data.name,
+          filters: normalizedFilters,
+        },
+      }));
+
+      applyFilters(normalizedFilters, { viewSlug: result.data.slug });
+      setMessage(`Saved view “${result.data.name}”.`);
+    });
   };
 
   const activeFilterCount =
-    (filters.status?.length || 0) +
-    (filters.type?.length || 0) +
+    (filters.status?.length ?? 0) +
+    (filters.type?.length ?? 0) +
     (filters.tenant_id ? 1 : 0) +
     (filters.unit_id ? 1 : 0) +
     (filters.date_from ? 1 : 0) +
     (filters.date_to ? 1 : 0);
 
+  const copied = Boolean(isCopied);
+
   return (
-    <div className="flex items-center space-x-2">
-      {/* Status Filter */}
+    <div className="flex flex-wrap items-center gap-2">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" size="sm">
@@ -97,11 +295,11 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
         <DropdownMenuContent align="end" className="w-48">
           <DropdownMenuLabel>Filter by Status</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {statusOptions.map((option) => (
+          {statusOptions.map(option => (
             <DropdownMenuCheckboxItem
               key={option.value}
-              checked={filters.status?.includes(option.value) || false}
-              onCheckedChange={(checked) => toggleStatusFilter(option.value, checked)}
+              checked={filters.status?.includes(option.value) ?? false}
+              onCheckedChange={checked => toggleStatusFilter(option.value, checked)}
             >
               {option.label}
             </DropdownMenuCheckboxItem>
@@ -109,7 +307,6 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Type Filter */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" size="sm">
@@ -124,11 +321,11 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
         <DropdownMenuContent align="end" className="w-48">
           <DropdownMenuLabel>Filter by Type</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {typeOptions.map((option) => (
+          {typeOptions.map(option => (
             <DropdownMenuCheckboxItem
               key={option.value}
-              checked={filters.type?.includes(option.value) || false}
-              onCheckedChange={(checked) => toggleTypeFilter(option.value, checked)}
+              checked={filters.type?.includes(option.value) ?? false}
+              onCheckedChange={checked => toggleTypeFilter(option.value, checked)}
             >
               {option.label}
             </DropdownMenuCheckboxItem>
@@ -136,7 +333,6 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Clear Filters */}
       {activeFilterCount > 0 && (
         <Button
           variant="ghost"
@@ -147,6 +343,35 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
           <X className="mr-2 size-4" />
           Clear ({activeFilterCount})
         </Button>
+      )}
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleShare}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <Share2 className="mr-2 size-4" />
+        {copied ? 'Copied' : 'Share'}
+      </Button>
+
+      <Button
+        size="sm"
+        onClick={handleSaveView}
+        disabled={isPending || isDocumentFilterEmpty(filters)}
+      >
+        <Save className="mr-2 size-4" />
+        {isPending ? 'Saving…' : 'Save view'}
+      </Button>
+
+      {(message || error) && (
+        <p
+          className={`w-full text-xs ${
+            error ? 'text-destructive' : 'text-muted-foreground'
+          }`}
+        >
+          {error ?? message}
+        </p>
       )}
     </div>
   );

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import { cookies } from 'next/headers';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { FileText, Users, Clock, Upload } from 'lucide-react';
@@ -8,8 +9,64 @@ import { DocumentsStats } from "./components/documents-stats";
 import { DocumentsList } from "./components/documents-list";
 import { DocumentsFilters } from "./components/documents-filters";
 import { DocumentListFilters } from '@/types/documents';
+import {
+  parseDocumentFiltersFromSearchParams,
+  normalizeDocumentFilters,
+  isDocumentFilterEmpty,
+} from '@/lib/document-filter-params';
+import { fetchSavedDocumentViewBySlug } from '@/lib/data/documents';
+import createSupabaseServer from '@/utils/supabase-server';
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 
-export default function DocumentsPage() {
+export const dynamic = 'force-dynamic';
+
+type DocumentsPageSearchParams = Record<string, string | string[] | undefined>;
+
+interface DocumentsPageProps {
+  searchParams?: DocumentsPageSearchParams;
+}
+
+function toViewSlug(value: string | string[] | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function mergeFilters(
+  urlFilters: DocumentListFilters,
+  savedViewFilters: DocumentListFilters | undefined
+): DocumentListFilters {
+  if (savedViewFilters && isDocumentFilterEmpty(urlFilters)) {
+    return normalizeDocumentFilters(savedViewFilters);
+  }
+
+  return normalizeDocumentFilters(urlFilters);
+}
+
+export default async function DocumentsPage({ searchParams = {} }: DocumentsPageProps) {
+  const filtersFromParams = parseDocumentFiltersFromSearchParams(searchParams);
+  const viewSlug = toViewSlug(searchParams.view);
+
+  let initialSavedView: Awaited<ReturnType<typeof fetchSavedDocumentViewBySlug>> = null;
+
+  if (viewSlug) {
+    try {
+      const cookieStore = cookies();
+      const supabase = createSupabaseServer(cookieStore);
+      const typedSupabase = supabase as unknown as TypedSupabaseClient;
+      initialSavedView = await fetchSavedDocumentViewBySlug({
+        client: typedSupabase,
+        slug: viewSlug,
+      });
+    } catch (error) {
+      console.error('Failed to load saved document view:', error);
+    }
+  }
+
+  const effectiveFilters = mergeFilters(filtersFromParams, initialSavedView?.filters);
+
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
@@ -26,36 +83,45 @@ export default function DocumentsPage() {
       </header>
 
       {/* Stats Overview */}
-      <Suspense fallback={<div className="grid gap-4 md:grid-cols-4">
-        {[...Array(4)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader className="pb-2">
-              <div className="h-4 w-3/4 rounded bg-muted"></div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-8 w-1/2 rounded bg-muted"></div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>}>
+      <Suspense
+        fallback={<div className="grid gap-4 md:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <Card key={i} className="animate-pulse">
+              <CardHeader className="pb-2">
+                <div className="h-4 w-3/4 rounded bg-muted"></div>
+              </CardHeader>
+              <CardContent>
+                <div className="h-8 w-1/2 rounded bg-muted"></div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>}
+      >
         <DocumentsStats />
       </Suspense>
 
       {/* Main Content Tabs */}
       <Tabs defaultValue="all" className="space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-4">
           <TabsList className="grid w-full max-w-md grid-cols-4">
             <TabsTrigger value="all">All</TabsTrigger>
             <TabsTrigger value="leases">Leases</TabsTrigger>
             <TabsTrigger value="pending">Pending</TabsTrigger>
             <TabsTrigger value="signed">Signed</TabsTrigger>
           </TabsList>
-          <DocumentsFilters />
+          <DocumentsFilters
+            initialFilters={effectiveFilters}
+            initialSavedView={initialSavedView ? {
+              slug: initialSavedView.slug,
+              name: initialSavedView.name,
+              filters: initialSavedView.filters,
+            } : null}
+          />
         </div>
 
         <TabsContent value="all" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{}} />
+            <DocumentsList filter={effectiveFilters} />
           </Suspense>
         </TabsContent>
 

--- a/lib/data/documents.ts
+++ b/lib/data/documents.ts
@@ -1,10 +1,16 @@
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import type { DocumentListFilters, DocumentStats, DocumentWithLease } from '@/types/documents';
 import type { Database } from '@/lib/supabase';
+import {
+  normalizeDocumentFilters,
+  isDocumentFilterEmpty,
+} from '@/lib/document-filter-params';
 
 type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
 
 type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
+
+type SavedViewRow = Database['public']['Tables']['saved_views']['Row'];
 
 type FetchDocumentsParams = {
   client: SupabaseClientLike;
@@ -100,4 +106,127 @@ export async function fetchDocumentStats({
     expired_documents: documents.filter(d => d.status === 'expired').length,
     draft_documents: documents.filter(d => d.status === 'draft').length,
   };
+}
+
+export interface SavedDocumentView {
+  id: string;
+  slug: string;
+  name: string;
+  resource: string;
+  created_by: string;
+  created_at: string | null;
+  filters: DocumentListFilters;
+}
+
+function mapSavedViewRow(row: SavedViewRow): SavedDocumentView {
+  const rawFilters = (row.filters ?? {}) as DocumentListFilters | Record<string, unknown>;
+  const normalizedFilters = normalizeDocumentFilters(rawFilters as DocumentListFilters);
+
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    resource: row.resource,
+    created_by: row.created_by,
+    created_at: row.created_at,
+    filters: normalizedFilters,
+  };
+}
+
+function slugifyName(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function generateSavedViewSlug(name: string): string {
+  const base = slugifyName(name) || 'view';
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return `${base}-${suffix}`;
+}
+
+function serializeFilters(filters: DocumentListFilters) {
+  const normalized = normalizeDocumentFilters(filters);
+  if (isDocumentFilterEmpty(normalized)) {
+    return {};
+  }
+
+  return JSON.parse(JSON.stringify(normalized));
+}
+
+interface FetchSavedDocumentViewBySlugParams {
+  client: SupabaseClientLike;
+  slug: string;
+}
+
+export async function fetchSavedDocumentViewBySlug({
+  client,
+  slug,
+}: FetchSavedDocumentViewBySlugParams): Promise<SavedDocumentView | null> {
+  const { data, error } = await (client as any)
+    .from('saved_views')
+    .select('id, slug, name, resource, created_by, created_at, filters')
+    .eq('slug', slug)
+    .eq('resource', 'documents')
+    .maybeSingle();
+
+  handlePostgrestError(error, 'Failed to load saved view');
+
+  if (!data) {
+    return null;
+  }
+
+  return mapSavedViewRow(data as SavedViewRow);
+}
+
+interface SaveDocumentViewParams {
+  client: SupabaseClientLike;
+  userId: string;
+  name: string;
+  filters: DocumentListFilters;
+}
+
+export async function saveDocumentView({
+  client,
+  userId,
+  name,
+  filters,
+}: SaveDocumentViewParams): Promise<SavedDocumentView> {
+  const payloadFilters = serializeFilters(filters);
+
+  let attempt = 0;
+  while (attempt < 3) {
+    const slug = generateSavedViewSlug(name);
+
+    const { data, error } = await (client as any)
+      .from('saved_views')
+      .insert({
+        slug,
+        name,
+        resource: 'documents',
+        created_by: userId,
+        filters: payloadFilters,
+      })
+      .select('id, slug, name, resource, created_by, created_at, filters')
+      .single();
+
+    if (error) {
+      const isDuplicate = typeof error.message === 'string' && error.message.toLowerCase().includes('duplicate key');
+      if (isDuplicate) {
+        attempt += 1;
+        continue;
+      }
+      handlePostgrestError(error, 'Failed to save document view');
+    }
+
+    if (!data) {
+      throw new Error('Failed to save document view');
+    }
+
+    return mapSavedViewRow(data as SavedViewRow);
+  }
+
+  throw new Error('Failed to save document view: could not generate unique slug');
 }

--- a/lib/document-filter-params.ts
+++ b/lib/document-filter-params.ts
@@ -1,0 +1,238 @@
+import { DocumentListFilters, DocumentStatus, DocumentType } from '@/types/documents';
+
+const STATUS_VALUES: readonly DocumentStatus[] = [
+  'draft',
+  'pending_signature',
+  'signed',
+  'expired',
+  'cancelled',
+];
+
+const TYPE_VALUES: readonly DocumentType[] = [
+  'lease',
+  'addendum',
+  'insurance',
+  'maintenance',
+  'other',
+];
+
+type SearchParamValue = string | string[] | undefined;
+type SearchParamsInput = URLSearchParams | { [key: string]: SearchParamValue };
+
+type SavedFilterKeys = keyof DocumentListFilters;
+
+const FILTER_KEYS: SavedFilterKeys[] = [
+  'status',
+  'type',
+  'tenant_id',
+  'unit_id',
+  'date_from',
+  'date_to',
+];
+
+function toArray(value: SearchParamValue): string[] {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((entry) => entry.split(','))
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  }
+
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function getAllValues(params: SearchParamsInput, key: string): string[] {
+  if (params instanceof URLSearchParams) {
+    const values = params.getAll(key);
+    if (values.length === 0) {
+      const single = params.get(key);
+      return toArray(single ?? undefined);
+    }
+    return toArray(values as string[]);
+  }
+
+  return toArray(params[key]);
+}
+
+function sanitizeArray<T extends string>(values: string[], allowed: readonly T[]): T[] {
+  const allowedSet = new Set(allowed);
+  return Array.from(
+    new Set(
+      values.filter((value): value is T => allowedSet.has(value as T))
+    )
+  );
+}
+
+function sanitizeFilters(filters: DocumentListFilters): DocumentListFilters {
+  const sanitized: DocumentListFilters = {};
+
+  if (filters.status?.length) {
+    const values = sanitizeArray(filters.status, STATUS_VALUES);
+    if (values.length) {
+      sanitized.status = values;
+    }
+  }
+
+  if (filters.type?.length) {
+    const values = sanitizeArray(filters.type, TYPE_VALUES);
+    if (values.length) {
+      sanitized.type = values;
+    }
+  }
+
+  if (filters.tenant_id) {
+    sanitized.tenant_id = filters.tenant_id;
+  }
+
+  if (filters.unit_id) {
+    sanitized.unit_id = filters.unit_id;
+  }
+
+  if (filters.date_from) {
+    sanitized.date_from = filters.date_from;
+  }
+
+  if (filters.date_to) {
+    sanitized.date_to = filters.date_to;
+  }
+
+  return sanitized;
+}
+
+export function parseDocumentFiltersFromSearchParams(
+  params: SearchParamsInput
+): DocumentListFilters {
+  const filters: DocumentListFilters = {};
+
+  const status = sanitizeArray(getAllValues(params, 'status'), STATUS_VALUES);
+  if (status.length > 0) {
+    filters.status = status;
+  }
+
+  const types = sanitizeArray(getAllValues(params, 'type'), TYPE_VALUES);
+  if (types.length > 0) {
+    filters.type = types;
+  }
+
+  const tenantId = getAllValues(params, 'tenant_id')[0];
+  if (tenantId) {
+    filters.tenant_id = tenantId;
+  }
+
+  const unitId = getAllValues(params, 'unit_id')[0];
+  if (unitId) {
+    filters.unit_id = unitId;
+  }
+
+  const dateFrom = getAllValues(params, 'date_from')[0];
+  if (dateFrom) {
+    filters.date_from = dateFrom;
+  }
+
+  const dateTo = getAllValues(params, 'date_to')[0];
+  if (dateTo) {
+    filters.date_to = dateTo;
+  }
+
+  return normalizeDocumentFilters(filters);
+}
+
+export function normalizeDocumentFilters(
+  filters: DocumentListFilters
+): DocumentListFilters {
+  const sanitized = sanitizeFilters(filters);
+  const normalized: DocumentListFilters = {};
+
+  if (sanitized.status?.length) {
+    normalized.status = [...sanitized.status].sort();
+  }
+
+  if (sanitized.type?.length) {
+    normalized.type = [...sanitized.type].sort();
+  }
+
+  if (sanitized.tenant_id) {
+    normalized.tenant_id = sanitized.tenant_id;
+  }
+
+  if (sanitized.unit_id) {
+    normalized.unit_id = sanitized.unit_id;
+  }
+
+  if (sanitized.date_from) {
+    normalized.date_from = sanitized.date_from;
+  }
+
+  if (sanitized.date_to) {
+    normalized.date_to = sanitized.date_to;
+  }
+
+  return normalized;
+}
+
+export function documentFiltersToSearchParams(
+  filters: DocumentListFilters,
+  base?: URLSearchParams
+): URLSearchParams {
+  const params = base ? new URLSearchParams(base.toString()) : new URLSearchParams();
+
+  for (const key of FILTER_KEYS) {
+    params.delete(key);
+  }
+
+  const normalized = normalizeDocumentFilters(filters);
+
+  normalized.status?.forEach((value) => {
+    params.append('status', value);
+  });
+
+  normalized.type?.forEach((value) => {
+    params.append('type', value);
+  });
+
+  if (normalized.tenant_id) {
+    params.set('tenant_id', normalized.tenant_id);
+  }
+
+  if (normalized.unit_id) {
+    params.set('unit_id', normalized.unit_id);
+  }
+
+  if (normalized.date_from) {
+    params.set('date_from', normalized.date_from);
+  }
+
+  if (normalized.date_to) {
+    params.set('date_to', normalized.date_to);
+  }
+
+  return params;
+}
+
+export function isDocumentFilterEmpty(filters: DocumentListFilters): boolean {
+  const normalized = normalizeDocumentFilters(filters);
+  return (
+    !normalized.status?.length &&
+    !normalized.type?.length &&
+    !normalized.tenant_id &&
+    !normalized.unit_id &&
+    !normalized.date_from &&
+    !normalized.date_to
+  );
+}
+
+export function areDocumentFiltersEqual(
+  first: DocumentListFilters,
+  second: DocumentListFilters
+): boolean {
+  const normalizedFirst = normalizeDocumentFilters(first);
+  const normalizedSecond = normalizeDocumentFilters(second);
+  return JSON.stringify(normalizedFirst) === JSON.stringify(normalizedSecond);
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -95,6 +95,16 @@ export type Database = {
         user_agent: string | null
         metadata: Json | null
       }>
+      saved_views: SupabaseTable<{
+        id: string
+        slug: string
+        name: string
+        resource: string
+        filters: Json | null
+        created_by: string
+        created_at: string | null
+        updated_at: string | null
+      }>
       leases: SupabaseTable<{
         id: string
         document_id: string

--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import {
+  fetchDocumentStats,
+  fetchDocumentsList,
+  fetchSavedDocumentViewBySlug,
+  saveDocumentView,
+} from '@/lib/data/documents';
 import type { DocumentListFilters } from '@/types/documents';
 
 type QueryResult<T> = { data: T; error: { message: string } | null };
@@ -47,6 +52,50 @@ function createSupabaseStub<T extends unknown[]>(query: QueryBuilder<T>) {
       return query;
     }),
   };
+}
+
+type SavedViewQueryResult<T> = { data: T; error: { message: string } | null };
+
+function createSavedViewSelectQuery<T>(result: SavedViewQueryResult<T>) {
+  const builder = {
+    select: vi.fn().mockImplementation(() => builder),
+    eq: vi.fn().mockImplementation(() => builder),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  } as const;
+
+  return builder;
+}
+
+function createSavedViewSelectClient<T>(result: SavedViewQueryResult<T>) {
+  const query = createSavedViewSelectQuery(result);
+  const supabase = {
+    from: vi.fn((table: string) => {
+      expect(table).toBe('saved_views');
+      return query;
+    }),
+  };
+
+  return { supabase, query };
+}
+
+function createSavedViewInsertClient(
+  responses: SavedViewQueryResult<unknown>[]
+) {
+  const queue = [...responses];
+  const builder = {
+    insert: vi.fn().mockImplementation(() => builder),
+    select: vi.fn().mockImplementation(() => builder),
+    single: vi.fn().mockImplementation(() => Promise.resolve(queue.shift()!)),
+  } as const;
+
+  const supabase = {
+    from: vi.fn((table: string) => {
+      expect(table).toBe('saved_views');
+      return builder;
+    }),
+  };
+
+  return { supabase, builder };
 }
 
 describe('fetchDocumentsList', () => {
@@ -147,5 +196,149 @@ describe('fetchDocumentStats', () => {
     await expect(
       fetchDocumentStats({ client: supabase, userId: 'user-1', role: 'tenant' })
     ).rejects.toThrow(/Failed to fetch document statistics: stats failed/);
+  });
+});
+
+describe('saved view helpers', () => {
+  it('fetchSavedDocumentViewBySlug returns normalized saved view data', async () => {
+    const { supabase, query } = createSavedViewSelectClient({
+      data: {
+        id: 'view-1',
+        slug: 'signed-leases',
+        name: 'Signed leases',
+        resource: 'documents',
+        created_by: 'user-1',
+        created_at: '2024-01-01',
+        filters: { status: ['signed', 'draft'], type: ['lease'] },
+      },
+      error: null,
+    });
+
+    const savedView = await fetchSavedDocumentViewBySlug({
+      client: supabase as any,
+      slug: 'signed-leases',
+    });
+
+    expect(query.eq).toHaveBeenNthCalledWith(1, 'slug', 'signed-leases');
+    expect(query.eq).toHaveBeenNthCalledWith(2, 'resource', 'documents');
+    expect(savedView).toEqual({
+      id: 'view-1',
+      slug: 'signed-leases',
+      name: 'Signed leases',
+      resource: 'documents',
+      created_by: 'user-1',
+      created_at: '2024-01-01',
+      filters: { status: ['draft', 'signed'], type: ['lease'] },
+    });
+  });
+
+  it('returns null when the saved view is not found', async () => {
+    const { supabase } = createSavedViewSelectClient({ data: null, error: null });
+
+    const result = await fetchSavedDocumentViewBySlug({
+      client: supabase as any,
+      slug: 'missing-view',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('throws when fetching a saved view fails', async () => {
+    const { supabase } = createSavedViewSelectClient({
+      data: null,
+      error: { message: 'boom' },
+    });
+
+    await expect(
+      fetchSavedDocumentViewBySlug({ client: supabase as any, slug: 'broken' })
+    ).rejects.toThrow(/Failed to load saved view: boom/);
+  });
+
+  it('saveDocumentView persists normalized filters and returns the saved view', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.123456);
+    try {
+      const { supabase, builder } = createSavedViewInsertClient([
+        {
+          data: {
+            id: 'view-42',
+            slug: 'important-abc123',
+            name: 'Important docs',
+            resource: 'documents',
+            created_by: 'user-99',
+            created_at: '2024-02-01',
+            filters: { status: ['signed'], type: ['lease'], unit_id: 'unit-9' },
+          },
+          error: null,
+        },
+      ]);
+
+      const result = await saveDocumentView({
+        client: supabase as any,
+        userId: 'user-99',
+        name: 'Important docs',
+        filters: {
+          status: ['signed', 'signed'],
+          type: ['lease'],
+          unit_id: 'unit-9',
+          tenant_id: undefined,
+        } as DocumentListFilters,
+      });
+
+      expect(builder.insert).toHaveBeenCalledWith(expect.objectContaining({
+        slug: expect.stringMatching(/^important-docs-/),
+        name: 'Important docs',
+        resource: 'documents',
+        created_by: 'user-99',
+        filters: { status: ['signed'], type: ['lease'], unit_id: 'unit-9' },
+      }));
+      expect(result).toEqual({
+        id: 'view-42',
+        slug: 'important-abc123',
+        name: 'Important docs',
+        resource: 'documents',
+        created_by: 'user-99',
+        created_at: '2024-02-01',
+        filters: { status: ['signed'], type: ['lease'], unit_id: 'unit-9' },
+      });
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it('retries slug generation when a duplicate is detected', async () => {
+    const randomSpy = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.1)
+      .mockReturnValueOnce(0.2);
+
+    try {
+      const { supabase, builder } = createSavedViewInsertClient([
+        { data: null, error: { message: 'duplicate key value violates unique constraint' } },
+        {
+          data: {
+            id: 'view-77',
+            slug: 'custom-slug',
+            name: 'My filters',
+            resource: 'documents',
+            created_by: 'user-77',
+            created_at: '2024-03-03',
+            filters: {},
+          },
+          error: null,
+        },
+      ]);
+
+      const result = await saveDocumentView({
+        client: supabase as any,
+        userId: 'user-77',
+        name: 'My filters',
+        filters: {},
+      });
+
+      expect(builder.insert).toHaveBeenCalledTimes(2);
+      expect(result.slug).toBe('custom-slug');
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 });

--- a/tests/lib/document-filter-params.test.ts
+++ b/tests/lib/document-filter-params.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  documentFiltersToSearchParams,
+  parseDocumentFiltersFromSearchParams,
+  normalizeDocumentFilters,
+  isDocumentFilterEmpty,
+  areDocumentFiltersEqual,
+} from '@/lib/document-filter-params';
+import type { DocumentListFilters } from '@/types/documents';
+
+describe('document filter URL helpers', () => {
+  it('round-trips filters through URL parameters for bookmarking', () => {
+    const filters: DocumentListFilters = {
+      status: ['signed', 'draft'],
+      type: ['lease'],
+      tenant_id: 'tenant-1',
+      unit_id: 'unit-2',
+      date_from: '2024-01-01',
+      date_to: '2024-02-01',
+    };
+
+    const params = documentFiltersToSearchParams(filters);
+    expect(params.getAll('status')).toEqual(['draft', 'signed']);
+    expect(params.getAll('type')).toEqual(['lease']);
+    expect(params.get('tenant_id')).toBe('tenant-1');
+    expect(params.get('unit_id')).toBe('unit-2');
+
+    const parsed = parseDocumentFiltersFromSearchParams(params);
+    const normalized = normalizeDocumentFilters(filters);
+
+    expect(parsed).toEqual(normalized);
+    expect(areDocumentFiltersEqual(parsed, filters)).toBe(true);
+  });
+
+  it('parses values provided as strings or arrays from server search params', () => {
+    const parsed = parseDocumentFiltersFromSearchParams({
+      status: 'signed,draft',
+      type: ['maintenance', 'lease'],
+      tenant_id: 'tenant-2',
+      date_from: '2024-03-01',
+      date_to: '2024-03-31',
+    });
+
+    expect(parsed).toEqual({
+      status: ['draft', 'signed'],
+      type: ['lease', 'maintenance'],
+      tenant_id: 'tenant-2',
+      date_from: '2024-03-01',
+      date_to: '2024-03-31',
+    });
+  });
+
+  it('detects empty filter sets and avoids serializing noise', () => {
+    const filters: DocumentListFilters = {
+      status: [],
+      type: undefined,
+      tenant_id: undefined,
+    };
+
+    expect(isDocumentFilterEmpty(filters)).toBe(true);
+    const params = documentFiltersToSearchParams(filters);
+    expect(params.toString()).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- synchronize document filters with search params, add share/save view actions, and hydrate state from saved view slugs
- add Supabase saved view helpers and typed schema plus URL filter parsing utilities
- expand documents tests to cover saved view persistence and filter URL round-tripping

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b6f95608328a729fe06a2593055