### PR TITLE
feat: add inline member editing

### DIFF
--- a/app/dashboard/members/actions/index.tsx
+++ b/app/dashboard/members/actions/index.tsx
@@ -1,23 +1,54 @@
-"use server";
+"use server"
 
-import { createSupbaseServerClient } from "@/utils/supaone";
+import { z } from "zod"
 
-import { redirect } from "next/navigation";
-
-type formData = {
-    email: string;
-    password: string;
-    confirm: string;
-    username: string;
-    role: string;
-    status: string; 
-}
+import type { DashboardMember } from "../data"
 
 export async function createMember() {
-	console.log("create member");
+        console.log("create member")
 }
+
 export async function updateMemberById(id: string) {
-	console.log("update member");
+        console.log("update member", id)
 }
-export async function deleteMemberById(id: string) {}
-export async function readMembers() {}
+
+export async function deleteMemberById(id: string) {
+        console.log("delete member", id)
+}
+
+export async function readMembers() {
+        console.log("read members")
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const patchMemberSchema = z.object({
+        id: z.string().min(1, "Member id is required"),
+        updates: z
+                .object({
+                        role: z.enum(["admin", "user"]).optional(),
+                        status: z.enum(["active", "resigned"]).optional(),
+                })
+                .refine((value) => value.role !== undefined || value.status !== undefined, {
+                        message: "Provide at least one field to update",
+                }),
+})
+
+export type PatchMemberInput = z.infer<typeof patchMemberSchema>
+
+export type PatchMemberResult = {
+        id: string
+        role?: DashboardMember["role"]
+        status?: DashboardMember["status"]
+}
+
+export async function patchMember(input: PatchMemberInput): Promise<PatchMemberResult> {
+        const payload = patchMemberSchema.parse(input)
+
+        await wait(120)
+
+        return {
+                id: payload.id,
+                ...payload.updates,
+        }
+}

--- a/app/dashboard/members/components/LegacyMemberTable.tsx
+++ b/app/dashboard/members/components/LegacyMemberTable.tsx
@@ -5,24 +5,28 @@ import ListOfMembers from "./ListOfMembers"
 
 const LEGACY_MEMBERS: DashboardMember[] = [
         {
+                id: "legacy-1",
                 name: "Admin Member",
                 role: "admin",
                 createdAt: new Date().toDateString(),
                 status: "active",
         },
         {
+                id: "legacy-2",
                 name: "Non Admin User",
                 role: "user",
                 createdAt: new Date().toDateString(),
                 status: "active",
         },
         {
+                id: "legacy-3",
                 name: "Administrator",
                 role: "admin",
                 createdAt: new Date().toDateString(),
                 status: "resigned",
         },
         {
+                id: "legacy-4",
                 name: "Satoshi",
                 role: "user",
                 createdAt: new Date().toDateString(),

--- a/app/dashboard/members/components/ListOfMembers.tsx
+++ b/app/dashboard/members/components/ListOfMembers.tsx
@@ -1,61 +1,164 @@
-import React from "react"
+"use client"
+
+import React, { useEffect, useRef, useState } from "react"
 
 import { Button } from "@/components/ui/button"
-import { TrashIcon } from "@radix-ui/react-icons"
+import EditableCell from "@/components/ui/editable-cell"
 import { cn } from "@/lib/utils"
+import { TrashIcon } from "@radix-ui/react-icons"
 
-import { DashboardMember } from "../data"
-import EditMember from "./edit/EditMember"
+import { patchMember } from "../actions"
+import type { DashboardMember } from "../data"
+
+type InlineEditableField = "role" | "status"
+
+const ROLE_OPTIONS = [
+        { label: "Admin", value: "admin" },
+        { label: "User", value: "user" },
+]
+
+const STATUS_OPTIONS = [
+        { label: "Active", value: "active" },
+        { label: "Resigned", value: "resigned" },
+]
 
 export default function ListOfMembers({ members }: { members: DashboardMember[] }) {
+        const [rows, setRows] = useState(members)
+        const rowsRef = useRef(rows)
+        const [pendingMap, setPendingMap] = useState<Record<string, boolean>>({})
+
+        useEffect(() => {
+                setRows(members)
+                rowsRef.current = members
+        }, [members])
+
+        async function commitChange(
+                id: string,
+                field: InlineEditableField,
+                nextValue: DashboardMember[InlineEditableField],
+        ) {
+                const previous = rowsRef.current
+                const optimistic = previous.map((member) =>
+                        member.id === id ? { ...member, [field]: nextValue } : member,
+                )
+
+                rowsRef.current = optimistic
+                setRows(optimistic)
+                setPendingMap((prev) => ({ ...prev, [`${id}:${field}`]: true }))
+
+                try {
+                        const response = await patchMember({
+                                id,
+                                updates: { [field]: nextValue },
+                        })
+
+                        const merged = rowsRef.current.map((member) =>
+                                member.id === id ? { ...member, ...response } : member,
+                        )
+
+                        rowsRef.current = merged
+                        setRows(merged)
+                } catch (error) {
+                        rowsRef.current = previous
+                        setRows(previous)
+                        throw error
+                } finally {
+                        setPendingMap((prev) => {
+                                const next = { ...prev }
+                                delete next[`${id}:${field}`]
+                                return next
+                        })
+                }
+        }
+
         return (
                 <div className="mx-2 rounded-sm bg-white dark:bg-inherit">
-                        {members.map((member, index) => {
+                        {rows.map((member) => {
+                                const rolePending = pendingMap[`${member.id}:role`] ?? false
+                                const statusPending = pendingMap[`${member.id}:status`] ?? false
+
                                 return (
                                         <div
-                                                className="grid grid-cols-5 rounded-sm p-3 align-middle font-normal"
-                                                key={member.name + index}
+                                                key={member.id}
+                                                className="grid grid-cols-5 items-center gap-2 rounded-sm p-3 font-normal"
                                         >
-                                                <h1>{member.name}</h1>
+                                                <span className="flex items-center text-sm font-medium text-zinc-900 dark:text-white">
+                                                        {member.name}
+                                                </span>
 
-                                                <div>
-                                                        <span
-                                                                className={cn(
-                                                                        "rounded-full border-[.5px] px-2 py-1 text-sm capitalize shadow dark:bg-zinc-800",
-                                                                        {
-                                                                                "border-green-500 bg-green-200 text-green-600":
-                                                                                        member.role === "admin",
-                                                                                "border-zinc-300 bg-yellow-50 px-4 text-yellow-700 dark:border-yellow-700 dark:text-yellow-300":
-                                                                                        member.role === "user",
-                                                                        },
+                                                <div className="flex items-center">
+                                                        <EditableCell
+                                                                label={`Role for ${member.name}`}
+                                                                value={member.role}
+                                                                options={ROLE_OPTIONS}
+                                                                pending={rolePending}
+                                                                rules={{ required: "Role is required" }}
+                                                                renderDisplay={(role) => (
+                                                                        <span
+                                                                                className={cn(
+                                                                                        "rounded-full border-[.5px] px-2 py-1 text-sm capitalize shadow dark:bg-zinc-800",
+                                                                                        {
+                                                                                                "border-green-500 bg-green-200 text-green-600":
+                                                                                                        role === "admin",
+                                                                                                "border-zinc-300 bg-yellow-50 px-4 text-yellow-700 dark:border-yellow-700 dark:text-yellow-300":
+                                                                                                        role === "user",
+                                                                                        },
+                                                                                )}
+                                                                        >
+                                                                                {role}
+                                                                        </span>
                                                                 )}
-                                                        >
-                                                                {member.role}
-                                                        </span>
-                                                </div>
-                                                <h1>{member.createdAt}</h1>
-                                                <div>
-                                                        <span
-                                                                className={cn(
-                                                                        "rounded-full border border-zinc-300 px-2 py-1 text-sm capitalize dark:bg-zinc-800",
-                                                                        {
-                                                                                "bg-green-200 px-4 text-green-600 dark:border-green-400":
-                                                                                        member.status === "active",
-                                                                                "bg-red-100 text-red-500 dark:border-red-400 dark:text-red-300":
-                                                                                        member.status === "resigned",
-                                                                        },
-                                                                )}
-                                                        >
-                                                                {member.status}
-                                                        </span>
+                                                                onSubmit={(value) =>
+                                                                        commitChange(
+                                                                                member.id,
+                                                                                "role",
+                                                                                value as DashboardMember["role"],
+                                                                        )
+                                                                }
+                                                        />
                                                 </div>
 
-                                                <div className="flex items-center gap-2">
+                                                <span className="flex items-center text-sm text-muted-foreground">
+                                                        {member.createdAt}
+                                                </span>
+
+                                                <div className="flex items-center">
+                                                        <EditableCell
+                                                                label={`Status for ${member.name}`}
+                                                                value={member.status}
+                                                                options={STATUS_OPTIONS}
+                                                                pending={statusPending}
+                                                                rules={{ required: "Status is required" }}
+                                                                renderDisplay={(status) => (
+                                                                        <span
+                                                                                className={cn(
+                                                                                        "rounded-full border border-zinc-300 px-2 py-1 text-sm capitalize dark:bg-zinc-800",
+                                                                                        {
+                                                                                                "bg-green-200 px-4 text-green-600 dark:border-green-400":
+                                                                                                        status === "active",
+                                                                                                "bg-red-100 text-red-500 dark:border-red-400 dark:text-red-300":
+                                                                                                        status === "resigned",
+                                                                                        },
+                                                                                )}
+                                                                        >
+                                                                                {status}
+                                                                        </span>
+                                                                )}
+                                                                onSubmit={(value) =>
+                                                                        commitChange(
+                                                                                member.id,
+                                                                                "status",
+                                                                                value as DashboardMember["status"],
+                                                                        )
+                                                                }
+                                                        />
+                                                </div>
+
+                                                <div className="flex items-center justify-end gap-2">
                                                         <Button variant="outline" className="flex items-center gap-2">
                                                                 <TrashIcon />
                                                                 Delete
                                                         </Button>
-                                                        <EditMember />
                                                 </div>
                                         </div>
                                 )

--- a/app/dashboard/members/data.ts
+++ b/app/dashboard/members/data.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { cache } from "react"
 
 export type DashboardMember = {
+        id: string
         name: string
         role: "admin" | "user"
         createdAt: string
@@ -17,24 +18,28 @@ export const getDashboardMembers = cache(async (): Promise<DashboardMember[]> =>
         await wait(260)
         return [
                 {
+                        id: "member-1",
                         name: "Admin Member",
                         role: "admin",
                         createdAt: new Date().toDateString(),
                         status: "active",
                 },
                 {
+                        id: "member-2",
                         name: "Non Admin User",
                         role: "user",
                         createdAt: new Date().toDateString(),
                         status: "active",
                 },
                 {
+                        id: "member-3",
                         name: "Administrator",
                         role: "admin",
                         createdAt: new Date().toDateString(),
                         status: "resigned",
                 },
                 {
+                        id: "member-4",
                         name: "Satoshi",
                         role: "user",
                         createdAt: new Date().toDateString(),

--- a/app/dashboard/todo/actions/index.ts
+++ b/app/dashboard/todo/actions/index.ts
@@ -1,9 +1,27 @@
-// "use server";
-export async function createTodo() {
-	console.log("create todo");
+"use server"
+
+import { z } from "zod"
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const patchTodoSchema = z.object({
+        id: z.string().min(1, "Todo id is required"),
+        updates: z.object({
+                status: z.enum(["completed", "pending", "in_progress"]),
+        }),
+})
+
+export type PatchTodoInput = z.infer<typeof patchTodoSchema>
+
+export type PatchTodoResult = PatchTodoInput["updates"] & { id: string }
+
+export async function patchTodo(input: PatchTodoInput): Promise<PatchTodoResult> {
+        const payload = patchTodoSchema.parse(input)
+
+        await wait(120)
+
+        return {
+                id: payload.id,
+                ...payload.updates,
+        }
 }
-export async function updateTodoById(id: string) {
-	console.log("update todo");
-}
-export async function deleteTodoById(id: string) {}
-export async function readTodos() {}

--- a/app/dashboard/todo/components/ListOfTodo.tsx
+++ b/app/dashboard/todo/components/ListOfTodo.tsx
@@ -1,87 +1,155 @@
-import React from "react";
-import { TrashIcon } from "@radix-ui/react-icons";
-import { Button } from "@/components/ui/button";
-import EditTodo from "./EditTodo";
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import EditableCell from "@/components/ui/editable-cell"
+import { cn } from "@/lib/utils"
+import { TrashIcon } from "@radix-ui/react-icons"
+
+import { patchTodo } from "../actions"
+import EditTodo from "./EditTodo"
+
+type TodoRecord = {
+        id: string
+        title: string
+        status: "completed" | "pending" | "in_progress"
+        created_at: string
+        create_by: string
+}
+
+const STATUS_OPTIONS = [
+        { label: "Completed", value: "completed" },
+        { label: "In progress", value: "in_progress" },
+        { label: "Pending", value: "pending" },
+]
 
 export default function ListOfTodo() {
-	const todos = [
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Garfield",
-		},
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Trender",
-		},
-		{
-			title: "Subscribe to my channel",
-			status: "completed",
-			created_at: new Date().toDateString(),
-			create_by: "Some string",
-		},
-	];
-	return (
-		<div className="mx-2 rounded-sm bg-white dark:bg-inherit">
-			{todos.map((todo, index) => {
-				return (
-					<div
-						className=" grid grid-cols-5  rounded-sm  p-3 align-middle font-normal "
-						key={index}
-					>
-						{Object.keys(todo).map((key, index) => {
-							if (key === "status") {
-								return (
-									<div
-										key={index}
-										className="flex items-center"
-									>
-										<div>
-											<span
-												className={cn(
-													"  rounded-full border-[.5px] px-2 py-1 text-sm capitalize  shadow dark:bg-zinc-800",
-													{
-														"border-green-500 bg-green-400 dark:text-green-400":
-															todo.status ===
-															"completed",
-													}
-												)}
-											>
-												{todo.status}
-											</span>
-										</div>
-									</div>
-								);
-							} else {
-								return (
-									<h1
-										className="flex items-center text-lg dark:text-white"
-										key={index}
-									>
-										{todo[key as keyof typeof todo]}
-									</h1>
-								);
-							}
-						})}
+        const [todos, setTodos] = useState<TodoRecord[]>([
+                {
+                        id: "todo-1",
+                        title: "Subscribe to my channel",
+                        status: "completed",
+                        created_at: new Date().toDateString(),
+                        create_by: "Garfield",
+                },
+                {
+                        id: "todo-2",
+                        title: "Subscribe to my channel",
+                        status: "completed",
+                        created_at: new Date().toDateString(),
+                        create_by: "Trender",
+                },
+                {
+                        id: "todo-3",
+                        title: "Subscribe to my channel",
+                        status: "completed",
+                        created_at: new Date().toDateString(),
+                        create_by: "Some string",
+                },
+        ])
+        const todosRef = useRef(todos)
+        const [pendingMap, setPendingMap] = useState<Record<string, boolean>>({})
 
-						<div className="flex items-center gap-2">
-							<Button
-								variant="outline"
-								className="bg-dark dark:bg-inherit"
-							>
-								<TrashIcon />
-								delete
-							</Button>
-							<EditTodo />
-						</div>
-					</div>
-				);
-			})}
-		</div>
-	);
+        useEffect(() => {
+                todosRef.current = todos
+        }, [todos])
+
+        async function updateStatus(id: string, nextStatus: TodoRecord["status"]) {
+                const previous = todosRef.current
+                const optimistic = previous.map((todo) =>
+                        todo.id === id ? { ...todo, status: nextStatus } : todo,
+                )
+
+                todosRef.current = optimistic
+                setTodos(optimistic)
+                setPendingMap((prev) => ({ ...prev, [id]: true }))
+
+                try {
+                        const response = await patchTodo({
+                                id,
+                                updates: { status: nextStatus },
+                        })
+
+                        const merged = todosRef.current.map((todo) =>
+                                todo.id === id ? { ...todo, ...response } : todo,
+                        )
+
+                        todosRef.current = merged
+                        setTodos(merged)
+                } catch (error) {
+                        todosRef.current = previous
+                        setTodos(previous)
+                        throw error
+                } finally {
+                        setPendingMap((prev) => {
+                                const next = { ...prev }
+                                delete next[id]
+                                return next
+                        })
+                }
+        }
+
+        return (
+                <div className="mx-2 rounded-sm bg-white dark:bg-inherit">
+                        {todos.map((todo) => (
+                                <div
+                                        className="grid grid-cols-5 items-center gap-2 rounded-sm p-3 font-normal"
+                                        key={todo.id}
+                                >
+                                        <h1 className="flex items-center text-lg dark:text-white">
+                                                {todo.title}
+                                        </h1>
+                                        <div className="flex items-center">
+                                                <EditableCell
+                                                        label={`Status for ${todo.title}`}
+                                                        value={todo.status}
+                                                        options={STATUS_OPTIONS}
+                                                        pending={pendingMap[todo.id] ?? false}
+                                                        renderDisplay={(status) => (
+                                                                <span
+                                                                        className={cn(
+                                                                                "rounded-full border-[.5px] px-2 py-1 text-sm capitalize shadow dark:bg-zinc-800",
+                                                                                {
+                                                                                        "border-green-500 bg-green-400 text-green-800 dark:text-green-400":
+                                                                                                status === "completed",
+                                                                                        "border-yellow-500 bg-yellow-200 text-yellow-700":
+                                                                                                status === "pending",
+                                                                                        "border-blue-500 bg-blue-200 text-blue-700":
+                                                                                                status === "in_progress",
+                                                                                },
+                                                                        )}
+                                                                >
+                                                                        {status.replace("_", " ")}
+                                                                </span>
+                                                        )}
+                                                        onSubmit={(value) =>
+                                                                updateStatus(
+                                                                        todo.id,
+                                                                        value as TodoRecord["status"],
+                                                                )
+                                                        }
+                                                />
+                                        </div>
+                                        <h1 className="flex items-center text-lg dark:text-white">
+                                                {todo.created_at}
+                                        </h1>
+                                        <h1 className="flex items-center text-lg dark:text-white">
+                                                {todo.create_by}
+                                        </h1>
+
+                                        <div className="flex items-center gap-2">
+                                                <Button
+                                                        variant="outline"
+                                                        className="bg-dark flex items-center gap-2 dark:bg-inherit"
+                                                >
+                                                        <TrashIcon />
+                                                        delete
+                                                </Button>
+                                                <EditTodo />
+                                        </div>
+                                </div>
+                        ))}
+                </div>
+        )
 }

--- a/components/ui/editable-cell.tsx
+++ b/components/ui/editable-cell.tsx
@@ -1,0 +1,224 @@
+"use client"
+
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { useForm } from "react-hook-form"
+import type { RegisterOptions } from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+
+type Option = {
+        label: string
+        value: string
+}
+
+type EditableCellFormValues = {
+        value: string
+}
+
+export type EditableCellProps = {
+        /**
+         * Accessible label describing the field rendered inside the table cell.
+         */
+        label: string
+        /**
+         * Current value for the cell. The component will keep itself in sync when
+         * this value changes as a result of optimistic updates completing.
+         */
+        value: string
+        /**
+         * Callback invoked when a new value is submitted. Return a promise to
+         * surface async validation errors inline.
+         */
+        onSubmit: (value: string) => Promise<void> | void
+        /**
+         * Optional collection of options to render the editor as a select input.
+         */
+        options?: Option[]
+        /**
+         * Optional placeholder rendered for text inputs.
+         */
+        placeholder?: string
+        /**
+         * Validation rules forwarded to react-hook-form.
+         */
+        rules?: RegisterOptions<EditableCellFormValues, "value">
+        /**
+         * Render prop for the read-only state. Defaults to the raw value.
+         */
+        renderDisplay?: (value: string) => React.ReactNode
+        /**
+         * Applies styles to the wrapper element.
+         */
+        className?: string
+        /**
+         * When true the cell stays interactive but visually indicates an
+         * in-flight update.
+         */
+        pending?: boolean
+}
+
+const DEFAULT_ERROR_MESSAGE = "Unable to save changes"
+
+export default function EditableCell({
+        label,
+        value,
+        options,
+        onSubmit,
+        placeholder,
+        rules,
+        renderDisplay,
+        className,
+        pending = false,
+}: EditableCellProps) {
+        const {
+                handleSubmit,
+                formState,
+                register,
+                reset,
+        } = useForm<EditableCellFormValues>({
+                defaultValues: { value },
+        })
+
+        const [isEditing, setIsEditing] = useState(false)
+        const [serverError, setServerError] = useState<string | null>(null)
+        const inputRef = useRef<HTMLInputElement | HTMLSelectElement | null>(null)
+
+        const displayLabel = useMemo(() => {
+                if (!options) return value
+                return options.find((option) => option.value === value)?.label ?? value
+        }, [options, value])
+
+        useEffect(() => {
+                if (isEditing) {
+                        return
+                }
+                reset({ value })
+        }, [isEditing, reset, value])
+
+        useEffect(() => {
+                if (!isEditing) return
+
+                const id = requestAnimationFrame(() => {
+                        inputRef.current?.focus()
+                })
+                return () => cancelAnimationFrame(id)
+        }, [isEditing])
+
+        const closeEditor = () => {
+                reset({ value })
+                setServerError(null)
+                setIsEditing(false)
+        }
+
+        const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement | HTMLSelectElement>) => {
+                if (event.key === "Escape") {
+                        event.preventDefault()
+                        closeEditor()
+                        return
+                }
+
+                if (event.key === "Enter") {
+                        event.preventDefault()
+                        void onValidSubmit()
+                }
+        }
+
+        const onValidSubmit = handleSubmit(async ({ value: nextValue }) => {
+                if (pending) return
+
+                try {
+                        await onSubmit(nextValue)
+                        setServerError(null)
+                        setIsEditing(false)
+                } catch (error) {
+                        if (error instanceof Error && error.message) {
+                                setServerError(error.message)
+                        } else {
+                                setServerError(DEFAULT_ERROR_MESSAGE)
+                        }
+                }
+        })
+
+        const field = register("value", rules)
+
+        return (
+                <div
+                        className={cn("relative w-full", className)}
+                        aria-busy={pending}
+                        data-pending={pending ? "true" : undefined}
+                >
+                        {isEditing ? (
+                                <form className="flex flex-col gap-1" onSubmit={onValidSubmit}>
+                                        {options ? (
+                                                <select
+                                                        {...field}
+                                                        ref={(element) => {
+                                                                field.ref(element)
+                                                                inputRef.current = element
+                                                        }}
+                                                        aria-label={label}
+                                                        className={cn(
+                                                                "w-full rounded border border-zinc-200 bg-white px-2 py-1 text-sm capitalize",
+                                                                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                                                        )}
+                                                        disabled={pending}
+                                                        onKeyDown={handleKeyDown}
+                                                >
+                                                        {options.map((option) => (
+                                                                <option key={option.value} value={option.value}>
+                                                                        {option.label}
+                                                                </option>
+                                                        ))}
+                                                </select>
+                                        ) : (
+                                                <input
+                                                        {...field}
+                                                        ref={(element) => {
+                                                                field.ref(element)
+                                                                inputRef.current = element
+                                                        }}
+                                                        aria-label={label}
+                                                        className={cn(
+                                                                "w-full rounded border border-zinc-200 bg-white px-2 py-1 text-sm",
+                                                                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                                                        )}
+                                                        disabled={pending}
+                                                        onKeyDown={handleKeyDown}
+                                                        placeholder={placeholder}
+                                                />
+                                        )}
+                                        {formState.errors.value ? (
+                                                <p className="text-xs text-red-500" role="alert">
+                                                        {formState.errors.value.message as string}
+                                                </p>
+                                        ) : null}
+                                        {serverError ? (
+                                                <p className="text-xs text-red-500" role="alert">
+                                                        {serverError}
+                                                </p>
+                                        ) : null}
+                                </form>
+                        ) : (
+                                <button
+                                        type="button"
+                                        className={cn(
+                                                "group/trigger w-full text-left text-sm",
+                                                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                                                pending ? "opacity-60" : undefined,
+                                        )}
+                                        aria-label={`${label}. Current value: ${displayLabel}`}
+                                        onClick={() => {
+                                                if (pending) return
+                                                setServerError(null)
+                                                setIsEditing(true)
+                                        }}
+                                        disabled={pending}
+                                >
+                                        <span aria-hidden="true">
+                                                {renderDisplay ? renderDisplay(value) : displayLabel}
+                                        </span>
+                                </button>
+                        )}
+                </div>
+        )
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
@@ -85,6 +88,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,15 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -225,6 +234,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,13 +248,16 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -255,6 +270,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@4.0.4':
+    resolution: {integrity: sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==}
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    resolution: {integrity: sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +395,40 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1628,11 +1686,43 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2012,6 +2102,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2032,6 +2126,9 @@ packages:
   aria-hidden@1.2.3:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2350,16 +2447,31 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2389,6 +2501,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -2455,6 +2570,12 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -2505,6 +2626,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.22.3:
@@ -2983,6 +3108,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3119,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3008,6 +3145,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3118,6 +3259,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
@@ -3201,6 +3345,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3470,10 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3324,6 +3481,10 @@ packages:
     resolution: {integrity: sha512-JZX+1fjpqxvQmEgItvPOAwRlqf0Eg9dSZMxljA2/V2M6dluOhQCPBhewIlSJWgkNu0M36kViOgmTAMnDaAMOFw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -3374,6 +3535,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
@@ -3493,6 +3657,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3671,6 +3839,9 @@ packages:
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -3712,9 +3883,6 @@ packages:
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3806,6 +3974,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3868,6 +4040,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
@@ -3945,6 +4120,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
     engines: {node: '>= 0.4'}
@@ -4001,6 +4180,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4195,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4198,6 +4387,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -4261,6 +4454,9 @@ packages:
   svelte@4.2.18:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
@@ -4361,6 +4557,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4369,8 +4572,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4622,6 +4833,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4634,6 +4849,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4867,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4930,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4732,6 +4982,8 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.2.1':
@@ -4744,6 +4996,23 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@4.0.4':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.1
+
+  '@asamuzakjp/dom-selector@6.5.5':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5168,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.4.32)':
+    dependencies:
+      postcss: 8.4.32
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -6195,11 +6488,47 @@ snapshots:
       '@tanstack/query-core': 5.51.9
       react: 18.2.0
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/runtime': 7.23.9
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@testing-library/dom': 10.4.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.5
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -6644,6 +6973,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -6660,6 +6991,10 @@ snapshots:
   aria-hidden@1.2.3:
     dependencies:
       tslib: 2.6.2
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7012,11 +7347,31 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.1(postcss@8.4.32):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.4
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.4.32)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   date-fns@3.3.1: {}
 
@@ -7031,6 +7386,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -7090,6 +7447,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -7142,6 +7503,8 @@ snapshots:
       tapable: 2.2.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.22.3:
     dependencies:
@@ -7851,6 +8214,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8233,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7883,6 +8261,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -7983,6 +8363,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.2:
     dependencies:
       '@types/estree': 1.0.5
@@ -8072,6 +8454,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.5
+      cssstyle: 5.3.1(postcss@8.4.32)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8167,6 +8577,8 @@ snapshots:
 
   lru-cache@10.1.0: {}
 
+  lru-cache@11.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -8174,6 +8586,8 @@ snapshots:
   lucide-react@0.302.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.176.0)(three@0.160.0):
     dependencies:
@@ -8294,6 +8708,8 @@ snapshots:
 
   mdn-data@2.0.30:
     optional: true
+
+  mdn-data@2.12.2: {}
 
   merge-anything@5.1.7:
     dependencies:
@@ -8496,7 +8912,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8527,6 +8943,8 @@ snapshots:
       mime-db: 1.52.0
 
   mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -8706,6 +9124,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -8739,8 +9161,6 @@ snapshots:
       is-reference: 3.0.2
 
   picocolors@1.0.0: {}
-
-  picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -8786,7 +9206,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -8823,6 +9243,12 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.6.2: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prop-types@15.8.1:
     dependencies:
@@ -8885,6 +9311,8 @@ snapshots:
       react: 18.2.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-merge-refs@1.1.0: {}
 
@@ -8960,6 +9388,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.4:
     dependencies:
@@ -9061,6 +9494,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9079,6 +9514,12 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9301,6 +9742,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -9374,6 +9819,8 @@ snapshots:
       magic-string: 0.30.19
       periscopic: 3.1.0
     optional: true
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.2.0:
     dependencies:
@@ -9502,13 +9949,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9644,13 +10105,13 @@ snapshots:
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.0(browserslist@4.23.2):
     dependencies:
       browserslist: 4.23.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
@@ -9736,7 +10197,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10225,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,6 +10251,10 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -9799,6 +10265,8 @@ snapshots:
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9832,6 +10300,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9903,6 +10382,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/tests/app/dashboard/members/list-of-members.test.tsx
+++ b/tests/app/dashboard/members/list-of-members.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ListOfMembers from '@/app/dashboard/members/components/ListOfMembers'
+import type { DashboardMember } from '@/app/dashboard/members/data'
+
+vi.mock('@/app/dashboard/members/actions', () => ({
+  patchMember: vi.fn(),
+  createMember: vi.fn(),
+  updateMemberById: vi.fn(),
+  deleteMemberById: vi.fn(),
+  readMembers: vi.fn(),
+}))
+
+const { patchMember } = await import('@/app/dashboard/members/actions')
+
+const members: DashboardMember[] = [
+  {
+    id: 'member-1',
+    name: 'Admin Member',
+    role: 'admin',
+    status: 'active',
+    createdAt: '2024-01-01',
+  },
+  {
+    id: 'member-2',
+    name: 'Roommate',
+    role: 'user',
+    status: 'resigned',
+    createdAt: '2024-01-01',
+  },
+]
+
+describe('ListOfMembers inline editing', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('persists role edits without a reload', async () => {
+    vi.mocked(patchMember).mockResolvedValue({ id: 'member-1', role: 'user' })
+
+    render(<ListOfMembers members={members} />)
+
+    const user = userEvent.setup()
+
+    const [roleTrigger] = screen.getAllByRole('button', { name: /role for admin member/i })
+    await user.click(roleTrigger)
+
+    const roleSelect = await screen.findByRole('combobox', { name: /role for admin member/i })
+    await user.selectOptions(roleSelect, 'user')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() =>
+      expect(patchMember).toHaveBeenCalledWith({
+        id: 'member-1',
+        updates: { role: 'user' },
+      }),
+    )
+
+    await waitFor(() => {
+      const [updatedTrigger] = screen.getAllByRole('button', { name: /role for admin member/i })
+      expect(updatedTrigger).toHaveTextContent(/user/i)
+    })
+  })
+
+  it('shows inline validation feedback when the server rejects an update', async () => {
+    vi.mocked(patchMember).mockRejectedValueOnce(new Error('Role update failed'))
+
+    render(<ListOfMembers members={members} />)
+
+    const user = userEvent.setup()
+    const [trigger] = screen.getAllByRole('button', { name: /role for admin member/i })
+    await user.click(trigger)
+
+    const roleSelect = await screen.findByRole('combobox', { name: /role for admin member/i })
+    await user.selectOptions(roleSelect, 'user')
+    await user.keyboard('{Enter}')
+
+    expect(await screen.findByText('Role update failed')).toBeVisible()
+
+    // The editor stays open so the user can correct their input.
+    expect(screen.getByRole('combobox', { name: /role for admin member/i })).toBeVisible()
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,9 @@ import path from "path"
 
 export default defineConfig({
   test: {
-    environment: "node",
-    include: ["tests/**/*.test.ts"],
+    environment: "jsdom",
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+    setupFiles: ["./tests/setup.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- introduce a reusable `EditableCell` component that toggles between read and edit modes with react-hook-form validation and keyboard support
- refactor the member and todo tables to use inline editing backed by new patch server actions and optimistic state management
- add vitest/jsdom configuration and tests that exercise inline edits and ensure validation errors surface inline

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d20b70a0108328a6c38db2c113923d