### PR TITLE
feat: add optimistic conflict resolution for edits

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
 import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
+import { ConflictDetails, evaluateConflict, extractChangedFields } from '@/lib/conflicts';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import {
   Document,
@@ -45,12 +46,53 @@ const documentListFiltersSchema = z.object({
   date_to: z.string().datetime().optional(),
 });
 
+const documentUpdateFieldsSchema = z.object({
+  title: z.string().min(1, 'Title cannot be empty').optional(),
+  description: z.string().optional().nullable(),
+  status: z.enum(['draft', 'pending_signature', 'signed', 'expired', 'cancelled']).optional(),
+  requires_signature: z.boolean().optional(),
+  expires_at: z.string().datetime().optional().nullable(),
+});
+
+const documentUpdatePayloadSchema = z.object({
+  documentId: z.string().uuid(),
+  updates: documentUpdateFieldsSchema,
+  expectedVersion: z.number().int().nonnegative().nullable().optional(),
+  expectedUpdatedAt: z.string().datetime().nullable().optional(),
+  resolution: z
+    .object({
+      type: z.enum(['keep_mine', 'keep_theirs', 'manual']),
+      mergedFields: z.record(z.any()).optional(),
+      baseVersion: z.number().int().nonnegative().nullable().optional(),
+    })
+    .optional(),
+});
+
+type DocumentUpdatePayload = z.infer<typeof documentUpdatePayloadSchema>;
+
+type EditableDocumentSnapshot = Pick<
+  Document,
+  'id' | 'title' | 'description' | 'status' | 'requires_signature' | 'expires_at' | 'updated_at' | 'version'
+>;
+
+export type DocumentConflictPayload = ConflictDetails<
+  EditableDocumentSnapshot,
+  Partial<Pick<Document, 'title' | 'description' | 'status' | 'requires_signature' | 'expires_at'>>
+>;
+
+type DocumentUpdateRecord = EditableDocumentSnapshot & {
+  created_by?: string | null;
+  tenant_id?: string | null;
+};
+
 // Action result interface
-interface ActionResult<T = any> {
+interface ActionResult<T = any, TConflict = any> {
   success: boolean;
   data?: T;
   error?: string;
   message?: string;
+  status?: 'conflict';
+  conflict?: TConflict;
 }
 
 // Get documents with optional filters
@@ -209,6 +251,150 @@ export async function uploadDocumentAction(
     return {
       success: false,
       error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+    };
+  }
+}
+
+export async function updateDocumentAction(
+  payload: DocumentUpdatePayload
+): Promise<ActionResult<DocumentWithLease, DocumentConflictPayload>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const parsed = documentUpdatePayloadSchema.safeParse(payload);
+    if (!parsed.success) {
+      const flattened = parsed.error.flatten();
+      const firstError = flattened.fieldErrors?.[Object.keys(flattened.fieldErrors)[0]]?.[0];
+      return { success: false, error: firstError || 'Invalid document update payload.' };
+    }
+
+    const { documentId, updates, expectedVersion, expectedUpdatedAt, resolution } = parsed.data;
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to update documents.' };
+    }
+
+    const { data: document, error: documentError } = await (supabase as any)
+      .from('documents')
+      .select(
+        'id, title, description, status, requires_signature, expires_at, updated_at, version, created_by, tenant_id'
+      )
+      .eq('id', documentId)
+      .single<DocumentUpdateRecord>();
+
+    if (documentError || !document) {
+      console.error('Document not found for update', documentError);
+      return { success: false, error: 'Document not found.' };
+    }
+
+    let role: Awaited<ReturnType<typeof fetchMemberRole>> | null = null;
+    try {
+      role = await fetchMemberRole(typedSupabase, user.id);
+    } catch (roleError) {
+      console.warn('Unable to resolve role when updating document:', roleError);
+    }
+
+    const canEdit =
+      role === 'property_manager' ||
+      role === 'admin' ||
+      document.created_by === user.id ||
+      document.tenant_id === user.id;
+
+    if (!canEdit) {
+      return { success: false, error: 'You do not have permission to edit this document.' };
+    }
+
+    const conflictCheck = evaluateConflict({
+      current: document,
+      incoming: updates,
+      expectedVersion: expectedVersion ?? undefined,
+      expectedUpdatedAt: expectedUpdatedAt ?? undefined,
+      message: 'This document was updated by someone else while you were editing.',
+    });
+
+    if (conflictCheck.hasConflict) {
+      return {
+        success: false,
+        status: 'conflict',
+        error: conflictCheck.details.message,
+        conflict: conflictCheck.details,
+      };
+    }
+
+    const sanitizedUpdates: Record<string, any> = {};
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) continue;
+      if (key === 'description' && value === '') {
+        sanitizedUpdates.description = null;
+        continue;
+      }
+      if (key === 'expires_at') {
+        sanitizedUpdates.expires_at = value || null;
+        continue;
+      }
+      sanitizedUpdates[key] = value;
+    }
+
+    if (Object.keys(sanitizedUpdates).length === 0) {
+      return {
+        success: true,
+        data: document as unknown as DocumentWithLease,
+        message: 'No changes detected.',
+      };
+    }
+
+    const nextVersion = (document.version ?? 1) + 1;
+
+    const { data: updatedDocument, error: updateError } = await (supabase as any)
+      .from('documents')
+      .update({
+        ...sanitizedUpdates,
+        version: nextVersion,
+      })
+      .eq('id', documentId)
+      .select(DOCUMENT_SELECT)
+      .single();
+
+    if (updateError || !updatedDocument) {
+      console.error('Error updating document record:', updateError);
+      return { success: false, error: 'Failed to update document.' };
+    }
+
+    if (resolution) {
+      const mergedFields = resolution.mergedFields ?? extractChangedFields(sanitizedUpdates, document as any);
+      try {
+        await supabase.rpc('log_conflict_resolution', {
+          p_entity_type: 'document',
+          p_entity_id: documentId,
+          p_resolution: resolution.type,
+          p_local_version: resolution.baseVersion ?? expectedVersion ?? null,
+          p_remote_version: document.version ?? null,
+          p_merged_fields: mergedFields,
+        });
+      } catch (logError) {
+        console.warn('Failed to log document conflict resolution:', logError);
+      }
+    }
+
+    revalidatePath('/documents');
+
+    return {
+      success: true,
+      data: updatedDocument as DocumentWithLease,
+      message: 'Document updated successfully.',
+    };
+  } catch (error) {
+    console.error('Unexpected error in updateDocumentAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
     };
   }
 }

--- a/app/documents/components/document-actions.tsx
+++ b/app/documents/components/document-actions.tsx
@@ -13,6 +13,7 @@ import { DocumentWithLease } from '@/types/documents';
 import { signDocumentAction, createSigningRequestAction, getSigningUrlAction } from '../actions';
 import { DocumentViewerDialog } from './document-viewer-dialog';
 import { CreateSignatureDialog } from './create-signature-dialog';
