### PR TITLE
Add notification digest preferences and scheduler

### DIFF
--- a/app/account/loaders.ts
+++ b/app/account/loaders.ts
@@ -14,7 +14,15 @@ import type { AccountProfile } from "./types"
 
 type ProfileRow = Pick<
   Database["public"]["Tables"]["profiles"]["Row"],
-  "full_name" | "username" | "website" | "avatar_url" | "email"
+  |
+    "full_name"
+    | "username"
+    | "website"
+    | "avatar_url"
+    | "email"
+    | "digest_frequency"
+    | "quiet_hours_start"
+    | "quiet_hours_end"
 >
 
 export interface AccountPageData {
@@ -36,7 +44,9 @@ export async function loadAccountPageData(): Promise<AccountPageData> {
 
   const { data, error } = await supabase
     .from("profiles")
-    .select("full_name, username, website, avatar_url, email")
+    .select(
+      "full_name, username, website, avatar_url, email, digest_frequency, quiet_hours_start, quiet_hours_end",
+    )
     .eq("id", user.id)
     .maybeSingle<ProfileRow>()
 
@@ -51,6 +61,9 @@ export async function loadAccountPageData(): Promise<AccountPageData> {
         website: data.website,
         avatarUrl: data.avatar_url,
         email: data.email,
+        digestFrequency: data.digest_frequency ?? "daily",
+        quietHoursStart: data.quiet_hours_start,
+        quietHoursEnd: data.quiet_hours_end,
       }
     : null
 

--- a/app/account/notification-preferences-form.tsx
+++ b/app/account/notification-preferences-form.tsx
@@ -1,0 +1,206 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import type { FormEvent } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
+import { persistNotificationPreferences } from "@/lib/data/preferences"
+import type { DigestFrequency } from "./types"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+interface NotificationPreferencesFormProps {
+  userId: string
+  preferences: {
+    digestFrequency: DigestFrequency
+    quietHoursStart: string | null
+    quietHoursEnd: string | null
+  }
+}
+
+interface FormState {
+  digestFrequency: DigestFrequency
+  quietHoursStart: string
+  quietHoursEnd: string
+}
+
+function toInputTime(value: string | null): string {
+  if (!value) return ""
+  const match = value.match(/^(\d{2}):(\d{2})/)
+  return match ? `${match[1]}:${match[2]}` : ""
+}
+
+function createStateFromPreferences(
+  preferences: NotificationPreferencesFormProps["preferences"],
+): FormState {
+  return {
+    digestFrequency: preferences.digestFrequency,
+    quietHoursStart: toInputTime(preferences.quietHoursStart),
+    quietHoursEnd: toInputTime(preferences.quietHoursEnd),
+  }
+}
+
+export default function NotificationPreferencesForm({
+  userId,
+  preferences,
+}: NotificationPreferencesFormProps) {
+  const supabase = useSupabaseBrowser()
+  const [initialState, setInitialState] = useState<FormState>(() =>
+    createStateFromPreferences(preferences),
+  )
+  const [formState, setFormState] = useState<FormState>(initialState)
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    const nextState = createStateFromPreferences(preferences)
+    setInitialState(nextState)
+    setFormState(nextState)
+  }, [
+    preferences.digestFrequency,
+    preferences.quietHoursStart,
+    preferences.quietHoursEnd,
+  ])
+
+  const hasChanges =
+    initialState.digestFrequency !== formState.digestFrequency ||
+    initialState.quietHoursStart !== formState.quietHoursStart ||
+    initialState.quietHoursEnd !== formState.quietHoursEnd
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!hasChanges || isSaving) return
+
+    setIsSaving(true)
+    try {
+      const payload = await persistNotificationPreferences(supabase, userId, {
+        digestFrequency: formState.digestFrequency,
+        quietHoursStart: formState.quietHoursStart || null,
+        quietHoursEnd: formState.quietHoursEnd || null,
+      })
+
+      const nextState: FormState = {
+        digestFrequency: payload.digest_frequency,
+        quietHoursStart: toInputTime(payload.quiet_hours_start),
+        quietHoursEnd: toInputTime(payload.quiet_hours_end),
+      }
+
+      setInitialState(nextState)
+      setFormState(nextState)
+
+      toast({
+        title: "Notification preferences updated",
+        description: "We will respect your new digest cadence and quiet hours.",
+      })
+    } catch (error) {
+      console.error("Failed to update notification preferences", error)
+      toast({
+        variant: "destructive",
+        title: "Unable to save preferences",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Something went wrong while saving your notification preferences.",
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <form
+      className="grid gap-6 md:max-w-xl"
+      onSubmit={handleSubmit}
+      noValidate
+    >
+      <div className="space-y-2">
+        <label
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          htmlFor="digestFrequency"
+        >
+          Digest cadence
+        </label>
+        <Select
+          value={formState.digestFrequency}
+          onValueChange={(value) =>
+            setFormState((previous) => ({
+              ...previous,
+              digestFrequency: value as DigestFrequency,
+            }))
+          }
+        >
+          <SelectTrigger id="digestFrequency">
+            <SelectValue placeholder="Choose a cadence" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="daily">Daily summary</SelectItem>
+            <SelectItem value="weekly">Weekly summary</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-sm text-muted-foreground">
+          {formState.digestFrequency === "weekly"
+            ? "We'll email a weekly roll-up of new activity."
+            : "We'll email a daily roll-up of new activity."}
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            htmlFor="quietHoursStart"
+          >
+            Quiet hours start
+          </label>
+          <Input
+            id="quietHoursStart"
+            step={900}
+            type="time"
+            value={formState.quietHoursStart}
+            onChange={(event) =>
+              setFormState((previous) => ({
+                ...previous,
+                quietHoursStart: event.target.value,
+              }))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <label
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            htmlFor="quietHoursEnd"
+          >
+            Quiet hours end
+          </label>
+          <Input
+            id="quietHoursEnd"
+            step={900}
+            type="time"
+            value={formState.quietHoursEnd}
+            onChange={(event) =>
+              setFormState((previous) => ({
+                ...previous,
+                quietHoursEnd: event.target.value,
+              }))
+            }
+          />
+        </div>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        We'll pause digest delivery during quiet hours. Leave either time blank to
+        disable the window.
+      </p>
+      <div>
+        <Button disabled={!hasChanges || isSaving} type="submit">
+          {isSaving ? "Saving..." : hasChanges ? "Save preferences" : "Preferences saved"}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -4,6 +4,7 @@ import { Separator } from "@/components/ui/separator"
 
 import AccountForm from "./supa-account-form"
 import { loadAccountPageData } from "./loaders"
+import NotificationPreferencesForm from "./notification-preferences-form"
 
 export default async function SettingsAccountPage() {
   const { user, profile } = await loadAccountPageData()
@@ -23,6 +24,23 @@ export default async function SettingsAccountPage() {
         </div>
         <Separator />
         <AccountForm profile={profile} user={user} />
+        <Separator />
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold tracking-tight">Notification preferences</h2>
+            <p className="text-sm text-muted-foreground">
+              Choose how often we bundle updates and optionally set quiet hours to pause overnight deliveries.
+            </p>
+          </div>
+          <NotificationPreferencesForm
+            userId={user.id}
+            preferences={{
+              digestFrequency: profile?.digestFrequency ?? "daily",
+              quietHoursStart: profile?.quietHoursStart ?? null,
+              quietHoursEnd: profile?.quietHoursEnd ?? null,
+            }}
+          />
+        </div>
       </div>
     </div>
   )

--- a/app/account/types.ts
+++ b/app/account/types.ts
@@ -1,7 +1,15 @@
+import type { Database } from "@/lib/supabase"
+
+export type DigestFrequency =
+  Database["public"]["Tables"]["profiles"]["Row"]["digest_frequency"]
+
 export interface AccountProfile {
   fullName: string | null
   username: string | null
   website: string | null
   avatarUrl: string | null
   email: string | null
+  digestFrequency: DigestFrequency
+  quietHoursStart: string | null
+  quietHoursEnd: string | null
 }

--- a/app/api/cron/digest/route.ts
+++ b/app/api/cron/digest/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { runDigestJob } from "@/lib/notifications/digest"
+
+export const dynamic = "force-dynamic"
+export const runtime = "nodejs"
+
+async function handleDigestRequest(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET
+  if (cronSecret) {
+    const authorization = request.headers.get("authorization")
+    if (authorization !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+  }
+
+  try {
+    const results = await runDigestJob()
+    return NextResponse.json({ results })
+  } catch (error) {
+    console.error("Digest cron job failed", error)
+    return NextResponse.json(
+      {
+        error: "Failed to run digest job",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    )
+  }
+}
+
+export const GET = handleDigestRequest
+export const POST = handleDigestRequest

--- a/lib/data/preferences.ts
+++ b/lib/data/preferences.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+export type NotificationDigestFrequency =
+  Database["public"]["Tables"]["profiles"]["Row"]["digest_frequency"]
+
+export interface NotificationPreferencesInput {
+  digestFrequency: NotificationDigestFrequency
+  quietHoursStart: string | null
+  quietHoursEnd: string | null
+}
+
+export interface PersistedNotificationPreferencesPayload {
+  digest_frequency: NotificationDigestFrequency
+  quiet_hours_start: string | null
+  quiet_hours_end: string | null
+  updated_at: string
+}
+
+export function normalizeQuietHour(
+  value: string | null | undefined,
+): string | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === "") {
+    return null
+  }
+
+  const match = trimmed.match(/^(\d{2}):(\d{2})(?::(\d{2}))?$/)
+  if (!match) {
+    throw new Error(`Invalid quiet hour value: ${value}`)
+  }
+
+  const [, hours, minutes, seconds] = match
+  const hourNumber = Number.parseInt(hours, 10)
+  const minuteNumber = Number.parseInt(minutes, 10)
+  const secondValue = seconds ?? "00"
+
+  if (
+    Number.isNaN(hourNumber) ||
+    Number.isNaN(minuteNumber) ||
+    hourNumber < 0 ||
+    hourNumber > 23 ||
+    minuteNumber < 0 ||
+    minuteNumber > 59
+  ) {
+    throw new Error(`Invalid quiet hour value: ${value}`)
+  }
+
+  return `${hours}:${minutes}:${secondValue}`
+}
+
+export async function persistNotificationPreferences(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  preferences: NotificationPreferencesInput,
+): Promise<PersistedNotificationPreferencesPayload> {
+  const quietHoursStart = normalizeQuietHour(preferences.quietHoursStart)
+  const quietHoursEnd = normalizeQuietHour(preferences.quietHoursEnd)
+
+  const payload: PersistedNotificationPreferencesPayload = {
+    digest_frequency: preferences.digestFrequency,
+    quiet_hours_start: quietHoursStart,
+    quiet_hours_end: quietHoursEnd,
+    updated_at: new Date().toISOString(),
+  }
+
+  const { error } = await supabase
+    .from("profiles")
+    .update(payload)
+    .eq("id", userId)
+
+  if (error) {
+    throw new Error(`Failed to update notification preferences: ${error.message}`)
+  }
+
+  return payload
+}

--- a/lib/notifications/digest.ts
+++ b/lib/notifications/digest.ts
@@ -1,0 +1,350 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+import { sendEmailNotification, sendInAppNotification } from "."
+
+export type DigestFrequency =
+  Database["public"]["Tables"]["profiles"]["Row"]["digest_frequency"]
+
+const DIGEST_TEMPLATE = "activity-digest"
+const DIGEST_SUMMARY_METADATA_KEY = "digest_summary"
+const MAX_NOTIFICATIONS_PER_DIGEST = 20
+
+const DIGEST_INTERVAL_MS: Record<DigestFrequency, number> = {
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+}
+
+export type DigestIneligibilityReason = "within_quiet_hours" | "interval_not_met"
+
+export interface DigestEligibilityResult {
+  eligible: boolean
+  reason?: DigestIneligibilityReason
+  windowStart: Date
+}
+
+function parseTimeToMinutes(value: string | null | undefined): number | null {
+  if (!value) return null
+  const match = value.match(/^(\d{2}):(\d{2})(?::\d{2})?$/)
+  if (!match) return null
+  const hours = Number.parseInt(match[1] ?? "0", 10)
+  const minutes = Number.parseInt(match[2] ?? "0", 10)
+
+  if (
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null
+  }
+
+  return hours * 60 + minutes
+}
+
+export function isWithinQuietHours(
+  now: Date,
+  quietHoursStart: string | null | undefined,
+  quietHoursEnd: string | null | undefined,
+): boolean {
+  const startMinutes = parseTimeToMinutes(quietHoursStart)
+  const endMinutes = parseTimeToMinutes(quietHoursEnd)
+
+  if (
+    startMinutes === null ||
+    endMinutes === null ||
+    startMinutes === endMinutes
+  ) {
+    return false
+  }
+
+  const currentMinutes = now.getHours() * 60 + now.getMinutes()
+
+  if (startMinutes < endMinutes) {
+    return currentMinutes >= startMinutes && currentMinutes < endMinutes
+  }
+
+  return currentMinutes >= startMinutes || currentMinutes < endMinutes
+}
+
+export function shouldSendDigest({
+  now,
+  frequency,
+  lastDigestAt,
+  quietHoursStart,
+  quietHoursEnd,
+}: {
+  now: Date
+  frequency: DigestFrequency
+  lastDigestAt: Date | null
+  quietHoursStart: string | null
+  quietHoursEnd: string | null
+}): DigestEligibilityResult {
+  const nowTime = now.getTime()
+  const intervalMs = DIGEST_INTERVAL_MS[frequency]
+  const intervalStart = new Date(nowTime - intervalMs)
+
+  let windowStart = intervalStart
+  if (lastDigestAt) {
+    const lastTime = lastDigestAt.getTime()
+    if (lastTime <= nowTime && lastTime >= intervalStart.getTime()) {
+      windowStart = lastDigestAt
+    }
+  }
+
+  if (isWithinQuietHours(now, quietHoursStart, quietHoursEnd)) {
+    return { eligible: false, reason: "within_quiet_hours", windowStart }
+  }
+
+  if (lastDigestAt && nowTime - lastDigestAt.getTime() < intervalMs) {
+    return { eligible: false, reason: "interval_not_met", windowStart }
+  }
+
+  return { eligible: true, windowStart }
+}
+
+async function fetchLastDigestAt(
+  client: SupabaseClient<Database>,
+  userId: string,
+): Promise<Date | null> {
+  const { data, error } = await client
+    .from("email_notifications")
+    .select("sent_at")
+    .eq("user_id", userId)
+    .eq("template", DIGEST_TEMPLATE)
+    .order("sent_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to look up last digest: ${error.message}`)
+  }
+
+  if (!data?.sent_at) {
+    return null
+  }
+
+  const parsed = new Date(data.sent_at)
+  return Number.isNaN(parsed.valueOf()) ? null : parsed
+}
+
+interface ProfileDigestRow {
+  id: string
+  email: string | null
+  full_name: string | null
+  digest_frequency: DigestFrequency | null
+  quiet_hours_start: string | null
+  quiet_hours_end: string | null
+}
+
+interface NotificationRow {
+  id: string
+  title: string
+  message: string
+  created_at: string
+}
+
+export interface DigestProcessingResult {
+  userId: string
+  status: "sent" | "skipped" | "failed"
+  reason?: string
+  notifications?: number
+}
+
+function sanitizeNotificationsForEmail(notifications: NotificationRow[]) {
+  return notifications.map((notification) => ({
+    title: notification.title,
+    message: notification.message,
+    createdAt: notification.created_at,
+  }))
+}
+
+function buildDigestSubject(
+  frequency: DigestFrequency,
+  notificationCount: number,
+): string {
+  const cadenceLabel = frequency === "weekly" ? "Weekly" : "Daily"
+  return `${cadenceLabel} household digest (${notificationCount} update${
+    notificationCount === 1 ? "" : "s"
+  })`
+}
+
+export async function processDigestForAllProfiles(
+  client: SupabaseClient<Database>,
+  now: Date = new Date(),
+): Promise<DigestProcessingResult[]> {
+  const results: DigestProcessingResult[] = []
+
+  const { data: profiles, error: profilesError } = await client
+    .from("profiles")
+    .select(
+      "id, email, full_name, digest_frequency, quiet_hours_start, quiet_hours_end",
+    )
+
+  if (profilesError) {
+    throw new Error(
+      `Failed to load profiles for digest processing: ${profilesError.message}`,
+    )
+  }
+
+  if (!profiles?.length) {
+    return results
+  }
+
+  for (const profile of profiles as ProfileDigestRow[]) {
+    const userId = profile.id
+
+    if (!profile.email) {
+      results.push({ userId, status: "skipped", reason: "missing_email" })
+      continue
+    }
+
+    const frequency = (profile.digest_frequency ?? "daily") as DigestFrequency
+
+    let lastDigestAt: Date | null
+    try {
+      lastDigestAt = await fetchLastDigestAt(client, userId)
+    } catch (error) {
+      console.error("Failed to fetch last digest timestamp", {
+        userId,
+        error,
+      })
+      results.push({ userId, status: "failed", reason: "last_digest_lookup" })
+      continue
+    }
+
+    const eligibility = shouldSendDigest({
+      now,
+      frequency,
+      lastDigestAt,
+      quietHoursStart: profile.quiet_hours_start,
+      quietHoursEnd: profile.quiet_hours_end,
+    })
+
+    if (!eligibility.eligible) {
+      results.push({
+        userId,
+        status: "skipped",
+        reason: eligibility.reason,
+      })
+      continue
+    }
+
+    const windowStartIso = eligibility.windowStart.toISOString()
+    const windowEndIso = now.toISOString()
+
+    const { data: notifications, error: notificationsError } = await client
+      .from("notifications")
+      .select("id, title, message, created_at")
+      .eq("user_id", userId)
+      .gte("created_at", windowStartIso)
+      .lte("created_at", windowEndIso)
+      .or(
+        `metadata->>${DIGEST_SUMMARY_METADATA_KEY}.is.null,metadata->>${DIGEST_SUMMARY_METADATA_KEY}.eq.false`,
+      )
+      .order("created_at", { ascending: true })
+      .limit(MAX_NOTIFICATIONS_PER_DIGEST)
+
+    if (notificationsError) {
+      console.error("Failed to load notifications for digest", {
+        userId,
+        error: notificationsError,
+      })
+      results.push({
+        userId,
+        status: "failed",
+        reason: "notification_query_failed",
+      })
+      continue
+    }
+
+    if (!notifications || notifications.length === 0) {
+      results.push({ userId, status: "skipped", reason: "no_activity" })
+      continue
+    }
+
+    const emailData = {
+      fullName: profile.full_name,
+      frequency,
+      notifications: sanitizeNotificationsForEmail(notifications as NotificationRow[]),
+      windowStart: windowStartIso,
+      windowEnd: windowEndIso,
+    }
+
+    const emailResult = await sendEmailNotification({
+      to: profile.email,
+      subject: buildDigestSubject(frequency, notifications.length),
+      template: DIGEST_TEMPLATE,
+      data: emailData,
+      userId,
+    })
+
+    if (!emailResult.success) {
+      console.error("Failed to send digest email", {
+        userId,
+        error: emailResult.error,
+      })
+      results.push({ userId, status: "failed", reason: "email_failed" })
+      continue
+    }
+
+    const inAppResult = await sendInAppNotification({
+      userId,
+      title:
+        frequency === "weekly"
+          ? "Weekly digest delivered"
+          : "Daily digest delivered",
+      message: `We just emailed ${notifications.length} update${
+        notifications.length === 1 ? "" : "s"
+      } from the last ${frequency === "weekly" ? "week" : "day"}.`,
+      type: "info",
+      actionUrl: "/notifications",
+      metadata: {
+        [DIGEST_SUMMARY_METADATA_KEY]: true,
+        total_notifications: notifications.length,
+        window_start: windowStartIso,
+        window_end: windowEndIso,
+      },
+    })
+
+    if (!inAppResult.success) {
+      console.warn("Digest email sent but in-app notification failed", {
+        userId,
+        error: inAppResult.error,
+      })
+    }
+
+    results.push({
+      userId,
+      status: "sent",
+      notifications: notifications.length,
+    })
+  }
+
+  return results
+}
+
+export async function runDigestJob(
+  now: Date = new Date(),
+): Promise<DigestProcessingResult[]> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      "Missing Supabase configuration for digest job. Ensure NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are set.",
+    )
+  }
+
+  const serviceClient = createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  })
+
+  return processDigestForAllProfiles(serviceClient, now)
+}

