### PR TITLE
feat: add avatar cropping workflow

### DIFF
--- a/app/account/avatar-helpers.ts
+++ b/app/account/avatar-helpers.ts
@@ -1,0 +1,90 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export const AVATAR_VARIANTS = [
+  { key: "sm", size: 96 },
+  { key: "md", size: 192 },
+  { key: "lg", size: 384 },
+] as const
+
+export type AvatarVariantKey = (typeof AVATAR_VARIANTS)[number]["key"]
+
+export type AvatarVariantBlobs = Partial<Record<AvatarVariantKey, Blob>> & { md: Blob }
+
+export interface UploadAvatarVariantsResult {
+  fileKey: string
+  paths: Partial<Record<AvatarVariantKey, string>>
+  defaultPath: string
+}
+
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+}
+
+function normaliseExtension(extension: string): string {
+  return extension.replace(/^\./, "").toLowerCase()
+}
+
+function inferMimeType(extension: string): string {
+  const normalised = normaliseExtension(extension)
+  return IMAGE_MIME_TYPES[normalised] ?? "image/jpeg"
+}
+
+export function buildVariantPathSet(path: string): Record<AvatarVariantKey, string | null> {
+  const trimmed = path.trim()
+  const match = trimmed.match(/^(.*)-(sm|md|lg)\.([A-Za-z0-9]+)$/)
+  if (!match) {
+    return { sm: null, md: trimmed, lg: null }
+  }
+
+  const [, base, , extension] = match
+
+  return {
+    sm: `${base}-sm.${extension}`,
+    md: trimmed,
+    lg: `${base}-lg.${extension}`,
+  }
+}
+
+export async function uploadAvatarVariants(
+  client: SupabaseClient,
+  uid: string,
+  blobs: AvatarVariantBlobs,
+  extension = "jpg",
+  now = Date.now(),
+): Promise<UploadAvatarVariantsResult> {
+  if (!uid) {
+    throw new Error("A user id is required to upload avatar variants")
+  }
+
+  const normalisedExtension = normaliseExtension(extension)
+  const contentType = inferMimeType(normalisedExtension)
+  const fileKey = `${uid}/avatar-${now}`
+  const bucket = client.storage.from("avatars")
+  const uploadedPaths: Partial<Record<AvatarVariantKey, string>> = {}
+
+  for (const [variant, blob] of Object.entries(blobs) as [AvatarVariantKey, Blob | undefined][]) {
+    if (!blob) continue
+
+    const path = `${fileKey}-${variant}.${normalisedExtension}`
+    const { error } = await bucket.upload(path, blob, {
+      cacheControl: "3600",
+      contentType,
+    })
+
+    if (error) {
+      throw error
+    }
+
+    uploadedPaths[variant] = path
+  }
+
+  const defaultPath = uploadedPaths.md
+  if (!defaultPath) {
+    throw new Error("A medium avatar variant must be provided")
+  }
+
+  return { fileKey, paths: uploadedPaths, defaultPath }
+}

--- a/app/account/avatar.tsx
+++ b/app/account/avatar.tsx
@@ -1,97 +1,345 @@
-'use client'
-import React, { useEffect, useState } from 'react'
-import useSupabaseBrowser from '@/utils/supabase-browser'
-import Image from 'next/image'
+"use client"
 