+import { EditDocumentDialog } from './edit-document-dialog';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
 import { MoreHorizontal, Eye, PenTool, Download, Share2 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -24,6 +25,7 @@ interface DocumentActionsProps {
 export function DocumentActions({ document }: DocumentActionsProps) {
   const [showViewer, setShowViewer] = useState(false);
   const [showSignatureDialog, setShowSignatureDialog] = useState(false);
+  const [showEditDialog, setShowEditDialog] = useState(false);
   const [loading, setLoading] = useState<string | null>(null);
   const permissions = useDocumentPermissions();
 
@@ -60,6 +62,10 @@ export function DocumentActions({ document }: DocumentActionsProps) {
 
   const handleCreateSigningRequest = () => {
     setShowSignatureDialog(true);
+  };
+
+  const handleEdit = () => {
+    setShowEditDialog(true);
   };
 
   const handleDownload = () => {
@@ -123,6 +129,13 @@ export function DocumentActions({ document }: DocumentActionsProps) {
             </DropdownMenuItem>
           )}
 
+          {canEdit && (
+            <DropdownMenuItem onClick={handleEdit}>
+              <PenTool className="mr-2 size-4" />
+              Edit Details
+            </DropdownMenuItem>
+          )}
+
           <DropdownMenuSeparator />
 
           <DropdownMenuItem onClick={handleDownload}>
@@ -147,6 +160,12 @@ export function DocumentActions({ document }: DocumentActionsProps) {
       <CreateSignatureDialog
         open={showSignatureDialog}
         onOpenChange={setShowSignatureDialog}
+        document={document}
+      />
+
+      <EditDocumentDialog
+        open={showEditDialog}
+        onOpenChange={setShowEditDialog}
         document={document}
       />
     </>

--- a/app/documents/components/edit-document-dialog.tsx
+++ b/app/documents/components/edit-document-dialog.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+
+import { ConflictDialog, ConflictField, ConflictResolutionPayload } from "@/components/conflicts/ConflictDialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import type { DocumentStatus, DocumentWithLease } from "@/types/documents";
+import { cn } from "@/lib/utils";
+import { updateDocumentAction } from "@/app/documents/actions";
+import type { DocumentConflictPayload } from "@/app/documents/actions";
+import { toast } from "sonner";
+
+const documentStatuses: { label: string; value: DocumentStatus }[] = [
+  { label: "Draft", value: "draft" },
+  { label: "Pending signature", value: "pending_signature" },
+  { label: "Signed", value: "signed" },
+  { label: "Expired", value: "expired" },
+  { label: "Cancelled", value: "cancelled" },
+];
+
+type DocumentFormState = {
+  title: string;
+  description: string;
+  status: DocumentStatus;
+  requiresSignature: boolean;
+  expiresAt: string;
+};
+
+type PendingConflictState = {
+  conflict: DocumentConflictPayload;
+  attemptedValues: DocumentFormState;
+  baseVersion: number | null;
+};
+
+export interface EditDocumentDialogProps {
+  document: DocumentWithLease;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EditDocumentDialog({ document, open, onOpenChange }: EditDocumentDialogProps) {
+  const [formState, setFormState] = useState<DocumentFormState>(() => initializeFormState(document));
+  const [optimisticVersion, setOptimisticVersion] = useState<number | null>(document.version ?? null);
+  const [optimisticUpdatedAt, setOptimisticUpdatedAt] = useState<string | null>(document.updated_at ?? null);
+  const [pendingConflict, setPendingConflict] = useState<PendingConflictState | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (open) {
+      setFormState(initializeFormState(document));
+      setOptimisticVersion(document.version ?? null);
+      setOptimisticUpdatedAt(document.updated_at ?? null);
+      setPendingConflict(null);
+    }
+  }, [document, open]);
+
+  const conflictFields: ConflictField[] = useMemo(() => {
+    if (!pendingConflict) {
+      return [];
+    }
+
+    const { conflict, attemptedValues } = pendingConflict;
+    const current = conflict.current;
+
+    return [
+      {
+        key: "title",
+        label: "Title",
+        mine: attemptedValues.title,
+        theirs: current.title ?? "",
+      },
+      {
+        key: "description",
+        label: "Description",
+        mine: attemptedValues.description,
+        theirs: current.description ?? "",
+        variant: "multiline",
+      },
+      {
+        key: "status",
+        label: "Status",
+        mine: attemptedValues.status,
+        theirs: current.status ?? "",
+      },
+      {
+        key: "requires_signature",
+        label: "Requires signature",
+        mine: attemptedValues.requiresSignature ? "true" : "false",
+        theirs: (current.requires_signature ?? false) ? "true" : "false",
+        helperText: "Enter true or false when merging manually.",
+      },
+      {
+        key: "expires_at",
+        label: "Expiration date",
+        mine: attemptedValues.expiresAt,
+        theirs: normalizeDateInput(current.expires_at),
+        helperText: "Use YYYY-MM-DD format when merging manually.",
+      },
+    ];
+  }, [pendingConflict]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const updates = buildUpdatePayload(formState);
+
+    startTransition(async () => {
+      const result = await updateDocumentAction({
+        documentId: document.id,
+        updates,
+        expectedVersion: optimisticVersion,
+        expectedUpdatedAt: optimisticUpdatedAt ?? undefined,
+      });
+
+      if (result.status === "conflict" && result.conflict) {
+        setPendingConflict({
+          conflict: result.conflict,
+          attemptedValues: formState,
+          baseVersion: optimisticVersion,
+        });
+        toast.error("We found a newer version. Review the differences before saving.");
+        return;
+      }
+
+      if (!result.success) {
+        toast.error(result.error ?? "Failed to update document");
+        return;
+      }
+
+      toast.success("Document updated successfully");
+      setOptimisticVersion(result.data?.version ?? null);
+      setOptimisticUpdatedAt(result.data?.updated_at ?? null);
+      if (result.data) {
+        setFormState(initializeFormState(result.data));
+      }
+      onOpenChange(false);
+    });
+  };
+
+  const handleConflictResolution = async ({ type, values, baseVersion }: ConflictResolutionPayload) => {
+    if (!pendingConflict) return;
+
+    const mergedFormState = applyResolvedValues(formState, values);
+    const updates = buildUpdatePayload(mergedFormState);
+
+    const result = await updateDocumentAction({
+      documentId: document.id,
+      updates,
+      expectedVersion: pendingConflict.conflict.latestVersion ?? undefined,
+      expectedUpdatedAt: pendingConflict.conflict.latestUpdatedAt ?? undefined,
+      resolution: {
+        type,
+        mergedFields: updates,
+        baseVersion: baseVersion ?? pendingConflict.baseVersion ?? optimisticVersion ?? null,
+      },
+    });
+
+    if (result.status === "conflict" && result.conflict) {
+      // Newer conflict emerged; update dialog with freshest values
+      setPendingConflict({
+        conflict: result.conflict,
+        attemptedValues: mergedFormState,
+        baseVersion: optimisticVersion,
+      });
+      toast.error("Another update happened before your merge. Review the latest version.");
+      return;
+    }
+
+    if (!result.success) {
+      toast.error(result.error ?? "Failed to apply conflict resolution");
+      return;
+    }
+
+    toast.success("Document changes saved");
+    setOptimisticVersion(result.data?.version ?? null);
+    setOptimisticUpdatedAt(result.data?.updated_at ?? null);
+    if (result.data) {
+      setFormState(initializeFormState(result.data));
+    }
+    setPendingConflict(null);
+    onOpenChange(false);
+  };
+
+  const conflictMessage = pendingConflict?.conflict.message;
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Edit document</DialogTitle>
+            <DialogDescription>
+              Update the metadata and signing requirements for this document.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="document-title">Title</Label>
+              <Input
+                id="document-title"
+                value={formState.title}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, title: event.target.value }))
+                }
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="document-description">Description</Label>
+              <Textarea
+                id="document-description"
+                value={formState.description}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, description: event.target.value }))
+                }
+                rows={3}
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Status</Label>
+                <Select
+                  value={formState.status}
+                  onValueChange={(value: DocumentStatus) =>
+                    setFormState((current) => ({ ...current, status: value }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {documentStatuses.map((status) => (
+                      <SelectItem key={status.value} value={status.value}>
+                        {status.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="document-expires">Expiration date</Label>
+                <Input
+                  id="document-expires"
+                  type="date"
+                  value={formState.expiresAt}
+                  onChange={(event) =>
+                    setFormState((current) => ({ ...current, expiresAt: event.target.value }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between rounded-md border p-3">
+              <div className="space-y-1">
+                <Label htmlFor="document-requires-signature" className="text-base">
+                  Requires signature
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  When enabled, the document will remain pending until all signatures are captured.
+                </p>
+              </div>
+              <Switch
+                id="document-requires-signature"
+                checked={formState.requiresSignature}
+                onCheckedChange={(checked) =>
+                  setFormState((current) => ({ ...current, requiresSignature: checked }))
+                }
+              />
+            </div>
+
+            <DialogFooter>
+              <Button type="submit" disabled={isPending} className={cn(isPending && "cursor-progress")}> 
+                {isPending ? "Saving..." : "Save changes"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ConflictDialog
+        open={pendingConflict != null}
+        onOpenChange={(next) => {
+          if (!next) {
+            setPendingConflict(null);
+          }
+        }}
+        entityName="Document"
+        message={conflictMessage}
+        fields={conflictFields}
+        isResolving={isPending}
+        baseVersion={pendingConflict?.baseVersion ?? optimisticVersion ?? null}
+        onResolve={handleConflictResolution}
+        onCancel={() => setPendingConflict(null)}
+      />
+    </>
+  );
+}
+
+function initializeFormState(document: DocumentWithLease): DocumentFormState {
+  return {
+    title: document.title,
+    description: document.description ?? "",
+    status: document.status,
+    requiresSignature: document.requires_signature,
+    expiresAt: normalizeDateInput(document.expires_at),
+  };
+}
+
+function normalizeDateInput(value?: string | null): string {
+  if (!value) return "";
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "";
+    const year = date.getUTCFullYear();
+    const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
+    const day = `${date.getUTCDate()}`.padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  } catch (error) {
+    return "";
+  }
+}
+
+function buildUpdatePayload(formState: DocumentFormState) {
+  return {
+    title: formState.title.trim(),
+    description: formState.description,
+    status: formState.status,
+    requires_signature: formState.requiresSignature,
+    expires_at: formState.expiresAt ? new Date(formState.expiresAt).toISOString() : null,
+  } as const;
+}
+
+function applyResolvedValues(
+  current: DocumentFormState,
+  values: Record<string, string>
+): DocumentFormState {
+  return {
+    title: values.title ?? current.title,
+    description: values.description ?? current.description,
+    status: (values.status as DocumentStatus) ?? current.status,
+    requiresSignature: parseBoolean(values.requires_signature, current.requiresSignature),
+    expiresAt: values.expires_at ?? current.expiresAt,
+  };
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value == null) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "y"].includes(normalized)) return true;
+  if (["false", "0", "no", "n"].includes(normalized)) return false;
+  return fallback;
+}

--- a/app/maintenance/actions.ts
+++ b/app/maintenance/actions.ts
@@ -1,0 +1,204 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { z } from "zod";
+
+import { ConflictDetails, evaluateConflict, extractChangedFields } from "@/lib/conflicts";
+import { fetchMemberRole } from "@/lib/data/members";
+import { createClient } from "@/utils/supa-server-actions";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+
+interface ActionResult<T = any, TConflict = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+  status?: "conflict";
+  conflict?: TConflict;
+}
+
+type MaintenanceSnapshot = {
+  id: string;
+  status: "pending" | "in_progress" | "completed" | "cancelled";
+  priority: "low" | "normal" | "high" | "urgent";
+  notes: string | null;
+  assigned_to: string | null;
+  updated_at: string | null;
+  version: number | null;
+};
+
+type MaintenanceConflictPayload = ConflictDetails<
+  MaintenanceSnapshot,
+  Partial<Pick<MaintenanceSnapshot, "status" | "priority" | "notes" | "assigned_to">>
+>;
+
+const maintenanceUpdateSchema = z.object({
+  requestId: z.string().uuid(),
+  updates: z.object({
+    status: z.enum(["pending", "in_progress", "completed", "cancelled"]).optional(),
+    priority: z.enum(["low", "normal", "high", "urgent"]).optional(),
+    notes: z.string().optional().nullable(),
+    assigned_to: z.string().uuid().optional().nullable(),
+  }),
+  expectedVersion: z.number().int().nonnegative().nullable().optional(),
+  expectedUpdatedAt: z.string().datetime().nullable().optional(),
+  resolution: z
+    .object({
+      type: z.enum(["keep_mine", "keep_theirs", "manual"]),
+      mergedFields: z.record(z.any()).optional(),
+      baseVersion: z.number().int().nonnegative().nullable().optional(),
+    })
+    .optional(),
+});
+
+type MaintenanceUpdatePayload = z.infer<typeof maintenanceUpdateSchema>;
+
+type MaintenanceUpdateRecord = MaintenanceSnapshot & {
+  unit_id: string | null;
+  requested_by: string;
+};
+
+type MaintenanceRequest = MaintenanceSnapshot & {
+  title: string;
+  description: string;
+  created_at: string;
+};
+
+export async function updateMaintenanceRequestAction(
+  payload: MaintenanceUpdatePayload
+): Promise<ActionResult<MaintenanceRequest, MaintenanceConflictPayload>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const parsed = maintenanceUpdateSchema.safeParse(payload);
+    if (!parsed.success) {
+      const flattened = parsed.error.flatten();
+      const firstError = flattened.fieldErrors?.[Object.keys(flattened.fieldErrors)[0]]?.[0];
+      return { success: false, error: firstError || "Invalid maintenance request update." };
+    }
+
+    const { requestId, updates, expectedVersion, expectedUpdatedAt, resolution } = parsed.data;
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { success: false, error: "You must be logged in to update maintenance requests." };
+    }
+
+    const { data: maintenance, error: maintenanceError } = await (supabase as any)
+      .from("maintenance_requests")
+      .select(
+        "id, status, priority, notes, assigned_to, updated_at, version, unit_id, requested_by, title, description, created_at"
+      )
+      .eq("id", requestId)
+      .single<MaintenanceUpdateRecord & MaintenanceRequest>();
+
+    if (maintenanceError || !maintenance) {
+      console.error("Maintenance request not found", maintenanceError);
+      return { success: false, error: "Maintenance request not found." };
+    }
+
+    let role: Awaited<ReturnType<typeof fetchMemberRole>> | null = null;
+    try {
+      role = await fetchMemberRole(typedSupabase, user.id);
+    } catch (roleError) {
+      console.warn("Unable to resolve role when updating maintenance request:", roleError);
+    }
+
+    const canEdit = role === "property_manager" || role === "admin";
+
+    if (!canEdit) {
+      return { success: false, error: "You do not have permission to modify this maintenance request." };
+    }
+
+    const conflictCheck = evaluateConflict({
+      current: maintenance,
+      incoming: updates,
+      expectedVersion: expectedVersion ?? undefined,
+      expectedUpdatedAt: expectedUpdatedAt ?? undefined,
+      message: "This maintenance request was updated by someone else while you were editing.",
+    });
+
+    if (conflictCheck.hasConflict) {
+      return {
+        success: false,
+        status: "conflict",
+        error: conflictCheck.details.message,
+        conflict: conflictCheck.details,
+      };
+    }
+
+    const sanitizedUpdates: Record<string, any> = {};
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) continue;
+      if (key === "notes" && value === "") {
+        sanitizedUpdates.notes = null;
+        continue;
+      }
+      sanitizedUpdates[key] = value;
+    }
+
+    if (Object.keys(sanitizedUpdates).length === 0) {
+      return {
+        success: true,
+        data: maintenance,
+        message: "No changes detected.",
+      };
+    }
+
+    const nextVersion = (maintenance.version ?? 1) + 1;
+
+    const { data: updated, error: updateError } = await (supabase as any)
+      .from("maintenance_requests")
+      .update({
+        ...sanitizedUpdates,
+        version: nextVersion,
+      })
+      .eq("id", requestId)
+      .select(
+        "id, status, priority, notes, assigned_to, updated_at, version, title, description, created_at"
+      )
+      .single<MaintenanceRequest>();
+
+    if (updateError || !updated) {
+      console.error("Failed to update maintenance request", updateError);
+      return { success: false, error: "Failed to update maintenance request." };
+    }
+
+    if (resolution) {
+      const mergedFields = resolution.mergedFields ?? extractChangedFields(sanitizedUpdates, maintenance as any);
+      try {
+        await supabase.rpc("log_conflict_resolution", {
+          p_entity_type: "maintenance_request",
+          p_entity_id: requestId,
+          p_resolution: resolution.type,
+          p_local_version: resolution.baseVersion ?? expectedVersion ?? null,
+          p_remote_version: maintenance.version ?? null,
+          p_merged_fields: mergedFields,
+        });
+      } catch (logError) {
+        console.warn("Failed to log maintenance conflict resolution:", logError);
+      }
+    }
+
+    revalidatePath("/maintenance");
+
+    return {
+      success: true,
+      data: updated,
+      message: "Maintenance request updated successfully.",
+    };
+  } catch (error) {
+    console.error("Unexpected error in updateMaintenanceRequestAction:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred.",
+    };
+  }
+}

