### PR TITLE
Add locale/timezone preferences and locale-aware formatting

### DIFF
--- a/app/account/account-form.tsx
+++ b/app/account/account-form.tsx
@@ -33,17 +33,27 @@ import {
 } from "@/components/ui/popover"
 import { toast } from "@/components/ui/use-toast"
 
-const languages = [
-  { label: "English", value: "en" },
-  { label: "French", value: "fr" },
-  { label: "German", value: "de" },
-  { label: "Spanish", value: "es" },
-  { label: "Portuguese", value: "pt" },
-  { label: "Russian", value: "ru" },
-  { label: "Japanese", value: "ja" },
-  { label: "Korean", value: "ko" },
-  { label: "Chinese", value: "zh" },
+const localeOptions = [
+  { label: "English (United States)", value: "en-US" },
+  { label: "English (United Kingdom)", value: "en-GB" },
+  { label: "Français (France)", value: "fr-FR" },
+  { label: "Deutsch (Deutschland)", value: "de-DE" },
+  { label: "Español (España)", value: "es-ES" },
+  { label: "Português (Brasil)", value: "pt-BR" },
+  { label: "Português (Portugal)", value: "pt-PT" },
+  { label: "日本語", value: "ja-JP" },
+  { label: "한국어", value: "ko-KR" },
+  { label: "中文（简体）", value: "zh-CN" },
+  { label: "中文（繁體）", value: "zh-TW" },
 ] as const
+
+const localeValues = localeOptions.map((option) => option.value)
+const supportedTimeZones = Intl.supportedValuesOf("timeZone")
+const supportedTimeZoneSet = new Set(supportedTimeZones)
+const timeZoneOptions = supportedTimeZones.map((value) => ({
+  value,
+  label: value.replace(/_/g, " "),
+}))
 
 const accountFormSchema = z.object({
   name: z
@@ -57,15 +67,28 @@ const accountFormSchema = z.object({
   dob: z.date({
     required_error: "A date of birth is required.",
   }),
-  language: z.string({
-    required_error: "Please select a language.",
-  }),
+  locale: z
+    .string({
+      required_error: "Please select a locale.",
+    })
+    .refine((value) => localeValues.includes(value), {
+      message: "Please select a supported locale.",
+    }),
+  timeZone: z
+    .string({
+      required_error: "Please select a timezone.",
+    })
+    .refine((value) => supportedTimeZoneSet.has(value), {
+      message: "Please select a supported timezone.",
+    }),
 })
 
 type AccountFormValues = z.infer<typeof accountFormSchema>
 
 // This can come from your database or API.
 const defaultValues: Partial<AccountFormValues> = {
+  locale: "en-US",
+  timeZone: "UTC",
   // name: "Your name",
   // dob: new Date("2023-01-23"),
 }
@@ -153,10 +176,10 @@ export function AccountForm() {
         />
         <FormField
           control={form.control}
-          name="language"
+          name="locale"
           render={({ field }) => (
             <FormItem className="flex flex-col">
-              <FormLabel>Language</FormLabel>
+              <FormLabel>Locale</FormLabel>
               <Popover>
                 <PopoverTrigger asChild>
                   <FormControl>
@@ -164,41 +187,39 @@ export function AccountForm() {
                       variant="outline"
                       role="combobox"
                       className={cn(
-                        "w-[200px] justify-between",
+                        "w-[220px] justify-between",
                         !field.value && "text-muted-foreground"
                       )}
                     >
                       {field.value
-                        ? languages.find(
-                            (language) => language.value === field.value
-                          )?.label
-                        : "Select language"}
+                        ? localeOptions.find((locale) => locale.value === field.value)?.label
+                        : "Select locale"}
                       <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
                     </Button>
                   </FormControl>
                 </PopoverTrigger>
-                <PopoverContent className="w-[200px] p-0">
+                <PopoverContent className="w-[240px] p-0">
                   <Command>
-                    <CommandInput placeholder="Search language..." />
-                    <CommandEmpty>No language found.</CommandEmpty>
+                    <CommandInput placeholder="Search locale..." />
+                    <CommandEmpty>No locale found.</CommandEmpty>
                     <CommandGroup>
-                      {languages.map((language) => (
+                      {localeOptions.map((locale) => (
                         <CommandItem
-                          value={language.label}
-                          key={language.value}
-                          onSelect={() => {
-                            form.setValue("language", language.value)
+                          value={locale.value}
+                          key={locale.value}
+                          onSelect={(value) => {
+                            form.setValue("locale", value)
                           }}
                         >
                           <CheckIcon
                             className={cn(
                               "mr-2 size-4",
-                              language.value === field.value
+                              locale.value === field.value
                                 ? "opacity-100"
                                 : "opacity-0"
                             )}
                           />
-                          {language.label}
+                          {locale.label}
                         </CommandItem>
                       ))}
                     </CommandGroup>
@@ -206,7 +227,66 @@ export function AccountForm() {
                 </PopoverContent>
               </Popover>
               <FormDescription>
-                This is the language that will be used in the dashboard.
+                This controls currency, date, and number formatting.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="timeZone"
+          render={({ field }) => (
+            <FormItem className="flex flex-col">
+              <FormLabel>Timezone</FormLabel>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <FormControl>
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      className={cn(
+                        "w-[260px] justify-between",
+                        !field.value && "text-muted-foreground"
+                      )}
+                    >
+                      {field.value
+                        ? timeZoneOptions.find((option) => option.value === field.value)?.label
+                        : "Select timezone"}
+                      <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
+                    </Button>
+                  </FormControl>
+                </PopoverTrigger>
+                <PopoverContent className="w-[320px] p-0">
+                  <Command>
+                    <CommandInput placeholder="Search timezone..." />
+                    <CommandEmpty>No timezone found.</CommandEmpty>
+                    <CommandGroup>
+                      {timeZoneOptions.map((option) => (
+                        <CommandItem
+                          value={option.value}
+                          key={option.value}
+                          onSelect={(value) => {
+                            form.setValue("timeZone", value)
+                          }}
+                        >
+                          <CheckIcon
+                            className={cn(
+                              "mr-2 size-4",
+                              option.value === field.value
+                                ? "opacity-100"
+                                : "opacity-0"
+                            )}
+                          />
+                          {option.label}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              <FormDescription>
+                Events and reminders will be shown using this timezone.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/app/account/loaders.ts
+++ b/app/account/loaders.ts
@@ -14,7 +14,7 @@ import type { AccountProfile } from "./types"
 
 type ProfileRow = Pick<
   Database["public"]["Tables"]["profiles"]["Row"],
-  "full_name" | "username" | "website" | "avatar_url" | "email"
+  "full_name" | "username" | "website" | "avatar_url" | "email" | "locale" | "timezone"
 >
 
 export interface AccountPageData {
@@ -36,7 +36,7 @@ export async function loadAccountPageData(): Promise<AccountPageData> {
 
   const { data, error } = await supabase
     .from("profiles")
-    .select("full_name, username, website, avatar_url, email")
+    .select("full_name, username, website, avatar_url, email, locale, timezone")
     .eq("id", user.id)
     .maybeSingle<ProfileRow>()
 
@@ -45,14 +45,16 @@ export async function loadAccountPageData(): Promise<AccountPageData> {
   }
 
   const profile: AccountProfile | null = data
-    ? {
-        fullName: data.full_name,
-        username: data.username,
-        website: data.website,
-        avatarUrl: data.avatar_url,
-        email: data.email,
-      }
-    : null
+      ? {
+          fullName: data.full_name,
+          username: data.username,
+          website: data.website,
+          avatarUrl: data.avatar_url,
+          email: data.email,
+          locale: data.locale,
+          timeZone: data.timezone,
+        }
+      : null
 
   return { user, profile }
 }

--- a/app/account/supa-account-form.tsx
+++ b/app/account/supa-account-form.tsx
@@ -1,17 +1,74 @@
 "use client"
 
-import { useCallback, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import type { ChangeEvent, FormEvent } from "react"
 
+import { CaretSortIcon, CheckIcon } from "@radix-ui/react-icons"
 import type { User } from "@supabase/supabase-js"
 
-import { buttonVariants } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+} from "@/components/ui/command"
 import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import { toast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
 import useSupabaseBrowser from "@/utils/supabase-browser"
 
 import Avatar from "./avatar"
 import type { AccountProfile } from "./types"
+
+const DEFAULT_LOCALE = "en-US"
+const DEFAULT_TIME_ZONE = "UTC"
+
+const SUPPORTED_TIME_ZONES = Intl.supportedValuesOf("timeZone")
+const SUPPORTED_TIME_ZONE_SET = new Set(SUPPORTED_TIME_ZONES)
+
+const DEFAULT_LOCALE_CANDIDATES = [
+  "en-US",
+  "en-GB",
+  "fr-FR",
+  "de-DE",
+  "es-ES",
+  "pt-BR",
+  "pt-PT",
+  "it-IT",
+  "ja-JP",
+  "ko-KR",
+  "zh-CN",
+  "zh-TW",
+  "hi-IN",
+]
+
+function normalizeLocale(value: string | null | undefined): string | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const [canonical] = Intl.getCanonicalLocales([value])
+    return canonical ?? null
+  } catch (error) {
+    return null
+  }
+}
+
+function normalizeTimeZone(value: string | null | undefined): string | null {
+  if (!value) {
+    return null
+  }
+
+  return SUPPORTED_TIME_ZONE_SET.has(value) ? value : null
+}
 
 interface AccountFormProps {
   user: User
@@ -24,15 +81,59 @@ type ProfileState = {
   website: string
   avatarUrl: string
   email: string
+  locale: string
+  timeZone: string
 }
 
 function createProfileState(user: User, profile: AccountProfile | null): ProfileState {
+  const metadata = (user.user_metadata ?? {}) as Record<string, unknown>
+  const metadataLocale =
+    typeof metadata.locale === "string"
+      ? metadata.locale
+      : typeof metadata.preferred_locale === "string"
+        ? metadata.preferred_locale
+        : null
+  const metadataTimeZone =
+    typeof metadata.timezone === "string"
+      ? metadata.timezone
+      : typeof metadata.timeZone === "string"
+        ? metadata.timeZone
+        : typeof metadata.preferred_timezone === "string"
+          ? metadata.preferred_timezone
+          : typeof metadata.preferredTimeZone === "string"
+            ? metadata.preferredTimeZone
+            : null
+
+  const navigatorLocale =
+    typeof navigator !== "undefined" && typeof navigator.language === "string"
+      ? navigator.language
+      : null
+
+  const resolvedLocale =
+    normalizeLocale(profile?.locale) ??
+    normalizeLocale(metadataLocale) ??
+    normalizeLocale(navigatorLocale) ??
+    (typeof Intl !== "undefined"
+      ? normalizeLocale(Intl.DateTimeFormat().resolvedOptions().locale)
+      : null) ??
+    DEFAULT_LOCALE
+
+  const resolvedTimeZone =
+    normalizeTimeZone(profile?.timeZone) ??
+    normalizeTimeZone(metadataTimeZone) ??
+    (typeof Intl !== "undefined"
+      ? normalizeTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone)
+      : null) ??
+    DEFAULT_TIME_ZONE
+
   return {
     fullName: profile?.fullName ?? "",
     username: profile?.username ?? "",
     website: profile?.website ?? "",
     avatarUrl: profile?.avatarUrl ?? "",
     email: profile?.email ?? user.email ?? "",
+    locale: resolvedLocale,
+    timeZone: resolvedTimeZone,
   }
 }
 
@@ -40,21 +141,112 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
   const supabase = useSupabaseBrowser()
   const [profileState, setProfileState] = useState(() => createProfileState(user, profile))
   const [isSaving, setIsSaving] = useState(false)
+  const [isLocaleOpen, setIsLocaleOpen] = useState(false)
+  const [isTimeZoneOpen, setIsTimeZoneOpen] = useState(false)
+
+  const localeDisplayNames = useMemo(() => {
+    if (typeof Intl.DisplayNames === "undefined") {
+      return null
+    }
+
+    try {
+      return new Intl.DisplayNames([profileState.locale || DEFAULT_LOCALE], {
+        type: "language",
+      })
+    } catch (error) {
+      try {
+        return new Intl.DisplayNames([DEFAULT_LOCALE], { type: "language" })
+      } catch (nestedError) {
+        return null
+      }
+    }
+  }, [profileState.locale])
+
+  const localeOptions = useMemo(() => {
+    const runtimeLocales =
+      typeof navigator !== "undefined" && Array.isArray(navigator.languages)
+        ? navigator.languages
+        : []
+
+    const combined = [
+      ...runtimeLocales,
+      profile?.locale ?? null,
+      profileState.locale,
+      ...DEFAULT_LOCALE_CANDIDATES,
+    ].filter((value): value is string => Boolean(value))
+
+    const canonicalLocales = (() => {
+      try {
+        return Intl.getCanonicalLocales(combined)
+      } catch (error) {
+        return combined
+      }
+    })()
+
+    const supportedLocales = Intl.DateTimeFormat.supportedLocalesOf(
+      canonicalLocales,
+    )
+    const uniqueLocales = Array.from(new Set(supportedLocales))
+
+    return uniqueLocales
+      .map((value) => ({
+        value,
+        label: localeDisplayNames?.of(value) ?? value,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [localeDisplayNames, profile?.locale, profileState.locale])
+
+  const timezoneOptions = useMemo(
+    () =>
+      SUPPORTED_TIME_ZONES.map((value) => ({
+        value,
+        label: value.replace(/_/g, " "),
+      })),
+    [],
+  )
+
+  const selectedLocaleOption = useMemo(
+    () => localeOptions.find((option) => option.value === profileState.locale) ?? null,
+    [localeOptions, profileState.locale],
+  )
+
+  const selectedTimeZoneOption = useMemo(
+    () =>
+      timezoneOptions.find((option) => option.value === profileState.timeZone) ??
+      (profileState.timeZone
+        ? {
+            value: profileState.timeZone,
+            label: profileState.timeZone.replace(/_/g, " "),
+          }
+        : null),
+    [profileState.timeZone, timezoneOptions],
+  )
 
   const persistProfile = useCallback(
     async (overrides: Partial<ProfileState> = {}) => {
-      const payload = { ...profileState, ...overrides }
-      setProfileState(payload)
+      const merged = { ...profileState, ...overrides }
+      const normalizedLocale = normalizeLocale(merged.locale) ?? DEFAULT_LOCALE
+      const normalizedTimeZone =
+        normalizeTimeZone(merged.timeZone) ?? DEFAULT_TIME_ZONE
+      const nextState: ProfileState = {
+        ...merged,
+        locale: normalizedLocale,
+        timeZone: normalizedTimeZone,
+      }
+
+      setProfileState(nextState)
 
       setIsSaving(true)
       try {
         const { error } = await supabase.from("profiles").upsert({
           id: user.id,
-          full_name: payload.fullName || null,
-          username: payload.username || null,
-          website: payload.website || null,
-          avatar_url: payload.avatarUrl || null,
-          email: payload.email || null,
+          full_name: nextState.fullName || null,
+          username: nextState.username || null,
+          website: nextState.website || null,
+          avatar_url: nextState.avatarUrl || null,
+          email: nextState.email || null,
+          locale: nextState.locale || null,
+          timezone: nextState.timeZone || null,
           updated_at: new Date().toISOString(),
         })
 
@@ -64,7 +256,7 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
 
         toast({
           title: "Profile updated",
-          description: "We saved your latest contact details.",
+          description: "We saved your latest contact details and preferences.",
         })
       } catch (error) {
         console.error("Failed to update profile", error)
@@ -157,6 +349,120 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
             onChange={handleChange("website")}
             placeholder="https://sharehouse.example"
           />
+        </div>
+        <div className="flex flex-col">
+          <label
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            htmlFor="locale"
+          >
+            Locale
+          </label>
+          <Popover open={isLocaleOpen} onOpenChange={setIsLocaleOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                role="combobox"
+                aria-expanded={isLocaleOpen}
+                className="justify-between"
+              >
+                {selectedLocaleOption?.label ?? profileState.locale ?? "Select locale"}
+                <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[280px] p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Search locale..." />
+                <CommandEmpty>No locale found.</CommandEmpty>
+                <CommandGroup>
+                  {localeOptions.map((option) => (
+                    <CommandItem
+                      key={option.value}
+                      value={option.value}
+                      onSelect={(nextValue) => {
+                        const normalized = normalizeLocale(nextValue) ?? DEFAULT_LOCALE
+                        setProfileState((previous) => ({
+                          ...previous,
+                          locale: normalized,
+                        }))
+                        setIsLocaleOpen(false)
+                      }}
+                    >
+                      <CheckIcon
+                        className={cn(
+                          "mr-2 size-4",
+                          option.value === profileState.locale
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                      {option.label}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </Command>
+            </PopoverContent>
+          </Popover>
+          <p className="text-sm text-muted-foreground">
+            Choose how dates, numbers, and currency appear across the portal.
+          </p>
+        </div>
+        <div className="flex flex-col">
+          <label
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            htmlFor="timeZone"
+          >
+            Timezone
+          </label>
+          <Popover open={isTimeZoneOpen} onOpenChange={setIsTimeZoneOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                role="combobox"
+                aria-expanded={isTimeZoneOpen}
+                className="justify-between"
+              >
+                {selectedTimeZoneOption?.label ?? profileState.timeZone ?? "Select timezone"}
+                <CaretSortIcon className="ml-2 size-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[320px] p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Search timezone..." />
+                <CommandEmpty>No timezone found.</CommandEmpty>
+                <CommandGroup>
+                  {timezoneOptions.map((option) => (
+                    <CommandItem
+                      key={option.value}
+                      value={option.value}
+                      onSelect={(nextValue) => {
+                        const normalized = normalizeTimeZone(nextValue) ?? DEFAULT_TIME_ZONE
+                        setProfileState((previous) => ({
+                          ...previous,
+                          timeZone: normalized,
+                        }))
+                        setIsTimeZoneOpen(false)
+                      }}
+                    >
+                      <CheckIcon
+                        className={cn(
+                          "mr-2 size-4",
+                          option.value === profileState.timeZone
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                      {option.label}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </Command>
+            </PopoverContent>
+          </Popover>
+          <p className="text-sm text-muted-foreground">
+            We will use this timezone for reminders and activity history.
+          </p>
         </div>
         <button
           className={buttonVariants({ variant: "outline" })}

--- a/app/account/types.ts
+++ b/app/account/types.ts
@@ -4,4 +4,6 @@ export interface AccountProfile {
   website: string | null
   avatarUrl: string | null
   email: string | null
+  locale: string | null
+  timeZone: string | null
 }

--- a/app/payments/_components/catch-up-payment-card.tsx
+++ b/app/payments/_components/catch-up-payment-card.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState, useTransition } from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { format, parseISO } from "date-fns"
 import { useForm } from "react-hook-form"
 
 import { Button } from "@/components/ui/button"
@@ -40,6 +39,7 @@ import {
 import { formatCurrency, parseCurrencyInput, roundToCurrency } from "@/lib/payments/currency"
 import { createCatchUpFormSchema } from "@/lib/payments/schemas"
 import { AUTOPAY_STATUS_BADGES } from "@/lib/payments/status"
+import { formatDate, type IntlPreferences } from "@/lib/utils"
 import type {
   CatchUpBalance,
   CatchUpPaymentFormValues,
@@ -50,6 +50,7 @@ import { submitCatchUpPayment } from "../actions"
 
 interface CatchUpPaymentCardProps {
   balances: CatchUpBalance[]
+  intl?: IntlPreferences
 }
 
 type QuickAmountKey = "next" | "half" | "full"
@@ -60,7 +61,7 @@ type QuickAmount = {
   value: number
 }
 
-export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
+export function CatchUpPaymentCard({ balances, intl }: CatchUpPaymentCardProps) {
   const schema = useMemo(() => createCatchUpFormSchema(balances), [balances])
   const form = useForm<CatchUpPaymentFormValues>({
     resolver: zodResolver(schema),
@@ -173,7 +174,9 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
     if (nextCharge) {
       amounts.push({
         key: "next",
-        label: `Next charge (${formatCurrency(nextCharge.outstandingAmount, selectedBalance.currency)})`,
+        label: `Next charge (${formatCurrency(nextCharge.outstandingAmount, selectedBalance.currency, {
+          locale: intl?.locale,
+        })})`,
         value: roundToCurrency(nextCharge.outstandingAmount),
       })
     }
@@ -182,14 +185,18 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
     if (half > 0) {
       amounts.push({
         key: "half",
-        label: `Half balance (${formatCurrency(half, selectedBalance.currency)})`,
+        label: `Half balance (${formatCurrency(half, selectedBalance.currency, {
+          locale: intl?.locale,
+        })})`,
         value: half,
       })
     }
 
     amounts.push({
       key: "full",
-      label: `Pay in full (${formatCurrency(outstandingBalance, selectedBalance.currency)})`,
+      label: `Pay in full (${formatCurrency(outstandingBalance, selectedBalance.currency, {
+        locale: intl?.locale,
+      })})`,
       value: roundToCurrency(outstandingBalance),
     })
 
@@ -230,7 +237,11 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
         setLastResult(result)
         toast({
           title: `Catch-up scheduled for ${result.roommateName}`,
-          description: `${formatCurrency(result.amount, result.currency)} applied • New balance ${formatCurrency(result.projectedBalance, result.currency)}`,
+          description: `${formatCurrency(result.amount, result.currency, {
+            locale: intl?.locale,
+          })} applied • New balance ${formatCurrency(result.projectedBalance, result.currency, {
+            locale: intl?.locale,
+          })}`,
         })
 
         form.setValue(
@@ -307,7 +318,9 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                   <span className="font-medium">Outstanding</span>
                   <span>
                     {selectedBalance
-                      ? formatCurrency(outstandingBalance, selectedBalance.currency)
+                      ? formatCurrency(outstandingBalance, selectedBalance.currency, {
+                          locale: intl?.locale,
+                        })
                       : "—"}
                   </span>
                 </div>
@@ -321,7 +334,15 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                     </div>
                     <div>
                       <p className="font-medium text-foreground">Last payment</p>
-                      <p>{format(parseISO(selectedBalance.lastPaymentDate), "MMM d, yyyy")}</p>
+                      <p>
+                        {formatDate(selectedBalance.lastPaymentDate, {
+                          locale: intl?.locale,
+                          timeZone: intl?.timeZone,
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </p>
                     </div>
                   </div>
                 ) : null}
@@ -344,7 +365,9 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                     </FormControl>
                     <FormDescription>
                       {selectedBalance
-                        ? `${formatCurrency(outstandingBalance, selectedBalance.currency)} outstanding`
+                        ? `${formatCurrency(outstandingBalance, selectedBalance.currency, {
+                            locale: intl?.locale,
+                          })} outstanding`
                         : "Enter an amount to distribute across open charges."}
                     </FormDescription>
                     <FormMessage />
@@ -371,7 +394,9 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                   <span>Projected remaining</span>
                   <span>
                     {selectedBalance
-                      ? formatCurrency(projectedBalance, selectedBalance.currency)
+                      ? formatCurrency(projectedBalance, selectedBalance.currency, {
+                          locale: intl?.locale,
+                        })
                       : "—"}
                   </span>
                 </div>
@@ -420,18 +445,29 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                               </div>
                             </td>
                             <td className="py-2 pr-2 text-sm text-muted-foreground">
-                              {format(parseISO(charge.dueDate), "MMM d")}
+                              {formatDate(charge.dueDate, {
+                                locale: intl?.locale,
+                                timeZone: intl?.timeZone,
+                                month: "short",
+                                day: "numeric",
+                              })}
                             </td>
                             <td className="py-2 pr-2 text-right">
-                              {formatCurrency(charge.outstandingAmount, selectedBalance.currency)}
+                              {formatCurrency(charge.outstandingAmount, selectedBalance.currency, {
+                                locale: intl?.locale,
+                              })}
                             </td>
                             <td className="py-2 pr-2 text-right text-emerald-600">
                               {applyingAmount > 0
-                                ? `-${formatCurrency(applyingAmount, selectedBalance.currency)}`
+                                ? `-${formatCurrency(applyingAmount, selectedBalance.currency, {
+                                    locale: intl?.locale,
+                                  })}`
                                 : "—"}
                             </td>
                             <td className="py-2 pr-4 text-right">
-                              {formatCurrency(remainingAmount, selectedBalance.currency)}
+                              {formatCurrency(remainingAmount, selectedBalance.currency, {
+                                locale: intl?.locale,
+                              })}
                             </td>
                           </tr>
                         )
@@ -518,11 +554,18 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
                 </p>
               </div>
               <div className="text-sm font-semibold">
-                {formatCurrency(lastResult.amount, lastResult.currency)}
+                {formatCurrency(lastResult.amount, lastResult.currency, {
+                  locale: intl?.locale,
+                })}
               </div>
             </div>
             <div className="flex w-full flex-wrap items-center gap-2 text-xs text-muted-foreground">
-              <span>Remaining balance {formatCurrency(lastResult.projectedBalance, lastResult.currency)}</span>
+              <span>
+                Remaining balance{' '}
+                {formatCurrency(lastResult.projectedBalance, lastResult.currency, {
+                  locale: intl?.locale,
+                })}
+              </span>
               <span aria-hidden="true">•</span>
               <span>
                 Allocated to {lastResult.allocations.length} charge{lastResult.allocations.length === 1 ? "" : "s"}
@@ -531,7 +574,10 @@ export function CatchUpPaymentCard({ balances }: CatchUpPaymentCardProps) {
             <div className="flex w-full flex-wrap gap-2">
               {lastResult.allocations.map((allocation) => (
                 <Badge key={allocation.chargeId} variant="outline">
-                  {allocation.description}: {formatCurrency(allocation.amount, lastResult.currency)}
+                  {allocation.description}:{' '}
+                  {formatCurrency(allocation.amount, lastResult.currency, {
+                    locale: intl?.locale,
+                  })}
                 </Badge>
               ))}
             </div>

--- a/app/payments/_components/contribution-summary-card.tsx
+++ b/app/payments/_components/contribution-summary-card.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/card"
 import { summarizeContributionCategories } from "@/lib/payments/status"
 import { formatCurrency } from "@/lib/payments/currency"
+import type { IntlPreferences } from "@/lib/utils"
 import type { CatchUpBalance, CatchUpChargeCategory } from "@/types/payments"
 
 const CATEGORY_LABELS: Record<CatchUpChargeCategory, string> = {
@@ -21,9 +22,10 @@ const CATEGORY_LABELS: Record<CatchUpChargeCategory, string> = {
 
 interface ContributionSummaryCardProps {
   balances: CatchUpBalance[]
+  intl?: IntlPreferences
 }
 
-export function ContributionSummaryCard({ balances }: ContributionSummaryCardProps) {
+export function ContributionSummaryCard({ balances, intl }: ContributionSummaryCardProps) {
   const summaries = summarizeContributionCategories(balances)
   const defaultCurrency = balances[0]?.currency ?? "USD"
 
@@ -49,11 +51,16 @@ export function ContributionSummaryCard({ balances }: ContributionSummaryCardPro
           <div>
             <p className="text-sm font-medium">Outstanding total</p>
             <p className="text-lg font-semibold">
-              {formatCurrency(totalOutstanding, defaultCurrency)}
+              {formatCurrency(totalOutstanding, defaultCurrency, {
+                locale: intl?.locale,
+              })}
             </p>
           </div>
           <p className="text-xs text-muted-foreground">
-            {formatCurrency(totalIssued, defaultCurrency)} originally invoiced
+            {formatCurrency(totalIssued, defaultCurrency, {
+              locale: intl?.locale,
+            })}{" "}
+            originally invoiced
           </p>
         </div>
 
@@ -78,10 +85,14 @@ export function ContributionSummaryCard({ balances }: ContributionSummaryCardPro
                     </div>
                   </td>
                   <td className="py-2 pr-2 text-right">
-                    {formatCurrency(summary.outstandingAmount, defaultCurrency)}
+                    {formatCurrency(summary.outstandingAmount, defaultCurrency, {
+                      locale: intl?.locale,
+                    })}
                   </td>
                   <td className="py-2 pr-4 text-right text-muted-foreground">
-                    {formatCurrency(summary.originalAmount, defaultCurrency)}
+                    {formatCurrency(summary.originalAmount, defaultCurrency, {
+                      locale: intl?.locale,
+                    })}
                   </td>
                 </tr>
               ))}

--- a/app/payments/_components/payment-status-feed.tsx
+++ b/app/payments/_components/payment-status-feed.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
-import { formatDistanceToNow, parseISO } from "date-fns"
 
 import { Badge } from "@/components/ui/badge"
 import {
@@ -24,12 +23,14 @@ import { formatCurrency, roundToCurrency } from "@/lib/payments/currency"
 import type { CatchUpBalance } from "@/types/payments"
 import type { Tables } from "@/lib/supabase"
 import { createClient } from "@/utils/supabase-browser"
+import { formatRelativeTimeFromNow, type IntlPreferences } from "@/lib/utils"
 
 type StripePaymentStatus = Tables<"rent_payments">["status"]
 type PaymentFeedStatus = StripePaymentStatus | "history"
 
 interface PaymentStatusFeedProps {
   balances: CatchUpBalance[]
+  intl?: IntlPreferences
 }
 
 interface PaymentFeedEvent {
@@ -48,23 +49,11 @@ interface PaymentFeedEvent {
 const MAX_FEED_EVENTS = 20
 
 function safeParseDate(value: string): string {
-  try {
-    const parsed = parseISO(value)
-    if (Number.isNaN(parsed.getTime())) {
-      return new Date().toISOString()
-    }
-    return parsed.toISOString()
-  } catch (error) {
+  const parsed = new Date(value)
+  if (!Number.isFinite(parsed.getTime())) {
     return new Date().toISOString()
   }
-}
-
-function formatRelativeTime(isoDate: string): string {
-  try {
-    return formatDistanceToNow(parseISO(isoDate), { addSuffix: true })
-  } catch (error) {
-    return "just now"
-  }
+  return parsed.toISOString()
 }
 
 function getFeedStatusLabel(status: StripePaymentStatus, isAutopay: boolean): string {
@@ -98,7 +87,7 @@ function getFeedBadgeVariant(status: PaymentFeedStatus): "outline" | "secondary"
   return "outline"
 }
 
-export function PaymentStatusFeed({ balances }: PaymentStatusFeedProps) {
+export function PaymentStatusFeed({ balances, intl }: PaymentStatusFeedProps) {
   const initialStatuses = useMemo<RoommateAutopayState[]>(
     () => createRoommateAutopayState(balances),
     [balances],
@@ -257,15 +246,10 @@ export function PaymentStatusFeed({ balances }: PaymentStatusFeedProps) {
       <CardContent className="space-y-6">
         <div className="space-y-3">
           {roommateStatuses.map((status) => {
-            const lastPaymentLabel = (() => {
-              try {
-                return formatDistanceToNow(parseISO(status.lastPaymentDate), {
-                  addSuffix: true,
-                })
-              } catch (error) {
-                return status.lastPaymentDate
-              }
-            })()
+            const lastPaymentLabel = formatRelativeTimeFromNow(
+              status.lastPaymentDate,
+              { locale: intl?.locale },
+            ) || status.lastPaymentDate
 
             return (
               <div
@@ -278,7 +262,10 @@ export function PaymentStatusFeed({ balances }: PaymentStatusFeedProps) {
                     {status.unitLabel} · {describeAutopayStatus(status.autopayStatus, status.autopayDay)}
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    Last payment {lastPaymentLabel} · {formatCurrency(status.lastPaymentAmount, status.currency)}
+                    Last payment {lastPaymentLabel} ·{' '}
+                    {formatCurrency(status.lastPaymentAmount, status.currency, {
+                      locale: intl?.locale,
+                    })}
                   </p>
                 </div>
                 <div className="text-right">
@@ -286,7 +273,10 @@ export function PaymentStatusFeed({ balances }: PaymentStatusFeedProps) {
                     {AUTOPAY_STATUS_BADGES[status.autopayStatus].label}
                   </Badge>
                   <p className="mt-1 text-xs text-muted-foreground">
-                    Outstanding {formatCurrency(status.outstanding, status.currency)}
+                    Outstanding{' '}
+                    {formatCurrency(status.outstanding, status.currency, {
+                      locale: intl?.locale,
+                    })}
                   </p>
                 </div>
               </div>
@@ -325,13 +315,19 @@ export function PaymentStatusFeed({ balances }: PaymentStatusFeedProps) {
                             : event.stripeStatus}
                         </Badge>
                         <p className="mt-1 text-xs text-muted-foreground">
-                          {formatCurrency(event.amount, event.currency)}
+                          {formatCurrency(event.amount, event.currency, {
+                            locale: intl?.locale,
+                          })}
                         </p>
                       </div>
                     </div>
                     <Separator />
                     <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
-                      <span>{formatRelativeTime(event.occurredAt)}</span>
+                      <span>
+                        {formatRelativeTimeFromNow(event.occurredAt, {
+                          locale: intl?.locale,
+                        })}
+                      </span>
                       {event.category ? <span className="capitalize">{event.category}</span> : null}
                     </div>
                   </div>

--- a/app/payments/_components/receipt-history-card.tsx
+++ b/app/payments/_components/receipt-history-card.tsx
@@ -1,4 +1,3 @@
-import { format, parseISO } from "date-fns"
 import { Download, FileText } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
@@ -18,9 +17,11 @@ import {
   summarizeReceiptHistory,
 } from "@/lib/payments/receipts"
 import type { PaymentReceiptHistoryEntry } from "@/types/payments"
+import { formatDate, type IntlPreferences } from "@/lib/utils"
 
 interface ReceiptHistoryCardProps {
   receipts: PaymentReceiptHistoryEntry[]
+  intl?: IntlPreferences
 }
 
 const statusStyles: Record<
@@ -35,26 +36,46 @@ const statusStyles: Record<
 function formatPeriod(
   periodStart: string | undefined,
   periodEnd: string | undefined,
+  intl?: IntlPreferences,
 ) {
   if (!periodStart && !periodEnd) {
     return "—"
   }
 
   if (periodStart && periodEnd) {
-    const start = format(parseISO(periodStart), "MMM d")
-    const end = format(parseISO(periodEnd), "MMM d, yyyy")
+    const start = formatDate(periodStart, {
+      locale: intl?.locale,
+      timeZone: intl?.timeZone,
+      month: "short",
+      day: "numeric",
+    })
+    const end = formatDate(periodEnd, {
+      locale: intl?.locale,
+      timeZone: intl?.timeZone,
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })
     return `${start} – ${end}`
   }
 
   const singleDate = periodStart ?? periodEnd
-  return singleDate ? format(parseISO(singleDate), "MMM d, yyyy") : "—"
+  return singleDate
+    ? formatDate(singleDate, {
+        locale: intl?.locale,
+        timeZone: intl?.timeZone,
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "—"
 }
 
 function encodeCsvForDownload(content: string) {
   return `data:text/csv;charset=utf-8,${encodeURIComponent(content)}`
 }
 
-export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
+export function ReceiptHistoryCard({ receipts, intl }: ReceiptHistoryCardProps) {
   if (!receipts.length) {
     return (
       <Card>
@@ -84,7 +105,13 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
   }).length
 
   const lastReceiptLabel = summary.lastReceiptDate
-    ? format(parseISO(summary.lastReceiptDate), "MMM d, yyyy")
+    ? formatDate(summary.lastReceiptDate, {
+        locale: intl?.locale,
+        timeZone: intl?.timeZone,
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
     : "—"
 
   const defaultCurrency = receipts[0]?.currency ?? "USD"
@@ -118,7 +145,9 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
               {paidReceiptsThisYear}
             </dd>
             <p className="text-xs text-muted-foreground">
-              {formatCurrency(summary.yearToDateAmount, defaultCurrency)}
+              {formatCurrency(summary.yearToDateAmount, defaultCurrency, {
+                locale: intl?.locale,
+              })}
               {" total processed"}
             </p>
           </div>
@@ -163,11 +192,17 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
                     <tr key={receipt.id} className="align-top">
                       <td className="p-4">
                         <div className="space-y-1">
-                          <p className="text-sm font-medium text-foreground">
+                        <p className="text-sm font-medium text-foreground">
                             {receipt.issuedTo}
                           </p>
                           <p className="text-xs text-muted-foreground">
-                            {format(parseISO(receipt.paymentDate), "MMM d, yyyy")} · {receipt.paymentMethod}
+                            {formatDate(receipt.paymentDate, {
+                              locale: intl?.locale,
+                              timeZone: intl?.timeZone,
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                            })} · {receipt.paymentMethod}
                           </p>
                           {receipt.memo ? (
                             <p className="text-xs text-muted-foreground">
@@ -177,7 +212,7 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
                         </div>
                       </td>
                       <td className="p-4 text-sm text-muted-foreground">
-                        {formatPeriod(receipt.periodStart, receipt.periodEnd)}
+                        {formatPeriod(receipt.periodStart, receipt.periodEnd, intl)}
                       </td>
                       <td className="p-4">
                         <ul className="space-y-1">
@@ -195,7 +230,9 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
                                   item.totalAmount < 0 && "text-destructive",
                                 )}
                               >
-                                {formatCurrency(item.totalAmount, receipt.currency)}
+                                {formatCurrency(item.totalAmount, receipt.currency, {
+                                  locale: intl?.locale,
+                                })}
                               </span>
                             </li>
                           ))}
@@ -208,7 +245,9 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
                             receipt.amount < 0 && "text-destructive",
                           )}
                         >
-                          {formatCurrency(receipt.amount, receipt.currency)}
+                          {formatCurrency(receipt.amount, receipt.currency, {
+                            locale: intl?.locale,
+                          })}
                         </div>
                         {receipt.amount < 0 ? (
                           <p className="text-xs text-muted-foreground">Credit issued</p>

--- a/app/payments/_components/roommate-ledger.tsx
+++ b/app/payments/_components/roommate-ledger.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from "react"
-import { format, parseISO } from "date-fns"
 
 import { Badge, type BadgeProps } from "@/components/ui/badge"
 import {
@@ -11,7 +10,7 @@ import {
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { formatCurrency, roundToCurrency } from "@/lib/payments/currency"
-import { cn } from "@/lib/utils"
+import { cn, formatDate, type IntlPreferences } from "@/lib/utils"
 import type {
   LedgerActorRole,
   LedgerEntryType,
@@ -20,6 +19,7 @@ import type {
 
 interface RoommateLedgerProps {
   ledgers: RoommateLedger[]
+  intl?: IntlPreferences
 }
 
 type LedgerRow = RoommateLedger["entries"][number] & { balanceAfter: number }
@@ -37,7 +37,7 @@ const actorRoleLabels: Record<LedgerActorRole, string> = {
   property_manager: "Property manager",
 }
 
-export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
+export function RoommateLedger({ ledgers, intl }: RoommateLedgerProps) {
   if (ledgers.length === 0) {
     return null
   }
@@ -90,7 +90,13 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
             index,
           ) => {
             const lastUpdatedLabel = lastUpdated
-              ? format(parseISO(lastUpdated), "MMM d, yyyy")
+              ? formatDate(lastUpdated, {
+                  locale: intl?.locale,
+                  timeZone: intl?.timeZone,
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })
               : null
             const contributionsCopy =
               contributionsCount === 1
@@ -124,10 +130,15 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
                         Outstanding
                       </p>
                       <p className="text-sm font-semibold">
-                        {formatCurrency(currentOutstanding, ledger.currency)}
+                        {formatCurrency(currentOutstanding, ledger.currency, {
+                          locale: intl?.locale,
+                        })}
                       </p>
                       <p className="text-xs text-muted-foreground">
-                        Started at {formatCurrency(ledger.startingBalance, ledger.currency)}
+                        Started at{' '}
+                        {formatCurrency(ledger.startingBalance, ledger.currency, {
+                          locale: intl?.locale,
+                        })}
                       </p>
                     </div>
                   </div>
@@ -141,9 +152,17 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
                       </div>
                       <div className="[&>div:not(:last-child)]:border-b">
                         {rows.map((entry) => {
-                          const entryDate = parseISO(entry.date)
-                          const formattedDate = format(entryDate, "MMM d")
-                          const formattedYear = format(entryDate, "yyyy")
+                          const formattedDate = formatDate(entry.date, {
+                            locale: intl?.locale,
+                            timeZone: intl?.timeZone,
+                            month: "short",
+                            day: "numeric",
+                          })
+                          const formattedYear = formatDate(entry.date, {
+                            locale: intl?.locale,
+                            timeZone: intl?.timeZone,
+                            year: "numeric",
+                          })
                           const amountClass =
                             entry.amount < 0
                               ? "text-emerald-600"
@@ -178,7 +197,7 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
                               </div>
                               <div className="flex flex-col items-end gap-1 text-right">
                                 <span className={cn("font-semibold", amountClass)}>
-                                  {formatLedgerChange(entry.amount, ledger.currency)}
+                                  {formatLedgerChange(entry.amount, ledger.currency, intl?.locale)}
                                 </span>
                                 <Badge
                                   variant={entryTypeMeta.badgeVariant}
@@ -189,7 +208,9 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
                               </div>
                               <div className="text-right">
                                 <p className="font-semibold">
-                                  {formatCurrency(entry.balanceAfter, ledger.currency)}
+                                  {formatCurrency(entry.balanceAfter, ledger.currency, {
+                                    locale: intl?.locale,
+                                  })}
                                 </p>
                                 <p className="text-xs text-muted-foreground">
                                   Running balance
@@ -216,11 +237,15 @@ export function RoommateLedger({ ledgers }: RoommateLedgerProps) {
   )
 }
 
-function formatLedgerChange(amount: number, currency: string): string {
+function formatLedgerChange(
+  amount: number,
+  currency: string,
+  locale?: string | null,
+): string {
   if (amount === 0) {
-    return formatCurrency(0, currency)
+    return formatCurrency(0, currency, { locale })
   }
 
   const prefix = amount > 0 ? "+" : "-"
-  return `${prefix}${formatCurrency(Math.abs(amount), currency)}`
+  return `${prefix}${formatCurrency(Math.abs(amount), currency, { locale })}`
 }

--- a/app/payments/loaders.ts
+++ b/app/payments/loaders.ts
@@ -2,11 +2,16 @@
 
 import "server-only"
 
+import { cookies } from "next/headers"
+
 import { catchUpBalances, receiptHistory } from "@/lib/payments/mock-data"
+import type { Database } from "@/lib/supabase"
 import type {
   CatchUpBalance,
   PaymentReceiptHistoryEntry,
 } from "@/types/payments"
+import type { IntlPreferences } from "@/lib/utils"
+import { createClient } from "@/utils/supa-server-actions"
 
 
 export async function loadCatchUpBalances(): Promise<CatchUpBalance[]> {
@@ -16,4 +21,55 @@ export async function loadCatchUpBalances(): Promise<CatchUpBalance[]> {
 export async function loadReceiptHistory(): Promise<PaymentReceiptHistoryEntry[]> {
   return receiptHistory
 
+}
+
+type ProfilePreferencesRow = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "locale" | "timezone"
+>
+
+export async function loadViewerFormattingPreferences(): Promise<IntlPreferences> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { locale: null, timeZone: null }
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("locale, timezone")
+    .eq("id", user.id)
+    .maybeSingle<ProfilePreferencesRow>()
+
+  if (error) {
+    console.error("Failed to load formatting preferences", error)
+  }
+
+  const metadata = (user.user_metadata ?? {}) as Record<string, unknown>
+  const metadataLocale =
+    typeof metadata.locale === "string"
+      ? metadata.locale
+      : typeof metadata.preferred_locale === "string"
+        ? metadata.preferred_locale
+        : null
+  const metadataTimeZone =
+    typeof metadata.timezone === "string"
+      ? metadata.timezone
+      : typeof metadata.timeZone === "string"
+        ? metadata.timeZone
+        : typeof metadata.preferred_timezone === "string"
+          ? metadata.preferred_timezone
+          : typeof metadata.preferredTimeZone === "string"
+            ? metadata.preferredTimeZone
+            : null
+
+  return {
+    locale: data?.locale ?? metadataLocale ?? null,
+    timeZone: data?.timezone ?? metadataTimeZone ?? null,
+  }
 }

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -1,4 +1,3 @@
-import { format, parseISO } from "date-fns"
 import { CheckCircle2 } from "lucide-react"
 
 import {
@@ -20,8 +19,13 @@ import {
 } from "@/lib/payments/catch-up"
 import { formatCurrency } from "@/lib/payments/currency"
 import { describeAutopayStatus } from "@/lib/payments/status"
+import { formatDate, type IntlPreferences } from "@/lib/utils"
 
-import { loadCatchUpBalances, loadReceiptHistory } from "./loaders"
+import {
+  loadCatchUpBalances,
+  loadReceiptHistory,
+  loadViewerFormattingPreferences,
+} from "./loaders"
 import { ReceiptHistoryCard } from "./_components/receipt-history-card"
 
 
@@ -68,15 +72,21 @@ const paymentHighlights = [
   },
 ]
 
-function formatFullDate(date: string) {
-  return format(parseISO(date), "MMM d, yyyy")
+function formatFullDate(date: string, intl: IntlPreferences) {
+  return formatDate(date, {
+    locale: intl.locale,
+    timeZone: intl.timeZone,
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
 }
 
 export default async function PaymentsPage() {
-  const [catchUpBalances, receiptHistory] = await Promise.all([
+  const [catchUpBalances, receiptHistory, formatting] = await Promise.all([
     loadCatchUpBalances(),
     loadReceiptHistory(),
-
+    loadViewerFormattingPreferences(),
   ])
   const outstandingSummaries = catchUpBalances.map((balance) => {
     const outstanding = calculateOutstanding(balance.charges)
@@ -157,7 +167,9 @@ export default async function PaymentsPage() {
                     Outstanding total
                   </dt>
                   <dd className="text-lg font-semibold">
-                    {formatCurrency(totalOutstanding, defaultCurrency)}
+                    {formatCurrency(totalOutstanding, defaultCurrency, {
+                      locale: formatting.locale,
+                    })}
                   </dd>
                   <p className="text-xs text-muted-foreground">
                     {catchUpBalances.length} roommates tracked
@@ -207,19 +219,27 @@ export default async function PaymentsPage() {
                       {balance.unitLabel} · {describeAutopayStatus(balance.autopayStatus, balance.autopayDay)}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      Last payment {formatFullDate(balance.lastPaymentDate)} · {formatCurrency(
-                        balance.lastPaymentAmount,
-                        balance.currency,
-                      )}
+                      Last payment {formatFullDate(balance.lastPaymentDate, formatting)} ·{' '}
+                      {formatCurrency(balance.lastPaymentAmount, balance.currency, {
+                        locale: formatting.locale,
+                      })}
                     </p>
                   </div>
                   <div className="text-right">
                     <p className="text-sm font-semibold">
-                      {formatCurrency(outstanding, balance.currency)}
+                      {formatCurrency(outstanding, balance.currency, {
+                        locale: formatting.locale,
+                      })}
                     </p>
                     {nextCharge ? (
                       <p className="text-xs text-muted-foreground">
-                        Next: {nextCharge.description} due {format(parseISO(nextCharge.dueDate), "MMM d")}
+                        Next: {nextCharge.description} due{' '}
+                        {formatDate(nextCharge.dueDate, {
+                          locale: formatting.locale,
+                          timeZone: formatting.timeZone,
+                          month: "short",
+                          day: "numeric",
+                        })}
                       </p>
                     ) : (
                       <p className="text-xs text-muted-foreground">No outstanding charges</p>
@@ -229,8 +249,8 @@ export default async function PaymentsPage() {
               ))}
             </CardContent>
           </Card>
-          <PaymentStatusFeed balances={catchUpBalances} />
-          <ContributionSummaryCard balances={catchUpBalances} />
+          <PaymentStatusFeed balances={catchUpBalances} intl={formatting} />
+          <ContributionSummaryCard balances={catchUpBalances} intl={formatting} />
           <Card>
             <CardHeader>
               <CardTitle>Pay with Stripe</CardTitle>
@@ -241,9 +261,9 @@ export default async function PaymentsPage() {
             </CardContent>
           </Card>
         </div>
-        <CatchUpPaymentCard balances={catchUpBalances} />
+        <CatchUpPaymentCard balances={catchUpBalances} intl={formatting} />
       </section>
-      <ReceiptHistoryCard receipts={receiptHistory} />
+      <ReceiptHistoryCard receipts={receiptHistory} intl={formatting} />
 
     </div>
   )

--- a/lib/payments/currency.ts
+++ b/lib/payments/currency.ts
@@ -1,3 +1,5 @@
+import { formatNumber } from "@/lib/utils"
+
 export function roundToCurrency(value: number): number {
   return Math.round(value * 100) / 100
 }
@@ -20,12 +22,24 @@ export function parseCurrencyInput(rawValue: string): number {
   return roundToCurrency(parsed)
 }
 
-export function formatCurrency(amount: number, currency: string): string {
+export interface CurrencyFormatOptions extends Intl.NumberFormatOptions {
+  locale?: string | null
+}
+
+export function formatCurrency(
+  amount: number,
+  currency: string,
+  options?: CurrencyFormatOptions,
+): string {
+  const { locale, ...overrides } = options ?? {}
+
   try {
-    return new Intl.NumberFormat("en-US", {
+    return formatNumber(amount, {
+      locale,
       style: "currency",
       currency,
-    }).format(amount)
+      ...overrides,
+    })
   } catch (error) {
     return `${roundToCurrency(amount).toFixed(2)} ${currency.toUpperCase()}`
   }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -42,6 +42,8 @@ export type Database = {
         unit_id: string | null
         phone: string | null
         language: string | null
+        locale: string | null
+        timezone: string | null
         stripe_customer_id: string | null
         rent_share: number | null
         metadata: Json | null

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -11,6 +11,64 @@ export interface CollectionCacheSignature {
 
 const fetchResponseCache = new Map<string, { etag: string; data: unknown }>()
 
+export interface IntlPreferences {
+  locale?: string | null
+  timeZone?: string | null
+}
+
+const systemDefaultLocale = (() => {
+  try {
+    const { locale } = new Intl.DateTimeFormat().resolvedOptions()
+    if (locale && locale.length > 0) {
+      return locale
+    }
+  } catch (error) {
+    // ignore and fallback below
+  }
+
+  return "en-US"
+})()
+
+const systemDefaultTimeZone = (() => {
+  try {
+    const { timeZone } = new Intl.DateTimeFormat().resolvedOptions()
+    if (timeZone && timeZone.length > 0) {
+      return timeZone
+    }
+  } catch (error) {
+    // ignore and fallback below
+  }
+
+  return "UTC"
+})()
+
+const defaultDateFormat: Intl.DateTimeFormatOptions = {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+}
+
+const defaultNumberFormat: Intl.NumberFormatOptions = {
+  style: "currency",
+  currency: "USD",
+}
+
+const resolveLocale = (locale?: string | null): string => {
+  if (typeof locale === "string" && locale.trim().length > 0) {
+    return locale
+  }
+
+  return systemDefaultLocale
+}
+
+const resolveTimeZone = (timeZone?: string | null): string => {
+  if (typeof timeZone === "string" && timeZone.trim().length > 0) {
+    return timeZone
+  }
+
+  return systemDefaultTimeZone
+}
+
 const toTimestamp = (value: TimestampInput): number => {
   if (value instanceof Date) {
     return Number.isFinite(value.getTime()) ? value.getTime() : 0
@@ -186,20 +244,118 @@ export async function fetcher<JSON = any>(
   return payload as JSON
 }
 
-export function formatDate(input: string | number | Date): string {
+export interface DateFormatOptions extends Intl.DateTimeFormatOptions, IntlPreferences {}
+
+export function formatDate(
+  input: string | number | Date,
+  options?: DateFormatOptions,
+): string {
   const date = new Date(input)
-  return date.toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric'
-  })
+  if (!Number.isFinite(date.getTime())) {
+    return ""
+  }
+
+  const { locale, timeZone, ...formatOverrides } = options ?? {}
+  const resolvedLocale = resolveLocale(locale)
+  const resolvedTimeZone = resolveTimeZone(timeZone)
+  const formatOptions =
+    Object.keys(formatOverrides).length > 0
+      ? formatOverrides
+      : defaultDateFormat
+
+  try {
+    return new Intl.DateTimeFormat(resolvedLocale, {
+      timeZone: resolvedTimeZone,
+      ...formatOptions,
+    }).format(date)
+  } catch (error) {
+    return new Intl.DateTimeFormat(systemDefaultLocale, {
+      timeZone: systemDefaultTimeZone,
+      ...formatOptions,
+    }).format(date)
+  }
 }
 
-export const formatNumber = (value: number) =>
-  new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD'
-  }).format(value)
+export interface NumberFormatOptions extends Intl.NumberFormatOptions {
+  locale?: string | null
+}
+
+export const formatNumber = (
+  value: number,
+  options?: NumberFormatOptions,
+) => {
+  const { locale, ...formatOverrides } = options ?? {}
+  const resolvedLocale = resolveLocale(locale)
+  const formatOptions =
+    Object.keys(formatOverrides).length > 0
+      ? formatOverrides
+      : defaultNumberFormat
+
+  try {
+    return new Intl.NumberFormat(resolvedLocale, formatOptions).format(value)
+  } catch (error) {
+    return new Intl.NumberFormat(systemDefaultLocale, formatOptions).format(value)
+  }
+}
+
+const RELATIVE_TIME_THRESHOLDS: Array<{
+  unit: Intl.RelativeTimeFormatUnit
+  milliseconds: number
+}> = [
+  { unit: "year", milliseconds: 1000 * 60 * 60 * 24 * 365 },
+  { unit: "month", milliseconds: 1000 * 60 * 60 * 24 * 30 },
+  { unit: "week", milliseconds: 1000 * 60 * 60 * 24 * 7 },
+  { unit: "day", milliseconds: 1000 * 60 * 60 * 24 },
+  { unit: "hour", milliseconds: 1000 * 60 * 60 },
+  { unit: "minute", milliseconds: 1000 * 60 },
+  { unit: "second", milliseconds: 1000 },
+]
+
+export interface RelativeTimeFormatOptions extends IntlPreferences {
+  now?: Date | number
+  numeric?: Intl.RelativeTimeFormatOptions["numeric"]
+  style?: Intl.RelativeTimeFormatOptions["style"]
+}
+
+export function formatRelativeTimeFromNow(
+  input: string | number | Date,
+  options?: RelativeTimeFormatOptions,
+): string {
+  const date = new Date(input)
+  if (!Number.isFinite(date.getTime())) {
+    return ""
+  }
+
+  const referenceTime = options?.now
+    ? options.now instanceof Date
+      ? options.now.getTime()
+      : options.now
+    : Date.now()
+
+  const difference = date.getTime() - referenceTime
+  const absoluteDifference = Math.abs(difference)
+
+  const { locale, numeric = "auto", style = "long" } = options ?? {}
+  const resolvedLocale = resolveLocale(locale)
+
+  try {
+    const formatter = new Intl.RelativeTimeFormat(resolvedLocale, {
+      numeric,
+      style,
+    })
+
+    for (const { unit, milliseconds } of RELATIVE_TIME_THRESHOLDS) {
+      if (absoluteDifference >= milliseconds || unit === "second") {
+        const value = Math.round(difference / milliseconds)
+        return formatter.format(value, unit)
+      }
+    }
+  } catch (error) {
+    // ignore and fall through to fallback below
+  }
+
+  return "just now"
+}
 
 export const runAsyncFnWithoutBlocking = (
   fn: (...args: any) => Promise<any>

--- a/supabase/migrations/20250220_profiles_locale_timezone.sql
+++ b/supabase/migrations/20250220_profiles_locale_timezone.sql
@@ -1,0 +1,68 @@
+-- Add locale and timezone preferences to profiles
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS locale text;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS timezone text;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN locale SET DEFAULT 'en-US';
+
+ALTER TABLE public.profiles
+  ALTER COLUMN timezone SET DEFAULT 'UTC';
+
+WITH profile_defaults AS (
+  SELECT
+    p.id,
+    NULLIF(p.locale, '') AS existing_locale,
+    NULLIF(p.timezone, '') AS existing_timezone,
+    NULLIF(u.raw_user_meta_data->>'locale', '') AS auth_locale,
+    NULLIF(
+      COALESCE(
+        u.raw_user_meta_data->>'timezone',
+        u.raw_user_meta_data->>'timeZone',
+        u.raw_user_meta_data->>'preferred_timezone',
+        u.raw_user_meta_data->>'preferredTimeZone'
+      ),
+      ''
+    ) AS auth_timezone
+  FROM public.profiles p
+  LEFT JOIN auth.users u ON u.id = p.id
+),
+computed_preferences AS (
+  SELECT
+    pd.id,
+    COALESCE(pd.existing_locale, pd.auth_locale, 'en-US') AS resolved_locale,
+    COALESCE(tz.name, pd.existing_timezone, 'UTC') AS resolved_timezone
+  FROM profile_defaults pd
+  LEFT JOIN LATERAL (
+    SELECT name
+    FROM pg_timezone_names tz
+    WHERE tz.name = pd.auth_timezone
+    LIMIT 1
+  ) AS tz ON TRUE
+)
+UPDATE public.profiles AS p
+SET
+  locale = computed_preferences.resolved_locale,
+  timezone = computed_preferences.resolved_timezone,
+  updated_at = timezone('utc', now())
+FROM computed_preferences
+WHERE computed_preferences.id = p.id
+  AND (
+    COALESCE(p.locale, '') <> COALESCE(computed_preferences.resolved_locale, '')
+    OR COALESCE(p.timezone, '') <> COALESCE(computed_preferences.resolved_timezone, '')
+  );
+
+UPDATE public.profiles AS p
+SET timezone = 'UTC'
+WHERE timezone IS NULL
+  OR timezone = ''
+  OR NOT EXISTS (
+    SELECT 1
+    FROM pg_timezone_names tz
+    WHERE tz.name = p.timezone
+  );
+
+CREATE INDEX IF NOT EXISTS idx_profiles_locale ON public.profiles(locale);
+CREATE INDEX IF NOT EXISTS idx_profiles_timezone ON public.profiles(timezone);

--- a/tests/lib/formatting.test.ts
+++ b/tests/lib/formatting.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import { formatDate, formatRelativeTimeFromNow } from "@/lib/utils"
+import { formatCurrency } from "@/lib/payments/currency"
+
+describe("formatting utilities honor locale and timezone overrides", () => {
+  it("adjusts dates when a different timezone is provided", () => {
+    const iso = "2024-06-01T02:00:00.000Z"
+
+    const pacific = formatDate(iso, {
+      locale: "en-US",
+      timeZone: "America/Los_Angeles",
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    })
+
+    const tokyo = formatDate(iso, {
+      locale: "ja-JP",
+      timeZone: "Asia/Tokyo",
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    })
+
+    expect(pacific).toBe("May 31, 2024")
+    expect(tokyo).toBe("2024年6月1日")
+    expect(pacific).not.toEqual(tokyo)
+  })
+
+  it("formats currency using the supplied locale", () => {
+    const usFormatted = formatCurrency(1234.56, "USD", { locale: "en-US" })
+    const germanFormatted = formatCurrency(1234.56, "EUR", { locale: "de-DE" })
+
+    expect(usFormatted).toBe("$1,234.56")
+    expect(germanFormatted).toBe("1.234,56 €")
+    expect(usFormatted).not.toEqual(germanFormatted)
+  })
+
+  it("renders relative time strings using the requested locale", () => {
+    const reference = new Date("2024-06-01T00:00:00Z").getTime()
+
+    const english = formatRelativeTimeFromNow("2024-06-03T00:00:00Z", {
+      locale: "en-US",
+      now: reference,
+      numeric: "always",
+    })
+    const french = formatRelativeTimeFromNow("2024-06-03T00:00:00Z", {
+      locale: "fr-FR",
+      now: reference,
+      numeric: "always",
+    })
+
+    expect(english).toBe("in 2 days")
+    expect(french.toLowerCase()).toContain("jours")
+    expect(english).not.toEqual(french)
+  })
+})


### PR DESCRIPTION
## Summary
- extend account profile state with locale and timezone selectors backed by Intl APIs and persist them to Supabase, including a migration that backfills existing rows from auth metadata
- enhance lib formatting helpers and currency utilities to accept locale/timezone preferences and update payments UI components to display dates, relative times, and currency using the viewer's settings
- add vitest coverage ensuring formatting output changes when user preferences are updated

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b96d2d0832894192355cf3a9411