### PR TITLE
feat: add high contrast theme and contrast audits

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,9 +3,17 @@
 @tailwind utilities;
 
 /* Minimal base colors */
-:root {}
+:root {
+  color-scheme: light;
+}
 
-.dark {}
+.dark {
+  color-scheme: dark;
+}
+
+.high-contrast {
+  color-scheme: dark;
+}
 
 body {}
 
@@ -32,6 +40,27 @@ body {}
     --input: 214 32% 91%;
     --ring: 222 47% 11%;
     --radius: 0.375rem;
+
+    /* High contrast palette tokens */
+    --hc-background: 222 87% 8%;
+    --hc-foreground: 210 40% 98%;
+    --hc-card: 222 84% 12%;
+    --hc-card-foreground: 210 40% 98%;
+    --hc-popover: 222 84% 12%;
+    --hc-popover-foreground: 210 40% 98%;
+    --hc-primary: 50 100% 56%;
+    --hc-primary-foreground: 222 87% 8%;
+    --hc-secondary: 196 100% 58%;
+    --hc-secondary-foreground: 222 87% 8%;
+    --hc-muted: 222 64% 22%;
+    --hc-muted-foreground: 210 35% 88%;
+    --hc-accent: 142 80% 52%;
+    --hc-accent-foreground: 222 87% 8%;
+    --hc-destructive: 0 100% 75%;
+    --hc-destructive-foreground: 222 87% 8%;
+    --hc-border: 196 100% 58%;
+    --hc-input: 196 100% 58%;
+    --hc-ring: 50 100% 56%;
   }
 
   .dark {
@@ -49,11 +78,33 @@ body {}
     --muted-foreground: 215 20% 65%;
     --accent: 217 33% 17%;
     --accent-foreground: 210 40% 98%;
-    --destructive: 0 62% 30%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 72% 60%;
+    --destructive-foreground: 222 47% 11%;
     --border: 217 33% 17%;
     --input: 217 33% 17%;
     --ring: 210 40% 98%;
+  }
+
+  .high-contrast {
+    --background: var(--hc-background);
+    --foreground: var(--hc-foreground);
+    --card: var(--hc-card);
+    --card-foreground: var(--hc-card-foreground);
+    --popover: var(--hc-popover);
+    --popover-foreground: var(--hc-popover-foreground);
+    --primary: var(--hc-primary);
+    --primary-foreground: var(--hc-primary-foreground);
+    --secondary: var(--hc-secondary);
+    --secondary-foreground: var(--hc-secondary-foreground);
+    --muted: var(--hc-muted);
+    --muted-foreground: var(--hc-muted-foreground);
+    --accent: var(--hc-accent);
+    --accent-foreground: var(--hc-accent-foreground);
+    --destructive: var(--hc-destructive);
+    --destructive-foreground: var(--hc-destructive-foreground);
+    --border: var(--hc-border);
+    --input: var(--hc-input);
+    --ring: var(--hc-ring);
   }
 }
 

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -4,6 +4,26 @@ import * as React from "react"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
 import { type ThemeProviderProps } from "next-themes/dist/types"
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+const AVAILABLE_THEMES = ["light", "dark", "high-contrast"] as const
+
+export function ThemeProvider({
+  children,
+  storageKey = "share-house-theme",
+  themes,
+  ...props
+}: ThemeProviderProps) {
+  const mergedThemes = React.useMemo(
+    () => Array.from(new Set([...(themes ?? []), ...AVAILABLE_THEMES])),
+    [themes],
+  )
+
+  return (
+    <NextThemesProvider
+      {...props}
+      storageKey={storageKey}
+      themes={mergedThemes}
+    >
+      {children}
+    </NextThemesProvider>
+  )
 }

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,23 +1,60 @@
 "use client"
 
 import * as React from "react"
