### PR TITLE
Add pull-to-refresh interactions with mobile safeguards

### DIFF
--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,46 +1,63 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
-import { getDocumentsAction } from '../actions';
-import { DocumentActions } from './document-actions';
-import { formatDistanceToNow } from 'date-fns';
-import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import { DocumentWithLease, DocumentListFilters } from "@/types/documents";
+import { getDocumentsAction } from "../actions";
+import { DocumentActions } from "./document-actions";
+import { formatDistanceToNow } from "date-fns";
+import { FileText, Users, Calendar, Eye } from "lucide-react";
+import { PullToRefresh } from "@/components/pull-to-refresh";
 
 interface DocumentsListProps {
   filter: DocumentListFilters;
 }
 
 export function DocumentsList({ filter }: DocumentsListProps) {
-  const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [documents, setDocuments] = useState<DocumentWithLease[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    const fetchDocuments = async () => {
+  const fetchDocuments = useCallback(
+    async ({ silent } = { silent: false }) => {
       try {
-        setLoading(true);
-        setError(null);
-        const result = await getDocumentsAction(filter);
-        if (result.success && result.data) {
-          setDocuments(result.data);
-          setError(null);
+        if (silent) {
+          setRefreshing(true)
         } else {
-          setError(result.error || 'Failed to fetch documents');
+          setLoading(true)
+        }
+        setError(null)
+        const result = await getDocumentsAction(filter)
+        if (result.success && result.data) {
+          setDocuments(result.data)
+          setError(null)
+        } else {
+          setError(result.error || "Failed to fetch documents")
         }
       } catch (err) {
-        console.error('Error fetching documents:', err);
-        setError('An unexpected error occurred');
+        console.error("Error fetching documents:", err)
+        setError("An unexpected error occurred")
       } finally {
-        setLoading(false);
+        if (silent) {
+          setRefreshing(false)
+        } else {
+          setLoading(false)
+        }
       }
-    };
+    },
+    [filter]
+  )
 
-    fetchDocuments();
-  }, [filter]);
+  useEffect(() => {
+    fetchDocuments()
+  }, [fetchDocuments])
+
+  const handleRefresh = useCallback(async () => {
+    await fetchDocuments({ silent: true })
+  }, [fetchDocuments])
 
   const getStatusBadge = (status: string) => {
     const variants = {
@@ -143,7 +160,8 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   }
 
   return (
-    <div className="space-y-4">
+    <PullToRefresh onRefresh={handleRefresh} isRefreshing={refreshing}>
+      <div className="space-y-4">
       {documents.map((doc) => (
         <Card key={doc.id} className="transition-shadow hover:shadow-md">
           <CardHeader className="pb-3">
@@ -213,6 +231,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
           )}
         </Card>
       ))}
-    </div>
+      </div>
+    </PullToRefresh>
   );
 }

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,4 +1,5 @@
 import ModerationControls from "@/components/messaging/moderation-controls"
+import { ThreadPostsRefresh } from "@/components/messaging/thread-posts-refresh"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -444,15 +445,16 @@ export default function MessagingPage() {
                 <span>Updated {activeThread.updated}</span>
               </div>
             </CardHeader>
-            <CardContent className="space-y-8">
-              {threadPosts.map((post, index) => (
-                <div key={post.id} className="space-y-4">
-                  <article className="space-y-4 rounded-lg border border-border/60 bg-background/90 p-4">
-                    <div className="flex items-start gap-3">
-                      <Avatar>
-                        <AvatarFallback className={cn("text-sm font-medium", post.author.accent)}>
-                          {post.author.initials}
-                        </AvatarFallback>
+            <CardContent>
+              <ThreadPostsRefresh>
+                {threadPosts.map((post, index) => (
+                  <div key={post.id} className="space-y-4">
+                    <article className="space-y-4 rounded-lg border border-border/60 bg-background/90 p-4">
+                      <div className="flex items-start gap-3">
+                        <Avatar>
+                          <AvatarFallback className={cn("text-sm font-medium", post.author.accent)}>
+                            {post.author.initials}
+                          </AvatarFallback>
                       </Avatar>
                       <div className="flex flex-col gap-1">
                         <div className="flex flex-wrap items-center gap-2">
@@ -558,10 +560,11 @@ export default function MessagingPage() {
                         </Button>
                       </div>
                     ) : null}
-                  </article>
-                  {index < threadPosts.length - 1 ? <Separator /> : null}
-                </div>
-              ))}
+                    </article>
+                    {index < threadPosts.length - 1 ? <Separator /> : null}
+                  </div>
+                ))}
+              </ThreadPostsRefresh>
             </CardContent>
           </Card>
 

