### PR TITLE
Add referral program schema and dashboard

### DIFF
--- a/app/account/referrals/ShareLinkInput.tsx
+++ b/app/account/referrals/ShareLinkInput.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { Check, Copy } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard"
+
+interface ShareLinkInputProps {
+  referralLink: string
+}
+
+export function ShareLinkInput({ referralLink }: ShareLinkInputProps) {
+  const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
+  const copied = Boolean(isCopied)
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <Input value={referralLink} readOnly className="font-mono" />
+      <Button
+        type="button"
+        variant={copied ? "secondary" : "outline"}
+        onClick={() => copyToClipboard(referralLink)}
+        className="sm:w-auto"
+      >
+        {copied ? (
+          <>
+            <Check className="mr-2 size-4" />
+            Copied
+          </>
+        ) : (
+          <>
+            <Copy className="mr-2 size-4" />
+            Copy link
+          </>
+        )}
+      </Button>
+    </div>
+  )
+}

--- a/app/account/referrals/loaders.ts
+++ b/app/account/referrals/loaders.ts
@@ -1,0 +1,214 @@
+"use server"
+
+import "server-only"
+
+import { cookies } from "next/headers"
+
+import type { User } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+import {
+  REFERRAL_REWARD_CURRENCY,
+  buildRewardSeed,
+  generateReferralCode,
+  summarizeRewards,
+  type RewardSummary,
+} from "@/lib/referrals"
+import { createClient } from "@/utils/supa-server-actions"
+
+interface ReferralDashboardReferral {
+  id: string
+  referredEmail: string
+  status: Database["public"]["Tables"]["referrals"]["Row"]["status"]
+  createdAt: string | null
+  signedUpAt: string | null
+  qualifiedAt: string | null
+  rewardedAt: string | null
+  reward: {
+    amount: number
+    currency: string
+    status: Database["public"]["Tables"]["rewards"]["Row"]["status"]
+  } | null
+}
+
+export interface ReferralDashboardData {
+  user: User | null
+  referralCode: string | null
+  referralLink: string | null
+  usageCount: number
+  referrals: ReferralDashboardReferral[]
+  rewardTotals: RewardSummary
+}
+
+type ReferralCodeRow = Pick<Database["public"]["Tables"]["referral_codes"]["Row"], "id" | "code" | "usage_count">
+type ReferralListRow = Pick<
+  Database["public"]["Tables"]["referrals"]["Row"],
+  | "id"
+  | "referrer_id"
+  | "referred_email"
+  | "status"
+  | "created_at"
+  | "signed_up_at"
+  | "qualified_at"
+  | "rewarded_at"
+  | "referred_user_id"
+>
+type RewardListRow = Pick<
+  Database["public"]["Tables"]["rewards"]["Row"],
+  "id" | "referral_id" | "reward_type" | "status" | "amount" | "currency" | "issued_at" | "paid_at"
+>
+
+type SupabaseClient = ReturnType<typeof createClient>
+
+export async function loadReferralDashboardData(): Promise<ReferralDashboardData> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      user: null,
+      referralCode: null,
+      referralLink: null,
+      usageCount: 0,
+      referrals: [],
+      rewardTotals: {
+        pending: 0,
+        earned: 0,
+        paid: 0,
+        cancelled: 0,
+        currency: REFERRAL_REWARD_CURRENCY,
+      },
+    }
+  }
+
+  const activeCode = await ensureReferralCode(supabase, user.id)
+  const appUrl = (process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000").replace(/\/$/, "")
+  const referralLink = activeCode ? `${appUrl}/onboarding?ref=${activeCode.code}` : null
+
+  const { data: referralRows, error: referralError } = await supabase
+    .from("referrals")
+    .select(
+      "id, referrer_id, referred_email, status, created_at, signed_up_at, qualified_at, rewarded_at, referred_user_id",
+    )
+    .eq("referrer_id", user.id)
+    .order("created_at", { ascending: false, nullsFirst: false })
+    .returns<ReferralListRow[]>()
+
+  if (referralError) {
+    console.error("Failed to load referral records", referralError)
+  }
+
+  const { data: rewardRows, error: rewardError } = await supabase
+    .from("rewards")
+    .select("id, referral_id, reward_type, status, amount, currency, issued_at, paid_at")
+    .eq("user_id", user.id)
+    .returns<RewardListRow[]>()
+
+  if (rewardError) {
+    console.error("Failed to load reward records", rewardError)
+  }
+
+  const rewardMap = new Map<string, RewardListRow>()
+  rewardRows?.forEach((reward) => {
+    if (reward.reward_type === "referrer") {
+      rewardMap.set(reward.referral_id, reward)
+    }
+  })
+
+  const referrals: ReferralDashboardReferral[] = (referralRows ?? []).map((referral) => {
+    const reward = rewardMap.get(referral.id)
+
+    const fallback = buildRewardSeed({
+      id: referral.id,
+      status: referral.status,
+      referrer_id: referral.referrer_id,
+      referred_user_id: referral.referred_user_id,
+    })
+
+    const referrerReward = reward
+      ? {
+          amount: typeof reward.amount === "string" ? Number(reward.amount) : reward.amount || 0,
+          currency: reward.currency || REFERRAL_REWARD_CURRENCY,
+          status: reward.status,
+        }
+      : fallback.length
+        ? {
+            amount:
+              typeof fallback[0].amount === "string" ? Number(fallback[0].amount) : fallback[0].amount || 0,
+            currency: fallback[0].currency || REFERRAL_REWARD_CURRENCY,
+            status: fallback[0].status,
+          }
+        : null
+
+    return {
+      id: referral.id,
+      referredEmail: referral.referred_email,
+      status: referral.status,
+      createdAt: referral.created_at,
+      signedUpAt: referral.signed_up_at,
+      qualifiedAt: referral.qualified_at,
+      rewardedAt: referral.rewarded_at,
+      reward: referrerReward,
+    }
+  })
+
+  const rewardTotals = summarizeRewards(rewardRows ?? [])
+
+  return {
+    user,
+    referralCode: activeCode?.code ?? null,
+    referralLink,
+    usageCount: activeCode?.usage_count ?? 0,
+    referrals,
+    rewardTotals,
+  }
+}
+
+async function ensureReferralCode(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<ReferralCodeRow | null> {
+  const { data: existingCodes, error: existingError } = await supabase
+    .from("referral_codes")
+    .select("id, code, usage_count")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .returns<ReferralCodeRow[]>()
+
+  if (existingError) {
+    console.error("Failed to fetch referral code", existingError)
+  }
+
+  if (existingCodes?.[0]) {
+    return existingCodes[0]
+  }
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const candidateCode = generateReferralCode()
+
+    const { data: newCodes, error } = await supabase
+      .from("referral_codes")
+      .insert({ user_id: userId, code: candidateCode })
+      .select("id, code, usage_count")
+      .returns<ReferralCodeRow[]>()
+
+    if (error) {
+      if (error.code === "23505") {
+        continue
+      }
+      console.error("Failed to create referral code", error)
+      break
+    }
+
+    if (newCodes?.[0]) {
+      return newCodes[0]
+    }
+  }
+
+  return null
+}

