### PR TITLE
Add survey feedback system and analytics dashboard

### DIFF
--- a/app/dashboard/(dashboard)/components/feedback-analytics.tsx
+++ b/app/dashboard/(dashboard)/components/feedback-analytics.tsx
@@ -1,0 +1,201 @@
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { getFeedbackAnalytics } from "../feedback-data"
+
+function formatTrend(delta: number | null) {
+  if (delta === null) {
+    return { label: 'No prior quarter', variant: 'secondary' as const }
+  }
+
+  if (delta > 0) {
+    return { label: `+${delta} vs last quarter`, variant: 'default' as const }
+  }
+
+  if (delta < 0) {
+    return { label: `${delta} vs last quarter`, variant: 'destructive' as const }
+  }
+
+  return { label: 'Flat vs last quarter', variant: 'outline' as const }
+}
+
+export async function FeedbackAnalyticsPanel() {
+  const analytics = await getFeedbackAnalytics()
+  const trend = formatTrend(analytics.nps.trendDelta)
+
+  return (
+    <div className="space-y-4 lg:grid lg:grid-cols-2 lg:gap-4 lg:space-y-0">
+      <Card className="border-border/70">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between text-lg">
+            Resident NPS
+            <Badge variant="outline" className="text-xs font-medium">
+              {analytics.nps.responseCount} responses
+            </Badge>
+          </CardTitle>
+          <CardDescription>
+            Quarterly sentiment from active households about the overall living
+            experience.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="flex items-baseline gap-3">
+            <span className="text-4xl font-semibold text-foreground">
+              {analytics.nps.currentScore ?? '—'}
+            </span>
+            <Badge variant={trend.variant}>{trend.label}</Badge>
+            {analytics.nps.previousScore !== null ? (
+              <span className="text-sm text-muted-foreground">
+                Prev: {analytics.nps.previousScore}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="grid grid-cols-3 gap-2 text-sm">
+            {(
+              [
+                { label: 'Promoters', value: analytics.nps.distribution.promoters },
+                { label: 'Passives', value: analytics.nps.distribution.passives },
+                { label: 'Detractors', value: analytics.nps.distribution.detractors },
+              ] as const
+            ).map((entry) => (
+              <div
+                key={entry.label}
+                className="rounded-md border border-border/60 p-3 text-center"
+              >
+                <p className="text-xs uppercase text-muted-foreground">
+                  {entry.label}
+                </p>
+                <p className="text-lg font-semibold text-foreground">
+                  {entry.value}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Recent comments
+            </p>
+            {analytics.nps.recentComments.length > 0 ? (
+              <ul className="space-y-2">
+                {analytics.nps.recentComments.map((comment) => (
+                  <li
+                    key={`${comment.createdAt}-${comment.feedback}`}
+                    className="rounded-md border border-border/50 bg-muted/40 p-3 text-sm"
+                  >
+                    <p className="text-foreground">{comment.feedback}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {new Date(comment.createdAt).toLocaleDateString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No written feedback captured for the current window.
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-border/70">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between text-lg">
+            CSAT by workflow
+            <Badge variant="outline" className="text-xs font-medium">
+              Avg {analytics.csat.averageRating ?? '—'} / 5
+            </Badge>
+          </CardTitle>
+          <CardDescription>
+            Post-completion satisfaction across digital signing and maintenance
+            resolution touch points.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3">
+            {analytics.csat.contextBreakdown.length > 0 ? (
+              analytics.csat.contextBreakdown.map((entry) => (
+                <div
+                  key={entry.context}
+                  className="flex items-center justify-between rounded-md border border-border/60 p-3"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-foreground">
+                      {entry.context === 'document_signed'
+                        ? 'Document signed'
+                        : 'Maintenance resolved'}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {entry.count} responses
+                    </p>
+                  </div>
+                  <span className="text-lg font-semibold text-foreground">
+                    {entry.average?.toFixed(2) ?? '—'}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No CSAT responses collected yet.
+              </p>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Encourage property teams to follow up on any CSAT below 3 to reinforce
+            service recovery.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="border-border/70 lg:col-span-2">
+        <CardHeader>
+          <CardTitle className="text-lg">Feedback velocity</CardTitle>
+          <CardDescription>
+            Rolling six-month snapshot comparing NPS and CSAT averages.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-hidden rounded-md border border-border/60">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/60 text-left text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2">Period</th>
+                  <th className="px-4 py-2">NPS</th>
+                  <th className="px-4 py-2">CSAT</th>
+                </tr>
+              </thead>
+              <tbody>
+                {analytics.timeline.map((entry, index) => (
+                  <tr
+                    key={`${entry.period}-${index}`}
+                    className={index % 2 === 0 ? 'bg-background' : 'bg-muted/30'}
+                  >
+                    <td className="px-4 py-2 font-medium text-foreground">
+                      {entry.period}
+                    </td>
+                    <td className="px-4 py-2 text-foreground">
+                      {entry.npsScore ?? '—'}
+                    </td>
+                    <td className="px-4 py-2 text-foreground">
+                      {entry.csatAverage?.toFixed(2) ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/(dashboard)/components/maintenance-overview-card.tsx
+++ b/app/dashboard/(dashboard)/components/maintenance-overview-card.tsx
@@ -1,21 +1,9 @@
 import SmartLink from "@/components/navigation/SmartLink"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { getMaintenanceTickets } from "../data"
 import { Wrench } from "lucide-react"
-
-const statusLabels: Record<"scheduled" | "in_progress" | "awaiting_vendor", string> = {
-  scheduled: "Scheduled",
-  in_progress: "In progress",
-  awaiting_vendor: "Awaiting vendor",
-}
-
-const priorityVariants: Record<"low" | "medium" | "high", "outline" | "secondary" | "destructive" | "complete"> = {
-  low: "outline",
-  medium: "secondary",
-  high: "destructive",
-}
+import { MaintenanceTicketItem } from "./maintenance-ticket-item"
 
 export async function MaintenanceOverviewCard() {
   const tickets = await getMaintenanceTickets()
@@ -36,28 +24,7 @@ export async function MaintenanceOverviewCard() {
       <CardContent className="space-y-4">
         <ul className="space-y-3">
           {tickets.map((ticket) => (
-            <li
-              key={ticket.id}
-              className="rounded-lg border border-dashed border-border/70 p-3"
-            >
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="space-y-1">
-                  <p className="text-sm font-medium text-foreground">{ticket.title}</p>
-                  <p className="text-xs text-muted-foreground">
-                    Last updated {new Date(ticket.updatedAt).toLocaleDateString(undefined, {
-                      month: "short",
-                      day: "numeric",
-                    })}
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Badge variant={priorityVariants[ticket.priority]} className="uppercase">
-                    {ticket.priority} priority
-                  </Badge>
-                  <Badge variant="outline">{statusLabels[ticket.status]}</Badge>
-                </div>
-              </div>
-            </li>
+            <MaintenanceTicketItem key={ticket.id} ticket={ticket} />
           ))}
         </ul>
 

--- a/app/dashboard/(dashboard)/components/maintenance-ticket-item.tsx
+++ b/app/dashboard/(dashboard)/components/maintenance-ticket-item.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { CsatPrompt } from "@/components/feedback/CsatPrompt"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { canShowCsatPrompt } from "@/lib/feedback/client"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+import type { MaintenanceTicket } from "../data"
+import { toast } from "sonner"
+
+const statusLabels: Record<
+  MaintenanceTicket['status'] | 'completed',
+  string
+> = {
+  scheduled: 'Scheduled',
+  in_progress: 'In progress',
+  awaiting_vendor: 'Awaiting vendor',
+  completed: 'Completed',
+}
+
+const priorityVariants: Record<
+  MaintenanceTicket['priority'],
+  'outline' | 'secondary' | 'destructive'
+> = {
+  low: 'outline',
+  medium: 'secondary',
+  high: 'destructive',
+}
+
+interface MaintenanceTicketItemProps {
+  ticket: MaintenanceTicket
+}
+
+type CsatState = {
+  open: boolean
+  contextId: string
+  entityName: string
+}
+
+export function MaintenanceTicketItem({ ticket }: MaintenanceTicketItemProps) {
+  const supabase = useSupabaseBrowser()
+  const client = supabase as unknown as TypedSupabaseClient
+  const [status, setStatus] = useState<MaintenanceTicket['status'] | 'completed'>(
+    ticket.status,
+  )
+  const [updatedAt, setUpdatedAt] = useState(ticket.updatedAt)
+  const [userId, setUserId] = useState<string | null>(null)
+  const [csatState, setCsatState] = useState<CsatState | null>(null)
+  const [resolving, setResolving] = useState(false)
+
+  useEffect(() => {
+    supabase.auth
+      .getUser()
+      .then(({ data }) => setUserId(data.user?.id ?? null))
+      .catch((error) => {
+        console.error('Unable to resolve user for maintenance CSAT prompt', error)
+      })
+  }, [supabase])
+
+  const handleCsatOpenChange = useCallback((nextOpen: boolean) => {
+    setCsatState((current) => (current ? { ...current, open: nextOpen } : current))
+  }, [])
+
+  const handleCsatClosed = useCallback(() => {
+    setCsatState(null)
+  }, [])
+
+  const handleResolve = useCallback(async () => {
+    if (status === 'completed' || resolving) {
+      return
+    }
+
+    setResolving(true)
+
+    try {
+      const now = new Date()
+      const nowIso = now.toISOString()
+
+      const { error } = await client
+        .from('maintenance_requests')
+        .update({
+          status: 'completed',
+          completed_at: nowIso,
+          updated_at: nowIso,
+        })
+        .eq('id', ticket.id)
+
+      if (error) {
+        throw error
+      }
+
+      setStatus('completed')
+      setUpdatedAt(nowIso)
+      toast.success('Maintenance request marked as resolved')
+
+      if (userId) {
+        const eligible = await canShowCsatPrompt(client, {
+          userId,
+          context: 'maintenance_resolved',
+          contextId: ticket.id,
+        })
+
+        if (eligible) {
+          setCsatState({
+            open: true,
+            contextId: ticket.id,
+            entityName: ticket.title,
+          })
+        }
+      }
+    } catch (error) {
+      console.error('Unable to mark maintenance resolved', error)
+      toast.error('Unable to update maintenance request')
+    } finally {
+      setResolving(false)
+    }
+  }, [client, resolving, status, ticket.id, ticket.title, userId])
+
+  const formattedDate = new Date(updatedAt).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })
+
+  return (
+    <li className="rounded-lg border border-dashed border-border/70 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">{ticket.title}</p>
+          <p className="text-xs text-muted-foreground">
+            Last updated {formattedDate}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={priorityVariants[ticket.priority]} className="uppercase">
+            {ticket.priority} priority
+          </Badge>
+          <Badge variant="outline">{statusLabels[status]}</Badge>
+        </div>
+      </div>
+
+      {status !== 'completed' ? (
+        <div className="mt-3 flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleResolve}
+            disabled={resolving || !userId}
+          >
+            {resolving ? 'Marking…' : 'Mark resolved'}
+          </Button>
+        </div>
+      ) : null}
+
+      {userId && csatState ? (
+        <CsatPrompt
+          open={csatState.open}
+          onOpenChange={handleCsatOpenChange}
+          onDismiss={handleCsatClosed}
+          onSubmitted={handleCsatClosed}
+          userId={userId}
+          context="maintenance_resolved"
+          contextId={csatState.contextId}
+          entityName={csatState.entityName}
+          metadata={{ maintenanceId: ticket.id, priority: ticket.priority }}
+        />
+      ) : null}
+    </li>
+  )
+}

--- a/app/dashboard/(dashboard)/components/nps-survey-entry.tsx
+++ b/app/dashboard/(dashboard)/components/nps-survey-entry.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { NpsSurveyModal } from "@/components/feedback/NpsSurveyModal"
+import {
+  DEFAULT_NPS_COOLDOWN_DAYS,
+  DEFAULT_NPS_DISMISSAL_DAYS,
+  parseIsoDate,
+  shouldDisplayNpsPrompt,
+} from "@/lib/feedback/prompt-logic"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+const DISMISSAL_PREFIX = "sharehouse:nps-dismissed"
+
+interface NpsSurveyEntryProps {
+  userId: string
+}
+
+type ActiveSurvey = {
+  windowId: string
+  quarterLabel: string
+  dismissalKey: string
+}
+
+export function NpsSurveyEntry({ userId }: NpsSurveyEntryProps) {
+  const supabase = useSupabaseBrowser()
+  const client = supabase as unknown as TypedSupabaseClient
+  const [activeSurvey, setActiveSurvey] = useState<ActiveSurvey | null>(null)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+
+    async function hydrate() {
+      const now = new Date()
+      const nowIso = now.toISOString()
+
+      const { data: windows, error: windowError } = await client
+        .from('nps_survey_windows')
+        .select('id, survey_year, survey_quarter, start_at, end_at')
+        .lte('start_at', nowIso)
+        .gte('end_at', nowIso)
+        .order('start_at', { ascending: false })
+        .limit(1)
+
+      if (windowError) {
+        console.error("Unable to load NPS survey window", windowError)
+        return
+      }
+
+      const windowRecord = windows?.[0]
+      if (!windowRecord || !mounted) {
+        return
+      }
+
+      const dismissalKey = `${DISMISSAL_PREFIX}:${windowRecord.id}`
+
+      const { data: existingResponse, error: existingError } = await client
+        .from('nps_responses')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('window_id', windowRecord.id)
+        .maybeSingle()
+
+      if (existingError) {
+        console.error("Unable to verify existing NPS response", existingError)
+        return
+      }
+
+      const respondedInWindow = Boolean(existingResponse)
+
+      const { data: lastResponse, error: lastResponseError } = await client
+        .from('nps_responses')
+        .select('created_at')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+      if (lastResponseError) {
+        console.error("Unable to fetch last NPS response", lastResponseError)
+        return
+      }
+
+      const lastResponseAt = parseIsoDate(lastResponse?.created_at ?? null)
+
+      let dismissedAt: Date | null = null
+      if (typeof window !== 'undefined') {
+        const dismissalValue = window.localStorage.getItem(dismissalKey)
+        dismissedAt = parseIsoDate(dismissalValue)
+      }
+
+      const shouldOpen = shouldDisplayNpsPrompt({
+        hasActiveWindow: true,
+        respondedInWindow,
+        lastResponseAt,
+        dismissedAt,
+        cooldownDays: DEFAULT_NPS_COOLDOWN_DAYS,
+        dismissalCooldownDays: DEFAULT_NPS_DISMISSAL_DAYS,
+        now,
+      })
+
+      if (shouldOpen && mounted) {
+        setActiveSurvey({
+          windowId: windowRecord.id,
+          quarterLabel: `Q${windowRecord.survey_quarter} ${windowRecord.survey_year}`,
+          dismissalKey,
+        })
+        setOpen(true)
+      }
+    }
+
+    void hydrate()
+
+    return () => {
+      mounted = false
+    }
+  }, [client, userId])
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+  }, [])
+
+  const handleDismiss = useCallback(() => {
+    if (activeSurvey && typeof window !== 'undefined') {
+      window.localStorage.setItem(activeSurvey.dismissalKey, new Date().toISOString())
+    }
+    setOpen(false)
+  }, [activeSurvey])
+
+  const handleSubmitted = useCallback(() => {
+    setOpen(false)
+    setActiveSurvey(null)
+  }, [])
+
+  if (!activeSurvey) {
+    return null
+  }
+
+  return (
+    <NpsSurveyModal
+      open={open}
+      onOpenChange={handleOpenChange}
+      onDismiss={handleDismiss}
+      onSubmitted={handleSubmitted}
+      windowId={activeSurvey.windowId}
+      userId={userId}
+      quarterLabel={activeSurvey.quarterLabel}
+    />
+  )
+}

--- a/app/dashboard/(dashboard)/feedback-data.ts
+++ b/app/dashboard/(dashboard)/feedback-data.ts
@@ -1,0 +1,47 @@
+import "server-only"
+
+import { cache } from "react"
+
+import { computeFeedbackAnalytics } from "@/lib/feedback/analytics"
+import type { Database } from "@/lib/supabase"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+
+export type FeedbackAnalytics = ReturnType<typeof computeFeedbackAnalytics>
+
+type NpsRow = Database['public']['Tables']['nps_responses']['Row']
+type CsatRow = Database['public']['Tables']['csat_responses']['Row']
+
+async function fetchFeedbackAnalytics() {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const now = new Date()
+  const since = new Date(now)
+  since.setMonth(since.getMonth() - 6)
+
+  const sinceIso = since.toISOString()
+
+  const { data: npsData, error: npsError } = await supabase
+    .from('nps_responses')
+    .select('score, created_at, feedback')
+    .gte('created_at', sinceIso)
+
+  if (npsError) {
+    console.error('Unable to load NPS analytics', npsError)
+  }
+
+  const { data: csatData, error: csatError } = await supabase
+    .from('csat_responses')
+    .select('rating, context, created_at')
+    .gte('created_at', sinceIso)
+
+  if (csatError) {
+    console.error('Unable to load CSAT analytics', csatError)
+  }
+
+  return computeFeedbackAnalytics(
+    (npsData ?? []) as NpsRow[],
+    (csatData ?? []) as CsatRow[],
+    now,
+  )
+}
+
+export const getFeedbackAnalytics = cache(fetchFeedbackAnalytics)

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "./components/skeletons"
 
 import InsightsPanel from "./components/insights-panel"
+import { FeedbackAnalyticsPanel } from "./components/feedback-analytics"
 
 export default function DashboardPage() {
   return (
@@ -65,6 +66,10 @@ export default function DashboardPage() {
           </Suspense>
         </div>
       </div>
+
+      <Suspense fallback={<DashboardCardSkeleton />}>
+        <FeedbackAnalyticsPanel />
+      </Suspense>
     </div>
   )
 }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ import { readUserSession } from "@/utils/actions"
 import MobileSideNav from "./components/MobileSideNav"
 import SideNav from "./components/SideNav"
 import ToggleSidebar from "./components/ToggleSidebar"
+import { NpsSurveyEntry } from "./(dashboard)/components/nps-survey-entry"
 
 export default async function Layout({ children }: { children: ReactNode }) {
 	const { data: userSession } = await readUserSession();
@@ -24,6 +25,9 @@ export default async function Layout({ children }: { children: ReactNode }) {
 
                         <div className="w-full space-y-5 bg-gray-100 p-5 sm:flex-1 sm:p-10 dark:bg-inherit">
                                 <ToggleSidebar />
+                                <Suspense fallback={null}>
+                                        <NpsSurveyEntry userId={userSession.session.user.id} />
+                                </Suspense>
                                 <ErrorBoundary>
                                         <Suspense fallback={<RouteSkeleton />}>
                                                 {children}

--- a/app/documents/components/document-actions.tsx
+++ b/app/documents/components/document-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -16,6 +16,10 @@ import { CreateSignatureDialog } from './create-signature-dialog';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
 import { MoreHorizontal, Eye, PenTool, Download, Share2 } from 'lucide-react';
 import { toast } from 'sonner';
+import useSupabaseBrowser from "@/utils/supabase-browser";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { CsatPrompt } from "@/components/feedback/CsatPrompt";
+import { canShowCsatPrompt } from "@/lib/feedback/client";
 
 interface DocumentActionsProps {
   document: DocumentWithLease;
@@ -25,7 +29,69 @@ export function DocumentActions({ document }: DocumentActionsProps) {
   const [showViewer, setShowViewer] = useState(false);
   const [showSignatureDialog, setShowSignatureDialog] = useState(false);
   const [loading, setLoading] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [csatState, setCsatState] = useState<
+    | {
+        open: boolean
+        contextId: string
+        entityName: string
+        reloadAfter: boolean
+      }
+    | null
+  >(null)
   const permissions = useDocumentPermissions();
+  const supabase = useSupabaseBrowser();
+  const client = supabase as unknown as TypedSupabaseClient;
+
+  useEffect(() => {
+    supabase.auth
+      .getUser()
+      .then(({ data }) => setUserId(data.user?.id ?? null))
+      .catch((error) => {
+        console.error('Unable to resolve user for CSAT prompt', error)
+      })
+  }, [supabase])
+
+  const handleCsatOpenChange = useCallback((nextOpen: boolean) => {
+    setCsatState((current) => (current ? { ...current, open: nextOpen } : current))
+  }, [])
+
+  const handleCsatClosed = useCallback(() => {
+    setCsatState((current) => {
+      if (current?.reloadAfter) {
+        window.location.reload()
+      }
+      return null
+    })
+  }, [])
+
+  const maybePromptDocumentCsat = useCallback(async () => {
+    if (!userId) {
+      return false
+    }
+
+    try {
+      const eligible = await canShowCsatPrompt(client, {
+        userId,
+        context: 'document_signed',
+        contextId: document.id,
+      })
+
+      if (eligible) {
+        setCsatState({
+          open: true,
+          contextId: document.id,
+          entityName: document.title,
+          reloadAfter: true,
+        })
+        return true
+      }
+    } catch (error) {
+      console.error('Unable to evaluate document CSAT eligibility', error)
+    }
+
+    return false
+  }, [client, document.id, document.title, userId])
 
   const handleView = () => {
     setShowViewer(true);
@@ -46,7 +112,10 @@ export function DocumentActions({ document }: DocumentActionsProps) {
       const result = await signDocumentAction(document.id);
       if (result.success) {
         toast.success('Document signed successfully');
-        window.location.reload();
+        const shouldDelayReload = await maybePromptDocumentCsat();
+        if (!shouldDelayReload) {
+          window.location.reload();
+        }
       } else {
         toast.error(result.error || 'Failed to sign document');
       }
@@ -149,6 +218,20 @@ export function DocumentActions({ document }: DocumentActionsProps) {
         onOpenChange={setShowSignatureDialog}
         document={document}
       />
+
+      {userId && csatState ? (
+        <CsatPrompt
+          open={csatState.open}
+          onOpenChange={handleCsatOpenChange}
+          onDismiss={handleCsatClosed}
+          onSubmitted={handleCsatClosed}
+          userId={userId}
+          context="document_signed"
+          contextId={csatState.contextId}
+          entityName={csatState.entityName}
+          metadata={{ documentId: document.id }}
+        />
+      ) : null}
     </>
   );
 }

--- a/components/feedback/CsatPrompt.tsx
+++ b/components/feedback/CsatPrompt.tsx
@@ -1,0 +1,217 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+import { persistCsatResponse } from "@/lib/feedback/persistence"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+import { toast } from "sonner"
+
+const RATING_OPTIONS = [1, 2, 3, 4, 5] as const
+
+const copyByContext: Record<
+  'document_signed' | 'maintenance_resolved',
+  { title: string; description: string; followUp: string }
+> = {
+  document_signed: {
+    title: 'How was signing your document?',
+    description: 'Quick CSAT pulse to confirm the Documenso experience met expectations.',
+    followUp: 'Anything you want your property manager to know about this signing experience?',
+  },
+  maintenance_resolved: {
+    title: 'Maintenance taken care of?',
+    description: 'Rate how satisfied you are with the resolution of this maintenance ticket.',
+    followUp: 'Share a quick note about the fix or technician visit (optional).',
+  },
+}
+
+interface CsatPromptProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onDismiss?: () => void
+  onSubmitted?: () => void
+  userId: string
+  context: 'document_signed' | 'maintenance_resolved'
+  contextId?: string
+  entityName?: string
+  metadata?: Record<string, unknown>
+}
+
+export function CsatPrompt({
+  open,
+  onOpenChange,
+  onDismiss,
+  onSubmitted,
+  userId,
+  context,
+  contextId,
+  entityName,
+  metadata,
+}: CsatPromptProps) {
+  const supabase = useSupabaseBrowser()
+  const client = supabase as unknown as TypedSupabaseClient
+  const [rating, setRating] = useState<number | null>(null)
+  const [comment, setComment] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const closingAfterSubmit = useRef(false)
+
+  useEffect(() => {
+    if (!open) {
+      setRating(null)
+      setComment("")
+      closingAfterSubmit.current = false
+    }
+  }, [open])
+
+  const contextCopy = copyByContext[context]
+
+  const ratingCaption = useMemo(() => {
+    if (rating === null) {
+      return "1 = Very dissatisfied, 5 = Very satisfied"
+    }
+
+    switch (rating) {
+      case 5:
+        return "Love it — everything was handled perfectly."
+      case 4:
+        return "Great overall — just a few tweaks away from perfect."
+      case 3:
+        return "It was okay — there’s room to improve."
+      case 2:
+        return "Not great — we should revisit this process."
+      default:
+        return "Rough experience — thanks for flagging it."
+    }
+  }, [rating])
+
+  const handleSubmit = async () => {
+    if (rating === null) {
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      await persistCsatResponse(client, {
+        userId,
+        context,
+        contextId,
+        rating,
+        comment: comment.trim() || undefined,
+        metadata,
+      })
+
+      toast.success("Feedback received — thank you!")
+      closingAfterSubmit.current = true
+      onSubmitted?.()
+      onOpenChange(false)
+    } catch (error) {
+      console.error("Unable to persist CSAT response", error)
+      toast.error("We couldn't save your response. Please try again.")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDialogChange = (nextOpen: boolean) => {
+    if (!nextOpen && open) {
+      if (!closingAfterSubmit.current) {
+        onDismiss?.()
+      }
+      closingAfterSubmit.current = false
+    }
+
+    onOpenChange(nextOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold">
+            {contextCopy.title}
+          </DialogTitle>
+          <DialogDescription className="space-y-1 text-sm text-muted-foreground">
+            <span>{contextCopy.description}</span>
+            {entityName ? (
+              <span className="block font-medium text-foreground">
+                {entityName}
+              </span>
+            ) : null}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <div className="space-y-3">
+            <Label className="text-sm font-medium text-foreground">
+              Satisfaction rating
+            </Label>
+            <div className="flex items-center gap-2">
+              {RATING_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={cn(
+                    "flex size-12 items-center justify-center rounded-full border text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+                    rating === option
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-muted text-muted-foreground hover:border-primary/70 hover:text-foreground",
+                  )}
+                  onClick={() => setRating(option)}
+                  aria-pressed={rating === option}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">{ratingCaption}</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="csat-comment" className="text-sm font-medium">
+              {contextCopy.followUp}
+            </Label>
+            <Textarea
+              id="csat-comment"
+              placeholder="Add helpful context for the team (optional)."
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              maxLength={400}
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => handleDialogChange(false)}
+            disabled={submitting}
+          >
+            Skip
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={rating === null || submitting}
+          >
+            {submitting ? "Sending..." : "Share feedback"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/feedback/NpsSurveyModal.tsx
+++ b/components/feedback/NpsSurveyModal.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+import { persistNpsResponse } from "@/lib/feedback/persistence"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+import { toast } from "sonner"
+
+const scores = Array.from({ length: 11 }, (_, index) => index)
+
+interface NpsSurveyModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onDismiss?: () => void
+  onSubmitted?: () => void
+  windowId: string
+  userId: string
+  quarterLabel: string
+}
+
+export function NpsSurveyModal({
+  open,
+  onOpenChange,
+  onDismiss,
+  onSubmitted,
+  windowId,
+  userId,
+  quarterLabel,
+}: NpsSurveyModalProps) {
+  const supabase = useSupabaseBrowser()
+  const client = supabase as unknown as TypedSupabaseClient
+  const [selectedScore, setSelectedScore] = useState<number | null>(null)
+  const [feedback, setFeedback] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const closingAfterSubmitRef = useRef(false)
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedScore(null)
+      setFeedback("")
+      closingAfterSubmitRef.current = false
+    }
+  }, [open])
+
+  const helperCopy = useMemo(() => {
+    if (selectedScore === null) {
+      return "0 = Not likely, 10 = Extremely likely"
+    }
+
+    if (selectedScore >= 9) {
+      return "Promoter — love that you're cheering us on!"
+    }
+
+    if (selectedScore >= 7) {
+      return "Passive — let us know how we can earn a 10."
+    }
+
+    return "Detractor — we appreciate the candor."
+  }, [selectedScore])
+
+  const handleSubmit = async () => {
+    if (selectedScore === null) {
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      await persistNpsResponse(client, {
+        userId,
+        windowId,
+        score: selectedScore,
+        feedback: feedback.trim() || undefined,
+      })
+
+      toast.success("Thanks for the feedback!")
+      closingAfterSubmitRef.current = true
+      onSubmitted?.()
+      onOpenChange(false)
+    } catch (error) {
+      console.error("Unable to persist NPS response", error)
+      toast.error("We couldn't save your score. Please try again.")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDialogChange = (nextOpen: boolean) => {
+    if (!nextOpen && open) {
+      if (!closingAfterSubmitRef.current) {
+        onDismiss?.()
+      }
+      closingAfterSubmitRef.current = false
+    }
+
+    onOpenChange(nextOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">
+            How likely are you to recommend Share House Portal?
+          </DialogTitle>
+          <DialogDescription>
+            Quarterly NPS • {quarterLabel}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <div className="space-y-3">
+            <Label className="text-sm font-medium text-foreground">
+              Your score
+            </Label>
+            <div className="grid grid-cols-11 gap-2">
+              {scores.map((score) => (
+                <button
+                  key={score}
+                  type="button"
+                  className={cn(
+                    "rounded-md border px-2 py-3 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+                    selectedScore === score
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-muted text-muted-foreground hover:border-primary/60 hover:text-foreground",
+                  )}
+                  onClick={() => setSelectedScore(score)}
+                  aria-pressed={selectedScore === score}
+                >
+                  {score}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">{helperCopy}</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="nps-notes" className="text-sm font-medium">
+              Anything else we should know?
+            </Label>
+            <Textarea
+              id="nps-notes"
+              placeholder="Share context, wins, or points of friction."
+              value={feedback}
+              onChange={(event) => setFeedback(event.target.value)}
+              maxLength={600}
+              rows={4}
+            />
+            <p className="text-xs text-muted-foreground">
+              Responses go straight to the property experience team.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => handleDialogChange(false)}
+            disabled={submitting}
+          >
+            Not now
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={selectedScore === null || submitting}
+          >
+            {submitting ? "Sending..." : "Submit score"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/feedback/analytics.ts
+++ b/lib/feedback/analytics.ts
@@ -1,0 +1,227 @@
+import type { Database } from "@/lib/supabase"
+
+import { getQuarterKey, parseIsoDate } from "./prompt-logic"
+
+type NpsRow = Database['public']['Tables']['nps_responses']['Row']
+type CsatRow = Database['public']['Tables']['csat_responses']['Row']
+
+type NpsRecord = {
+  score: number
+  createdAt: Date
+  feedback?: string | null
+}
+
+type CsatRecord = {
+  rating: number
+  context: CsatRow['context']
+  createdAt: Date
+}
+
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  year: 'numeric',
+})
+
+function isDefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined
+}
+
+function startOfMonth(date: Date) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1))
+}
+
+function shiftMonths(date: Date, delta: number) {
+  const shifted = startOfMonth(date)
+  shifted.setUTCMonth(shifted.getUTCMonth() + delta)
+  return shifted
+}
+
+export function calculateNpsScore(scores: number[]) {
+  if (!scores.length) {
+    return null
+  }
+
+  const total = scores.length
+  const promoters = scores.filter((score) => score >= 9).length
+  const detractors = scores.filter((score) => score <= 6).length
+  const rawScore = ((promoters - detractors) / total) * 100
+  return Math.round(rawScore)
+}
+
+export function calculateAverage(ratings: number[]) {
+  if (!ratings.length) {
+    return null
+  }
+
+  const sum = ratings.reduce((total, rating) => total + rating, 0)
+  return Number((sum / ratings.length).toFixed(2))
+}
+
+function buildDistribution(scores: number[]) {
+  return scores.reduce(
+    (acc, score) => {
+      if (score >= 9) {
+        acc.promoters += 1
+      } else if (score >= 7) {
+        acc.passives += 1
+      } else {
+        acc.detractors += 1
+      }
+
+      return acc
+    },
+    { promoters: 0, passives: 0, detractors: 0 },
+  )
+}
+
+export type FeedbackAnalytics = {
+  nps: {
+    currentScore: number | null
+    previousScore: number | null
+    trendDelta: number | null
+    responseCount: number
+    distribution: ReturnType<typeof buildDistribution>
+    recentComments: Array<{ feedback: string; createdAt: string }>
+  }
+  csat: {
+    averageRating: number | null
+    responseCount: number
+    contextBreakdown: Array<{
+      context: CsatRow['context']
+      average: number | null
+      count: number
+    }>
+  }
+  timeline: Array<{
+    period: string
+    npsScore: number | null
+    csatAverage: number | null
+  }>
+}
+
+export function computeFeedbackAnalytics(
+  npsResponses: NpsRow[],
+  csatResponses: CsatRow[],
+  now = new Date(),
+): FeedbackAnalytics {
+  const npsRecords: NpsRecord[] = npsResponses
+    .map((row) => {
+      const createdAt = parseIsoDate(row.created_at)
+      if (!createdAt) {
+        return null
+      }
+
+      return {
+        score: row.score,
+        createdAt,
+        feedback: row.feedback,
+      }
+    })
+    .filter(isDefined)
+
+  const csatRecords: CsatRecord[] = csatResponses
+    .map((row) => {
+      const createdAt = parseIsoDate(row.created_at)
+      if (!createdAt) {
+        return null
+      }
+
+      return {
+        rating: row.rating,
+        context: row.context,
+        createdAt,
+      }
+    })
+    .filter(isDefined)
+
+  const npsByQuarter = new Map<string, number[]>()
+  for (const record of npsRecords) {
+    const key = getQuarterKey(record.createdAt)
+    const scores = npsByQuarter.get(key) ?? []
+    scores.push(record.score)
+    npsByQuarter.set(key, scores)
+  }
+
+  const currentQuarterKey = getQuarterKey(now)
+  const previousQuarterKey = getQuarterKey(shiftMonths(now, -3))
+
+  const currentQuarterScores = npsByQuarter.get(currentQuarterKey) ?? []
+  const previousQuarterScores = npsByQuarter.get(previousQuarterKey) ?? []
+
+  const currentScore = calculateNpsScore(currentQuarterScores)
+  const previousScore = calculateNpsScore(previousQuarterScores)
+  const trendDelta =
+    currentScore !== null && previousScore !== null
+      ? currentScore - previousScore
+      : null
+
+  const distributionSource = currentQuarterScores.length
+    ? currentQuarterScores
+    : npsRecords.map((record) => record.score)
+
+  const timeline: FeedbackAnalytics['timeline'] = []
+  const monthsToDisplay = 6
+  for (let index = monthsToDisplay - 1; index >= 0; index -= 1) {
+    const periodStart = shiftMonths(now, -index)
+    const periodEnd = shiftMonths(now, -index + 1)
+
+    const periodNpsScores = npsRecords
+      .filter(
+        (record) =>
+          record.createdAt >= periodStart && record.createdAt < periodEnd,
+      )
+      .map((record) => record.score)
+
+    const periodCsatRatings = csatRecords
+      .filter(
+        (record) =>
+          record.createdAt >= periodStart && record.createdAt < periodEnd,
+      )
+      .map((record) => record.rating)
+
+    timeline.push({
+      period: monthFormatter.format(periodStart),
+      npsScore: calculateNpsScore(periodNpsScores),
+      csatAverage: calculateAverage(periodCsatRatings),
+    })
+  }
+
+  const recentComments = npsRecords
+    .filter((record) => Boolean(record.feedback?.trim()))
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .slice(0, 3)
+    .map((record) => ({
+      feedback: record.feedback!.trim(),
+      createdAt: record.createdAt.toISOString(),
+    }))
+
+  const csatByContext = new Map<CsatRow['context'], number[]>()
+  for (const record of csatRecords) {
+    const ratings = csatByContext.get(record.context) ?? []
+    ratings.push(record.rating)
+    csatByContext.set(record.context, ratings)
+  }
+
+  return {
+    nps: {
+      currentScore,
+      previousScore,
+      trendDelta,
+      responseCount: npsRecords.length,
+      distribution: buildDistribution(distributionSource),
+      recentComments,
+    },
+    csat: {
+      averageRating: calculateAverage(csatRecords.map((record) => record.rating)),
+      responseCount: csatRecords.length,
+      contextBreakdown: Array.from(csatByContext.entries()).map(
+        ([context, ratings]) => ({
+          context,
+          average: calculateAverage(ratings),
+          count: ratings.length,
+        }),
+      ),
+    },
+    timeline,
+  }
+}

--- a/lib/feedback/client.ts
+++ b/lib/feedback/client.ts
@@ -1,0 +1,63 @@
+import type { Database } from "@/lib/supabase"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+import { parseIsoDate, shouldDisplayCsatPrompt } from "./prompt-logic"
+
+type FeedbackContext = Database['public']['Tables']['csat_responses']['Row']['context']
+
+export async function canShowCsatPrompt(
+  client: TypedSupabaseClient,
+  {
+    userId,
+    context,
+    contextId,
+    cooldownHours,
+    now,
+  }: {
+    userId: string
+    context: FeedbackContext
+    contextId?: string
+    cooldownHours?: number
+    now?: Date
+  },
+) {
+  const existingQuery = client
+    .from('csat_responses')
+    .select('id, created_at')
+    .eq('user_id', userId)
+    .eq('context', context)
+    .limit(1)
+
+  const existingResponse = await (contextId
+    ? existingQuery.eq('context_id', contextId)
+    : existingQuery.is('context_id', null)
+  ).maybeSingle()
+
+  if (existingResponse.error) {
+    throw existingResponse.error
+  }
+
+  const respondedToEvent = Boolean(existingResponse.data)
+
+  const latestForContext = await client
+    .from('csat_responses')
+    .select('created_at')
+    .eq('user_id', userId)
+    .eq('context', context)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (latestForContext.error) {
+    throw latestForContext.error
+  }
+
+  const lastResponseAt = parseIsoDate(latestForContext.data?.created_at ?? null)
+
+  return shouldDisplayCsatPrompt({
+    respondedToEvent,
+    lastResponseAt,
+    cooldownHours,
+    now,
+  })
+}

--- a/lib/feedback/persistence.ts
+++ b/lib/feedback/persistence.ts
@@ -1,0 +1,66 @@
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+type NpsPayload = {
+  userId: string
+  windowId: string
+  score: number
+  feedback?: string
+  metadata?: Record<string, unknown>
+}
+
+type CsatPayload = {
+  userId: string
+  context: 'document_signed' | 'maintenance_resolved'
+  contextId?: string
+  rating: number
+  comment?: string
+  metadata?: Record<string, unknown>
+}
+
+export async function persistNpsResponse(
+  client: TypedSupabaseClient,
+  { userId, windowId, score, feedback, metadata }: NpsPayload,
+) {
+  const { data, error } = await client
+    .from('nps_responses')
+    .insert({
+      user_id: userId,
+      window_id: windowId,
+      score,
+      feedback: feedback ?? null,
+      metadata: metadata ?? null,
+    })
+    .select('id, created_at')
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  return data
+}
+
+export async function persistCsatResponse(
+  client: TypedSupabaseClient,
+  { userId, context, contextId, rating, comment, metadata }: CsatPayload,
+) {
+  const query = client.from('csat_responses')
+
+  const { data, error } = await query
+    .insert({
+      user_id: userId,
+      context,
+      context_id: contextId ?? null,
+      rating,
+      comment: comment ?? null,
+      metadata: metadata ?? null,
+    })
+    .select('id, created_at')
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  return data
+}

--- a/lib/feedback/prompt-logic.ts
+++ b/lib/feedback/prompt-logic.ts
@@ -1,0 +1,90 @@
+const DAY_IN_MS = 24 * 60 * 60 * 1000
+const HOUR_IN_MS = 60 * 60 * 1000
+
+export const DEFAULT_NPS_COOLDOWN_DAYS = 90
+export const DEFAULT_NPS_DISMISSAL_DAYS = 30
+export const DEFAULT_CSAT_COOLDOWN_HOURS = 48
+
+export type ShouldDisplayNpsPromptArgs = {
+  hasActiveWindow: boolean
+  respondedInWindow: boolean
+  lastResponseAt?: Date | null
+  dismissedAt?: Date | null
+  now?: Date
+  cooldownDays?: number
+  dismissalCooldownDays?: number
+}
+
+export function shouldDisplayNpsPrompt({
+  hasActiveWindow,
+  respondedInWindow,
+  lastResponseAt,
+  dismissedAt,
+  now = new Date(),
+  cooldownDays = DEFAULT_NPS_COOLDOWN_DAYS,
+  dismissalCooldownDays = DEFAULT_NPS_DISMISSAL_DAYS,
+}: ShouldDisplayNpsPromptArgs) {
+  if (!hasActiveWindow) {
+    return false
+  }
+
+  if (respondedInWindow) {
+    return false
+  }
+
+  if (dismissedAt) {
+    const dismissalDelta = now.getTime() - dismissedAt.getTime()
+    if (dismissalDelta < dismissalCooldownDays * DAY_IN_MS) {
+      return false
+    }
+  }
+
+  if (lastResponseAt) {
+    const responseDelta = now.getTime() - lastResponseAt.getTime()
+    if (responseDelta < cooldownDays * DAY_IN_MS) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export type ShouldDisplayCsatPromptArgs = {
+  respondedToEvent: boolean
+  lastResponseAt?: Date | null
+  now?: Date
+  cooldownHours?: number
+}
+
+export function shouldDisplayCsatPrompt({
+  respondedToEvent,
+  lastResponseAt,
+  now = new Date(),
+  cooldownHours = DEFAULT_CSAT_COOLDOWN_HOURS,
+}: ShouldDisplayCsatPromptArgs) {
+  if (respondedToEvent) {
+    return false
+  }
+
+  if (!lastResponseAt) {
+    return true
+  }
+
+  const responseDelta = now.getTime() - lastResponseAt.getTime()
+  return responseDelta >= cooldownHours * HOUR_IN_MS
+}
+
+export function getQuarterKey(date: Date) {
+  const year = date.getUTCFullYear()
+  const quarter = Math.floor(date.getUTCMonth() / 3) + 1
+  return `${year}-Q${quarter}`
+}
+
+export function parseIsoDate(value?: string | null) {
+  if (!value) {
+    return null
+  }
+
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -184,6 +184,34 @@ export type Database = {
         attachments: Json | null
         metadata: Json | null
       }>
+      nps_survey_windows: SupabaseTable<{
+        id: string
+        survey_year: number
+        survey_quarter: number
+        start_at: string
+        end_at: string
+        activated_at: string | null
+        created_at: string | null
+      }>
+      nps_responses: SupabaseTable<{
+        id: string
+        window_id: string
+        user_id: string
+        score: number
+        feedback: string | null
+        metadata: Json | null
+        created_at: string | null
+      }>
+      csat_responses: SupabaseTable<{
+        id: string
+        user_id: string
+        context: 'document_signed' | 'maintenance_resolved'
+        context_id: string | null
+        rating: number
+        comment: string | null
+        metadata: Json | null
+        created_at: string | null
+      }>
       visitor_logs: SupabaseTable<{
         id: string
         guest_name: string
@@ -277,6 +305,10 @@ export type Database = {
       }
       mark_notifications_read: {
         Args: { notification_ids: string[] }
+        Returns: void
+      }
+      activate_quarterly_nps: {
+        Args: Record<string, never>
         Returns: void
       }
       update_updated_at_column: {

--- a/supabase/migrations/20250318090000_feedback_surveys.sql
+++ b/supabase/migrations/20250318090000_feedback_surveys.sql
@@ -1,0 +1,135 @@
+-- Create survey windows to coordinate quarterly NPS prompts
+CREATE TABLE public.nps_survey_windows (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  survey_year INTEGER NOT NULL,
+  survey_quarter INTEGER NOT NULL CHECK (survey_quarter BETWEEN 1 AND 4),
+  start_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  end_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  activated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT nps_survey_windows_year_quarter_unique UNIQUE (survey_year, survey_quarter)
+);
+
+CREATE INDEX idx_nps_survey_windows_active ON public.nps_survey_windows (start_at DESC, end_at DESC);
+
+-- Capture individual NPS responses scoped to a survey window
+CREATE TABLE public.nps_responses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  window_id UUID NOT NULL REFERENCES public.nps_survey_windows(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  score SMALLINT NOT NULL CHECK (score BETWEEN 0 AND 10),
+  feedback TEXT,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_nps_responses_user_window ON public.nps_responses (user_id, window_id);
+CREATE INDEX idx_nps_responses_created_at ON public.nps_responses (created_at DESC);
+
+-- Store transactional CSAT feedback for high-impact flows
+CREATE TABLE public.csat_responses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  context TEXT NOT NULL CHECK (context IN ('document_signed', 'maintenance_resolved')),
+  context_id UUID,
+  rating SMALLINT NOT NULL CHECK (rating BETWEEN 1 AND 5),
+  comment TEXT,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_csat_responses_user_context ON public.csat_responses (user_id, context, context_id);
+CREATE INDEX idx_csat_responses_context ON public.csat_responses (context);
+CREATE INDEX idx_csat_responses_created_at ON public.csat_responses (created_at DESC);
+
+-- Enable RLS and expose data appropriately
+ALTER TABLE public.nps_survey_windows ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.nps_responses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.csat_responses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can view active NPS windows"
+  ON public.nps_survey_windows
+  FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Users can insert their own NPS responses"
+  ON public.nps_responses
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can view their own NPS responses"
+  ON public.nps_responses
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Property staff can view all NPS responses"
+  ON public.nps_responses
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Users can insert their own CSAT responses"
+  ON public.csat_responses
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can view their own CSAT responses"
+  ON public.csat_responses
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Property staff can view all CSAT responses"
+  ON public.csat_responses
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+-- Function used by cron to ensure an active survey window exists each quarter
+CREATE OR REPLACE FUNCTION public.activate_quarterly_nps()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_start TIMESTAMP WITH TIME ZONE := date_trunc('quarter', now());
+  current_end TIMESTAMP WITH TIME ZONE := (date_trunc('quarter', now()) + INTERVAL '3 months') - INTERVAL '1 second';
+  current_year INTEGER := EXTRACT(YEAR FROM current_start);
+  current_quarter INTEGER := EXTRACT(QUARTER FROM current_start);
+BEGIN
+  INSERT INTO public.nps_survey_windows (survey_year, survey_quarter, start_at, end_at, activated_at)
+  VALUES (current_year, current_quarter, current_start, current_end, NOW())
+  ON CONFLICT (survey_year, survey_quarter)
+  DO UPDATE SET
+    start_at = EXCLUDED.start_at,
+    end_at = EXCLUDED.end_at,
+    activated_at = NOW();
+END;
+$$;
+
+-- Ensure the cron job exists to activate the survey window on the first business day of the quarter
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'nps-quarterly-survey') THEN
+    PERFORM cron.schedule(
+      'nps-quarterly-survey',
+      '0 9 1 JAN,APR,JUL,OCT *',
+      $$select public.activate_quarterly_nps();$$
+    );
+  END IF;
+END $$;
+
+-- Seed the current quarter window immediately so clients can display prompts without waiting for cron
+SELECT public.activate_quarterly_nps();

--- a/tests/feedback.test.ts
+++ b/tests/feedback.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  DEFAULT_CSAT_COOLDOWN_HOURS,
+  DEFAULT_NPS_COOLDOWN_DAYS,
+  DEFAULT_NPS_DISMISSAL_DAYS,
+  shouldDisplayCsatPrompt,
+  shouldDisplayNpsPrompt,
+} from "@/lib/feedback/prompt-logic"
+import { persistCsatResponse, persistNpsResponse } from "@/lib/feedback/persistence"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+describe("prompt cooldown logic", () => {
+  it("does not show NPS prompt when user already responded this window", () => {
+    const result = shouldDisplayNpsPrompt({
+      hasActiveWindow: true,
+      respondedInWindow: true,
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it("respects NPS cooldown and dismissal windows", () => {
+    const now = new Date()
+    const recentResponse = new Date(now.getTime() - (DEFAULT_NPS_COOLDOWN_DAYS - 10) * 24 * 60 * 60 * 1000)
+    const recentDismissal = new Date(now.getTime() - (DEFAULT_NPS_DISMISSAL_DAYS - 5) * 24 * 60 * 60 * 1000)
+
+    const result = shouldDisplayNpsPrompt({
+      hasActiveWindow: true,
+      respondedInWindow: false,
+      lastResponseAt: recentResponse,
+      dismissedAt: recentDismissal,
+      now,
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it("shows NPS prompt when cooldown has elapsed", () => {
+    const now = new Date()
+    const olderResponse = new Date(now.getTime() - (DEFAULT_NPS_COOLDOWN_DAYS + 5) * 24 * 60 * 60 * 1000)
+
+    const result = shouldDisplayNpsPrompt({
+      hasActiveWindow: true,
+      respondedInWindow: false,
+      lastResponseAt: olderResponse,
+      now,
+    })
+
+    expect(result).toBe(true)
+  })
+
+  it("suppresses CSAT prompt when the same event already has feedback", () => {
+    const result = shouldDisplayCsatPrompt({
+      respondedToEvent: true,
+      cooldownHours: DEFAULT_CSAT_COOLDOWN_HOURS,
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it("enforces CSAT cooldown between events", () => {
+    const now = new Date()
+    const recent = new Date(now.getTime() - (DEFAULT_CSAT_COOLDOWN_HOURS - 2) * 60 * 60 * 1000)
+
+    const result = shouldDisplayCsatPrompt({
+      respondedToEvent: false,
+      lastResponseAt: recent,
+      now,
+      cooldownHours: DEFAULT_CSAT_COOLDOWN_HOURS,
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it("allows CSAT prompt when cooldown expires", () => {
+    const now = new Date()
+    const older = new Date(now.getTime() - (DEFAULT_CSAT_COOLDOWN_HOURS + 1) * 60 * 60 * 1000)
+
+    const result = shouldDisplayCsatPrompt({
+      respondedToEvent: false,
+      lastResponseAt: older,
+      now,
+      cooldownHours: DEFAULT_CSAT_COOLDOWN_HOURS,
+    })
+
+    expect(result).toBe(true)
+  })
+})
+
+describe("feedback persistence", () => {
+  const buildMockClient = () => {
+    const single = vi.fn().mockResolvedValue({ data: { id: "abc", created_at: "2024-01-01T00:00:00Z" }, error: null })
+    const select = vi.fn().mockReturnValue({ single })
+    const insert = vi.fn().mockReturnValue({ select })
+    const from = vi.fn().mockReturnValue({ insert })
+
+    const client = { from } as unknown as TypedSupabaseClient
+
+    return { client, from, insert, select, single }
+  }
+
+  it("persists NPS responses with metadata", async () => {
+    const { client, from, insert, select, single } = buildMockClient()
+
+    const result = await persistNpsResponse(client, {
+      userId: 'user-1',
+      windowId: 'window-1',
+      score: 9,
+      feedback: 'Great service',
+      metadata: { channel: 'in-app' },
+    })
+
+    expect(from).toHaveBeenCalledWith('nps_responses')
+    expect(insert).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      window_id: 'window-1',
+      score: 9,
+      feedback: 'Great service',
+      metadata: { channel: 'in-app' },
+    })
+    expect(select).toHaveBeenCalledWith('id, created_at')
+    expect(single).toHaveBeenCalled()
+    expect(result).toEqual({ id: 'abc', created_at: '2024-01-01T00:00:00Z' })
+  })
+
+  it("persists CSAT responses", async () => {
+    const { client, from, insert } = buildMockClient()
+
+    await persistCsatResponse(client, {
+      userId: 'user-2',
+      context: 'document_signed',
+      contextId: 'doc-1',
+      rating: 5,
+      comment: 'Smooth experience',
+    })
+
+    expect(from).toHaveBeenCalledWith('csat_responses')
+    expect(insert).toHaveBeenCalledWith({
+      user_id: 'user-2',
+      context: 'document_signed',
+      context_id: 'doc-1',
+      rating: 5,
+      comment: 'Smooth experience',
+      metadata: null,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add Supabase schema for NPS windows/responses and CSAT tracking with quarterly cron activation
- introduce reusable NPS and CSAT feedback prompts tied to document signing and maintenance resolution flows
- surface feedback analytics on the dashboard with new server components and ensure cooldown logic is tested

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d20ba157908328b238da90eb51f6e6