### PR TITLE
Add streamed CSV exports for dashboards

### DIFF
--- a/app/dashboard/members/actions/export-csv.ts
+++ b/app/dashboard/members/actions/export-csv.ts
@@ -1,0 +1,99 @@
+'use server';
+
+import { buildCsvStream } from '@/lib/export/csv';
+import { MEMBER_CSV_HEADERS, buildMemberCsvRows } from '@/lib/export/members';
+import { getDashboardMembers } from '../data';
+import { z } from 'zod';
+
+const roleEnum = z.enum(['admin', 'user']);
+const statusEnum = z.enum(['active', 'resigned']);
+const sortFieldEnum = z.enum(['name', 'role', 'createdAt', 'status']);
+const sortDirectionEnum = z.enum(['asc', 'desc']);
+
+const memberExportFiltersSchema = z.object({
+  query: z.string().trim().min(1).optional(),
+  roles: z.array(roleEnum).min(1).optional(),
+  statuses: z.array(statusEnum).min(1).optional(),
+  sort: z
+    .object({
+      field: sortFieldEnum,
+      direction: sortDirectionEnum.default('asc'),
+    })
+    .optional(),
+});
+
+export type MemberExportFilters = z.infer<typeof memberExportFiltersSchema>;
+
+function filterMembers(
+  members: Awaited<ReturnType<typeof getDashboardMembers>>,
+  filters: MemberExportFilters
+) {
+  const normalizedQuery = filters.query?.toLowerCase();
+
+  let results = members.filter((member) => {
+    if (normalizedQuery) {
+      const matchesQuery =
+        member.name.toLowerCase().includes(normalizedQuery) ||
+        member.role.toLowerCase().includes(normalizedQuery);
+      if (!matchesQuery) {
+        return false;
+      }
+    }
+
+    if (filters.roles && filters.roles.length > 0) {
+      if (!filters.roles.includes(member.role)) {
+        return false;
+      }
+    }
+
+    if (filters.statuses && filters.statuses.length > 0) {
+      if (!filters.statuses.includes(member.status)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  if (filters.sort) {
+    const { field, direction } = filters.sort;
+    const modifier = direction === 'desc' ? -1 : 1;
+
+    results = [...results].sort((a, b) => {
+      let comparison = 0;
+
+      if (field === 'createdAt') {
+        const aTime = Date.parse(a.createdAt);
+        const bTime = Date.parse(b.createdAt);
+
+        if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
+          comparison = aTime - bTime;
+        } else {
+          const aValue = a.createdAt.toLowerCase();
+          const bValue = b.createdAt.toLowerCase();
+          if (aValue < bValue) comparison = -1;
+          else if (aValue > bValue) comparison = 1;
+        }
+      } else {
+        const aValue = a[field].toString().toLowerCase();
+        const bValue = b[field].toString().toLowerCase();
+        if (aValue < bValue) comparison = -1;
+        else if (aValue > bValue) comparison = 1;
+      }
+
+      return comparison * modifier;
+    });
+  }
+
+  return results;
+}
+
+export async function exportMembersCsv(
+  filters: MemberExportFilters = {}
+): Promise<ReadableStream<Uint8Array>> {
+  const parsedFilters = memberExportFiltersSchema.parse(filters ?? {});
+  const members = await getDashboardMembers();
+  const filteredMembers = filterMembers(members, parsedFilters);
+  const rows = buildMemberCsvRows(filteredMembers);
+  return buildCsvStream(MEMBER_CSV_HEADERS, rows);
+}

--- a/app/dashboard/members/components/export-members-button.tsx
+++ b/app/dashboard/members/components/export-members-button.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useTransition } from 'react';
+
+import { Download } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { createDownloadLink, streamToBlob } from '@/lib/download-client';
+
+import { exportMembersCsv, type MemberExportFilters } from '../actions/export-csv';
+
+export function ExportMembersButton({ filters }: { filters: MemberExportFilters }) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleExport = () => {
+    startTransition(async () => {
+      try {
+        const stream = await exportMembersCsv(filters);
+        const blob = await streamToBlob(stream);
+        const filename = `members-${new Date().toISOString().slice(0, 10)}.csv`;
+        createDownloadLink(blob, filename);
+      } catch (error) {
+        console.error('Failed to export members CSV', error);
+      }
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="gap-2"
+      onClick={handleExport}
+      disabled={isPending}
+    >
+      <Download className="size-4" aria-hidden="true" />
+      {isPending ? 'Exporting…' : 'Export CSV'}
+    </Button>
+  );
+}

--- a/app/dashboard/members/page.tsx
+++ b/app/dashboard/members/page.tsx
@@ -7,6 +7,7 @@ import MemberTable from "./components/MemberTable"
 import { LegacyMemberTable } from "./components/LegacyMemberTable"
 import { MemberTableSkeleton } from "./components/skeletons"
 import SearchMembers from "./components/SearchMembers"
+import { ExportMembersButton } from "./components/export-members-button"
 
 export default function Members() {
         const streamingEnabled = isFeatureEnabled("streamingDashboards")
@@ -14,9 +15,12 @@ export default function Members() {
         return (
                 <div className="w-full space-y-5 overflow-y-auto px-3">
                         <h1 className="text-3xl font-bold">Members</h1>
-                        <div className="flex gap-2">
-                                <SearchMembers />
-                                <CreateMember />
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                                <div className="flex gap-2">
+                                        <SearchMembers />
+                                        <CreateMember />
+                                </div>
+                                <ExportMembersButton filters={{}} />
                         </div>
                         {streamingEnabled ? (
                                 <Suspense fallback={<MemberTableSkeleton />}>

--- a/app/documents/actions/export-csv.ts
+++ b/app/documents/actions/export-csv.ts
@@ -1,0 +1,49 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+import { buildCsvStream } from '@/lib/export/csv';
+import { DOCUMENT_CSV_HEADERS, buildDocumentCsvRows } from '@/lib/export/documents';
+import { fetchDocumentsList } from '@/lib/data/documents';
+import { fetchMemberRole } from '@/lib/data/members';
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+import { createClient } from '@/utils/supa-server-actions';
+import type { DocumentListFilters } from '@/types/documents';
+
+import { documentListFiltersSchema } from './index';
+
+export async function exportDocumentsCsv(
+  filters: DocumentListFilters = {}
+): Promise<ReadableStream<Uint8Array>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    throw new Error('You must be logged in to export documents.');
+  }
+
+  const validatedFilters = documentListFiltersSchema.parse(filters ?? {});
+
+  let role: Awaited<ReturnType<typeof fetchMemberRole>>;
+  try {
+    role = await fetchMemberRole(typedSupabase, user.id);
+  } catch (error) {
+    throw new Error('Unable to resolve your document permissions.');
+  }
+
+  const documents = await fetchDocumentsList({
+    client: typedSupabase,
+    userId: user.id,
+    role,
+    filters: validatedFilters,
+  });
+
+  const rows = buildDocumentCsvRows(documents);
+  return buildCsvStream(DOCUMENT_CSV_HEADERS, rows);
+}

--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -36,7 +36,7 @@ const documentSigningSchema = z.object({
   expires_in_days: z.number().min(1).max(365).optional(),
 });
 
-const documentListFiltersSchema = z.object({
+export const documentListFiltersSchema = z.object({
   status: z.array(z.enum(['draft', 'pending_signature', 'signed', 'expired', 'cancelled'])).optional(),
   type: z.array(z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other'])).optional(),
   tenant_id: z.string().uuid().optional(),

--- a/app/documents/components/documents-tabs.tsx
+++ b/app/documents/components/documents-tabs.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { Suspense, useMemo, useState } from 'react';
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { DocumentListFilters } from '@/types/documents';
+
+import { DocumentsList } from './documents-list';
+import { DocumentsFilters } from './documents-filters';
+import { ExportDocumentsButton } from './export-documents-button';
+
+const TAB_FILTERS = {
+  all: {},
+  leases: { type: ['lease'] as DocumentListFilters['type'] },
+  pending: { status: ['pending_signature'] as DocumentListFilters['status'] },
+  signed: { status: ['signed'] as DocumentListFilters['status'] },
+} satisfies Record<string, DocumentListFilters>;
+
+type TabValue = keyof typeof TAB_FILTERS;
+
+function mergeFilters(
+  base: DocumentListFilters,
+  overrides: DocumentListFilters
+): DocumentListFilters {
+  return {
+    ...overrides,
+    ...base,
+  };
+}
+
+function DocumentsListSkeleton() {
+  return (
+    <div className="space-y-4">
+      {[...Array(3)].map((_, index) => (
+        <Card key={index} className="animate-pulse">
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div className="space-y-2">
+                <div className="h-5 w-48 rounded bg-muted" />
+                <div className="h-4 w-32 rounded bg-muted" />
+              </div>
+              <div className="h-6 w-20 rounded bg-muted" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center justify-between">
+              <div className="h-4 w-24 rounded bg-muted" />
+              <div className="flex space-x-2">
+                <div className="h-8 w-16 rounded bg-muted" />
+                <div className="h-8 w-16 rounded bg-muted" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export function DocumentsTabsSection() {
+  const [activeTab, setActiveTab] = useState<TabValue>('all');
+  const [filterOverrides, setFilterOverrides] = useState<DocumentListFilters>({});
+
+  const currentFilters = useMemo(
+    () => mergeFilters(TAB_FILTERS[activeTab], filterOverrides),
+    [activeTab, filterOverrides]
+  );
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={(value) => setActiveTab(value as TabValue)}
+      className="space-y-6"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <TabsList className="grid w-full max-w-md grid-cols-4">
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="leases">Leases</TabsTrigger>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="signed">Signed</TabsTrigger>
+        </TabsList>
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
+          <DocumentsFilters onFiltersChange={setFilterOverrides} />
+          <ExportDocumentsButton filters={currentFilters} />
+        </div>
+      </div>
+
+      {(Object.keys(TAB_FILTERS) as TabValue[]).map((tab) => {
+        const filtersForTab = mergeFilters(TAB_FILTERS[tab], filterOverrides);
+
+        return (
+          <TabsContent key={tab} value={tab} className="space-y-6">
+            <Suspense fallback={<DocumentsListSkeleton />}>
+              <DocumentsList filter={filtersForTab} />
+            </Suspense>
+          </TabsContent>
+        );
+      })}
+    </Tabs>
+  );
+}

--- a/app/documents/components/export-documents-button.tsx
+++ b/app/documents/components/export-documents-button.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useTransition } from 'react';
+
+import { Download } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { createDownloadLink, streamToBlob } from '@/lib/download-client';
+import type { DocumentListFilters } from '@/types/documents';
+
+import { exportDocumentsCsv } from '../actions/export-csv';
+
+export function ExportDocumentsButton({ filters }: { filters: DocumentListFilters }) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleExport = () => {
+    startTransition(async () => {
+      try {
+        const stream = await exportDocumentsCsv(filters);
+        const blob = await streamToBlob(stream);
+        const filename = `documents-${new Date().toISOString().slice(0, 10)}.csv`;
+        createDownloadLink(blob, filename);
+      } catch (error) {
+        console.error('Failed to export documents CSV', error);
+      }
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="gap-2"
+      onClick={handleExport}
+      disabled={isPending}
+    >
+      <Download className="size-4" aria-hidden="true" />
+      {isPending ? 'Exporting…' : 'Export CSV'}
+    </Button>
+  );
+}

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -2,12 +2,9 @@ import { Suspense } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { FileText, Users, Clock, Upload } from 'lucide-react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UploadDocumentDialog } from "./components/upload-document-dialog";
 import { DocumentsStats } from "./components/documents-stats";
-import { DocumentsList } from "./components/documents-list";
-import { DocumentsFilters } from "./components/documents-filters";
-import { DocumentListFilters } from '@/types/documents';
+import { DocumentsTabsSection } from "./components/documents-tabs";
 
 export default function DocumentsPage() {
   return (
@@ -41,42 +38,7 @@ export default function DocumentsPage() {
         <DocumentsStats />
       </Suspense>
 
-      {/* Main Content Tabs */}
-      <Tabs defaultValue="all" className="space-y-6">
-        <div className="flex items-center justify-between">
-          <TabsList className="grid w-full max-w-md grid-cols-4">
-            <TabsTrigger value="all">All</TabsTrigger>
-            <TabsTrigger value="leases">Leases</TabsTrigger>
-            <TabsTrigger value="pending">Pending</TabsTrigger>
-            <TabsTrigger value="signed">Signed</TabsTrigger>
-          </TabsList>
-          <DocumentsFilters />
-        </div>
-
-        <TabsContent value="all" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{}} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="leases" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ type: ['lease'] }} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="pending" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['pending_signature'] }} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="signed" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['signed'] }} />
-          </Suspense>
-        </TabsContent>
-      </Tabs>
+      <DocumentsTabsSection />
 
       {/* Feature Highlights */}
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
@@ -136,35 +98,6 @@ export default function DocumentsPage() {
           </CardContent>
         </Card>
       </div>
-    </div>
-  );
-}
-
-function DocumentsListSkeleton() {
-  return (
-    <div className="space-y-4">
-      {[...Array(5)].map((_, i) => (
-        <Card key={i} className="animate-pulse">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <div className="space-y-2">
-                <div className="h-5 w-48 rounded bg-muted"></div>
-                <div className="h-4 w-32 rounded bg-muted"></div>
-              </div>
-              <div className="h-6 w-20 rounded bg-muted"></div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between">
-              <div className="h-4 w-24 rounded bg-muted"></div>
-              <div className="flex space-x-2">
-                <div className="h-8 w-16 rounded bg-muted"></div>
-                <div className="h-8 w-16 rounded bg-muted"></div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
     </div>
   );
 }

--- a/app/payments/_components/export-payment-history-button.tsx
+++ b/app/payments/_components/export-payment-history-button.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useTransition } from 'react';
+
+import { Download } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { createDownloadLink } from '@/lib/download-client';
+import { createPaymentHistoryCsv } from '@/lib/payments/receipts';
+import type { PaymentReceiptHistoryEntry } from '@/types/payments';
+
+export function ExportPaymentHistoryButton({
+  receipts,
+}: {
+  receipts: PaymentReceiptHistoryEntry[];
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleExport = () => {
+    startTransition(() => {
+      try {
+        const csvContent = createPaymentHistoryCsv(receipts);
+        const blob = new Blob([csvContent], {
+          type: 'text/csv;charset=utf-8',
+        });
+        const filename = `payments-${new Date().toISOString().slice(0, 10)}.csv`;
+        createDownloadLink(blob, filename);
+      } catch (error) {
+        console.error('Failed to export payment history CSV', error);
+      }
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="gap-2"
+      onClick={handleExport}
+      disabled={isPending}
+    >
+      <Download className="size-4" aria-hidden="true" />
+      {isPending ? 'Exporting…' : 'Export CSV'}
+    </Button>
+  );
+}

--- a/app/payments/_components/receipt-history-card.tsx
+++ b/app/payments/_components/receipt-history-card.tsx
@@ -13,10 +13,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
 import { formatCurrency } from "@/lib/payments/currency"
-import {
-  createPaymentHistoryCsv,
-  summarizeReceiptHistory,
-} from "@/lib/payments/receipts"
+import { formatReceiptPeriod, summarizeReceiptHistory } from "@/lib/payments/receipts"
 import type { PaymentReceiptHistoryEntry } from "@/types/payments"
 
 interface ReceiptHistoryCardProps {
@@ -30,28 +27,6 @@ const statusStyles: Record<
   paid: { label: "Paid", variant: "secondary" },
   processing: { label: "Processing", variant: "outline" },
   refunded: { label: "Refunded", variant: "destructive" },
-}
-
-function formatPeriod(
-  periodStart: string | undefined,
-  periodEnd: string | undefined,
-) {
-  if (!periodStart && !periodEnd) {
-    return "—"
-  }
-
-  if (periodStart && periodEnd) {
-    const start = format(parseISO(periodStart), "MMM d")
-    const end = format(parseISO(periodEnd), "MMM d, yyyy")
-    return `${start} – ${end}`
-  }
-
-  const singleDate = periodStart ?? periodEnd
-  return singleDate ? format(parseISO(singleDate), "MMM d, yyyy") : "—"
-}
-
-function encodeCsvForDownload(content: string) {
-  return `data:text/csv;charset=utf-8,${encodeURIComponent(content)}`
 }
 
 export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
@@ -70,8 +45,6 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
   }
 
   const summary = summarizeReceiptHistory(receipts)
-  const csvContent = createPaymentHistoryCsv(receipts)
-  const csvDownloadHref = encodeCsvForDownload(csvContent)
 
   const currentYear = new Date().getFullYear()
   const paidReceiptsThisYear = receipts.filter((receipt) => {
@@ -98,14 +71,6 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
             Download itemized receipts and export the full payment ledger for
             reimbursements, tax season, or dispute resolution.
           </CardDescription>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Button asChild variant="outline" size="sm" className="gap-2">
-            <a href={csvDownloadHref} download="roomsily-payment-history.csv">
-              <Download className="size-4" aria-hidden="true" />
-              Export CSV
-            </a>
-          </Button>
         </div>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -177,7 +142,7 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
                         </div>
                       </td>
                       <td className="p-4 text-sm text-muted-foreground">
-                        {formatPeriod(receipt.periodStart, receipt.periodEnd)}
+                        {formatReceiptPeriod(receipt.periodStart, receipt.periodEnd)}
                       </td>
                       <td className="p-4">
                         <ul className="space-y-1">

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -23,6 +23,7 @@ import { describeAutopayStatus } from "@/lib/payments/status"
 
 import { loadCatchUpBalances, loadReceiptHistory } from "./loaders"
 import { ReceiptHistoryCard } from "./_components/receipt-history-card"
+import { ExportPaymentHistoryButton } from "./_components/export-payment-history-button"
 
 
 const paymentHighlights = [
@@ -113,11 +114,14 @@ export default async function PaymentsPage() {
   return (
     <div className="container max-w-5xl space-y-10 py-12">
       <header className="space-y-4">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Payments</h1>
-          <p className="text-base text-muted-foreground sm:text-lg">
-            Manage rent, deposits, and roommate contributions with Stripe-powered autopay and real-time status updates.
-          </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Payments</h1>
+            <p className="text-base text-muted-foreground sm:text-lg">
+              Manage rent, deposits, and roommate contributions with Stripe-powered autopay and real-time status updates.
+            </p>
+          </div>
+          <ExportPaymentHistoryButton receipts={receiptHistory} />
         </div>
         <Separator />
       </header>

--- a/lib/download-client.ts
+++ b/lib/download-client.ts
@@ -1,0 +1,22 @@
+'use client';
+
+export function createDownloadLink(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export async function streamToBlob(
+  stream: ReadableStream<Uint8Array>,
+  contentType = 'text/csv;charset=utf-8'
+): Promise<Blob> {
+  const response = new Response(stream, {
+    headers: { 'Content-Type': contentType },
+  });
+  return response.blob();
+}

--- a/lib/export/csv.ts
+++ b/lib/export/csv.ts
@@ -1,0 +1,36 @@
+export type CsvCell = string | number | boolean | null | undefined;
+
+function serializeCell(value: CsvCell): string {
+  if (value === null || value === undefined) {
+    return '""';
+  }
+
+  const stringValue = typeof value === 'string' ? value : String(value);
+  const sanitized = stringValue.replace(/"/g, '""');
+  return `"${sanitized}"`;
+}
+
+export function serializeRow(values: CsvCell[]): string {
+  return values.map(serializeCell).join(',');
+}
+
+export function buildCsvString(headers: string[], rows: CsvCell[][]): string {
+  const serializedRows = rows.map(serializeRow);
+  return [serializeRow(headers), ...serializedRows].join('\n');
+}
+
+export function buildCsvStream(headers: string[], rows: CsvCell[][]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(`${serializeRow(headers)}\n`));
+
+      for (const row of rows) {
+        controller.enqueue(encoder.encode(`${serializeRow(row)}\n`));
+      }
+
+      controller.close();
+    },
+  });
+}

--- a/lib/export/documents.ts
+++ b/lib/export/documents.ts
@@ -1,0 +1,65 @@
+import { formatDistanceToNow } from 'date-fns';
+
+import type { DocumentStatus, DocumentWithLease } from '@/types/documents';
+
+import type { CsvCell } from './csv';
+
+export const DOCUMENT_CSV_HEADERS = [
+  'Title',
+  'Description',
+  'Status',
+  'Created',
+  'Lease summary',
+  'Signatures',
+];
+
+const statusLabels: Record<DocumentStatus, string> = {
+  draft: 'Draft',
+  pending_signature: 'Pending Signature',
+  signed: 'Signed',
+  expired: 'Expired',
+  cancelled: 'Cancelled',
+};
+
+function formatCreatedAt(timestamp: string): string {
+  try {
+    return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
+  } catch {
+    return '';
+  }
+}
+
+function formatLeaseSummary(document: DocumentWithLease): string {
+  if (!document.lease) {
+    return '';
+  }
+
+  const tenantCount = document.lease.tenant_ids?.length ?? 0;
+  const tenantLabel = tenantCount === 1 ? 'tenant' : 'tenants';
+  return `Lease • ${tenantCount} ${tenantLabel}`;
+}
+
+function formatSignatures(document: DocumentWithLease): string {
+  const signatures = document.signatures ?? [];
+  if (signatures.length === 0) {
+    return '';
+  }
+
+  const signedCount = signatures.filter((signature) => signature.status === 'signed').length;
+  return `${signedCount}/${signatures.length} signed`;
+}
+
+export function buildDocumentCsvRows(documents: DocumentWithLease[]): CsvCell[][] {
+  return documents.map((document) => {
+    const status = document.status as DocumentStatus;
+
+    return [
+      document.title,
+      document.description ?? '',
+      statusLabels[status] ?? status,
+      formatCreatedAt(document.created_at),
+      formatLeaseSummary(document),
+      formatSignatures(document),
+    ];
+  });
+}

--- a/lib/export/members.ts
+++ b/lib/export/members.ts
@@ -1,0 +1,22 @@
+import type { DashboardMember } from '@/app/dashboard/members/data';
+
+import type { CsvCell } from './csv';
+
+export const MEMBER_CSV_HEADERS = ['Name', 'Role', 'Joined', 'Status'];
+
+function capitalizeLabel(value: string): string {
+  if (!value) {
+    return '';
+  }
+
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function buildMemberCsvRows(members: DashboardMember[]): CsvCell[][] {
+  return members.map((member) => [
+    member.name,
+    capitalizeLabel(member.role),
+    member.createdAt,
+    capitalizeLabel(member.status),
+  ]);
+}

--- a/lib/payments/receipts.ts
+++ b/lib/payments/receipts.ts
@@ -1,4 +1,7 @@
-import { roundToCurrency } from "./currency"
+import { format, parseISO } from "date-fns"
+
+import { buildCsvString } from "@/lib/export/csv"
+import { formatCurrency, roundToCurrency } from "./currency"
 import type {
   PaymentReceiptHistoryEntry,
   PaymentReceiptLineItem,
@@ -50,57 +53,97 @@ export function summarizeReceiptHistory(
   }
 }
 
+export function formatReceiptPeriod(
+  periodStart: string | undefined,
+  periodEnd: string | undefined,
+): string {
+  if (!periodStart && !periodEnd) {
+    return "—"
+  }
+
+  if (periodStart && periodEnd) {
+    try {
+      const start = format(parseISO(periodStart), "MMM d")
+      const end = format(parseISO(periodEnd), "MMM d, yyyy")
+      return `${start} – ${end}`
+    } catch {
+      return `${periodStart} – ${periodEnd}`
+    }
+  }
+
+  const singleDate = periodStart ?? periodEnd
+  if (!singleDate) {
+    return "—"
+  }
+
+  try {
+    return format(parseISO(singleDate), "MMM d, yyyy")
+  } catch {
+    return singleDate
+  }
+}
+
+const statusLabels: Record<PaymentReceiptHistoryEntry["status"], string> = {
+  paid: "Paid",
+  processing: "Processing",
+  refunded: "Refunded",
+}
+
 export function createPaymentHistoryCsv(
   receipts: PaymentReceiptHistoryEntry[],
 ): string {
   const headers = [
-    "Receipt ID",
-    "Issued To",
-    "Payment Date",
-    "Period Start",
-    "Period End",
-    "Status",
+    "Payment",
+    "Period",
+    "Line items",
     "Amount",
-    "Currency",
-    "Payment Method",
-    "Line Items",
-    "Memo",
-    "Receipt URL",
-    "Invoice URL",
+    "Status",
+    "Actions",
   ]
 
   const rows = receipts.map((receipt) => {
-    const lineItems = receipt.lineItems
-      .map((item) => {
-        const formattedAmount = item.totalAmount.toFixed(2)
-        return `${item.description} [${item.category}] ${formattedAmount}`
-      })
-      .join(" | ")
+    const paymentDate = (() => {
+      try {
+        return format(parseISO(receipt.paymentDate), "MMM d, yyyy")
+      } catch {
+        return receipt.paymentDate
+      }
+    })()
+
+    const paymentDetails = [
+      receipt.issuedTo,
+      paymentDate
+        ? `${paymentDate}${receipt.paymentMethod ? ` · ${receipt.paymentMethod}` : ""}`
+        : receipt.paymentMethod,
+    ]
+
+    if (receipt.memo) {
+      paymentDetails.push(receipt.memo)
+    }
+
+    const lineItems = receipt.lineItems.map((item) => {
+      const amount = formatCurrency(item.totalAmount, receipt.currency)
+      return `${item.description} — ${amount}`
+    })
+
+    const amountCell = receipt.amount < 0
+      ? `${formatCurrency(receipt.amount, receipt.currency)}\nCredit issued`
+      : formatCurrency(receipt.amount, receipt.currency)
+
+    const actions = [
+      `Receipt: ${receipt.receiptUrl}`,
+      receipt.invoiceUrl ? `Invoice: ${receipt.invoiceUrl}` : null,
+    ].filter(Boolean) as string[]
 
     return [
-      receipt.id,
-      receipt.issuedTo,
-      receipt.paymentDate,
-      receipt.periodStart ?? "",
-      receipt.periodEnd ?? "",
-      receipt.status,
-      receipt.amount.toFixed(2),
-      receipt.currency,
-      receipt.paymentMethod,
-      lineItems,
-      receipt.memo ?? "",
-      receipt.receiptUrl,
-      receipt.invoiceUrl ?? "",
+      paymentDetails.filter(Boolean).join("\n"),
+      formatReceiptPeriod(receipt.periodStart, receipt.periodEnd),
+      lineItems.join("\n"),
+      amountCell,
+      statusLabels[receipt.status],
+      actions.join("\n"),
     ]
   })
 
-  const toCsvRow = (values: string[]) =>
-    values
-      .map((value) => {
-        const sanitized = value.replace(/"/g, '""')
-        return `"${sanitized}"`
-      })
-      .join(",")
-
-  return [headers, ...rows].map((row) => toCsvRow(row)).join("\n")
+  return buildCsvString(headers, rows)
 }

--- a/tests/lib/export/documents.test.ts
+++ b/tests/lib/export/documents.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DOCUMENT_CSV_HEADERS, buildDocumentCsvRows } from '@/lib/export/documents';
+import { buildCsvString } from '@/lib/export/csv';
+import type { DocumentWithLease } from '@/types/documents';
+
+function createDocument(partial: Partial<DocumentWithLease>): DocumentWithLease {
+  return {
+    id: 'doc-id',
+    created_at: '2024-06-08T12:00:00Z',
+    updated_at: '2024-06-08T12:00:00Z',
+    title: 'Untitled',
+    description: undefined,
+    document_type: 'lease',
+    status: 'draft',
+    file_url: undefined,
+    documenso_envelope_id: undefined,
+    documenso_template_id: undefined,
+    metadata: {},
+    created_by: undefined,
+    property_id: undefined,
+    tenant_id: undefined,
+    unit_id: undefined,
+    requires_signature: false,
+    expires_at: undefined,
+    signed_at: undefined,
+    version: 1,
+    parent_document_id: undefined,
+    lease: undefined,
+    signatures: undefined,
+    access_logs: undefined,
+    ...partial,
+  };
+}
+
+describe('buildDocumentCsvRows', () => {
+  it('creates rows matching the visible document columns', () => {
+    vi.setSystemTime(new Date('2024-06-10T12:00:00Z'));
+
+    const documents: DocumentWithLease[] = [
+      createDocument({
+        id: 'doc-1',
+        title: 'Lease Agreement',
+        description: 'Main unit lease',
+        status: 'pending_signature',
+        created_at: '2024-06-08T12:00:00Z',
+        lease: {
+          id: 'lease-1',
+          document_id: 'doc-1',
+          created_at: '2024-06-01T12:00:00Z',
+          updated_at: '2024-06-01T12:00:00Z',
+          start_date: '2024-06-01',
+          end_date: '2025-05-31',
+          rent_amount: 2500,
+          rent_frequency: 'monthly',
+          security_deposit: null,
+          tenant_ids: ['tenant-1', 'tenant-2'],
+          property_address: null,
+          unit_number: null,
+          landlord_name: null,
+          landlord_email: null,
+          auto_renew: true,
+          renewal_notice_days: 45,
+          special_terms: null,
+          status: 'pending_signature',
+        },
+        signatures: [
+          {
+            id: 'sig-1',
+            created_at: '2024-06-08T12:00:00Z',
+            updated_at: '2024-06-08T12:00:00Z',
+            document_id: 'doc-1',
+            signer_id: 'tenant-1',
+            signer_email: 'tenant1@example.com',
+            signer_name: 'Tenant One',
+            status: 'signed',
+            signed_at: '2024-06-08T12:30:00Z',
+            declined_at: null,
+            decline_reason: null,
+            documenso_signature_id: null,
+            ip_address: null,
+            user_agent: null,
+            signature_data: {},
+          },
+          {
+            id: 'sig-2',
+            created_at: '2024-06-08T12:00:00Z',
+            updated_at: '2024-06-08T12:00:00Z',
+            document_id: 'doc-1',
+            signer_id: 'tenant-2',
+            signer_email: 'tenant2@example.com',
+            signer_name: 'Tenant Two',
+            status: 'pending',
+            signed_at: null,
+            declined_at: null,
+            decline_reason: null,
+            documenso_signature_id: null,
+            ip_address: null,
+            user_agent: null,
+            signature_data: {},
+          },
+        ],
+      }),
+      createDocument({
+        id: 'doc-2',
+        title: 'Insurance certificate',
+        status: 'signed',
+        created_at: '2024-05-20T09:00:00Z',
+        signatures: [],
+      }),
+    ];
+
+    const rows = buildDocumentCsvRows(documents);
+    const csv = buildCsvString(DOCUMENT_CSV_HEADERS, rows);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual([
+      'Lease Agreement',
+      'Main unit lease',
+      'Pending Signature',
+      '2 days ago',
+      'Lease • 2 tenants',
+      '1/2 signed',
+    ]);
+    expect(rows[1]).toEqual([
+      'Insurance certificate',
+      '',
+      'Signed',
+      '21 days ago',
+      '',
+      '',
+    ]);
+
+    expect(csv.split('\n')[0]).toBe(
+      '"Title","Description","Status","Created","Lease summary","Signatures"'
+    );
+
+    vi.useRealTimers();
+  });
+});

--- a/tests/lib/export/members.test.ts
+++ b/tests/lib/export/members.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { MEMBER_CSV_HEADERS, buildMemberCsvRows } from '@/lib/export/members';
+import { buildCsvString } from '@/lib/export/csv';
+import type { DashboardMember } from '@/app/dashboard/members/data';
+
+describe('buildMemberCsvRows', () => {
+  it('maps members to the visible table columns', () => {
+    const members: DashboardMember[] = [
+      {
+        name: 'Alex Johnson',
+        role: 'admin',
+        createdAt: 'Mon Jun 10 2024',
+        status: 'active',
+      },
+      {
+        name: 'Taylor Singh',
+        role: 'user',
+        createdAt: 'Mon Jun 03 2024',
+        status: 'resigned',
+      },
+    ];
+
+    const rows = buildMemberCsvRows(members);
+    const csv = buildCsvString(MEMBER_CSV_HEADERS, rows);
+
+    expect(rows).toEqual([
+      ['Alex Johnson', 'Admin', 'Mon Jun 10 2024', 'Active'],
+      ['Taylor Singh', 'User', 'Mon Jun 03 2024', 'Resigned'],
+    ]);
+
+    expect(csv.split('\n')[0]).toBe('"Name","Role","Joined","Status"');
+  });
+});

--- a/tests/lib/payments/receipts.test.ts
+++ b/tests/lib/payments/receipts.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createPaymentHistoryCsv,
+  formatReceiptPeriod,
+} from '@/lib/payments/receipts';
+import type { PaymentReceiptHistoryEntry } from '@/types/payments';
+
+describe('formatReceiptPeriod', () => {
+  it('formats ranges and single dates to the display string', () => {
+    expect(formatReceiptPeriod('2024-06-01', '2024-06-30')).toBe('Jun 1 – Jun 30, 2024');
+    expect(formatReceiptPeriod(undefined, '2024-05-15')).toBe('May 15, 2024');
+    expect(formatReceiptPeriod(undefined, undefined)).toBe('—');
+  });
+});
+
+describe('createPaymentHistoryCsv', () => {
+  it('builds rows using the same columns as the receipt history table', () => {
+    const receipts: PaymentReceiptHistoryEntry[] = [
+      {
+        id: 'rcpt_1',
+        issuedTo: 'Alex Johnson',
+        paymentDate: '2024-06-01',
+        periodStart: '2024-06-01',
+        periodEnd: '2024-06-30',
+        currency: 'USD',
+        amount: 1305,
+        status: 'paid',
+        paymentMethod: 'Visa •••• 4242',
+        receiptUrl: 'https://receipts.example/rcpt_1.pdf',
+        invoiceUrl: 'https://invoices.example/rcpt_1',
+        memo: 'Rent for June',
+        lineItems: [
+          {
+            id: 'item-1',
+            description: 'June rent share',
+            category: 'rent',
+            quantity: 1,
+            unitAmount: 1260,
+            totalAmount: 1260,
+          },
+          {
+            id: 'item-2',
+            description: 'Wi-Fi reimbursement',
+            category: 'utilities',
+            quantity: 1,
+            unitAmount: 45,
+            totalAmount: 45,
+          },
+        ],
+      },
+      {
+        id: 'rcpt_2',
+        issuedTo: 'Taylor Singh',
+        paymentDate: '2024-05-15',
+        periodStart: undefined,
+        periodEnd: '2024-05-15',
+        currency: 'USD',
+        amount: -45,
+        status: 'refunded',
+        paymentMethod: 'ACH Refund',
+        receiptUrl: 'https://receipts.example/rcpt_2.pdf',
+        invoiceUrl: null,
+        memo: undefined,
+        lineItems: [
+          {
+            id: 'item-3',
+            description: 'Utility adjustment',
+            category: 'utilities',
+            quantity: 1,
+            unitAmount: -45,
+            totalAmount: -45,
+          },
+        ],
+      },
+    ];
+
+    const csv = createPaymentHistoryCsv(receipts);
+
+    const expected = [
+      '"Payment","Period","Line items","Amount","Status","Actions"',
+      '"Alex Johnson\nJun 1, 2024 · Visa •••• 4242\nRent for June","Jun 1 – Jun 30, 2024","June rent share — $1,260.00\nWi-Fi reimbursement — $45.00","$1,305.00","Paid","Receipt: https://receipts.example/rcpt_1.pdf\nInvoice: https://invoices.example/rcpt_1"',
+      '"Taylor Singh\nMay 15, 2024 · ACH Refund","May 15, 2024","Utility adjustment — -$45.00","-$45.00\nCredit issued","Refunded","Receipt: https://receipts.example/rcpt_2.pdf"',
+    ].join('\n');
+
+    expect(csv).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared CSV helpers and server actions so document and member exports stream filtered data
- surface export controls on documents, members, and payments toolbars with shared download utilities
- align payment receipt CSV columns with the UI and cover the exports with unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b78bb208328bcdadd0546d6fa5b