### PR TITLE
Add breadcrumb navigation across nested routes

### DIFF
--- a/app/bookings/layout.tsx
+++ b/app/bookings/layout.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react"
+
+import { cookies } from "next/headers"
+
+import Breadcrumbs from "@/components/navigation/Breadcrumbs"
+import createSupabaseServer from "@/utils/supabase-server"
+
+const hasText = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+async function resolveBookingLabel(bookingId: string): Promise<string | null> {
+  if (!bookingId) {
+    return null
+  }
+
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return null
+  }
+
+  try {
+    const supabase = createSupabaseServer(cookies())
+    const { data, error } = await supabase
+      .from("amenity_bookings")
+      .select("metadata,start_time")
+      .eq("id", bookingId)
+      .maybeSingle()
+
+    if (error) {
+      return null
+    }
+
+    if (data) {
+      if (isRecord(data.metadata)) {
+        const metadataTitle = data.metadata?.title
+        if (hasText(metadataTitle)) {
+          return metadataTitle
+        }
+      }
+
+      if (hasText(data.start_time)) {
+        const startDate = new Date(data.start_time)
+        if (!Number.isNaN(startDate.valueOf())) {
+          const formatted = new Intl.DateTimeFormat("en-US", {
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+          }).format(startDate)
+          return `Booking • ${formatted}`
+        }
+      }
+    }
+  } catch (error) {
+    return null
+  }
+
+  return null
+}
+
+const formatBookingFallback = (bookingId: string) =>
+  `Booking ${bookingId.slice(0, 8).toUpperCase()}`
+
+export default async function BookingsLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: { bookingId?: string }
+}) {
+  const bookingId = params?.bookingId
+  const resolvedLabel = bookingId ? await resolveBookingLabel(bookingId) : null
+  const segmentLabels = bookingId
+    ? { [bookingId]: resolvedLabel ?? formatBookingFallback(bookingId) }
+    : undefined
+
+  return (
+    <>
+      <div className="container max-w-7xl pb-4 pt-6">
+        <Breadcrumbs segmentLabels={segmentLabels} />
+      </div>
+      {children}
+    </>
+  )
+}

--- a/app/dashboard/members/layout.tsx
+++ b/app/dashboard/members/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react"
+
+import Breadcrumbs from "@/components/navigation/Breadcrumbs"
+
+export default function MembersLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <div className="px-3 pb-4">
+        <Breadcrumbs />
+      </div>
+      {children}
+    </>
+  )
+}

--- a/app/documents/layout.tsx
+++ b/app/documents/layout.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react"
+
+import { cookies } from "next/headers"
+
+import Breadcrumbs from "@/components/navigation/Breadcrumbs"
+import createSupabaseServer from "@/utils/supabase-server"
+
+const hasText = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+async function resolveDocumentLabel(documentId: string): Promise<string | null> {
+  if (!documentId) {
+    return null
+  }
+
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return null
+  }
+
+  try {
+    const supabase = createSupabaseServer(cookies())
+    const { data, error } = await supabase
+      .from("documents")
+      .select("title")
+      .eq("id", documentId)
+      .maybeSingle()
+
+    if (error) {
+      return null
+    }
+
+    if (data && hasText(data.title)) {
+      return data.title
+    }
+  } catch (error) {
+    return null
+  }
+
+  return null
+}
+
+const formatDocumentFallback = (documentId: string) =>
+  `Document ${documentId.slice(0, 8).toUpperCase()}`
+
+export default async function DocumentsLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: { documentId?: string }
+}) {
+  const documentId = params?.documentId
+  const resolvedLabel = documentId ? await resolveDocumentLabel(documentId) : null
+  const segmentLabels = documentId
+    ? { [documentId]: resolvedLabel ?? formatDocumentFallback(documentId) }
+    : undefined
+
+  return (
+    <>
+      <div className="container max-w-7xl pb-4 pt-6">
+        <Breadcrumbs segmentLabels={segmentLabels} />
+      </div>
+      {children}
+    </>
+  )
+}