--- a/app/messaging/actions.ts
+++ b/app/messaging/actions.ts
@@ -1,0 +1,189 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { z } from "zod";
+
+import { ConflictDetails, evaluateConflict, extractChangedFields } from "@/lib/conflicts";
+import { fetchMemberRole } from "@/lib/data/members";
+import { createClient } from "@/utils/supa-server-actions";
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+
+interface ActionResult<T = any, TConflict = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+  status?: "conflict";
+  conflict?: TConflict;
+}
+
+type MessageSnapshot = {
+  id: string;
+  content: string;
+  updated_at: string | null;
+  version: number | null;
+  thread_id: string | null;
+  author_id: string | null;
+};
+
+export type MessageConflictPayload = ConflictDetails<
+  MessageSnapshot,
+  Partial<Pick<MessageSnapshot, "content">>
+>;
+
+const messageUpdateSchema = z.object({
+  messageId: z.string().uuid(),
+  updates: z.object({
+    content: z.string().min(1, "Message content cannot be empty").optional(),
+  }),
+  expectedVersion: z.number().int().nonnegative().nullable().optional(),
+  expectedUpdatedAt: z.string().datetime().nullable().optional(),
+  resolution: z
+    .object({
+      type: z.enum(["keep_mine", "keep_theirs", "manual"]),
+      mergedFields: z.record(z.any()).optional(),
+      baseVersion: z.number().int().nonnegative().nullable().optional(),
+    })
+    .optional(),
+});
+
+type MessageUpdatePayload = z.infer<typeof messageUpdateSchema>;
+
+export type MessageRecord = MessageSnapshot & {
+  created_at: string;
+  reactions?: any;
+};
+
+export type Message = MessageRecord;
+
+export async function updateMessageAction(
+  payload: MessageUpdatePayload
+): Promise<ActionResult<Message, MessageConflictPayload>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const parsed = messageUpdateSchema.safeParse(payload);
+    if (!parsed.success) {
+      const flattened = parsed.error.flatten();
+      const firstError = flattened.fieldErrors?.[Object.keys(flattened.fieldErrors)[0]]?.[0];
+      return { success: false, error: firstError || "Invalid message update payload." };
+    }
+
+    const { messageId, updates, expectedVersion, expectedUpdatedAt, resolution } = parsed.data;
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { success: false, error: "You must be logged in to update messages." };
+    }
+
+    const { data: message, error: messageError } = await (supabase as any)
+      .from("messages")
+      .select("id, content, updated_at, version, thread_id, author_id, created_at")
+      .eq("id", messageId)
+      .single<MessageRecord>();
+
+    if (messageError || !message) {
+      console.error("Message not found", messageError);
+      return { success: false, error: "Message not found." };
+    }
+
+    let role: Awaited<ReturnType<typeof fetchMemberRole>> | null = null;
+    try {
+      role = await fetchMemberRole(typedSupabase, user.id);
+    } catch (roleError) {
+      console.warn("Unable to resolve role when updating message:", roleError);
+    }
+
+    const canEdit =
+      message.author_id === user.id || role === "property_manager" || role === "admin";
+
+    if (!canEdit) {
+      return { success: false, error: "You do not have permission to edit this message." };
+    }
+
+    const conflictCheck = evaluateConflict({
+      current: message,
+      incoming: updates,
+      expectedVersion: expectedVersion ?? undefined,
+      expectedUpdatedAt: expectedUpdatedAt ?? undefined,
+      message: "This message was updated by someone else while you were editing.",
+    });
+
+    if (conflictCheck.hasConflict) {
+      return {
+        success: false,
+        status: "conflict",
+        error: conflictCheck.details.message,
+        conflict: conflictCheck.details,
+      };
+    }
+
+    const sanitizedUpdates: Record<string, any> = {};
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) continue;
+      sanitizedUpdates[key] = value;
+    }
+
+    if (Object.keys(sanitizedUpdates).length === 0) {
+      return {
+        success: true,
+        data: message,
+        message: "No changes detected.",
+      };
+    }
+
+    const nextVersion = (message.version ?? 1) + 1;
+
+    const { data: updated, error: updateError } = await (supabase as any)
+      .from("messages")
+      .update({
+        ...sanitizedUpdates,
+        version: nextVersion,
+      })
+      .eq("id", messageId)
+      .select("id, content, updated_at, version, thread_id, author_id, created_at")
+      .single<Message>();
+
+    if (updateError || !updated) {
+      console.error("Failed to update message", updateError);
+      return { success: false, error: "Failed to update message." };
+    }
+
+    if (resolution) {
+      const mergedFields = resolution.mergedFields ?? extractChangedFields(sanitizedUpdates, message as any);
+      try {
+        await supabase.rpc("log_conflict_resolution", {
+          p_entity_type: "message",
+          p_entity_id: messageId,
+          p_resolution: resolution.type,
+          p_local_version: resolution.baseVersion ?? expectedVersion ?? null,
+          p_remote_version: message.version ?? null,
+          p_merged_fields: mergedFields,
+        });
+      } catch (logError) {
+        console.warn("Failed to log message conflict resolution:", logError);
+      }
+    }
+
+    revalidatePath("/messaging");
+
+    return {
+      success: true,
+      data: updated,
+      message: "Message updated successfully.",
+    };
+  } catch (error) {
+    console.error("Unexpected error in updateMessageAction:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred.",
+    };
+  }
+}

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,4 +1,6 @@
 import ModerationControls from "@/components/messaging/moderation-controls"
