### PR TITLE
Instrument SmartLink prefetch analytics metrics

### DIFF
--- a/app/perf/page.tsx
+++ b/app/perf/page.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import { useMemo } from "react"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { useNavigationPrefetchSummary } from "@/lib/analytics"
+
+const formatDuration = (value: number | null) => {
+  if (value === null || Number.isNaN(value)) {
+    return "—"
+  }
+
+  if (value < 1) {
+    return `${value.toFixed(2)} ms`
+  }
+
+  if (value < 10) {
+    return `${value.toFixed(1)} ms`
+  }
+
+  return `${Math.round(value)} ms`
+}
+
+const formatRelativeTime = (timestamp: number | null) => {
+  if (!timestamp) {
+    return "No samples yet"
+  }
+
+  const deltaMs = Date.now() - timestamp
+  if (deltaMs < 0) {
+    return "Just now"
+  }
+
+  const seconds = Math.floor(deltaMs / 1000)
+  if (seconds < 60) {
+    return seconds <= 1 ? "Just now" : `${seconds}s ago`
+  }
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) {
+    return `${minutes}m ago`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours}h ago`
+  }
+
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+const PerfPage = () => {
+  const summary = useNavigationPrefetchSummary()
+
+  const hoverStatus = useMemo(() => {
+    if (summary.hoverMedianDuration === null) {
+      return {
+        label: "Awaiting hover samples",
+        tone: "text-muted-foreground",
+      }
+    }
+
+    return summary.withinTarget
+      ? { label: "On target (<100 ms)", tone: "text-emerald-500" }
+      : { label: "Needs attention", tone: "text-amber-500" }
+  }, [summary.hoverMedianDuration, summary.withinTarget])
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Navigation prefetch health</CardTitle>
+          <CardDescription>
+            Hover-driven prefetches should resolve in under 100 ms to keep dense navigation clusters feeling instant.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">Hover median</p>
+              <p className="text-3xl font-semibold text-foreground">
+                {formatDuration(summary.hoverMedianDuration)}
+              </p>
+              <p className={`mt-1 text-sm font-medium ${hoverStatus.tone}`}>{hoverStatus.label}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">All transitions (median)</p>
+              <p className="text-3xl font-semibold text-foreground">
+                {formatDuration(summary.medianDuration)}
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {summary.successCount} successful · {summary.failureCount} failed
+              </p>
+            </div>
+          </div>
+
+          <dl className="grid gap-4 text-sm text-muted-foreground sm:grid-cols-3">
+            <div>
+              <dt>Hover samples</dt>
+              <dd className="text-base font-semibold text-foreground">{summary.hoverCount}</dd>
+            </div>
+            <div>
+              <dt>P95 duration</dt>
+              <dd className="text-base font-semibold text-foreground">{formatDuration(summary.p95Duration)}</dd>
+            </div>
+            <div>
+              <dt>Last capture</dt>
+              <dd className="text-base font-semibold text-foreground">
+                {formatRelativeTime(summary.lastUpdatedAt)}
+              </dd>
+            </div>
+          </dl>
+
+          {summary.recentEvents.length > 0 ? (
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">Recent captures</p>
+              <ul className="mt-2 space-y-2">
+                {summary.recentEvents.map((event) => (
+                  <li
+                    key={event.id}
+                    className="flex items-center justify-between rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm"
+                  >
+                    <span className="font-medium text-foreground">
+                      {event.trigger} · {event.href}
+                    </span>
+                    <span className="text-muted-foreground">{formatDuration(event.duration)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Interact with navigation links to populate live hover transition metrics.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default PerfPage

--- a/components/navigation/SmartLink.tsx
+++ b/components/navigation/SmartLink.tsx
@@ -4,6 +4,12 @@ import * as React from "react"
 import NextLink from "next/link"
 import { useRouter } from "next/navigation"
 
+import {
+  logNavigationPrefetchComplete,
+  logNavigationPrefetchStart,
+  type NavigationPrefetchTrigger,
+} from "@/lib/analytics"
+
 export type SmartLinkIntent = "standard" | "critical" | "passive" | "navigation"
 
 export interface SmartLinkProps
@@ -20,17 +26,35 @@ export interface SmartLinkProps
    * Custom root margin applied to the IntersectionObserver used for viewport based prefetching.
    */
   viewportMargin?: string
+  /**
+   * Fine tune the IntersectionObserver threshold used for viewport based prefetching.
+   */
+  viewportThreshold?: number | number[]
+  /**
+   * Opt-in flag to enable viewport driven prefetching even for hover-focused intents.
+   */
+  prefetchOnViewport?: boolean
 }
 
 type PrefetchHint = "never" | "hover" | "viewport" | "immediate"
 
 type AnchorRef = HTMLAnchorElement | null
 
+const createPrefetchRequestId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+
+  return `prefetch-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
 export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
   (props, forwardedRef) => {
     const {
       intent = "standard",
       viewportMargin = "200px",
+      viewportThreshold,
+      prefetchOnViewport = false,
       prefetch: prefetchProp,
       onPointerEnter,
       onFocus,
@@ -62,9 +86,7 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       return false
     }, [href])
 