-export default function Avatar({
-  uid,
-  url,
-  size,
-  onUpload,
-}: {
+import { type ChangeEventHandler, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { Area } from "react-easy-crop"
+
+import AvatarEditor, { type AvatarEditorResult } from "@/components/profile/AvatarEditor"
+import { Button } from "@/components/ui/button"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+import {
+  AVATAR_VARIANTS,
+  type AvatarVariantKey,
+  type AvatarVariantBlobs,
+  buildVariantPathSet,
+  uploadAvatarVariants,
+} from "./avatar-helpers"
+
+interface AvatarProps {
   uid: string | null
   url: string | null
   size: number
-  onUpload: (url: string) => void
-}) {
-  const supabase = useSupabaseBrowser()
-  const [avatarUrl, setAvatarUrl] = useState<string | null>(url)
-  const [uploading, setUploading] = useState(false)
+  onUpload: (url: string) => Promise<void> | void
+}
 
-  useEffect(() => {
-    async function downloadImage(path: string) {
-      try {
-        const { data, error } = await supabase.storage.from('avatars').download(path)
-        if (error) {
-          throw error
-        }
+type PreviewSources = Partial<Record<AvatarVariantKey, string>>
 
-        const url = URL.createObjectURL(data)
-        setAvatarUrl(url)
-      } catch (error) {
-        console.log('Error downloading image: ', error)
+const PLACEHOLDER_TEXT = "Upload avatar"
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.addEventListener("load", () => {
+      const result = reader.result
+      if (typeof result !== "string") {
+        reject(new Error("Unable to read image"))
+        return
       }
-    }
+      resolve(result)
+    })
+    reader.addEventListener("error", () => {
+      reject(reader.error ?? new Error("Unable to read image"))
+    })
+    reader.readAsDataURL(file)
+  })
+}
 
-    if (url) downloadImage(url)
-  }, [url, supabase])
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.addEventListener("load", () => resolve(image))
+    image.addEventListener("error", (event) => reject(event instanceof Error ? event : new Error("Failed to load image")))
+    image.crossOrigin = "anonymous"
+    image.src = src
+  })
+}
 