--- a/components/messaging/thread-posts-refresh.tsx
+++ b/components/messaging/thread-posts-refresh.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { useCallback } from "react"
+import { useRouter } from "next/navigation"
+
+import { PullToRefresh } from "@/components/pull-to-refresh"
+
+interface ThreadPostsRefreshProps {
+  children: ReactNode
+}
+
+export function ThreadPostsRefresh({ children }: ThreadPostsRefreshProps) {
+  const router = useRouter()
+
+  const handleRefresh = useCallback(async () => {
+    router.refresh()
+    await new Promise((resolve) => setTimeout(resolve, 150))
+  }, [router])
+
+  return (
+    <PullToRefresh onRefresh={handleRefresh}>
+      <div className="space-y-8">{children}</div>
+    </PullToRefresh>
+  )
+}

--- a/components/pull-to-refresh.tsx
+++ b/components/pull-to-refresh.tsx
@@ -1,0 +1,317 @@
+"use client"
+
+import type { PointerEvent as ReactPointerEvent, ReactNode } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { cn } from "@/lib/utils"
+
+const DEFAULT_THRESHOLD = 72
+const DEFAULT_MAX_PULL = 160
+const MIN_VISIBLE_DURATION = 320
+const VIBRATION_DURATION = 15
+
+interface PullToRefreshProps {
+  children: ReactNode
+  onRefresh: () => void | Promise<void>
+  className?: string
+  threshold?: number
+  maxPullDistance?: number
+  isRefreshing?: boolean
+}
+
+const isNavigatorVibrationSupported = (): boolean => {
+  if (typeof navigator === "undefined") return false
+  return typeof (navigator as Navigator & { vibrate?: unknown }).vibrate === "function"
+}
+
+const vibrate = (duration: number) => {
+  if (!isNavigatorVibrationSupported()) return
+  try {
+    ;(navigator as Navigator & { vibrate: (pattern: number | number[]) => boolean }).vibrate(
+      duration
+    )
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Failed to trigger vibration", error)
+    }
+  }
+}
+
+const getScrollTop = () => {
+  if (typeof document === "undefined") return 0
+  const scrollElement =
+    document.scrollingElement ?? document.documentElement ?? document.body
+  return scrollElement ? scrollElement.scrollTop : 0
+}
+
+export function PullToRefresh({
+  children,
+  onRefresh,
+  className,
+  threshold = DEFAULT_THRESHOLD,
+  maxPullDistance = DEFAULT_MAX_PULL,
+  isRefreshing,
+}: PullToRefreshProps) {
+  const startYRef = useRef(0)
+  const isDraggingRef = useRef(false)
+  const [isDragging, setIsDragging] = useState(false)
+  const [internalRefreshing, setInternalRefreshing] = useState(false)
+  const [pullDistance, setPullDistance] = useState(0)
+  const pullDistanceRef = useRef(0)
+  const moveListenerRef = useRef<(event: PointerEvent) => void>()
+  const upListenerRef = useRef<(event: PointerEvent) => void>()
+  const cancelListenerRef = useRef<(event: PointerEvent) => void>()
+  const refreshPromiseRef = useRef<Promise<void> | null>(null)
+  const [isEnabled, setIsEnabled] = useState(false)
+
+  const effectiveRefreshing = isRefreshing ?? internalRefreshing
+
+  useEffect(() => {
+    pullDistanceRef.current = pullDistance
+  }, [pullDistance])
+
+  const removeGlobalListeners = useCallback(() => {
+    if (typeof window === "undefined") return
+
+    if (moveListenerRef.current) {
+      window.removeEventListener("pointermove", moveListenerRef.current)
+      moveListenerRef.current = undefined
+    }
+
+    if (upListenerRef.current) {
+      window.removeEventListener("pointerup", upListenerRef.current)
+      upListenerRef.current = undefined
+    }
+
+    if (cancelListenerRef.current) {
+      window.removeEventListener("pointercancel", cancelListenerRef.current)
+      cancelListenerRef.current = undefined
+    }
+  }, [])
+
+  useEffect(() => removeGlobalListeners, [removeGlobalListeners])
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return
+    }
+
+    const mediaQuery = window.matchMedia("(hover: none) and (pointer: coarse)")
+
+    const handleChange = () => {
+      setIsEnabled(mediaQuery.matches)
+    }
+
+    handleChange()
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange)
+      return () => mediaQuery.removeEventListener("change", handleChange)
+    }
+
+    if (typeof mediaQuery.addListener === "function") {
+      mediaQuery.addListener(handleChange)
+      return () => mediaQuery.removeListener(handleChange)
+    }
+
+    return undefined
+  }, [])
+
+  useEffect(() => {
+    if (!isEnabled && !effectiveRefreshing) {
+      setPullDistance(0)
+      pullDistanceRef.current = 0
+    }
+  }, [effectiveRefreshing, isEnabled])
+
+  useEffect(() => {
+    if (!effectiveRefreshing && !isDraggingRef.current) {
+      setPullDistance(0)
+      pullDistanceRef.current = 0
+    }
+  }, [effectiveRefreshing])
+
+  const triggerRefresh = useCallback(async () => {
+    if (refreshPromiseRef.current) {
+      return refreshPromiseRef.current
+    }
+
+    if (isRefreshing === undefined) {
+      setInternalRefreshing(true)
+    }
+
+    vibrate(VIBRATION_DURATION)
+
+    const refreshPromise = (async () => {
+      const start = typeof performance !== "undefined" ? performance.now() : Date.now()
+      try {
+        await onRefresh?.()
+      } finally {
+        const end = typeof performance !== "undefined" ? performance.now() : Date.now()
+        const elapsed = end - start
+        if (elapsed < MIN_VISIBLE_DURATION) {
+          await new Promise((resolve) => setTimeout(resolve, MIN_VISIBLE_DURATION - elapsed))
+        }
+      }
+    })()
+
+    refreshPromiseRef.current = refreshPromise
+
+    try {
+      await refreshPromise
+    } finally {
+      refreshPromiseRef.current = null
+      if (isRefreshing === undefined) {
+        setInternalRefreshing(false)
+      }
+    }
+
+    return refreshPromise
+  }, [isRefreshing, onRefresh])
+
+  const handlePointerMoveFactory = useCallback(() => {
+    return (event: PointerEvent) => {
+      if (!isDraggingRef.current) return
+
+      const delta = event.clientY - startYRef.current
+      if (delta <= 0) {
+        setPullDistance(0)
+        pullDistanceRef.current = 0
+        return
+      }
+
+      if (event.cancelable) {
+        event.preventDefault()
+      }
+
+      const dampened = Math.min(maxPullDistance, delta * 0.6)
+      setPullDistance(dampened)
+      pullDistanceRef.current = dampened
+    }
+  }, [maxPullDistance])
+
+  const finishDrag = useCallback(
+    async (shouldRefresh: boolean) => {
+      if (!isDraggingRef.current) return
+
+      isDraggingRef.current = false
+      setIsDragging(false)
+
+      if (shouldRefresh) {
+        const settledDistance = Math.min(
+          maxPullDistance,
+          Math.max(threshold, pullDistanceRef.current)
+        )
+        setPullDistance(settledDistance)
+        pullDistanceRef.current = settledDistance
+        try {
+          await triggerRefresh()
+        } catch (error) {
+          if (process.env.NODE_ENV !== "production") {
+            console.error("PullToRefresh onRefresh error", error)
+          }
+        }
+      } else {
+        setPullDistance(0)
+        pullDistanceRef.current = 0
+      }
+    },
+    [maxPullDistance, threshold, triggerRefresh]
+  )
+
+  const handlePointerUpFactory = useCallback(
+    () =>
+      async () => {
+        removeGlobalListeners()
+        const shouldRefresh = pullDistanceRef.current >= threshold
+        await finishDrag(shouldRefresh)
+      },
+    [finishDrag, removeGlobalListeners, threshold]
+  )
+
+  const handlePointerCancelFactory = useCallback(
+    () =>
+      () => {
+        removeGlobalListeners()
+        if (!isDraggingRef.current) return
+        isDraggingRef.current = false
+        setIsDragging(false)
+        setPullDistance(0)
+        pullDistanceRef.current = 0
+      },
+    [removeGlobalListeners]
+  )
+
+  const addGlobalListeners = useCallback(() => {
+    if (typeof window === "undefined") return
+
+    const moveHandler = handlePointerMoveFactory()
+    const upHandler = handlePointerUpFactory()
+    const cancelHandler = handlePointerCancelFactory()
+
+    moveListenerRef.current = moveHandler
+    upListenerRef.current = upHandler
+    cancelListenerRef.current = cancelHandler
+
+    window.addEventListener("pointermove", moveHandler, { passive: false })
+    window.addEventListener("pointerup", upHandler)
+    window.addEventListener("pointercancel", cancelHandler)
+  }, [handlePointerCancelFactory, handlePointerMoveFactory, handlePointerUpFactory])
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isEnabled || effectiveRefreshing) return
+      if (event.pointerType === "mouse") return
+      if (event.isPrimary === false) return
+      if (getScrollTop() > 0) return
+
+      startYRef.current = event.clientY
+      pullDistanceRef.current = 0
+      setPullDistance(0)
+      isDraggingRef.current = true
+      setIsDragging(true)
+      addGlobalListeners()
+    },
+    [addGlobalListeners, effectiveRefreshing, isEnabled]
+  )
+
+  const progress = useMemo(() => {
+    if (threshold <= 0) return 0
+    return Math.min(1, pullDistance / threshold)
+  }, [pullDistance, threshold])
+
+  const indicatorMessage = useMemo(() => {
+    if (!isEnabled) return ""
+    if (effectiveRefreshing) return "Refreshing…"
+    return progress >= 1 ? "Release to refresh" : "Pull to refresh"
+  }, [effectiveRefreshing, isEnabled, progress])
+
+  const indicatorVisible = isEnabled && (isDragging || effectiveRefreshing || pullDistance > 0)
+
+  return (
+    <div
+      data-pull-to-refresh-root=""
+      className={cn("relative", className)}
+      style={{ touchAction: isEnabled ? "pan-y" : undefined }}
+      onPointerDown={isEnabled ? handlePointerDown : undefined}
+    >
+      <div
+        role="status"
+        aria-live="polite"
+        className="pointer-events-none absolute left-1/2 top-2 z-10 -translate-x-1/2 rounded-full bg-background/95 px-3 py-1 text-xs font-medium text-muted-foreground shadow-sm ring-1 ring-border transition-opacity"
+        style={{ opacity: indicatorVisible ? 1 : 0 }}
+      >
+        {indicatorMessage}
+      </div>
+      <div
+        className="transition-transform duration-150 ease-out will-change-transform"
+        style={{
+          transform: `translateY(${pullDistance}px)`,
+          transitionDuration: isDragging ? "0ms" : undefined,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,7 +239,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
@@ -255,6 +258,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@4.0.4':
+    resolution: {integrity: sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==}
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    resolution: {integrity: sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +383,40 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -2350,16 +2396,28 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2389,6 +2447,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -2505,6 +2566,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.22.3:
@@ -2983,6 +3048,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3059,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3118,6 +3195,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
@@ -3201,6 +3281,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3406,10 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3374,6 +3467,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
@@ -3670,6 +3766,9 @@ packages:
 
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -4001,6 +4100,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4115,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4262,6 +4371,9 @@ packages:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
 
@@ -4361,6 +4473,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4369,8 +4488,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4622,6 +4749,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4634,6 +4765,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4783,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4846,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4744,6 +4910,23 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@4.0.4':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.1
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5082,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.4.32)':
+    dependencies:
+      postcss: 8.4.32
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -7012,11 +7219,29 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.1(postcss@8.4.32):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.4
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.4.32)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   date-fns@3.3.1: {}
 
@@ -7031,6 +7256,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -7142,6 +7369,8 @@ snapshots:
       tapable: 2.2.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.22.3:
     dependencies:
@@ -7851,6 +8080,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8099,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7983,6 +8227,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.2:
     dependencies:
       '@types/estree': 1.0.5
@@ -8072,6 +8318,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.5
+      cssstyle: 5.3.1(postcss@8.4.32)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8166,6 +8440,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.1.0: {}
+
+  lru-cache@11.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -8294,6 +8570,8 @@ snapshots:
 
   mdn-data@2.0.30:
     optional: true
+
+  mdn-data@2.12.2: {}
 
   merge-anything@5.1.7:
     dependencies:
@@ -8706,6 +8984,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -9061,6 +9343,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9079,6 +9363,12 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9375,6 +9665,8 @@ snapshots:
       periscopic: 3.1.0
     optional: true
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@2.2.0:
     dependencies:
       '@babel/runtime': 7.23.7
@@ -9502,13 +9794,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9736,7 +10042,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10070,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,6 +10096,10 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -9799,6 +10110,8 @@ snapshots:
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9832,6 +10145,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9903,6 +10227,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/tests/documents-refresh.test.tsx
+++ b/tests/documents-refresh.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import { act } from "react-dom/test-utils"
+import { createRoot } from "react-dom/client"
+
+import { DocumentsList } from "@/app/documents/components/documents-list"
+import type { DocumentListFilters, DocumentWithLease } from "@/types/documents"
+
+const { getDocumentsAction } = vi.hoisted(() => ({
+  getDocumentsAction: vi.fn(),
+}))
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const { storeRefreshHandler, getRefreshHandler, resetRefreshHandler } = vi.hoisted(() => {
+  let handler: (() => Promise<void> | void) | undefined
+  return {
+    storeRefreshHandler(fn?: () => Promise<void> | void) {
+      handler = fn
+    },
+    getRefreshHandler: () => handler,
+    resetRefreshHandler() {
+      handler = undefined
+    },
+  }
+})
+
+vi.mock("@/app/documents/actions", () => ({
+  getDocumentsAction,
+}))
+
+vi.mock("@/app/documents/components/document-actions", () => ({
+  DocumentActions: () => null,
+}))
+
+vi.mock("@/components/pull-to-refresh", () => ({
+  PullToRefresh: ({ onRefresh, children }: any) => {
+    storeRefreshHandler(onRefresh)
+    return <div data-testid="pull-mock">{children}</div>
+  },
+}))
+
+const flushPromises = async () => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe("DocumentsList pull-to-refresh", () => {
+  afterEach(() => {
+    getDocumentsAction.mockReset()
+    resetRefreshHandler()
+  })
+
+  it("refetches documents when the refresh handler runs", async () => {
+    const baseDocument: DocumentWithLease = {
+      id: "doc-1",
+      created_at: "2024-01-01T00:00:00.000Z",
+      updated_at: "2024-01-01T00:00:00.000Z",
+      title: "Lease agreement v1",
+      description: "Initial version",
+      document_type: "lease",
+      status: "draft",
+      metadata: {},
+      requires_signature: true,
+      version: 1,
+    }
+
+    const updatedDocument: DocumentWithLease = {
+      ...baseDocument,
+      id: "doc-1",
+      updated_at: "2024-02-01T00:00:00.000Z",
+      title: "Lease agreement v2",
+      status: "pending_signature",
+    }
+
+    getDocumentsAction
+      .mockResolvedValueOnce({ success: true, data: [baseDocument] })
+      .mockResolvedValueOnce({ success: true, data: [updatedDocument] })
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<DocumentsList filter={{} as DocumentListFilters} />)
+    })
+
+    await flushPromises()
+
+    expect(container.textContent).toContain("Lease agreement v1")
+
+    const refreshHandler = getRefreshHandler()
+    expect(refreshHandler).toBeTruthy()
+
+    await act(async () => {
+      await refreshHandler?.()
+    })
+
+    await flushPromises()
+
+    expect(getDocumentsAction).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain("Lease agreement v2")
+
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+})

--- a/tests/messaging-refresh.test.tsx
+++ b/tests/messaging-refresh.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import { act } from "react-dom/test-utils"
+import { createRoot } from "react-dom/client"
+
+import { ThreadPostsRefresh } from "@/components/messaging/thread-posts-refresh"
+
+const { routerRefresh } = vi.hoisted(() => ({
+  routerRefresh: vi.fn(),
+}))
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const { storeRefreshHandler, getRefreshHandler, resetRefreshHandler } = vi.hoisted(() => {
+  let handler: (() => Promise<void> | void) | undefined
+  return {
+    storeRefreshHandler(fn?: () => Promise<void> | void) {
+      handler = fn
+    },
+    getRefreshHandler: () => handler,
+    resetRefreshHandler() {
+      handler = undefined
+    },
+  }
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: routerRefresh,
+  }),
+}))
+
+vi.mock("@/components/pull-to-refresh", () => ({
+  PullToRefresh: ({ onRefresh, children }: any) => {
+    storeRefreshHandler(onRefresh)
+    return <div data-testid="thread-pull">{children}</div>
+  },
+}))
+
+describe("ThreadPostsRefresh", () => {
+  afterEach(() => {
+    routerRefresh.mockReset()
+    resetRefreshHandler()
+  })
+
+  it("calls router.refresh when triggered", async () => {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <ThreadPostsRefresh>
+          <div>Message one</div>
+        </ThreadPostsRefresh>
+      )
+    })
+
+    const refreshHandler = getRefreshHandler()
+    expect(refreshHandler).toBeTruthy()
+
+    vi.useFakeTimers()
+
+    await act(async () => {
+      const result = refreshHandler?.()
+      vi.runAllTimers()
+      if (result instanceof Promise) {
+        await result
+      }
+    })
+
+    vi.useRealTimers()
+
+    expect(routerRefresh).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+})