-    const [isVisible, setIsVisible] = React.useState(false)
     const hasPrefetchedRef = React.useRef(false)
-
     const prefetchHint = React.useMemo<PrefetchHint>(() => {
       if (!isInternalHref) {
         return "never"
@@ -101,8 +123,97 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       return undefined
     }, [href, isInternalHref])
 
+    const computedPrefetchProp = React.useMemo(() => {
+      if (typeof prefetchProp === "boolean") {
+        return prefetchProp
+      }
+
+      return false
+    }, [prefetchProp])
+
+    const allowManualPrefetch = computedPrefetchProp === false
+
+    const triggerPrefetch = React.useCallback(
+      (trigger: NavigationPrefetchTrigger) => {
+        if (!allowManualPrefetch) {
+          return
+        }
+
+        if (hasPrefetchedRef.current) {
+          return
+        }
+
+        if (!prefetchHref) {
+          return
+        }
+
+        hasPrefetchedRef.current = true
+
+        const requestId = createPrefetchRequestId()
+        const startedAt = Date.now()
+
+        logNavigationPrefetchStart({
+          id: requestId,
+          href: prefetchHref,
+          trigger,
+          startedAt,
+        })
+
+        const finalize = (status: "success" | "error", error?: unknown) => {
+          const finishedAt = Date.now()
+
+          logNavigationPrefetchComplete({
+            id: requestId,
+            href: prefetchHref,
+            trigger,
+            startedAt,
+            finishedAt,
+            status,
+            errorMessage:
+              status === "error"
+                ? error instanceof Error
+                  ? error.message
+                  : String(error)
+                : undefined,
+          })
+        }
+
+        try {
+          const result = router.prefetch(prefetchHref)
+          Promise.resolve(result)
+            .then(() => {
+              finalize("success")
+            })
+            .catch((error) => {
+              finalize("error", error)
+            })
+        } catch (error) {
+          finalize("error", error)
+        }
+      },
+      [allowManualPrefetch, prefetchHref, router]
+    )
+
     React.useEffect(() => {
-      if (prefetchHint !== "viewport") {
+      if (prefetchHint === "immediate") {
+        triggerPrefetch("immediate")
+      }
+    }, [prefetchHint, triggerPrefetch])
+
+    const enableViewportPrefetch = React.useMemo(() => {
+      if (!allowManualPrefetch) {
+        return false
+      }
+
+      if (prefetchHint === "never") {
+        return false
+      }
+
+      return prefetchHint === "viewport" || prefetchOnViewport
+    }, [allowManualPrefetch, prefetchHint, prefetchOnViewport])
+
+    React.useEffect(() => {
+      if (!enableViewportPrefetch) {
         return
       }
 
@@ -115,11 +226,14 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
         (entries) => {
           const entry = entries[0]
           if (entry?.isIntersecting) {
-            setIsVisible(true)
+            triggerPrefetch("viewport")
             observer.disconnect()
           }
         },
-        { rootMargin: viewportMargin }
+        {
+          rootMargin: viewportMargin,
+          threshold: viewportThreshold,
+        }
       )
 
       observer.observe(node)
@@ -127,32 +241,7 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       return () => {
         observer.disconnect()
       }
-    }, [prefetchHint, viewportMargin])
-
-    const triggerPrefetch = React.useCallback(() => {
-      if (hasPrefetchedRef.current) {
-        return
-      }
-
-      if (!prefetchHref) {
-        return
-      }
-
-      router.prefetch(prefetchHref)
-      hasPrefetchedRef.current = true
-    }, [prefetchHref, router])
-
-    React.useEffect(() => {
-      if (prefetchHint === "immediate") {
-        triggerPrefetch()
-      }
-    }, [prefetchHint, triggerPrefetch])
-
-    React.useEffect(() => {
-      if (prefetchHint === "viewport" && isVisible && prefetchHref) {
-        hasPrefetchedRef.current = true
-      }
-    }, [isVisible, prefetchHint, prefetchHref])
+    }, [enableViewportPrefetch, triggerPrefetch, viewportMargin, viewportThreshold])
 
     const handlePointerEnter = React.useCallback(
       (event: React.PointerEvent<HTMLAnchorElement>) => {
@@ -165,7 +254,7 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
           return
         }
 
-        triggerPrefetch()
+        triggerPrefetch("hover")
       },
       [onPointerEnter, prefetchHint, triggerPrefetch]
     )
