### PR TITLE
Add curated template gallery and admin management

### DIFF
--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { LayoutTemplate } from "lucide-react";
 import SmartLink from "@/components/navigation/SmartLink";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -36,22 +37,28 @@ export default function NavLinks() {
 		load();
 	}, []);
 
-	const isLandlord = role === 'property_manager' || role === 'admin' || role === 'landlord';
+        const isLandlord = role === 'property_manager' || role === 'admin' || role === 'landlord';
 
-	const links = isLandlord
-		? [
-			{ href: "/dashboard/members", text: "Members", Icon: PersonIcon },
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-		]
-		: [
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-			{ href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
-			{ href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
-		];
+        const landlordLinks = [
+                { href: "/dashboard/members", text: "Members", Icon: PersonIcon },
+                { href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
+                { href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
+                { href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
+        ];
+
+        if (role === 'admin') {
+                landlordLinks.push({ href: "/dashboard/templates", text: "Templates", Icon: LayoutTemplate });
+        }
+
+        const links = isLandlord
+                ? landlordLinks
+                : [
+                        { href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
+                        { href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
+                        { href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
+                        { href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
+                        { href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
+                ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/templates/actions.ts
+++ b/app/dashboard/templates/actions.ts
@@ -1,0 +1,69 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import { createSupbaseServerClient } from '@/utils/supaone'
+
+interface UpdateTemplatePayload {
+  id: string
+  name: string
+  description: string | null
+  category: string | null
+  is_curated: boolean
+}
+
+export async function updateTemplateMetadataAction(payload: UpdateTemplatePayload) {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession()
+
+  if (sessionError) {
+    throw new Error(`Unable to read session: ${sessionError.message}`)
+  }
+
+  if (!session?.user) {
+    throw new Error('Not authenticated')
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', session.user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw new Error(`Failed to verify user role: ${profileError.message}`)
+  }
+
+  if (profile?.role !== 'admin') {
+    throw new Error('You do not have permission to modify templates')
+  }
+
+  const normalizedName = payload.name.trim()
+  const normalizedDescription = payload.description?.trim() || null
+  const normalizedCategory = payload.category?.trim() || null
+
+  if (!normalizedName) {
+    throw new Error('Template name is required')
+  }
+
+  const { error } = await supabase
+    .from('templates')
+    .update({
+      name: normalizedName,
+      description: normalizedDescription,
+      category: normalizedCategory,
+      is_curated: payload.is_curated,
+    })
+    .eq('id', payload.id)
+
+  if (error) {
+    throw new Error(error.message || 'Failed to update template metadata')
+  }
+
+  revalidatePath('/dashboard/templates')
+
+  return { success: true }
+}

--- a/app/dashboard/templates/page.tsx
+++ b/app/dashboard/templates/page.tsx
@@ -1,0 +1,58 @@
+import { redirect } from 'next/navigation'
+
+import { TemplateMetadataTable } from './template-metadata-table'
+import { createSupbaseServerClient } from '@/utils/supaone'
+import type { TemplateRecord } from '@/types/templates'
+
+export default async function TemplatesAdminPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession()
+
+  if (sessionError) {
+    throw new Error(`Unable to read session: ${sessionError.message}`)
+  }
+
+  if (!session?.user) {
+    redirect('/auth')
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', session.user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw new Error(`Failed to determine user role: ${profileError.message}`)
+  }
+
+  if (profile?.role !== 'admin') {
+    redirect('/dashboard')
+  }
+
+  const { data: templates, error } = await supabase
+    .from('templates')
+    .select('*')
+    .order('updated_at', { ascending: false })
+
+  if (error) {
+    throw new Error(error.message || 'Failed to load templates')
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-semibold tracking-tight">Template library</h1>
+        <p className="text-muted-foreground">
+          Maintain curated onboarding and document templates that power prefilled forms across the
+          tenant experience.
+        </p>
+      </div>
+
+      <TemplateMetadataTable templates={(templates ?? []) as TemplateRecord[]} />
+    </div>
+  )
+}

--- a/app/dashboard/templates/template-metadata-table.tsx
+++ b/app/dashboard/templates/template-metadata-table.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import type { TemplateRecord } from '@/types/templates'
+import { toast } from 'sonner'
+
+import { updateTemplateMetadataAction } from './actions'
+
+interface TemplateMetadataTableProps {
+  templates: TemplateRecord[]
+}
+
+interface TemplateFormState {
+  name: string
+  description: string
+  category: string
+  is_curated: boolean
+}
+
+export function TemplateMetadataTable({ templates }: TemplateMetadataTableProps) {
+  if (!templates.length) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-sm text-muted-foreground">
+          No templates found. Create a template in Supabase to start curating onboarding and document
+          defaults.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {templates.map((template) => (
+        <TemplateMetadataCard key={template.id} template={template} />
+      ))}
+    </div>
+  )
+}
+
+function TemplateMetadataCard({ template }: { template: TemplateRecord }) {
+  const [formState, setFormState] = useState<TemplateFormState>({
+    name: template.name,
+    description: template.description ?? '',
+    category: template.category ?? '',
+    is_curated: template.is_curated,
+  })
+  const [isPending, startTransition] = useTransition()
+
+  const formattedUpdatedAt = useMemo(() => {
+    const timestamp = template.updated_at ?? template.created_at
+    if (!timestamp) {
+      return 'Not yet updated'
+    }
+
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      }).format(new Date(timestamp))
+    } catch (error) {
+      console.error('Failed to format timestamp', error)
+      return timestamp
+    }
+  }, [template.created_at, template.updated_at])
+
+  const formValuesPreview = useMemo(() => {
+    try {
+      return JSON.stringify(template.form_values, null, 2)
+    } catch (error) {
+      console.error('Failed to stringify template values', error)
+      return String(template.form_values)
+    }
+  }, [template.form_values])
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    startTransition(async () => {
+      try {
+        await updateTemplateMetadataAction({
+          id: template.id,
+          name: formState.name,
+          description: formState.description || null,
+          category: formState.category || null,
+          is_curated: formState.is_curated,
+        })
+        toast.success('Template updated')
+      } catch (error) {
+        console.error('Failed to update template metadata', error)
+        toast.error(
+          error instanceof Error ? error.message : 'An unexpected error occurred while updating the template.',
+        )
+      }
+    })
+  }
+
+  return (
+    <Card>
+      <form onSubmit={handleSubmit} className="space-y-0">
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle className="text-lg">{template.name}</CardTitle>
+            <CardDescription>
+              Context: <span className="font-medium text-foreground">{template.context}</span> • Last
+              updated {formattedUpdatedAt}
+            </CardDescription>
+          </div>
+          <Badge variant={formState.is_curated ? 'default' : 'outline'}>
+            {formState.is_curated ? 'Curated' : 'Hidden'}
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor={`template-name-${template.id}`}>Template name</Label>
+              <Input
+                id={`template-name-${template.id}`}
+                value={formState.name}
+                onChange={(event) => setFormState((previous) => ({ ...previous, name: event.target.value }))}
+                placeholder="Lease renewal checklist"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`template-category-${template.id}`}>Category</Label>
+              <Input
+                id={`template-category-${template.id}`}
+                value={formState.category}
+                onChange={(event) =>
+                  setFormState((previous) => ({ ...previous, category: event.target.value }))
+                }
+                placeholder="Lease"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`template-description-${template.id}`}>Description</Label>
+            <Textarea
+              id={`template-description-${template.id}`}
+              value={formState.description}
+              onChange={(event) =>
+                setFormState((previous) => ({ ...previous, description: event.target.value }))
+              }
+              rows={3}
+              placeholder="Explain when and how to use this template."
+            />
+          </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id={`template-curated-${template.id}`}
+              checked={formState.is_curated}
+              onCheckedChange={(checked) =>
+                setFormState((previous) => ({ ...previous, is_curated: Boolean(checked) }))
+              }
+            />
+            <Label htmlFor={`template-curated-${template.id}`} className="text-sm">
+              Show in curated gallery
+            </Label>
+          </div>
+          <div className="space-y-1">
+            <Label className="text-sm font-medium">Prefill JSON</Label>
+            <pre className="max-h-48 overflow-auto rounded-md bg-muted p-3 text-xs">
+              <code>{formValuesPreview}</code>
+            </pre>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-wrap items-center justify-end gap-3">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? 'Saving...' : 'Save changes'}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/app/documents/components/upload-document-dialog.tsx
+++ b/app/documents/components/upload-document-dialog.tsx
@@ -25,8 +25,21 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { uploadDocumentAction } from '../actions';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
+import { TemplatesGallery } from '@/components/templates/TemplatesGallery';
+import { applyTemplatePrefill, clearLastTemplateChoice, loadLastTemplateChoice, saveLastTemplateChoice } from '@/lib/templates';
+import type { TemplateRecord, TemplateSelectionMeta } from '@/types/templates';
 import { Upload, FileText } from 'lucide-react';
 import { toast } from 'sonner';
+
+const DOCUMENT_TEMPLATE_FIELDS = [
+  'title',
+  'description',
+  'document_type',
+  'tenant_id',
+  'unit_id',
+  'requires_signature',
+  'expires_at',
+] as const;
 
 export function UploadDocumentDialog() {
   const [open, setOpen] = useState(false);
@@ -41,6 +54,9 @@ export function UploadDocumentDialog() {
     expires_at: '',
   });
   const [file, setFile] = useState<File | null>(null);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(() =>
+    loadLastTemplateChoice('document')
+  );
   const router = useRouter();
   const permissions = useDocumentPermissions();
 
@@ -48,6 +64,26 @@ export function UploadDocumentDialog() {
   if (!permissions.canUploadDocuments) {
     return null;
   }
+
+  const handleTemplateSelect = (
+    template: TemplateRecord,
+    meta?: TemplateSelectionMeta,
+  ) => {
+    setFormData(prev =>
+      applyTemplatePrefill(prev, template, {
+        allowedKeys: DOCUMENT_TEMPLATE_FIELDS,
+      })
+    );
+    setSelectedTemplateId(template.id);
+    if (!meta || meta.source === 'manual') {
+      saveLastTemplateChoice('document', template.id);
+    }
+  };
+
+  const handleTemplateClear = () => {
+    setSelectedTemplateId(null);
+    clearLastTemplateChoice('document');
+  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
@@ -146,6 +182,19 @@ export function UploadDocumentDialog() {
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label>Start from a template</Label>
+            <p className="text-xs text-muted-foreground">
+              Selecting a template will prefill the document details below.
+            </p>
+            <TemplatesGallery
+              context="document"
+              defaultTemplateId={selectedTemplateId}
+              onSelect={handleTemplateSelect}
+              onClear={handleTemplateClear}
+            />
+          </div>
+
           {/* File Upload */}
           <div className="space-y-2">
             <Label htmlFor="file">Document File</Label>

--- a/app/onboarding/components/tenant-onboarding-form.tsx
+++ b/app/onboarding/components/tenant-onboarding-form.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useState } from 'react'
+
+import { TemplatesGallery } from '@/components/templates/TemplatesGallery'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { applyTemplatePrefill, clearLastTemplateChoice, loadLastTemplateChoice, saveLastTemplateChoice } from '@/lib/templates'
+import type { TemplateRecord, TemplateSelectionMeta } from '@/types/templates'
+import { toast } from 'sonner'
+
+type OnboardingFormState = {
+  full_name: string
+  unit: string
+  rent_share: string
+  move_in_date: string
+  emergency_contact: {
+    name: string
+    phone: string
+  }
+  vehicle_information: string
+  notes: string
+}
+
+const TEMPLATE_FIELDS = [
+  'full_name',
+  'unit',
+  'rent_share',
+  'move_in_date',
+  'emergency_contact',
+  'vehicle_information',
+  'notes',
+] as const satisfies readonly (keyof OnboardingFormState & string)[]
+
+const createEmptyForm = (): OnboardingFormState => ({
+  full_name: '',
+  unit: '',
+  rent_share: '',
+  move_in_date: '',
+  emergency_contact: {
+    name: '',
+    phone: '',
+  },
+  vehicle_information: '',
+  notes: '',
+})
+
+export function TenantOnboardingForm() {
+  const [formState, setFormState] = useState<OnboardingFormState>(() => createEmptyForm())
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(() =>
+    loadLastTemplateChoice('onboarding'),
+  )
+
+  const handleTemplateSelect = (template: TemplateRecord, meta: TemplateSelectionMeta) => {
+    setFormState((previous) =>
+      applyTemplatePrefill(previous, template, {
+        allowedKeys: TEMPLATE_FIELDS,
+      }),
+    )
+    setSelectedTemplateId(template.id)
+
+    if (meta.source === 'manual') {
+      saveLastTemplateChoice('onboarding', template.id)
+    }
+  }
+
+  const handleTemplateClear = () => {
+    setSelectedTemplateId(null)
+    clearLastTemplateChoice('onboarding')
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    toast.success('Onboarding details captured', {
+      description: 'The prefilled information has been staged for review.',
+    })
+  }
+
+  const handleFieldChange = (field: keyof OnboardingFormState, value: string) => {
+    setFormState((previous) => ({
+      ...previous,
+      [field]: value,
+    }))
+  }
+
+  const handleEmergencyContactChange = (
+    field: keyof OnboardingFormState['emergency_contact'],
+    value: string,
+  ) => {
+    setFormState((previous) => ({
+      ...previous,
+      emergency_contact: {
+        ...previous.emergency_contact,
+        [field]: value,
+      },
+    }))
+  }
+
+  const handleReset = () => {
+    setFormState(createEmptyForm())
+    setSelectedTemplateId(null)
+    clearLastTemplateChoice('onboarding')
+  }
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle>Household onboarding</CardTitle>
+        <CardDescription>
+          Use curated templates to jump start resident intake and complete the required onboarding
+          checklist in minutes.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Start from a template</Label>
+          <TemplatesGallery
+            context="onboarding"
+            defaultTemplateId={selectedTemplateId}
+            onSelect={handleTemplateSelect}
+            onClear={handleTemplateClear}
+          />
+          <p className="text-xs text-muted-foreground">
+            Selecting a template will populate the intake form with example unit assignments,
+            emergency contacts, and household notes.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="full_name">Full name</Label>
+              <Input
+                id="full_name"
+                value={formState.full_name}
+                onChange={(event) => handleFieldChange('full_name', event.target.value)}
+                placeholder="Jordan Rivers"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="unit">Unit</Label>
+              <Input
+                id="unit"
+                value={formState.unit}
+                onChange={(event) => handleFieldChange('unit', event.target.value)}
+                placeholder="2B"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="rent_share">Monthly rent share</Label>
+              <Input
+                id="rent_share"
+                type="number"
+                min="0"
+                step="0.01"
+                value={formState.rent_share}
+                onChange={(event) => handleFieldChange('rent_share', event.target.value)}
+                placeholder="950"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="move_in_date">Move-in date</Label>
+              <Input
+                id="move_in_date"
+                type="date"
+                value={formState.move_in_date}
+                onChange={(event) => handleFieldChange('move_in_date', event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="emergency_contact_name">Emergency contact name</Label>
+              <Input
+                id="emergency_contact_name"
+                value={formState.emergency_contact.name}
+                onChange={(event) => handleEmergencyContactChange('name', event.target.value)}
+                placeholder="Jamie Lee"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="emergency_contact_phone">Emergency contact phone</Label>
+              <Input
+                id="emergency_contact_phone"
+                value={formState.emergency_contact.phone}
+                onChange={(event) => handleEmergencyContactChange('phone', event.target.value)}
+                placeholder="(555) 123-4567"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="vehicle_information">Vehicle information</Label>
+              <Input
+                id="vehicle_information"
+                value={formState.vehicle_information}
+                onChange={(event) => handleFieldChange('vehicle_information', event.target.value)}
+                placeholder="Blue Honda Civic - License 7ABC123"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="notes">Household notes</Label>
+              <Textarea
+                id="notes"
+                value={formState.notes}
+                onChange={(event) => handleFieldChange('notes', event.target.value)}
+                rows={4}
+                placeholder="Allergic to pets, prefers email communication."
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="submit">Save onboarding details</Button>
+            <Button type="button" variant="ghost" onClick={handleReset}>
+              Reset form
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next"
 import Image from "next/image"
 import SmartLink from "@/components/navigation/SmartLink"
 
+import { TenantOnboardingForm } from './components/tenant-onboarding-form'
+
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
 import AuthForm from "@/app/auth/components/AuthForm"
@@ -105,6 +107,9 @@ export default function OnboardingPage() {
               </SmartLink>
               .
             </p>
+          </div>
+          <div className="mt-10 max-w-3xl">
+            <TenantOnboardingForm />
           </div>
         </div>
       </div>

--- a/components/templates/TemplatesGallery.tsx
+++ b/components/templates/TemplatesGallery.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useEffect, useMemo, useState, useTransition } from 'react'
+
+import { createClient } from '@/utils/supabase-browser'
+import { cn } from '@/lib/utils'
+import type { TemplateContext, TemplateRecord, TemplateSelectionMeta } from '@/types/templates'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+interface TemplatesGalleryProps {
+  context: TemplateContext
+  onSelect?: (template: TemplateRecord, meta: TemplateSelectionMeta) => void
+  onClear?: () => void
+  defaultTemplateId?: string | null
+  className?: string
+  emptyStateMessage?: string
+}
+
+export function TemplatesGallery({
+  context,
+  onSelect,
+  onClear,
+  defaultTemplateId,
+  className,
+  emptyStateMessage = 'No curated templates are available for this workflow yet.',
+}: TemplatesGalleryProps) {
+  const [templates, setTemplates] = useState<TemplateRecord[]>([])
+  const [search, setSearch] = useState('')
+  const [selectedId, setSelectedId] = useState<string | null>(defaultTemplateId ?? null)
+  const [error, setError] = useState<string | null>(null)
+  const [hasAppliedDefault, setHasAppliedDefault] = useState(false)
+  const [hasLoaded, setHasLoaded] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    setSelectedId(defaultTemplateId ?? null)
+    setHasAppliedDefault(false)
+  }, [defaultTemplateId])
+
+  useEffect(() => {
+    setHasAppliedDefault(false)
+  }, [context])
+
+  useEffect(() => {
+    let mounted = true
+    const supabase = createClient()
+
+    setHasLoaded(false)
+    setError(null)
+    startTransition(async () => {
+      const { data, error: fetchError } = await supabase
+        .from('templates')
+        .select('*')
+        .eq('is_curated', true)
+        .eq('context', context)
+        .order('name', { ascending: true })
+
+      if (!mounted) {
+        return
+      }
+
+      if (fetchError) {
+        console.error('Failed to load templates', fetchError)
+        setError('We could not load curated templates right now.')
+        setTemplates([])
+        setHasLoaded(true)
+        return
+      }
+
+      setError(null)
+      setTemplates((data ?? []) as TemplateRecord[])
+      setHasLoaded(true)
+    })
+
+    return () => {
+      mounted = false
+    }
+  }, [context, startTransition])
+
+  useEffect(() => {
+    if (hasAppliedDefault || !defaultTemplateId) {
+      return
+    }
+
+    const template = templates.find((item) => item.id === defaultTemplateId)
+    if (!template) {
+      return
+    }
+
+    setHasAppliedDefault(true)
+    setSelectedId(defaultTemplateId)
+    onSelect?.(template, { source: 'auto' })
+  }, [defaultTemplateId, hasAppliedDefault, onSelect, templates])
+
+  const filteredTemplates = useMemo(() => {
+    if (!search.trim()) {
+      return templates
+    }
+
+    const term = search.trim().toLowerCase()
+    return templates.filter((template) => {
+      return (
+        template.name.toLowerCase().includes(term) ||
+        (template.description ?? '').toLowerCase().includes(term) ||
+        (template.category ?? '').toLowerCase().includes(term)
+      )
+    })
+  }, [search, templates])
+
+  const handleSelect = (template: TemplateRecord) => {
+    setSelectedId(template.id)
+    onSelect?.(template, { source: 'manual' })
+  }
+
+  const handleClear = () => {
+    setSelectedId(null)
+    onClear?.()
+  }
+
+  const showSkeleton = !hasLoaded && !error
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <div className="flex items-center gap-2">
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search templates"
+          className="h-9"
+        />
+        <Button type="button" variant="ghost" size="sm" onClick={handleClear} disabled={!selectedId}>
+          Clear
+        </Button>
+      </div>
+
+      {error ? (
+        <Card>
+          <CardContent className="py-6 text-sm text-destructive">{error}</CardContent>
+        </Card>
+      ) : showSkeleton ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-20 w-full animate-pulse rounded-md border border-dashed border-muted bg-muted/40"
+            />
+          ))}
+        </div>
+      ) : !filteredTemplates.length ? (
+        <Card>
+          <CardContent className="py-6 text-sm text-muted-foreground">{emptyStateMessage}</CardContent>
+        </Card>
+      ) : (
+        <ScrollArea className="h-56 rounded-md border">
+          <div className="space-y-2 p-2">
+            {filteredTemplates.map((template) => {
+              const isSelected = selectedId === template.id
+              return (
+                <button
+                  type="button"
+                  key={template.id}
+                  onClick={() => handleSelect(template)}
+                  className={cn(
+                    'w-full rounded-md border p-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-ring',
+                    isSelected
+                      ? 'border-primary bg-primary/5'
+                      : 'border-transparent hover:border-border/80 hover:bg-muted/60',
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-foreground">{template.name}</p>
+                      {template.description ? (
+                        <p className="text-xs text-muted-foreground">{template.description}</p>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-col items-end gap-1">
+                      <Badge variant={isSelected ? 'default' : 'outline'}>
+                        {template.category ?? 'General'}
+                      </Badge>
+                      {isSelected ? <Badge variant="secondary">Selected</Badge> : null}
+                    </div>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -224,6 +224,18 @@ export type Database = {
         error_message: string | null
         metadata: Json | null
       }>
+      templates: SupabaseTable<{
+        id: string
+        name: string
+        description: string | null
+        category: string | null
+        context: 'document' | 'onboarding'
+        form_values: Json
+        is_curated: boolean
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
       meetings: SupabaseTable<{
         id: string
         user_id: string

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1,0 +1,133 @@
+import type { TemplateContext, TemplateRecord, TemplatePrefillValues } from '@/types/templates'
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+const STORAGE_KEY_PREFIX = 'roomsily:last-template:'
+
+function resolveStorage(storage?: StorageLike | null): StorageLike | null {
+  if (storage) {
+    return storage
+  }
+
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage
+  }
+
+  return null
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function deepMergeRecords<T extends Record<string, unknown>>(
+  target: T,
+  source: Record<string, unknown>,
+): T {
+  const next: Record<string, unknown> = { ...target }
+
+  for (const [key, value] of Object.entries(source)) {
+    if (Array.isArray(value)) {
+      next[key] = value.slice()
+      continue
+    }
+
+    if (isPlainObject(value)) {
+      const current = next[key]
+      if (isPlainObject(current)) {
+        next[key] = deepMergeRecords(current, value)
+      } else {
+        next[key] = deepMergeRecords({}, value)
+      }
+      continue
+    }
+
+    next[key] = value
+  }
+
+  return next as T
+}
+
+export function extractTemplatePrefill(template: TemplateRecord): TemplatePrefillValues {
+  const values = template.form_values
+
+  if (!isPlainObject(values)) {
+    return {}
+  }
+
+  return values
+}
+
+export function applyTemplatePrefill<FormState extends Record<string, unknown>>(
+  formState: FormState,
+  template: TemplateRecord,
+  options: { allowedKeys?: readonly (keyof FormState & string)[] } = {},
+): FormState {
+  const templateValues = extractTemplatePrefill(template)
+  const { allowedKeys } = options
+
+  const filteredEntries = allowedKeys
+    ? Object.entries(templateValues).filter(([key]) =>
+        allowedKeys.includes(key as keyof FormState & string),
+      )
+    : Object.entries(templateValues)
+
+  if (!filteredEntries.length) {
+    return formState
+  }
+
+  const filteredValues = Object.fromEntries(filteredEntries)
+
+  return deepMergeRecords(formState, filteredValues as Record<string, unknown>)
+}
+
+export function getTemplateStorageKey(context: TemplateContext): string {
+  return `${STORAGE_KEY_PREFIX}${context}`
+}
+
+export function loadLastTemplateChoice(
+  context: TemplateContext,
+  storage?: StorageLike | null,
+): string | null {
+  const resolved = resolveStorage(storage)
+  if (!resolved) {
+    return null
+  }
+
+  const value = resolved.getItem(getTemplateStorageKey(context))
+  return value || null
+}
+
+export function saveLastTemplateChoice(
+  context: TemplateContext,
+  templateId: string | null,
+  storage?: StorageLike | null,
+): void {
+  const resolved = resolveStorage(storage)
+  if (!resolved) {
+    return
+  }
+
+  const key = getTemplateStorageKey(context)
+
+  if (!templateId) {
+    resolved.removeItem(key)
+    return
+  }
+
+  resolved.setItem(key, templateId)
+}
+
+export function clearLastTemplateChoice(
+  context: TemplateContext,
+  storage?: StorageLike | null,
+): void {
+  const resolved = resolveStorage(storage)
+  if (!resolved) {
+    return
+  }
+
+  resolved.removeItem(getTemplateStorageKey(context))
+}
+
+export type { StorageLike }

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyTemplatePrefill, clearLastTemplateChoice, loadLastTemplateChoice, saveLastTemplateChoice } from '@/lib/templates'
+import type { TemplateRecord } from '@/types/templates'
+
+type DocumentFormState = {
+  title: string
+  description: string
+  document_type: string
+  tenant_id: string
+  unit_id: string
+  requires_signature: boolean
+  expires_at: string
+  emergency_contact: {
+    name: string
+    phone: string
+  }
+}
+
+const baseTemplate: TemplateRecord = {
+  id: 'template-123',
+  name: 'Lease starter',
+  description: 'Prefills standard lease metadata',
+  category: 'lease',
+  context: 'document',
+  form_values: {
+    title: 'Lease agreement - Unit 2B',
+    requires_signature: true,
+    emergency_contact: {
+      name: 'Jamie Lee',
+    },
+  },
+  is_curated: true,
+  metadata: null,
+  created_at: null,
+  updated_at: null,
+}
+
+describe('template helpers', () => {
+  it('prefills form state while preserving untouched fields', () => {
+    const initialForm: DocumentFormState = {
+      title: 'Original title',
+      description: 'Existing description',
+      document_type: 'other',
+      tenant_id: '',
+      unit_id: '',
+      requires_signature: false,
+      expires_at: '',
+      emergency_contact: {
+        name: '',
+        phone: '',
+      },
+    }
+
+    const result = applyTemplatePrefill(initialForm, baseTemplate, {
+      allowedKeys: [
+        'title',
+        'requires_signature',
+        'emergency_contact',
+      ],
+    })
+
+    expect(result).not.toBe(initialForm)
+    expect(result.title).toBe('Lease agreement - Unit 2B')
+    expect(result.description).toBe('Existing description')
+    expect(result.requires_signature).toBe(true)
+    expect(result.emergency_contact).toEqual({ name: 'Jamie Lee', phone: '' })
+  })
+
+  it('ignores non-whitelisted template values', () => {
+    const templateWithExtra: TemplateRecord = {
+      ...baseTemplate,
+      id: 'template-extra',
+      form_values: {
+        ...baseTemplate.form_values,
+        document_type: 'lease',
+        unexpected_field: 'ignore-me',
+      },
+    }
+
+    const initialForm: DocumentFormState = {
+      title: '',
+      description: '',
+      document_type: 'other',
+      tenant_id: '',
+      unit_id: '',
+      requires_signature: false,
+      expires_at: '',
+      emergency_contact: {
+        name: '',
+        phone: '',
+      },
+    }
+
+    const result = applyTemplatePrefill(initialForm, templateWithExtra, {
+      allowedKeys: ['title'],
+    })
+
+    expect(result.title).toBe('Lease agreement - Unit 2B')
+    expect(result.document_type).toBe('other')
+    expect((result as any).unexpected_field).toBeUndefined()
+  })
+
+  it("persists the user's last selected template", () => {
+    const storage = createMemoryStorage()
+
+    expect(loadLastTemplateChoice('document', storage)).toBeNull()
+    saveLastTemplateChoice('document', 'template-xyz', storage)
+    expect(loadLastTemplateChoice('document', storage)).toBe('template-xyz')
+
+    clearLastTemplateChoice('document', storage)
+    expect(loadLastTemplateChoice('document', storage)).toBeNull()
+  })
+})
+
+function createMemoryStorage() {
+  const store = new Map<string, string>()
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+  }
+}

--- a/types/templates.ts
+++ b/types/templates.ts
@@ -1,0 +1,12 @@
+import type { Database } from '@/lib/supabase'
+
+export type TemplateRecord = Database['public']['Tables']['templates']['Row']
+export type TemplateContext = TemplateRecord['context']
+
+export type TemplatePrefillValues = Record<string, unknown>
+
+export type TemplateSelectionSource = 'auto' | 'manual'
+
+export interface TemplateSelectionMeta {
+  source: TemplateSelectionSource
+}


### PR DESCRIPTION
## Summary
- add a Supabase-backed templates gallery component with persistence helpers
- surface template selection in document upload and onboarding flows
- provide an admin-only dashboard page for managing template metadata

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b80c4608328b54630d47cd6e707