### PR TITLE
Add activity feed with audit logging

### DIFF
--- a/app/bookings/[id]/page.tsx
+++ b/app/bookings/[id]/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+import ActivityFeed from "@/components/activity/ActivityFeed";
+import { Separator } from "@/components/ui/separator";
+
+interface BookingDetailPageProps {
+  params: { id: string };
+}
+
+export default function BookingDetailPage({ params }: BookingDetailPageProps) {
+  const bookingId = params.id;
+
+  return (
+    <div className="container max-w-4xl space-y-6 py-10">
+      <div className="space-y-2">
+        <Link
+          href="/bookings"
+          className="text-sm text-muted-foreground transition hover:text-primary"
+        >
+          ← Back to bookings
+        </Link>
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Booking activity</h1>
+          <p className="text-sm text-muted-foreground">
+            Updates for amenity booking {bookingId}, including notes and schedule changes.
+          </p>
+        </div>
+      </div>
+
+      <Separator />
+
+      <ActivityFeed entityId={bookingId} entityType="booking" />
+    </div>
+  );
+}

--- a/app/bookings/components/booking-history.tsx
+++ b/app/bookings/components/booking-history.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export function BookingHistory() {
@@ -10,14 +12,16 @@ export function BookingHistory() {
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
       {items.map((x) => (
-        <Card key={x.id}>
-          <CardHeader>
-            <CardTitle className="text-base">{x.title}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-sm text-muted-foreground">{x.when}</div>
-          </CardContent>
-        </Card>
+        <Link key={x.id} href={`/bookings/${x.id}`} className="transition hover:no-underline">
+          <Card className="h-full transition hover:border-primary/50">
+            <CardHeader>
+              <CardTitle className="text-base">{x.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-sm text-muted-foreground">{x.when}</div>
+            </CardContent>
+          </Card>
+        </Link>
       ))}
     </div>
   );

--- a/app/documents/[id]/page.tsx
+++ b/app/documents/[id]/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+import ActivityFeed from "@/components/activity/ActivityFeed";
+import { Separator } from "@/components/ui/separator";
+
+interface DocumentDetailPageProps {
+  params: { id: string };
+}
+
+export default function DocumentDetailPage({ params }: DocumentDetailPageProps) {
+  const documentId = params.id;
+
+  return (
+    <div className="container max-w-4xl space-y-6 py-10">
+      <div className="space-y-2">
+        <Link
+          href="/documents"
+          className="text-sm text-muted-foreground transition hover:text-primary"
+        >
+          ← Back to documents
+        </Link>
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Document activity</h1>
+          <p className="text-sm text-muted-foreground">
+            Timeline of updates, comments, and shared files for document {documentId}.
+          </p>
+        </div>
+      </div>
+
+      <Separator />
+
+      <ActivityFeed entityId={documentId} entityType="document" />
+    </div>
+  );
+}

--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -6,6 +6,7 @@ import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
 import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import { recordActivityEvent } from '@/lib/data/activity';
 import { fetchMemberRole } from '@/lib/data/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import {
@@ -116,6 +117,7 @@ export async function uploadDocumentAction(
 ): Promise<ActionResult<Document>> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
   try {
     // Check authentication
@@ -201,6 +203,24 @@ export async function uploadDocumentAction(
       p_action: 'upload',
       p_metadata: { file_name: file.name, file_size: file.size }
     });
+
+    try {
+      await recordActivityEvent({
+        client: typedSupabase,
+        entityType: 'document',
+        entityId: document.id,
+        actorId: user.id,
+        eventType: 'attachment',
+        metadata: {
+          actor_label: user.email ?? user.id,
+          file_name: file.name,
+          file_size: file.size,
+          action: 'upload',
+        },
+      });
+    } catch (activityError) {
+      console.error('Failed to record document upload activity', activityError);
+    }
 
     revalidatePath('/documents');
     return { success: true, data: document, message: 'Document uploaded successfully.' };
@@ -379,6 +399,24 @@ export async function createSigningRequestAction(
       p_metadata: { envelope_id: signingResult.id, recipients: tenantEmails }
     });
 
+    try {
+      await recordActivityEvent({
+        client: typedSupabase,
+        entityType: 'document',
+        entityId: document.id,
+        actorId: user.id,
+        eventType: 'status_change',
+        metadata: {
+          actor_label: user.email ?? user.id,
+          to: 'pending_signature',
+          recipients: tenantEmails,
+          envelope_id: signingResult.id,
+        },
+      });
+    } catch (activityError) {
+      console.error('Failed to record signing request activity', activityError);
+    }
+
     revalidatePath('/documents');
     return {
       success: true,
@@ -401,6 +439,7 @@ export async function signDocumentAction(
 ): Promise<ActionResult> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
   try {
     // Check authentication
@@ -456,6 +495,23 @@ export async function signDocumentAction(
       p_action: 'signed',
       p_metadata: signatureData
     });
+
+    try {
+      await recordActivityEvent({
+        client: typedSupabase,
+        entityType: 'document',
+        entityId: documentId,
+        actorId: user.id,
+        eventType: 'status_change',
+        metadata: {
+          actor_label: user.email ?? user.id,
+          status: allSigned ? 'signed' : 'partially_signed',
+          signature_id: signature.id,
+        },
+      });
+    } catch (activityError) {
+      console.error('Failed to record signing activity', activityError);
+    }
 
     revalidatePath('/documents');
     return { success: true, message: 'Document signed successfully.' };

--- a/app/maintenance/[id]/page.tsx
+++ b/app/maintenance/[id]/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+import ActivityFeed from "@/components/activity/ActivityFeed";
+import { Separator } from "@/components/ui/separator";
+
+interface MaintenanceDetailPageProps {
+  params: { id: string };
+}
+
+export default function MaintenanceDetailPage({
+  params,
+}: MaintenanceDetailPageProps) {
+  const requestId = params.id;
+
+  return (
+    <div className="container max-w-4xl space-y-6 py-10">
+      <div className="space-y-2">
+        <Link
+          href="/maintenance"
+          className="text-sm text-muted-foreground transition hover:text-primary"
+        >
+          ← Back to maintenance
+        </Link>
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Maintenance request activity</h1>
+          <p className="text-sm text-muted-foreground">
+            Follow-up comments, attachments, and status history for request {requestId}.
+          </p>
+        </div>
+      </div>
+
+      <Separator />
+
+      <ActivityFeed entityId={requestId} entityType="maintenance" />
+    </div>
+  );
+}

--- a/components/activity/ActivityFeed.tsx
+++ b/components/activity/ActivityFeed.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import {
+  MessageSquareText,
+  Paperclip,
+  RefreshCw,
+  Loader2,
+  NotepadText,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { createClient } from "@/utils/supabase-browser";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import {
+  filterActivityEvents,
+  sortActivityEvents,
+  fetchActivityEvents,
+  normaliseActivityCategory,
+  type ActivityCategory,
+  type ActivityEntityType,
+  type ActivityEvent,
+} from "@/lib/data/activity";
+import { cn } from "@/lib/utils";
+
+const FILTER_OPTIONS: { label: string; value: ActivityCategory; icon: typeof MessageSquareText }[] = [
+  { label: "Comments", value: "comment", icon: MessageSquareText },
+  { label: "Status", value: "status_change", icon: RefreshCw },
+  { label: "Attachments", value: "attachment", icon: Paperclip },
+];
+
+interface ActivityFeedProps {
+  entityId: string;
+  entityType: ActivityEntityType;
+  className?: string;
+  initialFilters?: ActivityCategory[];
+}
+
+function eventIcon(category: ActivityCategory | null) {
+  switch (category) {
+    case "status_change":
+      return RefreshCw;
+    case "attachment":
+      return Paperclip;
+    case "comment":
+    default:
+      return MessageSquareText;
+  }
+}
+
+function formatStatusLabel(value: unknown) {
+  if (typeof value !== "string" || !value.length) {
+    return null;
+  }
+
+  return value
+    .replace(/_/g, " ")
+    .split(" ")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function renderEventSummary(event: ActivityEvent) {
+  const { category, message, metadata } = event;
+
+  if (typeof message === "string" && message.trim().length > 0) {
+    return message;
+  }
+
+  if (metadata && typeof metadata === "object") {
+    const record = metadata as Record<string, unknown>;
+
+    if (category === "comment") {
+      const comment = record.comment ?? record.note ?? record.body;
+      if (typeof comment === "string" && comment.trim().length > 0) {
+        return comment;
+      }
+      const summary = record.summary ?? record.message;
+      if (typeof summary === "string" && summary.trim().length > 0) {
+        return summary;
+      }
+      return "Left a comment.";
+    }
+
+    if (category === "status_change") {
+      const from = formatStatusLabel(record.from ?? record.previous_status);
+      const to = formatStatusLabel(record.to ?? record.status);
+
+      if (from && to) {
+        return `Status changed from ${from} to ${to}.`;
+      }
+
+      if (to) {
+        return `Status changed to ${to}.`;
+      }
+
+      return "Status updated.";
+    }
+
+    if (category === "attachment") {
+      const fileName =
+        record.file_name ?? record.filename ?? record.label ?? record.name;
+      if (typeof fileName === "string" && fileName.length > 0) {
+        return `Uploaded ${fileName}.`;
+      }
+
+      return "Added an attachment.";
+    }
+
+    const fallback = record.message ?? record.summary ?? record.description;
+    if (typeof fallback === "string" && fallback.trim().length > 0) {
+      return fallback;
+    }
+  }
+
+  switch (category) {
+    case "attachment":
+      return "Added an attachment.";
+    case "status_change":
+      return "Status updated.";
+    case "comment":
+    default:
+      return "New activity recorded.";
+  }
+}
+
+export function ActivityFeed({
+  entityId,
+  entityType,
+  className,
+  initialFilters,
+}: ActivityFeedProps) {
+  const supabase = useMemo(() => createClient() as unknown as TypedSupabaseClient, []);
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeFilters, setActiveFilters] = useState<ActivityCategory[]>(
+    initialFilters && initialFilters.length > 0
+      ? initialFilters
+      : FILTER_OPTIONS.map((option) => option.value),
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    setError(null);
+
+    fetchActivityEvents({
+      client: supabase,
+      entityId,
+      entityType,
+    })
+      .then((data) => {
+        if (!isMounted) return;
+        setEvents(sortActivityEvents(data));
+      })
+      .catch((fetchError) => {
+        console.error("Failed to load activity feed", fetchError);
+        if (!isMounted) return;
+        setError(
+          fetchError instanceof Error
+            ? fetchError.message
+            : "Failed to load activity feed.",
+        );
+      })
+      .finally(() => {
+        if (!isMounted) return;
+        setLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [entityId, entityType, supabase]);
+
+  const toggleFilter = useCallback(
+    (category: ActivityCategory) => {
+      setActiveFilters((current) => {
+        const set = new Set(current);
+        if (set.has(category)) {
+          set.delete(category);
+        } else {
+          set.add(category);
+        }
+
+        if (set.size === 0) {
+          return [];
+        }
+
+        return Array.from(set);
+      });
+    },
+    [],
+  );
+
+  const visibleEvents = useMemo(() => {
+    const filters = activeFilters.filter((value, index, array) => {
+      return array.indexOf(value) === index;
+    });
+
+    const filtered = filterActivityEvents(events, filters);
+    return sortActivityEvents(filtered);
+  }, [activeFilters, events]);
+
+  return (
+    <section className={cn("space-y-4", className)} aria-live="polite">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Activity</h2>
+          <p className="text-sm text-muted-foreground">
+            Comments, status changes, and attachments logged for this {entityType}.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {FILTER_OPTIONS.map((option) => {
+            const Icon = option.icon;
+            const normalisedFilters = activeFilters.map((value) =>
+              normaliseActivityCategory(value),
+            );
+            const isActive = normalisedFilters.includes(option.value);
+            return (
+              <Button
+                key={option.value}
+                type="button"
+                size="sm"
+                variant={isActive ? "default" : "outline"}
+                onClick={() => toggleFilter(option.value)}
+                className="flex items-center gap-1"
+              >
+                <Icon className="size-4" />
+                {option.label}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+
+      <Separator />
+
+      {loading ? (
+        <div className="space-y-3">
+          {[...Array(3)].map((_, index) => (
+            <div
+              key={index}
+              className="flex items-start gap-3 rounded-lg border bg-card/30 p-4"
+            >
+              <div className="mt-1 rounded-full bg-muted p-2">
+                <Loader2 className="size-4 animate-spin text-muted-foreground" />
+              </div>
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-1/4 rounded bg-muted" />
+                <div className="h-3 w-2/3 rounded bg-muted" />
+                <div className="h-3 w-1/3 rounded bg-muted" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4">
+          <p className="text-sm font-medium text-destructive">Unable to load activity.</p>
+          <p className="text-xs text-destructive/80">{error}</p>
+        </div>
+      ) : visibleEvents.length === 0 ? (
+        <div className="rounded-lg border bg-card/30 p-6 text-center">
+          <NotepadText className="mx-auto mb-3 size-6 text-muted-foreground" />
+          <p className="text-sm font-medium">No activity yet</p>
+          <p className="text-xs text-muted-foreground">
+            Updates will appear here as teammates leave comments, update statuses, or share files.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {visibleEvents.map((event) => {
+            const Icon = eventIcon(event.category);
+            const timestamp = (() => {
+              const date = new Date(event.createdAt);
+              if (Number.isNaN(date.getTime())) return null;
+              return formatDistanceToNow(date, { addSuffix: true });
+            })();
+            const summary = renderEventSummary(event);
+            const actor = event.actorName ?? event.metadata?.actor_label ?? "System";
+            return (
+              <li key={event.id} className="flex items-start gap-3">
+                <div className="mt-1 rounded-full bg-primary/10 p-2 text-primary">
+                  <Icon className="size-4" />
+                </div>
+                <article className="flex-1 space-y-3 rounded-lg border bg-card/50 p-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium">{actor}</span>
+                    {event.category && (
+                      <Badge variant="secondary" className="capitalize">
+                        {event.category.replace("_", " ")}
+                      </Badge>
+                    )}
+                    {timestamp && (
+                      <span className="text-xs text-muted-foreground">{timestamp}</span>
+                    )}
+                  </div>
+                  <p className="text-sm text-muted-foreground">{summary}</p>
+
+                  {event.attachments && event.attachments.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {event.attachments.map((attachment, index) => {
+                        const key = `${event.id}-attachment-${index}`;
+                        if (!attachment.label) {
+                          return null;
+                        }
+
+                        const badge = (
+                          <Badge key={key} variant="outline" className="max-w-xs truncate">
+                            <Paperclip className="mr-1 size-3" />
+                            {attachment.label}
+                          </Badge>
+                        );
+
+                        if (attachment.url) {
+                          return (
+                            <a
+                              key={key}
+                              href={attachment.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex"
+                            >
+                              {badge}
+                            </a>
+                          );
+                        }
+
+                        return badge;
+                      })}
+                    </div>
+                  )}
+                </article>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default ActivityFeed;

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -14,6 +14,7 @@ import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
+import { recordActivityEvent } from "@/lib/data/activity";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
 const maintenanceRequestSchema = z.object({
@@ -123,6 +124,24 @@ export function MaintenanceRequestForm() {
         title: "Maintenance request submitted",
         description: "Your maintenance request has been submitted and notifications sent.",
       });
+
+      try {
+        await recordActivityEvent({
+          client: typedSupabase,
+          entityType: 'maintenance',
+          entityId: request.id,
+          actorId: user.id,
+          eventType: 'comment',
+          metadata: {
+            actor_label: profile.full_name || user.email || user.id,
+            comment: data.description,
+            priority: data.priority,
+            title: data.title,
+          },
+        });
+      } catch (activityError) {
+        console.error('Failed to record maintenance activity', activityError);
+      }
 
       form.reset();
     } catch (error) {

--- a/lib/data/activity.ts
+++ b/lib/data/activity.ts
@@ -1,0 +1,295 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+
+export type ActivityEntityType = 'document' | 'booking' | 'maintenance';
+export type ActivityCategory = 'comment' | 'status_change' | 'attachment';
+
+export interface ActivityAttachment {
+  label: string;
+  url?: string | null;
+}
+
+export interface ActivityEvent {
+  id: string;
+  entityId: string;
+  entityType: ActivityEntityType;
+  category: ActivityCategory | null;
+  rawType: string;
+  createdAt: string;
+  actorId: string | null;
+  actorName: string | null;
+  message: string | null;
+  metadata: Record<string, unknown> | null;
+  attachments: ActivityAttachment[] | null;
+}
+
+export interface ActivityFilter {
+  types?: ActivityCategory[];
+}
+
+type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
+
+type ActivityRow = {
+  id: string;
+  created_at: string | null;
+  event_type: string | null;
+  actor_id: string | null;
+  message?: string | null;
+  description?: string | null;
+  note?: string | null;
+  metadata?: Record<string, unknown> | null;
+  attachments?: unknown;
+};
+
+type ActivityTableMetadata = {
+  table: string;
+  foreignKey: string;
+  label: string;
+};
+
+const ACTIVITY_TABLES: Record<ActivityEntityType, ActivityTableMetadata> = {
+  document: {
+    table: 'document_events',
+    foreignKey: 'document_id',
+    label: 'document',
+  },
+  booking: {
+    table: 'booking_events',
+    foreignKey: 'booking_id',
+    label: 'booking',
+  },
+  maintenance: {
+    table: 'maintenance_events',
+    foreignKey: 'request_id',
+    label: 'maintenance',
+  },
+};
+
+function normaliseAttachments(input: unknown): ActivityAttachment[] | null {
+  if (!input) {
+    return null;
+  }
+
+  const array = Array.isArray(input) ? input : [input];
+  const attachments = array
+    .map((item) => {
+      if (typeof item === 'string') {
+        return { label: item } satisfies ActivityAttachment;
+      }
+
+      if (!item || typeof item !== 'object') {
+        return null;
+      }
+
+      const record = item as Record<string, unknown>;
+      const labelCandidate =
+        record.label ??
+        record.name ??
+        record.file_name ??
+        record.filename ??
+        record.title;
+
+      const label = typeof labelCandidate === 'string' ? labelCandidate : null;
+      const urlCandidate = record.url ?? record.href ?? record.link;
+      const url = typeof urlCandidate === 'string' ? urlCandidate : null;
+
+      if (!label) {
+        return null;
+      }
+
+      return { label, url } satisfies ActivityAttachment;
+    })
+    .filter((value): value is ActivityAttachment => Boolean(value));
+
+  return attachments.length > 0 ? attachments : null;
+}
+
+export function normaliseActivityCategory(value: unknown): ActivityCategory | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalised = value.trim().toLowerCase();
+  switch (normalised) {
+    case 'comment':
+      return 'comment';
+    case 'status_change':
+    case 'status-change':
+    case 'status':
+      return 'status_change';
+    case 'attachment':
+    case 'attachments':
+      return 'attachment';
+    default:
+      return null;
+  }
+}
+
+function mapRowToEvent(
+  row: ActivityRow,
+  entityType: ActivityEntityType,
+  entityId: string,
+): ActivityEvent {
+  const rawType = row.event_type ?? 'unknown';
+  const category = normaliseActivityCategory(rawType);
+  const metadataRecord =
+    row.metadata && typeof row.metadata === 'object'
+      ? (row.metadata as Record<string, unknown>)
+      : null;
+
+  const message =
+    typeof row.message === 'string'
+      ? row.message
+      : typeof row.description === 'string'
+        ? row.description
+        : typeof row.note === 'string'
+          ? row.note
+          : metadataRecord && typeof metadataRecord['message'] === 'string'
+            ? (metadataRecord['message'] as string)
+            : metadataRecord && typeof metadataRecord['summary'] === 'string'
+              ? (metadataRecord['summary'] as string)
+              : null;
+
+  const actorNameCandidate =
+    metadataRecord && typeof metadataRecord['actor_name'] === 'string'
+      ? (metadataRecord['actor_name'] as string)
+      : null;
+  const actorName =
+    typeof actorNameCandidate === 'string' && actorNameCandidate.trim().length > 0
+      ? actorNameCandidate
+      : null;
+
+  const attachments = normaliseAttachments(
+    row.attachments ?? (metadataRecord ? metadataRecord['attachments'] : undefined),
+  );
+
+  return {
+    id: row.id,
+    entityId,
+    entityType,
+    rawType,
+    category,
+    createdAt: row.created_at ?? new Date().toISOString(),
+    actorId: row.actor_id ?? null,
+    actorName,
+    message,
+    metadata: metadataRecord,
+    attachments,
+  } satisfies ActivityEvent;
+}
+
+export function sortActivityEvents(events: ActivityEvent[]): ActivityEvent[] {
+  return [...events].sort((a, b) => {
+    const dateA = new Date(a.createdAt).getTime();
+    const dateB = new Date(b.createdAt).getTime();
+
+    if (Number.isNaN(dateA) && Number.isNaN(dateB)) {
+      return 0;
+    }
+
+    if (Number.isNaN(dateA)) {
+      return 1;
+    }
+
+    if (Number.isNaN(dateB)) {
+      return -1;
+    }
+
+    return dateB - dateA;
+  });
+}
+
+export function filterActivityEvents(
+  events: ActivityEvent[],
+  categories: ActivityCategory[] | undefined,
+): ActivityEvent[] {
+  if (!categories || categories.length === 0) {
+    return events;
+  }
+
+  const set = new Set(categories.map((category) => normaliseActivityCategory(category)).filter(Boolean));
+
+  if (set.size === 0) {
+    return events;
+  }
+
+  return events.filter((event) => {
+    if (!event.category) {
+      return true;
+    }
+
+    return set.has(event.category);
+  });
+}
+
+function handleSupabaseError(error: { message: string } | null, label: string) {
+  if (error) {
+    throw new Error(`Failed to fetch ${label} activity: ${error.message}`);
+  }
+}
+
+interface FetchActivityParams {
+  client: SupabaseClientLike;
+  entityType: ActivityEntityType;
+  entityId: string;
+  filters?: ActivityFilter;
+}
+
+export async function fetchActivityEvents({
+  client,
+  entityType,
+  entityId,
+  filters,
+}: FetchActivityParams): Promise<ActivityEvent[]> {
+  const tableMetadata = ACTIVITY_TABLES[entityType];
+  let query = (client as any)
+    .from(tableMetadata.table)
+    .select('id, created_at, event_type, actor_id, message, description, note, metadata, attachments')
+    .eq(tableMetadata.foreignKey, entityId)
+    .order('created_at', { ascending: false });
+
+  if (filters?.types && filters.types.length > 0) {
+    query = query.in('event_type', filters.types);
+  }
+
+  const { data, error } = await query;
+  handleSupabaseError(error, tableMetadata.label);
+
+  const rows = Array.isArray(data) ? (data as ActivityRow[]) : [];
+  const events = rows.map((row) => mapRowToEvent(row, entityType, entityId));
+
+  return sortActivityEvents(events);
+}
+
+interface CreateActivityEventParams {
+  client: SupabaseClientLike;
+  entityType: ActivityEntityType;
+  entityId: string;
+  actorId: string;
+  eventType: ActivityCategory;
+  metadata?: Record<string, unknown>;
+}
+
+export async function recordActivityEvent({
+  client,
+  entityType,
+  entityId,
+  actorId,
+  eventType,
+  metadata,
+}: CreateActivityEventParams): Promise<void> {
+  const tableMetadata = ACTIVITY_TABLES[entityType];
+  const payload = {
+    [tableMetadata.foreignKey]: entityId,
+    actor_id: actorId,
+    event_type: eventType,
+    metadata: metadata ?? {},
+  };
+
+  const { error } = await (client as any)
+    .from(tableMetadata.table)
+    .insert(payload);
+
+  if (error) {
+    throw new Error(`Failed to record ${tableMetadata.label} activity: ${error.message}`);
+  }
+}

--- a/tests/lib/data/activity.test.ts
+++ b/tests/lib/data/activity.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  filterActivityEvents,
+  sortActivityEvents,
+  fetchActivityEvents,
+  type ActivityEvent,
+} from '@/lib/data/activity';
+
+type QueryResult<T> = { data: T; error: { message: string } | null };
+
+type QueryBuilder<T> = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  then: (onFulfilled: (value: QueryResult<T>) => unknown) => Promise<unknown>;
+};
+
+function createActivityQuery<T extends unknown[]>(result: QueryResult<T>, tableName: string) {
+  const builder: Partial<QueryBuilder<T>> & {
+    select: ReturnType<typeof vi.fn>;
+    eq: ReturnType<typeof vi.fn>;
+    order: ReturnType<typeof vi.fn>;
+    in: ReturnType<typeof vi.fn>;
+  } = {
+    select: vi.fn().mockImplementation(() => builder),
+    eq: vi.fn().mockImplementation(() => builder),
+    order: vi.fn().mockImplementation(() => builder),
+    in: vi.fn().mockImplementation(() => builder),
+  };
+
+  (builder as QueryBuilder<T>).then = (onFulfilled) => Promise.resolve(onFulfilled(result));
+
+  const supabase = {
+    from: vi.fn((table: string) => {
+      expect(table).toBe(tableName);
+      return builder;
+    }),
+  };
+
+  return { builder: builder as QueryBuilder<T>, supabase };
+}
+
+describe('fetchActivityEvents', () => {
+  it('applies filters and sorts events for documents', async () => {
+    const rows = [
+      {
+        id: 'evt-1',
+        created_at: '2024-01-01T12:00:00.000Z',
+        event_type: 'comment',
+        actor_id: 'actor-1',
+        metadata: { comment: 'First comment', actor_name: 'Ada' },
+      },
+    ];
+
+    const { builder, supabase } = createActivityQuery({ data: rows as any, error: null }, 'document_events');
+
+    const events = await fetchActivityEvents({
+      client: supabase as any,
+      entityId: 'doc-1',
+      entityType: 'document',
+      filters: { types: ['comment'] },
+    });
+
+    expect(builder.select).toHaveBeenCalledWith(
+      'id, created_at, event_type, actor_id, message, description, note, metadata, attachments',
+    );
+    expect(builder.eq).toHaveBeenCalledWith('document_id', 'doc-1');
+    expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+    expect(builder.in).toHaveBeenCalledWith('event_type', ['comment']);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      id: 'evt-1',
+      entityId: 'doc-1',
+      entityType: 'document',
+      category: 'comment',
+      actorName: 'Ada',
+    });
+  });
+
+  it('throws when Supabase returns an error', async () => {
+    const { supabase } = createActivityQuery(
+      { data: null as any, error: { message: 'boom' } },
+      'document_events',
+    );
+
+    await expect(
+      fetchActivityEvents({ client: supabase as any, entityType: 'document', entityId: 'doc-1' })
+    ).rejects.toThrow(/Failed to fetch document activity: boom/);
+  });
+});
+
+describe('filterActivityEvents', () => {
+  it('keeps events that match the requested categories', () => {
+    const events: ActivityEvent[] = [
+      {
+        id: 'one',
+        entityId: '1',
+        entityType: 'document',
+        rawType: 'comment',
+        category: 'comment',
+        createdAt: '2024-01-01T12:00:00.000Z',
+        actorId: null,
+        actorName: null,
+        message: 'Hello',
+        metadata: null,
+        attachments: null,
+      },
+      {
+        id: 'two',
+        entityId: '1',
+        entityType: 'document',
+        rawType: 'status_change',
+        category: 'status_change',
+        createdAt: '2024-01-02T12:00:00.000Z',
+        actorId: null,
+        actorName: null,
+        message: 'Status',
+        metadata: null,
+        attachments: null,
+      },
+      {
+        id: 'three',
+        entityId: '1',
+        entityType: 'document',
+        rawType: 'attachment',
+        category: 'attachment',
+        createdAt: '2024-01-03T12:00:00.000Z',
+        actorId: null,
+        actorName: null,
+        message: 'File',
+        metadata: null,
+        attachments: null,
+      },
+    ];
+
+    const filtered = filterActivityEvents(events, ['comment', 'attachment']);
+    expect(filtered.map((event) => event.id)).toEqual(['one', 'three']);
+  });
+});
+
+describe('sortActivityEvents', () => {
+  it('orders events in reverse chronological order', () => {
+    const events: ActivityEvent[] = [
+      {
+        id: 'older',
+        entityId: '1',
+        entityType: 'booking',
+        rawType: 'comment',
+        category: 'comment',
+        createdAt: '2024-01-01T10:00:00.000Z',
+        actorId: null,
+        actorName: null,
+        message: 'A',
+        metadata: null,
+        attachments: null,
+      },
+      {
+        id: 'newer',
+        entityId: '1',
+        entityType: 'booking',
+        rawType: 'status_change',
+        category: 'status_change',
+        createdAt: '2024-01-03T10:00:00.000Z',
+        actorId: null,
+        actorName: null,
+        message: 'B',
+        metadata: null,
+        attachments: null,
+      },
+      {
+        id: 'middle',
+        entityId: '1',
+        entityType: 'booking',
+        rawType: 'attachment',
+        category: 'attachment',
+        createdAt: '2024-01-02T10:00:00.000Z',
+        actorId: null,
+        actorName: null,
+        message: 'C',
+        metadata: null,
+        attachments: null,
+      },
+    ];
+
+    const sorted = sortActivityEvents(events);
+    expect(sorted.map((event) => event.id)).toEqual(['newer', 'middle', 'older']);
+  });
+});


### PR DESCRIPTION
## Summary
- add an activity data access layer and React feed component that surfaces document, booking, and maintenance audit events with type filters
- hook document and maintenance mutations to persist audit entries and expose new entity detail routes that render the feed
- cover sorting and filtering behaviour with unit tests for the activity data helpers while wiring bookings UI to the new detail view

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b90e3c4832898108e230e65607b