@@ -181,33 +270,16 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
           return
         }
 
-        triggerPrefetch()
+        triggerPrefetch("focus")
       },
       [onFocus, prefetchHint, triggerPrefetch]
     )
-
-    const shouldPrefetch = React.useMemo(() => {
-      if (!isInternalHref) {
-        return false
-      }
-
-      switch (prefetchHint) {
-        case "immediate":
-          return true
-        case "viewport":
-          return isVisible
-        case "hover":
-        case "never":
-        default:
-          return false
-      }
-    }, [isInternalHref, isVisible, prefetchHint])
 
     return (
       <NextLink
         ref={combinedRef}
         href={href}
-        prefetch={shouldPrefetch}
+        prefetch={computedPrefetchProp}
         onPointerEnter={handlePointerEnter}
         onFocus={handleFocus}
         {...rest}

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -1,0 +1,268 @@
+import { useSyncExternalStore } from "react"
+import type { Metric } from "web-vitals"
+
+export type NavigationPrefetchTrigger = "hover" | "focus" | "viewport" | "immediate"
+
+interface NavigationPrefetchStartEvent {
+  id: string
+  href: string
+  trigger: NavigationPrefetchTrigger
+  startedAt: number
+}
+
+export interface NavigationPrefetchRecord extends NavigationPrefetchStartEvent {
+  finishedAt: number
+  duration: number
+  status: "success" | "error"
+  errorMessage?: string
+}
+
+interface AnalyticsStore {
+  pending: Map<string, NavigationPrefetchStartEvent>
+  completed: NavigationPrefetchRecord[]
+  listeners: Set<() => void>
+  webVitals: Metric[]
+}
+
+interface AnalyticsGlobal {
+  __ROOMSILY_ANALYTICS__?: AnalyticsStore
+}
+
+const ANALYTICS_KEY = "__ROOMSILY_ANALYTICS__"
+const MAX_COMPLETED_RECORDS = 200
+const MAX_WEB_VITALS = 200
+const HOVER_MEDIAN_TARGET_MS = 100
+
+const getAnalyticsStore = (): AnalyticsStore => {
+  const globalTarget = globalThis as AnalyticsGlobal
+
+  if (!globalTarget[ANALYTICS_KEY]) {
+    globalTarget[ANALYTICS_KEY] = {
+      pending: new Map(),
+      completed: [],
+      listeners: new Set(),
+      webVitals: [],
+    }
+  }
+
+  return globalTarget[ANALYTICS_KEY]!
+}
+
+const durationRating = (duration: number): Metric["rating"] => {
+  if (duration < HOVER_MEDIAN_TARGET_MS) {
+    return "good"
+  }
+
+  if (duration < 250) {
+    return "needs-improvement"
+  }
+
+  return "poor"
+}
+
+const emitWebVital = (metric: Metric) => {
+  const store = getAnalyticsStore()
+  store.webVitals.push(metric)
+  if (store.webVitals.length > MAX_WEB_VITALS) {
+    store.webVitals.splice(0, store.webVitals.length - MAX_WEB_VITALS)
+  }
+}
+
+const notifyNavigationListeners = () => {
+  const store = getAnalyticsStore()
+  for (const listener of store.listeners) {
+    listener()
+  }
+}
+
+const subscribeToNavigationStore = (listener: () => void) => {
+  const store = getAnalyticsStore()
+  store.listeners.add(listener)
+  return () => {
+    store.listeners.delete(listener)
+  }
+}
+
+const subscribeToNavigationStoreSafe = (listener: () => void) => {
+  if (typeof window === "undefined") {
+    return () => {}
+  }
+
+  return subscribeToNavigationStore(listener)
+}
+
+export const logNavigationPrefetchStart = (event: NavigationPrefetchStartEvent) => {
+  const store = getAnalyticsStore()
+  store.pending.set(event.id, event)
+
+  emitWebVital({
+    name: "navigation-prefetch-start",
+    id: event.id,
+    value: event.startedAt,
+    delta: 0,
+    entries: [],
+    rating: "good",
+  })
+}
+
+export interface NavigationPrefetchCompleteEvent
+  extends Omit<NavigationPrefetchRecord, "duration" | "finishedAt"> {
+  finishedAt: number
+}
+
+export const logNavigationPrefetchComplete = (
+  event: NavigationPrefetchCompleteEvent,
+): NavigationPrefetchRecord => {
+  const store = getAnalyticsStore()
+  const pending = store.pending.get(event.id) ?? {
+    id: event.id,
+    href: event.href,
+    trigger: event.trigger,
+    startedAt: event.startedAt,
+  }
+
+  store.pending.delete(event.id)
+
+  const finishedAt = event.finishedAt
+  const startedAt = pending.startedAt
+  const duration = Math.max(0, finishedAt - startedAt)
+
+  const record: NavigationPrefetchRecord = {
+    id: event.id,
+    href: pending.href,
+    trigger: pending.trigger,
+    startedAt,
+    finishedAt,
+    duration,
+    status: event.status,
+    errorMessage: event.errorMessage,
+  }
+
+  store.completed.push(record)
+  if (store.completed.length > MAX_COMPLETED_RECORDS) {
+    store.completed.splice(0, store.completed.length - MAX_COMPLETED_RECORDS)
+  }
+
+  emitWebVital({
+    name: "navigation-prefetch-complete",
+    id: event.id,
+    value: finishedAt,
+    delta: duration,
+    entries: [],
+    rating: durationRating(duration),
+  })
+
+  notifyNavigationListeners()
+
+  return record
+}
+
+const median = (values: number[]): number | null => {
+  if (values.length === 0) {
+    return null
+  }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2
+  }
+
+  return sorted[middle]
+}
+
+const percentile = (values: number[], percentileRank: number): number | null => {
+  if (values.length === 0) {
+    return null
+  }
+
+  if (percentileRank <= 0) {
+    return values[0]
+  }
+
+  if (percentileRank >= 1) {
+    return values[values.length - 1]
+  }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = (sorted.length - 1) * percentileRank
+  const lower = Math.floor(index)
+  const upper = Math.ceil(index)
+
+  if (lower === upper) {
+    return sorted[lower]
+  }
+
+  const weight = index - lower
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight
+}
+
+export interface NavigationPrefetchSummary {
+  totalPrefetches: number
+  successCount: number
+  failureCount: number
+  medianDuration: number | null
+  averageDuration: number | null
+  hoverMedianDuration: number | null
+  hoverCount: number
+  p95Duration: number | null
+  withinTarget: boolean
+  lastUpdatedAt: number | null
+  recentEvents: NavigationPrefetchRecord[]
+}
+
+export const getNavigationPrefetchSummary = (): NavigationPrefetchSummary => {
+  const store = getAnalyticsStore()
+  const completed = store.completed
+  const successes = completed.filter((record) => record.status === "success")
+  const failures = completed.filter((record) => record.status === "error")
+
+  const durations = successes.map((record) => record.duration)
+  const hoverDurations = successes
+    .filter((record) => record.trigger === "hover")
+    .map((record) => record.duration)
+
+  const medianDuration = median(durations)
+  const hoverMedianDuration = median(hoverDurations)
+  const withinTarget = hoverMedianDuration !== null && hoverMedianDuration < HOVER_MEDIAN_TARGET_MS
+  const averageDuration =
+    durations.length > 0 ? durations.reduce((sum, value) => sum + value, 0) / durations.length : null
+  const p95Duration = percentile(durations, 0.95)
+  const lastUpdatedAt = completed.length > 0 ? completed[completed.length - 1].finishedAt : null
+  const recentEvents = completed.slice(-5).reverse()
+
+  return {
+    totalPrefetches: completed.length,
+    successCount: successes.length,
+    failureCount: failures.length,
+    medianDuration,
+    averageDuration,
+    hoverMedianDuration,
+    hoverCount: hoverDurations.length,
+    p95Duration,
+    withinTarget,
+    lastUpdatedAt,
+    recentEvents,
+  }
+}
+
+export const useNavigationPrefetchSummary = (): NavigationPrefetchSummary =>
+  useSyncExternalStore(
+    subscribeToNavigationStoreSafe,
+    getNavigationPrefetchSummary,
+    getNavigationPrefetchSummary,
+  )
+
+export const resetNavigationPrefetchMetrics = () => {
+  const store = getAnalyticsStore()
+  store.pending.clear()
+  store.completed = []
+  store.webVitals = []
+  notifyNavigationListeners()
+}
+
+export const getWebVitalMetrics = () => {
+  const store = getAnalyticsStore()
+  return [...store.webVitals]
+}

