### PR TITLE
Add indexed search service and UI integration

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,195 @@
+import { NextResponse } from "next/server"
+import { performance } from "node:perf_hooks"
+
+import { searchPortal, type SearchRequest } from "@/lib/search/client"
+
+type SearchPayload = {
+  query?: string
+  scope?: string
+  filters?: Record<string, string | string[]>
+  limit?: number
+  typoTolerance?: "min" | "strict" | "false"
+}
+
+const normalizeFilters = (
+  filters: SearchPayload["filters"]
+): Record<string, string[]> => {
+  if (!filters) {
+    return {}
+  }
+
+  return Object.entries(filters).reduce<Record<string, string[]>>(
+    (acc, [key, value]) => {
+      if (value === undefined || value === null) {
+        return acc
+      }
+
+      const normalized = Array.isArray(value)
+        ? value
+        : String(value)
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean)
+
+      if (normalized.length) {
+        acc[key] = normalized
+      }
+
+      return acc
+    },
+    {}
+  )
+}
+
+const logSearchMetric = (payload: {
+  query: string
+  scope?: string
+  serviceLatency: number
+  totalDuration: number
+  hitCount: number
+}) => {
+  const entry = {
+    event: "search_query",
+    queryLength: payload.query.length,
+    scope: payload.scope ?? "global",
+    serviceLatency: payload.serviceLatency,
+    totalDuration: payload.totalDuration,
+    hitCount: payload.hitCount,
+    timestamp: new Date().toISOString(),
+  }
+
+  console.info("portal.search", entry)
+}
+
+export async function POST(request: Request) {
+  let payload: SearchPayload
+  try {
+    payload = (await request.json()) as SearchPayload
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 }
+    )
+  }
+
+  const query = typeof payload.query === "string" ? payload.query : ""
+  const scope = typeof payload.scope === "string" ? payload.scope : undefined
+  const filters = normalizeFilters(payload.filters)
+  const limit = typeof payload.limit === "number" ? payload.limit : undefined
+  const typoTolerance = payload.typoTolerance
+
+  if (!query && Object.keys(filters).length === 0) {
+    return NextResponse.json(
+      { error: "Query or filters must be provided" },
+      { status: 400 }
+    )
+  }
+
+  const startedAt = performance.now()
+
+  const requestOptions: SearchRequest = {
+    query,
+    scope,
+    filters,
+    limit,
+    typoTolerance,
+  }
+
+  try {
+    const result = await searchPortal(requestOptions)
+    const totalDuration = Math.round(performance.now() - startedAt)
+
+    logSearchMetric({
+      query,
+      scope,
+      serviceLatency: result.processingTimeMS,
+      totalDuration,
+      hitCount: result.hits.length,
+    })
+
+    return NextResponse.json(
+      {
+        query: result.query,
+        hits: result.hits,
+        facets: result.facets,
+        processingTimeMS: result.processingTimeMS,
+        totalDurationMS: totalDuration,
+        appliedFilters: result.appliedFilters,
+      },
+      { status: 200 }
+    )
+  } catch (error) {
+    console.error("portal.search.error", error)
+    return NextResponse.json(
+      { error: "Search service unavailable" },
+      { status: 502 }
+    )
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const query = searchParams.get("q") ?? ""
+  const scope = searchParams.get("scope") ?? undefined
+  const limitParam = searchParams.get("limit")
+  const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined
+  const typoTolerance =
+    (searchParams.get("typoTolerance") as SearchRequest["typoTolerance"]) ?? "min"
+
+  const filters: Record<string, string[]> = {}
+  for (const [key, value] of searchParams.entries()) {
+    if (key.startsWith("facet.")) {
+      const facetKey = key.replace(/^facet\./, "")
+      filters[facetKey] = value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    }
+  }
+
+  if (!query && Object.keys(filters).length === 0) {
+    return NextResponse.json(
+      { error: "Query or filters must be provided" },
+      { status: 400 }
+    )
+  }
+
+  const startedAt = performance.now()
+
+  try {
+    const result = await searchPortal({
+      query,
+      scope,
+      filters,
+      limit,
+      typoTolerance,
+    })
+    const totalDuration = Math.round(performance.now() - startedAt)
+
+    logSearchMetric({
+      query,
+      scope,
+      serviceLatency: result.processingTimeMS,
+      totalDuration,
+      hitCount: result.hits.length,
+    })
+
+    return NextResponse.json(
+      {
+        query: result.query,
+        hits: result.hits,
+        facets: result.facets,
+        processingTimeMS: result.processingTimeMS,
+        totalDurationMS: totalDuration,
+        appliedFilters: result.appliedFilters,
+      },
+      { status: 200 }
+    )
+  } catch (error) {
+    console.error("portal.search.error", error)
+    return NextResponse.json(
+      { error: "Search service unavailable" },
+      { status: 502 }
+    )
+  }
+}

--- a/app/documents/components/documents-filters.tsx
+++ b/app/documents/components/documents-filters.tsx
@@ -1,75 +1,92 @@
-'use client';
+"use client"
 
-import { useState } from 'react';
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuCheckboxItem,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Badge } from "@/components/ui/badge";
-import { DocumentListFilters, DocumentStatus, DocumentType } from '@/types/documents';
-import { Filter, X } from 'lucide-react';
+} from "@/components/ui/dropdown-menu"
+import { Badge } from "@/components/ui/badge"
+import type { DocumentListFilters, DocumentStatus, DocumentType } from "@/types/documents"
+import type { SearchFacetCounts } from "@/lib/search/client"
+import { Filter, X } from "lucide-react"
 
 interface DocumentsFiltersProps {
-  onFiltersChange?: (filters: DocumentListFilters) => void;
+  value: DocumentListFilters
+  facets?: SearchFacetCounts | null
+  onValueChange?: (filters: DocumentListFilters) => void
 }
 
-export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
-  const [filters, setFilters] = useState<DocumentListFilters>({});
+const getFacetCount = (
+  facets: SearchFacetCounts | null | undefined,
+  key: string,
+  value: string
+): number => {
+  if (!facets) {
+    return 0
+  }
+
+  const group = facets[key]
+  if (!group) {
+    return 0
+  }
+
+  return group[value] ?? 0
+}
+
+export function DocumentsFilters({ value, facets, onValueChange }: DocumentsFiltersProps) {
+  const filters = value
 
   const statusOptions: { value: DocumentStatus; label: string }[] = [
-    { value: 'draft', label: 'Draft' },
-    { value: 'pending_signature', label: 'Pending Signature' },
-    { value: 'signed', label: 'Signed' },
-    { value: 'expired', label: 'Expired' },
-    { value: 'cancelled', label: 'Cancelled' },
-  ];
+    { value: "draft", label: "Draft" },
+    { value: "pending_signature", label: "Pending Signature" },
+    { value: "signed", label: "Signed" },
+    { value: "expired", label: "Expired" },
+    { value: "cancelled", label: "Cancelled" },
+  ]
 
   const typeOptions: { value: DocumentType; label: string }[] = [
-    { value: 'lease', label: 'Lease' },
-    { value: 'addendum', label: 'Addendum' },
-    { value: 'insurance', label: 'Insurance' },
-    { value: 'maintenance', label: 'Maintenance' },
-    { value: 'other', label: 'Other' },
-  ];
+    { value: "lease", label: "Lease" },
+    { value: "addendum", label: "Addendum" },
+    { value: "insurance", label: "Insurance" },
+    { value: "maintenance", label: "Maintenance" },
+    { value: "other", label: "Other" },
+  ]
 
   const updateFilters = (newFilters: DocumentListFilters) => {
-    setFilters(newFilters);
-    onFiltersChange?.(newFilters);
-  };
+    onValueChange?.(newFilters)
+  }
 
   const toggleStatusFilter = (status: DocumentStatus, checked: boolean) => {
-    const currentStatuses = filters.status || [];
+    const currentStatuses = filters.status || []
     const newStatuses = checked
       ? [...currentStatuses, status]
-      : currentStatuses.filter(s => s !== status);
+      : currentStatuses.filter((s) => s !== status)
 
     updateFilters({
       ...filters,
       status: newStatuses.length > 0 ? newStatuses : undefined,
-    });
-  };
+    })
+  }
 
   const toggleTypeFilter = (type: DocumentType, checked: boolean) => {
-    const currentTypes = filters.type || [];
+    const currentTypes = filters.type || []
     const newTypes = checked
       ? [...currentTypes, type]
-      : currentTypes.filter(t => t !== type);
+      : currentTypes.filter((t) => t !== type)
 
     updateFilters({
       ...filters,
       type: newTypes.length > 0 ? newTypes : undefined,
-    });
-  };
+    })
+  }
 
   const clearFilters = () => {
-    setFilters({});
-    onFiltersChange?.({});
-  };
+    onValueChange?.({})
+  }
 
   const activeFilterCount =
     (filters.status?.length || 0) +
@@ -77,7 +94,7 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
     (filters.tenant_id ? 1 : 0) +
     (filters.unit_id ? 1 : 0) +
     (filters.date_from ? 1 : 0) +
-    (filters.date_to ? 1 : 0);
+    (filters.date_to ? 1 : 0)
 
   return (
     <div className="flex items-center space-x-2">
@@ -103,7 +120,12 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
               checked={filters.status?.includes(option.value) || false}
               onCheckedChange={(checked) => toggleStatusFilter(option.value, checked)}
             >
-              {option.label}
+              <span className="flex w-full items-center justify-between">
+                <span>{option.label}</span>
+                <span className="text-xs text-muted-foreground">
+                  {getFacetCount(facets, "status", option.value) || "—"}
+                </span>
+              </span>
             </DropdownMenuCheckboxItem>
           ))}
         </DropdownMenuContent>
@@ -130,14 +152,19 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
               checked={filters.type?.includes(option.value) || false}
               onCheckedChange={(checked) => toggleTypeFilter(option.value, checked)}
             >
-              {option.label}
+              <span className="flex w-full items-center justify-between">
+                <span>{option.label}</span>
+                <span className="text-xs text-muted-foreground">
+                  {getFacetCount(facets, "type", option.value) || "—"}
+                </span>
+              </span>
             </DropdownMenuCheckboxItem>
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
 
       {/* Clear Filters */}
-      {activeFilterCount > 0 && (
+      {activeFilterCount > 0 ? (
         <Button
           variant="ghost"
           size="sm"
@@ -147,7 +174,7 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
           <X className="mr-2 size-4" />
           Clear ({activeFilterCount})
         </Button>
-      )}
+      ) : null}
     </div>
-  );
+  )
 }

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,83 +1,94 @@
-'use client';
+"use client"
 