--- a/lib/notifications/index.ts
+++ b/lib/notifications/index.ts
@@ -50,6 +50,7 @@ class NotificationService {
         ),
         "payment-receipt": this.getPaymentReceiptTemplate(notification.data),
         "document-signed": this.getDocumentSignedTemplate(notification.data),
+        "activity-digest": this.getActivityDigestTemplate(notification.data),
         welcome: this.getWelcomeTemplate(notification.data),
       }
 
@@ -242,6 +243,105 @@ class NotificationService {
         <a href="${
           process.env.NEXT_PUBLIC_APP_URL
         }/dashboard" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">Get Started</a>
+      </div>
+    `
+  }
+
+  private getActivityDigestTemplate(data?: any) {
+    const notifications = Array.isArray(data?.notifications)
+      ? data.notifications
+      : []
+    const frequency = data?.frequency === "weekly" ? "weekly" : "daily"
+    const fullName = typeof data?.fullName === "string" ? data.fullName : null
+
+    const toDate = (value: unknown) => {
+      if (typeof value !== "string") return null
+      const parsed = new Date(value)
+      return Number.isNaN(parsed.valueOf()) ? null : parsed
+    }
+
+    const windowStart = toDate(data?.windowStart)
+    const windowEnd = toDate(data?.windowEnd)
+    const rangeLabel =
+      windowStart && windowEnd
+        ? `${windowStart.toLocaleString(undefined, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          })} – ${windowEnd.toLocaleString(undefined, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          })}`
+        : "recent activity"
+
+    const digestItems = notifications
+      .map((item: any) => {
+        const title =
+          typeof item?.title === "string" && item.title.trim().length > 0
+            ? item.title.trim()
+            : "Update"
+        const message =
+          typeof item?.message === "string" ? item.message.trim() : ""
+        const createdAt = toDate(item?.createdAt)
+        const timestamp = createdAt
+          ? createdAt.toLocaleString(undefined, {
+              dateStyle: "medium",
+              timeStyle: "short",
+            })
+          : null
+
+        return {
+          title,
+          message,
+          timestamp,
+        }
+      })
+      .filter((item) => item.title || item.message)
+
+    const activityList = digestItems.length
+      ? `<ul style="padding-left: 16px;">
+          ${digestItems
+            .map(
+              (item) => `
+                <li style="margin-bottom: 16px;">
+                  <p style="margin: 0; font-weight: 600; color: #111827;">
+                    ${item.title}${
+                item.timestamp
+                  ? ` <span style="font-weight: 400; color: #4b5563;">(${item.timestamp})</span>`
+                  : ""
+              }
+                  </p>
+                  ${
+                    item.message
+                      ? `<p style="margin: 4px 0 0 0; color: #374151;">${item.message}</p>`
+                      : ""
+                  }
+                </li>
+              `,
+            )
+            .join("")}
+        </ul>`
+      : `<p style="color: #4b5563;">No new updates in this window.</p>`
+
+    const portalUrl = process.env.NEXT_PUBLIC_APP_URL || "https://roomsily.com"
+
+    return `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2>${
+          frequency === "weekly"
+            ? "Weekly household digest"
+            : "Daily household digest"
+        }</h2>
+        <p>${fullName ? `Hi ${fullName.split(" ")[0]},` : "Hi there,"}</p>
+        <p>Here's what happened in ${
+          windowStart && windowEnd
+            ? rangeLabel
+            : "your recent activity window"
+        }:</p>
+        ${activityList}
+        <p style="color: #4b5563;">Visit your portal to review the full details or respond.</p>
+        <a href="${
+          portalUrl
+        }/dashboard" style="background: #111827; color: #ffffff; padding: 10px 20px; text-decoration: none; border-radius: 6px; display: inline-block;">Open portal</a>
       </div>
     `
   }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -42,6 +42,9 @@ export type Database = {
         unit_id: string | null
         phone: string | null
         language: string | null
+        digest_frequency: 'daily' | 'weekly'
+        quiet_hours_start: string | null
+        quiet_hours_end: string | null
         stripe_customer_id: string | null
         rent_share: number | null
         metadata: Json | null

--- a/supabase/migrations/20250301_profiles_notification_preferences.sql
+++ b/supabase/migrations/20250301_profiles_notification_preferences.sql
@@ -1,0 +1,33 @@
+-- Add notification preferences columns to profiles for digest scheduling
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS digest_frequency TEXT;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN digest_frequency SET DEFAULT 'daily';
+
+UPDATE public.profiles
+SET digest_frequency = 'daily'
+WHERE digest_frequency IS NULL;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN digest_frequency SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.profiles'::regclass
+      AND conname = 'profiles_digest_frequency_check'
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_digest_frequency_check
+      CHECK (digest_frequency IN ('daily', 'weekly'));
+  END IF;
+END $$;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS quiet_hours_start TIME WITHOUT TIME ZONE;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS quiet_hours_end TIME WITHOUT TIME ZONE;

--- a/tests/lib/data/preferences.test.ts
+++ b/tests/lib/data/preferences.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  normalizeQuietHour,
+  persistNotificationPreferences,
+  type NotificationPreferencesInput,
+} from "@/lib/data/preferences"
+
+function createSupabaseStub(response: { error: { message: string } | null }) {
+  const eq = vi.fn().mockResolvedValue(response)
+  const update = vi.fn().mockReturnValue({ eq })
+  const from = vi.fn((table: string) => {
+    expect(table).toBe("profiles")
+    return { update }
+  })
+
+  return { from, update, eq }
+}
+
+describe("normalizeQuietHour", () => {
+  it("normalizes HH:MM values to include seconds", () => {
+    expect(normalizeQuietHour("21:30")).toBe("21:30:00")
+  })
+
+  it("returns existing seconds when provided", () => {
+    expect(normalizeQuietHour("07:45:30")).toBe("07:45:30")
+  })
+
+  it("returns null for empty values", () => {
+    expect(normalizeQuietHour(null)).toBeNull()
+    expect(normalizeQuietHour(" ")).toBeNull()
+  })
+
+  it("throws for invalid inputs", () => {
+    expect(() => normalizeQuietHour("99:00")).toThrow(/Invalid quiet hour value/)
+    expect(() => normalizeQuietHour("08:99")).toThrow(/Invalid quiet hour value/)
+    expect(() => normalizeQuietHour("invalid" as unknown as string)).toThrow(
+      /Invalid quiet hour value/,
+    )
+  })
+})
+
+describe("persistNotificationPreferences", () => {
+  const preferences: NotificationPreferencesInput = {
+    digestFrequency: "weekly",
+    quietHoursStart: "21:30",
+    quietHoursEnd: null,
+  }
+
+  it("updates the profile with normalized quiet hours", async () => {
+    const supabase = createSupabaseStub({ error: null })
+
+    const result = await persistNotificationPreferences(
+      supabase as any,
+      "user-123",
+      preferences,
+    )
+
+    expect(supabase.from).toHaveBeenCalledWith("profiles")
+    expect(supabase.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        digest_frequency: "weekly",
+        quiet_hours_start: "21:30:00",
+        quiet_hours_end: null,
+      }),
+    )
+    expect(supabase.eq).toHaveBeenCalledWith("id", "user-123")
+
+    expect(result.digest_frequency).toBe("weekly")
+    expect(result.quiet_hours_start).toBe("21:30:00")
+    expect(result.quiet_hours_end).toBeNull()
+    expect(result.updated_at).toMatch(/T/)
+  })
+
+  it("throws when supabase reports an error", async () => {
+    const supabase = createSupabaseStub({ error: { message: "boom" } })
+
+    await expect(
+      persistNotificationPreferences(supabase as any, "user-123", preferences),
+    ).rejects.toThrow(/Failed to update notification preferences: boom/)
+  })
+})

--- a/tests/lib/notifications/digest.test.ts
+++ b/tests/lib/notifications/digest.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isWithinQuietHours,
+  shouldSendDigest,
+  type DigestFrequency,
+} from "@/lib/notifications/digest"
+
+describe("isWithinQuietHours", () => {
+  it("returns true when current time falls within an overnight window", () => {
+    const now = new Date("2024-01-01T23:30:00")
+    expect(isWithinQuietHours(now, "22:00:00", "06:00:00")).toBe(true)
+  })
+
+  it("returns false when quiet hours are not configured", () => {
+    const now = new Date("2024-01-01T12:00:00")
+    expect(isWithinQuietHours(now, null, "06:00:00")).toBe(false)
+    expect(isWithinQuietHours(now, "22:00:00", null)).toBe(false)
+  })
+})
+
+describe("shouldSendDigest", () => {
+  const frequency: DigestFrequency = "daily"
+
+  it("skips sending when inside quiet hours", () => {
+    const now = new Date("2024-01-01T23:00:00")
+    const lastDigestAt = new Date("2023-12-31T09:00:00")
+
+    const result = shouldSendDigest({
+      now,
+      frequency,
+      lastDigestAt,
+      quietHoursStart: "22:00:00",
+      quietHoursEnd: "06:00:00",
+    })
+
+    expect(result.eligible).toBe(false)
+    expect(result.reason).toBe("within_quiet_hours")
+  })
+
+  it("skips when the digest interval has not elapsed", () => {
+    const now = new Date("2024-01-02T09:00:00")
+    const lastDigestAt = new Date(now.getTime() - 10 * 60 * 60 * 1000)
+
+    const result = shouldSendDigest({
+      now,
+      frequency,
+      lastDigestAt,
+      quietHoursStart: null,
+      quietHoursEnd: null,
+    })
+
+    expect(result.eligible).toBe(false)
+    expect(result.reason).toBe("interval_not_met")
+    expect(result.windowStart.toISOString()).toBe(lastDigestAt.toISOString())
+  })
+
+  it("allows sending once the interval has elapsed and outside quiet hours", () => {
+    const now = new Date("2024-01-02T09:30:00")
+    const lastDigestAt = new Date(now.getTime() - 26 * 60 * 60 * 1000)
+
+    const result = shouldSendDigest({
+      now,
+      frequency,
+      lastDigestAt,
+      quietHoursStart: "22:00:00",
+      quietHoursEnd: "06:00:00",
+    })
+
+    expect(result.eligible).toBe(true)
+    const expectedWindowStart = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+    expect(result.windowStart.toISOString()).toBe(expectedWindowStart.toISOString())
+  })
+})


### PR DESCRIPTION
## Summary
- add digest frequency and quiet hours columns to profiles and expose them through account settings
- provide a notification preferences form and persistence helpers for digest cadence and quiet hours
- implement digest compilation utilities with a cron endpoint and email template support

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b8f81f483288b889bc3c253823b