### PR TITLE
Implement messaging mentions with notifications

### DIFF
--- a/app/messaging/actions.ts
+++ b/app/messaging/actions.ts
@@ -1,0 +1,51 @@
+'use server'
+
+import { createSupbaseServerClient } from '@/utils/supaone'
+import { sendInAppNotification } from '@/lib/notifications'
+import {
+  createMessageWithMentions,
+  type MentionNotifier,
+} from '@/lib/messaging/mentions'
+import type { StoredMention } from '@/lib/messaging/types'
+
+interface CreateThreadMessageInput {
+  threadId: string
+  senderId: string
+  senderDisplayName: string
+  content: string
+  mentions: StoredMention[]
+}
+
+const mentionNotifier: MentionNotifier = async payload => {
+  await sendInAppNotification({
+    userId: payload.recipientId,
+    title: `Mentioned by ${payload.senderDisplayName}`,
+    message: payload.preview,
+    type: 'info',
+    actionUrl: `/messaging/${payload.message.thread_id}?focus=${payload.message.id}`,
+    metadata: {
+      kind: 'mention',
+      threadId: payload.message.thread_id,
+      messageId: payload.message.id,
+      actorId: payload.senderId,
+      actorName: payload.senderDisplayName,
+      mention: payload.mention,
+    },
+  })
+}
+
+export async function createThreadMessage(input: CreateThreadMessageInput) {
+  const supabase = await createSupbaseServerClient()
+
+  await createMessageWithMentions(
+    supabase,
+    {
+      threadId: input.threadId,
+      senderId: input.senderId,
+      senderDisplayName: input.senderDisplayName,
+      content: input.content,
+      mentions: input.mentions,
+    },
+    mentionNotifier,
+  )
+}

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,4 +1,6 @@
 import ModerationControls from "@/components/messaging/moderation-controls"
