### PR TITLE
feat: add quick add command workflow

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation"
 
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+import { QuickAddInput } from "@/components/quick-add/quick-add-input"
 import { readUserSession } from "@/utils/actions"
 import MobileSideNav from "./components/MobileSideNav"
 import SideNav from "./components/SideNav"
@@ -23,7 +24,14 @@ export default async function Layout({ children }: { children: ReactNode }) {
 			</div>
 
                         <div className="w-full space-y-5 bg-gray-100 p-5 sm:flex-1 sm:p-10 dark:bg-inherit">
-                                <ToggleSidebar />
+                                <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                                        <ToggleSidebar />
+                                        <QuickAddInput
+                                                variant="header"
+                                                className="w-full lg:max-w-xl"
+                                                placeholder="Quick add — e.g. “Invoice 200 CAD due Friday”"
+                                        />
+                                </div>
                                 <ErrorBoundary>
                                         <Suspense fallback={<RouteSkeleton />}>
                                                 {children}

--- a/app/dashboard/quick-add/actions.ts
+++ b/app/dashboard/quick-add/actions.ts
@@ -1,0 +1,260 @@
+"use server"
+
+import { z } from "zod"
+
+import {
+  type QuickAddIntent,
+  type BookingQuickAddPayload,
+  type InvoiceQuickAddPayload,
+  type MaintenanceQuickAddPayload,
+  type VisitorQuickAddPayload,
+} from "@/lib/nlp/quick-add"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+const invoiceSubmissionSchema = z.object({
+  amountCents: z.number().int().positive(),
+  currency: z.string().length(3),
+  dueDate: z.string().optional(),
+  description: z.string().optional(),
+  counterparty: z.string().optional(),
+})
+
+const bookingSubmissionSchema = z.object({
+  amenityId: z.string().min(1),
+  amenityLabel: z.string().min(1),
+  startTime: z.string().min(1),
+  endTime: z.string().min(1),
+  hasExplicitEnd: z.boolean(),
+  note: z.string().optional(),
+})
+
+const maintenanceSubmissionSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1),
+  priority: z.enum(["low", "normal", "high", "urgent"]),
+})
+
+const visitorSubmissionSchema = z.object({
+  guestName: z.string().min(1),
+  guestEmail: z.string().email(),
+  guestPhone: z.string().optional(),
+  checkIn: z.string().min(1),
+  checkOut: z.string().min(1),
+  purpose: z.string().min(1),
+})
+
+const quickAddSubmissionSchema = z.discriminatedUnion("intent", [
+  z.object({
+    intent: z.literal("invoice"),
+    commandText: z.string().min(1),
+    payload: invoiceSubmissionSchema,
+  }),
+  z.object({
+    intent: z.literal("booking"),
+    commandText: z.string().min(1),
+    payload: bookingSubmissionSchema,
+  }),
+  z.object({
+    intent: z.literal("maintenance"),
+    commandText: z.string().min(1),
+    payload: maintenanceSubmissionSchema,
+  }),
+  z.object({
+    intent: z.literal("visitor"),
+    commandText: z.string().min(1),
+    payload: visitorSubmissionSchema,
+  }),
+])
+
+export type QuickAddSubmissionInput = z.infer<typeof quickAddSubmissionSchema>
+
+export interface QuickAddSubmissionResult {
+  success: boolean
+  intent: QuickAddIntent
+  recordId?: string
+  message: string
+}
+
+export async function submitQuickAdd(
+  submission: QuickAddSubmissionInput,
+): Promise<QuickAddSubmissionResult> {
+  const parsed = quickAddSubmissionSchema.safeParse(submission)
+
+  if (!parsed.success) {
+    throw new Error("Invalid quick-add payload.")
+  }
+
+  const payload = parsed.data
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    throw new Error(userError.message)
+  }
+
+  if (!user) {
+    throw new Error("You must be signed in to use Quick Add.")
+  }
+
+  switch (payload.intent) {
+    case "invoice":
+      return submitInvoice(payload.commandText, payload.payload, user.id, supabase)
+    case "booking":
+      return submitBooking(payload.commandText, payload.payload, user.id, supabase)
+    case "maintenance":
+      return submitMaintenance(payload.commandText, payload.payload, user.id, supabase)
+    case "visitor":
+      return submitVisitor(payload.commandText, payload.payload, user.id, supabase)
+    default:
+      throw new Error("Unsupported quick-add intent.")
+  }
+}
+
+type SupabaseClient = Awaited<ReturnType<typeof createSupbaseServerClient>>
+
+async function submitInvoice(
+  commandText: string,
+  payload: InvoiceQuickAddPayload,
+  userId: string,
+  supabase: SupabaseClient,
+): Promise<QuickAddSubmissionResult> {
+  const { data, error } = await supabase
+    .from("rent_payments")
+    .insert({
+      user_id: userId,
+      amount: payload.amountCents,
+      currency: payload.currency.toLowerCase(),
+      status: "pending",
+      description:
+        payload.description ??
+        (payload.counterparty
+          ? `Quick add invoice for ${payload.counterparty}`
+          : "Quick add invoice"),
+      payer_name: payload.counterparty ?? null,
+      metadata: {
+        quick_add: true,
+        due_date: payload.dueDate ?? null,
+        command_text: commandText,
+      },
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return {
+    success: true,
+    intent: "invoice",
+    recordId: data?.id,
+    message: "Invoice draft recorded.",
+  }
+}
+
+async function submitBooking(
+  commandText: string,
+  payload: BookingQuickAddPayload,
+  userId: string,
+  supabase: SupabaseClient,
+): Promise<QuickAddSubmissionResult> {
+  const { data, error } = await supabase
+    .from("amenity_bookings")
+    .insert({
+      amenity_id: payload.amenityId,
+      created_by: userId,
+      status: payload.hasExplicitEnd ? "confirmed" : "pending",
+      start_time: payload.startTime,
+      end_time: payload.endTime,
+      metadata: {
+        quick_add: true,
+        note: payload.note ?? null,
+        amenity_label: payload.amenityLabel,
+        command_text: commandText,
+      },
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return {
+    success: true,
+    intent: "booking",
+    recordId: data?.id,
+    message: "Amenity booking created.",
+  }
+}
+
+async function submitMaintenance(
+  commandText: string,
+  payload: MaintenanceQuickAddPayload,
+  userId: string,
+  supabase: SupabaseClient,
+): Promise<QuickAddSubmissionResult> {
+  const { data, error } = await supabase
+    .from("maintenance_requests")
+    .insert({
+      title: payload.title,
+      description: payload.description,
+      priority: payload.priority,
+      status: "pending",
+      requested_by: userId,
+      metadata: {
+        quick_add: true,
+        command_text: commandText,
+      },
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return {
+    success: true,
+    intent: "maintenance",
+    recordId: data?.id,
+    message: "Maintenance request filed.",
+  }
+}
+
+async function submitVisitor(
+  commandText: string,
+  payload: VisitorQuickAddPayload,
+  userId: string,
+  supabase: SupabaseClient,
+): Promise<QuickAddSubmissionResult> {
+  const { data, error } = await supabase
+    .from("visitor_logs")
+    .insert({
+      guest_name: payload.guestName,
+      guest_email: payload.guestEmail,
+      guest_phone: payload.guestPhone ?? null,
+      host_id: userId,
+      check_in_date: payload.checkIn,
+      check_out_date: payload.checkOut,
+      purpose: payload.purpose,
+      status: "pending",
+      special_notes: commandText,
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return {
+    success: true,
+    intent: "visitor",
+    recordId: data?.id,
+    message: "Visitor registered for review.",
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import "./globals.css"
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
 import { CookieButton } from "@/components/cookie-button"
+import { CommandPalette } from "@/components/command-palette"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
@@ -119,48 +120,45 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <ReactQueryClientProvider>
     <html lang="en" suppressHydrationWarning>
     <head></head>
-      <body className={cn(
-            "min-h-screen bg-background font-sans antialiased",
-            fontSans.variable
-          )}
+      <body
+        className={cn(
+          "min-h-screen bg-background font-sans antialiased",
+          fontSans.variable,
+        )}
+      >
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
         >
-<ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-             <div className="relative flex min-h-screen flex-col">
-              <SiteHeader />
-              <div className="flex-1">
-                <ErrorBoundary>
-                  <Suspense fallback={<RouteSkeleton />}>
-                    {children}
-                  </Suspense>
-                </ErrorBoundary>
-                <Toaster />
-                <Analytics />
-                <SpeedInsights />
-              </div>
+          <div className="relative flex min-h-screen flex-col">
+            <CommandPalette />
+            <SiteHeader />
+            <main className="flex-1">
+              <ErrorBoundary>
+                <Suspense fallback={<RouteSkeleton />}>
+                  {children}
+                </Suspense>
+              </ErrorBoundary>
+            </main>
+            <SiteFooter />
+          </div>
+          <Toaster />
+          <Analytics />
+          <SpeedInsights />
 
-   </div>
-<SiteFooter/>
-
-
-{/*
-enter your api info from termly.io or a provider of your choice
-<Script
-  type="text/javascript"
-  src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
-
- */}
-   <CookieButton />
-   <TailwindIndicator />
-          </ThemeProvider>
-
-
-
-</body>
+          {/*
+            enter your api info from termly.io or a provider of your choice
+            <Script
+              type="text/javascript"
+              src="https://app.termly.io/resource-blocker/123456789abcdefg"
+            />
+          */}
+          <CookieButton />
+          <TailwindIndicator />
+        </ThemeProvider>
+      </body>
     </html>
     </ReactQueryClientProvider>
   )

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+import { usePathname, useRouter } from "next/navigation"
+
+import { QuickAddInput } from "@/components/quick-add/quick-add-input"
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command"
+import { Badge } from "@/components/ui/badge"
+
+const navigationCommands = [
+  {
+    id: "dashboard",
+    label: "Dashboard overview",
+    href: "/dashboard",
+    description: "See rent, bookings, visitors and recent documents",
+  },
+  {
+    id: "payments",
+    label: "Payments",
+    href: "/payments",
+    description: "Review rent history and record catch-up payments",
+  },
+  {
+    id: "schedule",
+    label: "Amenity schedule",
+    href: "/schedule",
+    description: "Reserve kitchen, TV room, parking and more",
+  },
+  {
+    id: "documents",
+    label: "Documents",
+    href: "/documents",
+    description: "Access leases, house rules and shared files",
+  },
+  {
+    id: "maintenance",
+    label: "Maintenance",
+    href: "/maintenance",
+    description: "Track open tickets and vendor status",
+  },
+  {
+    id: "visitors",
+    label: "Visitor log",
+    href: "/visitors",
+    description: "Manage overnight guest approvals",
+  },
+] as const
+
+type NavigationCommand = (typeof navigationCommands)[number]
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+  const pathname = usePathname()
+  const quickAddRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const down = (event: KeyboardEvent) => {
+      if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault()
+        setOpen((previous) => !previous)
+        return
+      }
+
+      if (event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        const target = event.target as HTMLElement | null
+        const tagName = target?.tagName?.toLowerCase()
+        const isEditable = target?.isContentEditable
+        const isFormElement = tagName && ["input", "textarea", "select"].includes(tagName)
+
+        if (!isFormElement && !isEditable) {
+          event.preventDefault()
+          setOpen(true)
+          requestAnimationFrame(() => {
+            quickAddRef.current?.focus()
+          })
+        }
+      }
+    }
+
+    window.addEventListener("keydown", down)
+    return () => window.removeEventListener("keydown", down)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const handle = requestAnimationFrame(() => {
+      quickAddRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(handle)
+  }, [open])
+
+  const handleSelect = (command: NavigationCommand) => {
+    setOpen(false)
+    router.push(command.href)
+  }
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <div className="border-b bg-muted/40 p-3">
+        <QuickAddInput
+          ref={quickAddRef}
+          variant="command"
+          placeholder="/invoice 200 CAD due Friday"
+          onCompleted={() => setOpen(false)}
+        />
+      </div>
+      <CommandInput placeholder="Search destinations" autoFocus={false} />
+      <CommandList>
+        <CommandEmpty>No matching commands.</CommandEmpty>
+        <CommandGroup heading="Navigation">
+          {navigationCommands.map((command) => (
+            <CommandItem
+              key={command.id}
+              value={`${command.label} ${command.description}`}
+              onSelect={() => handleSelect(command)}
+            >
+              <div className="flex w-full items-center justify-between gap-4">
+                <div className="flex flex-col text-sm">
+                  <span className="font-medium text-foreground">{command.label}</span>
+                  <span className="text-xs text-muted-foreground">{command.description}</span>
+                </div>
+                {pathname === command.href ? (
+                  <Badge variant="outline">Current</Badge>
+                ) : null}
+              </div>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Shortcuts">
+          <CommandItem disabled>/ opens quick add</CommandItem>
+          <CommandItem disabled>⌘K (or Ctrl+K) toggles this palette</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/components/quick-add/quick-add-input.tsx
+++ b/components/quick-add/quick-add-input.tsx
@@ -1,0 +1,333 @@
+"use client"
+
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react"
+
+import { Sparkles, Loader2 } from "lucide-react"
+
+import {
+  type QuickAddIntent,
+  type QuickAddParseResult,
+  parseQuickAddCommand,
+} from "@/lib/nlp/quick-add"
+import {
+  submitQuickAdd,
+  type QuickAddSubmissionInput,
+} from "@/app/dashboard/quick-add/actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { useToast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+
+const intentLabels: Record<QuickAddIntent, string> = {
+  invoice: "Invoice",
+  booking: "Amenity booking",
+  maintenance: "Maintenance",
+  visitor: "Visitor log",
+  unknown: "Unknown",
+}
+
+type StatusTone = "default" | "success" | "warning" | "error" | "muted"
+
+const toneToClass: Record<StatusTone, string> = {
+  default: "text-muted-foreground",
+  muted: "text-muted-foreground",
+  success: "text-emerald-600 dark:text-emerald-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  error: "text-destructive",
+}
+
+export interface QuickAddInputProps {
+  variant?: "header" | "command"
+  placeholder?: string
+  autoFocus?: boolean
+  className?: string
+  onCompleted?: () => void
+}
+
+export const QuickAddInput = forwardRef<HTMLInputElement, QuickAddInputProps>(
+  (
+    {
+      variant = "header",
+      placeholder = "Try “Add invoice 200 CAD due Friday”",
+      autoFocus = false,
+      className,
+      onCompleted,
+    },
+    ref,
+  ) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    const { toast } = useToast()
+    const [value, setValue] = useState("")
+    const [reviewOpen, setReviewOpen] = useState(false)
+    const [isSubmitting, startTransition] = useTransition()
+
+    useImperativeHandle(ref, () => inputRef.current as HTMLInputElement | null)
+
+    useEffect(() => {
+      if (!autoFocus) return
+      const handle = requestAnimationFrame(() => {
+        inputRef.current?.focus()
+      })
+      return () => cancelAnimationFrame(handle)
+    }, [autoFocus])
+
+    const parsed = useMemo<QuickAddParseResult | null>(() => {
+      if (!value.trim()) return null
+      return parseQuickAddCommand(value)
+    }, [value])
+
+    useEffect(() => {
+      if (!parsed?.isReady) {
+        setReviewOpen(false)
+      }
+    }, [parsed?.isReady])
+
+    const status = useMemo(() => {
+      if (!parsed) {
+        return {
+          tone: "muted" as StatusTone,
+          message: "Quickly add invoices, bookings, visitors or maintenance tasks.",
+        }
+      }
+
+      if (parsed.errors.length > 0) {
+        return { tone: "error" as StatusTone, message: parsed.errors[0] }
+      }
+
+      if (parsed.warnings.length > 0) {
+        return { tone: "warning" as StatusTone, message: parsed.warnings[0] }
+      }
+
+      const missing = parsed.fields.filter((field) => field.required && !field.isValid)
+      if (missing.length > 0) {
+        return {
+          tone: "muted" as StatusTone,
+          message: `Add ${formatList(missing.map((item) => item.label.toLowerCase()))} to continue.`,
+        }
+      }
+
+      if (parsed.summary) {
+        return {
+          tone: "success" as StatusTone,
+          message: `Ready: ${parsed.summary}`,
+        }
+      }
+
+      return {
+        tone: "success" as StatusTone,
+        message: "Looks good — review before saving.",
+      }
+    }, [parsed])
+
+    const handleOpenReview = () => {
+      if (parsed?.isReady) {
+        setReviewOpen(true)
+      }
+    }
+
+    const handleSubmit = () => {
+      if (!parsed?.isReady || !parsed.payload) return
+
+      const submission = toSubmission(parsed)
+      if (!submission) return
+
+      startTransition(async () => {
+        try {
+          const response = await submitQuickAdd(submission)
+          toast({ title: "Quick add saved", description: response.message })
+          setReviewOpen(false)
+          setValue("")
+          onCompleted?.()
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Something went wrong."
+          toast({
+            title: "Quick add failed",
+            description: message,
+            variant: "destructive",
+          })
+        }
+      })
+    }
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault()
+        if (parsed?.isReady) {
+          setReviewOpen(true)
+        }
+      }
+    }
+
+    return (
+      <div className={cn("space-y-2", className)}>
+        <div
+          className={cn(
+            "flex items-center gap-2",
+            variant === "command" ? "flex-col items-stretch gap-3" : "",
+          )}
+        >
+          <div className="relative flex-1">
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              className={cn(
+                "pr-10",
+                variant === "command" && "h-12 text-base",
+                variant === "header" && "h-10",
+              )}
+            />
+            <Sparkles className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          </div>
+          <Button
+            type="button"
+            size={variant === "command" ? "default" : "sm"}
+            onClick={handleOpenReview}
+            disabled={!parsed?.isReady}
+          >
+            Review
+          </Button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          {parsed ? (
+            <Badge variant="secondary">{intentLabels[parsed.intent]}</Badge>
+          ) : null}
+          {parsed ? (
+            <Badge variant="outline">{`Confidence ${(parsed.confidence * 100).toFixed(0)}%`}</Badge>
+          ) : null}
+          <span className={cn("flex-1 text-left", toneToClass[status.tone])}>
+            {status.message}
+          </span>
+        </div>
+
+        <Dialog open={reviewOpen} onOpenChange={setReviewOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Confirm quick add</DialogTitle>
+              <DialogDescription>
+                Review the parsed details before saving to Supabase. You can edit
+                the text if something looks off.
+              </DialogDescription>
+            </DialogHeader>
+
+            {parsed ? (
+              <div className="space-y-4">
+                <div className="flex flex-wrap items-center gap-2 text-sm">
+                  <Badge variant="secondary">{intentLabels[parsed.intent]}</Badge>
+                  <Badge variant="outline">{parsed.raw}</Badge>
+                </div>
+
+                {parsed.summary ? (
+                  <div className="rounded-md bg-muted/60 p-3 text-sm text-muted-foreground">
+                    {parsed.summary}
+                  </div>
+                ) : null}
+
+                <div className="rounded-md border">
+                  <div className="grid gap-3 p-4">
+                    {parsed.fields.map((field) => (
+                      <div key={field.field} className="flex items-start justify-between gap-3 text-sm">
+                        <span className="font-medium text-foreground">{field.label}</span>
+                        <span
+                          className={cn(
+                            "max-w-[60%] text-right",
+                            field.isValid
+                              ? "text-foreground"
+                              : "italic text-muted-foreground",
+                          )}
+                        >
+                          {field.value ?? (field.isValid ? "—" : "Missing")}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {parsed.warnings.length > 0 ? (
+                  <div className="rounded-md bg-amber-100/60 p-3 text-sm text-amber-700 dark:bg-amber-900/40 dark:text-amber-200">
+                    {parsed.warnings[0]}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setReviewOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleSubmit} disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : null}
+                Confirm & save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    )
+  },
+)
+
+QuickAddInput.displayName = "QuickAddInput"
+
+function toSubmission(result: QuickAddParseResult): QuickAddSubmissionInput | null {
+  if (!result.payload || !result.isReady) return null
+
+  switch (result.intent) {
+    case "invoice":
+      return {
+        intent: "invoice",
+        commandText: result.raw,
+        payload: result.payload,
+      }
+    case "booking":
+      return {
+        intent: "booking",
+        commandText: result.raw,
+        payload: result.payload,
+      }
+    case "maintenance":
+      return {
+        intent: "maintenance",
+        commandText: result.raw,
+        payload: result.payload,
+      }
+    case "visitor":
+      return {
+        intent: "visitor",
+        commandText: result.raw,
+        payload: result.payload,
+      }
+    default:
+      return null
+  }
+}
+
+function formatList(items: string[]): string {
+  if (items.length === 0) return ""
+  if (items.length === 1) return items[0]
+  if (items.length === 2) return `${items[0]} and ${items[1]}`
+  return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`
+}

--- a/lib/nlp/quick-add.ts
+++ b/lib/nlp/quick-add.ts
@@ -1,0 +1,794 @@
+import * as chrono from "chrono-node"
+
+export type QuickAddIntent =
+  | "invoice"
+  | "booking"
+  | "maintenance"
+  | "visitor"
+  | "unknown"
+
+export interface InvoiceQuickAddPayload {
+  amount: number
+  amountCents: number
+  currency: string
+  dueDate?: string
+  description?: string
+  counterparty?: string
+}
+
+export interface BookingQuickAddPayload {
+  amenityId: string
+  amenityLabel: string
+  startTime: string
+  endTime: string
+  note?: string
+  hasExplicitEnd: boolean
+}
+
+export interface MaintenanceQuickAddPayload {
+  title: string
+  description: string
+  priority: "low" | "normal" | "high" | "urgent"
+}
+
+export interface VisitorQuickAddPayload {
+  guestName: string
+  guestEmail: string
+  checkIn: string
+  checkOut: string
+  purpose: string
+  guestPhone?: string
+}
+
+type QuickAddPayloadMap = {
+  invoice: InvoiceQuickAddPayload
+  booking: BookingQuickAddPayload
+  maintenance: MaintenanceQuickAddPayload
+  visitor: VisitorQuickAddPayload
+  unknown: never
+}
+
+export interface QuickAddField {
+  field: string
+  label: string
+  required: boolean
+  isValid: boolean
+  value?: string
+  helperText?: string
+}
+
+export interface QuickAddParseOptions {
+  referenceDate?: Date
+}
+
+interface QuickAddResultBase<T extends QuickAddIntent> {
+  intent: T
+  raw: string
+  summary: string | null
+  confidence: number
+  fields: QuickAddField[]
+  errors: string[]
+  warnings: string[]
+  isReady: boolean
+  payload: QuickAddPayloadMap[T] | null
+}
+
+export type QuickAddParseResult =
+  | QuickAddResultBase<"invoice">
+  | QuickAddResultBase<"booking">
+  | QuickAddResultBase<"maintenance">
+  | QuickAddResultBase<"visitor">
+  | QuickAddResultBase<"unknown">
+
+type IntentDetection = {
+  intent: QuickAddIntent
+  confidence: number
+}
+
+type ChronoResult = chrono.ParsedResult
+
+const KNOWN_CODES = new Set([
+  "USD",
+  "CAD",
+  "EUR",
+  "GBP",
+  "JPY",
+  "AUD",
+  "NZD",
+  "CHF",
+  "SEK",
+  "NOK",
+  "DKK",
+  "ZAR",
+  "BRL",
+  "MXN",
+  "CNY",
+  "HKD",
+  "SGD",
+  "INR",
+])
+
+const AMENITIES = [
+  {
+    id: "kitchen",
+    label: "Kitchen",
+    patterns: [/kitchen/i, /cook|cooking/i],
+  },
+  {
+    id: "tv_room",
+    label: "TV room",
+    patterns: [/tv\s?room/i, /movie/i, /screen/i],
+  },
+  {
+    id: "parking",
+    label: "Parking spot",
+    patterns: [/parking/i, /garage/i, /car\s?spot/i],
+  },
+  {
+    id: "playstation",
+    label: "PlayStation nook",
+    patterns: [/playstation/i, /ps5/i, /gaming/i],
+  },
+  {
+    id: "shared_computer",
+    label: "Shared computer",
+    patterns: [/computer/i, /workstation/i, /shared\s?pc/i],
+  },
+] as const
+
+type AmenityMatch = (typeof AMENITIES)[number]
+
+type CurrencyDetection = {
+  amount: number
+  amountCents: number
+  currency: string
+  match: string
+}
+
+type DateDetection = {
+  isoDate: string
+  source: string
+}
+
+type DateRangeDetection = {
+  start: string
+  end: string
+  source: string
+  hasExplicitEnd: boolean
+}
+
+const quickAddChrono = chrono.casual.clone()
+
+quickAddChrono.refiners.push({
+  refine: (text, results) =>
+    results.map((result) => {
+      const source =
+        typeof text === "string"
+          ? text
+          : typeof (text as { text?: string })?.text === "string"
+            ? (text as { text?: string }).text!
+            : ""
+      const prefix = source
+        .slice(Math.max(0, result.index - 8), result.index)
+        .toLowerCase()
+      if (/\b(due|by|before|on)\s+$/.test(prefix)) {
+        result.tags.quickAddDueDate = true
+      }
+
+      if (result.end) {
+        result.tags.quickAddHasExplicitEnd = true
+      }
+
+      return result
+    }),
+})
+
+const SYMBOL_TO_CODE: Record<string, string> = {
+  "$": "USD",
+  "CA$": "CAD",
+  "C$": "CAD",
+  "€": "EUR",
+  "£": "GBP",
+  "¥": "JPY",
+  "A$": "AUD",
+}
+
+export function parseQuickAddCommand(
+  input: string,
+  options: QuickAddParseOptions = {},
+): QuickAddParseResult {
+  const raw = input.trim()
+  const referenceDate = options.referenceDate ?? new Date()
+
+  if (!raw) {
+    return {
+      intent: "unknown",
+      raw,
+      summary: null,
+      confidence: 0,
+      fields: [],
+      errors: ["Enter a command, e.g. “Add invoice 200 CAD due Friday”."],
+      warnings: [],
+      isReady: false,
+      payload: null,
+    }
+  }
+
+  const detection = detectIntent(raw)
+  const chronoResults = quickAddChrono.parse(raw, referenceDate, {
+    forwardDate: true,
+  })
+
+  switch (detection.intent) {
+    case "invoice":
+      return parseInvoice(raw, detection, chronoResults)
+    case "booking":
+      return parseBooking(raw, detection, chronoResults)
+    case "maintenance":
+      return parseMaintenance(raw, detection)
+    case "visitor":
+      return parseVisitor(raw, detection, chronoResults)
+    default:
+      return {
+        intent: "unknown",
+        raw,
+        summary: null,
+        confidence: detection.confidence,
+        fields: [],
+        errors: ["We couldn’t detect what to do with that yet."],
+        warnings: [],
+        isReady: false,
+        payload: null,
+      }
+  }
+}
+
+function parseInvoice(
+  text: string,
+  detection: IntentDetection,
+  chronoResults: ChronoResult[],
+): QuickAddParseResult {
+  const currency = detectCurrency(text)
+  const dueDate = extractDueDate(chronoResults)
+  const counterparty = extractCounterparty(text)
+  const description = extractDescription(text)
+
+  const fields: QuickAddField[] = [
+    {
+      field: "amount",
+      label: "Amount",
+      required: true,
+      isValid: Boolean(currency?.amount),
+      value: currency ? formatCurrency(currency.amount, currency.currency) : undefined,
+      helperText: currency ? undefined : "Include an amount, e.g. 200 CAD or $125.",
+    },
+    {
+      field: "currency",
+      label: "Currency",
+      required: true,
+      isValid: Boolean(currency?.currency),
+      value: currency?.currency,
+      helperText: currency?.currency ? undefined : "Specify a currency like USD, CAD, EUR…",
+    },
+    {
+      field: "dueDate",
+      label: "Due date",
+      required: false,
+      isValid: true,
+      value: dueDate?.isoDate,
+      helperText: dueDate ? undefined : "Add “due Friday” or a specific date (optional).",
+    },
+  ]
+
+  const payload: InvoiceQuickAddPayload | null = currency
+    ? {
+        amount: currency.amount,
+        amountCents: currency.amountCents,
+        currency: currency.currency,
+        dueDate: dueDate?.isoDate,
+        counterparty: counterparty ?? undefined,
+        description: description ?? undefined,
+      }
+    : null
+
+  const summaryParts = ["Invoice"]
+  if (currency) {
+    summaryParts.push(formatCurrency(currency.amount, currency.currency))
+  }
+  if (counterparty) {
+    summaryParts.push(`for ${titleCase(counterparty)}`)
+  }
+  if (dueDate) {
+    summaryParts.push(`due ${formatDate(dueDate.isoDate)}`)
+  }
+
+  const errors: string[] = []
+  if (!currency) {
+    errors.push("Add an amount with currency to continue.")
+  }
+
+  return {
+    intent: "invoice",
+    raw: text,
+    summary: summaryParts.length > 1 ? summaryParts.join(" ") : null,
+    confidence: detection.confidence,
+    fields,
+    errors,
+    warnings: [],
+    isReady: Boolean(payload),
+    payload,
+  }
+}
+
+function parseBooking(
+  text: string,
+  detection: IntentDetection,
+  chronoResults: ChronoResult[],
+): QuickAddParseResult {
+  const amenity = detectAmenity(text)
+  const range = extractDateRange(chronoResults)
+
+  const fields: QuickAddField[] = [
+    {
+      field: "amenity",
+      label: "Amenity",
+      required: true,
+      isValid: Boolean(amenity),
+      value: amenity?.label,
+      helperText: amenity ? undefined : "Mention kitchen, TV room, parking, PlayStation…",
+    },
+    {
+      field: "startTime",
+      label: "Start",
+      required: true,
+      isValid: Boolean(range?.start),
+      value: range ? formatDateTime(range.start) : undefined,
+      helperText: range ? undefined : "Add when it should start, e.g. tomorrow 6pm.",
+    },
+    {
+      field: "endTime",
+      label: "End",
+      required: true,
+      isValid: Boolean(range?.end),
+      value: range ? formatDateTime(range.end) : undefined,
+      helperText: range
+        ? undefined
+        : "Include an end time like “until 8pm” or “for 2 hours”.",
+    },
+  ]
+
+  const warnings: string[] = []
+  if (range && !range.hasExplicitEnd) {
+    warnings.push("No explicit end time detected — defaulted to 60 minutes.")
+  }
+
+  const payload: BookingQuickAddPayload | null = amenity && range
+    ? {
+        amenityId: amenity.id,
+        amenityLabel: amenity.label,
+        startTime: range.start,
+        endTime: range.end,
+        hasExplicitEnd: range.hasExplicitEnd,
+      }
+    : null
+
+  const summary =
+    amenity && range
+      ? `${amenity.label} • ${formatDate(range.start)} ${formatTimeRange(range.start, range.end)}`
+      : null
+
+  const errors: string[] = []
+  if (!amenity) {
+    errors.push("Specify which amenity to reserve.")
+  }
+  if (!range) {
+    errors.push("Tell us when the booking should happen.")
+  }
+
+  return {
+    intent: "booking",
+    raw: text,
+    summary,
+    confidence: detection.confidence,
+    fields,
+    errors,
+    warnings,
+    isReady: Boolean(payload),
+    payload,
+  }
+}
+
+function parseMaintenance(
+  text: string,
+  detection: IntentDetection,
+): QuickAddParseResult {
+  const priority = detectPriority(text)
+  const cleaned = text
+    .replace(/^(?:log|add|create|submit)\s+/i, "")
+    .replace(/maintenance\s+(?:ticket|issue|request)/i, "")
+    .trim()
+
+  const title = titleCase(cleaned.split(/for |because |due to /i)[0]?.trim() || "")
+  const description = sentenceCase(text)
+
+  const hasTitle = title.length > 0
+
+  const fields: QuickAddField[] = [
+    {
+      field: "title",
+      label: "Title",
+      required: true,
+      isValid: hasTitle,
+      value: hasTitle ? title : undefined,
+      helperText: hasTitle ? undefined : "Briefly describe the issue, e.g. “sink leak”.",
+    },
+    {
+      field: "priority",
+      label: "Priority",
+      required: false,
+      isValid: true,
+      value: priority.toUpperCase(),
+      helperText: "Mention urgent/high/low to adjust priority.",
+    },
+  ]
+
+  const payload: MaintenanceQuickAddPayload | null = hasTitle
+    ? {
+        title,
+        description,
+        priority,
+      }
+    : null
+
+  const errors = hasTitle ? [] : ["Describe what needs attention."]
+
+  return {
+    intent: "maintenance",
+    raw: text,
+    summary: hasTitle ? `${title} (${priority} priority)` : null,
+    confidence: detection.confidence,
+    fields,
+    errors,
+    warnings: [],
+    isReady: Boolean(payload),
+    payload,
+  }
+}
+
+function parseVisitor(
+  text: string,
+  detection: IntentDetection,
+  chronoResults: ChronoResult[],
+): QuickAddParseResult {
+  const guestName = extractGuestName(text)
+  const guestEmail = extractEmail(text)
+  const guestPhone = extractPhone(text)
+  const purpose = extractPurpose(text)
+  const range = extractDateRange(chronoResults)
+
+  const fields: QuickAddField[] = [
+    {
+      field: "guestName",
+      label: "Guest",
+      required: true,
+      isValid: Boolean(guestName),
+      value: guestName ? titleCase(guestName) : undefined,
+      helperText: guestName ? undefined : "Include the guest’s name after “visitor” or “guest”.",
+    },
+    {
+      field: "guestEmail",
+      label: "Email",
+      required: true,
+      isValid: Boolean(guestEmail),
+      value: guestEmail ?? undefined,
+      helperText: guestEmail
+        ? undefined
+        : "Add their email in parentheses or after the name.",
+    },
+    {
+      field: "dates",
+      label: "Stay",
+      required: true,
+      isValid: Boolean(range?.start && range?.end),
+      value: range ? `${formatDate(range.start)} → ${formatDate(range.end)}` : undefined,
+      helperText: range
+        ? undefined
+        : "Use a range like “Sept 1-3” or “from Friday to Sunday”.",
+    },
+    {
+      field: "purpose",
+      label: "Purpose",
+      required: true,
+      isValid: Boolean(purpose),
+      value: purpose ? sentenceCase(purpose) : undefined,
+      helperText: purpose ? undefined : "Mention why they’re visiting (e.g. wedding, family).",
+    },
+  ]
+
+  const payload: VisitorQuickAddPayload | null =
+    guestName && guestEmail && purpose && range
+      ? {
+          guestName: titleCase(guestName),
+          guestEmail,
+          guestPhone: guestPhone ?? undefined,
+          checkIn: range.start,
+          checkOut: range.end,
+          purpose: sentenceCase(purpose),
+        }
+      : null
+
+  const errors: string[] = []
+  if (!guestName) {
+    errors.push("Provide the guest’s name.")
+  }
+  if (!guestEmail) {
+    errors.push("Provide the guest’s email address.")
+  }
+  if (!range) {
+    errors.push("Include the stay dates.")
+  }
+  if (!purpose) {
+    errors.push("State the purpose of the visit.")
+  }
+
+  return {
+    intent: "visitor",
+    raw: text,
+    summary:
+      payload
+        ? `${payload.guestName} • ${formatDate(payload.checkIn)} to ${formatDate(payload.checkOut)} for ${payload.purpose}`
+        : null,
+    confidence: detection.confidence,
+    fields,
+    errors,
+    warnings: [],
+    isReady: Boolean(payload),
+    payload,
+  }
+}
+
+function detectIntent(text: string): IntentDetection {
+  const lowered = text.toLowerCase()
+  const scores: Record<QuickAddIntent, number> = {
+    invoice: 0,
+    booking: 0,
+    maintenance: 0,
+    visitor: 0,
+    unknown: 0,
+  }
+
+  const addScore = (intent: QuickAddIntent, weight = 1) => {
+    scores[intent] += weight
+  }
+
+  if (/^\/(invoice|booking|maintenance|visitor)\b/.test(lowered)) {
+    const match = lowered.match(/^\/(invoice|booking|maintenance|visitor)\b/)
+    if (match) {
+      addScore(match[1] as QuickAddIntent, 3)
+    }
+  }
+
+  if (/(invoice|rent|bill|payment)/i.test(lowered)) addScore("invoice", 2)
+  if (/(due|charge|amount)/i.test(lowered)) addScore("invoice", 1)
+  if (/\b(book|reserve|schedule)\b/.test(lowered)) addScore("booking", 2)
+  if (/\bamenity|kitchen|parking|playstation|tv\b/.test(lowered)) addScore("booking", 1.5)
+  if (/\bmaintenance|repair|fix|broken|leak\b/.test(lowered)) addScore("maintenance", 2)
+  if (/\bvisitor|guest|overnight\b/.test(lowered)) addScore("visitor", 2)
+  if (/\bapprove|register|log\b/.test(lowered)) addScore("visitor", 1)
+
+  const currency = detectCurrency(text)
+  if (currency) addScore("invoice", 0.5)
+
+  let bestIntent: QuickAddIntent = "unknown"
+  let bestScore = 0
+  for (const [intent, score] of Object.entries(scores) as Array<[
+    QuickAddIntent,
+    number,
+  ]>) {
+    if (score > bestScore) {
+      bestIntent = intent
+      bestScore = score
+    }
+  }
+
+  const confidence = bestScore === 0 ? 0 : Math.min(1, bestScore / 3)
+
+  return { intent: bestIntent, confidence }
+}
+
+function detectCurrency(text: string): CurrencyDetection | null {
+  const normalized = text.replace(/,/g, "")
+
+  const symbolMatch = normalized.match(
+    /(CA\$|C\$|A\$|\$|€|£|¥)\s*(\d+(?:\.\d{1,2})?)/,
+  )
+  if (symbolMatch) {
+    const symbol = symbolMatch[1]
+    const amount = Number.parseFloat(symbolMatch[2])
+    const currency = SYMBOL_TO_CODE[symbol]
+    if (!Number.isNaN(amount) && currency) {
+      return {
+        amount,
+        amountCents: Math.round(amount * 100),
+        currency,
+        match: symbolMatch[0],
+      }
+    }
+  }
+
+  const codeLeading = normalized.match(
+    /\b([A-Za-z]{3})\s*(\d+(?:\.\d{1,2})?)\b/,
+  )
+  if (codeLeading) {
+    const code = codeLeading[1].toUpperCase()
+    const amount = Number.parseFloat(codeLeading[2])
+    if (KNOWN_CODES.has(code) && !Number.isNaN(amount)) {
+      return {
+        amount,
+        amountCents: Math.round(amount * 100),
+        currency: code,
+        match: codeLeading[0],
+      }
+    }
+  }
+
+  const codeTrailing = normalized.match(
+    /\b(\d+(?:\.\d{1,2})?)\s*([A-Za-z]{3})\b/,
+  )
+  if (codeTrailing) {
+    const code = codeTrailing[2].toUpperCase()
+    const amount = Number.parseFloat(codeTrailing[1])
+    if (KNOWN_CODES.has(code) && !Number.isNaN(amount)) {
+      return {
+        amount,
+        amountCents: Math.round(amount * 100),
+        currency: code,
+        match: codeTrailing[0],
+      }
+    }
+  }
+
+  return null
+}
+
+function extractDueDate(results: ChronoResult[]): DateDetection | null {
+  if (results.length === 0) return null
+
+  let target = results.find((result) => result.tags.quickAddDueDate)
+  if (!target) {
+    target = results[0]
+  }
+
+  const date = target.start?.date()
+  if (!date) return null
+
+  return {
+    isoDate: toISODate(date),
+    source: target.text,
+  }
+}
+
+function extractDateRange(results: ChronoResult[]): DateRangeDetection | null {
+  if (results.length === 0) return null
+
+  let target = results.find((result) => result.end)
+  if (!target) {
+    target = results[0]
+  }
+
+  const start = target.start?.date()
+  if (!start) return null
+
+  const end = target.end?.date()
+  const hasExplicitEnd = Boolean(target.tags.quickAddHasExplicitEnd)
+
+  return {
+    start: start.toISOString(),
+    end: (end ?? addMinutes(start, 60)).toISOString(),
+    source: target.text,
+    hasExplicitEnd: Boolean(end) || hasExplicitEnd,
+  }
+}
+
+function detectAmenity(text: string): AmenityMatch | null {
+  for (const amenity of AMENITIES) {
+    if (amenity.patterns.some((pattern) => pattern.test(text))) {
+      return amenity
+    }
+  }
+  return null
+}
+
+function detectPriority(text: string): "low" | "normal" | "high" | "urgent" {
+  if (/urgent|asap|immediately/i.test(text)) return "urgent"
+  if (/high priority|critical/i.test(text)) return "high"
+  if (/low priority|minor/i.test(text)) return "low"
+  return "normal"
+}
+
+function extractCounterparty(text: string): string | null {
+  const match = text.match(/(?:for|from|to)\s+([A-Za-z][A-Za-z\s'-]{1,40})/i)
+  return match ? match[1].trim() : null
+}
+
+function extractDescription(text: string): string | null {
+  const afterFor = text.split(/(?:for|about)\s+/i)[1]
+  if (afterFor) {
+    return sentenceCase(afterFor.trim())
+  }
+  return null
+}
+
+function extractGuestName(text: string): string | null {
+  const match = text.match(/(?:visitor|guest)\s+(?:named\s+)?([A-Za-z][A-Za-z\s'-]{1,40})/i)
+  return match ? match[1].trim() : null
+}
+
+function extractEmail(text: string): string | null {
+  const match = text.match(/([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/)
+  return match ? match[1] : null
+}
+
+function extractPhone(text: string): string | null {
+  const match = text.match(/(\+?\d[\d\s-]{7,}\d)/)
+  return match ? match[1].replace(/\s+/g, " ").trim() : null
+}
+
+function extractPurpose(text: string): string | null {
+  const match = text.match(/(?:for|about|regarding)\s+([A-Za-z][A-Za-z\s'-]{2,})/i)
+  return match ? match[1].trim() : null
+}
+
+function toISODate(date: Date): string {
+  const iso = date.toISOString()
+  return iso.slice(0, 10)
+}
+
+function formatCurrency(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).format(amount)
+  } catch (error) {
+    return `${currency} ${amount.toFixed(2)}`
+  }
+}
+
+function formatDate(isoDate: string): string {
+  const date = new Date(isoDate)
+  return new Intl.DateTimeFormat("en", { dateStyle: "medium" }).format(date)
+}
+
+function formatDateTime(isoString: string): string {
+  const date = new Date(isoString)
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}
+
+function formatTimeRange(startIso: string, endIso: string): string {
+  const start = new Date(startIso)
+  const end = new Date(endIso)
+  const formatter = new Intl.DateTimeFormat("en", { timeStyle: "short" })
+  return `${formatter.format(start)} – ${formatter.format(end)}`
+}
+
+function addMinutes(date: Date, minutes: number): Date {
+  return new Date(date.getTime() + minutes * 60 * 1000)
+}
+
+function titleCase(input: string): string {
+  return input
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0]?.toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ")
+}
+
+function sentenceCase(input: string): string {
+  if (!input) return ""
+  const lowered = input.trim().toLowerCase()
+  return lowered.charAt(0).toUpperCase() + lowered.slice(1)
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vercel/analytics": "^1.3.1",
     "@vercel/speed-insights": "^1.0.12",
     "bech32": "^2.0.0",
+    "chrono-node": "^2.9.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "cmdk": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
+      chrono-node:
+        specifier: ^2.9.0
+        version: 2.9.0
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -2267,6 +2270,10 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  chrono-node@2.9.0:
+    resolution: {integrity: sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   class-variance-authority@0.7.0:
     resolution: {integrity: sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==}
@@ -6930,6 +6937,8 @@ snapshots:
   chownr@1.1.4: {}
 
   chrome-trace-event@1.0.4: {}
+
+  chrono-node@2.9.0: {}
 
   class-variance-authority@0.7.0:
     dependencies:

--- a/tests/lib/nlp/quick-add.test.ts
+++ b/tests/lib/nlp/quick-add.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import { parseQuickAddCommand } from "@/lib/nlp/quick-add"
+
+describe("quick add parser", () => {
+  const referenceDate = new Date("2024-07-24T10:00:00Z")
+
+  it("extracts currency and due date for invoices", () => {
+    const result = parseQuickAddCommand("Add invoice 200 CAD due Fri", {
+      referenceDate,
+    })
+
+    expect(result.intent).toBe("invoice")
+    expect(result.isReady).toBe(true)
+    expect(result.payload).not.toBeNull()
+
+    const payload = result.payload!
+    expect(payload.amount).toBe(200)
+    expect(payload.currency).toBe("CAD")
+    expect(payload.dueDate).toBe("2024-07-26")
+  })
+
+  it("detects amenity bookings and time ranges", () => {
+    const result = parseQuickAddCommand(
+      "Book the kitchen tomorrow 6-8pm for dinner",
+      { referenceDate },
+    )
+
+    expect(result.intent).toBe("booking")
+    expect(result.isReady).toBe(true)
+    expect(result.payload).not.toBeNull()
+
+    const payload = result.payload!
+    expect(payload.amenityId).toBe("kitchen")
+    expect(payload.hasExplicitEnd).toBe(true)
+
+    const start = new Date(payload.startTime).getTime()
+    const end = new Date(payload.endTime).getTime()
+    expect(end - start).toBe(2 * 60 * 60 * 1000)
+  })
+
+  it("classifies maintenance issues with priority", () => {
+    const result = parseQuickAddCommand(
+      "Log maintenance urgent leak under sink",
+      { referenceDate },
+    )
+
+    expect(result.intent).toBe("maintenance")
+    expect(result.isReady).toBe(true)
+    expect(result.payload).not.toBeNull()
+
+    const payload = result.payload!
+    expect(payload.priority).toBe("urgent")
+    expect(payload.title.toLowerCase()).toContain("leak")
+  })
+})


### PR DESCRIPTION
## Summary
- implement a chrono-powered quick add parser for invoices, amenity bookings, maintenance, and visitor commands
- surface a reusable QuickAdd input in the command palette and dashboard header with confirmation and Supabase actions
- add Vitest coverage for currency, due date, and entity detection logic

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b7383488328816978e672eb554f