--- a/app/account/referrals/page.tsx
+++ b/app/account/referrals/page.tsx
@@ -1,0 +1,233 @@
+import { redirect } from "next/navigation"
+
+import { Gift, Link2, Users } from "lucide-react"
+
+import { Badge, type BadgeProps } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+
+import { loadReferralDashboardData } from "./loaders"
+import { ShareLinkInput } from "./ShareLinkInput"
+
+const STATUS_METADATA: Record<
+  string,
+  {
+    label: string
+    description: string
+    variant: BadgeProps["variant"]
+  }
+> = {
+  invited: {
+    label: "Invited",
+    description: "Waiting for signup",
+    variant: "outline",
+  },
+  signed_up: {
+    label: "Signed up",
+    description: "Account created",
+    variant: "secondary",
+  },
+  qualified: {
+    label: "Qualified",
+    description: "Reward ready",
+    variant: "default",
+  },
+  rewarded: {
+    label: "Rewarded",
+    description: "Payout sent",
+    variant: "complete",
+  },
+  cancelled: {
+    label: "Cancelled",
+    description: "Invite withdrawn",
+    variant: "destructive",
+  },
+}
+
+function formatCurrency(amount: number, currency: string) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+function formatDateTime(value: string | null) {
+  if (!value) {
+    return "—"
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value))
+}
+
+export default async function ReferralDashboardPage() {
+  const data = await loadReferralDashboardData()
+
+  if (!data.user) {
+    redirect("/auth")
+  }
+
+  const { referralCode, referralLink, referrals, rewardTotals } = data
+
+  const totalInvites = referrals.length
+  const signedUpCount = referrals.filter((referral) => referral.status === "signed_up" || referral.status === "qualified" || referral.status === "rewarded").length
+  const qualifiedCount = referrals.filter((referral) => referral.status === "qualified" || referral.status === "rewarded").length
+
+  return (
+    <div className="mt-10 px-2 lg:p-8">
+      <div className="mx-auto flex w-full flex-col space-y-6 lg:max-w-5xl">
+        <div className="flex flex-col space-y-2 text-left">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-5xl">Referral Rewards</h1>
+          <p className="text-base text-muted-foreground">
+            Share your invite link with future roommates to unlock rent credits and bonuses when they join Roomsily.
+          </p>
+        </div>
+        <Separator />
+        <Card>
+          <CardHeader className="gap-2 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <CardTitle className="text-xl">Share your invite</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Send your personalized link to track signups and rewards in real time.
+              </p>
+            </div>
+            {referralCode ? (
+              <div className="flex flex-col items-start text-sm font-medium lg:items-end">
+                <span className="text-muted-foreground">Referral code</span>
+                <span className="font-mono text-lg">{referralCode}</span>
+              </div>
+            ) : null}
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {referralLink ? (
+              <ShareLinkInput referralLink={referralLink} />
+            ) : (
+              <div className="rounded-md border border-dashed border-muted-foreground/50 p-4 text-sm text-muted-foreground">
+                We couldn&apos;t generate a link right now. Refresh to try again.
+              </div>
+            )}
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div className="flex items-start gap-3 rounded-md border p-4">
+                <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <Users className="size-4" />
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Invites sent</p>
+                  <p className="text-xl font-semibold">{totalInvites}</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-md border p-4">
+                <div className="flex size-10 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
+                  <Link2 className="size-4" />
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Signups credited</p>
+                  <p className="text-xl font-semibold">{signedUpCount}</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-md border p-4">
+                <div className="flex size-10 items-center justify-center rounded-full bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300">
+                  <Gift className="size-4" />
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Qualified rewards</p>
+                  <p className="text-xl font-semibold">{qualifiedCount}</p>
+                </div>
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-3">
+              <Metric
+                label="Pending"
+                amount={rewardTotals.pending}
+                currency={rewardTotals.currency}
+              />
+              <Metric
+                label="Earned"
+                amount={rewardTotals.earned}
+                currency={rewardTotals.currency}
+              />
+              <Metric
+                label="Paid out"
+                amount={rewardTotals.paid}
+                currency={rewardTotals.currency}
+              />
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Referral activity</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {referrals.length === 0 ? (
+              <div className="rounded-md border border-dashed border-muted-foreground/40 p-6 text-center text-sm text-muted-foreground">
+                No referrals yet. Share your link to see progress here.
+              </div>
+            ) : (
+              <div className="overflow-hidden rounded-md border">
+                <table className="min-w-full divide-y divide-muted-foreground/20 text-sm">
+                  <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">
+                        Invitee
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">
+                        Status
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">
+                        Reward
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">
+                        Last update
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-muted-foreground/20">
+                    {referrals.map((referral) => {
+                      const statusMeta = STATUS_METADATA[referral.status] ?? STATUS_METADATA.invited
+                      const lastTouch = referral.rewardedAt || referral.qualifiedAt || referral.signedUpAt || referral.createdAt
+                      const rewardLabel = referral.reward
+                        ? `${formatCurrency(referral.reward.amount, referral.reward.currency)} • ${referral.reward.status
+                            .replace(/_/g, " ")
+                            .replace(/\b\w/g, (char) => char.toUpperCase())}`
+                        : "—"
+
+                      return (
+                        <tr key={referral.id} className="bg-background/50">
+                          <td className="px-4 py-3 font-medium text-foreground">
+                            {referral.referredEmail}
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex flex-col">
+                              <Badge variant={statusMeta.variant}>{statusMeta.label}</Badge>
+                              <span className="text-xs text-muted-foreground">{statusMeta.description}</span>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-muted-foreground">{rewardLabel}</td>
+                          <td className="px-4 py-3 text-muted-foreground">{formatDateTime(lastTouch)}</td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, amount, currency }: { label: string; amount: number; currency: string }) {
+  return (
+    <div className="rounded-md border p-4">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="text-xl font-semibold">{formatCurrency(amount, currency)}</p>
+    </div>
+  )
+}

--- a/app/auth-server-action/actions/index.ts
+++ b/app/auth-server-action/actions/index.ts
@@ -3,21 +3,108 @@
 import { createSupbaseServerClient } from "@/utils/supaone";
 import { redirect } from "next/navigation";
 
-export async function signUpWithEmailAndPassword(data: {
-	email: string;
-	password: string;
-	confirm: string;
-}) {
-	const supabase = await createSupbaseServerClient();
+import type { Database } from "@/lib/supabase";
+import { normalizeReferralCode } from "@/lib/referrals";
+import { createServiceRoleClient } from "@/utils/supabase/service-role";
 
-	const result = await supabase.auth.signUp(data);
-	return JSON.stringify(result);
+export async function signUpWithEmailAndPassword(data: {
+        email: string;
+        password: string;
+        confirm: string;
+        referralCode?: string;
+}) {
+        const supabase = await createSupbaseServerClient();
+
+        const { referralCode, ...authPayload } = data;
+
+        const result = await supabase.auth.signUp(authPayload);
+
+        const normalizedCode = normalizeReferralCode(referralCode);
+
+        if (normalizedCode) {
+                await processReferralSignup({
+                        referralCode: normalizedCode,
+                        email: data.email,
+                        referredUserId: result.data?.user?.id ?? null,
+                });
+        }
+
+        return JSON.stringify(result);
 }
 
 export async function logout() {
 	const supabase = await createSupbaseServerClient();
-	await supabase.auth.signOut();
-	redirect("/auth");
+        await supabase.auth.signOut();
+        redirect("/auth");
+}
+
+interface ProcessReferralSignupParams {
+        referralCode: string;
+        email: string;
+        referredUserId: string | null;
+}
+
+type ReferralCodeRow = Database["public"]["Tables"]["referral_codes"]["Row"];
+
+async function processReferralSignup({
+        referralCode,
+        email,
+        referredUserId,
+}: ProcessReferralSignupParams) {
+        try {
+                const serviceClient = createServiceRoleClient();
+
+                const { data: code, error: codeError } = await serviceClient
+                        .from("referral_codes")
+                        .select("id, user_id, usage_count, max_uses, expires_at")
+                        .eq("code", referralCode)
+                        .maybeSingle<Pick<ReferralCodeRow, "id" | "user_id" | "usage_count" | "max_uses" | "expires_at">>();
+
+                if (codeError || !code) {
+                        if (codeError) {
+                                console.error("Failed to look up referral code", codeError);
+                        }
+                        return;
+                }
+
+                if (code.expires_at && new Date(code.expires_at) < new Date()) {
+                        return;
+                }
+
+                if (code.max_uses && code.usage_count >= code.max_uses) {
+                        return;
+                }
+
+                const now = new Date().toISOString();
+
+                const { data: referrals, error: referralError } = await serviceClient
+                        .from("referrals")
+                        .insert({
+                                referral_code_id: code.id,
+                                referrer_id: code.user_id,
+                                referred_email: email,
+                                referred_user_id: referredUserId,
+                                status: referredUserId ? "signed_up" : "invited",
+                                invited_at: now,
+                                signed_up_at: referredUserId ? now : null,
+                        })
+                        .select()
+                        .returns<Database["public"]["Tables"]["referrals"]["Row"][]>();
+
+                if (referralError || !referrals?.length) {
+                        if (referralError) {
+                                console.error("Failed to create referral entry", referralError);
+                        }
+                        return;
+                }
+
+                await serviceClient
+                        .from("referral_codes")
+                        .update({ usage_count: (code.usage_count ?? 0) + 1 })
+                        .eq("id", code.id);
+        } catch (error) {
+                console.error("Referral signup processing failed", error);
+        }
 }
 
 

--- a/app/auth-server-action/components/AuthFormLegacy.tsx
+++ b/app/auth-server-action/components/AuthFormLegacy.tsx
@@ -5,22 +5,26 @@ import SignInForm from "./SignInForm";
 import RegisterForm from "./RegisterForm";
 import OAuthForm from "./OAuthForm";
 
-export function AuthFormLegacy() {
-	return (
-		<div className="w-full space-y-5">
-			<Tabs defaultValue="signin" className="w-full">
-				<TabsList className="grid w-full grid-cols-2">
-					<TabsTrigger value="signin">SignIn</TabsTrigger>
+interface AuthFormLegacyProps {
+        referralToken?: string;
+}
+
+export function AuthFormLegacy({ referralToken }: AuthFormLegacyProps) {
+        return (
+                <div className="w-full space-y-5">
+                        <Tabs defaultValue="signin" className="w-full">
+                                <TabsList className="grid w-full grid-cols-2">
+                                        <TabsTrigger value="signin">SignIn</TabsTrigger>
 					<TabsTrigger value="register">Register</TabsTrigger>
 				</TabsList>
-				<TabsContent value="signin">
-					<SignInForm />
-				</TabsContent>
-				<TabsContent value="register">
-					<RegisterForm />
-				</TabsContent>
-			</Tabs>
-			<OAuthForm />
-		</div>
-	);
+                                <TabsContent value="signin">
+                                        <SignInForm />
+                                </TabsContent>
+                                <TabsContent value="register">
+                                        <RegisterForm referralToken={referralToken} />
+                                </TabsContent>
+                        </Tabs>
+                        <OAuthForm />
+                </div>
+        );
 }

--- a/app/auth-server-action/components/RegisterForm.tsx
+++ b/app/auth-server-action/components/RegisterForm.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
-import { signUpWithEmailAndPassword } from '@/app/auth-server-action/actions'
+import { signUpWithEmailAndPassword } from "@/app/auth-server-action/actions";
 
 import {
 	Form,
@@ -22,35 +22,49 @@ import { useTransition } from "react";
 import { AuthTokenResponse } from "@supabase/supabase-js";
 
 const RegisterSchema = z
-	.object({
-		email: z.string().email(),
-		password: z.string().min(6, {
-			message: "Password is required.",
-		}),
-		confirm: z.string().min(6, {
-			message: "Password is required.",
-		}),
-	})
-	.refine((data) => data.confirm === data.password, {
-		message: "Password did not match",
-		path: ["confirm"],
-	});
-export default function RegisterForm() {
-	const [isPending, startTransition] = useTransition();
-	const form = useForm<z.infer<typeof RegisterSchema>>({
-		resolver: zodResolver(RegisterSchema),
-		defaultValues: {
-			email: "",
-			password: "",
-			confirm: "",
-		},
-	});
+        .object({
+                email: z.string().email(),
+                password: z.string().min(6, {
+                        message: "Password is required.",
+                }),
+                confirm: z.string().min(6, {
+                        message: "Password is required.",
+                }),
+                referralCode: z
+                        .string()
+                        .optional()
+                        .transform((value) => value?.trim() ?? ""),
+        })
+        .refine((data) => data.confirm === data.password, {
+                message: "Password did not match",
+                path: ["confirm"],
+        });
+interface RegisterFormProps {
+        referralToken?: string;
+}
 
-	function onSubmit(data: z.infer<typeof RegisterSchema>) {
-		startTransition(async () => {
+export default function RegisterForm({ referralToken }: RegisterFormProps) {
+        const [isPending, startTransition] = useTransition();
+        const form = useForm<z.infer<typeof RegisterSchema>>({
+                resolver: zodResolver(RegisterSchema),
+                defaultValues: {
+                        email: "",
+                        password: "",
+                        confirm: "",
+                        referralCode: referralToken ?? "",
+                },
+        });
+
+        function onSubmit(data: z.infer<typeof RegisterSchema>) {
+                startTransition(async () => {
 			const { error } = JSON.parse(
-				await signUpWithEmailAndPassword(data)
-			) as AuthTokenResponse;
+                                await signUpWithEmailAndPassword({
+                                        email: data.email,
+                                        password: data.password,
+                                        confirm: data.confirm,
+                                        referralCode: data.referralCode,
+                                })
+                        ) as AuthTokenResponse;
 		
 		if (error)	{	
 			toast({
@@ -114,34 +128,54 @@ export default function RegisterForm() {
 						</FormItem>
 					)}
 				/>
-				<FormField
-					control={form.control}
-					name="confirm"
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Confirm Password</FormLabel>
-							<FormControl>
-								<Input
-									placeholder="Confirm Password"
-									{...field}
-									type="password"
-									onChange={field.onChange}
-								/>
-							</FormControl>
+                                <FormField
+                                        control={form.control}
+                                        name="confirm"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Confirm Password</FormLabel>
+                                                        <FormControl>
+                                                                <Input
+                                                                        placeholder="Confirm Password"
+                                                                        {...field}
+                                                                        type="password"
+                                                                        onChange={field.onChange}
+                                                                />
+                                                        </FormControl>
 
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
-<Button
-				className="flex w-full items-center gap-2"
-				variant="outline"
-			>
-				Register{" "}
-				<AiOutlineLoading3Quarters
-					className={cn(" animate-spin", { hidden: !isPending })}
-				/>
-			</Button>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <FormField
+                                        control={form.control}
+                                        name="referralCode"
+                                        render={({ field }) => (
+                                                <FormItem>
+                                                        <FormLabel>Referral code</FormLabel>
+                                                        <FormControl>
+                                                                <Input
+                                                                        placeholder="Optional code from a roommate"
+                                                                        {...field}
+                                                                        onChange={field.onChange}
+                                                                />
+                                                        </FormControl>
+                                                        <FormDescription>
+                                                                Earn rewards when you join with a roommate invite.
+                                                        </FormDescription>
+                                                        <FormMessage />
+                                                </FormItem>
+                                        )}
+                                />
+                                <Button
+                                        className="flex w-full items-center gap-2"
+                                        variant="outline"
+                                >
+                                        Register{" "}
+                                <AiOutlineLoading3Quarters
+                                        className={cn(" animate-spin", { hidden: !isPending })}
+                                />
+                                </Button>
 			</form>
 		</Form>
 	);

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -4,15 +4,30 @@ import SmartLink from "@/components/navigation/SmartLink"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
-import AuthForm from "@/app/auth/components/AuthForm"
-import { AuthFormLegacy } from '@/app/auth-server-action/components/AuthFormLegacy'
+import { AuthFormLegacy } from "@/app/auth-server-action/components/AuthFormLegacy"
+
+interface OnboardingPageProps {
+  searchParams?: Record<string, string | string[] | undefined>
+}
 
 export const metadata: Metadata = {
   title: "Onboarding",
   description: "Roomsily household onboarding",
 }
 
-export default function OnboardingPage() {
+export default function OnboardingPage({ searchParams }: OnboardingPageProps) {
+  const referralToken = (() => {
+    const candidate =
+      typeof searchParams?.ref === 'string'
+        ? searchParams?.ref
+        : typeof searchParams?.referral === 'string'
+          ? searchParams?.referral
+          : typeof searchParams?.token === 'string'
+            ? searchParams?.token
+            : undefined
+
+    return typeof candidate === 'string' ? candidate : undefined
+  })()
   return (
     <>
       <div className="hidden">
@@ -87,7 +102,12 @@ export default function OnboardingPage() {
                 Enter your email below to create your account
               </p>
             </div>
-            <AuthFormLegacy />
+            {referralToken ? (
+              <div className="rounded-md border border-primary/40 bg-primary/10 p-3 text-sm text-primary">
+                Referral code applied. Complete signup to credit your roommate.
+              </div>
+            ) : null}
+            <AuthFormLegacy referralToken={referralToken} />
             <p className="px-8 text-center text-sm text-muted-foreground">
               By clicking continue, you agree to our{" "}
               <SmartLink

--- a/lib/referrals.ts
+++ b/lib/referrals.ts
@@ -1,0 +1,155 @@
+import { randomBytes } from 'node:crypto'
+
+import type { Database, TablesInsert, TablesUpdate } from './supabase'
+
+type ReferralRow = Database['public']['Tables']['referrals']['Row']
+type RewardRow = Database['public']['Tables']['rewards']['Row']
+
+export type ReferralStatus = ReferralRow['status']
+export type RewardStatus = RewardRow['status']
+export type RewardType = RewardRow['reward_type']
+
+export const REFERRER_REWARD_AMOUNT = 50
+export const REFEREE_REWARD_AMOUNT = 25
+export const REFERRAL_REWARD_CURRENCY = 'USD'
+
+const REWARD_STATUS_MATRIX: Record<ReferralStatus, Record<RewardType, RewardStatus>> = {
+  invited: { referrer: 'pending', referee: 'pending' },
+  signed_up: { referrer: 'earned', referee: 'pending' },
+  qualified: { referrer: 'earned', referee: 'earned' },
+  rewarded: { referrer: 'paid', referee: 'paid' },
+  cancelled: { referrer: 'cancelled', referee: 'cancelled' },
+}
+
+export interface RewardSummary {
+  pending: number
+  earned: number
+  paid: number
+  cancelled: number
+  currency: string
+}
+
+export function normalizeReferralCode(code?: string | null): string | undefined {
+  if (!code) {
+    return undefined
+  }
+
+  const trimmed = code.trim()
+  if (!trimmed) {
+    return undefined
+  }
+
+  return trimmed.replace(/[^a-zA-Z0-9]/g, '').toUpperCase()
+}
+
+export function deriveRewardStatusFromReferralStatus(
+  status: ReferralStatus,
+  rewardType: RewardType,
+): RewardStatus {
+  return REWARD_STATUS_MATRIX[status][rewardType]
+}
+
+export function summarizeRewards(
+  rewards: Array<Pick<RewardRow, 'status' | 'amount' | 'currency'>>,
+): RewardSummary {
+  return rewards.reduce<RewardSummary>(
+    (acc, reward) => {
+      const amount = typeof reward.amount === 'string' ? Number(reward.amount) : reward.amount || 0
+      const currency = reward.currency || REFERRAL_REWARD_CURRENCY
+
+      switch (reward.status) {
+        case 'pending':
+          acc.pending += amount
+          break
+        case 'earned':
+          acc.earned += amount
+          break
+        case 'paid':
+          acc.paid += amount
+          break
+        case 'cancelled':
+          acc.cancelled += amount
+          break
+      }
+
+      acc.currency = currency
+      return acc
+    },
+    { pending: 0, earned: 0, paid: 0, cancelled: 0, currency: REFERRAL_REWARD_CURRENCY },
+  )
+}
+
+export function buildRewardSeed(
+  referral: Pick<ReferralRow, 'id' | 'status' | 'referrer_id' | 'referred_user_id'>,
+  now: string = new Date().toISOString(),
+): TablesInsert<'rewards'>[] {
+  const statuses = REWARD_STATUS_MATRIX[referral.status]
+  const rows: TablesInsert<'rewards'>[] = [
+    {
+      referral_id: referral.id,
+      user_id: referral.referrer_id,
+      reward_type: 'referrer',
+      amount: REFERRER_REWARD_AMOUNT,
+      currency: REFERRAL_REWARD_CURRENCY,
+      status: statuses.referrer,
+      issued_at: ['earned', 'paid'].includes(statuses.referrer) ? now : null,
+      paid_at: statuses.referrer === 'paid' ? now : null,
+    },
+  ]
+
+  if (referral.referred_user_id) {
+    rows.push({
+      referral_id: referral.id,
+      user_id: referral.referred_user_id,
+      reward_type: 'referee',
+      amount: REFEREE_REWARD_AMOUNT,
+      currency: REFERRAL_REWARD_CURRENCY,
+      status: statuses.referee,
+      issued_at: ['earned', 'paid'].includes(statuses.referee) ? now : null,
+      paid_at: statuses.referee === 'paid' ? now : null,
+    })
+  }
+
+  return rows
+}
+
+export function buildRewardStatusUpdates(
+  referralStatus: ReferralStatus,
+  rewards: Array<Pick<RewardRow, 'id' | 'reward_type' | 'status' | 'issued_at' | 'paid_at'>>,
+  now: string = new Date().toISOString(),
+): TablesUpdate<'rewards'>[] {
+  const statuses = REWARD_STATUS_MATRIX[referralStatus]
+
+  return rewards
+    .map((reward) => {
+      const targetStatus = statuses[reward.reward_type]
+
+      if (reward.status === targetStatus) {
+        return null
+      }
+
+      return {
+        id: reward.id,
+        status: targetStatus,
+        issued_at:
+          ['earned', 'paid'].includes(targetStatus) && !reward.issued_at ? now : reward.issued_at ?? null,
+        paid_at: targetStatus === 'paid' && !reward.paid_at ? now : reward.paid_at ?? null,
+      }
+    })
+    .filter((update): update is TablesUpdate<'rewards'> => Boolean(update))
+}
+
+export function generateReferralCode(): string {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const candidate = randomBytes(9)
+      .toString('base64url')
+      .replace(/[^a-zA-Z0-9]/g, '')
+      .toUpperCase()
+
+    if (candidate.length >= 8) {
+      return candidate.slice(0, 10)
+    }
+  }
+
+  return randomBytes(6).toString('hex').slice(0, 10).toUpperCase()
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -258,6 +258,47 @@ export type Database = {
         updated_at: string | null
         metadata: Json | null
       }>
+      referral_codes: SupabaseTable<{
+        id: string
+        user_id: string
+        code: string
+        usage_count: number
+        max_uses: number | null
+        expires_at: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
+      referrals: SupabaseTable<{
+        id: string
+        referral_code_id: string
+        referrer_id: string
+        referred_email: string
+        referred_user_id: string | null
+        status: 'invited' | 'signed_up' | 'qualified' | 'rewarded' | 'cancelled'
+        household_id: string | null
+        invited_at: string | null
+        signed_up_at: string | null
+        qualified_at: string | null
+        rewarded_at: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
+      rewards: SupabaseTable<{
+        id: string
+        referral_id: string
+        user_id: string
+        reward_type: 'referrer' | 'referee'
+        amount: number
+        currency: string
+        status: 'pending' | 'earned' | 'paid' | 'cancelled'
+        issued_at: string | null
+        paid_at: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
     }
     Views: Record<string, never>
     Functions: {

--- a/supabase/migrations/20250301_referrals_schema.sql
+++ b/supabase/migrations/20250301_referrals_schema.sql
@@ -1,0 +1,174 @@
+-- Referral program schema additions
+CREATE TABLE public.referral_codes (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  code TEXT NOT NULL UNIQUE,
+  usage_count INTEGER NOT NULL DEFAULT 0 CHECK (usage_count >= 0),
+  max_uses INTEGER CHECK (max_uses IS NULL OR max_uses > 0),
+  expires_at TIMESTAMP WITH TIME ZONE,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.referrals (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  referral_code_id UUID NOT NULL REFERENCES public.referral_codes(id) ON DELETE CASCADE,
+  referrer_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  referred_email TEXT NOT NULL,
+  referred_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'invited' CHECK (status IN ('invited', 'signed_up', 'qualified', 'rewarded', 'cancelled')),
+  household_id UUID REFERENCES public.households(id) ON DELETE SET NULL,
+  invited_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  signed_up_at TIMESTAMP WITH TIME ZONE,
+  qualified_at TIMESTAMP WITH TIME ZONE,
+  rewarded_at TIMESTAMP WITH TIME ZONE,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.rewards (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  referral_id UUID NOT NULL REFERENCES public.referrals(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  reward_type TEXT NOT NULL CHECK (reward_type IN ('referrer', 'referee')),
+  amount NUMERIC(10, 2) NOT NULL DEFAULT 0,
+  currency TEXT NOT NULL DEFAULT 'USD',
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'earned', 'paid', 'cancelled')),
+  issued_at TIMESTAMP WITH TIME ZONE,
+  paid_at TIMESTAMP WITH TIME ZONE,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  UNIQUE (referral_id, user_id, reward_type)
+);
+
+CREATE INDEX idx_referral_codes_user_id ON public.referral_codes(user_id);
+CREATE INDEX idx_referrals_referrer_id ON public.referrals(referrer_id);
+CREATE INDEX idx_referrals_referred_user_id ON public.referrals(referred_user_id);
+CREATE INDEX idx_referrals_status ON public.referrals(status);
+CREATE INDEX idx_rewards_user_id ON public.rewards(user_id);
+CREATE INDEX idx_rewards_status ON public.rewards(status);
+
+ALTER TABLE public.referral_codes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.referrals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rewards ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their referral codes" ON public.referral_codes
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users manage their referral codes" ON public.referral_codes
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users update their referral codes" ON public.referral_codes
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Referrers view their referrals" ON public.referrals
+  FOR SELECT USING (auth.uid() = referrer_id OR auth.uid() = referred_user_id);
+
+CREATE POLICY "Referrers create referrals" ON public.referrals
+  FOR INSERT WITH CHECK (auth.uid() = referrer_id);
+
+CREATE POLICY "Referrers update referrals" ON public.referrals
+  FOR UPDATE USING (auth.uid() = referrer_id);
+
+CREATE POLICY "Users view their rewards" ON public.rewards
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users manage their rewards" ON public.rewards
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE OR REPLACE FUNCTION public.sync_referral_reward_status()
+RETURNS TRIGGER AS $$
+DECLARE
+  target_referrer_status TEXT;
+  target_referee_status TEXT;
+BEGIN
+  target_referrer_status := CASE NEW.status
+    WHEN 'invited' THEN 'pending'
+    WHEN 'signed_up' THEN 'earned'
+    WHEN 'qualified' THEN 'earned'
+    WHEN 'rewarded' THEN 'paid'
+    WHEN 'cancelled' THEN 'cancelled'
+    ELSE 'pending'
+  END;
+
+  target_referee_status := CASE NEW.status
+    WHEN 'invited' THEN 'pending'
+    WHEN 'signed_up' THEN 'pending'
+    WHEN 'qualified' THEN 'earned'
+    WHEN 'rewarded' THEN 'paid'
+    WHEN 'cancelled' THEN 'cancelled'
+    ELSE 'pending'
+  END;
+
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO public.rewards (referral_id, user_id, reward_type, amount, currency, status, issued_at)
+    VALUES
+      (NEW.id, NEW.referrer_id, 'referrer', 50, 'USD', target_referrer_status,
+        CASE WHEN target_referrer_status IN ('earned', 'paid') THEN NOW() ELSE NULL END)
+    ON CONFLICT (referral_id, user_id, reward_type) DO UPDATE
+      SET status = EXCLUDED.status,
+          issued_at = COALESCE(public.rewards.issued_at, EXCLUDED.issued_at),
+          paid_at = CASE WHEN EXCLUDED.status = 'paid' THEN NOW() ELSE public.rewards.paid_at END,
+          updated_at = NOW();
+
+    IF NEW.referred_user_id IS NOT NULL THEN
+      INSERT INTO public.rewards (referral_id, user_id, reward_type, amount, currency, status, issued_at)
+      VALUES
+        (NEW.id, NEW.referred_user_id, 'referee', 25, 'USD', target_referee_status,
+          CASE WHEN target_referee_status IN ('earned', 'paid') THEN NOW() ELSE NULL END)
+      ON CONFLICT (referral_id, user_id, reward_type) DO UPDATE
+        SET status = EXCLUDED.status,
+            issued_at = COALESCE(public.rewards.issued_at, EXCLUDED.issued_at),
+            paid_at = CASE WHEN EXCLUDED.status = 'paid' THEN NOW() ELSE public.rewards.paid_at END,
+            updated_at = NOW();
+    END IF;
+  ELSE
+    UPDATE public.rewards
+    SET status = target_referrer_status,
+        issued_at = CASE
+          WHEN target_referrer_status IN ('earned', 'paid') AND issued_at IS NULL THEN NOW()
+          ELSE issued_at
+        END,
+        paid_at = CASE WHEN target_referrer_status = 'paid' THEN COALESCE(paid_at, NOW()) ELSE paid_at END,
+        updated_at = NOW()
+    WHERE referral_id = NEW.id AND reward_type = 'referrer';
+
+    UPDATE public.rewards
+    SET status = target_referee_status,
+        issued_at = CASE
+          WHEN target_referee_status IN ('earned', 'paid') AND issued_at IS NULL THEN NOW()
+          ELSE issued_at
+        END,
+        paid_at = CASE WHEN target_referee_status = 'paid' THEN COALESCE(paid_at, NOW()) ELSE paid_at END,
+        updated_at = NOW()
+    WHERE referral_id = NEW.id AND reward_type = 'referee';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER sync_referral_rewards_on_insert
+  AFTER INSERT ON public.referrals
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_referral_reward_status();
+
+CREATE TRIGGER sync_referral_rewards_on_update
+  AFTER UPDATE OF status ON public.referrals
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_referral_reward_status();
+
+CREATE TRIGGER update_referral_codes_updated_at
+  BEFORE UPDATE ON public.referral_codes
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_referrals_updated_at
+  BEFORE UPDATE ON public.referrals
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_rewards_updated_at
+  BEFORE UPDATE ON public.rewards
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/tests/referrals.test.ts
+++ b/tests/referrals.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  REFEREE_REWARD_AMOUNT,
+  REFERRER_REWARD_AMOUNT,
+  buildRewardSeed,
+  buildRewardStatusUpdates,
+  deriveRewardStatusFromReferralStatus,
+  normalizeReferralCode,
+} from "@/lib/referrals"
+
+describe("referral reward helpers", () => {
+  it("normalizes referral codes for lookup", () => {
+    expect(normalizeReferralCode(" abc-123 ")).toBe("ABC123")
+    expect(normalizeReferralCode("\t\n")).toBeUndefined()
+    expect(normalizeReferralCode(undefined)).toBeUndefined()
+  })
+
+  it("creates reward seed entries when referrals are recorded", () => {
+    const rewards = buildRewardSeed({
+      id: "referral_1",
+      status: "signed_up",
+      referrer_id: "user_referrer",
+      referred_user_id: "user_new",
+    })
+
+    expect(rewards).toHaveLength(2)
+    const referrerReward = rewards.find((reward) => reward.reward_type === "referrer")
+    const refereeReward = rewards.find((reward) => reward.reward_type === "referee")
+
+    expect(referrerReward?.amount).toBe(REFERRER_REWARD_AMOUNT)
+    expect(referrerReward?.status).toBe("earned")
+    expect(refereeReward?.amount).toBe(REFEREE_REWARD_AMOUNT)
+    expect(refereeReward?.status).toBe("pending")
+  })
+
+  it("propagates status changes to associated rewards", () => {
+    const updates = buildRewardStatusUpdates(
+      "rewarded",
+      [
+        {
+          id: "reward_referrer",
+          reward_type: "referrer",
+          status: "earned",
+          issued_at: "2024-02-01T00:00:00Z",
+          paid_at: null,
+        },
+        {
+          id: "reward_referee",
+          reward_type: "referee",
+          status: "pending",
+          issued_at: null,
+          paid_at: null,
+        },
+      ],
+      "2024-03-01T00:00:00Z",
+    )
+
+    expect(updates).toHaveLength(2)
+    expect(updates.find((update) => update.id === "reward_referrer")?.status).toBe("paid")
+    expect(updates.find((update) => update.id === "reward_referee")?.status).toBe("paid")
+  })
+
+  it("derives reward status mapping for each referral milestone", () => {
+    expect(deriveRewardStatusFromReferralStatus("invited", "referrer")).toBe("pending")
+    expect(deriveRewardStatusFromReferralStatus("signed_up", "referrer")).toBe("earned")
+    expect(deriveRewardStatusFromReferralStatus("qualified", "referee")).toBe("earned")
+    expect(deriveRewardStatusFromReferralStatus("rewarded", "referee")).toBe("paid")
+    expect(deriveRewardStatusFromReferralStatus("cancelled", "referee")).toBe("cancelled")
+  })
+})

--- a/utils/supabase/service-role.ts
+++ b/utils/supabase/service-role.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@supabase/supabase-js'
+
+import type { Database } from '@/lib/supabase'
+
+export function createServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceRoleKey) {
+    throw new Error('Missing Supabase service role configuration')
+  }
+
+  return createClient<Database>(url, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add Supabase tables, RLS policies, and triggers for referral codes, referrals, and rewards
- extend Supabase types and referral utilities while wiring referral capture into onboarding and signup
- introduce a referral dashboard with data loaders, shareable invite links, and supporting tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20ba349d08328bd999a65f2a97be0