-  const uploadAvatar: React.ChangeEventHandler<HTMLInputElement> = async (event) => {
-    try {
-      setUploading(true)
+async function createAvatarBlobs(imageSrc: string, cropArea: Area) {
+  const image = await loadImage(imageSrc)
+  const maxDimension = Math.max(1, Math.min(cropArea.width, cropArea.height))
 
-      if (!event.target.files || event.target.files.length === 0) {
-        throw new Error('You must select an image to upload.')
+  const variants = await Promise.all(
+    AVATAR_VARIANTS.map(async (definition) => {
+      const targetSize = Math.max(1, Math.floor(Math.min(definition.size, maxDimension)))
+      const canvas = document.createElement("canvas")
+      canvas.width = targetSize
+      canvas.height = targetSize
+      const context = canvas.getContext("2d")
+
+      if (!context) {
+        throw new Error("Unable to access canvas context")
       }
 
-      const file = event.target.files[0]
-      const fileExt = file.name.split('.').pop()
-      const filePath = `${uid}-${Math.random()}.${fileExt}`
+      context.imageSmoothingEnabled = true
+      context.imageSmoothingQuality = "high"
 
-      const { error: uploadError } = await supabase.storage.from('avatars').upload(filePath, file)
+      context.drawImage(
+        image,
+        cropArea.x,
+        cropArea.y,
+        cropArea.width,
+        cropArea.height,
+        0,
+        0,
+        targetSize,
+        targetSize,
+      )
 
-      if (uploadError) {
-        throw uploadError
-      }
+      const blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((value) => {
+          if (!value) {
+            reject(new Error("Unable to create avatar image"))
+            return
+          }
+          resolve(value)
+        }, "image/jpeg", 0.92)
+      })
 
-      onUpload(filePath)
-    } catch (error) {
-      alert('Error uploading avatar!')
-    } finally {
-      setUploading(false)
-    }
+      return { key: definition.key, blob }
+    }),
+  )
+
+  return variants
+}
+
+function createBlobMap(variants: Awaited<ReturnType<typeof createAvatarBlobs>>): AvatarVariantBlobs {
+  const mediumVariant = variants.find((variant) => variant.key === "md")
+  if (!mediumVariant) {
+    throw new Error("A medium avatar variant is required")
   }
 
+  return variants.reduce<AvatarVariantBlobs>(
+    (accumulator, variant) => {
+      accumulator[variant.key] = variant.blob
+      return accumulator
+    },
+    { md: mediumVariant.blob },
+  )
+}
+
+function sourcesFromBlobs(variants: Awaited<ReturnType<typeof createAvatarBlobs>>) {
+  const sources: PreviewSources = {}
+  const urls: string[] = []
+
+  for (const variant of variants) {
+    const objectUrl = URL.createObjectURL(variant.blob)
+    sources[variant.key] = objectUrl
+    urls.push(objectUrl)
+  }
+
+  return { sources, urls }
+}
+
+export default function Avatar({ uid, url, size, onUpload }: AvatarProps) {
+  const supabase = useSupabaseBrowser()
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const previewUrlRef = useRef<string[]>([])
+
+  const [previewSources, setPreviewSources] = useState<PreviewSources>({})
+  const [editorImage, setEditorImage] = useState<string | null>(null)
+  const [isEditing, setIsEditing] = useState(false)
+  const [uploading, setUploading] = useState(false)
+
+  const primaryPreview = useMemo(() => previewSources.lg ?? previewSources.md ?? previewSources.sm ?? null, [previewSources])
+
+  const resetFileInput = useCallback(() => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""
+    }
+  }, [])
+
+  const updatePreviewSources = useCallback((nextSources: PreviewSources, urls: string[]) => {
+    for (const existing of previewUrlRef.current) {
+      URL.revokeObjectURL(existing)
+    }
+    previewUrlRef.current = urls
+    setPreviewSources(nextSources)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      for (const existing of previewUrlRef.current) {
+        URL.revokeObjectURL(existing)
+      }
+      previewUrlRef.current = []
+    }
+  }, [])
+
+  useEffect(() => {
+    let isActive = true
+
+    async function downloadImage(path: string) {
+      try {
+        const variantPaths = buildVariantPathSet(path)
+        const mediumPath = variantPaths.md
+        if (!mediumPath) return
+
+        const activeUrls: string[] = []
+        const sources: PreviewSources = {}
+
+        const { data: mediumData, error: mediumError } = await supabase.storage.from("avatars").download(mediumPath)
+        if (mediumError || !mediumData) {
+          throw mediumError ?? new Error("Unable to download avatar")
+        }
+        const mediumUrl = URL.createObjectURL(mediumData)
+        sources.md = mediumUrl
+        activeUrls.push(mediumUrl)
+
+        for (const variant of ["sm", "lg"] as AvatarVariantKey[]) {
+          const variantPath = variantPaths[variant]
+          if (!variantPath) continue
+          try {
+            const { data, error } = await supabase.storage.from("avatars").download(variantPath)
+            if (error || !data) continue
+            const objectUrl = URL.createObjectURL(data)
+            sources[variant] = objectUrl
+            activeUrls.push(objectUrl)
+          } catch (error) {
+            console.warn("Unable to load avatar variant", error)
+          }
+        }
+
+        if (!isActive) {
+          for (const objectUrl of activeUrls) {
+            URL.revokeObjectURL(objectUrl)
+          }
+          return
+        }
+
+        updatePreviewSources(sources, activeUrls)
+      } catch (error) {
+        console.error("Error downloading image: ", error)
+      }
+    }
+
+    if (url) {
+      downloadImage(url)
+    } else {
+      updatePreviewSources({}, [])
+    }
+
+    return () => {
+      isActive = false
+    }
+  }, [supabase, updatePreviewSources, url])
+
+  const handleFileChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    async (event) => {
+      try {
+        if (!event.target.files || event.target.files.length === 0) {
+          throw new Error("You must select an image to upload.")
+        }
+
+        const file = event.target.files[0]
+        if (!file.type.startsWith("image/")) {
+          throw new Error("Please choose a valid image file.")
+        }
+
+        const dataUrl = await readFileAsDataUrl(file)
+        setEditorImage(dataUrl)
+        setIsEditing(true)
+      } catch (error) {
+        console.error("Failed to prepare avatar", error)
+        alert(error instanceof Error ? error.message : "Unable to open the selected image.")
+        resetFileInput()
+      }
+    },
+    [resetFileInput],
+  )
+
+  const handleCancelEdit = useCallback(() => {
+    setIsEditing(false)
+    setEditorImage(null)
+    resetFileInput()
+  }, [resetFileInput])
+
+  const handleConfirmEdit = useCallback(
+    async ({ croppedAreaPixels }: AvatarEditorResult) => {
+      if (!uid) {
+        alert("We were unable to confirm your account. Please refresh and try again.")
+        return
+      }
+      if (!editorImage) return
+
+      try {
+        setUploading(true)
+        const variants = await createAvatarBlobs(editorImage, croppedAreaPixels)
+        const blobMap = createBlobMap(variants)
+        const uploadResult = await uploadAvatarVariants(supabase, uid, blobMap, "jpg")
+
+        const { sources, urls } = sourcesFromBlobs(variants)
+        updatePreviewSources(sources, urls)
+
+        await onUpload(uploadResult.defaultPath)
+        setIsEditing(false)
+        setEditorImage(null)
+        resetFileInput()
+      } catch (error) {
+        console.error("Error uploading avatar", error)
+        alert("Error uploading avatar!")
+      } finally {
+        setUploading(false)
+      }
+    },
+    [editorImage, onUpload, resetFileInput, supabase, uid, updatePreviewSources],
+  )
+
+  const handleTriggerFilePicker = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
   return (
-    <div>
-      {avatarUrl ? (
-        <Image
-          width={size}
-          height={size}
-          src={avatarUrl}
-          alt="Avatar"
-          className="relative flex size-10 shrink-0 overflow-hidden rounded-full"
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <div
+          className="relative shrink-0 overflow-hidden rounded-full bg-muted text-muted-foreground"
           style={{ height: size, width: size }}
-        />
-      ) : (
-        <div className="avatar no-image" style={{ height: size, width: size }} />
-      )}
-      <div style={{ width: size }}>
-        <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" htmlFor="single">
-          {uploading ? 'Uploading ...' : 'Upload Image'}
-        </label>
-        <input
-          style={{
-            visibility: 'hidden',
-            position: 'absolute',
-          }}
-          type="file"
-          id="single"
-          accept="image/*"
-          onChange={uploadAvatar}
-          disabled={uploading}
-        />
+        >
+          {primaryPreview ? (
+            <picture>
+              {previewSources.sm && <source media="(max-width: 480px)" srcSet={previewSources.sm} />}
+              {previewSources.md && <source media="(max-width: 1024px)" srcSet={previewSources.md} />}
+              <img
+                alt="Avatar preview"
+                className="block size-full object-cover"
+                height={size}
+                src={primaryPreview}
+                width={size}
+              />
+            </picture>
+          ) : (
+            <div className="flex size-full items-center justify-center text-sm font-medium">{PLACEHOLDER_TEXT}</div>
+          )}
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            Choose a square-friendly photo. You can zoom and reposition before saving.
+          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              accept="image/*"
+              className="sr-only"
+              id="avatar-upload"
+              onChange={handleFileChange}
+              ref={fileInputRef}
+              type="file"
+            />
+            <Button disabled={uploading} onClick={handleTriggerFilePicker} type="button" variant="outline">
+              {uploading ? "Uploading..." : "Select image"}
+            </Button>
+          </div>
+        </div>
       </div>
+
+      {isEditing && editorImage ? (
+        <AvatarEditor
+          aspect={1}
+          disabled={uploading}
+          imageSrc={editorImage}
+          onCancel={handleCancelEdit}
+          onConfirm={handleConfirmEdit}
+        />
+      ) : null}
     </div>
   )
 }

