### PR TITLE
feat: add mobile dashboard bottom nav

### DIFF
--- a/app/dashboard/components/MobileSideNav.tsx
+++ b/app/dashboard/components/MobileSideNav.tsx
@@ -1,30 +1,98 @@
 "use client";
 
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import { SideBar } from "./SideNav";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 
-export default function MobileSideNav() {
-	useEffect(() => {
-		window.addEventListener("resize", (e: UIEvent) => {
-			const w = e.target as Window;
-			if (w.innerWidth >= 1024) {
-				document.getElementById("sidebar-close")?.click();
-			}
-		});
-		return () => {
-			window.removeEventListener("resize", () => {});
-		};
-	}, []);
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { Menu } from "lucide-react";
 
-	return (
-		<Sheet>
-			<SheetTrigger asChild id="toggle-sidebar">
-				<span></span>
-			</SheetTrigger>
-			<SheetContent side={"left"} className="dark:bg-gradient-dark flex">
-				<SideBar />
-			</SheetContent>
-		</Sheet>
-	);
+import { SideBar } from "./SideNav";
+import {
+        MOBILE_NAV_ITEMS,
+        MOBILE_TOUCH_TARGET_CLASSNAMES,
+        MOBILE_TOUCH_TARGET_MIN_HEIGHT,
+} from "./mobile-nav.config";
+
+const BOTTOM_NAV_WRAPPER_CLASSES =
+        "fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 pb-[env(safe-area-inset-bottom)] " +
+        "supports-[backdrop-filter]:bg-background/60 lg:hidden";
+
+const BOTTOM_NAV_CONTENT_CLASSES = "mx-auto flex max-w-xl items-stretch gap-1 px-2 py-2";
+
+export default function MobileSideNav() {
+        useEffect(() => {
+                const handleResize = () => {
+                        if (window.innerWidth >= 1024) {
+                                document.getElementById("sidebar-close")?.click();
+                        }
+                };
+
+                window.addEventListener("resize", handleResize);
+                return () => {
+                        window.removeEventListener("resize", handleResize);
+                };
+        }, []);
+
+        const pathname = usePathname();
+
+        return (
+                <Sheet>
+                        <nav aria-label="Primary" className={BOTTOM_NAV_WRAPPER_CLASSES}>
+                                <div className={BOTTOM_NAV_CONTENT_CLASSES}>
+                                        {MOBILE_NAV_ITEMS.map((item) => {
+                                                const isActive =
+                                                        pathname === item.href ||
+                                                        pathname.startsWith(`${item.href}/`);
+
+                                                return (
+                                                        <Button
+                                                                aria-current={isActive ? "page" : undefined}
+                                                                aria-label={item.label}
+                                                                asChild
+                                                                className={cn(
+                                                                        MOBILE_TOUCH_TARGET_CLASSNAMES,
+                                                                        "flex-1 flex-col gap-1 px-2 text-xs font-medium",
+                                                                        isActive
+                                                                                ? "shadow-sm"
+                                                                                : "text-muted-foreground"
+                                                                )}
+                                                                key={item.href}
+                                                                style={{ minHeight: MOBILE_TOUCH_TARGET_MIN_HEIGHT }}
+                                                                variant={isActive ? "default" : "ghost"}
+                                                        >
+                                                                <Link href={item.href}>
+                                                                        <item.icon aria-hidden="true" className="size-5" />
+                                                                        <span>{item.label}</span>
+                                                                </Link>
+                                                        </Button>
+                                                );
+                                        })}
+
+                                        <SheetTrigger asChild>
+                                                <Button
+                                                        aria-label="Open overflow menu"
+                                                        className={cn(
+                                                                MOBILE_TOUCH_TARGET_CLASSNAMES,
+                                                                "flex-1 flex-col gap-1 px-2 text-xs font-medium text-muted-foreground"
+                                                        )}
+                                                        style={{ minHeight: MOBILE_TOUCH_TARGET_MIN_HEIGHT }}
+                                                        variant="ghost"
+                                                >
+                                                        <Menu aria-hidden="true" className="size-5" />
+                                                        <span>More</span>
+                                                </Button>
+                                        </SheetTrigger>
+                                </div>
+                        </nav>
+                        <SheetContent
+                                className="dark:bg-gradient-dark flex max-w-sm flex-1 overflow-y-auto lg:hidden"
+                                side="left"
+                        >
+                                <SideBar />
+                        </SheetContent>
+                </Sheet>
+        );
 }

--- a/app/dashboard/components/mobile-nav.config.ts
+++ b/app/dashboard/components/mobile-nav.config.ts
@@ -1,0 +1,45 @@
+import { type LucideIcon } from "lucide-react"
+import {
+  CalendarDays,
+  CreditCard,
+  LayoutDashboard,
+  MessageCircle,
+  UserRound,
+} from "lucide-react"
+
+export type MobileNavItem = {
+  label: string
+  href: string
+  icon: LucideIcon
+}
+
+export const MOBILE_TOUCH_TARGET_MIN_HEIGHT = 48
+export const MOBILE_TOUCH_TARGET_CLASSNAMES = "h-12 min-h-[48px]"
+
+export const MOBILE_NAV_ITEMS: MobileNavItem[] = [
+  {
+    label: "Dashboard",
+    href: "/dashboard",
+    icon: LayoutDashboard,
+  },
+  {
+    label: "Payments",
+    href: "/payments",
+    icon: CreditCard,
+  },
+  {
+    label: "Messaging",
+    href: "/messaging",
+    icon: MessageCircle,
+  },
+  {
+    label: "Schedule",
+    href: "/schedule",
+    icon: CalendarDays,
+  },
+  {
+    label: "Profile",
+    href: "/account",
+    icon: UserRound,
+  },
+]

--- a/tests/mobile-side-nav.test.ts
+++ b/tests/mobile-side-nav.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  MOBILE_NAV_ITEMS,
+  MOBILE_TOUCH_TARGET_CLASSNAMES,
+  MOBILE_TOUCH_TARGET_MIN_HEIGHT,
+} from "@/app/dashboard/components/mobile-nav.config"
+
+const expectedRoutes = [
+  { label: "Dashboard", href: "/dashboard" },
+  { label: "Payments", href: "/payments" },
+  { label: "Messaging", href: "/messaging" },
+  { label: "Schedule", href: "/schedule" },
+  { label: "Profile", href: "/account" },
+]
+
+describe("mobile bottom navigation", () => {
+  it("maps the key resident workflows", () => {
+    expect(MOBILE_NAV_ITEMS).toHaveLength(expectedRoutes.length)
+
+    for (const route of expectedRoutes) {
+      expect(MOBILE_NAV_ITEMS).toContainEqual(
+        expect.objectContaining(route),
+      )
+    }
+  })
+
+  it("meets WCAG touch target sizing for small screens", () => {
+    expect(MOBILE_TOUCH_TARGET_MIN_HEIGHT).toBeGreaterThanOrEqual(44)
+  })
+
+  it("applies utility classes that enforce touch target height", () => {
+    expect(MOBILE_TOUCH_TARGET_CLASSNAMES.split(" ")).toEqual(
+      expect.arrayContaining(["h-12", "min-h-[48px]"]),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- replace the mobile sidebar trigger with a persistent bottom navigation bar that highlights the active route and links to dashboard, payments, messaging, schedule, and profile
- retain the sheet-driven overflow menu while enforcing ≥44px button sizing for mobile touch targets
- extract mobile nav configuration and cover it with responsive tests that validate route coverage and WCAG touch sizing

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b8a513c83289d5fb8f65e0298b2