+import { MessageEditor } from "@/components/messaging/message-editor"
+import type { Message } from "@/app/messaging/actions"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -248,6 +250,17 @@ const threadPosts: ThreadPost[] = [
   },
 ]
 
+const featuredMessage: Message = {
+  id: "msg-featured-announcement",
+  content:
+    "Thanks everyone for jumping in on the spring reset! Here's the summary of next steps and the links we'll keep pinned for quick reference.",
+  updated_at: "2024-05-18T16:30:00.000Z",
+  version: 1,
+  thread_id: "chore-rotation",
+  author_id: "pm_maya",
+  created_at: "2024-05-18T15:45:00.000Z",
+}
+
 const attachmentSummary: AttachmentSummary[] = [
   {
     id: "rotation",
@@ -317,6 +330,8 @@ export default function MessagingPage() {
 
       <div className="grid gap-6 lg:grid-cols-[320px,1fr] xl:grid-cols-[320px,1fr]">
         <div className="space-y-6">
+          <MessageEditor message={featuredMessage} />
+
           <Card>
             <CardHeader className="space-y-4">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">

--- a/components/conflicts/ConflictDialog.tsx
+++ b/components/conflicts/ConflictDialog.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+export type ConflictField = {
+  key: string;
+  label: string;
+  mine: string;
+  theirs: string;
+  variant?: "single" | "multiline";
+  helperText?: string;
+};
+
+export type ConflictResolutionMode = "keep_mine" | "keep_theirs" | "manual";
+
+export type ConflictResolutionPayload = {
+  type: ConflictResolutionMode;
+  values: Record<string, string>;
+  baseVersion?: number | null;
+};
+
+export interface ConflictDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entityName: string;
+  message?: string;
+  fields: ConflictField[];
+  isResolving?: boolean;
+  baseVersion?: number | null;
+  onResolve: (payload: ConflictResolutionPayload) => void | Promise<void>;
+  onCancel?: () => void;
+}
+
+export function ConflictDialog({
+  open,
+  onOpenChange,
+  entityName,
+  message,
+  fields,
+  isResolving = false,
+  baseVersion,
+  onResolve,
+  onCancel,
+}: ConflictDialogProps) {
+  const [mode, setMode] = useState<ConflictResolutionMode>("keep_mine");
+  const [manualValues, setManualValues] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (open) {
+      const initialManual: Record<string, string> = {};
+      for (const field of fields) {
+        initialManual[field.key] = field.mine;
+      }
+      setManualValues(initialManual);
+      setMode("keep_mine");
+    }
+  }, [open, fields]);
+
+  const changedFields = useMemo(() => {
+    return fields.filter((field) => field.mine !== field.theirs).map((field) => field.key);
+  }, [fields]);
+
+  const handleClose = (nextOpen: boolean) => {
+    onOpenChange(nextOpen);
+    if (!nextOpen && onCancel) {
+      onCancel();
+    }
+  };
+
+  const resolveValues = (): Record<string, string> => {
+    if (mode === "keep_theirs") {
+      return fields.reduce<Record<string, string>>((acc, field) => {
+        acc[field.key] = field.theirs;
+        return acc;
+      }, {});
+    }
+
+    if (mode === "manual") {
+      return { ...manualValues };
+    }
+
+    return fields.reduce<Record<string, string>>((acc, field) => {
+      acc[field.key] = field.mine;
+      return acc;
+    }, {});
+  };
+
+  const handleConfirm = async () => {
+    const payload: ConflictResolutionPayload = {
+      type: mode,
+      values: resolveValues(),
+      baseVersion,
+    };
+
+    await onResolve(payload);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Resolve {entityName} conflict</DialogTitle>
+          <DialogDescription>
+            {message ??
+              `Someone else updated this ${entityName.toLowerCase()} before your changes were saved. Review the differences below and choose how to continue.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm font-medium">Resolution</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant={mode === "keep_mine" ? "default" : "outline"}
+                onClick={() => setMode("keep_mine")}
+              >
+                Keep my edits
+              </Button>
+              <Button
+                type="button"
+                variant={mode === "keep_theirs" ? "default" : "outline"}
+                onClick={() => setMode("keep_theirs")}
+              >
+                Use latest version
+              </Button>
+              <Button
+                type="button"
+                variant={mode === "manual" ? "default" : "outline"}
+                onClick={() => setMode("manual")}
+              >
+                Manual merge
+              </Button>
+            </div>
+          </div>
+
+          <ScrollArea className="max-h-[320px] rounded-md border">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-muted/40 text-xs uppercase">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Field</th>
+                  <th className="px-4 py-3 font-medium">My version</th>
+                  <th className="px-4 py-3 font-medium">Latest version</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fields.map((field) => {
+                  const isChanged = changedFields.includes(field.key);
+                  return (
+                    <tr
+                      key={field.key}
+                      className={cn(isChanged && "bg-destructive/5")}
+                    >
+                      <td className="align-top px-4 py-3 font-medium text-foreground">
+                        <div className="space-y-1">
+                          <div>{field.label}</div>
+                          {field.helperText ? (
+                            <p className="text-xs text-muted-foreground">{field.helperText}</p>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td className="w-1/3 px-4 py-3 align-top">
+                        <ValuePreview value={field.mine} multiline={field.variant === "multiline"} />
+                      </td>
+                      <td className="w-1/3 px-4 py-3 align-top">
+                        <ValuePreview value={field.theirs} multiline={field.variant === "multiline"} />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </ScrollArea>
+
+          {mode === "manual" ? (
+            <div className="space-y-4">
+              {fields.map((field) => (
+                <div key={field.key} className="space-y-2">
+                  <Label htmlFor={`manual-${field.key}`}>{field.label}</Label>
+                  {field.variant === "multiline" ? (
+                    <Textarea
+                      id={`manual-${field.key}`}
+                      value={manualValues[field.key] ?? ""}
+                      onChange={(event) =>
+                        setManualValues((current) => ({
+                          ...current,
+                          [field.key]: event.target.value,
+                        }))
+                      }
+                      rows={3}
+                    />
+                  ) : (
+                    <Input
+                      id={`manual-${field.key}`}
+                      value={manualValues[field.key] ?? ""}
+                      onChange={(event) =>
+                        setManualValues((current) => ({
+                          ...current,
+                          [field.key]: event.target.value,
+                        }))
+                      }
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-between">
+          <div className="text-xs text-muted-foreground">
+            {changedFields.length > 0
+              ? `${changedFields.length} field${changedFields.length === 1 ? "" : "s"} differ between versions.`
+              : "No differences detected between the two versions."}
+          </div>
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleClose(false)}
+              disabled={isResolving}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleConfirm} disabled={isResolving}>
+              {mode === "manual" ? "Confirm merge" : "Apply selection"}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ValuePreviewProps {
+  value: string;
+  multiline?: boolean;
+}
+
+function ValuePreview({ value, multiline = false }: ValuePreviewProps) {
+  if (!value) {
+    return <span className="text-muted-foreground">Empty</span>;
+  }
+
+  if (multiline) {
+    return (
+      <pre className="whitespace-pre-wrap rounded-md border bg-muted/40 px-3 py-2 text-xs">
+        {value}
+      </pre>
+    );
+  }
+
+  return <span className="text-sm text-foreground">{value}</span>;
+}

--- a/components/messaging/message-editor.tsx
+++ b/components/messaging/message-editor.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+
+import { ConflictDialog, ConflictField, ConflictResolutionPayload } from "@/components/conflicts/ConflictDialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { updateMessageAction } from "@/app/messaging/actions";
+import type { Message, MessageConflictPayload } from "@/app/messaging/actions";
+import { toast } from "sonner";
+
+type MessageEditorProps = {
+  message: Message;
+};
+
+type ConflictState = {
+  conflict: MessageConflictPayload;
+  attemptedContent: string;
+  baseVersion: number | null;
+};
+
+export function MessageEditor({ message }: MessageEditorProps) {
+  const [open, setOpen] = useState(false);
+  const [content, setContent] = useState(message.content);
+  const [currentMessage, setCurrentMessage] = useState(message);
+  const [optimisticVersion, setOptimisticVersion] = useState<number | null>(message.version ?? null);
+  const [optimisticUpdatedAt, setOptimisticUpdatedAt] = useState<string | null>(message.updated_at ?? null);
+  const [pendingConflict, setPendingConflict] = useState<ConflictState | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (open) {
+      setContent(currentMessage.content);
+      setPendingConflict(null);
+    }
+  }, [open, currentMessage]);
+
+  const conflictFields: ConflictField[] = useMemo(() => {
+    if (!pendingConflict) return [];
+    return [
+      {
+        key: "content",
+        label: "Message",
+        mine: pendingConflict.attemptedContent,
+        theirs: pendingConflict.conflict.current.content,
+        variant: "multiline",
+      },
+    ];
+  }, [pendingConflict]);
+
+  const handleSave = () => {
+    startTransition(async () => {
+      const result = await updateMessageAction({
+        messageId: currentMessage.id,
+        updates: { content },
+        expectedVersion: optimisticVersion,
+        expectedUpdatedAt: optimisticUpdatedAt ?? undefined,
+      });
+
+      if (result.status === "conflict" && result.conflict) {
+        setPendingConflict({
+          conflict: result.conflict,
+          attemptedContent: content,
+          baseVersion: optimisticVersion,
+        });
+        toast.error("Someone else edited this message. Resolve the differences to continue.");
+        return;
+      }
+
+      if (!result.success) {
+        toast.error(result.error ?? "Failed to update message");
+        return;
+      }
+
+      toast.success("Message updated");
+      if (result.data) {
+        setCurrentMessage(result.data);
+        setContent(result.data.content);
+        setOptimisticVersion(result.data.version ?? null);
+        setOptimisticUpdatedAt(result.data.updated_at ?? null);
+      }
+      setOpen(false);
+    });
+  };
+
+  const handleConflictResolution = async ({ type, values, baseVersion }: ConflictResolutionPayload) => {
+    if (!pendingConflict) return;
+    const resolvedContent = values.content ?? content;
+
+    const result = await updateMessageAction({
+      messageId: currentMessage.id,
+      updates: { content: resolvedContent },
+      expectedVersion: pendingConflict.conflict.latestVersion ?? undefined,
+      expectedUpdatedAt: pendingConflict.conflict.latestUpdatedAt ?? undefined,
+      resolution: {
+        type,
+        mergedFields: { content: resolvedContent },
+        baseVersion: baseVersion ?? pendingConflict.baseVersion ?? optimisticVersion ?? null,
+      },
+    });
+
+    if (result.status === "conflict" && result.conflict) {
+      setPendingConflict({
+        conflict: result.conflict,
+        attemptedContent: resolvedContent,
+        baseVersion: optimisticVersion,
+      });
+      toast.error("The message changed again. Review the newest version before saving.");
+      return;
+    }
+
+    if (!result.success) {
+      toast.error(result.error ?? "Failed to resolve conflict");
+      return;
+    }
+
+    toast.success("Message updated");
+    if (result.data) {
+      setCurrentMessage(result.data);
+      setContent(result.data.content);
+      setOptimisticVersion(result.data.version ?? null);
+      setOptimisticUpdatedAt(result.data.updated_at ?? null);
+    }
+    setPendingConflict(null);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <div className="rounded-lg border bg-card p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium">Pinned update</p>
+            <p className="text-xs text-muted-foreground">
+              Last edited {new Date(currentMessage.updated_at ?? currentMessage.created_at).toLocaleString()}
+            </p>
+          </div>
+          <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+            Edit message
+          </Button>
+        </div>
+        <p className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">{currentMessage.content}</p>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit message</DialogTitle>
+            <DialogDescription>
+              Update the announcement and resolve any conflicts before publishing your changes.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <Textarea
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+              rows={6}
+              placeholder="Share an update with your household"
+            />
+          </div>
+
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleSave} disabled={isPending}>
+              {isPending ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ConflictDialog
+        open={pendingConflict != null}
+        onOpenChange={(next) => {
+          if (!next) {
+            setPendingConflict(null);
+          }
+        }}
+        entityName="message"
+        fields={conflictFields}
+        isResolving={isPending}
+        baseVersion={pendingConflict?.baseVersion ?? optimisticVersion ?? null}
+        onResolve={handleConflictResolution}
+        onCancel={() => setPendingConflict(null)}
+        message={pendingConflict?.conflict.message}
+      />
+    </>
+  );
+}

--- a/lib/conflicts.ts
+++ b/lib/conflicts.ts
@@ -1,0 +1,78 @@
+export type OptimisticMetadata = {
+  version?: number | null
+  updated_at?: string | null
+}
+
+export type ConflictDetails<TCurrent, TIncoming> = {
+  message: string
+  current: TCurrent & OptimisticMetadata
+  incoming: TIncoming
+  latestVersion: number | null
+  latestUpdatedAt: string | null
+}
+
+export type ConflictEvaluation<TCurrent, TIncoming> =
+  | { hasConflict: false }
+  | { hasConflict: true; details: ConflictDetails<TCurrent, TIncoming> }
+
+export function evaluateConflict<TCurrent extends OptimisticMetadata, TIncoming>(
+  params: {
+    current: TCurrent
+    incoming: TIncoming
+    expectedVersion?: number | null
+    expectedUpdatedAt?: string | null
+    message?: string
+  }
+): ConflictEvaluation<TCurrent, TIncoming> {
+  const { current, incoming, expectedVersion, expectedUpdatedAt } = params
+  const message =
+    params.message ??
+    'Someone else changed this record while you were editing. Review the latest version before saving again.'
+
+  const normalizedExpectedUpdatedAt = expectedUpdatedAt
+    ? new Date(expectedUpdatedAt).toISOString()
+    : null
+  const normalizedCurrentUpdatedAt = current.updated_at
+    ? new Date(current.updated_at).toISOString()
+    : null
+
+  const versionMismatch =
+    typeof expectedVersion === 'number' && current.version != null
+      ? expectedVersion !== current.version
+      : false
+
+  const timestampMismatch = normalizedExpectedUpdatedAt
+    ? normalizedCurrentUpdatedAt !== normalizedExpectedUpdatedAt
+    : false
+
+  if (!versionMismatch && !timestampMismatch) {
+    return { hasConflict: false }
+  }
+
+  return {
+    hasConflict: true,
+    details: {
+      message,
+      current,
+      incoming,
+      latestVersion: current.version ?? null,
+      latestUpdatedAt: normalizedCurrentUpdatedAt,
+    },
+  }
+}
+
+export function extractChangedFields<T extends Record<string, any>>(
+  incoming: Partial<T>,
+  base: T
+): Record<string, any> {
+  const result: Record<string, any> = {}
+  for (const key of Object.keys(incoming)) {
+    const incomingValue = (incoming as Record<string, any>)[key]
+    const baseValue = (base as Record<string, any>)[key]
+
+    if (incomingValue !== undefined && incomingValue !== baseValue) {
+      result[key] = incomingValue
+    }
+  }
+  return result
+}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,10 @@
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
     "@types/eslint": "^8.56.2",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/user-event": "^14.5.2",
+    "jsdom": "^25.0.0",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,15 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@testing-library/jest-dom':
+        specifier: ^6.5.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^15.0.7
+        version: 15.0.7(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -225,6 +234,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,13 +248,16 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -255,6 +270,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +389,34 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1628,11 +1674,39 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@15.0.7':
+    resolution: {integrity: sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': ^18.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2012,6 +2086,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2032,6 +2110,9 @@ packages:
   aria-hidden@1.2.3:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2080,6 +2161,9 @@ packages:
 
   asynciterator.prototype@1.0.0:
     resolution: {integrity: sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   autoprefixer@10.4.16:
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
@@ -2314,6 +2398,10 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -2350,16 +2438,27 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2390,6 +2489,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
@@ -2419,6 +2521,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2454,6 +2560,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2507,6 +2619,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   es-abstract@1.22.3:
     resolution: {integrity: sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==}
     engines: {node: '>= 0.4'}
@@ -2531,6 +2647,10 @@ packages:
 
   es-set-tostringtag@2.0.2:
     resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   es-shim-unscopables@1.0.2:
@@ -2792,6 +2912,10 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
 
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
@@ -2966,8 +3090,8 @@ packages:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.0:
-    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -2983,6 +3107,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3118,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3008,6 +3144,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3118,6 +3258,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
@@ -3201,6 +3344,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3469,9 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3324,6 +3479,10 @@ packages:
     resolution: {integrity: sha512-JZX+1fjpqxvQmEgItvPOAwRlqf0Eg9dSZMxljA2/V2M6dluOhQCPBhewIlSJWgkNu0M36kViOgmTAMnDaAMOFw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -3494,6 +3653,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -3608,6 +3771,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.22:
+    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3671,6 +3837,9 @@ packages:
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -3712,9 +3881,6 @@ packages:
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3806,6 +3972,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3868,6 +4038,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
@@ -3945,6 +4118,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
     engines: {node: '>= 0.4'}
@@ -4001,6 +4178,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4196,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4198,6 +4388,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -4261,6 +4455,9 @@ packages:
   svelte@4.2.18:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
@@ -4361,6 +4558,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4369,8 +4573,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4622,6 +4834,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4634,6 +4850,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4868,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4931,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4732,6 +4983,8 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.2.1':
@@ -4744,6 +4997,14 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5160,26 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -6195,11 +6476,47 @@ snapshots:
       '@tanstack/query-core': 5.51.9
       react: 18.2.0
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/runtime': 7.23.9
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@15.0.7(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@testing-library/dom': 10.4.1
+      '@types/react-dom': 18.3.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.5
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -6644,6 +6961,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -6660,6 +6979,10 @@ snapshots:
   aria-hidden@1.2.3:
     dependencies:
       tslib: 2.6.2
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -6714,7 +7037,7 @@ snapshots:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
@@ -6727,6 +7050,8 @@ snapshots:
   asynciterator.prototype@1.0.0:
     dependencies:
       has-symbols: 1.0.3
+
+  asynckit@0.4.0: {}
 
   autoprefixer@10.4.16(postcss@8.4.32):
     dependencies:
@@ -6982,6 +7307,10 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
@@ -7012,11 +7341,23 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   date-fns@3.3.1: {}
 
@@ -7031,6 +7372,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -7050,7 +7393,7 @@ snapshots:
 
   define-data-property@1.1.1:
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
@@ -7059,6 +7402,8 @@ snapshots:
       define-data-property: 1.1.1
       has-property-descriptors: 1.0.1
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -7089,6 +7434,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -7143,6 +7492,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   es-abstract@1.22.3:
     dependencies:
       array-buffer-byte-length: 1.0.0
@@ -7159,7 +7510,7 @@ snapshots:
       has-property-descriptors: 1.0.1
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.2
       internal-slot: 1.0.6
       is-array-buffer: 3.0.2
       is-callable: 1.2.7
@@ -7216,11 +7567,18 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.2
       has-tostringtag: 1.0.0
-      hasown: 2.0.0
+      hasown: 2.0.2
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   es-shim-unscopables@1.0.2:
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   es-to-primitive@1.2.1:
     dependencies:
@@ -7590,6 +7948,14 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fraction.js@4.3.7: {}
 
   framer-motion@10.18.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
@@ -7645,7 +8011,7 @@ snapshots:
       function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -7670,7 +8036,7 @@ snapshots:
   get-symbol-description@1.0.0:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
 
   get-tsconfig@4.7.2:
     dependencies:
@@ -7762,7 +8128,7 @@ snapshots:
 
   gopd@1.0.1:
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
 
   gopd@1.2.0: {}
 
@@ -7798,9 +8164,9 @@ snapshots:
     dependencies:
       has-symbols: 1.0.3
 
-  hasown@2.0.0:
+  has-tostringtag@1.0.2:
     dependencies:
-      function-bind: 1.1.2
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -7851,6 +8217,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8236,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7883,6 +8264,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -7900,7 +8283,7 @@ snapshots:
   internal-slot@1.0.6:
     dependencies:
       get-intrinsic: 1.2.2
-      hasown: 2.0.0
+      hasown: 2.0.2
       side-channel: 1.0.4
 
   invariant@2.2.4:
@@ -7917,7 +8300,7 @@ snapshots:
   is-array-buffer@3.0.2:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       is-typed-array: 1.1.12
 
   is-arrayish@0.3.2: {}
@@ -7943,7 +8326,7 @@ snapshots:
 
   is-core-module@2.13.1:
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   is-date-object@1.0.5:
     dependencies:
@@ -7982,6 +8365,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-reference@3.0.2:
     dependencies:
@@ -8026,7 +8411,7 @@ snapshots:
   is-weakset@2.0.2:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
 
   is-what@4.1.16: {}
 
@@ -8072,6 +8457,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.4
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.22
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8167,6 +8580,8 @@ snapshots:
 
   lru-cache@10.1.0: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -8174,6 +8589,8 @@ snapshots:
   lucide-react@0.302.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.176.0)(three@0.160.0):
     dependencies:
@@ -8496,7 +8913,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8527,6 +8944,8 @@ snapshots:
       mime-db: 1.52.0
 
   mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -8623,6 +9042,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  nwsapi@2.2.22: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -8706,6 +9127,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -8739,8 +9164,6 @@ snapshots:
       is-reference: 3.0.2
 
   picocolors@1.0.0: {}
-
-  picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -8786,7 +9209,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -8823,6 +9246,12 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.6.2: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prop-types@15.8.1:
     dependencies:
@@ -8885,6 +9314,8 @@ snapshots:
       react: 18.2.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-merge-refs@1.1.0: {}
 
@@ -8961,12 +9392,17 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.4:
     dependencies:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       globalthis: 1.0.3
       which-builtin-type: 1.1.3
 
@@ -9061,6 +9497,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9077,8 +9517,14 @@ snapshots:
   safe-regex-test@1.0.0:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9118,7 +9564,7 @@ snapshots:
   set-function-length@1.1.1:
     dependencies:
       define-data-property: 1.1.1
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
@@ -9301,6 +9747,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -9374,6 +9824,8 @@ snapshots:
       magic-string: 0.30.19
       periscopic: 3.1.0
     optional: true
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.2.0:
     dependencies:
@@ -9502,13 +9954,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9563,7 +10029,7 @@ snapshots:
   typed-array-buffer@1.0.0:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       is-typed-array: 1.1.12
 
   typed-array-byte-length@1.0.0:
@@ -9644,13 +10110,13 @@ snapshots:
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.0(browserslist@4.23.2):
     dependencies:
       browserslist: 4.23.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
@@ -9736,7 +10202,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10230,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,6 +10256,10 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -9799,6 +10270,8 @@ snapshots:
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9832,6 +10305,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9903,6 +10387,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/supabase/migrations/20250118_conflict_logging.sql
+++ b/supabase/migrations/20250118_conflict_logging.sql
@@ -1,0 +1,81 @@
+-- Add optimistic locking support and conflict resolution logging
+
+-- Ensure maintenance requests track optimistic version numbers
+ALTER TABLE public.maintenance_requests
+  ADD COLUMN IF NOT EXISTS version INTEGER DEFAULT 1;
+
+UPDATE public.maintenance_requests
+SET version = COALESCE(version, 1)
+WHERE version IS NULL;
+
+-- Conflict resolution audit table
+CREATE TABLE public.conflict_resolution_logs (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  entity_type TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  resolution TEXT NOT NULL,
+  local_version INTEGER,
+  remote_version INTEGER,
+  merged_fields JSONB DEFAULT '{}'::jsonb,
+  resolved_by UUID DEFAULT auth.uid(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+ALTER TABLE public.conflict_resolution_logs ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to review their own logs and give property staff broader visibility
+CREATE POLICY "Users can view their conflict logs" ON public.conflict_resolution_logs
+  FOR SELECT USING (resolved_by = auth.uid());
+
+CREATE POLICY "Staff can view all conflict logs" ON public.conflict_resolution_logs
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+  );
+
+-- Upsert helper for recording conflict outcomes
+CREATE OR REPLACE FUNCTION log_conflict_resolution(
+  p_entity_type TEXT,
+  p_entity_id UUID,
+  p_resolution TEXT,
+  p_local_version INTEGER,
+  p_remote_version INTEGER,
+  p_merged_fields JSONB DEFAULT '{}'::jsonb
+)
+RETURNS UUID AS $$
+DECLARE
+  v_log_id UUID;
+BEGIN
+  INSERT INTO public.conflict_resolution_logs (
+    entity_type,
+    entity_id,
+    resolution,
+    local_version,
+    remote_version,
+    merged_fields,
+    resolved_by
+  )
+  VALUES (
+    p_entity_type,
+    p_entity_id,
+    p_resolution,
+    p_local_version,
+    p_remote_version,
+    COALESCE(p_merged_fields, '{}'::jsonb),
+    auth.uid()
+  )
+  RETURNING id INTO v_log_id;
+
+  RETURN v_log_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE INDEX IF NOT EXISTS idx_conflict_resolution_logs_entity
+  ON public.conflict_resolution_logs(entity_type, entity_id, created_at DESC);
+
+CREATE TRIGGER update_conflict_resolution_logs_updated_at
+  BEFORE UPDATE ON public.conflict_resolution_logs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/tests/conflicts/document-edit-dialog.test.tsx
+++ b/tests/conflicts/document-edit-dialog.test.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import type { DocumentWithLease } from "@/types/documents"
+import type { DocumentConflictPayload } from "@/app/documents/actions"
+
+vi.mock("@/app/documents/actions", () => ({
+  updateDocumentAction: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { updateDocumentAction } from "@/app/documents/actions"
+import { EditDocumentDialog } from "@/app/documents/components/edit-document-dialog"
+
+const baseDocument: DocumentWithLease = {
+  id: "doc-123",
+  title: "Lease agreement",
+  description: "Original description",
+  document_type: "lease",
+  status: "draft",
+  file_url: "https://example.com/doc.pdf",
+  created_at: "2024-05-01T10:00:00.000Z",
+  updated_at: "2024-05-02T12:00:00.000Z",
+  requires_signature: true,
+  version: 2,
+  metadata: {},
+  created_by: "pm-1",
+  documenso_envelope_id: null,
+  documenso_template_id: null,
+  property_id: null,
+  tenant_id: null,
+  unit_id: null,
+  expires_at: "2024-07-01T00:00:00.000Z",
+  signed_at: null,
+  parent_document_id: null,
+}
+
+function setup() {
+  const Wrapper = () => {
+    const [open, setOpen] = useState(true)
+    return (
+      <EditDocumentDialog
+        document={baseDocument}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    )
+  }
+
+  return render(<Wrapper />)
+}
+
+function buildConflictPayload(partial?: Partial<DocumentConflictPayload>): DocumentConflictPayload {
+  return {
+    message: "The document changed.",
+    current: {
+      ...baseDocument,
+      title: "Updated server title",
+      description: "Server side description",
+      status: "pending_signature",
+      requires_signature: false,
+      expires_at: "2024-07-15T00:00:00.000Z",
+    },
+    incoming: {
+      title: "Conflicting title",
+    },
+    latestVersion: 3,
+    latestUpdatedAt: "2024-05-03T14:00:00.000Z",
+    ...partial,
+  }
+}
+
+describe("EditDocumentDialog optimistic concurrency", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("surfaces conflicts and applies manual merges", async () => {
+    const user = userEvent.setup()
+    const updateDocumentActionMock = updateDocumentAction as unknown as vi.Mock
+
+    updateDocumentActionMock.mockResolvedValueOnce({
+      success: false,
+      status: "conflict",
+      conflict: buildConflictPayload(),
+    })
+    updateDocumentActionMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseDocument,
+        title: "Merged title",
+        description: "Merged description",
+        status: "pending_signature",
+        requires_signature: false,
+        updated_at: "2024-05-03T14:00:00.000Z",
+        version: 4,
+      },
+    })
+
+    setup()
+
+    const titleInput = screen.getByLabelText(/title/i)
+    await user.clear(titleInput)
+    await user.type(titleInput, "Conflicting title")
+
+    const descriptionInput = screen.getByLabelText(/description/i)
+    await user.clear(descriptionInput)
+    await user.type(descriptionInput, "Merged description")
+
+    const saveButton = screen.getByRole("button", { name: /save changes/i })
+    await user.click(saveButton)
+
+    await screen.findByText(/resolve document conflict/i)
+
+    expect(updateDocumentAction).toHaveBeenCalledTimes(1)
+
+    const manualButton = screen.getByRole("button", { name: /manual merge/i })
+    await user.click(manualButton)
+
+    const manualTitle = screen.getAllByLabelText(/title/i)[1]
+    await user.clear(manualTitle)
+    await user.type(manualTitle, "Merged title")
+
+    const manualConfirm = screen.getByRole("button", { name: /confirm merge/i })
+    await user.click(manualConfirm)
+
+    await waitFor(() => expect(updateDocumentAction).toHaveBeenCalledTimes(2))
+
+    const secondCall = updateDocumentActionMock.mock.calls[1][0]
+    expect(secondCall.resolution?.type).toBe("manual")
+    expect(secondCall.resolution?.mergedFields?.title).toBe("Merged title")
+    expect(secondCall.updates.title).toBe("Merged title")
+
+    await waitFor(() => {
+      expect(screen.queryByText(/resolve document conflict/i)).not.toBeInTheDocument()
+    })
+  })
+})
+

--- a/tests/conflicts/message-editor.test.tsx
+++ b/tests/conflicts/message-editor.test.tsx
@@ -1,0 +1,106 @@
+import React from "react"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import type { Message, MessageConflictPayload } from "@/app/messaging/actions"
+
+vi.mock("@/app/messaging/actions", () => ({
+  updateMessageAction: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { updateMessageAction } from "@/app/messaging/actions"
+import { MessageEditor } from "@/components/messaging/message-editor"
+
+const baseMessage: Message = {
+  id: "msg-1",
+  content: "Initial announcement",
+  created_at: "2024-05-01T10:00:00.000Z",
+  updated_at: "2024-05-02T08:00:00.000Z",
+  version: 1,
+  thread_id: "thread-1",
+  author_id: "author-1",
+  reactions: [],
+}
+
+function buildConflict(partial?: Partial<MessageConflictPayload>): MessageConflictPayload {
+  return {
+    message: "This message changed.",
+    current: {
+      ...baseMessage,
+      content: "Server side update",
+      version: 2,
+      updated_at: "2024-05-02T09:00:00.000Z",
+    },
+    incoming: {
+      content: "User draft",
+    },
+    latestVersion: 2,
+    latestUpdatedAt: "2024-05-02T09:00:00.000Z",
+    ...partial,
+  }
+}
+
+describe("MessageEditor optimistic concurrency", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("allows selecting the latest version when conflicts occur", async () => {
+    const user = userEvent.setup()
+    const updateMessageActionMock = updateMessageAction as unknown as vi.Mock
+
+    updateMessageActionMock.mockResolvedValueOnce({
+      success: false,
+      status: "conflict",
+      conflict: buildConflict(),
+    })
+
+    updateMessageActionMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseMessage,
+        content: "Server side update",
+        version: 3,
+        updated_at: "2024-05-02T10:00:00.000Z",
+      },
+    })
+
+    render(<MessageEditor message={baseMessage} />)
+
+    const editButton = screen.getByRole("button", { name: /edit message/i })
+    await user.click(editButton)
+
+    const textarea = screen.getByRole("textbox")
+    await user.clear(textarea)
+    await user.type(textarea, "User draft")
+
+    const saveButton = screen.getByRole("button", { name: /^save$/i })
+    await user.click(saveButton)
+
+    await screen.findByText(/resolve message conflict/i)
+
+    const theirsButton = screen.getByRole("button", { name: /use latest version/i })
+    await user.click(theirsButton)
+
+    const applyButton = screen.getByRole("button", { name: /apply selection/i })
+    await user.click(applyButton)
+
+    await waitFor(() => expect(updateMessageActionMock).toHaveBeenCalledTimes(2))
+
+    const secondCall = updateMessageActionMock.mock.calls[1][0]
+    expect(secondCall.resolution?.type).toBe("keep_theirs")
+    expect(secondCall.updates.content).toBe("Server side update")
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,17 @@
+import "@testing-library/jest-dom/vitest"
+import React from "react"
+
+// Ensure React is available globally for components compiled with the old JSX runtime
+// used by Next.js server/client components during testing.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).React = React
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// Provide a minimal ResizeObserver implementation used by Radix UI components.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).ResizeObserver = ResizeObserver

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,9 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+    environmentMatchGlobs: [["tests/**/*.test.tsx", "jsdom"]],
+    setupFiles: ["./tests/setup.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add shared conflict evaluation utilities, Supabase audit logging, and server actions for updating documents, maintenance requests, and messages with optimistic concurrency checks
- introduce a reusable ConflictDialog component plus new document and message editing experiences that surface conflicts and allow merges
- extend testing infrastructure for React components and cover concurrent edit flows; add a migration for conflict resolution logs

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b835504832890753e37c295508a