--- a/package.json
+++ b/package.json
@@ -70,10 +70,12 @@
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "0.160.0",
+    "web-vitals": "^5.1.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
@@ -85,6 +87,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       three:
         specifier: 0.160.0
         version: 0.160.0
+      web-vitals:
+        specifier: ^5.1.0
+        version: 5.1.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -192,6 +195,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -225,6 +231,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,7 +245,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
@@ -255,6 +264,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@4.0.4':
+    resolution: {integrity: sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==}
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    resolution: {integrity: sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +389,40 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1628,11 +1680,33 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2012,6 +2086,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2032,6 +2110,9 @@ packages:
   aria-hidden@1.2.3:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2350,16 +2431,28 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2389,6 +2482,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -2455,6 +2551,9 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -2505,6 +2604,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.22.3:
@@ -2983,6 +3086,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3097,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3118,6 +3233,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
@@ -3201,6 +3319,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3444,10 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3324,6 +3455,10 @@ packages:
     resolution: {integrity: sha512-JZX+1fjpqxvQmEgItvPOAwRlqf0Eg9dSZMxljA2/V2M6dluOhQCPBhewIlSJWgkNu0M36kViOgmTAMnDaAMOFw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -3374,6 +3509,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
@@ -3671,6 +3809,9 @@ packages:
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -3806,6 +3947,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3868,6 +4013,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
@@ -4001,6 +4149,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4164,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4262,6 +4420,9 @@ packages:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
 
@@ -4361,6 +4522,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4369,8 +4537,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4622,9 +4798,16 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
+
+  web-vitals@5.1.0:
+    resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
 
   webgl-constants@1.1.1:
     resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
@@ -4634,6 +4817,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4835,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4898,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4744,6 +4962,23 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@4.0.4':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.1
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5134,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.4.32)':
+    dependencies:
+      postcss: 8.4.32
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -6195,11 +6454,34 @@ snapshots:
       '@tanstack/query-core': 5.51.9
       react: 18.2.0
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/runtime': 7.23.9
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@testing-library/dom': 10.4.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.5
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -6644,6 +6926,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -6660,6 +6944,10 @@ snapshots:
   aria-hidden@1.2.3:
     dependencies:
       tslib: 2.6.2
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7012,11 +7300,29 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.1(postcss@8.4.32):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.4
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.4.32)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   date-fns@3.3.1: {}
 
