### PR TITLE
Add realtime presence helper and presence UI

### DIFF
--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import PresenceAvatars from "@/components/presence/PresenceAvatars";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { FileText, Users, Clock, Upload } from 'lucide-react';
@@ -9,18 +10,32 @@ import { DocumentsList } from "./components/documents-list";
 import { DocumentsFilters } from "./components/documents-filters";
 import { DocumentListFilters } from '@/types/documents';
 
+const documentsPresenceViewer = {
+  id: "manager-avery",
+  displayName: "Avery Chen",
+  avatarUrl: null,
+  accentColor: "#8b5cf6",
+};
+
 export default function DocumentsPage() {
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
             <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Documents</h1>
             <p className="text-base text-muted-foreground sm:text-lg">
               Manage leases, agreements, and household documents with secure signing and version control.
             </p>
           </div>
-          <UploadDocumentDialog />
+          <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4 lg:items-end">
+            <PresenceAvatars
+              entity={{ type: "documents", id: "household-archive" }}
+              currentUser={documentsPresenceViewer}
+              className="sm:order-2"
+            />
+            <UploadDocumentDialog />
+          </div>
         </div>
         <Separator />
       </header>

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,4 +1,5 @@
 import ModerationControls from "@/components/messaging/moderation-controls"
+import PresenceAvatars from "@/components/presence/PresenceAvatars"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -94,6 +95,13 @@ const threadFilters = [
   { label: "Maintenance", active: false },
   { label: "Social", active: false },
 ]
+
+const threadViewerPresence = {
+  id: "resident-maya",
+  displayName: "Maya Patel",
+  avatarUrl: null,
+  accentColor: "#0ea5e9",
+}
 
 const threadList: ThreadListItem[] = [
   {
@@ -443,6 +451,11 @@ export default function MessagingPage() {
                 <span>{activeThread.participants} roommates involved</span>
                 <span>Updated {activeThread.updated}</span>
               </div>
+              <PresenceAvatars
+                entity={{ type: "thread", id: "chore-rotation" }}
+                currentUser={threadViewerPresence}
+                className="pt-1"
+              />
             </CardHeader>
             <CardContent className="space-y-8">
               {threadPosts.map((post, index) => (

--- a/components/presence/PresenceAvatars.tsx
+++ b/components/presence/PresenceAvatars.tsx
@@ -1,0 +1,308 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { createPortal } from "react-dom"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import {
+  createPresenceChannel,
+  type PresenceChannelHandle,
+  type PresenceEntity,
+  type PresenceParticipant,
+  type PresenceProfile,
+} from "@/lib/realtime/presence"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+const MAX_DEFAULT_AVATARS = 3
+const CURSOR_UPDATE_THROTTLE = 120
+const CURSOR_STALE_MS = 6_000
+const FALLBACK_COLORS = [
+  "#2563eb",
+  "#0ea5e9",
+  "#f97316",
+  "#a855f7",
+  "#10b981",
+  "#f43f5e",
+]
+
+type PresenceAvatarsProps = {
+  entity: PresenceEntity
+  currentUser: PresenceProfile
+  className?: string
+  showCursors?: boolean
+  maxAvatars?: number
+}
+
+export default function PresenceAvatars({
+  entity,
+  currentUser,
+  className,
+  showCursors = true,
+  maxAvatars = MAX_DEFAULT_AVATARS,
+}: PresenceAvatarsProps) {
+  const supabase = useSupabaseBrowser()
+  const [participants, setParticipants] = useState<PresenceParticipant[]>([])
+  const [presenceHandle, setPresenceHandle] = useState<PresenceChannelHandle | null>(null)
+
+  const profile = useMemo(
+    () => ({
+      id: currentUser.id,
+      displayName: currentUser.displayName,
+      avatarUrl: currentUser.avatarUrl ?? null,
+      accentColor: currentUser.accentColor ?? null,
+    }),
+    [
+      currentUser.id,
+      currentUser.displayName,
+      currentUser.avatarUrl,
+      currentUser.accentColor,
+    ],
+  )
+
+  const entityRef = useMemo(
+    () => ({
+      id: entity.id,
+      type: entity.type,
+    }),
+    [entity.id, entity.type],
+  )
+
+  const handleSync = useCallback((state: PresenceParticipant[]) => {
+    setParticipants(state)
+  }, [])
+
+  useEffect(() => {
+    if (!profile.id || !entityRef.id || !entityRef.type) {
+      return
+    }
+
+    const handle = createPresenceChannel(supabase, {
+      entity: entityRef,
+      profile,
+      throttleMs: 180,
+      onSync: handleSync,
+    })
+
+    setPresenceHandle(handle)
+
+    return () => {
+      void handle.unsubscribe()
+    }
+  }, [supabase, entityRef, profile, handleSync])
+
+  useEffect(() => {
+    if (!showCursors || !presenceHandle) {
+      return
+    }
+
+    let lastSent = 0
+    let pending: { x: number; y: number } | null = null
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    let isUnmounted = false
+
+    const flush = () => {
+      if (!pending || isUnmounted) {
+        return
+      }
+
+      const payload = {
+        cursor: {
+          x: pending.x,
+          y: pending.y,
+          updatedAt: Date.now(),
+        },
+      } as const
+
+      pending = null
+      lastSent = Date.now()
+      void presenceHandle.update(payload)
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      pending = { x: event.clientX, y: event.clientY }
+      const now = Date.now()
+      const elapsed = now - lastSent
+      if (elapsed >= CURSOR_UPDATE_THROTTLE) {
+        flush()
+      } else if (!timeout) {
+        timeout = setTimeout(() => {
+          timeout = null
+          flush()
+        }, CURSOR_UPDATE_THROTTLE - elapsed)
+      }
+    }
+
+    const clearCursor = () => {
+      pending = null
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      void presenceHandle.update({ cursor: null })
+    }
+
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerleave", clearCursor)
+    window.addEventListener("blur", clearCursor)
+
+    return () => {
+      isUnmounted = true
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerleave", clearCursor)
+      window.removeEventListener("blur", clearCursor)
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+    }
+  }, [presenceHandle, showCursors])
+
+  const uniqueParticipants = useMemo(() => {
+    const latestByUser = new Map<string, PresenceParticipant>()
+
+    for (const participant of participants) {
+      const current = latestByUser.get(participant.userId)
+      if (!current || participant.lastActiveAt > current.lastActiveAt) {
+        latestByUser.set(participant.userId, participant)
+      }
+    }
+
+    return Array.from(latestByUser.values()).sort(
+      (a, b) => b.lastActiveAt - a.lastActiveAt,
+    )
+  }, [participants])
+
+  const displayedParticipants = uniqueParticipants.slice(0, maxAvatars)
+  const overflowCount = Math.max(uniqueParticipants.length - displayedParticipants.length, 0)
+  const totalUsers = uniqueParticipants.length
+  const statusLabel =
+    totalUsers === 0
+      ? "Connecting…"
+      : totalUsers === 1
+      ? "You’re here"
+      : `${totalUsers} active`
+
+  const now = Date.now()
+  const activeCursors = showCursors
+    ? participants.filter((participant) => {
+        if (participant.isSelf || !participant.cursor) {
+          return false
+        }
+
+        return now - participant.cursor.updatedAt < CURSOR_STALE_MS
+      })
+    : []
+
+  const cursorLayer =
+    showCursors && typeof document !== "undefined" && activeCursors.length > 0
+      ? createPortal(
+          <div className="pointer-events-none fixed inset-0 z-[70]">
+            {activeCursors.map((participant) => {
+              const color = getAccentColor(participant)
+              const cursor = participant.cursor!
+              return (
+                <div
+                  key={participant.sessionId}
+                  className="pointer-events-none absolute"
+                  style={{
+                    transform: `translate3d(${cursor.x}px, ${cursor.y}px, 0)`,
+                  }}
+                >
+                  <div className="flex translate-x-3 -translate-y-3 items-center gap-1.5">
+                    <span
+                      className="block size-3 rotate-45 rounded-sm shadow"
+                      style={{ backgroundColor: color }}
+                      aria-hidden
+                    />
+                    <span className="rounded-md bg-background/95 px-2 py-0.5 text-xs font-medium text-foreground shadow-lg ring-1 ring-border/70">
+                      {participant.displayName}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>,
+          document.body,
+        )
+      : null
+
+  return (
+    <>
+      <div className={cn("flex items-center gap-3", className)} aria-live="polite">
+        <div className="flex items-center -space-x-2">
+          {displayedParticipants.length === 0 ? (
+            <div className="flex size-8 items-center justify-center rounded-full border border-dashed border-border bg-background text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              …
+            </div>
+          ) : null}
+          {displayedParticipants.map((participant) => {
+            const accent = getAccentColor(participant)
+            const initials = getInitials(participant.displayName)
+            return (
+              <div key={participant.userId} className="relative inline-flex">
+                <Avatar
+                  className="size-8 border-2 border-background shadow-sm"
+                  title={participant.isSelf ? "You" : participant.displayName}
+                >
+                  {participant.avatarUrl ? (
+                    <AvatarImage src={participant.avatarUrl} alt={participant.displayName} />
+                  ) : (
+                    <AvatarFallback
+                      className="text-[11px] font-semibold uppercase text-white"
+                      style={{ backgroundColor: accent }}
+                    >
+                      {initials}
+                    </AvatarFallback>
+                  )}
+                </Avatar>
+                <span className="absolute -bottom-0.5 -right-0.5 block size-2.5 rounded-full bg-emerald-400 ring-2 ring-background" />
+              </div>
+            )
+          })}
+          {overflowCount > 0 ? (
+            <div className="flex size-8 items-center justify-center rounded-full border border-dashed border-border bg-background text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              +{overflowCount}
+            </div>
+          ) : null}
+        </div>
+        <Badge
+          variant="outline"
+          className="border-dashed px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          {statusLabel}
+        </Badge>
+        <span className="sr-only">{totalUsers} people currently viewing this surface</span>
+      </div>
+      {cursorLayer}
+    </>
+  )
+}
+
+function getAccentColor(participant: PresenceParticipant) {
+  if (participant.accentColor) {
+    return participant.accentColor
+  }
+
+  const index = Math.abs(hashString(participant.userId)) % FALLBACK_COLORS.length
+  return FALLBACK_COLORS[index]
+}
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("")
+    .slice(0, 2)
+}
+
+function hashString(value: string) {
+  let hash = 0
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index)
+    hash |= 0
+  }
+  return hash
+}

--- a/lib/realtime/presence.ts
+++ b/lib/realtime/presence.ts
@@ -1,0 +1,284 @@
+import type { RealtimeChannel } from "@supabase/supabase-js"
+
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+const PRESENCE_NAMESPACE = "presence"
+const DEFAULT_THROTTLE_MS = 200
+
+type PresenceState = Record<string, PresenceStatePayload[]>
+
+type PresenceStatePayload = PresenceMetadata & {
+  presence_ref?: string
+}
+
+export type PresenceEntity = {
+  id: string
+  type: string
+}
+
+export type PresenceProfile = {
+  id: string
+  displayName: string
+  avatarUrl?: string | null
+  accentColor?: string | null
+}
+
+export type PresenceCursor = {
+  x: number
+  y: number
+  updatedAt: number
+}
+
+export type PresenceMetadata = {
+  sessionId: string
+  entity: PresenceEntity
+  userId: string
+  displayName: string
+  avatarUrl?: string | null
+  accentColor?: string | null
+  cursor?: PresenceCursor
+  lastActiveAt: number
+}
+
+export type PresenceParticipant = {
+  sessionId: string
+  userId: string
+  displayName: string
+  avatarUrl?: string | null
+  accentColor?: string | null
+  cursor?: PresenceCursor
+  lastActiveAt: number
+  isSelf: boolean
+}
+
+type PresenceUpdate = {
+  displayName?: string
+  avatarUrl?: string | null
+  accentColor?: string | null
+  cursor?: PresenceCursor | null
+}
+
+type PresenceChannelOptions = {
+  entity: PresenceEntity
+  profile: PresenceProfile
+  throttleMs?: number
+  onSync?: (participants: PresenceParticipant[]) => void
+}
+
+export type PresenceChannelHandle = {
+  channel: RealtimeChannel
+  sessionId: string
+  getPresence: () => PresenceParticipant[]
+  update: (patch: PresenceUpdate) => Promise<void>
+  unsubscribe: () => Promise<void>
+}
+
+export function buildPresenceChannelName(entity: PresenceEntity) {
+  return `${PRESENCE_NAMESPACE}:${entity.type}:${entity.id}`
+}
+
+export function createPresenceChannel(
+  client: TypedSupabaseClient,
+  options: PresenceChannelOptions,
+): PresenceChannelHandle {
+  const { entity, profile } = options
+  const throttleMs = Math.max(0, options.throttleMs ?? DEFAULT_THROTTLE_MS)
+  const sessionId = createSessionId()
+
+  let cachedParticipants: PresenceParticipant[] = []
+  let pendingParticipants: PresenceParticipant[] | null = null
+  let lastEmit = 0
+  let emitTimeout: ReturnType<typeof setTimeout> | null = null
+  let hasJoined = false
+
+  const channel = client.channel(buildPresenceChannelName(entity), {
+    config: {
+      presence: { key: profile.id },
+    },
+  })
+
+  let currentMetadata: PresenceMetadata = {
+    sessionId,
+    entity,
+    userId: profile.id,
+    displayName: profile.displayName,
+    avatarUrl: profile.avatarUrl ?? null,
+    accentColor: profile.accentColor ?? null,
+    lastActiveAt: Date.now(),
+  }
+
+  const cleanupHandlers: Array<() => void> = []
+
+  const emitParticipants = (participants: PresenceParticipant[]) => {
+    cachedParticipants = participants
+
+    if (!options.onSync) {
+      return
+    }
+
+    const now = Date.now()
+    if (now - lastEmit >= throttleMs) {
+      lastEmit = now
+      options.onSync(participants)
+      return
+    }
+
+    pendingParticipants = participants
+    if (emitTimeout) {
+      return
+    }
+
+    const delay = Math.max(throttleMs - (now - lastEmit), 0)
+    emitTimeout = setTimeout(() => {
+      emitTimeout = null
+      lastEmit = Date.now()
+      const payload = pendingParticipants ?? participants
+      pendingParticipants = null
+      options.onSync?.(payload)
+    }, delay)
+  }
+
+  const handleSync = () => {
+    const state = channel.presenceState<PresenceMetadata>() as PresenceState
+    const participants = deriveParticipants(state, entity, sessionId)
+    emitParticipants(participants)
+  }
+
+  channel.on("presence", { event: "sync" }, handleSync)
+
+  channel.subscribe(async (status) => {
+    if (status === "SUBSCRIBED") {
+      hasJoined = true
+      await channel.track(currentMetadata)
+    }
+  })
+
+  if (typeof window !== "undefined") {
+    const handleBeforeUnload = () => {
+      void channel.untrack()
+    }
+
+    window.addEventListener("beforeunload", handleBeforeUnload)
+    cleanupHandlers.push(() =>
+      window.removeEventListener("beforeunload", handleBeforeUnload),
+    )
+
+    const handleVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        void channel.untrack()
+      } else if (document.visibilityState === "visible" && hasJoined) {
+        void channel.track(currentMetadata)
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibility)
+    cleanupHandlers.push(() =>
+      document.removeEventListener("visibilitychange", handleVisibility),
+    )
+  }
+
+  const update = async (patch: PresenceUpdate) => {
+    const nextMetadata: PresenceMetadata = {
+      ...currentMetadata,
+      lastActiveAt: Date.now(),
+    }
+
+    if (Object.prototype.hasOwnProperty.call(patch, "displayName")) {
+      if (typeof patch.displayName === "string") {
+        nextMetadata.displayName = patch.displayName
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(patch, "avatarUrl")) {
+      nextMetadata.avatarUrl = patch.avatarUrl ?? null
+    }
+
+    if (Object.prototype.hasOwnProperty.call(patch, "accentColor")) {
+      nextMetadata.accentColor = patch.accentColor ?? null
+    }
+
+    if (Object.prototype.hasOwnProperty.call(patch, "cursor")) {
+      nextMetadata.cursor = patch.cursor ?? undefined
+    }
+
+    currentMetadata = nextMetadata
+
+    if (hasJoined) {
+      await channel.update(nextMetadata)
+    }
+  }
+
+  const getPresence = () => cachedParticipants
+
+  const unsubscribe = async () => {
+    cleanupHandlers.forEach((handler) => handler())
+    cleanupHandlers.length = 0
+
+    if (emitTimeout) {
+      clearTimeout(emitTimeout)
+      emitTimeout = null
+      pendingParticipants = null
+    }
+
+    if (hasJoined) {
+      await channel.untrack()
+      hasJoined = false
+    }
+
+    await channel.unsubscribe()
+    emitParticipants([])
+  }
+
+  return {
+    channel,
+    sessionId,
+    getPresence,
+    update,
+    unsubscribe,
+  }
+}
+
+function deriveParticipants(
+  state: PresenceState,
+  entity: PresenceEntity,
+  sessionId: string,
+): PresenceParticipant[] {
+  const participants: PresenceParticipant[] = []
+
+  for (const [userId, sessions] of Object.entries(state)) {
+    for (const session of sessions) {
+      if (!session.entity) {
+        continue
+      }
+
+      if (session.entity.id !== entity.id || session.entity.type !== entity.type) {
+        continue
+      }
+
+      const participant: PresenceParticipant = {
+        sessionId:
+          session.sessionId ?? session.presence_ref ?? `${userId}:${participants.length}`,
+        userId,
+        displayName: session.displayName ?? "Guest",
+        avatarUrl: session.avatarUrl ?? null,
+        accentColor: session.accentColor ?? null,
+        cursor: session.cursor,
+        lastActiveAt: session.lastActiveAt ?? 0,
+        isSelf: session.sessionId === sessionId,
+      }
+
+      participants.push(participant)
+    }
+  }
+
+  return participants.sort((a, b) => b.lastActiveAt - a.lastActiveAt)
+}
+
+function createSessionId() {
+  const globalCrypto = globalThis.crypto as { randomUUID?: () => string } | undefined
+  if (globalCrypto?.randomUUID) {
+    return globalCrypto.randomUUID()
+  }
+
+  return `session_${Math.random().toString(36).slice(2, 10)}`
+}

--- a/tests/lib/realtime/presence.test.ts
+++ b/tests/lib/realtime/presence.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { buildPresenceChannelName, createPresenceChannel, type PresenceEntity, type PresenceMetadata, type PresenceProfile } from "@/lib/realtime/presence"
+import type { RealtimeChannel } from "@supabase/supabase-js"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+class MockRealtimeChannel {
+  name = ""
+  presenceKey = ""
+  state: Record<string, PresenceMetadata[]> = {}
+  handlers: Record<string, Array<() => void>> = {}
+  subscribeCalls = 0
+  trackCalls = 0
+  updateCalls = 0
+  untrackCalls = 0
+  unsubscribeCalls = 0
+  lastTracked: PresenceMetadata | null = null
+  currentSessionId: string | null = null
+
+  on(_type: string, filter: { event?: string }, callback: () => void) {
+    const event = filter.event ?? "sync"
+    if (!this.handlers[event]) {
+      this.handlers[event] = []
+    }
+    this.handlers[event]!.push(callback)
+    return this as unknown as RealtimeChannel
+  }
+
+  subscribe(callback?: (status: string) => void) {
+    this.subscribeCalls += 1
+    if (callback) {
+      callback("SUBSCRIBED")
+    }
+    return this as unknown as RealtimeChannel
+  }
+
+  async track(payload: PresenceMetadata) {
+    this.trackCalls += 1
+    this.lastTracked = payload
+    this.currentSessionId = payload.sessionId
+
+    const list = this.state[this.presenceKey] ?? []
+    const filtered = list.filter((item) => item.sessionId !== payload.sessionId)
+    this.state[this.presenceKey] = [...filtered, payload]
+
+    this.emit("sync")
+    return "ok" as const
+  }
+
+  async update(payload: PresenceMetadata) {
+    this.updateCalls += 1
+    const list = this.state[this.presenceKey] ?? []
+    this.state[this.presenceKey] = list.map((item) =>
+      item.sessionId === payload.sessionId ? { ...item, ...payload } : item,
+    )
+    this.emit("sync")
+    return "ok" as const
+  }
+
+  async untrack() {
+    this.untrackCalls += 1
+    if (this.currentSessionId) {
+      const list = this.state[this.presenceKey] ?? []
+      this.state[this.presenceKey] = list.filter(
+        (item) => item.sessionId !== this.currentSessionId,
+      )
+    } else {
+      delete this.state[this.presenceKey]
+    }
+    this.emit("sync")
+    return "ok" as const
+  }
+
+  async unsubscribe() {
+    this.unsubscribeCalls += 1
+    return "ok" as const
+  }
+
+  presenceState() {
+    return this.state
+  }
+
+  setPresenceKey(key: string) {
+    this.presenceKey = key
+  }
+
+  addExternalPresence(userId: string, payload: PresenceMetadata) {
+    const list = this.state[userId] ?? []
+    const filtered = list.filter((item) => item.sessionId !== payload.sessionId)
+    this.state[userId] = [...filtered, { ...payload, userId }]
+    this.emit("sync")
+  }
+
+  removeExternalPresence(userId: string, sessionId: string) {
+    const list = this.state[userId] ?? []
+    this.state[userId] = list.filter((item) => item.sessionId !== sessionId)
+    if (this.state[userId]?.length === 0) {
+      delete this.state[userId]
+    }
+    this.emit("sync")
+  }
+
+  private emit(event: string) {
+    for (const handler of this.handlers[event] ?? []) {
+      handler()
+    }
+  }
+}
+
+function createMockClient(channel: MockRealtimeChannel) {
+  const client = {
+    channel: vi.fn(
+      (name: string, config?: { config?: { presence?: { key?: string } } }) => {
+        channel.name = name
+        const key = config?.config?.presence?.key
+        if (key) {
+          channel.setPresenceKey(key)
+        }
+        return channel as unknown as RealtimeChannel
+      },
+    ),
+  }
+
+  return client as unknown as TypedSupabaseClient
+}
+
+describe("createPresenceChannel", () => {
+  const entity: PresenceEntity = { type: "thread", id: "chore-rotation" }
+  const profile: PresenceProfile = {
+    id: "resident-maya",
+    displayName: "Maya Patel",
+    avatarUrl: null,
+    accentColor: "#0ea5e9",
+  }
+
+  it("joins the realtime presence channel and emits the current session", () => {
+    const channel = new MockRealtimeChannel()
+    const client = createMockClient(channel)
+    const onSync = vi.fn()
+
+    const handle = createPresenceChannel(client, {
+      entity,
+      profile,
+      throttleMs: 0,
+      onSync,
+    })
+
+    expect(channel.name).toBe(buildPresenceChannelName(entity))
+    expect(channel.subscribeCalls).toBe(1)
+    expect(channel.trackCalls).toBe(1)
+    expect(onSync).toHaveBeenCalledTimes(1)
+
+    const state = handle.getPresence()
+    expect(state).toHaveLength(1)
+    expect(state[0]).toMatchObject({
+      userId: profile.id,
+      isSelf: true,
+    })
+  })
+
+  it("reflects other sessions joining and leaving", () => {
+    const channel = new MockRealtimeChannel()
+    const client = createMockClient(channel)
+    const onSync = vi.fn()
+
+    const handle = createPresenceChannel(client, {
+      entity,
+      profile,
+      throttleMs: 0,
+      onSync,
+    })
+
+    onSync.mockClear()
+
+    const remotePresence: PresenceMetadata = {
+      sessionId: "session-remote",
+      entity,
+      userId: "resident-jordan",
+      displayName: "Jordan Lee",
+      avatarUrl: null,
+      accentColor: "#f97316",
+      cursor: { x: 24, y: 48, updatedAt: Date.now() },
+      lastActiveAt: Date.now(),
+    }
+
+    channel.addExternalPresence(remotePresence.userId, remotePresence)
+
+    expect(onSync).toHaveBeenCalled()
+    let state = handle.getPresence()
+    expect(state).toHaveLength(2)
+    const remoteEntry = state.find((entry) => entry.userId === remotePresence.userId)
+    expect(remoteEntry?.isSelf).toBe(false)
+
+    onSync.mockClear()
+    channel.removeExternalPresence(remotePresence.userId, remotePresence.sessionId)
+
+    state = handle.getPresence()
+    expect(state).toHaveLength(1)
+    expect(onSync).toHaveBeenCalledTimes(1)
+  })
+
+  it("cleans up subscriptions when unsubscribed", async () => {
+    const channel = new MockRealtimeChannel()
+    const client = createMockClient(channel)
+    const onSync = vi.fn()
+
+    const handle = createPresenceChannel(client, {
+      entity,
+      profile,
+      throttleMs: 0,
+      onSync,
+    })
+
+    onSync.mockClear()
+
+    await handle.unsubscribe()
+
+    expect(channel.untrackCalls).toBe(1)
+    expect(channel.unsubscribeCalls).toBe(1)
+    expect(handle.getPresence()).toEqual([])
+    expect(onSync).toHaveBeenLastCalledWith([])
+  })
+})


### PR DESCRIPTION
## Summary
- add a Supabase realtime presence helper with throttled syncs, cursor updates, and disconnect cleanup
- render collaborative PresenceAvatars with live cursors on messaging threads and the documents hub
- cover join/leave flows with mocked realtime channel tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b82c4588328b561e1c1d45452f9