--- a/tests/pull-to-refresh.test.tsx
+++ b/tests/pull-to-refresh.test.tsx
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import { act } from "react-dom/test-utils"
+import { createRoot } from "react-dom/client"
+
+import { PullToRefresh } from "@/components/pull-to-refresh"
+
+const originalMatchMedia = window.matchMedia
+const originalPointerEvent = (window as any).PointerEvent
+const originalVibrate = (navigator as any).vibrate
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+describe("PullToRefresh", () => {
+  let matchMediaMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+
+    matchMediaMock = vi.fn().mockImplementation(() => ({
+      matches: true,
+      media: "(hover: none) and (pointer: coarse)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    window.matchMedia = matchMediaMock as unknown as typeof window.matchMedia
+
+    class MockPointerEvent extends Event {
+      clientY: number
+      pointerId: number
+      pointerType: string
+      isPrimary: boolean
+
+      constructor(type: string, init: PointerEventInit = {}) {
+        super(type, init)
+        this.clientY = init.clientY ?? 0
+        this.pointerId = init.pointerId ?? 1
+        this.pointerType = init.pointerType ?? "touch"
+        this.isPrimary = init.isPrimary ?? true
+      }
+
+      get cancelable() {
+        return true
+      }
+
+      preventDefault() {
+        // no-op for tests
+      }
+    }
+
+    ;(window as any).PointerEvent = MockPointerEvent
+    ;(navigator as any).vibrate = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.runAllTimers()
+    vi.useRealTimers()
+    window.matchMedia = originalMatchMedia
+
+    if (originalPointerEvent) {
+      (window as any).PointerEvent = originalPointerEvent
+    } else {
+      delete (window as any).PointerEvent
+    }
+
+    if (originalVibrate) {
+      (navigator as any).vibrate = originalVibrate
+    } else {
+      delete (navigator as any).vibrate
+    }
+  })
+
+  it("calls onRefresh and vibrates after crossing the pull threshold", async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined)
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <PullToRefresh threshold={40} onRefresh={onRefresh}>
+          <div>Feed</div>
+        </PullToRefresh>
+      )
+    })
+
+    const region = container.querySelector(
+      "[data-pull-to-refresh-root]"
+    ) as HTMLElement
+    expect(region).toBeTruthy()
+
+    await act(async () => {
+      region.dispatchEvent(
+        new window.PointerEvent("pointerdown", {
+          clientY: 0,
+          pointerId: 1,
+          bubbles: true,
+        })
+      )
+    })
+
+    await act(async () => {
+      window.dispatchEvent(
+        new window.PointerEvent("pointermove", {
+          clientY: 120,
+          pointerId: 1,
+          bubbles: true,
+        })
+      )
+    })
+
+    await act(async () => {
+      window.dispatchEvent(
+        new window.PointerEvent("pointerup", {
+          clientY: 120,
+          pointerId: 1,
+          bubbles: true,
+        })
+      )
+    })
+
+    await act(async () => {
+      vi.runAllTimers()
+    })
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    expect((navigator as any).vibrate).toHaveBeenCalled()
+
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+
+  it("does not trigger refresh when the media query is disabled", async () => {
+    matchMediaMock.mockImplementation(() => ({
+      matches: false,
+      media: "(hover: none) and (pointer: coarse)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    const onRefresh = vi.fn().mockResolvedValue(undefined)
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <PullToRefresh threshold={30} onRefresh={onRefresh}>
+          <div>Feed</div>
+        </PullToRefresh>
+      )
+    })
+
+    const region = container.querySelector(
+      "[data-pull-to-refresh-root]"
+    ) as HTMLElement
+    expect(region).toBeTruthy()
+
+    await act(async () => {
+      region.dispatchEvent(
+        new window.PointerEvent("pointerdown", {
+          clientY: 0,
+          pointerId: 1,
+          bubbles: true,
+        })
+      )
+    })
+
+    await act(async () => {
+      window.dispatchEvent(
+        new window.PointerEvent("pointermove", {
+          clientY: 80,
+          pointerId: 1,
+          bubbles: true,
+        })
+      )
+    })
+
+    await act(async () => {
+      window.dispatchEvent(
+        new window.PointerEvent("pointerup", {
+          clientY: 80,
+          pointerId: 1,
+          bubbles: true,
+        })
+      )
+    })
+
+    await act(async () => {
+      vi.runAllTimers()
+    })
+
+    expect(onRefresh).not.toHaveBeenCalled()
+
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,12 @@ import path from "path"
 
 export default defineConfig({
   test: {
-    environment: "node",
-    include: ["tests/**/*.test.ts"],
+    environment: "jsdom",
+    include: ["tests/**/*.test.{ts,tsx}"],
+  },
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "react",
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a reusable client-side PullToRefresh component that gates drag detection behind mobile media queries and fires haptic feedback when refreshing
- wrap the documents list and messaging thread feed with pull-to-refresh handlers to silently re-fetch data and trigger router refreshes without disrupting desktop scrolling
- extend the test suite to cover pull-to-refresh interaction behaviour, document re-fetching, and messaging router refresh integration while switching Vitest to jsdom

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d20b8ba7a083289b1298b56f0a78db