@@ -7031,6 +7337,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -7090,6 +7398,8 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -7142,6 +7452,8 @@ snapshots:
       tapable: 2.2.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.22.3:
     dependencies:
@@ -7851,6 +8163,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8182,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7983,6 +8310,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.2:
     dependencies:
       '@types/estree': 1.0.5
@@ -8072,6 +8401,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.5
+      cssstyle: 5.3.1(postcss@8.4.32)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8167,6 +8524,8 @@ snapshots:
 
   lru-cache@10.1.0: {}
 
+  lru-cache@11.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -8174,6 +8533,8 @@ snapshots:
   lucide-react@0.302.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.176.0)(three@0.160.0):
     dependencies:
@@ -8294,6 +8655,8 @@ snapshots:
 
   mdn-data@2.0.30:
     optional: true
+
+  mdn-data@2.12.2: {}
 
   merge-anything@5.1.7:
     dependencies:
@@ -8496,7 +8859,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8706,6 +9069,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -8824,6 +9191,12 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8885,6 +9258,8 @@ snapshots:
       react: 18.2.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-merge-refs@1.1.0: {}
 
@@ -9061,6 +9436,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9079,6 +9456,12 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9375,6 +9758,8 @@ snapshots:
       periscopic: 3.1.0
     optional: true
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@2.2.0:
     dependencies:
       '@babel/runtime': 7.23.7