-import { useEffect, useState } from 'react';
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
-import { getDocumentsAction } from '../actions';
-import { DocumentActions } from './document-actions';
-import { formatDistanceToNow } from 'date-fns';
-import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import { useEffect, useMemo, useState } from "react"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import type { DocumentWithLease, DocumentListFilters } from "@/types/documents"
+import { getDocumentsAction } from "../actions"
+import { DocumentActions } from "./document-actions"
+import { formatDistanceToNow } from "date-fns"
+import { FileText, Users, Calendar, Eye } from "lucide-react"
 
 interface DocumentsListProps {
-  filter: DocumentListFilters;
+  filter: DocumentListFilters
+  searchIds?: string[] | null
+  searchQuery?: string
 }
 
-export function DocumentsList({ filter }: DocumentsListProps) {
-  const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+export function DocumentsList({ filter, searchIds, searchQuery }: DocumentsListProps) {
+  const [documents, setDocuments] = useState<DocumentWithLease[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
-        setLoading(true);
-        setError(null);
-        const result = await getDocumentsAction(filter);
+        setLoading(true)
+        setError(null)
+        const result = await getDocumentsAction(filter)
         if (result.success && result.data) {
-          setDocuments(result.data);
-          setError(null);
+          setDocuments(result.data)
+          setError(null)
         } else {
-          setError(result.error || 'Failed to fetch documents');
+          setError(result.error || "Failed to fetch documents")
         }
       } catch (err) {
-        console.error('Error fetching documents:', err);
-        setError('An unexpected error occurred');
+        console.error("Error fetching documents:", err)
+        setError("An unexpected error occurred")
       } finally {
-        setLoading(false);
+        setLoading(false)
       }
-    };
+    }
 
-    fetchDocuments();
-  }, [filter]);
+    fetchDocuments()
+  }, [filter])
+
+  const displayedDocuments = useMemo(() => {
+    if (!searchQuery || !searchIds) {
+      return documents
+    }
+
+    const idSet = new Set(searchIds)
+    return documents.filter((doc) => idSet.has(doc.id))
+  }, [documents, searchIds, searchQuery])
 
   const getStatusBadge = (status: string) => {
     const variants = {
-      draft: 'secondary',
-      pending_signature: 'outline',
-      signed: 'default',
-      expired: 'destructive',
-      cancelled: 'secondary',
-    } as const;
+      draft: "secondary",
+      pending_signature: "outline",
+      signed: "default",
+      expired: "destructive",
+      cancelled: "secondary",
+    } as const
 
     const labels = {
-      draft: 'Draft',
-      pending_signature: 'Pending Signature',
-      signed: 'Signed',
-      expired: 'Expired',
-      cancelled: 'Cancelled',
-    };
+      draft: "Draft",
+      pending_signature: "Pending Signature",
+      signed: "Signed",
+      expired: "Expired",
+      cancelled: "Cancelled",
+    }
 
     return (
-      <Badge variant={variants[status as keyof typeof variants] || 'secondary'}>
+      <Badge variant={variants[status as keyof typeof variants] || "secondary"}>
         {labels[status as keyof typeof labels] || status}
       </Badge>
-    );
-  };
+    )
+  }
 
   const getTypeIcon = (type: string) => {
     switch (type) {
-      case 'lease':
-        return <FileText className="size-4" />;
-      case 'addendum':
-        return <FileText className="size-4" />;
-      case 'insurance':
-        return <Users className="size-4" />;
+      case "lease":
+        return <FileText className="size-4" />
+      case "addendum":
+        return <FileText className="size-4" />
+      case "insurance":
+        return <Users className="size-4" />
       default:
-        return <FileText className="size-4" />;
+        return <FileText className="size-4" />
     }
-  };
+  }
 
   if (loading) {
     return (
@@ -105,7 +116,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
           </Card>
         ))}
       </div>