--- a/components/profile/AvatarEditor.tsx
+++ b/components/profile/AvatarEditor.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import { type ChangeEvent, useCallback, useId, useMemo, useRef, useState } from "react"
+import Cropper from "react-easy-crop"
+import type { Area, Point } from "react-easy-crop"
+
+import { Button } from "@/components/ui/button"
+
+export interface AvatarEditorResult {
+  croppedAreaPixels: Area
+  zoom: number
+}
+
+interface AvatarEditorProps {
+  imageSrc: string
+  onCancel: () => void
+  onConfirm: (result: AvatarEditorResult) => void
+  aspect?: number
+  disabled?: boolean
+}
+
+const INITIAL_CROP: Point = { x: 0, y: 0 }
+const INITIAL_ZOOM = 1
+const MIN_ZOOM = 1
+const MAX_ZOOM = 3
+const ZOOM_STEP = 0.1
+
+interface HistoryEntry {
+  crop: Point
+  zoom: number
+}
+
+function clonePoint(point: Point): Point {
+  return { x: point.x, y: point.y }
+}
+
+export default function AvatarEditor({
+  imageSrc,
+  onCancel,
+  onConfirm,
+  aspect = 1,
+  disabled = false,
+}: AvatarEditorProps) {
+  const zoomInputId = useId()
+  const [crop, setCrop] = useState<Point>(clonePoint(INITIAL_CROP))
+  const [zoom, setZoom] = useState(INITIAL_ZOOM)
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null)
+  const [hasHistory, setHasHistory] = useState(false)
+
+  const historyRef = useRef<HistoryEntry[]>([{ crop: clonePoint(INITIAL_CROP), zoom: INITIAL_ZOOM }])
+  const historyIndexRef = useRef(0)
+
+  const commitHistory = useCallback(
+    (nextCrop: Point, nextZoom: number) => {
+      const history = historyRef.current.slice(0, historyIndexRef.current + 1)
+      const lastEntry = history.at(-1)
+      if (lastEntry && lastEntry.zoom === nextZoom && lastEntry.crop.x === nextCrop.x && lastEntry.crop.y === nextCrop.y) {
+        historyRef.current = history
+        setHasHistory(history.length > 1)
+        return
+      }
+
+      history.push({ crop: clonePoint(nextCrop), zoom: nextZoom })
+      historyRef.current = history
+      historyIndexRef.current = history.length - 1
+      setHasHistory(history.length > 1)
+    },
+    [],
+  )
+
+  const handleUndo = useCallback(() => {
+    if (historyIndexRef.current === 0) return
+
+    historyIndexRef.current -= 1
+    const target = historyRef.current[historyIndexRef.current]
+    setCrop(clonePoint(target.crop))
+    setZoom(target.zoom)
+    setHasHistory(historyIndexRef.current > 0)
+  }, [])
+
+  const handleReset = useCallback(() => {
+    historyRef.current = [{ crop: clonePoint(INITIAL_CROP), zoom: INITIAL_ZOOM }]
+    historyIndexRef.current = 0
+    setCrop(clonePoint(INITIAL_CROP))
+    setZoom(INITIAL_ZOOM)
+    setHasHistory(false)
+  }, [])
+
+  const handleZoomChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const newZoom = Number(event.currentTarget.value)
+      setZoom(newZoom)
+      commitHistory(crop, newZoom)
+    },
+    [commitHistory, crop],
+  )
+
+  const handleInteractionEnd = useCallback(() => {
+    commitHistory(crop, zoom)
+  }, [commitHistory, crop, zoom])
+
+  const canConfirm = useMemo(() => Boolean(croppedAreaPixels) && !disabled, [croppedAreaPixels, disabled])
+
+  const handleConfirm = useCallback(() => {
+    if (!croppedAreaPixels) return
+    onConfirm({ croppedAreaPixels, zoom })
+  }, [croppedAreaPixels, onConfirm, zoom])
+
+  return (
+    <div className="space-y-4" aria-live="polite">
+      <div
+        aria-busy={disabled}
+        className="relative h-80 w-full overflow-hidden rounded-xl border border-dashed border-border bg-muted"
+      >
+        {disabled && <div aria-hidden="true" className="absolute inset-0 z-10 cursor-wait bg-background/50" />}
+        <Cropper
+          image={imageSrc}
+          crop={crop}
+          zoom={zoom}
+          aspect={aspect}
+          onCropChange={(nextCrop) => setCrop(nextCrop)}
+          onCropComplete={(_, areaPixels) => setCroppedAreaPixels(areaPixels)}
+          onZoomChange={(value) => setZoom(value)}
+          onInteractionEnd={handleInteractionEnd}
+          restrictPosition
+          objectFit="horizontal-cover"
+          showGrid={false}
+        />
+      </div>
+
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium" htmlFor={zoomInputId}>
+            Zoom
+          </label>
+          <input
+            aria-describedby={`${zoomInputId}-helper`}
+            aria-label="Zoom avatar"
+            className="h-2 w-full cursor-pointer appearance-none rounded-full bg-muted"
+            disabled={disabled}
+            id={zoomInputId}
+            max={MAX_ZOOM}
+            min={MIN_ZOOM}
+            onChange={handleZoomChange}
+            step={ZOOM_STEP}
+            type="range"
+            value={zoom}
+          />
+          <span className="text-xs text-muted-foreground" id={`${zoomInputId}-helper`}>
+            Use the arrow keys for precise zoom control.
+          </span>
+        </div>
+        <div className="flex gap-2">
+          <Button onClick={handleUndo} type="button" variant="outline" disabled={!hasHistory || disabled}>
+            Undo
+          </Button>
+          <Button onClick={handleReset} type="button" variant="outline" disabled={disabled}>
+            Reset
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <Button onClick={onCancel} type="button" variant="ghost" disabled={disabled}>
+          Cancel
+        </Button>
+        <Button onClick={handleConfirm} type="button" disabled={!canConfirm}>
+          Save crop
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react": "^18.2.0",
     "react-day-picker": "^8.10.0",
     "react-dom": "^18.2.0",
+    "react-easy-crop": "^5.5.1",
     "react-hook-form": "^7.49.3",
     "react-icons": "^5.0.1",
     "resend": "^4.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-easy-crop:
+        specifier: ^5.5.1
+        version: 5.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-hook-form:
         specifier: ^7.49.3
         version: 7.49.3(react@18.2.0)
@@ -3608,6 +3611,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3854,6 +3860,12 @@ packages:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
       react: ^18.2.0
+
+  react-easy-crop@5.5.1:
+    resolution: {integrity: sha512-8m6lCmfr6cSE9/447iHu+OniJuy7sdFbTqbsYyAXKygXJplvGCLpodujodWQeBGse11nDIgCbMUKbgucIxQWSQ==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react-hook-form@7.49.3:
     resolution: {integrity: sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==}
@@ -8623,6 +8635,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  normalize-wheel@1.0.1: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -8875,6 +8889,13 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.2
+
+  react-easy-crop@5.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
 
   react-hook-form@7.49.3(react@18.2.0):
     dependencies:

--- a/tests/avatar-upload.test.ts
+++ b/tests/avatar-upload.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { buildVariantPathSet, uploadAvatarVariants } from "@/app/account/avatar-helpers"
+
+describe("avatar storage helpers", () => {
+  it("uploads cropped avatar variants with predictable file names", async () => {
+    const upload = vi.fn().mockResolvedValue({ data: { path: "uploaded" }, error: null })
+    const storageFrom = vi.fn(() => ({ upload }))
+    const supabase = {
+      storage: {
+        from: storageFrom,
+      },
+    } as unknown as Parameters<typeof uploadAvatarVariants>[0]
+
+    const blobs = {
+      sm: new Blob(["small"]),
+      md: new Blob(["medium"]),
+      lg: new Blob(["large"]),
+    }
+
+    const result = await uploadAvatarVariants(supabase, "user-123", blobs, "jpg", 1700000000000)
+
+    expect(storageFrom).toHaveBeenCalledWith("avatars")
+    expect(upload).toHaveBeenCalledTimes(3)
+    expect(upload).toHaveBeenNthCalledWith(
+      1,
+      "user-123/avatar-1700000000000-sm.jpg",
+      blobs.sm,
+      expect.objectContaining({ contentType: "image/jpeg", cacheControl: "3600" }),
+    )
+    expect(upload).toHaveBeenNthCalledWith(
+      2,
+      "user-123/avatar-1700000000000-md.jpg",
+      blobs.md,
+      expect.objectContaining({ contentType: "image/jpeg", cacheControl: "3600" }),
+    )
+    expect(upload).toHaveBeenNthCalledWith(
+      3,
+      "user-123/avatar-1700000000000-lg.jpg",
+      blobs.lg,
+      expect.objectContaining({ contentType: "image/jpeg", cacheControl: "3600" }),
+    )
+
+    expect(result.defaultPath).toBe("user-123/avatar-1700000000000-md.jpg")
+    expect(result.paths).toMatchObject({
+      sm: "user-123/avatar-1700000000000-sm.jpg",
+      md: "user-123/avatar-1700000000000-md.jpg",
+      lg: "user-123/avatar-1700000000000-lg.jpg",
+    })
+  })
+
+  it("derives sibling variant paths for responsive previews", () => {
+    expect(buildVariantPathSet("tenant/avatar-99-md.jpg")).toEqual({
+      sm: "tenant/avatar-99-sm.jpg",
+      md: "tenant/avatar-99-md.jpg",
+      lg: "tenant/avatar-99-lg.jpg",
+    })
+  })
+
+  it("preserves original extension casing when matching variants", () => {
+    expect(buildVariantPathSet("tenant/avatar-01-md.JPG")).toEqual({
+      sm: "tenant/avatar-01-sm.JPG",
+      md: "tenant/avatar-01-md.JPG",
+      lg: "tenant/avatar-01-lg.JPG",
+    })
+  })
+
+  it("falls back to the provided path for legacy avatars", () => {
+    expect(buildVariantPathSet("legacy-avatar.png")).toEqual({
+      sm: null,
+      md: "legacy-avatar.png",
+      lg: null,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable avatar editor built on react-easy-crop with zoom, undo, and reset controls
- update the account avatar client to enforce square cropping, generate responsive variants, and upload them to Supabase Storage
- add helper utilities and tests covering variant path derivation and upload behavior

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d20b7dec048328b10e2cd2edecb6a6