### PR TITLE
Add web share handling for documents and bookings

### DIFF
--- a/app/bookings/components/amenity-booking-form.tsx
+++ b/app/bookings/components/amenity-booking-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState, useTransition } from "react"
+import { useEffect, useMemo, useState, useTransition } from "react"
 import type { FormEvent } from "react"
 import { Loader2 } from "lucide-react"
 import { toast } from "sonner"
@@ -18,6 +18,15 @@ interface Amenity {
   description: string
   duration: string
   maxAdvance: string
+}
+
+export interface BookingShareDefaults {
+  amenityId?: string
+  start?: string
+  end?: string
+  summary?: string
+  notes?: string
+  sourceUrl?: string
 }
 
 type ConflictCode =
@@ -57,6 +66,13 @@ function formatDateTimeLocal(date: Date) {
   const minutes = pad(date.getMinutes())
 
   return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+function toLocalInputValue(iso?: string) {
+  if (!iso) return undefined
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return undefined
+  return formatDateTimeLocal(date)
 }
 
 const displayFormatter = new Intl.DateTimeFormat(undefined, {
@@ -111,14 +127,27 @@ function normaliseConflicts(payload: RpcPayload): ConflictEntry[] {
     .filter((entry): entry is ConflictEntry => Boolean(entry))
 }
 
-export function AmenityBookingForm({ amenity }: { amenity: Amenity }) {
+export function AmenityBookingForm({
+  amenity,
+  shareDefaults,
+}: {
+  amenity: Amenity
+  shareDefaults?: BookingShareDefaults
+}) {
   const supabase = useMemo(() => createClient(), [])
+  const applyShare =
+    shareDefaults && (!shareDefaults.amenityId || shareDefaults.amenityId === amenity.id)
+  const shareStartValue = applyShare ? toLocalInputValue(shareDefaults?.start) : undefined
+  const shareEndValue = applyShare ? toLocalInputValue(shareDefaults?.end) : undefined
+
   const [startValue, setStartValue] = useState(() => {
+    if (shareStartValue) return shareStartValue
     const now = new Date()
     const defaultStart = new Date(now.getTime() + 60 * 60 * 1000)
     return formatDateTimeLocal(defaultStart)
   })
   const [endValue, setEndValue] = useState(() => {
+    if (shareEndValue) return shareEndValue
     const now = new Date()
     const defaultStart = new Date(now.getTime() + 60 * 60 * 1000)
     const defaultEnd = new Date(defaultStart.getTime() + 60 * 60 * 1000)
@@ -142,6 +171,16 @@ export function AmenityBookingForm({ amenity }: { amenity: Amenity }) {
         return <Badge variant="outline">Awaiting check</Badge>
     }
   })()
+
+  useEffect(() => {
+    if (!applyShare) return
+    if (shareStartValue) setStartValue(shareStartValue)
+    if (shareEndValue) setEndValue(shareEndValue)
+  }, [applyShare, shareStartValue, shareEndValue])
+
+  const shareSummary = applyShare ? shareDefaults?.summary ?? shareDefaults?.notes : undefined
+  const shareSource = applyShare ? shareDefaults?.sourceUrl : undefined
+  const showShareNotice = applyShare && (shareSummary || shareSource || shareStartValue || shareEndValue)
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -200,6 +239,16 @@ export function AmenityBookingForm({ amenity }: { amenity: Amenity }) {
 
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
+      {showShareNotice && (
+        <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-3 text-xs text-primary">
+          <p className="font-medium text-sm">Imported from share</p>
+          <p className="mt-1 text-primary/80">
+            {shareSummary ?? 'Booking details'}
+            {shareSource ? ` • ${shareSource}` : ''}
+          </p>
+        </div>
+      )}
+
       <div className="space-y-2">
         <Label htmlFor={`${amenity.id}-start`}>Start time</Label>
         <Input

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -19,8 +19,14 @@ import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import { AmenityBookingForm } from "./components/amenity-booking-form"
+import type { BookingShareDefaults } from "./components/amenity-booking-form"
 import { BookingHistory } from "./components/booking-history"
 import { BookingStats } from "./components/booking-stats"
+
+function toSearchString(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0]
+  return value ?? undefined
+}
 
 const amenities = [
   {
@@ -65,7 +71,24 @@ const amenities = [
   },
 ]
 
-export default function BookingsPage() {
+export default function BookingsPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>
+}) {
+  const shareIntent = toSearchString(searchParams?.shareIntent)
+  const shareDefaults: BookingShareDefaults | undefined =
+    shareIntent === "booking"
+      ? {
+          amenityId: toSearchString(searchParams?.shareAmenity),
+          start: toSearchString(searchParams?.shareStart),
+          end: toSearchString(searchParams?.shareEnd),
+          summary: toSearchString(searchParams?.shareTitle),
+          notes: toSearchString(searchParams?.shareNotes),
+          sourceUrl: toSearchString(searchParams?.shareUrl),
+        }
+      : undefined
+
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
@@ -129,7 +152,7 @@ export default function BookingsPage() {
                     <span>Duration: {amenity.duration}</span>
                     <span>Max advance: {amenity.maxAdvance}</span>
                   </div>
-                  <AmenityBookingForm amenity={amenity} />
+                  <AmenityBookingForm amenity={amenity} shareDefaults={shareDefaults} />
                 </CardContent>
               </Card>
             ))}

--- a/app/documents/components/document-actions.tsx
+++ b/app/documents/components/document-actions.tsx
@@ -16,6 +16,7 @@ import { CreateSignatureDialog } from './create-signature-dialog';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
 import { MoreHorizontal, Eye, PenTool, Download, Share2 } from 'lucide-react';
 import { toast } from 'sonner';
+import { shareLink } from '@/utils/share';
 
 interface DocumentActionsProps {
   document: DocumentWithLease;
@@ -68,16 +69,30 @@ export function DocumentActions({ document }: DocumentActionsProps) {
     }
   };
 
-  const handleShare = () => {
-    if (navigator.share && document.file_url) {
-      navigator.share({
-        title: document.title,
-        url: document.file_url,
+  const handleShare = async () => {
+    if (!document.file_url) {
+      toast.error('Document link is unavailable');
+      return;
+    }
+
+    try {
+      const outcome = await shareLink({
+        shareData: {
+          title: document.title,
+          text: document.description ?? undefined,
+          url: document.file_url,
+        },
+        fallbackValue: document.file_url,
       });
-    } else {
-      // Fallback: copy URL to clipboard
-      navigator.clipboard.writeText(document.file_url || '');
-      toast.success('Document URL copied to clipboard');
+
+      if (outcome === 'shared') {
+        toast.success('Share sheet opened');
+      } else {
+        toast.success('Document URL copied to clipboard');
+      }
+    } catch (error) {
+      console.error('Unable to share document', error);
+      toast.error('Sharing is not supported on this device');
     }
   };
 

--- a/app/documents/components/upload-document-dialog.tsx
+++ b/app/documents/components/upload-document-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -42,7 +42,39 @@ export function UploadDocumentDialog() {
   });
   const [file, setFile] = useState<File | null>(null);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const [shareApplied, setShareApplied] = useState(false);
+  const [shareInfo, setShareInfo] = useState<{ url?: string; fileName?: string } | null>(null);
   const permissions = useDocumentPermissions();
+
+  useEffect(() => {
+    if (shareApplied) return;
+
+    const intent = searchParams.get('shareIntent');
+    if (intent !== 'document') return;
+
+    const sharedTitle = searchParams.get('shareTitle') ?? undefined;
+    const sharedDescription = searchParams.get('shareDescription') ?? undefined;
+    const sharedUrl = searchParams.get('shareUrl') ?? undefined;
+    const sharedFileName = searchParams.get('shareFileName') ?? undefined;
+
+    setFormData(prev => ({
+      ...prev,
+      title: sharedTitle ?? sharedFileName ?? prev.title,
+      description: sharedDescription ?? prev.description,
+    }));
+
+    setShareInfo(sharedUrl || sharedFileName ? { url: sharedUrl, fileName: sharedFileName ?? undefined } : null);
+    setShareApplied(true);
+    setOpen(true);
+    toast.success('Document details imported from share');
+
+    if (typeof window !== 'undefined') {
+      const next = new URL(window.location.href);
+      ['shareIntent', 'shareTitle', 'shareDescription', 'shareUrl', 'shareFileName'].forEach(param => next.searchParams.delete(param));
+      router.replace(`${next.pathname}${next.search}`, { scroll: false });
+    }
+  }, [searchParams, router, shareApplied]);
 
   // Don't render upload button if user doesn't have permission
   if (!permissions.canUploadDocuments) {
@@ -146,6 +178,16 @@ export function UploadDocumentDialog() {
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {shareInfo && (
+            <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-3 text-sm text-primary">
+              <p className="font-medium">Imported from share</p>
+              <p className="text-xs text-primary/80">
+                {shareInfo.fileName ? shareInfo.fileName : 'Document details'}
+                {shareInfo.url ? ` • ${shareInfo.url}` : ''}
+              </p>
+            </div>
+          )}
+
           {/* File Upload */}
           <div className="space-y-2">
             <Label htmlFor="file">Document File</Label>

--- a/app/share/route.ts
+++ b/app/share/route.ts
@@ -1,0 +1,245 @@
+import { NextResponse } from "next/server"
+
+type ParsedCalendarEvent = {
+  summary?: string
+  description?: string
+  location?: string
+  start?: string
+  end?: string
+}
+
+type BookingShareDetails = {
+  amenityId?: string
+  start?: string
+  end?: string
+  summary?: string
+  notes?: string
+  sourceUrl?: string
+}
+
+const AMENITY_KEYWORDS: Record<string, string[]> = {
+  kitchen: ["kitchen", "cook", "meal prep"],
+  "tv-room": ["tv room", "tv-room", "television", "living room"],
+  playstation: ["playstation", "gaming", "console"],
+  parking: ["parking", "garage", "visitor parking"],
+  computer: ["computer", "workstation", "desktop"],
+}
+
+function extractString(entry: FormDataEntryValue | null): string | undefined {
+  if (typeof entry !== "string") return undefined
+  const value = entry.trim()
+  return value.length > 0 ? value : undefined
+}
+
+function extractFiles(formData: FormData, key: string): File[] {
+  return formData
+    .getAll(key)
+    .filter((item): item is File => item instanceof File && item.size > 0)
+}
+
+function normaliseIsoInput(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const parsed = parseICalDate(value)
+  if (parsed) return parsed
+
+  const isoCandidate = value.includes(" ") ? value.replace(" ", "T") : value
+  const date = new Date(isoCandidate)
+  if (!Number.isNaN(date.getTime())) {
+    return date.toISOString()
+  }
+
+  return undefined
+}
+
+function extractDateTimesFromText(text?: string): { start?: string; end?: string } {
+  if (!text) return {}
+
+  const matches: string[] = []
+  const isoPattern = /\d{4}-\d{2}-\d{2}(?:[T\s]\d{2}:\d{2}(?::\d{2})?)?/g
+  let match: RegExpExecArray | null
+  while ((match = isoPattern.exec(text)) !== null) {
+    matches.push(match[0])
+    if (matches.length === 2) break
+  }
+
+  const results: { start?: string; end?: string } = {}
+  if (matches[0]) {
+    results.start = normaliseIsoInput(matches[0])
+  }
+  if (matches[1]) {
+    results.end = normaliseIsoInput(matches[1])
+  }
+
+  if (!results.start || !results.end) {
+    const icsPattern = /\d{8}T\d{6}Z?/g
+    const rawTokens = text.match(icsPattern) ?? []
+    if (!results.start && rawTokens[0]) {
+      results.start = parseICalDate(rawTokens[0])
+    }
+    if (!results.end && rawTokens[1]) {
+      results.end = parseICalDate(rawTokens[1])
+    }
+  }
+
+  return results
+}
+
+function detectAmenityId(...sources: Array<string | undefined>): string | undefined {
+  const haystacks = sources
+    .filter((source): source is string => Boolean(source && source.trim().length > 0))
+    .map((value) => value.toLowerCase())
+
+  for (const [amenityId, keywords] of Object.entries(AMENITY_KEYWORDS)) {
+    for (const haystack of haystacks) {
+      if (keywords.some((keyword) => haystack.includes(keyword))) {
+        return amenityId
+      }
+    }
+  }
+
+  return undefined
+}
+
+function looksLikeBooking(text?: string, url?: string): boolean {
+  const combined = `${text ?? ""} ${url ?? ""}`.toLowerCase()
+  return /booking|reservation|amenity|calendar/.test(combined)
+}
+
+function parseICalendar(payload: string): ParsedCalendarEvent {
+  const lines = payload.split(/\r?\n/)
+  const record: Record<string, string> = {}
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith("BEGIN") || line.startsWith("END")) continue
+    const separatorIndex = line.indexOf(":")
+    if (separatorIndex === -1) continue
+    const key = line.slice(0, separatorIndex)
+    const value = line.slice(separatorIndex + 1)
+    record[key] = value
+  }
+
+  const summary = selectField(record, "SUMMARY")
+  const description = selectField(record, "DESCRIPTION")
+  const location = selectField(record, "LOCATION")
+  const start = parseICalDate(selectField(record, "DTSTART"))
+  const end = parseICalDate(selectField(record, "DTEND"))
+
+  return { summary, description, location, start, end }
+}
+
+function selectField(record: Record<string, string>, field: string): string | undefined {
+  if (record[field]) return record[field]
+  const matchingKey = Object.keys(record).find((key) => key.startsWith(`${field};`))
+  if (!matchingKey) return undefined
+  return record[matchingKey]
+}
+
+function parseICalDate(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const token = trimmed.includes(":") ? trimmed.split(":").pop() ?? trimmed : trimmed
+  const basicMatch = token.match(/^(\d{4})(\d{2})(\d{2})(T(\d{2})(\d{2})(\d{2})(Z)?)?$/)
+
+  if (basicMatch) {
+    const [, year, month, day, , hour = "00", minute = "00", second = "00", suffix] = basicMatch
+    const yearNum = Number(year)
+    const monthNum = Number(month) - 1
+    const dayNum = Number(day)
+    const hourNum = Number(hour)
+    const minuteNum = Number(minute)
+    const secondNum = Number(second)
+
+    const date = suffix === "Z"
+      ? new Date(Date.UTC(yearNum, monthNum, dayNum, hourNum, minuteNum, secondNum))
+      : new Date(yearNum, monthNum, dayNum, hourNum, minuteNum, secondNum)
+
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString()
+    }
+  }
+
+  const isoCandidate = token.includes(" ") ? token.replace(" ", "T") : token
+  const parsed = new Date(isoCandidate)
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString()
+  }
+
+  return undefined
+}
+
+function buildBookingShareDetails(args: {
+  calendarEvent?: ParsedCalendarEvent
+  title?: string
+  text?: string
+  url?: string
+}): BookingShareDetails {
+  const { calendarEvent, title, text, url } = args
+  const derivedTimes = extractDateTimesFromText(text)
+
+  const start = calendarEvent?.start ?? derivedTimes.start
+  const end = calendarEvent?.end ?? derivedTimes.end
+  const summary = calendarEvent?.summary ?? title
+  const description = calendarEvent?.description ?? text
+  const amenityId = detectAmenityId(summary, description, calendarEvent?.location, text, title)
+
+  return {
+    amenityId,
+    start,
+    end,
+    summary,
+    notes: description ?? undefined,
+    sourceUrl: url,
+  }
+}
+
+function redirectWithParams(request: Request, path: string, params: URLSearchParams) {
+  const destination = new URL(path, request.url)
+  destination.search = params.toString()
+  return NextResponse.redirect(destination)
+}
+
+export async function POST(request: Request) {
+  const formData = await request.formData()
+
+  const title = extractString(formData.get("title"))
+  const text = extractString(formData.get("text"))
+  const url = extractString(formData.get("url"))
+  const documentFiles = extractFiles(formData, "documents")
+  const calendarFiles = extractFiles(formData, "calendar")
+
+  const hasCalendar = calendarFiles.length > 0
+  const treatAsBooking = hasCalendar || (documentFiles.length === 0 && looksLikeBooking(text, url))
+
+  if (treatAsBooking) {
+    const calendarEvent = hasCalendar ? parseICalendar(await calendarFiles[0].text()) : undefined
+    const details = buildBookingShareDetails({ calendarEvent, title, text, url })
+
+    const params = new URLSearchParams()
+    params.set("shareIntent", "booking")
+    if (details.amenityId) params.set("shareAmenity", details.amenityId)
+    if (details.start) params.set("shareStart", details.start)
+    if (details.end) params.set("shareEnd", details.end)
+    if (details.summary) params.set("shareTitle", details.summary)
+    if (details.notes) params.set("shareNotes", details.notes)
+    if (details.sourceUrl) params.set("shareUrl", details.sourceUrl)
+
+    return redirectWithParams(request, "/bookings", params)
+  }
+
+  const params = new URLSearchParams()
+  params.set("shareIntent", "document")
+  if (title) params.set("shareTitle", title)
+  if (text) params.set("shareDescription", text)
+  if (url) params.set("shareUrl", url)
+  const firstDocument = documentFiles[0]
+  if (firstDocument) params.set("shareFileName", firstDocument.name)
+
+  return redirectWithParams(request, "/documents", params)
+}
+
+export function GET(request: Request) {
+  return NextResponse.redirect(new URL("/", request.url))
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,6 +5,31 @@
   "start_url": "/", 
   "display": "standalone",
   "background_color": "#fff",
+  "share_target": {
+    "action": "/share",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url",
+      "files": [
+        {
+          "name": "documents",
+          "accept": [
+            "application/pdf",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "image/*"
+          ]
+        },
+        {
+          "name": "calendar",
+          "accept": ["text/calendar", "application/ics", "application/x-ics"]
+        }
+      ]
+    }
+  },
   "icons": [
     {
       "src": "images/touch/homescreen48.png",

--- a/tests/share-flows.test.ts
+++ b/tests/share-flows.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { POST } from "@/app/share/route"
+import { shareLink } from "@/utils/share"
+
+describe("share flows", () => {
+  it("uses navigator.share when available", async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined)
+    const canShareMock = vi.fn(() => true)
+    const writeTextMock = vi.fn().mockResolvedValue(undefined)
+
+    const outcome = await shareLink({
+      shareData: { title: "Lease", url: "https://example.com/lease.pdf" },
+      fallbackValue: "https://example.com/lease.pdf",
+      navigatorOverride: {
+        share: shareMock,
+        canShare: canShareMock,
+        clipboard: { writeText: writeTextMock },
+      },
+    })
+
+    expect(outcome).toBe("shared")
+    expect(shareMock).toHaveBeenCalledWith({
+      title: "Lease",
+      url: "https://example.com/lease.pdf",
+    })
+    expect(writeTextMock).not.toHaveBeenCalled()
+  })
+
+  it("falls back to copying when share fails", async () => {
+    const shareMock = vi.fn().mockRejectedValue(new Error("share unsupported"))
+    const writeTextMock = vi.fn().mockResolvedValue(undefined)
+
+    const outcome = await shareLink({
+      shareData: { title: "Lease", url: "https://example.com/lease.pdf" },
+      fallbackValue: "https://example.com/lease.pdf",
+      navigatorOverride: {
+        share: shareMock,
+        canShare: () => true,
+        clipboard: { writeText: writeTextMock },
+      },
+    })
+
+    expect(outcome).toBe("copied")
+    expect(writeTextMock).toHaveBeenCalledWith("https://example.com/lease.pdf")
+  })
+
+  it("redirects document shares to the documents flow", async () => {
+    const form = new FormData()
+    form.set("title", "Shared Lease")
+    form.set("text", "Lease agreement for Unit 3B")
+    form.set("url", "https://example.com/lease.pdf")
+    form.append("documents", new File(["dummy"], "lease.pdf", { type: "application/pdf" }))
+
+    const request = new Request("https://roomsily.test/share", {
+      method: "POST",
+      body: form,
+    })
+
+    const response = await POST(request)
+    const location = response.headers.get("location")
+    expect(location).toBeTruthy()
+
+    const redirectUrl = new URL(location ?? "", "https://roomsily.test")
+    expect(redirectUrl.pathname).toBe("/documents")
+    expect(redirectUrl.searchParams.get("shareIntent")).toBe("document")
+    expect(redirectUrl.searchParams.get("shareTitle")).toBe("Shared Lease")
+    expect(redirectUrl.searchParams.get("shareDescription")).toBe("Lease agreement for Unit 3B")
+    expect(redirectUrl.searchParams.get("shareFileName")).toBe("lease.pdf")
+  })
+
+  it("redirects calendar shares to the booking flow", async () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "SUMMARY:Kitchen Reservation",
+      "DTSTART:20240601T180000Z",
+      "DTEND:20240601T190000Z",
+      "DESCRIPTION:Reserve the kitchen for dinner",
+      "LOCATION:Kitchen",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\n")
+
+    const form = new FormData()
+    form.set("title", "Kitchen Reservation")
+    form.append("calendar", new File([ics], "booking.ics", { type: "text/calendar" }))
+
+    const request = new Request("https://roomsily.test/share", {
+      method: "POST",
+      body: form,
+    })
+
+    const response = await POST(request)
+    const location = response.headers.get("location")
+    expect(location).toBeTruthy()
+
+    const redirectUrl = new URL(location ?? "", "https://roomsily.test")
+    expect(redirectUrl.pathname).toBe("/bookings")
+    expect(redirectUrl.searchParams.get("shareIntent")).toBe("booking")
+    expect(redirectUrl.searchParams.get("shareAmenity")).toBe("kitchen")
+    expect(redirectUrl.searchParams.get("shareStart")).toBe("2024-06-01T18:00:00.000Z")
+    expect(redirectUrl.searchParams.get("shareEnd")).toBe("2024-06-01T19:00:00.000Z")
+  })
+})

--- a/utils/share.ts
+++ b/utils/share.ts
@@ -1,0 +1,61 @@
+export type ShareOutcome = "shared" | "copied"
+
+interface MinimalNavigator {
+  share?: Navigator["share"]
+  canShare?: Navigator["canShare"]
+  clipboard?: Pick<Navigator["clipboard"], "writeText"> | null
+}
+
+interface ShareLinkOptions {
+  shareData: ShareData
+  fallbackValue: string
+  navigatorOverride?: MinimalNavigator
+  clipboardOverride?: Pick<Navigator["clipboard"], "writeText"> | null
+}
+
+function getNavigator(options: ShareLinkOptions): MinimalNavigator | undefined {
+  if (options.navigatorOverride) {
+    return options.navigatorOverride
+  }
+
+  if (typeof navigator !== "undefined") {
+    return navigator
+  }
+
+  return undefined
+}
+
+function getClipboard(
+  options: ShareLinkOptions,
+  nav: MinimalNavigator | undefined,
+): Pick<Navigator["clipboard"], "writeText"> | null {
+  if (options.clipboardOverride) {
+    return options.clipboardOverride
+  }
+
+  return nav?.clipboard ?? null
+}
+
+export async function shareLink(options: ShareLinkOptions): Promise<ShareOutcome> {
+  const nav = getNavigator(options)
+  const clipboard = getClipboard(options, nav)
+
+  if (nav?.share) {
+    try {
+      const canShare = typeof nav.canShare === "function" ? nav.canShare(options.shareData) : true
+      if (canShare) {
+        await nav.share(options.shareData)
+        return "shared"
+      }
+    } catch (error) {
+      console.warn("navigator.share failed, falling back to clipboard", error)
+    }
+  }
+
+  if (clipboard?.writeText) {
+    await clipboard.writeText(options.fallbackValue)
+    return "copied"
+  }
+
+  throw new Error("Share APIs are unavailable")
+}


### PR DESCRIPTION
## Summary
- configure the PWA manifest with document and booking share targets and implement /share POST handling
- update document and booking creation flows to prefill from shared data and expose a reusable share helper
- expand share UI to handle navigator.share fallback and cover the flows with new vitest end-to-end coverage

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b8be4c083288ccc0d4cef6f8d0f