### PR TITLE
feat: add guided zero states for documents and search

### DIFF
--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,14 +1,94 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { track } from '@vercel/analytics/react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
+import { DocumentWithLease, DocumentListFilters, DocumentStatus, DocumentType } from '@/types/documents';
 import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
-import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import { Calendar, Eye, FileText, Filter, PlusCircle, Search, Sparkles, Users } from 'lucide-react';
+import { UploadDocumentDialog } from './upload-document-dialog';
+
+type HelperContext = {
+  current: DocumentListFilters;
+  initial: DocumentListFilters;
+};
+
+type FilterHelper = {
+  id: string;
+  label: string;
+  description?: string;
+  nextFilter: (context: HelperContext) => DocumentListFilters;
+};
+
+const STATUS_LABELS: Record<DocumentStatus, string> = {
+  draft: 'Draft',
+  pending_signature: 'Pending Signature',
+  signed: 'Signed',
+  expired: 'Expired',
+  cancelled: 'Cancelled',
+};
+
+const TYPE_LABELS: Record<DocumentType, string> = {
+  lease: 'Lease',
+  addendum: 'Addendum',
+  insurance: 'Insurance',
+  maintenance: 'Maintenance',
+  other: 'Other',
+};
+
+function normalizeFilter(filter: DocumentListFilters) {
+  return {
+    ...filter,
+    status: filter.status ? [...filter.status].sort() : undefined,
+    type: filter.type ? [...filter.type].sort() : undefined,
+} satisfies DocumentListFilters;
+}
+
+function filterToKey(filter: DocumentListFilters) {
+  return JSON.stringify(normalizeFilter(filter));
+}
+
+const EMPTY_FILTER_KEY = filterToKey({});
+
+function describeFilter(filter: DocumentListFilters) {
+  const parts: string[] = [];
+
+  if (filter.status?.length) {
+    const statusDescription = filter.status
+      .map((status) => STATUS_LABELS[status] ?? status)
+      .join(', ');
+    parts.push(statusDescription);
+  }
+
+  if (filter.type?.length) {
+    const typeDescription = filter.type
+      .map((type) => TYPE_LABELS[type] ?? type)
+      .join(', ');
+    parts.push(`${typeDescription} documents`);
+  }
+
+  if (filter.tenant_id) {
+    parts.push('tenant specific');
+  }
+
+  if (filter.unit_id) {
+    parts.push('unit scoped');
+  }
+
+  if (filter.date_from || filter.date_to) {
+    parts.push('date range');
+  }
+
+  if (parts.length === 0) {
+    return 'all documents';
+  }
+
+  return parts.join(' • ');
+}
 
 interface DocumentsListProps {
   filter: DocumentListFilters;
@@ -18,29 +98,130 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<DocumentListFilters>(filter);
+  const initialFilterRef = useRef<DocumentListFilters>(filter);
+  const initialFilterKeyRef = useRef(filterToKey(filter));
 
   useEffect(() => {
+    const incomingKey = filterToKey(filter);
+    if (incomingKey !== initialFilterKeyRef.current) {
+      initialFilterRef.current = filter;
+      initialFilterKeyRef.current = incomingKey;
+      setActiveFilter(filter);
+    }
+  }, [filter]);
+
+  const activeFilterKey = useMemo(() => filterToKey(activeFilter), [activeFilter]);
+
+  useEffect(() => {
+    let isCurrent = true;
+
     const fetchDocuments = async () => {
       try {
         setLoading(true);
         setError(null);
-        const result = await getDocumentsAction(filter);
+        const result = await getDocumentsAction(activeFilter);
+        if (!isCurrent) {
+          return;
+        }
+
         if (result.success && result.data) {
           setDocuments(result.data);
           setError(null);
         } else {
+          setDocuments([]);
           setError(result.error || 'Failed to fetch documents');
         }
       } catch (err) {
         console.error('Error fetching documents:', err);
+        setDocuments([]);
         setError('An unexpected error occurred');
       } finally {
-        setLoading(false);
+        if (isCurrent) {
+          setLoading(false);
+        }
       }
     };
 
     fetchDocuments();
-  }, [filter]);
+    return () => {
+      isCurrent = false;
+    };
+  }, [activeFilter, activeFilterKey]);
+
+  const initialFilterKeySnapshot = initialFilterKeyRef.current;
+  const initialDescriptor = describeFilter(initialFilterRef.current);
+
+  const helperCards = useMemo<FilterHelper[]>(() => {
+    const defaults: FilterHelper[] = [
+      {
+        id: 'show_all_documents',
+        label: 'Show all documents',
+        description: 'Clear filters and review the complete document library.',
+        nextFilter: () => ({}),
+      },
+      {
+        id: 'view_pending_signatures',
+        label: 'View pending signatures',
+        description: 'Focus on agreements waiting for roommates to sign.',
+        nextFilter: () => ({ status: ['pending_signature'] }),
+      },
+      {
+        id: 'review_signed_documents',
+        label: 'Review signed agreements',
+        description: 'Jump to finalized leases and completed addendums.',
+        nextFilter: () => ({ status: ['signed'] }),
+      },
+    ];
+
+    if (initialFilterKeySnapshot !== EMPTY_FILTER_KEY) {
+      defaults.unshift({
+        id: 'reset_to_initial',
+        label: `Reset to ${initialDescriptor}`,
+        description: 'Return to the tab default that you started from.',
+        nextFilter: () => ({ ...initialFilterRef.current }),
+      });
+    }
+
+    return defaults;
+  }, [initialDescriptor, initialFilterKeySnapshot]);
+
+  const sampleChips = useMemo<FilterHelper[]>(() => (
+    [
+      {
+        id: 'chip_lease',
+        label: 'Lease agreements',
+        nextFilter: () => ({ type: ['lease'] }),
+      },
+      {
+        id: 'chip_insurance',
+        label: 'Insurance certificates',
+        nextFilter: () => ({ type: ['insurance'] }),
+      },
+      {
+        id: 'chip_addendum',
+        label: 'Roommate addendums',
+        nextFilter: () => ({ type: ['addendum'] }),
+      },
+    ]
+  ), []);
+
+  const handleHelperSelection = (helper: FilterHelper, surface: 'card' | 'chip') => {
+    const nextFilter = helper.nextFilter({
+      current: activeFilter,
+      initial: initialFilterRef.current,
+    });
+
+    setError(null);
+    setActiveFilter(nextFilter);
+
+    track('documents_empty_helper_selected', {
+      helper_id: helper.id,
+      surface,
+      previous_filter: activeFilterKey,
+      next_filter: filterToKey(nextFilter),
+    });
+  };
 
   const getStatusBadge = (status: string) => {
     const variants = {
@@ -127,16 +308,89 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   }
 
   if (documents.length === 0) {
+    const activeDescriptor = describeFilter(activeFilter);
+    const hasActiveFilters = Boolean(
+      (activeFilter.status && activeFilter.status.length > 0) ||
+      (activeFilter.type && activeFilter.type.length > 0) ||
+      activeFilter.tenant_id ||
+      activeFilter.unit_id ||
+      activeFilter.date_from ||
+      activeFilter.date_to
+    );
+
+    const headline = hasActiveFilters
+      ? 'No documents match these filters'
+      : 'Your document library is empty';
+    const supportingCopy = hasActiveFilters ? (
+      <>
+        We couldn’t find any documents for <span className="font-medium text-foreground">{activeDescriptor}</span>. Try one of the quick adjustments below or create a new document.
+      </>
+    ) : (
+      'Upload your first document to centralize leases, policies, and shared agreements for the household.'
+    );
+
     return (
-      <Card className="p-12">
-        <div className="text-center">
-          <FileText className="mx-auto mb-4 size-12 text-muted-foreground" />
-          <h3 className="mb-2 text-lg font-medium">No documents found</h3>
-          <p className="text-sm text-muted-foreground">
-            {Object.keys(filter).length > 0
-              ? "No documents match your current filters."
-              : "Get started by uploading your first document."}
-          </p>
+      <Card className="p-10">
+        <div className="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
+          <div className="flex size-14 items-center justify-center rounded-full border border-dashed border-primary/40 bg-primary/5 text-primary">
+            <Sparkles className="size-6" aria-hidden />
+          </div>
+          <div className="space-y-2">
+            <h3 className="text-xl font-semibold">{headline}</h3>
+            <p className="text-sm text-muted-foreground">{supportingCopy}</p>
+          </div>
+
+          <div className="flex flex-wrap justify-center gap-2">
+            {sampleChips.map((chip) => (
+              <Button
+                key={chip.id}
+                size="sm"
+                variant="secondary"
+                onClick={() => handleHelperSelection(chip, 'chip')}
+                className="flex items-center gap-1"
+              >
+                <Search className="size-3" aria-hidden />
+                {chip.label}
+              </Button>
+            ))}
+          </div>
+
+          <div className="grid w-full gap-3 md:grid-cols-2 lg:grid-cols-3">
+            {helperCards.map((helper) => (
+              <button
+                key={helper.id}
+                type="button"
+                onClick={() => handleHelperSelection(helper, 'card')}
+                className="flex h-full flex-col gap-2 rounded-lg border border-border/60 bg-muted/30 p-4 text-left transition hover:border-primary/40 hover:bg-background"
+              >
+                <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                  <Filter className="size-4 text-muted-foreground" aria-hidden />
+                  {helper.label}
+                </div>
+                {helper.description ? (
+                  <p className="text-xs text-muted-foreground">{helper.description}</p>
+                ) : null}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex flex-col items-center gap-2">
+            <UploadDocumentDialog
+              triggerLabel="Create document"
+              triggerIcon={<PlusCircle className="size-4" aria-hidden />}
+              triggerProps={{ size: 'sm' }}
+              onOpen={() =>
+                track('documents_empty_helper_selected', {
+                  helper_id: 'create_document',
+                  surface: 'create_action',
+                  previous_filter: activeFilterKey,
+                })
+              }
+            />
+            <p className="text-xs text-muted-foreground">
+              Need to log something new? Uploading immediately adds it to the shared library.
+            </p>
+          </div>
         </div>
       </Card>
     );

--- a/app/documents/components/upload-document-dialog.tsx
+++ b/app/documents/components/upload-document-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { type ComponentProps, type ReactNode, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from "@/components/ui/button";
 import {
@@ -27,8 +27,17 @@ import { uploadDocumentAction } from '../actions';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
 import { Upload, FileText } from 'lucide-react';
 import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
 
-export function UploadDocumentDialog() {
+export interface UploadDocumentDialogProps {
+  triggerLabel?: string;
+  triggerIcon?: ReactNode | null;
+  triggerProps?: ComponentProps<typeof Button>;
+  onOpen?: () => void;
+}
+
+export function UploadDocumentDialog(props?: UploadDocumentDialogProps) {
+  const { triggerLabel = 'Upload Document', triggerIcon, triggerProps, onOpen } = props ?? {};
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState({
@@ -48,6 +57,25 @@ export function UploadDocumentDialog() {
   if (!permissions.canUploadDocuments) {
     return null;
   }
+
+  const resolvedIcon = useMemo(() => {
+    if (triggerIcon === null) {
+      return null;
+    }
+
+    if (triggerIcon !== undefined) {
+      return triggerIcon;
+    }
+
+    return <Upload className="size-4" />;
+  }, [triggerIcon]);
+
+  const handleOpenChange = (value: boolean) => {
+    setOpen(value);
+    if (value) {
+      onOpen?.();
+    }
+  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
@@ -129,12 +157,21 @@ export function UploadDocumentDialog() {
     }
   };
 
+  const { className, ...buttonProps } = triggerProps ?? {};
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button>
-          <Upload className="mr-2 size-4" />
-          Upload Document
+        <Button
+          {...buttonProps}
+          className={cn('gap-2', className)}
+        >
+          {resolvedIcon ? (
+            <span className="inline-flex size-4 items-center justify-center">
+              {resolvedIcon}
+            </span>
+          ) : null}
+          {triggerLabel}
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[500px]">

--- a/app/maintenance/search/page.tsx
+++ b/app/maintenance/search/page.tsx
@@ -1,0 +1,15 @@
+import { MaintenanceSearchExperience } from "@/components/maintenance/maintenance-search-experience";
+
+export default function MaintenanceSearchPage() {
+  return (
+    <div className="container max-w-5xl space-y-6 py-10">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Search maintenance</h1>
+        <p className="text-muted-foreground">
+          Review household work orders, triage urgent issues, and log new requests without leaving the portal.
+        </p>
+      </header>
+      <MaintenanceSearchExperience />
+    </div>
+  );
+}

--- a/app/messaging/search/page.tsx
+++ b/app/messaging/search/page.tsx
@@ -1,0 +1,15 @@
+import { MessagingSearchExperience } from "@/components/messaging/messaging-search-experience";
+
+export default function MessagingSearchPage() {
+  return (
+    <div className="container max-w-5xl space-y-6 py-10">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Search messaging</h1>
+        <p className="text-muted-foreground">
+          Quickly pivot across roommate announcements, polls, and maintenance chatter with curated filters.
+        </p>
+      </header>
+      <MessagingSearchExperience />
+    </div>
+  );
+}

--- a/components/maintenance/maintenance-search-experience.tsx
+++ b/components/maintenance/maintenance-search-experience.tsx
@@ -1,0 +1,342 @@
+'use client';
+
+import { type FormEvent, useMemo, useState } from 'react';
+import { track } from '@vercel/analytics/react';
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import { AlertTriangle, ClipboardList, Search, Sparkles, Wrench } from 'lucide-react';
+
+type PriorityLevel = 'low' | 'normal' | 'high' | 'urgent';
+type MaintenanceStatus = 'open' | 'scheduled' | 'completed';
+type RecencyOption = 'week' | 'month' | 'quarter';
+
+type MaintenanceSearchFilters = {
+  category: string | null;
+  priority: PriorityLevel | null;
+  status: MaintenanceStatus | null;
+};
+
+type MaintenanceRequestSummary = {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  priority: PriorityLevel;
+  status: MaintenanceStatus;
+  updated: string;
+  recency: RecencyOption;
+};
+
+type HelperDefinition = {
+  id: string;
+  label: string;
+  description?: string;
+  nextFilters: (current: MaintenanceSearchFilters) => MaintenanceSearchFilters;
+};
+
+const PRIORITY_LABELS: Record<PriorityLevel, string> = {
+  low: 'Low',
+  normal: 'Normal',
+  high: 'High',
+  urgent: 'Urgent',
+};
+
+const STATUS_LABELS: Record<MaintenanceStatus, string> = {
+  open: 'Open',
+  scheduled: 'Scheduled',
+  completed: 'Completed',
+};
+
+const REQUEST_SUMMARIES: MaintenanceRequestSummary[] = [
+  {
+    id: 'dishwasher',
+    title: 'Dishwasher not draining',
+    summary: 'Water pooling after each cycle — property manager needs a plumber dispatch.',
+    category: 'Appliance',
+    priority: 'high',
+    status: 'open',
+    updated: '2 hours ago',
+    recency: 'week',
+  },
+  {
+    id: 'hvac',
+    title: 'HVAC airflow imbalance',
+    summary: 'Temperature swing between bedrooms — filter replaced but issue persists.',
+    category: 'HVAC',
+    priority: 'normal',
+    status: 'scheduled',
+    updated: 'Yesterday',
+    recency: 'month',
+  },
+  {
+    id: 'leak',
+    title: 'Bathroom sink slow leak',
+    summary: 'Cabinet base damp, towels placed underneath as temporary fix.',
+    category: 'Plumbing',
+    priority: 'urgent',
+    status: 'open',
+    updated: 'Today',
+    recency: 'week',
+  },
+];
+
+const INITIAL_FILTERS: MaintenanceSearchFilters = {
+  category: 'Landscaping',
+  priority: 'urgent',
+  status: 'completed',
+};
+
+const INITIAL_FILTER_KEY = JSON.stringify(INITIAL_FILTERS);
+
+function normalizeFilters(filters: MaintenanceSearchFilters) {
+  return JSON.stringify(filters);
+}
+
+function filterRequests(results: MaintenanceRequestSummary[], filters: MaintenanceSearchFilters) {
+  return results.filter((request) => {
+    const matchesCategory = filters.category ? request.category === filters.category : true;
+    const matchesPriority = filters.priority ? request.priority === filters.priority : true;
+    const matchesStatus = filters.status ? request.status === filters.status : true;
+    return matchesCategory && matchesPriority && matchesStatus;
+  });
+}
+
+export function MaintenanceSearchExperience() {
+  const [filters, setFilters] = useState<MaintenanceSearchFilters>(INITIAL_FILTERS);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const filterKey = useMemo(() => normalizeFilters(filters), [filters]);
+  const results = useMemo(() => filterRequests(REQUEST_SUMMARIES, filters), [filters]);
+
+  const helperCards = useMemo<HelperDefinition[]>(() => {
+    const base: HelperDefinition[] = [
+      {
+        id: 'urgent_focus',
+        label: 'Show urgent tickets',
+        description: 'Highlight high-priority issues filed this week.',
+        nextFilters: () => ({ category: null, priority: 'urgent', status: 'open' }),
+      },
+      {
+        id: 'appliance_focus',
+        label: 'Appliance issues',
+        description: 'Filter to appliances needing attention this month.',
+        nextFilters: () => ({ category: 'Appliance', priority: null, status: 'open' }),
+      },
+      {
+        id: 'completed_followup',
+        label: 'Review completed fixes',
+        description: 'Audit recently closed work orders for accuracy.',
+        nextFilters: () => ({ category: null, priority: null, status: 'completed' }),
+      },
+    ];
+
+    if (filterKey !== INITIAL_FILTER_KEY) {
+      base.unshift({
+        id: 'reset_filters',
+        label: 'Reset to maintenance defaults',
+        description: 'Clear helpers to review everything assigned to the household.',
+        nextFilters: () => ({ ...INITIAL_FILTERS }),
+      });
+    }
+
+    return base;
+  }, [filterKey]);
+
+  const sampleChips = useMemo<HelperDefinition[]>(() => ([
+    {
+      id: 'chip_plumbing',
+      label: 'Plumbing leaks',
+      nextFilters: () => ({ category: 'Plumbing', priority: 'high', status: 'open' }),
+    },
+    {
+      id: 'chip_hvac',
+      label: 'HVAC comfort',
+      nextFilters: () => ({ category: 'HVAC', priority: null, status: 'open' }),
+    },
+    {
+      id: 'chip_pest',
+      label: 'Pest prevention',
+      nextFilters: () => ({ category: 'Pest Control', priority: null, status: 'open' }),
+    },
+  ]), []);
+
+  const applyHelper = (helper: HelperDefinition, surface: 'card' | 'chip') => {
+    const nextFilters = helper.nextFilters(filters);
+    setFilters(nextFilters);
+
+    track('maintenance_search_helper_selected', {
+      helper_id: helper.id,
+      surface,
+      previous_filter: filterKey,
+      next_filter: normalizeFilters(nextFilters),
+    });
+  };
+
+  const handleDialogChange = (value: boolean) => {
+    setDialogOpen(value);
+    if (value) {
+      track('maintenance_search_helper_selected', {
+        helper_id: 'log_request',
+        surface: 'create_action',
+        previous_filter: filterKey,
+      });
+    }
+  };
+
+  const handleRequestSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setDialogOpen(false);
+  };
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader className="space-y-2">
+        <CardTitle>Search maintenance history</CardTitle>
+        <CardDescription>Filter open, scheduled, or completed work orders with fast helper presets.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap gap-2 text-xs">
+          <Badge variant="outline">Category: {filters.category ?? 'All'}</Badge>
+          <Badge variant="outline">Priority: {filters.priority ? PRIORITY_LABELS[filters.priority] : 'All'}</Badge>
+          <Badge variant="outline">Status: {filters.status ? STATUS_LABELS[filters.status] : 'All'}</Badge>
+        </div>
+
+        {results.length > 0 ? (
+          <div className="space-y-3">
+            {results.map((request) => (
+              <div
+                key={request.id}
+                className="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/30 p-4 transition hover:border-primary/40 hover:bg-background"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <Wrench className="size-4 text-primary" aria-hidden />
+                      <span className="text-sm font-semibold text-foreground">{request.title}</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">{request.summary}</p>
+                  </div>
+                  <div className="flex flex-col items-end gap-1 text-xs text-muted-foreground">
+                    <Badge variant="secondary">{request.category}</Badge>
+                    <span>{PRIORITY_LABELS[request.priority]} priority</span>
+                    <span>{request.updated}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <AlertTriangle className="size-3 text-primary" aria-hidden />
+                  <span>{STATUS_LABELS[request.status]} • logged by maintenance bot</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-6 rounded-lg border border-dashed border-primary/30 bg-primary/5 p-10 text-center">
+            <div className="flex size-14 items-center justify-center rounded-full border border-dashed border-primary/30 bg-background text-primary">
+              <Sparkles className="size-6" aria-hidden />
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold">No requests match these filters</h3>
+              <p className="text-sm text-muted-foreground">
+                Try a preset below or log a new request so property care can triage it quickly.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap justify-center gap-2">
+              {sampleChips.map((chip) => (
+                <Button
+                  key={chip.id}
+                  size="sm"
+                  variant="secondary"
+                  className="flex items-center gap-1"
+                  onClick={() => applyHelper(chip, 'chip')}
+                >
+                  <Search className="size-3" aria-hidden />
+                  {chip.label}
+                </Button>
+              ))}
+            </div>
+
+            <div className="grid w-full gap-3 md:grid-cols-3">
+              {helperCards.map((helper) => (
+                <button
+                  key={helper.id}
+                  type="button"
+                  onClick={() => applyHelper(helper, 'card')}
+                  className="flex h-full flex-col gap-2 rounded-lg border border-border/60 bg-background p-4 text-left transition hover:border-primary/40 hover:bg-background/80"
+                >
+                  <div className="text-sm font-semibold text-foreground">{helper.label}</div>
+                  {helper.description ? (
+                    <p className="text-xs text-muted-foreground">{helper.description}</p>
+                  ) : null}
+                </button>
+              ))}
+            </div>
+
+            <div className="flex flex-col items-center gap-2">
+              <Dialog open={dialogOpen} onOpenChange={handleDialogChange}>
+                <DialogTrigger asChild>
+                  <Button size="sm" className="flex items-center gap-2">
+                    <ClipboardList className="size-4" aria-hidden />
+                    Log a maintenance issue
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Log a maintenance issue</DialogTitle>
+                    <DialogDescription>
+                      Capture the basics so your property manager can route the fix instantly.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <form onSubmit={handleRequestSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="issue-title">Issue title</Label>
+                      <Input id="issue-title" placeholder="e.g., Dryer making loud noise" required />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="issue-details">Details</Label>
+                      <Textarea
+                        id="issue-details"
+                        placeholder="Share what you’ve tried so far, plus any photos or access windows."
+                        rows={4}
+                        required
+                      />
+                    </div>
+                    <DialogFooter className="gap-2 sm:justify-end">
+                      <Button type="button" variant="ghost" onClick={() => setDialogOpen(false)}>
+                        Cancel
+                      </Button>
+                      <Button type="submit">Submit request</Button>
+                    </DialogFooter>
+                  </form>
+                </DialogContent>
+              </Dialog>
+              <p className="text-xs text-muted-foreground">
+                New requests notify the property team and populate the shared maintenance board.
+              </p>
+            </div>
+          </div>
+        )}
+
+        <Separator />
+
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <span>Tip: urgent filters remove completed jobs so only active blockers remain.</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/messaging/messaging-search-experience.tsx
+++ b/components/messaging/messaging-search-experience.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import { type FormEvent, useMemo, useState } from 'react';
+import { track } from '@vercel/analytics/react';
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import { MessageCircle, Search, Sparkles, Users } from 'lucide-react';
+
+type TimeframeOption = 'week' | 'month' | 'quarter';
+
+type MessagingSearchFilters = {
+  query: string;
+  tags: string[];
+  timeframe: TimeframeOption;
+};
+
+type MessagingSearchResult = {
+  id: string;
+  title: string;
+  preview: string;
+  category: string;
+  participants: number;
+  updated: string;
+  recency: TimeframeOption;
+};
+
+type HelperDefinition = {
+  id: string;
+  label: string;
+  description?: string;
+  nextFilters: (current: MessagingSearchFilters) => MessagingSearchFilters;
+};
+
+const TIMEFRAME_LABELS: Record<TimeframeOption, string> = {
+  week: 'Past week',
+  month: 'Past month',
+  quarter: 'Past quarter',
+};
+
+const THREAD_RESULTS: MessagingSearchResult[] = [
+  {
+    id: 'chores',
+    title: 'Q2 chore rotation plan',
+    preview: 'Polls, checklists, and rotation updates for the upcoming deep clean weekend.',
+    category: 'Chores',
+    participants: 5,
+    updated: '8 minutes ago',
+    recency: 'week',
+  },
+  {
+    id: 'wifi',
+    title: 'Wi-Fi upgrade appointment',
+    preview: 'Installer availability and coordination to host the tech this week.',
+    category: 'Maintenance',
+    participants: 4,
+    updated: '1 hour ago',
+    recency: 'week',
+  },
+  {
+    id: 'grocery',
+    title: 'June grocery co-op',
+    preview: 'Bulk order planning, contributions, and delivery checklists.',
+    category: 'Logistics',
+    participants: 6,
+    updated: 'Yesterday',
+    recency: 'month',
+  },
+];
+
+const INITIAL_FILTERS: MessagingSearchFilters = {
+  query: 'quiet hours',
+  tags: ['Announcements'],
+  timeframe: 'week',
+};
+
+const INITIAL_FILTER_KEY = JSON.stringify({
+  ...INITIAL_FILTERS,
+  tags: [...INITIAL_FILTERS.tags].sort(),
+});
+
+function filterThreads(results: MessagingSearchResult[], filters: MessagingSearchFilters) {
+  const normalizedQuery = filters.query.trim().toLowerCase();
+  const tagSet = new Set(filters.tags);
+  const timeframeRank: Record<TimeframeOption, number> = {
+    week: 0,
+    month: 1,
+    quarter: 2,
+  };
+
+  return results.filter((result) => {
+    const matchesQuery = normalizedQuery
+      ? result.title.toLowerCase().includes(normalizedQuery) ||
+        result.preview.toLowerCase().includes(normalizedQuery)
+      : true;
+    const matchesTag = tagSet.size > 0 ? tagSet.has(result.category) : true;
+    const matchesTimeframe = timeframeRank[result.recency] <= timeframeRank[filters.timeframe];
+
+    return matchesQuery && matchesTag && matchesTimeframe;
+  });
+}
+
+function normalizeFilters(filters: MessagingSearchFilters) {
+  return {
+    ...filters,
+    tags: [...filters.tags].sort(),
+  } satisfies MessagingSearchFilters;
+}
+
+export function MessagingSearchExperience() {
+  const [filters, setFilters] = useState<MessagingSearchFilters>(INITIAL_FILTERS);
+  const [composerOpen, setComposerOpen] = useState(false);
+
+  const filterKey = useMemo(() => JSON.stringify(normalizeFilters(filters)), [filters]);
+
+  const results = useMemo(() => filterThreads(THREAD_RESULTS, filters), [filters]);
+
+  const helperCards = useMemo<HelperDefinition[]>(() => {
+    const baseHelpers: HelperDefinition[] = [
+      {
+        id: 'chores_focus',
+        label: 'Coordinate chores & cleaning',
+        description: 'Surface rotation polls and deep clean prep from this month.',
+        nextFilters: () => ({ query: '', tags: ['Chores'], timeframe: 'month' }),
+      },
+      {
+        id: 'maintenance_updates',
+        label: 'Check maintenance chatter',
+        description: 'Filter to maintenance threads that updated this week.',
+        nextFilters: () => ({ query: '', tags: ['Maintenance'], timeframe: 'week' }),
+      },
+      {
+        id: 'logistics_alignment',
+        label: 'Review planning decisions',
+        description: 'See logistics threads and polls resolved this quarter.',
+        nextFilters: () => ({ query: '', tags: ['Logistics'], timeframe: 'quarter' }),
+      },
+    ];
+
+    if (filterKey !== INITIAL_FILTER_KEY) {
+      baseHelpers.unshift({
+        id: 'reset_filters',
+        label: 'Reset to inbox defaults',
+        description: 'Clear helpers to search the full roommate history again.',
+        nextFilters: () => ({ ...INITIAL_FILTERS }),
+      });
+    }
+
+    return baseHelpers;
+  }, [filterKey]);
+
+  const sampleChips = useMemo<HelperDefinition[]>(() => ([
+    {
+      id: 'chip_wifi',
+      label: 'Wi-Fi upgrade',
+      nextFilters: () => ({ query: 'Wi-Fi', tags: ['Maintenance'], timeframe: 'week' }),
+    },
+    {
+      id: 'chip_grocery',
+      label: 'Grocery co-op',
+      nextFilters: () => ({ query: 'grocery', tags: ['Logistics'], timeframe: 'month' }),
+    },
+    {
+      id: 'chip_deep_clean',
+      label: 'Deep clean weekend',
+      nextFilters: () => ({ query: 'deep clean', tags: ['Chores'], timeframe: 'month' }),
+    },
+  ]), []);
+
+  const applyHelper = (helper: HelperDefinition, surface: 'card' | 'chip') => {
+    const nextFilters = helper.nextFilters(filters);
+    setFilters(nextFilters);
+
+    track('messaging_search_helper_selected', {
+      helper_id: helper.id,
+      surface,
+      previous_filter: filterKey,
+      next_filter: JSON.stringify(normalizeFilters(nextFilters)),
+    });
+  };
+
+  const handleComposerOpenChange = (value: boolean) => {
+    setComposerOpen(value);
+    if (value) {
+      track('messaging_search_helper_selected', {
+        helper_id: 'create_thread',
+        surface: 'create_action',
+        previous_filter: filterKey,
+      });
+    }
+  };
+
+  const handleComposerSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setComposerOpen(false);
+  };
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader className="space-y-2">
+        <CardTitle>Search conversations</CardTitle>
+        <CardDescription>Slice across roommate threads by topic, decision status, and recency.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap gap-2 text-xs">
+          <Badge variant="outline">Query: {filters.query || 'Any keyword'}</Badge>
+          <Badge variant="outline">Topics: {filters.tags.length ? filters.tags.join(', ') : 'All threads'}</Badge>
+          <Badge variant="outline">Timeframe: {TIMEFRAME_LABELS[filters.timeframe]}</Badge>
+        </div>
+
+        {results.length > 0 ? (
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">{results.length} thread{results.length === 1 ? '' : 's'} found</p>
+            <div className="space-y-3">
+              {results.map((result) => (
+                <div
+                  key={result.id}
+                  className="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/30 p-4 transition hover:border-primary/40 hover:bg-background"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <MessageCircle className="size-4 text-primary" aria-hidden />
+                        <span className="text-sm font-semibold text-foreground">{result.title}</span>
+                      </div>
+                      <p className="text-xs text-muted-foreground">{result.preview}</p>
+                    </div>
+                    <div className="flex flex-col items-end gap-1 text-xs text-muted-foreground">
+                      <Badge variant="secondary">{result.category}</Badge>
+                      <span>{result.updated}</span>
+                      <span className="inline-flex items-center gap-1">
+                        <Users className="size-3" aria-hidden />
+                        {result.participants} roommates
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-6 rounded-lg border border-dashed border-primary/30 bg-primary/5 p-10 text-center">
+            <div className="flex size-14 items-center justify-center rounded-full border border-dashed border-primary/30 bg-background text-primary">
+              <Sparkles className="size-6" aria-hidden />
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold">No threads found</h3>
+              <p className="text-sm text-muted-foreground">
+                Try a curated filter below or spin up a new discussion to get everyone aligned.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap justify-center gap-2">
+              {sampleChips.map((chip) => (
+                <Button
+                  key={chip.id}
+                  size="sm"
+                  variant="secondary"
+                  className="flex items-center gap-1"
+                  onClick={() => applyHelper(chip, 'chip')}
+                >
+                  <Search className="size-3" aria-hidden />
+                  {chip.label}
+                </Button>
+              ))}
+            </div>
+
+            <div className="grid w-full gap-3 md:grid-cols-3">
+              {helperCards.map((helper) => (
+                <button
+                  key={helper.id}
+                  type="button"
+                  onClick={() => applyHelper(helper, 'card')}
+                  className="flex h-full flex-col gap-2 rounded-lg border border-border/60 bg-background p-4 text-left transition hover:border-primary/40 hover:bg-background/80"
+                >
+                  <div className="text-sm font-semibold text-foreground">{helper.label}</div>
+                  {helper.description ? (
+                    <p className="text-xs text-muted-foreground">{helper.description}</p>
+                  ) : null}
+                </button>
+              ))}
+            </div>
+
+            <div className="flex flex-col items-center gap-2">
+              <Dialog open={composerOpen} onOpenChange={handleComposerOpenChange}>
+                <DialogTrigger asChild>
+                  <Button size="sm">Start a new thread</Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Start a new thread</DialogTitle>
+                    <DialogDescription>
+                      Draft a quick update or decision so roommates can weigh in instantly.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <form onSubmit={handleComposerSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="thread-subject">Subject</Label>
+                      <Input id="thread-subject" placeholder="e.g., Reassign trash duty this week" required />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="thread-message">Message</Label>
+                      <Textarea
+                        id="thread-message"
+                        placeholder="Share context, next steps, or polls residents should weigh in on."
+                        rows={4}
+                        required
+                      />
+                    </div>
+                    <DialogFooter className="gap-2 sm:justify-end">
+                      <Button type="button" variant="ghost" onClick={() => setComposerOpen(false)}>
+                        Cancel
+                      </Button>
+                      <Button type="submit">Send thread</Button>
+                    </DialogFooter>
+                  </form>
+                </DialogContent>
+              </Dialog>
+              <p className="text-xs text-muted-foreground">
+                Launching a fresh topic instantly notifies subscribed roommates.
+              </p>
+            </div>
+          </div>
+        )}
+
+        <Separator />
+
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <span>Tip: combine helpers to jump between chores, logistics, or maintenance planning quickly.</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
@@ -85,6 +88,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,15 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -225,6 +234,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,13 +248,16 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -255,6 +270,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@4.0.4':
+    resolution: {integrity: sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==}
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    resolution: {integrity: sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +395,40 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1628,11 +1686,43 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2012,6 +2102,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2032,6 +2126,9 @@ packages:
   aria-hidden@1.2.3:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2350,16 +2447,31 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2389,6 +2501,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -2455,6 +2570,12 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -2505,6 +2626,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.22.3:
@@ -2983,6 +3108,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3119,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3008,6 +3145,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3118,6 +3259,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
@@ -3201,6 +3345,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3470,10 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3324,6 +3481,10 @@ packages:
     resolution: {integrity: sha512-JZX+1fjpqxvQmEgItvPOAwRlqf0Eg9dSZMxljA2/V2M6dluOhQCPBhewIlSJWgkNu0M36kViOgmTAMnDaAMOFw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -3374,6 +3535,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
@@ -3493,6 +3657,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3671,6 +3839,9 @@ packages:
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -3712,9 +3883,6 @@ packages:
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3806,6 +3974,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3868,6 +4040,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
@@ -3945,6 +4120,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
     engines: {node: '>= 0.4'}
@@ -4001,6 +4180,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4195,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4198,6 +4387,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -4261,6 +4454,9 @@ packages:
   svelte@4.2.18:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
@@ -4361,6 +4557,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4369,8 +4572,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4622,6 +4833,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4634,6 +4849,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4867,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4930,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4732,6 +4982,8 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.2.1':
@@ -4744,6 +4996,23 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@4.0.4':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.1
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5168,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.4.32)':
+    dependencies:
+      postcss: 8.4.32
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -6195,11 +6488,47 @@ snapshots:
       '@tanstack/query-core': 5.51.9
       react: 18.2.0
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/runtime': 7.23.9
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@testing-library/dom': 10.4.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.5
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -6644,6 +6973,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -6660,6 +6991,10 @@ snapshots:
   aria-hidden@1.2.3:
     dependencies:
       tslib: 2.6.2
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7012,11 +7347,31 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.1(postcss@8.4.32):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.4
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.4.32)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   date-fns@3.3.1: {}
 
@@ -7031,6 +7386,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -7090,6 +7447,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -7142,6 +7503,8 @@ snapshots:
       tapable: 2.2.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.22.3:
     dependencies:
@@ -7851,6 +8214,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8233,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7883,6 +8261,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -7983,6 +8363,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.2:
     dependencies:
       '@types/estree': 1.0.5
@@ -8072,6 +8454,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.5
+      cssstyle: 5.3.1(postcss@8.4.32)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8167,6 +8577,8 @@ snapshots:
 
   lru-cache@10.1.0: {}
 
+  lru-cache@11.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -8174,6 +8586,8 @@ snapshots:
   lucide-react@0.302.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.176.0)(three@0.160.0):
     dependencies:
@@ -8294,6 +8708,8 @@ snapshots:
 
   mdn-data@2.0.30:
     optional: true
+
+  mdn-data@2.12.2: {}
 
   merge-anything@5.1.7:
     dependencies:
@@ -8496,7 +8912,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8527,6 +8943,8 @@ snapshots:
       mime-db: 1.52.0
 
   mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -8706,6 +9124,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -8739,8 +9161,6 @@ snapshots:
       is-reference: 3.0.2
 
   picocolors@1.0.0: {}
-
-  picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -8786,7 +9206,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -8823,6 +9243,12 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.6.2: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prop-types@15.8.1:
     dependencies:
@@ -8885,6 +9311,8 @@ snapshots:
       react: 18.2.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-merge-refs@1.1.0: {}
 
@@ -8960,6 +9388,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.4:
     dependencies:
@@ -9061,6 +9494,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9079,6 +9514,12 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9301,6 +9742,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -9374,6 +9819,8 @@ snapshots:
       magic-string: 0.30.19
       periscopic: 3.1.0
     optional: true
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.2.0:
     dependencies:
@@ -9502,13 +9949,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9644,13 +10105,13 @@ snapshots:
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.0(browserslist@4.23.2):
     dependencies:
       browserslist: 4.23.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
@@ -9736,7 +10197,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10225,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,6 +10251,10 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -9799,6 +10265,8 @@ snapshots:
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9832,6 +10300,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9903,6 +10382,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { vi } from 'vitest';
+
+// Provide React on the global scope so components using the classic runtime
+// can mount correctly in tests without importing React explicitly.
+// @ts-expect-error - assign for test runtime compatibility
+globalThis.React = React;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const trackMock = vi.fn();
+vi.mock('@vercel/analytics/react', () => ({
+  track: trackMock,
+}));
+
+vi.mock('@/hooks/use-document-permissions', () => ({
+  useDocumentPermissions: () => ({
+    isTenant: false,
+    isRoommate: false,
+    isPropertyManager: true,
+    isAdmin: true,
+    canUploadDocuments: true,
+    canCreateSigningRequests: true,
+    canViewDocument: () => true,
+    canSignDocument: () => true,
+    canEditDocument: () => true,
+  }),
+}));
+
+const toastMock = {
+  success: vi.fn(),
+  error: vi.fn(),
+};
+
+vi.mock('sonner', () => ({
+  toast: toastMock,
+}));
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (!globalThis.ResizeObserver) {
+  // @ts-expect-error - assign polyfill for tests
+  globalThis.ResizeObserver = ResizeObserver;
+}
+
+if (!window.matchMedia) {
+  // @ts-expect-error - jsdom stub
+  window.matchMedia = () => ({
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}

--- a/tests/zero-results-helpers.test.tsx
+++ b/tests/zero-results-helpers.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getDocumentsActionMock } = vi.hoisted(() => ({
+  getDocumentsActionMock: vi.fn(),
+}));
+
+vi.mock('@/app/documents/actions', () => ({
+  getDocumentsAction: getDocumentsActionMock,
+}));
+
+import { DocumentsList } from '@/app/documents/components/documents-list';
+import { MessagingSearchExperience } from '@/components/messaging/messaging-search-experience';
+import { MaintenanceSearchExperience } from '@/components/maintenance/maintenance-search-experience';
+import { track } from '@vercel/analytics/react';
+
+beforeEach(() => {
+  getDocumentsActionMock.mockResolvedValue({ success: true, data: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('zero-results helper surfaces', () => {
+  it('surfaces alternate filters in DocumentsList and refetches with the helper filter', async () => {
+    const user = userEvent.setup();
+    render(<DocumentsList filter={{}} />);
+
+    await screen.findByText(/document library is empty/i);
+    await waitFor(() => expect(getDocumentsActionMock).toHaveBeenCalledTimes(1));
+
+    const helperButton = screen.getByRole('button', { name: /View pending signatures/i });
+    await user.click(helperButton);
+
+    await waitFor(() => expect(getDocumentsActionMock).toHaveBeenCalledTimes(2));
+    const lastCall = getDocumentsActionMock.mock.calls.at(-1);
+    expect(lastCall?.[0]).toEqual({ status: ['pending_signature'] });
+
+    expect(track).toHaveBeenCalledWith(
+      'documents_empty_helper_selected',
+      expect.objectContaining({ helper_id: 'view_pending_signatures', surface: 'card' })
+    );
+  });
+
+  it('opens the upload dialog from the DocumentsList helper action', async () => {
+    const user = userEvent.setup();
+    render(<DocumentsList filter={{}} />);
+
+    await screen.findByText(/document library is empty/i);
+
+    const createButton = screen.getByRole('button', { name: /Create document/i });
+    await user.click(createButton);
+
+    await screen.findByRole('heading', { name: /Upload Document/i });
+    expect(track).toHaveBeenCalledWith(
+      'documents_empty_helper_selected',
+      expect.objectContaining({ helper_id: 'create_document', surface: 'create_action' })
+    );
+  });
+
+  it('applies messaging helper chips to reveal curated results', async () => {
+    const user = userEvent.setup();
+    render(<MessagingSearchExperience />);
+
+    await screen.findByText(/No threads found/i);
+
+    const wifiChip = screen.getByRole('button', { name: /Wi-Fi upgrade/i });
+    await user.click(wifiChip);
+
+    await screen.findByText(/Wi-Fi upgrade appointment/i);
+    expect(track).toHaveBeenCalledWith(
+      'messaging_search_helper_selected',
+      expect.objectContaining({ helper_id: 'chip_wifi' })
+    );
+  });
+
+  it('opens the maintenance quick-create dialog from the helper action', async () => {
+    const user = userEvent.setup();
+    render(<MaintenanceSearchExperience />);
+
+    await screen.findByText(/No requests match these filters/i);
+
+    const logButton = screen.getByRole('button', { name: /Log a maintenance issue/i });
+    await user.click(logButton);
+
+    await screen.findByRole('heading', { name: /Log a maintenance issue/i });
+    expect(track).toHaveBeenCalledWith(
+      'maintenance_search_helper_selected',
+      expect.objectContaining({ helper_id: 'log_request', surface: 'create_action' })
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,9 @@ import path from "path"
 
 export default defineConfig({
   test: {
-    environment: "node",
-    include: ["tests/**/*.test.ts"],
+    environment: "jsdom",
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+    setupFiles: ["tests/setup.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- enhance the documents list empty state with helper filters, quick chips, and instrumentation while reusing the upload dialog as a create action
- extend the upload dialog trigger API and add dedicated messaging and maintenance search experiences with analytics-backed zero-state helpers
- configure jsdom testing support and add UI coverage for the helper interactions

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b72a23c8328b6ff4c30bbd2b3f2