@@ -9502,13 +9887,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9736,7 +10135,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10163,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,16 +10189,24 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+
+  web-vitals@5.1.0: {}
 
   webgl-constants@1.1.1: {}
 
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9832,6 +10240,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9903,6 +10322,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/tests/components/smartlink.test.tsx
+++ b/tests/components/smartlink.test.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import SmartLink from "@/components/navigation/SmartLink"
+import * as analytics from "@/lib/analytics"
+
+const prefetchMock = vi.fn<(href: string) => Promise<void>>(() => Promise.resolve())
+
+vi.mock("next/link", () => {
+  return {
+    __esModule: true,
+    default: React.forwardRef<
+      HTMLAnchorElement,
+      React.ComponentProps<"a"> & { prefetch?: boolean }
+    >(({ prefetch: _prefetch, ...rest }, ref) => <a ref={ref} {...rest} />),
+  }
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    prefetch: prefetchMock,
+  }),
+}))
+
+describe("SmartLink prefetch heuristics", () => {
+  const startSpy = vi.spyOn(analytics, "logNavigationPrefetchStart")
+  const completeSpy = vi.spyOn(analytics, "logNavigationPrefetchComplete")
+
+  beforeEach(() => {
+    prefetchMock.mockReset()
+    prefetchMock.mockResolvedValue(undefined)
+    startSpy.mockClear()
+    completeSpy.mockClear()
+    analytics.resetNavigationPrefetchMetrics()
+  })
+
+  it("prefetches on hover for navigation-heavy clusters", async () => {
+    render(
+      <SmartLink href="/payments" intent="navigation">
+        Payments
+      </SmartLink>,
+    )
+
+    const link = screen.getByRole("link", { name: "Payments" })
+    fireEvent.pointerEnter(link)
+
+    expect(prefetchMock).toHaveBeenCalledWith("/payments")
+    expect(startSpy).toHaveBeenCalled()
+    const startArgs = startSpy.mock.calls[0]?.[0]
+    expect(startArgs?.trigger).toBe("hover")
+
+    await Promise.resolve()
+
+    expect(completeSpy).toHaveBeenCalled()
+    const completeArgs = completeSpy.mock.calls[0]?.[0]
+    expect(completeArgs?.trigger).toBe("hover")
+  })
+
+  it("prefetches on focus for keyboard intent", async () => {
+    render(
+      <SmartLink href="/documents" intent="passive">
+        Documents
+      </SmartLink>,
+    )
+
+    const link = screen.getByRole("link", { name: "Documents" })
+    fireEvent.focus(link)
+
+    expect(prefetchMock).toHaveBeenCalledWith("/documents")
+    expect(startSpy).toHaveBeenCalled()
+    const startArgs = startSpy.mock.calls[0]?.[0]
+    expect(startArgs?.trigger).toBe("focus")
+
+    await Promise.resolve()
+
+    expect(completeSpy).toHaveBeenCalled()
+    const completeArgs = completeSpy.mock.calls[0]?.[0]
+    expect(completeArgs?.trigger).toBe("focus")
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,8 @@ import path from "path"
 
 export default defineConfig({
   test: {
-    environment: "node",
-    include: ["tests/**/*.test.ts"],
+    environment: "jsdom",
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- instrument SmartLink to capture manual prefetch lifecycle events, log to web-vitals, and expose configurable viewport prefetch options
- add a client-side analytics store and /perf dashboard card that visualises hover transition medians alongside recent captures
- add SmartLink interaction tests on jsdom and wire up testing-library support for the new analytics behaviour

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d20b87153c8328bbd610a2d2176f99