-import { Moon, Sun } from "lucide-react"
+import { Contrast, Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
 
 import { Button } from "@/components/ui/button"
 
+const THEME_SEQUENCE = ["light", "dark", "high-contrast"] as const
+type ThemeName = (typeof THEME_SEQUENCE)[number]
+
+const themeIcons: Record<ThemeName, typeof Sun> = {
+  light: Sun,
+  dark: Moon,
+  "high-contrast": Contrast,
+}
+
+const themeLabels: Record<ThemeName, string> = {
+  light: "Light",
+  dark: "Dark",
+  "high-contrast": "High contrast",
+}
+
 export function ThemeToggle() {
-  const { setTheme, theme } = useTheme()
+  const { resolvedTheme, setTheme, theme } = useTheme()
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const activeTheme = React.useMemo(() => {
+    const candidate = theme === "system" ? resolvedTheme : theme
+    return THEME_SEQUENCE.includes(candidate as ThemeName)
+      ? (candidate as ThemeName)
+      : undefined
+  }, [resolvedTheme, theme])
+
+  const currentTheme = mounted && activeTheme ? activeTheme : "light"
+  const currentIndex = THEME_SEQUENCE.indexOf(currentTheme)
+  const nextTheme = THEME_SEQUENCE[(currentIndex + 1) % THEME_SEQUENCE.length]
+  const Icon = themeIcons[currentTheme]
+
+  const handleToggle = React.useCallback(() => {
+    setTheme(nextTheme)
+  }, [nextTheme, setTheme])
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+      onClick={handleToggle}
+      aria-label={`Enable ${themeLabels[nextTheme]} theme`}
+      title={`Enable ${themeLabels[nextTheme]} theme`}
     >
-      <Sun className="h-6 w-5 dark:hidden" />
-      <Moon className="hidden size-5 dark:block" />
-      <span className="sr-only">Toggle theme</span>
+      <Icon className="size-5" />
+      <span className="sr-only">{`Theme currently set to ${themeLabels[currentTheme]}`}</span>
     </Button>
   )
 }