+import { MessageComposer } from "@/components/messaging/message-composer"
+import { MessageContent } from "@/components/messaging/message-content"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -12,8 +14,11 @@ import {
 import { Progress } from "@/components/ui/progress"
 
 import { Separator } from "@/components/ui/separator"
+import type { StoredMention } from "@/lib/messaging/types"
 import { cn } from "@/lib/utils"
 import { Paperclip } from "lucide-react"
+
+import { createThreadMessage } from "./actions"
 
 type ThreadListItem = {
   id: string
@@ -63,7 +68,8 @@ type ThreadPost = {
     accent: string
   }
   timestamp: string
-  content: string[]
+  content: string
+  mentions?: StoredMention[]
   attachments?: Attachment[]
   poll?: ThreadPoll
   reactions?: PostReaction[]
@@ -95,9 +101,17 @@ const threadFilters = [
   { label: "Social", active: false },
 ]
 
+const activeThreadId = "thread-chore-rotation"
+
+const currentUser = {
+  id: "profile-jordan-lee",
+  name: "Jordan Lee",
+  unitId: "unit-3b",
+}
+
 const threadList: ThreadListItem[] = [
   {
-    id: "chore-rotation",
+    id: activeThreadId,
     title: "Q2 chore rotation plan",
     category: "Chores",
     summary:
@@ -149,6 +163,7 @@ const threadList: ThreadListItem[] = [
 ]
 
 const activeThread = {
+  id: activeThreadId,
   title: "Q2 chore rotation plan",
   summary:
     "Keep the shared areas sparkling with a rotation everyone can reference — vote on the deep clean weekend and review updated checklists in one place.",
@@ -168,9 +183,24 @@ const threadPosts: ThreadPost[] = [
       accent: "bg-sky-500/20 text-sky-700",
     },
     timestamp: "Today • 8:45 AM",
-    content: [
-      "Kicking off the Q2 chore rotation thread so we can stay ahead of the spring deep clean.",
-      "Please vote in the poll for when we should tackle the deep clean together. I added the updated checklist and rotation calendar so everyone can review before voting.",
+    content:
+      "Kicking off the Q2 chore rotation thread so we can stay ahead of the spring deep clean. Please vote in the poll for when we should tackle the deep clean weekend together. I added #Deep clean checklist and #Q2 rotation calendar so everyone can review before voting.",
+    mentions: [
+      {
+        entityId: "document-deep-clean-checklist",
+        entityType: "document",
+        trigger: "#",
+        label: "Deep clean checklist",
+        order: 0,
+        metadata: { document_type: "checklist" },
+      },
+      {
+        entityId: "document-q2-rotation-calendar",
+        entityType: "document",
+        trigger: "#",
+        label: "Q2 rotation calendar",
+        order: 1,
+      },
     ],
     attachments: [
       {
@@ -211,9 +241,16 @@ const threadPosts: ThreadPost[] = [
       accent: "bg-amber-500/20 text-amber-700",
     },
     timestamp: "Today • 9:05 AM",
-    content: [
-      "Looks good to me. I left a couple of notes in the sheet about trading weekends because of my travel schedule.",
-      "If we go with the Saturday 10 AM block, I can take recycling duty during the week so Sunday stays open.",
+    content:
+      "Looks good to me. I left a couple of notes in the sheet about trading weekends because of my travel schedule. @Avery Chen I can take recycling duty during the week so Sunday stays open if we land on Saturday morning.",
+    mentions: [
+      {
+        entityId: "profile-avery-chen",
+        entityType: "profile",
+        trigger: "@",
+        label: "Avery Chen",
+        order: 0,
+      },
     ],
     attachments: [
       {
@@ -237,9 +274,17 @@ const threadPosts: ThreadPost[] = [
       accent: "bg-purple-500/20 text-purple-700",
     },
     timestamp: "Today • 9:42 AM",
-    content: [
-      "Thanks everyone! Once the poll closes I'll lock the rotation and post a PDF to the documents hub.",
-      "Reminder that the spring inspection is on April 18 — make sure kitchen counters and the entryway are cleared the night before.",
+    content:
+      "Thanks everyone! Once the poll closes I'll lock the rotation and post a PDF to the documents hub. Reminder that the spring inspection is on April 18 — I reserved #Shared storage closet so supplies are easy to grab next weekend.",
+    mentions: [
+      {
+        entityId: "amenity-shared-storage",
+        entityType: "amenity",
+        trigger: "#",
+        label: "Shared storage closet",
+        order: 0,
+        metadata: { slug: "shared-storage" },
+      },
     ],
     reactions: [
       { emoji: "📌", count: 2 },
@@ -303,6 +348,21 @@ const pollSnapshots: PollSnapshot[] = [
 ]
 
 export default function MessagingPage() {
+  async function submitMessage(payload: {
+    content: string
+    mentions: StoredMention[]
+  }) {
+    "use server"
+
+    await createThreadMessage({
+      threadId: activeThread.id,
+      senderId: currentUser.id,
+      senderDisplayName: currentUser.name,
+      content: payload.content,
+      mentions: payload.mentions,
+    })
+  }
+
   return (
     <div className="container max-w-6xl space-y-10 py-12">
       <header className="space-y-4">
@@ -463,12 +523,12 @@ export default function MessagingPage() {
                       </div>
                     </div>
 
-                    <div className="space-y-3 text-sm leading-6 text-foreground">
-                      {post.content.map((paragraph, idx) => (
-                        <p key={`${post.id}-content-${idx}`} className="text-muted-foreground">
-                          {paragraph}
-                        </p>
-                      ))}
+                    <div className="text-sm leading-6 text-foreground">
+                      <MessageContent
+                        content={post.content}
+                        mentions={post.mentions ?? []}
+                        className="text-muted-foreground"
+                      />
                     </div>
 
                     {post.attachments?.length ? (
@@ -562,6 +622,15 @@ export default function MessagingPage() {
                   {index < threadPosts.length - 1 ? <Separator /> : null}
                 </div>
               ))}
+              <div className="pt-2">
+                <MessageComposer
+                  threadId={activeThread.id}
+                  currentUserId={currentUser.id}
+                  currentUserName={currentUser.name}
+                  unitId={currentUser.unitId}
+                  onSubmit={submitMessage}
+                />
+              </div>
             </CardContent>
           </Card>
 

--- a/components/messaging/message-composer.tsx
+++ b/components/messaging/message-composer.tsx
@@ -1,0 +1,344 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { AtSign, Hash, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+import useSupabaseBrowser from '@/utils/supabase-browser'
+
+import {
+  findActiveMentionTrigger,
+  insertMentionToken,
+  pruneMissingMentions,
+  type MentionTriggerState,
+} from '@/lib/messaging/composer-utils'
+import { getMentionSuggestions } from '@/lib/messaging/mentions'
+import type {
+  MentionSuggestion,
+  MentionTrigger,
+  StoredMention,
+} from '@/lib/messaging/types'
+
+interface MessageComposerProps {
+  threadId: string
+  currentUserId: string
+  currentUserName: string
+  unitId?: string | null
+  onSubmit?: (payload: {
+    content: string
+    mentions: StoredMention[]
+  }) => Promise<void> | void
+}
+
+type SuggestionState = {
+  trigger: MentionTrigger
+  items: MentionSuggestion[]
+}
+
+export function MessageComposer({
+  threadId,
+  currentUserId,
+  currentUserName,
+  unitId,
+  onSubmit,
+}: MessageComposerProps) {
+  const supabase = useSupabaseBrowser()
+
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const [value, setValue] = useState('')
+  const [mentions, setMentions] = useState<StoredMention[]>([])
+  const [triggerState, setTriggerState] = useState<MentionTriggerState | null>(
+    null,
+  )
+  const [suggestions, setSuggestions] = useState<SuggestionState | null>(null)
+  const [isSearching, setIsSearching] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const helperText = useMemo(
+    () =>
+      'Use @ to mention roommates and # to link documents or amenities. Mentions notify roommates unless they mute the thread.',
+    [],
+  )
+
+  const resetSuggestions = useCallback(() => {
+    setSuggestions(null)
+    setActiveIndex(0)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const loadSuggestions = async () => {
+      if (!triggerState) {
+        resetSuggestions()
+        return
+      }
+
+      setIsSearching(true)
+      try {
+        const items = await getMentionSuggestions(
+          supabase,
+          triggerState.trigger,
+          triggerState.query,
+          { unitId: unitId ?? undefined },
+        )
+
+        if (!cancelled) {
+          setSuggestions({ trigger: triggerState.trigger, items })
+          setActiveIndex(0)
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Failed to load mention suggestions', error)
+          resetSuggestions()
+        }
+      } finally {
+        if (!cancelled) {
+          setIsSearching(false)
+        }
+      }
+    }
+
+    void loadSuggestions()
+
+    return () => {
+      cancelled = true
+    }
+  }, [resetSuggestions, supabase, triggerState, unitId])
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const nextValue = event.target.value
+      setValue(nextValue)
+      setMentions(prev => pruneMissingMentions(nextValue, prev))
+
+      const caret = event.target.selectionStart ?? nextValue.length
+      setTriggerState(findActiveMentionTrigger(nextValue, caret))
+    },
+    [],
+  )
+
+  const applySuggestion = useCallback(
+    (suggestion: MentionSuggestion) => {
+      if (!triggerState) {
+        return
+      }
+
+      const result = insertMentionToken(value, triggerState, suggestion)
+      setValue(result.value)
+
+      setMentions(prev =>
+        pruneMissingMentions(result.value, [
+          ...prev,
+          {
+            entityId: suggestion.id,
+            entityType: suggestion.entityType,
+            trigger: suggestion.trigger,
+            label: suggestion.label,
+            order: prev.length,
+            metadata: suggestion.metadata,
+          },
+        ]),
+      )
+
+      requestAnimationFrame(() => {
+        if (textareaRef.current) {
+          textareaRef.current.focus()
+          textareaRef.current.setSelectionRange(result.caret, result.caret)
+        }
+      })
+
+      setTriggerState(null)
+      resetSuggestions()
+    },
+    [resetSuggestions, triggerState, value],
+  )
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!suggestions || suggestions.items.length === 0) {
+        if (event.key === 'Escape') {
+          setTriggerState(null)
+          resetSuggestions()
+        }
+        return
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setActiveIndex(current =>
+          current + 1 >= suggestions.items.length ? 0 : current + 1,
+        )
+        return
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setActiveIndex(current =>
+          current - 1 < 0 ? suggestions.items.length - 1 : current - 1,
+        )
+        return
+      }
+
+      if (event.key === 'Enter') {
+        if (triggerState) {
+          event.preventDefault()
+          const suggestion = suggestions.items[activeIndex]
+          if (suggestion) {
+            applySuggestion(suggestion)
+          }
+        }
+        return
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setTriggerState(null)
+        resetSuggestions()
+      }
+    },
+    [activeIndex, applySuggestion, resetSuggestions, suggestions, triggerState],
+  )
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const trimmed = value.trim()
+      if (trimmed.length === 0) {
+        return
+      }
+
+      const normalizedMentions = pruneMissingMentions(trimmed, mentions)
+
+      try {
+        setIsSubmitting(true)
+        await onSubmit?.({
+          content: trimmed,
+          mentions: normalizedMentions,
+        })
+        setValue('')
+        setMentions([])
+        setTriggerState(null)
+        resetSuggestions()
+      } catch (error) {
+        console.error('Failed to submit message', error)
+      } finally {
+        setIsSubmitting(false)
+      }
+    },
+    [mentions, onSubmit, resetSuggestions, value],
+  )
+
+  const activeTrigger = suggestions?.trigger
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-3 rounded-lg border border-border/60 bg-muted/20 p-4"
+      data-author-id={currentUserId}
+      data-thread-id={threadId}
+    >
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium text-foreground">
+          Share an update, {currentUserName.split(' ')[0] ?? 'roommate'}
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <AtSign className="size-3" />
+            Roommates
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Hash className="size-3" />
+            Docs & amenities
+          </span>
+        </div>
+      </div>
+
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder="Announce wins, assign chores, or drop quick reminders with @mentions and #links."
+        disabled={isSubmitting}
+        className="min-h-[120px]"
+      />
+
+      {mentions.length > 0 ? (
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          {mentions.map(mention => (
+            <Badge
+              key={`${mention.entityType}-${mention.entityId}-${mention.order}`}
+              variant="outline"
+              className="gap-1"
+            >
+              {mention.trigger}
+              {mention.label}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+
+      {triggerState ? (
+        <div className="rounded-md border border-border/60 bg-background shadow-sm">
+          <div className="flex items-center justify-between px-3 py-2 text-xs text-muted-foreground">
+            <span>
+              {activeTrigger === '@'
+                ? 'Tag a roommate to send them a notification'
+                : 'Link documents or amenities for quick reference'}
+            </span>
+            {isSearching ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+            ) : null}
+          </div>
+          {suggestions && suggestions.items.length > 0 ? (
+            <ul className="divide-y divide-border/60">
+              {suggestions.items.map((item, index) => (
+                <li key={`${item.entityType}-${item.id}`}>
+                  <button
+                    type="button"
+                    className={cn(
+                      'flex w-full items-start gap-2 px-3 py-2 text-left text-sm',
+                      index === activeIndex && 'bg-muted/40',
+                    )}
+                    onMouseDown={event => {
+                      event.preventDefault()
+                      applySuggestion(item)
+                    }}
+                  >
+                    <span className="font-medium text-foreground">
+                      {item.trigger}
+                      {item.label}
+                    </span>
+                    {item.description ? (
+                      <span className="text-xs text-muted-foreground">
+                        {item.description}
+                      </span>
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+              {triggerState.query
+                ? 'No results match your search.'
+                : 'Start typing to search roommates, documents, or amenities.'}
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-muted-foreground">{helperText}</p>
+        <Button type="submit" disabled={isSubmitting || value.trim().length === 0}>
+          {isSubmitting ? 'Posting…' : 'Post update'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/components/messaging/message-content.tsx
+++ b/components/messaging/message-content.tsx
@@ -1,0 +1,60 @@
+import { Fragment, useMemo } from 'react'
+
+import {
+  segmentContentWithMentions,
+  type MentionSegment,
+} from '@/lib/messaging/content'
+import type { StoredMention } from '@/lib/messaging/types'
+
+interface MessageContentProps {
+  content: string
+  mentions: StoredMention[]
+  className?: string
+}
+
+function renderText(text: string, key: string) {
+  const parts = text.split(/(\n)/)
+  return parts.map((part, index) => {
+    if (part === '\n') {
+      return <br key={`${key}-break-${index}`} />
+    }
+    return <Fragment key={`${key}-text-${index}`}>{part}</Fragment>
+  })
+}
+
+export function MessageContent({ content, mentions, className }: MessageContentProps) {
+  const segments = useMemo<MentionSegment[]>(
+    () => segmentContentWithMentions(content, mentions),
+    [content, mentions],
+  )
+
+  if (segments.length === 0) {
+    return null
+  }
+
+  return (
+    <span className={className}>
+      {segments.map((segment, index) => {
+        if (segment.type === 'text') {
+          return renderText(segment.text, `segment-${index}`)
+        }
+
+        const { mention } = segment
+        return (
+          <a
+            key={`mention-${mention.entityType}-${mention.entityId}-${mention.order}`}
+            href={segment.href}
+            className="font-medium text-primary underline-offset-2 transition-colors hover:text-primary/80 hover:underline"
+            data-mention-type={mention.entityType}
+            data-mention-entity-id={mention.entityId}
+            data-mention-trigger={mention.trigger}
+            data-mention-order={mention.order}
+            title={`View details for ${segment.text}`}
+          >
+            {segment.text}
+          </a>
+        )
+      })}
+    </span>
+  )
+}

--- a/components/notifications/notification-center.tsx
+++ b/components/notifications/notification-center.tsx
@@ -17,6 +17,7 @@ interface Notification {
   message: string;
   type: 'info' | 'success' | 'warning' | 'error';
   action_url?: string;
+  metadata?: Record<string, unknown> | string | null;
   read: boolean;
   created_at: string;
 }
@@ -68,9 +69,10 @@ export function NotificationCenter() {
           setUnreadCount(prev => prev + 1);
 
           // Show toast for new notification
+          const display = resolveNotificationDisplay(newNotification);
           toast({
-            title: newNotification.title,
-            description: newNotification.message,
+            title: display.title,
+            description: display.message,
             variant: newNotification.type === 'error' ? 'destructive' :
                     newNotification.type === 'warning' ? 'default' : 'default',
           });
@@ -173,6 +175,84 @@ export function NotificationCenter() {
     return date.toLocaleDateString();
   };
 
+  type MentionMetadata = {
+    kind?: string;
+    actorName?: string;
+    preview?: string;
+    threadId?: string;
+    messageId?: string;
+  };
+
+  type NotificationDisplay = {
+    title: string;
+    message: string;
+    badgeLabel: string;
+    actionUrl?: string;
+  };
+
+  const parseNotificationMetadata = (
+    metadata: Notification['metadata'],
+  ): Record<string, unknown> | null => {
+    if (!metadata) {
+      return null;
+    }
+
+    if (typeof metadata === 'string') {
+      try {
+        return JSON.parse(metadata) as Record<string, unknown>;
+      } catch (error) {
+        console.warn('Failed to parse notification metadata', error);
+        return null;
+      }
+    }
+
+    if (typeof metadata === 'object') {
+      return metadata as Record<string, unknown>;
+    }
+
+    return null;
+  };
+
+  const resolveNotificationDisplay = (
+    notification: Notification,
+  ): NotificationDisplay => {
+    const metadata = parseNotificationMetadata(notification.metadata);
+
+    if (metadata?.kind === 'mention') {
+      const mentionMeta = metadata as MentionMetadata;
+      const actorName = typeof mentionMeta.actorName === 'string'
+        ? mentionMeta.actorName
+        : undefined;
+
+      const message =
+        typeof mentionMeta.preview === 'string' && mentionMeta.preview.length > 0
+          ? mentionMeta.preview
+          : notification.message;
+
+      const actionUrl =
+        notification.action_url ??
+        (typeof mentionMeta.threadId === 'string'
+          ? `/messaging/${mentionMeta.threadId}${
+              mentionMeta.messageId ? `?focus=${mentionMeta.messageId}` : ''
+            }`
+          : undefined);
+
+      return {
+        title: actorName ? `Mentioned by ${actorName}` : 'You were mentioned',
+        message,
+        badgeLabel: 'mention',
+        actionUrl,
+      };
+    }
+
+    return {
+      title: notification.title,
+      message: notification.message,
+      badgeLabel: notification.type,
+      actionUrl: notification.action_url,
+    };
+  };
+
   return (
     <div className="relative">
       <Button
@@ -230,70 +310,75 @@ export function NotificationCenter() {
                 </div>
               ) : (
                 <div className="space-y-1">
-                  {notifications.map((notification, index) => (
-                    <div key={notification.id}>
-                      <div
-                        className={cn(
-                          "cursor-pointer p-3 transition-colors hover:bg-muted/50",
-                          !notification.read && "bg-muted/20"
-                        )}
-                        onClick={() => {
-                          if (!notification.read) {
-                            markAsRead(notification.id);
-                          }
-                          if (notification.action_url) {
-                            window.location.href = notification.action_url;
-                            setIsOpen(false);
-                          }
-                        }}
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="flex-1 space-y-1">
-                            <div className="flex items-center gap-2">
-                              <Badge
-                                variant="outline"
-                                className={cn("text-xs", getTypeColor(notification.type))}
-                              >
-                                {notification.type}
-                              </Badge>
-                              <span className="text-xs text-muted-foreground">
-                                {formatTime(notification.created_at)}
-                              </span>
+                  {notifications.map((notification, index) => {
+                    const display = resolveNotificationDisplay(notification);
+                    const actionUrl = display.actionUrl ?? notification.action_url;
+
+                    return (
+                      <div key={notification.id}>
+                        <div
+                          className={cn(
+                            "cursor-pointer p-3 transition-colors hover:bg-muted/50",
+                            !notification.read && "bg-muted/20"
+                          )}
+                          onClick={() => {
+                            if (!notification.read) {
+                              markAsRead(notification.id);
+                            }
+                            if (actionUrl) {
+                              window.location.href = actionUrl;
+                              setIsOpen(false);
+                            }
+                          }}
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="flex-1 space-y-1">
+                              <div className="flex items-center gap-2">
+                                <Badge
+                                  variant="outline"
+                                  className={cn("text-xs", getTypeColor(notification.type))}
+                                >
+                                  {display.badgeLabel}
+                                </Badge>
+                                <span className="text-xs text-muted-foreground">
+                                  {formatTime(notification.created_at)}
+                                </span>
+                              </div>
+                              <p className="text-sm font-medium">{display.title}</p>
+                              <p className="text-xs text-muted-foreground">{display.message}</p>
                             </div>
-                            <p className="text-sm font-medium">{notification.title}</p>
-                            <p className="text-xs text-muted-foreground">{notification.message}</p>
-                          </div>
-                          <div className="flex gap-1">
-                            {!notification.read && (
+                            <div className="flex gap-1">
+                              {!notification.read && (
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    markAsRead(notification.id);
+                                  }}
+                                  className="size-6"
+                                >
+                                  <Check className="size-3" />
+                                </Button>
+                              )}
                               <Button
                                 variant="ghost"
                                 size="icon"
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  markAsRead(notification.id);
+                                  deleteNotification(notification.id);
                                 }}
-                                className="size-6"
+                                className="size-6 text-muted-foreground hover:text-destructive"
                               >
-                                <Check className="size-3" />
+                                <X className="size-3" />
                               </Button>
-                            )}
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                deleteNotification(notification.id);
-                              }}
-                              className="size-6 text-muted-foreground hover:text-destructive"
-                            >
-                              <X className="size-3" />
-                            </Button>
+                            </div>
                           </div>
                         </div>
+                        {index < notifications.length - 1 && <Separator />}
                       </div>
-                      {index < notifications.length - 1 && <Separator />}
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </ScrollArea>

--- a/lib/messaging/composer-utils.ts
+++ b/lib/messaging/composer-utils.ts
@@ -1,0 +1,97 @@
+import type { MentionSuggestion, MentionTrigger, StoredMention } from './types'
+
+export interface MentionTriggerState {
+  trigger: MentionTrigger
+  start: number
+  end: number
+  query: string
+}
+
+const WORD_BREAK_REGEX = /[\s.,;!?()\[\]{}<>"'`]/
+const EMAIL_PREFIX_REGEX = /[A-Za-z0-9._%+-]/
+
+export function findActiveMentionTrigger(
+  value: string,
+  caret: number,
+): MentionTriggerState | null {
+  if (caret === 0) {
+    return null
+  }
+
+  let index = caret - 1
+  while (index >= 0) {
+    const char = value[index]
+    if (char === '@' || char === '#') {
+      const prev = index > 0 ? value[index - 1] : undefined
+      if (prev && !WORD_BREAK_REGEX.test(prev) && EMAIL_PREFIX_REGEX.test(prev)) {
+        return null
+      }
+
+      const query = value.slice(index + 1, caret)
+      if (query.includes('\n')) {
+        return null
+      }
+
+      if (query.length === 0) {
+        return { trigger: char, start: index, end: caret, query: '' }
+      }
+
+      if (WORD_BREAK_REGEX.test(query[query.length - 1])) {
+        return null
+      }
+
+      return { trigger: char, start: index, end: caret, query }
+    }
+
+    if (WORD_BREAK_REGEX.test(char)) {
+      break
+    }
+
+    index -= 1
+  }
+
+  return null
+}
+
+export function insertMentionToken(
+  value: string,
+  triggerState: MentionTriggerState,
+  suggestion: MentionSuggestion,
+): { value: string; caret: number } {
+  const prefix = value.slice(0, triggerState.start)
+  const suffix = value.slice(triggerState.end)
+  const mentionText = `${suggestion.trigger}${suggestion.label}`
+
+  let nextValue = `${prefix}${mentionText}`
+  let nextCaret = nextValue.length
+
+  const needsSpace = suffix.length === 0 || !/^\s/.test(suffix)
+  if (needsSpace) {
+    nextValue = `${nextValue} `
+    nextCaret = nextValue.length
+  }
+
+  nextValue = `${nextValue}${suffix}`
+
+  return { value: nextValue, caret: nextCaret }
+}
+
+export function pruneMissingMentions(
+  value: string,
+  mentions: StoredMention[],
+): StoredMention[] {
+  const ordered = [...mentions].sort((a, b) => a.order - b.order)
+  const next: StoredMention[] = []
+  let cursor = 0
+
+  for (const mention of ordered) {
+    const searchText = `${mention.trigger}${mention.label}`
+    const index = value.indexOf(searchText, cursor)
+    if (index !== -1) {
+      next.push({ ...mention, order: next.length })
+      cursor = index + searchText.length
+    }
+  }
+
+  return next
+}

--- a/lib/messaging/content.ts
+++ b/lib/messaging/content.ts
@@ -1,0 +1,68 @@
+import type { StoredMention } from './types'
+
+export type MentionSegment =
+  | { type: 'text'; text: string }
+  | { type: 'mention'; text: string; mention: StoredMention; href: string }
+
+function resolveSlug(mention: StoredMention): string {
+  const slug = mention.metadata?.slug
+  if (typeof slug === 'string' && slug.length > 0) {
+    return slug
+  }
+  return mention.entityId
+}
+
+export function resolveMentionHref(mention: StoredMention): string {
+  switch (mention.entityType) {
+    case 'profile':
+      return `/dashboard/members/${mention.entityId}`
+    case 'document':
+      return `/documents/${mention.entityId}`
+    case 'amenity':
+      return `/bookings/amenities/${resolveSlug(mention)}`
+    default:
+      return '#'
+  }
+}
+
+export function segmentContentWithMentions(
+  content: string,
+  mentions: StoredMention[],
+): MentionSegment[] {
+  if (mentions.length === 0) {
+    return content ? [{ type: 'text', text: content }] : []
+  }
+
+  const ordered = [...mentions].sort((a, b) => a.order - b.order)
+  const segments: MentionSegment[] = []
+  let cursor = 0
+  let searchIndex = 0
+
+  for (const mention of ordered) {
+    const token = `${mention.trigger}${mention.label}`
+    const index = content.indexOf(token, searchIndex)
+    if (index === -1) {
+      continue
+    }
+
+    if (index > cursor) {
+      segments.push({ type: 'text', text: content.slice(cursor, index) })
+    }
+
+    segments.push({
+      type: 'mention',
+      text: token,
+      mention,
+      href: resolveMentionHref(mention),
+    })
+
+    cursor = index + token.length
+    searchIndex = cursor
+  }
+
+  if (cursor < content.length) {
+    segments.push({ type: 'text', text: content.slice(cursor) })
+  }
+
+  return segments
+}

--- a/lib/messaging/mentions.ts
+++ b/lib/messaging/mentions.ts
@@ -1,0 +1,280 @@
+import type { PostgrestError } from '@supabase/supabase-js'
+
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+
+import type {
+  MentionQueryOptions,
+  MentionSuggestion,
+  MentionTrigger,
+  MessageRecord,
+  StoredMention,
+} from './types'
+
+const DEFAULT_SUGGESTION_LIMIT = 8
+
+function sanitizeSearchTerm(term: string) {
+  return term.replace(/[%_]/g, match => `\\${match}`)
+}
+
+function handlePostgrestError(error: PostgrestError | null, context: string) {
+  if (error) {
+    throw new Error(`${context}: ${error.message}`)
+  }
+}
+
+type ProfileResult = {
+  id: string
+  full_name: string | null
+  username: string | null
+  role: string | null
+  metadata: Record<string, unknown> | null
+}
+
+type DocumentResult = {
+  id: string
+  title: string
+  document_type: string | null
+  metadata: Record<string, unknown> | null
+}
+
+type AmenityResult = {
+  id: string
+  name: string
+  slug: string | null
+  metadata: Record<string, unknown> | null
+}
+
+export async function getMentionSuggestions(
+  client: TypedSupabaseClient,
+  trigger: MentionTrigger,
+  term: string,
+  options: MentionQueryOptions = {},
+): Promise<MentionSuggestion[]> {
+  const queryTerm = sanitizeSearchTerm(term.trim())
+  const limit = options.limit ?? DEFAULT_SUGGESTION_LIMIT
+
+  if (trigger === '@') {
+    let query = client
+      .from('profiles')
+      .select('id, full_name, username, role, metadata')
+      .order('full_name', { ascending: true })
+      .limit(limit)
+
+    if (options.unitId) {
+      query = query.eq('unit_id', options.unitId)
+    }
+
+    if (queryTerm.length > 0) {
+      query = query.or(
+        `full_name.ilike.%${queryTerm}%,username.ilike.%${queryTerm}%`,
+      )
+    }
+
+    const { data, error } = await query
+    handlePostgrestError(error, 'Failed to load profile mentions')
+
+    const profiles = (data ?? []) as ProfileResult[]
+
+    return profiles.map(profile => ({
+      id: profile.id,
+      label: profile.full_name ?? profile.username ?? 'Roommate',
+      description:
+        profile.username && profile.role
+          ? `@${profile.username} • ${profile.role.replace('_', ' ')}`
+          : profile.username
+          ? `@${profile.username}`
+          : profile.role ?? undefined,
+      entityType: 'profile',
+      trigger: '@',
+      metadata: profile.metadata ?? undefined,
+    }))
+  }
+
+  const documentQuery = client
+    .from('documents')
+    .select('id, title, document_type, metadata')
+    .order('updated_at', { ascending: false })
+    .limit(limit)
+
+  const amenityQuery = client
+    .from('amenities')
+    .select('id, name, slug, metadata')
+    .order('name', { ascending: true })
+    .limit(limit)
+
+  const filter = queryTerm.length > 0 ? `%${queryTerm}%` : null
+
+  const [documentsResult, amenitiesResult] = await Promise.all([
+    filter
+      ? documentQuery.ilike('title', filter)
+      : documentQuery,
+    filter
+      ? amenityQuery.ilike('name', filter)
+      : amenityQuery,
+  ])
+
+  handlePostgrestError(documentsResult.error, 'Failed to search documents')
+  handlePostgrestError(amenitiesResult.error, 'Failed to search amenities')
+
+  const documents = (documentsResult.data ?? []) as DocumentResult[]
+  const amenities = (amenitiesResult.data ?? []) as AmenityResult[]
+
+  const suggestions: MentionSuggestion[] = [
+    ...documents.map(document => ({
+      id: document.id,
+      label: document.title,
+      description: document.document_type ?? undefined,
+      entityType: 'document',
+      trigger: '#',
+      metadata: document.metadata ?? undefined,
+    })),
+    ...amenities.map(amenity => ({
+      id: amenity.id,
+      label: amenity.name,
+      description: 'Amenity',
+      entityType: 'amenity',
+      trigger: '#',
+      metadata: {
+        ...(amenity.metadata ?? {}),
+        slug: amenity.slug ?? undefined,
+      },
+    })),
+  ]
+
+  return suggestions.slice(0, limit)
+}
+
+interface MentionNotificationInput {
+  recipientId: string
+  mention: StoredMention
+  message: MessageRecord
+  senderId: string
+  senderDisplayName: string
+  preview: string
+}
+
+export type MentionNotifier = (
+  payload: MentionNotificationInput,
+) => Promise<void>
+
+function isMentionMuted(
+  metadata: Record<string, unknown> | null,
+  threadId: string,
+): boolean {
+  if (!metadata || typeof metadata !== 'object') {
+    return false
+  }
+
+  const notifications = metadata.notifications
+  if (notifications && typeof notifications === 'object') {
+    const mentions = (notifications as Record<string, unknown>).mentions
+    if (mentions && typeof mentions === 'object') {
+      const mentionSettings = mentions as Record<string, unknown>
+      if (mentionSettings.muted === true) {
+        return true
+      }
+      const mutedThreads = mentionSettings.mutedThreads
+      if (Array.isArray(mutedThreads) && mutedThreads.includes(threadId)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+const PREVIEW_LENGTH = 140
+
+function buildPreview(content: string) {
+  if (content.length <= PREVIEW_LENGTH) {
+    return content
+  }
+  return `${content.slice(0, PREVIEW_LENGTH - 1)}…`
+}
+
+interface CreateMessageInput {
+  threadId: string
+  senderId: string
+  senderDisplayName: string
+  content: string
+  mentions: StoredMention[]
+}
+
+export async function createMessageWithMentions(
+  client: TypedSupabaseClient,
+  input: CreateMessageInput,
+  notifyMention?: MentionNotifier,
+): Promise<MessageRecord> {
+  const { data, error } = await client
+    .from('messages')
+    .insert({
+      thread_id: input.threadId,
+      sender_id: input.senderId,
+      content: input.content,
+      mentions: input.mentions,
+    })
+    .select()
+    .single()
+
+  handlePostgrestError(error, 'Failed to save message')
+
+  const message = (data ?? null) as MessageRecord
+  if (!message) {
+    throw new Error('Message insert did not return a record')
+  }
+
+  if (!notifyMention) {
+    return message
+  }
+
+  const profileMentions = input.mentions.filter(
+    mention => mention.entityType === 'profile',
+  )
+
+  const uniqueProfiles = Array.from(
+    new Set(
+      profileMentions
+        .map(mention => mention.entityId)
+        .filter(profileId => profileId !== input.senderId),
+    ),
+  )
+
+  if (uniqueProfiles.length === 0) {
+    return message
+  }
+
+  const { data: profiles, error: profileError } = await client
+    .from('profiles')
+    .select('id, full_name, metadata')
+    .in('id', uniqueProfiles)
+
+  handlePostgrestError(profileError, 'Failed to load mention preferences')
+
+  const preview = buildPreview(input.content)
+
+  for (const profile of profiles ?? []) {
+    const record = profile as ProfileResult
+    if (isMentionMuted(record.metadata, input.threadId)) {
+      continue
+    }
+
+    const mention = profileMentions.find(
+      item => item.entityId === record.id,
+    )
+
+    if (!mention) {
+      continue
+    }
+
+    await notifyMention({
+      recipientId: record.id,
+      mention,
+      message,
+      senderId: input.senderId,
+      senderDisplayName: input.senderDisplayName,
+      preview,
+    })
+  }
+
+  return message
+}

--- a/lib/messaging/types.ts
+++ b/lib/messaging/types.ts
@@ -1,0 +1,30 @@
+import type { Tables } from '@/lib/supabase'
+
+export type MentionTrigger = '@' | '#'
+
+export type MentionEntityType = 'profile' | 'document' | 'amenity'
+
+export interface MentionSuggestion {
+  id: string
+  label: string
+  description?: string
+  entityType: MentionEntityType
+  trigger: MentionTrigger
+  metadata?: Record<string, unknown>
+}
+
+export interface StoredMention {
+  entityId: string
+  entityType: MentionEntityType
+  trigger: MentionTrigger
+  label: string
+  order: number
+  metadata?: Record<string, unknown>
+}
+
+export interface MentionQueryOptions {
+  unitId?: string | null
+  limit?: number
+}
+
+export type MessageRecord = Tables<'messages'>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -29,6 +29,16 @@ export type Database = {
         updated_at: string | null
         metadata: Json | null
       }>
+      amenities: SupabaseTable<{
+        id: string
+        name: string
+        slug: string | null
+        description: string | null
+        icon: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
       profiles: SupabaseTable<{
         id: string
         created_at: string | null
@@ -183,6 +193,15 @@ export type Database = {
         notes: string | null
         attachments: Json | null
         metadata: Json | null
+      }>
+      messages: SupabaseTable<{
+        id: string
+        thread_id: string
+        sender_id: string
+        content: string
+        mentions: Json | null
+        created_at: string | null
+        updated_at: string | null
       }>
       visitor_logs: SupabaseTable<{
         id: string

--- a/supabase/migrations/20250305_messaging_mentions.sql
+++ b/supabase/migrations/20250305_messaging_mentions.sql
@@ -1,0 +1,51 @@
+-- Messaging mentions infrastructure
+
+-- Amenity catalog powers hash-mention search for booking context
+CREATE TABLE IF NOT EXISTS public.amenities (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT UNIQUE,
+  description TEXT,
+  icon TEXT,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_amenities_name ON public.amenities USING gin ((to_tsvector('english', coalesce(name, ''))));
+CREATE INDEX IF NOT EXISTS idx_amenities_slug ON public.amenities(slug);
+
+ALTER TABLE public.amenities ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public amenities readable" ON public.amenities
+  FOR SELECT USING (true);
+
+-- Thread messages persist mention metadata for rendering + notifications
+CREATE TABLE IF NOT EXISTS public.messages (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  thread_id UUID NOT NULL,
+  sender_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  mentions JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_thread_id ON public.messages(thread_id);
+CREATE INDEX IF NOT EXISTS idx_messages_sender_id ON public.messages(sender_id);
+CREATE INDEX IF NOT EXISTS idx_messages_created_at ON public.messages(created_at DESC);
+
+ALTER TABLE public.messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authors can insert messages" ON public.messages
+  FOR INSERT WITH CHECK (auth.uid() = sender_id);
+
+CREATE POLICY "Roommates can read messages" ON public.messages
+  FOR SELECT USING (
+    TRUE
+  );
+
+CREATE TRIGGER update_messages_updated_at
+  BEFORE UPDATE ON public.messages
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/tests/lib/messaging/mentions.test.ts
+++ b/tests/lib/messaging/mentions.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { insertMentionToken } from '@/lib/messaging/composer-utils'
+import { getMentionSuggestions } from '@/lib/messaging/mentions'
+import { segmentContentWithMentions } from '@/lib/messaging/content'
+import type { MentionSuggestion, StoredMention } from '@/lib/messaging/types'
+
+function createAsyncBuilder<T>(result: { data: T; error: { message: string } | null }) {
+  const builder: any = {
+    select: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    or: vi.fn(() => builder),
+    ilike: vi.fn(() => builder),
+  }
+
+  builder.then = (onFulfilled: (value: typeof result) => unknown) =>
+    Promise.resolve(onFulfilled(result))
+
+  return builder
+}
+
+describe('getMentionSuggestions', () => {
+  it('fetches roommate suggestions for @ triggers', async () => {
+    const profiles = [
+      { id: 'profile-1', full_name: 'Jordan Lee', username: 'jordan', role: 'roommate', metadata: null },
+    ]
+    const builder = createAsyncBuilder({ data: profiles, error: null })
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        expect(table).toBe('profiles')
+        return builder
+      }),
+    } as any
+
+    const suggestions = await getMentionSuggestions(supabase, '@', 'jor')
+
+    expect(builder.select).toHaveBeenCalledWith('id, full_name, username, role, metadata')
+    expect(builder.order).toHaveBeenCalledWith('full_name', { ascending: true })
+    expect(builder.or).toHaveBeenCalledWith('full_name.ilike.%jor%,username.ilike.%jor%')
+    expect(suggestions).toEqual([
+      {
+        id: 'profile-1',
+        label: 'Jordan Lee',
+        description: '@jordan • roommate',
+        entityType: 'profile',
+        trigger: '@',
+        metadata: undefined,
+      },
+    ])
+  })
+
+  it('combines document and amenity suggestions for # triggers', async () => {
+    const documents = [
+      { id: 'doc-1', title: 'Inspection checklist', document_type: 'policy', metadata: { revision: 'v2' } },
+    ]
+    const amenities = [
+      { id: 'amenity-1', name: 'Shared workspace', slug: 'workspace', metadata: { floor: '2' } },
+    ]
+
+    const documentBuilder = createAsyncBuilder({ data: documents, error: null })
+    const amenityBuilder = createAsyncBuilder({ data: amenities, error: null })
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'documents') {
+          return documentBuilder
+        }
+        if (table === 'amenities') {
+          return amenityBuilder
+        }
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    } as any
+
+    const suggestions = await getMentionSuggestions(supabase, '#', 'work')
+
+    expect(documentBuilder.ilike).toHaveBeenCalledWith('title', '%work%')
+    expect(amenityBuilder.ilike).toHaveBeenCalledWith('name', '%work%')
+    expect(suggestions).toEqual([
+      {
+        id: 'doc-1',
+        label: 'Inspection checklist',
+        description: 'policy',
+        entityType: 'document',
+        trigger: '#',
+        metadata: { revision: 'v2' },
+      },
+      {
+        id: 'amenity-1',
+        label: 'Shared workspace',
+        description: 'Amenity',
+        entityType: 'amenity',
+        trigger: '#',
+        metadata: { floor: '2', slug: 'workspace' },
+      },
+    ])
+  })
+})
+
+describe('composer utilities', () => {
+  it('inserts mention tokens and appends spacing', () => {
+    const suggestion: MentionSuggestion = {
+      id: 'profile-2',
+      label: 'Avery Chen',
+      entityType: 'profile',
+      trigger: '@',
+    }
+
+    const result = insertMentionToken('Thanks @Ave', {
+      trigger: '@',
+      start: 7,
+      end: 11,
+      query: 'Ave',
+    }, suggestion)
+
+    expect(result.value).toBe('Thanks @Avery Chen ')
+    expect(result.caret).toBe(result.value.length)
+  })
+})
+
+describe('segmentContentWithMentions', () => {
+  it('produces hyperlink segments for stored mentions', () => {
+    const mentions: StoredMention[] = [
+      {
+        entityId: 'profile-1',
+        entityType: 'profile',
+        trigger: '@',
+        label: 'Jordan Lee',
+        order: 0,
+      },
+      {
+        entityId: 'doc-9',
+        entityType: 'document',
+        trigger: '#',
+        label: 'Lease agreement',
+        order: 1,
+      },
+    ]
+
+    const segments = segmentContentWithMentions(
+      'Ping @Jordan Lee after reviewing #Lease agreement',
+      mentions,
+    )
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Ping ' },
+      {
+        type: 'mention',
+        text: '@Jordan Lee',
+        mention: mentions[0],
+        href: '/dashboard/members/profile-1',
+      },
+      { type: 'text', text: ' after reviewing ' },
+      {
+        type: 'mention',
+        text: '#Lease agreement',
+        mention: mentions[1],
+        href: '/documents/doc-9',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- introduce Supabase-backed mention utilities and a thread composer that suggests @profiles and #resources while tracking structured metadata
- render stored mentions with rich hyperlinks, persist messages via a server action, and surface mention-aware notifications with metadata parsing
- add amenities/messages schema support plus unit tests covering suggestion fetching, mention insertion, and content resolution

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d20b7f1b708328a2c48ab7ed033c86