--- a/components/navigation/Breadcrumbs.tsx
+++ b/components/navigation/Breadcrumbs.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import React from "react"
+
+import { useSelectedLayoutSegments } from "next/navigation"
+
+import { cn } from "@/lib/utils"
+
+import { SmartLink } from "./SmartLink"
+
+export type BreadcrumbLabels = Record<string, string | undefined>
+
+export interface BreadcrumbItem {
+  href: string
+  label: string
+  segment: string
+}
+
+export interface BreadcrumbsProps {
+  className?: string
+  segmentLabels?: BreadcrumbLabels
+  segments?: string[]
+}
+
+const DEFAULT_SEGMENT_LABELS: Record<string, string> = {
+  account: "Account",
+  amenities: "Amenities",
+  applications: "Applications",
+  bookings: "Bookings",
+  confirmation: "Confirmation",
+  dashboard: "Dashboard",
+  documents: "Documents",
+  guests: "Guests",
+  members: "Members",
+  messaging: "Messaging",
+  onboarding: "Onboarding",
+  payments: "Payments",
+  privacy: "Privacy",
+  schedule: "Schedule",
+  settings: "Settings",
+  supplies: "Supplies",
+  visitors: "Visitors",
+}
+
+const HOME_CRUMB: BreadcrumbItem = {
+  segment: "",
+  href: "/",
+  label: "Home",
+}
+
+const hasText = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+const decodeSegment = (segment: string): string => {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return segment
+  }
+}
+
+const startCase = (value: string): string => {
+  return value
+    .replace(/[-_]+/g, " ")
+    .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ")
+}
+
+const resolveSegmentLabel = (
+  segment: string,
+  overrides?: BreadcrumbLabels
+): string => {
+  const decoded = decodeSegment(segment)
+  const override = overrides?.[segment] ?? overrides?.[decoded]
+  if (hasText(override)) {
+    return override
+  }
+
+  const lower = decoded.toLowerCase()
+  if (DEFAULT_SEGMENT_LABELS[lower]) {
+    return DEFAULT_SEGMENT_LABELS[lower]
+  }
+
+  return startCase(decoded)
+}
+
+export const buildBreadcrumbItems = (
+  segments: string[],
+  overrides?: BreadcrumbLabels
+): BreadcrumbItem[] => {
+  const normalizedSegments = segments.filter((segment) => segment && segment !== "")
+  const items: BreadcrumbItem[] = [HOME_CRUMB]
+
+  normalizedSegments.forEach((segment, index) => {
+    const href = `/${normalizedSegments.slice(0, index + 1).join("/")}`
+    const label = resolveSegmentLabel(segment, overrides)
+    items.push({
+      segment,
+      href,
+      label,
+    })
+  })
+
+  return items
+}
+
+export default function Breadcrumbs({
+  className,
+  segmentLabels,
+  segments: providedSegments,
+}: BreadcrumbsProps) {
+  const selectedSegments = useSelectedLayoutSegments()
+  const segments = providedSegments ?? selectedSegments
+  const items = buildBreadcrumbItems(segments, segmentLabels)
+
+  return (
+    <nav aria-label="Breadcrumb" className={cn("text-sm text-muted-foreground", className)}>
+      <ol className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1
+          return (
+            <li key={`${item.href}-${item.segment}`} className="flex items-center gap-2">
+              {index !== 0 && <span className="text-muted-foreground/60">/</span>}
+              {isLast ? (
+                <span className="font-medium text-foreground" aria-current="page">
+                  {item.label}
+                </span>
+              ) : (
+                <SmartLink
+                  href={item.href}
+                  className="transition-colors hover:text-foreground"
+                  intent="navigation"
+                >
+                  {item.label}
+                </SmartLink>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/tests/breadcrumbs.test.tsx
+++ b/tests/breadcrumbs.test.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("next/navigation", () => ({
+  useSelectedLayoutSegments: () => [],
+  useRouter: () => ({
+    prefetch: () => Promise.resolve(),
+    push: () => {},
+    replace: () => {},
+  }),
+}))
+
+import Breadcrumbs, {
+  buildBreadcrumbItems,
+} from "@/components/navigation/Breadcrumbs"
+
+describe("Breadcrumbs", () => {
+  it("renders navigable links for intermediate segments", () => {
+    const html = renderToStaticMarkup(
+      <Breadcrumbs segments={["dashboard", "members"]} />
+    )
+
+    expect(html).toContain('href="/"')
+    expect(html).toContain('href="/dashboard"')
+    expect(html).not.toContain('href="/dashboard/members"')
+    expect(html).toContain(">Home<")
+    expect(html).toContain(">Dashboard<")
+    expect(html).toContain(">Members<")
+  })
+
+  it("applies segment label overrides for dynamic entities", () => {
+    const html = renderToStaticMarkup(
+      <Breadcrumbs
+        segments={["documents", "abc123"]}
+        segmentLabels={{ abc123: "Lease Agreement" }}
+      />
+    )
+
+    expect(html).toContain('href="/documents"')
+    expect(html).toContain("Lease Agreement")
+  })
+
+  it("formats unknown segments into readable labels", () => {
+    const items = buildBreadcrumbItems(["maintenance-requests", "details"])
+    expect(items[1]).toMatchObject({
+      href: "/maintenance-requests",
+      label: "Maintenance Requests",
+    })
+    expect(items[2]).toMatchObject({
+      href: "/maintenance-requests/details",
+      label: "Details",
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- implement a reusable breadcrumbs component that maps route segments to friendly labels and supports server-provided overrides
- surface breadcrumbs in the documents, bookings, and dashboard members layouts, including Supabase lookups for entity names
- add coverage for breadcrumb link rendering and allow Vitest to pick up TSX test files

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d20b75dc3c8328ad526d638fec335d