-    );
+    )
   }
 
   if (error) {
@@ -123,7 +134,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
           </Button>
         </div>
       </Card>
-    );
+    )
   }
 
   if (documents.length === 0) {
@@ -139,12 +150,26 @@ export function DocumentsList({ filter }: DocumentsListProps) {
           </p>
         </div>
       </Card>
-    );
+    )
+  }
+
+  if (searchQuery && searchIds && searchIds.length === 0) {
+    return (
+      <Card className="p-12">
+        <div className="text-center">
+          <FileText className="mx-auto mb-4 size-12 text-muted-foreground" />
+          <h3 className="mb-2 text-lg font-medium">No results for "{searchQuery}"</h3>
+          <p className="text-sm text-muted-foreground">
+            Try adjusting your search terms or selecting different filters.
+          </p>
+        </div>
+      </Card>
+    )
   }
 
   return (
     <div className="space-y-4">
-      {documents.map((doc) => (
+      {displayedDocuments.map((doc) => (
         <Card key={doc.id} className="transition-shadow hover:shadow-md">
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between">
@@ -160,15 +185,15 @@ export function DocumentsList({ filter }: DocumentsListProps) {
                     </p>
                   )}
                   <div className="flex items-center space-x-4 text-xs text-muted-foreground">
-                    <div className="flex items-center space-x-1">
-                      <Calendar className="size-3" />
-                      <span>
+                  <div className="flex items-center space-x-1">
+                    <Calendar className="size-3" />
+                    <span>
                         {formatDistanceToNow(new Date(doc.created_at), { addSuffix: true })}
-                      </span>
-                    </div>
-                    {doc.lease && (
-                      <div className="flex items-center space-x-1">
-                        <Users className="size-3" />
+                    </span>
+                  </div>
+                  {doc.lease && (
+                    <div className="flex items-center space-x-1">
+                      <Users className="size-3" />
                         <span>Lease • {doc.lease.tenant_ids?.length || 0} tenants</span>
                       </div>
                     )}
@@ -190,7 +215,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
               </div>
             </div>
           </CardHeader>
-          {doc.signatures && doc.signatures.length > 0 && (
+                    {doc.signatures && doc.signatures.length > 0 && (
             <CardContent className="pt-0">
               <div className="flex items-center space-x-2">
                 <span className="text-xs text-muted-foreground">Signers:</span>

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,15 +1,133 @@
-import { Suspense } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { FileText, Users, Clock, Upload } from 'lucide-react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { UploadDocumentDialog } from "./components/upload-document-dialog";
-import { DocumentsStats } from "./components/documents-stats";
-import { DocumentsList } from "./components/documents-list";
-import { DocumentsFilters } from "./components/documents-filters";
-import { DocumentListFilters } from '@/types/documents';
+"use client"
+
+import { Suspense, useMemo, useState } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { FileText, Users, Clock, Upload } from "lucide-react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { UploadDocumentDialog } from "./components/upload-document-dialog"
+import { DocumentsStats } from "./components/documents-stats"
+import { DocumentsList } from "./components/documents-list"
+import { DocumentsFilters } from "./components/documents-filters"
+import type { DocumentListFilters } from "@/types/documents"
+import type { SearchResult } from "@/lib/search/client"
+import { SearchBar } from "@/components/search/search-bar"
+
+type TabKey = "all" | "leases" | "pending" | "signed"
+
+const TAB_FILTERS: Record<TabKey, DocumentListFilters> = {
+  all: {},
+  leases: { type: ["lease"] },
+  pending: { status: ["pending_signature"] },
+  signed: { status: ["signed"] },
+}
+
+const mergeFilters = (
+  base: DocumentListFilters,
+  user: DocumentListFilters
+): DocumentListFilters => {
+  const intersect = (baseValues?: string[], userValues?: string[]) => {
+    if (baseValues && baseValues.length) {
+      if (userValues && userValues.length) {
+        return baseValues.filter((value) => userValues.includes(value))
+      }
+      return baseValues
+    }
+    return userValues
+  }
+
+  const next: DocumentListFilters = {
+    status: intersect(base.status, user.status) ?? undefined,
+    type: intersect(base.type, user.type) ?? undefined,
+    tenant_id: user.tenant_id ?? base.tenant_id,
+    unit_id: user.unit_id ?? base.unit_id,
+    date_from: user.date_from ?? base.date_from,
+    date_to: user.date_to ?? base.date_to,
+  }
+
+  if (!next.status?.length) {
+    delete next.status
+  }
+  if (!next.type?.length) {
+    delete next.type
+  }
+  if (!next.tenant_id) {
+    delete next.tenant_id
+  }
+  if (!next.unit_id) {
+    delete next.unit_id
+  }
+  if (!next.date_from) {
+    delete next.date_from
+  }
+  if (!next.date_to) {
+    delete next.date_to
+  }
+
+  return next
+}
+
+const toSearchFilters = (filters: DocumentListFilters): Record<string, string[]> => {
+  const record: Record<string, string[]> = {}
+  if (filters.status?.length) {
+    record.status = filters.status
+  }
+  if (filters.type?.length) {
+    record.type = filters.type
+  }
+  if (filters.tenant_id) {
+    record.tenant_id = [filters.tenant_id]
+  }
+  if (filters.unit_id) {
+    record.unit_id = [filters.unit_id]
+  }
+  if (filters.date_from) {
+    record.date_from = [filters.date_from]
+  }
+  if (filters.date_to) {
+    record.date_to = [filters.date_to]
+  }
+  return record
+}
 
 export default function DocumentsPage() {
+  const [activeTab, setActiveTab] = useState<TabKey>("all")
+  const [filters, setFilters] = useState<DocumentListFilters>({})
+  const [searchResult, setSearchResult] = useState<SearchResult | null>(null)
+  const [searchIds, setSearchIds] = useState<string[] | null>(null)
+  const [searchQuery, setSearchQuery] = useState("")
+
+  const activeBaseFilters = TAB_FILTERS[activeTab]
+  const combinedFilters = useMemo(
+    () => mergeFilters(activeBaseFilters, filters),
+    [activeBaseFilters, filters]
+  )
+  const searchFilters = useMemo(() => toSearchFilters(combinedFilters), [combinedFilters])
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value as TabKey)
+  }
+
+  const handleSearchResults = (result: SearchResult) => {
+    setSearchResult(result)
+    setSearchQuery(result.query)
+
+    const appliedFilterCount = Object.values(result.appliedFilters ?? {}).reduce(
+      (count, values) => count + (values?.length ?? 0),
+      0
+    )
+
+    if (result.query.trim().length === 0 && result.hits.length === 0 && appliedFilterCount === 0) {
+      setSearchIds(null)
+      return
+    }
+
+    const ids = result.hits
+      .filter((hit) => hit.scope === "documents")
+      .map((hit) => hit.id)
+    setSearchIds(ids)
+  }
+
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
@@ -42,38 +160,67 @@ export default function DocumentsPage() {
       </Suspense>
 
       {/* Main Content Tabs */}
-      <Tabs defaultValue="all" className="space-y-6">
-        <div className="flex items-center justify-between">
-          <TabsList className="grid w-full max-w-md grid-cols-4">
-            <TabsTrigger value="all">All</TabsTrigger>
-            <TabsTrigger value="leases">Leases</TabsTrigger>
-            <TabsTrigger value="pending">Pending</TabsTrigger>
-            <TabsTrigger value="signed">Signed</TabsTrigger>
-          </TabsList>
-          <DocumentsFilters />
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
+        <div className="space-y-4">
+          <SearchBar
+            scope="documents"
+            placeholder="Search agreements, leases, and signatures"
+            activeFilters={searchFilters}
+            onResults={handleSearchResults}
+            onQueryChange={setSearchQuery}
+          />
+          <div className="flex items-center justify-between">
+            <TabsList className="grid w-full max-w-md grid-cols-4">
+              <TabsTrigger value="all">All</TabsTrigger>
+              <TabsTrigger value="leases">Leases</TabsTrigger>
+              <TabsTrigger value="pending">Pending</TabsTrigger>
+              <TabsTrigger value="signed">Signed</TabsTrigger>
+            </TabsList>
+            <DocumentsFilters
+              value={filters}
+              facets={searchResult?.facets ?? null}
+              onValueChange={setFilters}
+            />
+          </div>
         </div>
 
         <TabsContent value="all" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{}} />
+            <DocumentsList
+              filter={mergeFilters(TAB_FILTERS.all, filters)}
+              searchIds={activeTab === "all" ? searchIds : undefined}
+              searchQuery={activeTab === "all" ? searchQuery : undefined}
+            />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="leases" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ type: ['lease'] }} />
+            <DocumentsList
+              filter={mergeFilters(TAB_FILTERS.leases, filters)}
+              searchIds={activeTab === "leases" ? searchIds : undefined}
+              searchQuery={activeTab === "leases" ? searchQuery : undefined}
+            />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="pending" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['pending_signature'] }} />
+            <DocumentsList
+              filter={mergeFilters(TAB_FILTERS.pending, filters)}
+              searchIds={activeTab === "pending" ? searchIds : undefined}
+              searchQuery={activeTab === "pending" ? searchQuery : undefined}
+            />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="signed" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['signed'] }} />
+            <DocumentsList
+              filter={mergeFilters(TAB_FILTERS.signed, filters)}
+              searchIds={activeTab === "signed" ? searchIds : undefined}
+              searchQuery={activeTab === "signed" ? searchQuery : undefined}
+            />
           </Suspense>
         </TabsContent>
       </Tabs>

--- a/app/messaging/components/messaging-page-client.tsx
+++ b/app/messaging/components/messaging-page-client.tsx
@@ -1,0 +1,517 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import ModerationControls from "@/components/messaging/moderation-controls"
+import { SearchBar } from "@/components/search/search-bar"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { Separator } from "@/components/ui/separator"
+import type { SearchFacetCounts, SearchResult } from "@/lib/search/client"
+import { cn } from "@/lib/utils"
+import { Paperclip } from "lucide-react"
+
+export type ThreadListItem = {
+  id: string
+  title: string
+  category: string
+  summary: string
+  lastMessageAt: string
+  unreadCount: number
+  participants: number
+  attachments: number
+  activity: string
+  reactions: string[]
+  pinned?: boolean
+}
+
+export type Attachment = {
+  id: string
+  label: string
+  description: string
+  type: string
+}
+
+export type PollOption = {
+  label: string
+  votes: number
+}
+
+export type ThreadPoll = {
+  question: string
+  closesAt: string
+  totalVotes: number
+  options: PollOption[]
+}
+
+export type PostReaction = {
+  emoji: string
+  count: number
+  active?: boolean
+}
+
+export type ThreadPost = {
+  id: string
+  author: {
+    name: string
+    role: string
+    initials: string
+    accent: string
+  }
+  timestamp: string
+  content: string[]
+  attachments?: Attachment[]
+  poll?: ThreadPoll
+  reactions?: PostReaction[]
+}
+
+export type AttachmentSummary = {
+  id: string
+  title: string
+  thread: string
+  updatedBy: string
+  type: string
+}
+
+export type PollSnapshot = {
+  id: string
+  title: string
+  thread: string
+  closesAt: string
+  leadingOption: string
+  votes: number
+  progress: number
+}
+
+export type MessagingThread = {
+  title: string
+  summary: string
+  category: string
+  owner: string
+  participants: number
+  updated: string
+}
+
+interface MessagingPageClientProps {
+  threadFilters: Array<{ label: string; value: string | null }>
+  threadList: ThreadListItem[]
+  threadPosts: ThreadPost[]
+  attachmentSummary: AttachmentSummary[]
+  pollSnapshots: PollSnapshot[]
+  activeThread: MessagingThread
+}
+
+const computeBaseCategoryCounts = (threads: ThreadListItem[]) => {
+  const counts: Record<string, number> = {}
+  for (const thread of threads) {
+    counts[thread.category] = (counts[thread.category] ?? 0) + 1
+  }
+  return counts
+}
+
+export function MessagingPageClient({
+  threadFilters,
+  threadList,
+  threadPosts,
+  attachmentSummary,
+  pollSnapshots,
+  activeThread,
+}: MessagingPageClientProps) {
+  const [activeCategory, setActiveCategory] = useState<string | null>(null)
+  const [facetCounts, setFacetCounts] = useState<SearchFacetCounts | null>(null)
+  const [searchThreadIds, setSearchThreadIds] = useState<Set<string> | null>(null)
+  const [searchQuery, setSearchQuery] = useState("")
+
+  const baseCategoryCounts = useMemo(
+    () => computeBaseCategoryCounts(threadList),
+    [threadList]
+  )
+
+  const searchFilters = useMemo(
+    () => (activeCategory ? { category: [activeCategory] } : {}),
+    [activeCategory]
+  )
+
+  const handleSearchResults = (result: SearchResult) => {
+    setFacetCounts(result.facets ?? null)
+    setSearchQuery(result.query)
+
+    const appliedFilterCount = Object.values(result.appliedFilters ?? {}).reduce(
+      (count, values) => count + (values?.length ?? 0),
+      0
+    )
+
+    if (result.query.trim().length === 0 && result.hits.length === 0 && appliedFilterCount === 0) {
+      setSearchThreadIds(null)
+      return
+    }
+
+    const threads = result.hits
+      .filter((hit) => hit.type === "thread")
+      .map((hit) => hit.id)
+
+    setSearchThreadIds(new Set(threads))
+  }
+
+  const displayedThreads = useMemo(() => {
+    const scoped = activeCategory
+      ? threadList.filter((thread) => thread.category === activeCategory)
+      : threadList
+
+    if (!searchThreadIds) {
+      return scoped
+    }
+
+    return scoped.filter((thread) => searchThreadIds.has(thread.id))
+  }, [activeCategory, searchThreadIds, threadList])
+
+  const categoryFacetCounts = facetCounts?.category ?? {}
+
+  const getCategoryCount = (value: string | null) => {
+    if (value === null) {
+      if (searchThreadIds) {
+        return searchThreadIds.size
+      }
+      const facetTotal = Object.values(categoryFacetCounts).reduce(
+        (acc, count) => acc + count,
+        0
+      )
+      return facetTotal || threadList.length
+    }
+
+    if (categoryFacetCounts[value]) {
+      return categoryFacetCounts[value]
+    }
+
+    if (searchThreadIds) {
+      return displayedThreads.filter((thread) => thread.category === value).length
+    }
+
+    return baseCategoryCounts[value] ?? 0
+  }
+
+  const noResults =
+    searchQuery.trim().length > 0 &&
+    searchThreadIds !== null &&
+    (searchThreadIds?.size ?? 0) === 0
+
+  return (
+    <div className="container max-w-6xl space-y-10 py-12">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Messaging</h1>
+          <p className="text-base text-muted-foreground sm:text-lg">
+            Organize roommate discussions by topic, capture reactions, and close the loop on decisions with polls and shared attachments.
+          </p>
+        </div>
+        <Separator />
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[320px,1fr] xl:grid-cols-[320px,1fr]">
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <CardTitle>Threaded conversations</CardTitle>
+                  <CardDescription>
+                    Keep every roommate topic in its own thread so updates, reactions, and attachments stay in context.
+                  </CardDescription>
+                </div>
+                <Button size="sm">New thread</Button>
+              </div>
+              <SearchBar
+                scope="messaging"
+                placeholder="Search threads, polls, and attachments"
+                activeFilters={searchFilters}
+                limit={20}
+                onResults={handleSearchResults}
+                onQueryChange={setSearchQuery}
+              />
+              <div className="flex flex-wrap gap-2">
+                {threadFilters.map((filter) => {
+                  const isActive =
+                    (filter.value === null && activeCategory === null) ||
+                    (filter.value !== null && filter.value === activeCategory)
+
+                  return (
+                    <button
+                      key={filter.label}
+                      type="button"
+                      onClick={() => setActiveCategory(filter.value)}
+                      className={cn(
+                        "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition",
+                        isActive
+                          ? "border-primary/30 bg-primary/10 text-primary"
+                          : "border-border/70 text-muted-foreground hover:border-primary/40 hover:text-primary"
+                      )}
+                    >
+                      <span>{filter.label}</span>
+                      <span className="ml-2 rounded-full bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
+                        {getCategoryCount(filter.value)}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {noResults ? (
+                <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+                  No threads found for "{searchQuery}". Try refining your keywords or resetting the filters.
+                </div>
+              ) : (
+                displayedThreads.map((thread) => (
+                  <div
+                    key={thread.id}
+                    className="space-y-3 rounded-lg border border-border/60 bg-muted/30 p-4 transition hover:border-primary/50 hover:bg-background"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant="secondary">{thread.category}</Badge>
+                          {thread.pinned ? (
+                            <Badge variant="outline" className="uppercase">
+                              Pinned
+                            </Badge>
+                          ) : null}
+                        </div>
+                        <p className="text-sm font-semibold text-foreground">{thread.title}</p>
+                        <p className="text-xs text-muted-foreground">{thread.summary}</p>
+                      </div>
+                      <div className="flex flex-col items-end gap-2 text-xs">
+                        <span className="text-muted-foreground">{thread.lastMessageAt}</span>
+                        {thread.unreadCount > 0 ? (
+                          <span className="rounded-full bg-primary/10 px-2 py-1 font-medium text-primary">
+                            {thread.unreadCount} new
+                          </span>
+                        ) : null}
+                        <div className="flex gap-1">
+                          {thread.reactions.map((reaction) => (
+                            <span
+                              key={`${thread.id}-${reaction}`}
+                              className="inline-flex size-6 items-center justify-center rounded-full bg-background text-sm"
+                              aria-hidden
+                            >
+                              {reaction}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-4 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      <span>{thread.participants} participants</span>
+                      <span>{thread.attachments} attachments</span>
+                      <span>{thread.activity}</span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Polls & alignment</CardTitle>
+              <CardDescription>
+                Track decisions across threads so chores, logistics, and maintenance stay in sync.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="space-y-3">
+                {pollSnapshots.map((poll) => (
+                  <div
+                    key={poll.id}
+                    className="space-y-3 rounded-lg border border-border/60 bg-background/80 p-4"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">{poll.title}</p>
+                        <p className="text-xs text-muted-foreground">{poll.thread}</p>
+                      </div>
+                      <Badge variant="secondary">{poll.closesAt}</Badge>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+                        <span>{poll.leadingOption}</span>
+                        <span>{poll.votes} votes</span>
+                      </div>
+                      <Progress value={poll.progress} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <CardTitle>{activeThread.title}</CardTitle>
+                  <CardDescription>{activeThread.summary}</CardDescription>
+                </div>
+                <Badge variant="secondary">{activeThread.category}</Badge>
+              </div>
+              <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                <span>Owned by {activeThread.owner}</span>
+                <span>{activeThread.participants} participants</span>
+                <span>Updated {activeThread.updated}</span>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-8">
+              {threadPosts.map((post, index) => (
+                <div key={post.id} className="space-y-4">
+                  <article className="space-y-4">
+                    <div className="flex items-start gap-3">
+                      <Avatar className={cn("size-10", post.author.accent)}>
+                        <AvatarFallback>{post.author.initials}</AvatarFallback>
+                      </Avatar>
+                      <div className="flex-1 space-y-2">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <div>
+                            <p className="text-sm font-semibold text-foreground">{post.author.name}</p>
+                            <p className="text-xs text-muted-foreground">{post.author.role}</p>
+                          </div>
+                          <span className="text-xs text-muted-foreground">{post.timestamp}</span>
+                        </div>
+                        <div className="space-y-2 text-sm leading-relaxed text-foreground">
+                          {post.content.map((paragraph, idx) => (
+                            <p key={`${post.id}-paragraph-${idx}`}>{paragraph}</p>
+                          ))}
+                        </div>
+
+                        {post.attachments?.length ? (
+                          <div className="space-y-2">
+                            {post.attachments.map((attachment) => (
+                              <div
+                                key={`${post.id}-${attachment.id}`}
+                                className="flex items-center gap-3 rounded-lg border border-dashed border-border/60 bg-muted/40 px-3 py-2"
+                              >
+                                <Paperclip className="size-4 text-muted-foreground" aria-hidden />
+                                <div className="flex flex-1 flex-col">
+                                  <span className="text-sm font-medium text-foreground">{attachment.label}</span>
+                                  <span className="text-xs text-muted-foreground">{attachment.description}</span>
+                                </div>
+                                <Badge variant="outline" className="whitespace-nowrap">
+                                  {attachment.type}
+                                </Badge>
+                              </div>
+                            ))}
+                          </div>
+                        ) : null}
+
+                        {post.poll ? (
+                          <div className="space-y-4 rounded-lg border border-primary/30 bg-primary/5 p-4">
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <div>
+                                <p className="text-sm font-semibold text-foreground">{post.poll.question}</p>
+                                <p className="text-xs text-muted-foreground">Vote once to lock in the weekend.</p>
+                              </div>
+                              <Badge variant="secondary">Closes {post.poll.closesAt}</Badge>
+                            </div>
+                            <div className="space-y-3">
+                              {post.poll.options.map((option) => {
+                                const percent =
+                                  post.poll && post.poll.totalVotes > 0
+                                    ? Math.round((option.votes / post.poll.totalVotes) * 100)
+                                    : 0
+
+                                return (
+                                  <div key={`${post.id}-${option.label}`} className="space-y-1">
+                                    <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+                                      <span>{option.label}</span>
+                                      <span>
+                                        {option.votes} vote{option.votes === 1 ? "" : "s"} · {percent}%
+                                      </span>
+                                    </div>
+                                    <Progress value={percent} />
+                                  </div>
+                                )
+                              })}
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                              {post.poll.totalVotes} roommate votes collected so far
+                            </p>
+                          </div>
+                        ) : null}
+
+                        {post.reactions?.length ? (
+                          <div className="flex flex-wrap gap-2">
+                            {post.reactions.map((reaction) => (
+                              <Button
+                                key={`${post.id}-${reaction.emoji}`}
+                                variant="outline"
+                                size="sm"
+                                className={cn(
+                                  "h-8 rounded-full border-dashed bg-background/60 px-3 text-xs",
+                                  reaction.active && "border-primary text-primary"
+                                )}
+                              >
+                                <span className="mr-1 text-base" aria-hidden>
+                                  {reaction.emoji}
+                                </span>
+                                {reaction.count}
+                              </Button>
+                            ))}
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 rounded-full px-3 text-xs text-muted-foreground"
+                            >
+                              + Add reaction
+                            </Button>
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                  </article>
+                  {index < threadPosts.length - 1 ? <Separator /> : null}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Shared attachments</CardTitle>
+              <CardDescription>
+                Surface the latest files pinned across threads so everyone can reference the source of truth.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {attachmentSummary.map((attachment) => (
+                <div
+                  key={attachment.id}
+                  className="flex items-center gap-3 rounded-lg border border-border/60 bg-muted/30 p-3"
+                >
+                  <Paperclip className="size-4 text-muted-foreground" aria-hidden />
+                  <div className="flex-1 space-y-1">
+                    <p className="text-sm font-medium text-foreground">{attachment.title}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {attachment.thread} • {attachment.updatedBy}
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="whitespace-nowrap">
+                    {attachment.type}
+                  </Badge>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+      <ModerationControls />
+    </div>
+  )
+}

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,98 +1,20 @@
-import ModerationControls from "@/components/messaging/moderation-controls"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import type { SearchEntity } from "@/lib/search/client"
+import { ingestTopEntities } from "@/lib/search/client"
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
+  MessagingPageClient,
+  type AttachmentSummary,
+  type MessagingThread,
+  type PollSnapshot,
+  type ThreadListItem,
+  type ThreadPost,
+} from "./components/messaging-page-client"
 
-import { Separator } from "@/components/ui/separator"
-import { cn } from "@/lib/utils"
-import { Paperclip } from "lucide-react"
-
-type ThreadListItem = {
-  id: string
-  title: string
-  category: string
-  summary: string
-  lastMessageAt: string
-  unreadCount: number
-  participants: number
-  attachments: number
-  activity: string
-  reactions: string[]
-  pinned?: boolean
-}
-
-type Attachment = {
-  id: string
-  label: string
-  description: string
-  type: string
-}
-
-type PollOption = {
-  label: string
-  votes: number
-}
-
-type ThreadPoll = {
-  question: string
-  closesAt: string
-  totalVotes: number
-  options: PollOption[]
-}
-
-type PostReaction = {
-  emoji: string
-  count: number
-  active?: boolean
-}
-
-type ThreadPost = {
-  id: string
-  author: {
-    name: string
-    role: string
-    initials: string
-    accent: string
-  }
-  timestamp: string
-  content: string[]
-  attachments?: Attachment[]
-  poll?: ThreadPoll
-  reactions?: PostReaction[]
-}
-
-type AttachmentSummary = {
-  id: string
-  title: string
-  thread: string
-  updatedBy: string
-  type: string
-}
-
-type PollSnapshot = {
-  id: string
-  title: string
-  thread: string
-  closesAt: string
-  leadingOption: string
-  votes: number
-  progress: number
-}
-
-const threadFilters = [
-  { label: "All topics", active: true },
-  { label: "Chores", active: false },
-  { label: "Logistics", active: false },
-  { label: "Maintenance", active: false },
-  { label: "Social", active: false },
+const threadFilters: Array<{ label: string; value: string | null }> = [
+  { label: "All topics", value: null },
+  { label: "Chores", value: "Chores" },
+  { label: "Logistics", value: "Logistics" },
+  { label: "Maintenance", value: "Maintenance" },
+  { label: "Social", value: "Social" },
 ]
 
 const threadList: ThreadListItem[] = [
@@ -148,7 +70,7 @@ const threadList: ThreadListItem[] = [
   },
 ]
 
-const activeThread = {
+const activeThread: MessagingThread = {
   title: "Q2 chore rotation plan",
   summary:
     "Keep the shared areas sparkling with a rotation everyone can reference — vote on the deep clean weekend and review updated checklists in one place.",
@@ -302,299 +224,91 @@ const pollSnapshots: PollSnapshot[] = [
   },
 ]
 
-export default function MessagingPage() {
+const buildMessagingSearchEntities = (): SearchEntity[] => {
+  const threadEntities: SearchEntity[] = threadList.map((thread) => ({
+    id: thread.id,
+    scope: "messaging",
+    title: thread.title,
+    description: thread.summary,
+    content: `${thread.summary} ${thread.activity}`,
+    type: "thread",
+    priority: thread.pinned ? 50 : 10,
+    keywords: [thread.category, ...thread.reactions],
+    synonyms: thread.reactions,
+    facets: {
+      category: thread.category,
+      pinned: thread.pinned ? "true" : "false",
+    },
+  }))
+
+  const postEntities: SearchEntity[] = threadPosts.map((post) => ({
+    id: `post-${post.id}`,
+    scope: "messaging",
+    title: `${post.author.name} update`,
+    description: post.content.join(" "),
+    content: [
+      post.content.join(" "),
+      post.poll?.question ?? "",
+      post.attachments?.map((attachment) => attachment.label).join(" ") ?? "",
+    ].join(" "),
+    type: "message",
+    priority:
+      post.reactions?.reduce((acc, reaction) => acc + reaction.count, 0) ??
+      (post.poll?.totalVotes ?? 0),
+    keywords: [post.author.name, post.author.role],
+    synonyms: post.reactions?.map((reaction) => reaction.emoji) ?? [],
+    facets: {
+      author: post.author.name,
+      category: activeThread.category,
+    },
+  }))
+
+  const attachmentEntities: SearchEntity[] = attachmentSummary.map((attachment) => ({
+    id: `attachment-${attachment.id}`,
+    scope: "messaging",
+    title: attachment.title,
+    description: `${attachment.thread} • ${attachment.updatedBy}`,
+    content: `${attachment.title} ${attachment.thread} ${attachment.updatedBy}`,
+    type: "attachment",
+    priority: 5,
+    keywords: [attachment.thread, attachment.type],
+    synonyms: [],
+    facets: {
+      thread: attachment.thread,
+      type: attachment.type,
+    },
+  }))
+
+  const pollEntities: SearchEntity[] = pollSnapshots.map((poll) => ({
+    id: `poll-${poll.id}`,
+    scope: "messaging",
+    title: poll.title,
+    description: poll.thread,
+    content: `${poll.thread} ${poll.leadingOption} ${poll.closesAt}`,
+    type: "poll",
+    priority: poll.votes,
+    keywords: [poll.thread, poll.leadingOption],
+    synonyms: [],
+    facets: {
+      thread: poll.thread,
+    },
+  }))
+
+  return [...threadEntities, ...postEntities, ...attachmentEntities, ...pollEntities]
+}
+
+export default async function MessagingPage() {
+  const searchEntities = buildMessagingSearchEntities()
+  await ingestTopEntities(searchEntities, { limit: 200 })
+
   return (
-    <div className="container max-w-6xl space-y-10 py-12">
-      <header className="space-y-4">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Messaging</h1>
-          <p className="text-base text-muted-foreground sm:text-lg">
-            Organize roommate discussions by topic, capture reactions, and close the loop on decisions with polls and shared attachments.
-          </p>
-        </div>
-        <Separator />
-      </header>
-
-      <div className="grid gap-6 lg:grid-cols-[320px,1fr] xl:grid-cols-[320px,1fr]">
-        <div className="space-y-6">
-          <Card>
-            <CardHeader className="space-y-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="space-y-1">
-                  <CardTitle>Threaded conversations</CardTitle>
-                  <CardDescription>
-                    Keep every roommate topic in its own thread so updates, reactions, and attachments stay in context.
-                  </CardDescription>
-                </div>
-                <Button size="sm">New thread</Button>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {threadFilters.map((filter) => (
-                  <span
-                    key={filter.label}
-                    className={cn(
-                      "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium",
-                      filter.active
-                        ? "border-primary/30 bg-primary/10 text-primary"
-                        : "border-border/70 text-muted-foreground"
-                    )}
-                  >
-                    {filter.label}
-                  </span>
-                ))}
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {threadList.map((thread) => (
-                <div
-                  key={thread.id}
-                  className="space-y-3 rounded-lg border border-border/60 bg-muted/30 p-4 transition hover:border-primary/50 hover:bg-background"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="space-y-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant="secondary">{thread.category}</Badge>
-                        {thread.pinned ? (
-                          <Badge variant="outline" className="uppercase">
-                            Pinned
-                          </Badge>
-                        ) : null}
-                      </div>
-                      <p className="text-sm font-semibold text-foreground">{thread.title}</p>
-                      <p className="text-xs text-muted-foreground">{thread.summary}</p>
-                    </div>
-                    <div className="flex flex-col items-end gap-2 text-xs">
-                      <span className="text-muted-foreground">{thread.lastMessageAt}</span>
-                      {thread.unreadCount > 0 ? (
-                        <span className="rounded-full bg-primary/10 px-2 py-1 font-medium text-primary">
-                          {thread.unreadCount} new
-                        </span>
-                      ) : null}
-                      <div className="flex gap-1">
-                        {thread.reactions.map((reaction) => (
-                          <span
-                            key={`${thread.id}-${reaction}`}
-                            className="inline-flex size-6 items-center justify-center rounded-full bg-background text-sm"
-                            aria-hidden
-                          >
-                            {reaction}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex flex-wrap gap-4 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    <span>{thread.participants} participants</span>
-                    <span>{thread.attachments} attachments</span>
-                    <span>{thread.activity}</span>
-                  </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Polls & alignment</CardTitle>
-              <CardDescription>
-                Track decisions across threads so chores, logistics, and maintenance stay in sync.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-3">
-                {pollSnapshots.map((poll) => (
-                  <div
-                    key={poll.id}
-                    className="space-y-3 rounded-lg border border-border/60 bg-background/80 p-4"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="text-sm font-semibold text-foreground">{poll.title}</p>
-                        <p className="text-xs text-muted-foreground">{poll.thread}</p>
-                      </div>
-                      <Badge variant="secondary">{poll.closesAt}</Badge>
-                    </div>
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
-                        <span>{poll.leadingOption}</span>
-                        <span>{poll.votes} votes</span>
-                      </div>
-                      <Progress value={poll.progress} />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="space-y-6">
-          <Card>
-            <CardHeader className="space-y-4">
-              <div className="flex flex-wrap items-start justify-between gap-4">
-                <div className="space-y-1">
-                  <CardTitle>{activeThread.title}</CardTitle>
-                  <CardDescription>{activeThread.summary}</CardDescription>
-                </div>
-                <Badge variant="secondary">{activeThread.category}</Badge>
-              </div>
-              <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
-                <span>Owner: {activeThread.owner}</span>
-                <span>{activeThread.participants} roommates involved</span>
-                <span>Updated {activeThread.updated}</span>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-8">
-              {threadPosts.map((post, index) => (
-                <div key={post.id} className="space-y-4">
-                  <article className="space-y-4 rounded-lg border border-border/60 bg-background/90 p-4">
-                    <div className="flex items-start gap-3">
-                      <Avatar>
-                        <AvatarFallback className={cn("text-sm font-medium", post.author.accent)}>
-                          {post.author.initials}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div className="flex flex-col gap-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="text-sm font-semibold text-foreground">{post.author.name}</span>
-                          <Badge variant="outline">{post.author.role}</Badge>
-                        </div>
-                        <span className="text-xs text-muted-foreground">{post.timestamp}</span>
-                      </div>
-                    </div>
-
-                    <div className="space-y-3 text-sm leading-6 text-foreground">
-                      {post.content.map((paragraph, idx) => (
-                        <p key={`${post.id}-content-${idx}`} className="text-muted-foreground">
-                          {paragraph}
-                        </p>
-                      ))}
-                    </div>
-
-                    {post.attachments?.length ? (
-                      <div className="space-y-2">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                          Attachments
-                        </p>
-                        <div className="space-y-2">
-                          {post.attachments.map((attachment) => (
-                            <div
-                              key={`${post.id}-${attachment.id}`}
-                              className="flex items-center gap-3 rounded-lg border border-dashed border-border/60 bg-muted/40 px-3 py-2"
-                            >
-                              <Paperclip className="size-4 text-muted-foreground" aria-hidden />
-                              <div className="flex flex-1 flex-col">
-                                <span className="text-sm font-medium text-foreground">{attachment.label}</span>
-                                <span className="text-xs text-muted-foreground">{attachment.description}</span>
-                              </div>
-                              <Badge variant="outline" className="whitespace-nowrap">
-                                {attachment.type}
-                              </Badge>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    ) : null}
-
-                    {post.poll ? (
-                      <div className="space-y-4 rounded-lg border border-primary/30 bg-primary/5 p-4">
-                        <div className="flex flex-wrap items-start justify-between gap-3">
-                          <div>
-                            <p className="text-sm font-semibold text-foreground">{post.poll.question}</p>
-                            <p className="text-xs text-muted-foreground">Vote once to lock in the weekend.</p>
-                          </div>
-                          <Badge variant="secondary">Closes {post.poll.closesAt}</Badge>
-                        </div>
-                        <div className="space-y-3">
-                          {post.poll.options.map((option) => {
-                            const percent =
-                              post.poll && post.poll.totalVotes > 0
-                                ? Math.round((option.votes / post.poll.totalVotes) * 100)
-                                : 0
-
-                            return (
-                              <div key={`${post.id}-${option.label}`} className="space-y-1">
-                                <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
-                                  <span>{option.label}</span>
-                                  <span>
-                                    {option.votes} vote{option.votes === 1 ? "" : "s"} · {percent}%
-                                  </span>
-                                </div>
-                                <Progress value={percent} />
-                              </div>
-                            )
-                          })}
-                        </div>
-                        <p className="text-xs text-muted-foreground">
-                          {post.poll.totalVotes} roommate votes collected so far
-                        </p>
-                      </div>
-                    ) : null}
-
-                    {post.reactions?.length ? (
-                      <div className="flex flex-wrap gap-2">
-                        {post.reactions.map((reaction) => (
-                          <Button
-                            key={`${post.id}-${reaction.emoji}`}
-                            variant="outline"
-                            size="sm"
-                            className={cn(
-                              "h-8 rounded-full border-dashed bg-background/60 px-3 text-xs",
-                              reaction.active && "border-primary text-primary"
-                            )}
-                          >
-                            <span className="mr-1 text-base" aria-hidden>
-                              {reaction.emoji}
-                            </span>
-                            {reaction.count}
-                          </Button>
-                        ))}
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 rounded-full px-3 text-xs text-muted-foreground"
-                        >
-                          + Add reaction
-                        </Button>
-                      </div>
-                    ) : null}
-                  </article>
-                  {index < threadPosts.length - 1 ? <Separator /> : null}
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Shared attachments</CardTitle>
-              <CardDescription>
-                Surface the latest files pinned across threads so everyone can reference the source of truth.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {attachmentSummary.map((attachment) => (
-                <div
-                  key={attachment.id}
-                  className="flex items-center gap-3 rounded-lg border border-border/60 bg-muted/30 p-3"
-                >
-                  <Paperclip className="size-4 text-muted-foreground" aria-hidden />
-                  <div className="flex-1 space-y-1">
-                    <p className="text-sm font-medium text-foreground">{attachment.title}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {attachment.thread} • {attachment.updatedBy}
-                    </p>
-                  </div>
-                  <Badge variant="outline" className="whitespace-nowrap">
-                    {attachment.type}
-                  </Badge>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-      <ModerationControls />
-    </div>
+    <MessagingPageClient
+      threadFilters={threadFilters}
+      threadList={threadList}
+      threadPosts={threadPosts}
+      attachmentSummary={attachmentSummary}
+      pollSnapshots={pollSnapshots}
+      activeThread={activeThread}
+    />
   )
 }

--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -1,0 +1,224 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react"
+import { track } from "@vercel/analytics/react"
+import { Search, Loader2 } from "lucide-react"
+
+import type { SearchResult } from "@/lib/search/client"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+
+export interface SearchBarProps {
+  scope: string
+  placeholder?: string
+  activeFilters?: Record<string, string[]>
+  limit?: number
+  debounceMs?: number
+  typoTolerance?: "min" | "strict" | "false"
+  onResults?: (result: SearchResult) => void
+  onLatencyMeasured?: (payload: { query: string; latency: number; totalDuration: number }) => void
+  onQueryChange?: (query: string) => void
+}
+
+const useDebouncedValue = <T,>(value: T, delay: number) => {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setDebounced(value)
+    }, delay)
+
+    return () => {
+      window.clearTimeout(handle)
+    }
+  }, [value, delay])
+
+  return debounced
+}
+
+const shouldExecuteSearch = (query: string, filters: Record<string, string[]>): boolean => {
+  if (query.trim().length > 0) {
+    return true
+  }
+
+  return Object.values(filters).some((values) => values.length > 0)
+}
+
+const computeP95 = (latencies: number[]): number => {
+  if (latencies.length === 0) {
+    return 0
+  }
+
+  const sorted = [...latencies].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)
+  return sorted[index]
+}
+
+export function SearchBar({
+  scope,
+  placeholder = "Search",
+  activeFilters = {},
+  limit = 8,
+  debounceMs = 200,
+  typoTolerance = "min",
+  onResults,
+  onLatencyMeasured,
+  onQueryChange,
+}: SearchBarProps) {
+  const [query, setQuery] = useState("")
+  const [result, setResult] = useState<SearchResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const [p95Latency, setP95Latency] = useState(0)
+  const samplesRef = useRef<number[]>([])
+
+  const filtersSignature = useMemo(
+    () => JSON.stringify(activeFilters ?? {}),
+    [activeFilters]
+  )
+  const debouncedQuery = useDebouncedValue(query, debounceMs)
+
+  const executeSearch = useCallback(
+    async (currentQuery: string, filters: Record<string, string[]>) => {
+      if (!shouldExecuteSearch(currentQuery, filters)) {
+        const emptyResult: SearchResult = {
+          query: currentQuery,
+          hits: [],
+          facets: {},
+          processingTimeMS: 0,
+          appliedFilters: filters,
+        }
+        setResult(null)
+        setError(null)
+        onResults?.(emptyResult)
+        samplesRef.current = []
+        setP95Latency(0)
+        return
+      }
+
+      const startedAt = performance.now()
+
+      try {
+        setError(null)
+        const response = await fetch("/api/search", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            query: currentQuery,
+            scope,
+            filters,
+            limit,
+            typoTolerance,
+          }),
+        })
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({ error: "Search failed" }))
+          throw new Error(payload.error ?? "Search service unavailable")
+        }
+
+        const payload = (await response.json()) as {
+          hits: SearchResult["hits"]
+          facets: SearchResult["facets"]
+          processingTimeMS: number
+          totalDurationMS?: number
+          query: string
+          appliedFilters: Record<string, string[]>
+        }
+
+        const nextResult: SearchResult = {
+          query: payload.query,
+          hits: payload.hits,
+          facets: payload.facets,
+          processingTimeMS: payload.processingTimeMS,
+          appliedFilters: payload.appliedFilters,
+        }
+
+        setResult(nextResult)
+        onResults?.(nextResult)
+
+        const totalDuration =
+          typeof payload.totalDurationMS === "number"
+            ? payload.totalDurationMS
+            : Math.round(performance.now() - startedAt)
+
+        const latency = nextResult.processingTimeMS
+        samplesRef.current = [...samplesRef.current.slice(-49), latency]
+        setP95Latency(computeP95(samplesRef.current))
+
+        onLatencyMeasured?.({
+          query: currentQuery,
+          latency,
+          totalDuration,
+        })
+
+        try {
+          track("search_query_client", {
+            scope,
+            latency,
+            totalDuration,
+            queryLength: currentQuery.length,
+            hitCount: nextResult.hits.length,
+          })
+        } catch (err) {
+          console.warn("search instrumentation unavailable", err)
+        }
+      } catch (err) {
+        console.error("client search error", err)
+        setError(err instanceof Error ? err.message : "Search failed")
+      }
+    },
+    [limit, onLatencyMeasured, onResults, scope, typoTolerance]
+  )
+
+  useEffect(() => {
+    const filters = activeFilters ?? {}
+    startTransition(() => {
+      void executeSearch(debouncedQuery, filters)
+    })
+  }, [debouncedQuery, executeSearch, filtersSignature])
+
+  const sloStatus = p95Latency > 0 ? (p95Latency <= 150 ? "within" : "breached") : "unknown"
+
+  return (
+    <div className="space-y-2">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
+        <Input
+          value={query}
+          onChange={(event) => {
+            const value = event.target.value
+            setQuery(value)
+            onQueryChange?.(value)
+          }}
+          placeholder={placeholder}
+          className="pl-9"
+          aria-label="Search"
+        />
+        {isPending ? (
+          <Loader2 className="absolute right-3 top-1/2 size-4 -translate-y-1/2 animate-spin text-muted-foreground" aria-hidden />
+        ) : null}
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <span>
+            {result
+              ? `${result.hits.length} result${result.hits.length === 1 ? "" : "s"} • ${result.processingTimeMS} ms`
+              : "Refine by keyword or filters"}
+          </span>
+          {error ? <span className="text-destructive">{error}</span> : null}
+        </div>
+        {p95Latency > 0 ? (
+          <Badge
+            variant={sloStatus === "within" ? "secondary" : "destructive"}
+            className="uppercase tracking-wide"
+          >
+            P95 {p95Latency} ms {sloStatus === "within" ? "≤ 150" : "> 150"}
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/lib/search/client.ts
+++ b/lib/search/client.ts
@@ -1,0 +1,583 @@
+import algoliasearch, {
+  type SearchClient as AlgoliaSearchClient,
+  type SearchIndex,
+  type SearchOptions as AlgoliaSearchOptions,
+  type Synonym as AlgoliaSynonym,
+} from "algoliasearch"
+import { performance } from "node:perf_hooks"
+
+export type SearchScope = "documents" | "messaging" | string
+
+export interface SearchEntity {
+  id: string
+  scope: SearchScope
+  title: string
+  description?: string
+  content: string
+  type: string
+  priority?: number
+  keywords?: string[]
+  synonyms?: string[]
+  facets?: Record<string, string | number | boolean | Array<string | number | boolean>>
+  updatedAt?: string | number | Date
+}
+
+export interface SearchHit {
+  id: string
+  scope: SearchScope
+  type: string
+  title: string
+  description?: string
+  highlights?: string[]
+  facets: Record<string, string[]>
+  score: number
+}
+
+export type SearchFacetCounts = Record<string, Record<string, number>>
+
+export interface SearchRequest {
+  query: string
+  scope?: SearchScope
+  filters?: Record<string, string[]>
+  limit?: number
+  typoTolerance?: "min" | "strict" | "false"
+}
+
+export interface SearchResult {
+  query: string
+  hits: SearchHit[]
+  facets: SearchFacetCounts
+  processingTimeMS: number
+  appliedFilters: Record<string, string[]>
+}
+
+interface PreparedRecord {
+  objectID: string
+  id: string
+  scope: SearchScope
+  type: string
+  title: string
+  description?: string
+  searchable: string
+  keywords: string[]
+  synonymTokens: string[]
+  phoneticTokens: string[]
+  facets: Record<string, string[]>
+  priority: number
+  updatedAtISO?: string
+}
+
+interface SynonymDefinition {
+  objectID: string
+  synonyms: string[]
+}
+
+interface SearchAdapter {
+  ingest(payload: { records: PreparedRecord[]; synonyms: SynonymDefinition[] }): Promise<void>
+  search(request: SearchRequest): Promise<SearchResult>
+  readonly adapterId: string
+}
+
+const sanitize = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+
+const dedupe = <T>(values: T[]): T[] => Array.from(new Set(values.filter(Boolean)))
+
+const createPhoneticToken = (value: string): string => {
+  const normalized = sanitize(value)
+  if (!normalized) {
+    return ""
+  }
+
+  const first = normalized.charAt(0)
+  const consonants = normalized
+    .slice(1)
+    .replace(/[aeiou\s]/g, "")
+    .slice(0, 7)
+
+  return `${first}${consonants}`
+}
+
+const extractKeywords = (entity: SearchEntity): string[] => {
+  const base = [entity.title, entity.description ?? "", entity.content]
+    .join(" ")
+    .split(/\s+/)
+    .filter((token) => token.length > 3)
+  const keywords = entity.keywords ?? []
+  return dedupe([...base, ...keywords])
+}
+
+const buildFacetMap = (
+  facets: SearchEntity["facets"] | undefined
+): Record<string, string[]> => {
+  if (!facets) {
+    return {}
+  }
+
+  return Object.entries(facets).reduce<Record<string, string[]>>((acc, [key, value]) => {
+    const ensureArray = Array.isArray(value) ? value : [value]
+    acc[key] = ensureArray.map((item) => String(item))
+    return acc
+  }, {})
+}
+
+const buildSynonyms = (entity: SearchEntity): string[] => {
+  const explicit = entity.synonyms ?? []
+  const inferred = extractKeywords(entity).map((keyword) =>
+    keyword
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "")
+  )
+
+  return dedupe([...explicit, ...inferred])
+}
+
+const prepareRecord = (entity: SearchEntity): PreparedRecord => {
+  const keywords = extractKeywords(entity)
+  const synonymTokens = buildSynonyms(entity)
+  const phoneticTokens = dedupe(
+    synonymTokens.map(createPhoneticToken).filter((token) => token.length > 1)
+  )
+  const facets = buildFacetMap(entity.facets)
+
+  return {
+    objectID: entity.id,
+    id: entity.id,
+    scope: entity.scope,
+    type: entity.type,
+    title: entity.title,
+    description: entity.description,
+    searchable: dedupe([
+      entity.title,
+      entity.description ?? "",
+      entity.content,
+      ...keywords,
+      ...synonymTokens,
+      ...phoneticTokens,
+    ])
+      .join(" ")
+      .trim(),
+    keywords,
+    synonymTokens,
+    phoneticTokens,
+    facets,
+    priority: entity.priority ?? 0,
+    updatedAtISO:
+      entity.updatedAt ? new Date(entity.updatedAt).toISOString() : undefined,
+  }
+}
+
+const buildSynonymDefinitions = (
+  record: PreparedRecord
+): SynonymDefinition | null => {
+  if (!record.synonymTokens.length) {
+    return null
+  }
+
+  return {
+    objectID: `synonym_${record.objectID}`,
+    synonyms: record.synonymTokens,
+  }
+}
+
+const levenshtein = (a: string, b: string): number => {
+  if (a === b) {
+    return 0
+  }
+
+  const aLen = a.length
+  const bLen = b.length
+
+  if (aLen === 0) {
+    return bLen
+  }
+
+  if (bLen === 0) {
+    return aLen
+  }
+
+  const matrix = Array.from({ length: aLen + 1 }, () => new Array<number>(bLen + 1))
+
+  for (let i = 0; i <= aLen; i += 1) {
+    matrix[i][0] = i
+  }
+
+  for (let j = 0; j <= bLen; j += 1) {
+    matrix[0][j] = j
+  }
+
+  for (let i = 1; i <= aLen; i += 1) {
+    for (let j = 1; j <= bLen; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      )
+    }
+  }
+
+  return matrix[aLen][bLen]
+}
+
+const isTypoMatch = (query: string, target: string, tolerance: "min" | "strict" | "false") => {
+  if (tolerance === "false") {
+    return sanitize(target).includes(sanitize(query))
+  }
+
+  const maxDistance = tolerance === "min" ? 2 : 1
+  return levenshtein(sanitize(query), sanitize(target)) <= maxDistance
+}
+
+class InMemorySearchAdapter implements SearchAdapter {
+  private records: Map<string, PreparedRecord> = new Map()
+
+  private synonyms: Map<string, string[]> = new Map()
+
+  public readonly adapterId = "in-memory"
+
+  async ingest({
+    records,
+    synonyms,
+  }: {
+    records: PreparedRecord[]
+    synonyms: SynonymDefinition[]
+  }): Promise<void> {
+    this.records.clear()
+    this.synonyms.clear()
+
+    for (const record of records) {
+      this.records.set(record.objectID, record)
+    }
+
+    for (const entry of synonyms) {
+      if (entry.synonyms.length > 0) {
+        this.synonyms.set(entry.objectID.replace(/^synonym_/, ""), entry.synonyms)
+      }
+    }
+  }
+
+  async search(request: SearchRequest): Promise<SearchResult> {
+    const start = performance.now()
+    const results: SearchHit[] = []
+    const facetCounts: SearchFacetCounts = {}
+    const { query, scope, filters = {}, limit = 10, typoTolerance = "min" } = request
+    const normalizedQuery = sanitize(query)
+
+    for (const record of this.records.values()) {
+      if (scope && record.scope !== scope) {
+        continue
+      }
+
+      let matches = false
+      if (!normalizedQuery) {
+        matches = true
+      } else {
+        const combinedTokens = dedupe([
+          record.title,
+          record.description ?? "",
+          record.searchable,
+          ...record.synonymTokens,
+          ...record.phoneticTokens,
+          ...(this.synonyms.get(record.objectID) ?? []),
+        ])
+
+        matches = combinedTokens.some((token) =>
+          isTypoMatch(normalizedQuery, token, typoTolerance)
+        )
+      }
+
+      if (!matches) {
+        continue
+      }
+
+      const recordFacets = record.facets
+      const filterKeys = Object.keys(filters)
+      let passesFilters = true
+
+      for (const key of filterKeys) {
+        const expected = filters[key]
+        const actual = recordFacets[key] ?? []
+        if (!expected.some((value) => actual.includes(value))) {
+          passesFilters = false
+          break
+        }
+      }
+
+      if (!passesFilters) {
+        continue
+      }
+
+      for (const [facetKey, values] of Object.entries(recordFacets)) {
+        facetCounts[facetKey] = facetCounts[facetKey] ?? {}
+        for (const value of values) {
+          facetCounts[facetKey][value] = (facetCounts[facetKey][value] ?? 0) + 1
+        }
+      }
+
+      if (results.length < limit) {
+        results.push({
+          id: record.id,
+          scope: record.scope,
+          type: record.type,
+          title: record.title,
+          description: record.description,
+          highlights: normalizedQuery ? [record.title, record.description ?? ""] : [],
+          facets: record.facets,
+          score: record.priority,
+        })
+      }
+    }
+
+    const processingTimeMS = Math.max(Math.round(performance.now() - start), 1)
+
+    return {
+      query,
+      hits: results,
+      facets: facetCounts,
+      processingTimeMS,
+      appliedFilters: filters,
+    }
+  }
+}
+
+const toAlgoliaFacetFilters = (filters: Record<string, string[]>): string[][] =>
+  Object.entries(filters).map(([key, values]) => values.map((value) => `${key}:${value}`))
+
+class AlgoliaSearchAdapter implements SearchAdapter {
+  private client: AlgoliaSearchClient
+
+  private index: SearchIndex
+
+  private settingsApplied = false
+
+  public readonly adapterId = "algolia"
+
+  constructor(indexName: string) {
+    const appId = process.env.ALGOLIA_APP_ID
+    const adminKey = process.env.ALGOLIA_ADMIN_KEY
+
+    if (!appId || !adminKey) {
+      throw new Error("Algolia credentials are not configured")
+    }
+
+    this.client = algoliasearch(appId, adminKey)
+    this.index = this.client.initIndex(indexName)
+  }
+
+  private async ensureSettings(records: PreparedRecord[]) {
+    if (this.settingsApplied) {
+      return
+    }
+
+    const facetKeys = new Set<string>()
+    for (const record of records) {
+      for (const key of Object.keys(record.facets)) {
+        facetKeys.add(key)
+      }
+    }
+
+    const attributesForFaceting = Array.from(facetKeys)
+    if (!attributesForFaceting.includes("scope")) {
+      attributesForFaceting.push("scope")
+    }
+    if (!attributesForFaceting.includes("type")) {
+      attributesForFaceting.push("type")
+    }
+
+    await this.index.setSettings({
+      searchableAttributes: [
+        "title",
+        "description",
+        "keywords",
+        "synonymTokens",
+        "phoneticTokens",
+        "searchable",
+      ],
+      attributesForFaceting,
+      typoTolerance: "min",
+    })
+
+    this.settingsApplied = true
+  }
+
+  async ingest({
+    records,
+    synonyms,
+  }: {
+    records: PreparedRecord[]
+    synonyms: SynonymDefinition[]
+  }): Promise<void> {
+    await this.ensureSettings(records)
+
+    const payload = records.map((record) => ({
+      objectID: record.objectID,
+      id: record.id,
+      scope: record.scope,
+      type: record.type,
+      title: record.title,
+      description: record.description,
+      keywords: record.keywords,
+      synonymTokens: record.synonymTokens,
+      phoneticTokens: record.phoneticTokens,
+      searchable: record.searchable,
+      facets: record.facets,
+      priority: record.priority,
+      updatedAtISO: record.updatedAtISO,
+    }))
+
+    await this.index.saveObjects(payload, { autoGenerateObjectIDIfNotExist: false })
+
+    const algoliaSynonyms: AlgoliaSynonym[] = synonyms
+      .filter((entry) => entry.synonyms.length >= 2)
+      .map((entry) => ({
+        objectID: entry.objectID,
+        type: "synonym",
+        synonyms: entry.synonyms,
+      }))
+
+    if (algoliaSynonyms.length > 0) {
+      await this.index.saveSynonyms(algoliaSynonyms, {
+        replaceExistingSynonyms: false,
+        forwardToReplicas: true,
+      })
+    }
+  }
+
+  async search(request: SearchRequest): Promise<SearchResult> {
+    const {
+      query,
+      scope,
+      filters = {},
+      limit = 10,
+      typoTolerance = "min",
+    } = request
+
+    const facetFilters = toAlgoliaFacetFilters(filters)
+    if (scope) {
+      facetFilters.push([`scope:${scope}`])
+    }
+
+    const options: Partial<AlgoliaSearchOptions> = {
+      hitsPerPage: limit,
+      typoTolerance,
+      facetFilters,
+      facets: ["*"],
+    }
+
+    const response = await this.index.search(query, options)
+
+    const hits: SearchHit[] = response.hits.map((hit: any) => {
+      const highlightEntries: string[] = []
+      if (hit._highlightResult && typeof hit._highlightResult === "object") {
+        for (const value of Object.values(hit._highlightResult)) {
+          if (value && typeof value === "object" && "value" in value) {
+            highlightEntries.push(String((value as any).value))
+          }
+        }
+      }
+
+      return {
+        id: hit.id ?? hit.objectID,
+        scope: hit.scope ?? scope ?? "default",
+        type: hit.type ?? "unknown",
+        title: hit.title ?? "",
+        description: hit.description ?? undefined,
+        highlights: highlightEntries.length ? highlightEntries : undefined,
+        facets: hit.facets ?? {},
+        score: typeof hit.priority === "number" ? hit.priority : 0,
+      }
+    })
+
+    const facets: SearchFacetCounts = response.facets ?? {}
+
+    return {
+      query,
+      hits,
+      facets,
+      processingTimeMS: response.processingTimeMS ?? 0,
+      appliedFilters: filters,
+    }
+  }
+}
+
+class PortalSearchClient {
+  private adapter: SearchAdapter
+
+  constructor() {
+    const provider = process.env.PORTAL_SEARCH_PROVIDER ?? "auto"
+
+    if (provider === "algolia" || provider === "auto") {
+      try {
+        this.adapter = new AlgoliaSearchAdapter(
+          process.env.ALGOLIA_INDEX ?? "roomsily_portal"
+        )
+        return
+      } catch (error) {
+        if (provider === "algolia") {
+          throw error
+        }
+      }
+    }
+
+    this.adapter = new InMemorySearchAdapter()
+  }
+
+  get adapterId() {
+    return this.adapter.adapterId
+  }
+
+  async ingestTopEntities(
+    entities: SearchEntity[],
+    options?: { limit?: number }
+  ) {
+    const limit = options?.limit ?? 250
+    const sorted = [...entities].sort(
+      (a, b) => (b.priority ?? 0) - (a.priority ?? 0)
+    )
+    const selected = sorted.slice(0, limit)
+
+    const records = selected.map(prepareRecord)
+    const synonyms = records
+      .map((record) => buildSynonymDefinitions(record))
+      .filter((entry): entry is SynonymDefinition => Boolean(entry))
+
+    await this.adapter.ingest({ records, synonyms })
+  }
+
+  async search(request: SearchRequest): Promise<SearchResult> {
+    return this.adapter.search(request)
+  }
+}
+
+let cachedClient: PortalSearchClient | null = null
+
+export const getPortalSearchClient = (): PortalSearchClient => {
+  if (!cachedClient) {
+    cachedClient = new PortalSearchClient()
+  }
+
+  return cachedClient
+}
+
+export async function ingestTopEntities(
+  entities: SearchEntity[],
+  options?: { limit?: number }
+) {
+  const client = getPortalSearchClient()
+  await client.ingestTopEntities(entities, options)
+}
+
+export async function searchPortal(
+  request: SearchRequest
+): Promise<SearchResult> {
+  const client = getPortalSearchClient()
+  return client.search(request)
+}
+
+export type { PreparedRecord }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/mdx": "^2.0.13",
     "@vercel/analytics": "^1.3.1",
     "@vercel/speed-insights": "^1.0.12",
+    "algoliasearch": "^5.37.0",
     "bech32": "^2.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.0.12
         version: 1.0.12(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(svelte@4.2.18)(vue@3.4.35(typescript@5.5.4))
+      algoliasearch:
+        specifier: ^5.37.0
+        version: 5.37.0
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -243,6 +246,62 @@ packages:
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  '@algolia/abtesting@1.3.0':
+    resolution: {integrity: sha512-KqPVLdVNfoJzX5BKNGM9bsW8saHeyax8kmPFXul5gejrSPN3qss7PgsFH5mMem7oR8tvjvNkia97ljEYPYCN8Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-abtesting@5.37.0':
+    resolution: {integrity: sha512-Dp2Zq+x9qQFnuiQhVe91EeaaPxWBhzwQ6QnznZQnH9C1/ei3dvtmAFfFeaTxM6FzfJXDLvVnaQagTYFTQz3R5g==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-analytics@5.37.0':
+    resolution: {integrity: sha512-wyXODDOluKogTuZxRII6mtqhAq4+qUR3zIUJEKTiHLe8HMZFxfUEI4NO2qSu04noXZHbv/sRVdQQqzKh12SZuQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-common@5.37.0':
+    resolution: {integrity: sha512-GylIFlPvLy9OMgFG8JkonIagv3zF+Dx3H401Uo2KpmfMVBBJiGfAb9oYfXtplpRMZnZPxF5FnkWaI/NpVJMC+g==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-insights@5.37.0':
+    resolution: {integrity: sha512-T63afO2O69XHKw2+F7mfRoIbmXWGzgpZxgOFAdP3fR4laid7pWBt20P4eJ+Zn23wXS5kC9P2K7Bo3+rVjqnYiw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-personalization@5.37.0':
+    resolution: {integrity: sha512-1zOIXM98O9zD8bYDCJiUJRC/qNUydGHK/zRK+WbLXrW1SqLFRXECsKZa5KoG166+o5q5upk96qguOtE8FTXDWQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-query-suggestions@5.37.0':
+    resolution: {integrity: sha512-31Nr2xOLBCYVal+OMZn1rp1H4lPs1914Tfr3a34wU/nsWJ+TB3vWjfkUUuuYhWoWBEArwuRzt3YNLn0F/KRVkg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-search@5.37.0':
+    resolution: {integrity: sha512-DAFVUvEg+u7jUs6BZiVz9zdaUebYULPiQ4LM2R4n8Nujzyj7BZzGr2DCd85ip4p/cx7nAZWKM8pLcGtkTRTdsg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/ingestion@1.37.0':
+    resolution: {integrity: sha512-pkCepBRRdcdd7dTLbFddnu886NyyxmhgqiRcHHaDunvX03Ij4WzvouWrQq7B7iYBjkMQrLS8wQqSP0REfA4W8g==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/monitoring@1.37.0':
+    resolution: {integrity: sha512-fNw7pVdyZAAQQCJf1cc/ih4fwrRdQSgKwgor4gchsI/Q/ss9inmC6bl/69jvoRSzgZS9BX4elwHKdo0EfTli3w==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/recommend@5.37.0':
+    resolution: {integrity: sha512-U+FL5gzN2ldx3TYfQO5OAta2TBuIdabEdFwD5UVfWPsZE5nvOKkc/6BBqP54Z/adW/34c5ZrvvZhlhNTZujJXQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-browser-xhr@5.37.0':
+    resolution: {integrity: sha512-Ao8GZo8WgWFABrU7iq+JAftXV0t+UcOtCDL4mzHHZ+rQeTTf1TZssr4d0vIuoqkVNnKt9iyZ7T4lQff4ydcTrw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-fetch@5.37.0':
+    resolution: {integrity: sha512-H7OJOXrFg5dLcGJ22uxx8eiFId0aB9b0UBhoOi4SMSuDBe6vjJJ/LeZyY25zPaSvkXNBN3vAM+ad6M0h6ha3AA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-node-http@5.37.0':
+    resolution: {integrity: sha512-npZ9aeag4SGTx677eqPL3rkSPlQrnzx/8wNrl1P7GpWq9w/eTmRbOq+wKrJ2r78idlY0MMgmY/mld2tq6dc44g==}
+    engines: {node: '>= 14.0.0'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1995,6 +2054,10 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  algoliasearch@5.37.0:
+    resolution: {integrity: sha512-y7gau/ZOQDqoInTQp0IwTOjkrHc4Aq4R8JgpmCleFwiLl+PbN2DMWoDUWZnrK8AhNJwT++dn28Bt4NZYNLAmuA==}
+    engines: {node: '>= 14.0.0'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -4732,6 +4795,90 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
+  '@algolia/abtesting@1.3.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/client-abtesting@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/client-analytics@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/client-common@5.37.0': {}
+
+  '@algolia/client-insights@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/client-personalization@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/client-query-suggestions@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/client-search@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/ingestion@1.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/monitoring@1.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/recommend@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
+
+  '@algolia/requester-browser-xhr@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+
+  '@algolia/requester-fetch@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+
+  '@algolia/requester-node-http@5.37.0':
+    dependencies:
+      '@algolia/client-common': 5.37.0
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.2.1':
@@ -6631,6 +6778,23 @@ snapshots:
       fast-uri: 3.0.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  algoliasearch@5.37.0:
+    dependencies:
+      '@algolia/abtesting': 1.3.0
+      '@algolia/client-abtesting': 5.37.0
+      '@algolia/client-analytics': 5.37.0
+      '@algolia/client-common': 5.37.0
+      '@algolia/client-insights': 5.37.0
+      '@algolia/client-personalization': 5.37.0
+      '@algolia/client-query-suggestions': 5.37.0
+      '@algolia/client-search': 5.37.0
+      '@algolia/ingestion': 1.37.0
+      '@algolia/monitoring': 1.37.0
+      '@algolia/recommend': 5.37.0
+      '@algolia/requester-browser-xhr': 5.37.0
+      '@algolia/requester-fetch': 5.37.0
+      '@algolia/requester-node-http': 5.37.0
 
   ansi-regex@5.0.1: {}
 

--- a/tests/search.contract.test.ts
+++ b/tests/search.contract.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  ingestTopEntities,
+  searchPortal,
+  type SearchEntity,
+} from "@/lib/search/client"
+
+const sampleEntities: SearchEntity[] = [
+  {
+    id: "lease-master",
+    scope: "documents",
+    title: "Master Lease Agreement",
+    description: "Primary lease for Unit 3B",
+    content: "Lease agreement covering responsibilities, rent schedule, and renewal terms.",
+    type: "document",
+    priority: 10,
+    keywords: ["lease", "agreement", "unit", "renewal"],
+    synonyms: ["rental contract", "tenancy agreement"],
+    facets: {
+      status: "signed",
+      type: "lease",
+    },
+  },
+  {
+    id: "maintenance-log",
+    scope: "documents",
+    title: "Maintenance Log",
+    description: "Quarterly maintenance updates",
+    content: "Maintenance checklist with HVAC filter replacements and safety inspections.",
+    type: "document",
+    priority: 6,
+    keywords: ["maintenance", "safety", "inspection"],
+    synonyms: ["upkeep", "service record"],
+    facets: {
+      status: "pending_signature",
+      type: "maintenance",
+    },
+  },
+  {
+    id: "insurance-proof",
+    scope: "documents",
+    title: "Insurance Proof",
+    description: "Liability coverage confirmation",
+    content: "Certificate of insurance for the shared property covering liability and contents.",
+    type: "document",
+    priority: 4,
+    keywords: ["insurance", "coverage", "certificate"],
+    synonyms: ["policy", "liability coverage"],
+    facets: {
+      status: "signed",
+      type: "insurance",
+    },
+  },
+  {
+    id: "house-rules",
+    scope: "documents",
+    title: "House Rules",
+    description: "Visitor and quiet hours policy",
+    content: "Quiet hours run 10pm-7am. Guests must be registered if staying overnight.",
+    type: "guideline",
+    priority: 3,
+    keywords: ["rules", "policy", "guests"],
+    synonyms: ["guidelines", "quiet hours"],
+    facets: {
+      status: "draft",
+      type: "policy",
+    },
+  },
+]
+
+const fuzzQueries = Array.from({ length: 100 }, (_, index) =>
+  [
+    "rental kontrakt",
+    "rental contract",
+    "service record",
+    "upkeep",
+    "liability",
+    "quiet our",
+    "guidelines",
+    "policy",
+  ][index % 8]
+)
+
+describe("indexed search client", () => {
+  beforeEach(async () => {
+    await ingestTopEntities(sampleEntities)
+  })
+
+  it("matches synonyms and phonetic variations", async () => {
+    const result = await searchPortal({
+      query: "rental kontrakt",
+      scope: "documents",
+      typoTolerance: "min",
+    })
+
+    expect(result.hits.map((hit) => hit.id)).toContain("lease-master")
+  })
+
+  it("returns facet counts aligned with filters", async () => {
+    const result = await searchPortal({
+      query: "maintenance",
+      scope: "documents",
+      typoTolerance: "min",
+      filters: { status: ["pending_signature"] },
+    })
+
+    expect(result.hits.some((hit) => hit.id === "maintenance-log")).toBe(true)
+    expect(result.facets.status?.pending_signature ?? 0).toBeGreaterThan(0)
+  })
+
+  it("maintains P95 latency under 150 ms across 100 queries", async () => {
+    const latencies: number[] = []
+
+    for (const query of fuzzQueries) {
+      const result = await searchPortal({
+        query,
+        scope: "documents",
+        typoTolerance: "min",
+      })
+
+      latencies.push(result.processingTimeMS)
+      expect(result.hits.length).toBeGreaterThan(0)
+    }
+
+    const sorted = [...latencies].sort((a, b) => a - b)
+    const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)
+
+    expect(sorted[index]).toBeLessThanOrEqual(150)
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable search client with Algolia support, phonetic tokenisation, and ingestion helpers
- expose a search API route and SearchBar component with latency instrumentation and facet awareness
- wire messaging and documents surfaces to the indexed search experience and add contract tests for accuracy and performance

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d20b70d42c8328873a04370ca2406a