--- a/docs/accessibility/themes.md
+++ b/docs/accessibility/themes.md
@@ -1,0 +1,37 @@
+# Theme accessibility guidelines
+
+The portal now ships three display modes powered by `next-themes`:
+
+- **Light**: default experience tuned for daylight readability.
+- **Dark**: low-light option aligned to the original palette.
+- **High contrast**: WCAG AAA-focused palette for residents who need additional visual separation.
+
+## Color token reference
+
+All design tokens live in `app/globals.css` as CSS custom properties. Each theme maps the shared semantic tokens (`--background`, `--foreground`, etc.) to the appropriate palette values, so component code should continue to rely on semantic utilities such as `bg-background`, `text-foreground`, `bg-primary`, and `text-muted-foreground`.
+
+For the high-contrast mode we additionally expose the `--hc-*` tokens and Tailwind aliases (`theme("colors.highContrast.*")`) to support edge cases where a component must reference the palette directly.
+
+| Token | Purpose | High contrast value |
+| --- | --- | --- |
+| `--background` | Application chrome | `hsl(222 87% 8%)` |
+| `--foreground` | Primary body copy | `hsl(210 40% 98%)` |
+| `--primary` | Calls to action / payment CTAs | `hsl(50 100% 56%)` |
+| `--secondary` | Informational badges | `hsl(196 100% 58%)` |
+| `--accent` | Messaging chips & status tags | `hsl(142 80% 52%)` |
+| `--destructive` | Error states & destructive buttons | `hsl(0 100% 75%)` |
+| `--muted-foreground` | Metadata & timestamps | `hsl(210 35% 88%)` |
+
+## Usage checklist
+
+1. **Prefer semantic utilities**: reach for `bg-secondary` + `text-secondary-foreground` or `text-muted-foreground` instead of hard-coded colors. This ensures all three themes stay in sync.
+2. **Respect minimum contrast**: the automated audit in `tests/accessibility/contrast.test.ts` enforces WCAG AA for light/dark themes and AAA for the high-contrast palette. Add new token pairs to that test when creating novel combinations.
+3. **Iconography**: icons inside buttons should inherit the text color (`text-current`) so they follow the active theme. Avoid embedding raw hex values inside SVGs.
+4. **Gradients and illustrations**: when absolutely necessary, wrap non-compliant artwork with `aria-hidden` and provide accessible text alternatives.
+5. **Persistence**: the theme toggle stores the user’s selection under `share-house-theme`. Respect this key when building import/export utilities so resident preferences travel with backups.
+
+## Manual audit tips
+
+- Exercise payments, documents, and messaging surfaces in all three modes whenever adding new components. Look for focus rings, subtle dividers, and badge text.
+- Confirm that error banners use the updated dark-theme destructive foreground (`--destructive-foreground: hsl(222 47% 11%)`) to stay legible on brighter reds.
+- When introducing new palettes (e.g., seasonal themes), start from the semantic token map rather than redefining component styles in isolation.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -62,6 +62,41 @@ const config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        highContrast: {
+          background: "hsl(var(--hc-background))",
+          foreground: "hsl(var(--hc-foreground))",
+          border: "hsl(var(--hc-border))",
+          input: "hsl(var(--hc-input))",
+          ring: "hsl(var(--hc-ring))",
+          card: {
+            DEFAULT: "hsl(var(--hc-card))",
+            foreground: "hsl(var(--hc-card-foreground))",
+          },
+          popover: {
+            DEFAULT: "hsl(var(--hc-popover))",
+            foreground: "hsl(var(--hc-popover-foreground))",
+          },
+          primary: {
+            DEFAULT: "hsl(var(--hc-primary))",
+            foreground: "hsl(var(--hc-primary-foreground))",
+          },
+          secondary: {
+            DEFAULT: "hsl(var(--hc-secondary))",
+            foreground: "hsl(var(--hc-secondary-foreground))",
+          },
+          muted: {
+            DEFAULT: "hsl(var(--hc-muted))",
+            foreground: "hsl(var(--hc-muted-foreground))",
+          },
+          accent: {
+            DEFAULT: "hsl(var(--hc-accent))",
+            foreground: "hsl(var(--hc-accent-foreground))",
+          },
+          destructive: {
+            DEFAULT: "hsl(var(--hc-destructive))",
+            foreground: "hsl(var(--hc-destructive-foreground))",
+          },
+        },
       },
       borderRadius: {
         lg: "var(--radius)",

--- a/tests/accessibility/contrast.test.ts
+++ b/tests/accessibility/contrast.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from "vitest"
+
+type ThemeName = "light" | "dark" | "high-contrast"
+
+type ThemeTokens = Record<string, string>
+
+type ContrastPair = {
+  label: string
+  tokens: [string, string]
+  thresholds?: Partial<Record<ThemeName | "default", number>>
+}
+
+const themeTokens: Record<ThemeName, ThemeTokens> = {
+  light: {
+    background: "0 0% 100%",
+    foreground: "222 47% 11%",
+    card: "0 0% 100%",
+    "card-foreground": "222 47% 11%",
+    primary: "222 47% 11%",
+    "primary-foreground": "0 0% 100%",
+    secondary: "210 40% 96%",
+    "secondary-foreground": "222 47% 11%",
+    muted: "210 40% 96%",
+    "muted-foreground": "215 20% 45%",
+    accent: "210 40% 96%",
+    "accent-foreground": "222 47% 11%",
+    destructive: "0 72% 51%",
+    "destructive-foreground": "0 0% 100%",
+  },
+  dark: {
+    background: "222 47% 11%",
+    foreground: "210 40% 98%",
+    card: "222 47% 11%",
+    "card-foreground": "210 40% 98%",
+    primary: "210 40% 98%",
+    "primary-foreground": "222 47% 11%",
+    secondary: "217 33% 17%",
+    "secondary-foreground": "210 40% 98%",
+    muted: "217 33% 17%",
+    "muted-foreground": "215 20% 65%",
+    accent: "217 33% 17%",
+    "accent-foreground": "210 40% 98%",
+    destructive: "0 72% 60%",
+    "destructive-foreground": "222 47% 11%",
+  },
+  "high-contrast": {
+    background: "222 87% 8%",
+    foreground: "210 40% 98%",
+    card: "222 84% 12%",
+    "card-foreground": "210 40% 98%",
+    primary: "50 100% 56%",
+    "primary-foreground": "222 87% 8%",
+    secondary: "196 100% 58%",
+    "secondary-foreground": "222 87% 8%",
+    muted: "222 64% 22%",
+    "muted-foreground": "210 35% 88%",
+    accent: "142 80% 52%",
+    "accent-foreground": "222 87% 8%",
+    destructive: "0 100% 75%",
+    "destructive-foreground": "222 87% 8%",
+  },
+}
+
+const contrastPairs: ContrastPair[] = [
+  {
+    label: "Body text",
+    tokens: ["foreground", "background"],
+    thresholds: { default: 4.5, "high-contrast": 7 },
+  },
+  {
+    label: "Card copy",
+    tokens: ["card-foreground", "card"],
+    thresholds: { default: 4.5, "high-contrast": 7 },
+  },
+  {
+    label: "Muted metadata",
+    tokens: ["muted-foreground", "background"],
+    thresholds: { default: 4.5, "high-contrast": 7 },
+  },
+  {
+    label: "Muted container copy",
+    tokens: ["muted-foreground", "muted"],
+    thresholds: { default: 4.5, "high-contrast": 7 },
+  },
+  {
+    label: "Primary button",
+    tokens: ["primary-foreground", "primary"],
+    thresholds: { default: 4.5, "high-contrast": 7 },
+  },
+  {
+    label: "Secondary badge",
+    tokens: ["secondary-foreground", "secondary"],
+    thresholds: { default: 4.5, "high-contrast": 7 },
+  },
+  {
+    label: "Accent chip",
+    tokens: ["accent-foreground", "accent"],
+    thresholds: { default: 4.5, "high-contrast": 7 },
+  },
+  {
+    label: "Destructive action",
+    tokens: ["destructive-foreground", "destructive"],
+    thresholds: { default: 4.5, "high-contrast": 7 },
+  },
+]
+
+const WCAG = {
+  AA: 4.5,
+  AAA: 7,
+} as const
+
+type Rating = keyof typeof WCAG | "fail"
+
+function parseHsl(value: string) {
+  const [rawH, rawS, rawL] = value.trim().split(/\s+/)
+  const h = Number.parseFloat(rawH)
+  const s = Number.parseFloat(rawS.replace("%", "")) / 100
+  const l = Number.parseFloat(rawL.replace("%", "")) / 100
+  return { h, s, l }
+}
+
+function hslToRgb({ h, s, l }: ReturnType<typeof parseHsl>) {
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const hp = h / 60
+  const x = c * (1 - Math.abs((hp % 2) - 1))
+  let r1 = 0
+  let g1 = 0
+  let b1 = 0
+
+  if (hp >= 0 && hp < 1) {
+    r1 = c
+    g1 = x
+  } else if (hp >= 1 && hp < 2) {
+    r1 = x
+    g1 = c
+  } else if (hp >= 2 && hp < 3) {
+    g1 = c
+    b1 = x
+  } else if (hp >= 3 && hp < 4) {
+    g1 = x
+    b1 = c
+  } else if (hp >= 4 && hp < 5) {
+    r1 = x
+    b1 = c
+  } else if (hp >= 5 && hp <= 6) {
+    r1 = c
+    b1 = x
+  }
+
+  const m = l - c / 2
+
+  return [r1 + m, g1 + m, b1 + m] as const
+}
+
+function relativeLuminance(rgb: readonly number[]) {
+  const [r, g, b] = rgb.map((value) =>
+    value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4),
+  ) as const
+
+  return r * 0.2126 + g * 0.7152 + b * 0.0722
+}
+
+function contrastRatio(foreground: string, background: string) {
+  const fgRgb = hslToRgb(parseHsl(foreground))
+  const bgRgb = hslToRgb(parseHsl(background))
+  const fgLuminance = relativeLuminance(fgRgb)
+  const bgLuminance = relativeLuminance(bgRgb)
+  const [lighter, darker] = fgLuminance > bgLuminance
+    ? [fgLuminance, bgLuminance]
+    : [bgLuminance, fgLuminance]
+
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+function wcagRating(ratio: number): Rating {
+  if (ratio >= WCAG.AAA) return "AAA"
+  if (ratio >= WCAG.AA) return "AA"
+  return "fail"
+}
+function auditTheme(themeName: ThemeName) {
+  const palette = themeTokens[themeName]
+
+  return contrastPairs.map(({ label, tokens, thresholds }) => {
+    const [foregroundToken, backgroundToken] = tokens
+    const foreground = palette[foregroundToken]
+    const background = palette[backgroundToken]
+
+    if (!foreground || !background) {
+      throw new Error(`Missing token pair ${foregroundToken} / ${backgroundToken} for theme ${themeName}`)
+    }
+
+    const ratio = Number(contrastRatio(foreground, background).toFixed(2))
+    const requirement = thresholds?.[themeName] ?? thresholds?.default ?? WCAG.AA
+
+    if (ratio < requirement) {
+      throw new Error(
+        `${label} failed ${themeName} requirement: got ${ratio}, expected ≥ ${requirement}`,
+      )
+    }
+
+    const requirementLevel: Rating = requirement >= WCAG.AAA ? "AAA" : "AA"
+    const achieved = wcagRating(ratio)
+
+    return {
+      pair: label,
+      ratio,
+      required: requirementLevel,
+      achieved,
+    }
+  })
+}
+
+describe("theme color contrast", () => {
+  it("light palette clears contrast audits", () => {
+    expect(auditTheme("light")).toMatchInlineSnapshot(`
+      [
+        {
+          "achieved": "AAA",
+          "pair": "Body text",
+          "ratio": 17.9,
+          "required": "AA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Card copy",
+          "ratio": 17.9,
+          "required": "AA",
+        },
+        {
+          "achieved": "AA",
+          "pair": "Muted metadata",
+          "ratio": 5.14,
+          "required": "AA",
+        },
+        {
+          "achieved": "AA",
+          "pair": "Muted container copy",
+          "ratio": 4.68,
+          "required": "AA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Primary button",
+          "ratio": 17.9,
+          "required": "AA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Secondary badge",
+          "ratio": 16.31,
+          "required": "AA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Accent chip",
+          "ratio": 16.31,
+          "required": "AA",
+        },
+        {
+          "achieved": "AA",
+          "pair": "Destructive action",
+          "ratio": 4.8,
+          "required": "AA",
+        },
+      ]
+    `)
+  })
+
+  it("dark palette clears contrast audits", () => {
+    expect(auditTheme("dark")).toMatchInlineSnapshot(`
+      [
+        {
+          "achieved": "AAA",
+          "pair": "Body text",
+          "ratio": 17.09,
+          "required": "AA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Card copy",
+          "ratio": 17.09,
+          "required": "AA",
+        },
+        {
+          "achieved": "AA",
+          "pair": "Muted metadata",
+          "ratio": 6.96,
+          "required": "AA",
+        },
+        {
+          "achieved": "AA",
+          "pair": "Muted container copy",
+          "ratio": 5.77,
+          "required": "AA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Primary button",
+          "ratio": 17.09,
+          "required": "AA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Secondary badge",
+          "ratio": 14.16,
+          "required": "AA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Accent chip",
+          "ratio": 14.16,
+          "required": "AA",
+        },
+        {
+          "achieved": "AA",
+          "pair": "Destructive action",
+          "ratio": 4.69,
+          "required": "AA",
+        },
+      ]
+    `)
+  })
+
+  it("high-contrast palette clears contrast audits", () => {
+    expect(auditTheme("high-contrast")).toMatchInlineSnapshot(`
+      [
+        {
+          "achieved": "AAA",
+          "pair": "Body text",
+          "ratio": 18.38,
+          "required": "AAA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Card copy",
+          "ratio": 17.19,
+          "required": "AAA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Muted metadata",
+          "ratio": 14.45,
+          "required": "AAA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Muted container copy",
+          "ratio": 10.42,
+          "required": "AAA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Primary button",
+          "ratio": 13.99,
+          "required": "AAA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Secondary badge",
+          "ratio": 9.72,
+          "required": "AAA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Accent chip",
+          "ratio": 11.6,
+          "required": "AAA",
+        },
+        {
+          "achieved": "AAA",
+          "pair": "Destructive action",
+          "ratio": 7.91,
+          "required": "AAA",
+        },
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
## Summary
- add high contrast color tokens to the global styles and expose a tailwind palette for direct access when needed
- update the theme provider/toggle to support cycling through light, dark, and high contrast modes with persisted preferences
- introduce automated contrast audits covering key UI surfaces and document the new accessibility guidelines

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b98957c8328af7596b6d0426493