### PR TITLE
Implement optimistic update helpers and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,15 +627,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "roomsily-rust-api"
-version = "0.1.0"
-dependencies = [
- "serde_json",
- "tokio",
- "vercel_runtime",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +730,15 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "roomsily-rust-api"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "tokio",
+ "vercel_runtime",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+'use client'
+
+import React, { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,37 +13,45 @@ import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
 import { FileText, Users, Calendar, Eye } from 'lucide-react';
 
+void React;
+
 interface DocumentsListProps {
   filter: DocumentListFilters;
 }
 
 export function DocumentsList({ filter }: DocumentsListProps) {
-  const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const normalizedFilter = useMemo(() => normalizeFilter(filter), [filter])
+  const filterSignature = useMemo(
+    () => JSON.stringify(normalizedFilter),
+    [normalizedFilter],
+  )
 
-  useEffect(() => {
-    const fetchDocuments = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const result = await getDocumentsAction(filter);
-        if (result.success && result.data) {
-          setDocuments(result.data);
-          setError(null);
-        } else {
-          setError(result.error || 'Failed to fetch documents');
-        }
-      } catch (err) {
-        console.error('Error fetching documents:', err);
-        setError('An unexpected error occurred');
-      } finally {
-        setLoading(false);
+  const {
+    data,
+    isPending,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['documents', filterSignature],
+    queryFn: async () => {
+      const result = await getDocumentsAction(normalizedFilter)
+      if (result.success && result.data) {
+        return result.data
       }
-    };
 
-    fetchDocuments();
-  }, [filter]);
+      throw new Error(result.error || 'Failed to fetch documents')
+    },
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+  })
+
+  const documents = data ?? []
+  const errorMessage = isError
+    ? error instanceof Error
+      ? error.message
+      : 'Failed to fetch documents'
+    : null
 
   const getStatusBadge = (status: string) => {
     const variants = {
@@ -79,7 +90,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     }
   };
 
-  if (loading) {
+  if (isPending && documents.length === 0) {
     return (
       <div className="space-y-4">
         {[...Array(3)].map((_, i) => (
@@ -108,16 +119,18 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     );
   }
 
-  if (error) {
+  if (errorMessage) {
     return (
       <Card className="p-6">
         <div className="text-center">
           <p className="mb-2 text-destructive">Error loading documents</p>
-          <p className="text-sm text-muted-foreground">{error}</p>
+          <p className="text-sm text-muted-foreground">{errorMessage}</p>
           <Button
             variant="outline"
             className="mt-4"
-            onClick={() => window.location.reload()}
+            onClick={() => {
+              void refetch()
+            }}
           >
             Try Again
           </Button>
@@ -216,3 +229,36 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     </div>
   );
 }
+
+function normalizeFilter(filter: DocumentListFilters): DocumentListFilters {
+  const source = filter ?? {}
+  const normalized: DocumentListFilters = {}
+
+  if (source.status?.length) {
+    normalized.status = [...source.status].sort()
+  }
+
+  if (source.type?.length) {
+    normalized.type = [...source.type].sort()
+  }
+
+  if (source.tenant_id) {
+    normalized.tenant_id = source.tenant_id
+  }
+
+  if (source.unit_id) {
+    normalized.unit_id = source.unit_id
+  }
+
+  if (source.date_from) {
+    normalized.date_from = source.date_from
+  }
+
+  if (source.date_to) {
+    normalized.date_to = source.date_to
+  }
+
+  return normalized
+}
+
+export { DocumentsList as DocumentList }

--- a/app/documents/components/upload-document-dialog.tsx
+++ b/app/documents/components/upload-document-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from "@/components/ui/button";
 import {
@@ -23,14 +23,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
-import { uploadDocumentAction } from '../actions';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
 import { Upload, FileText } from 'lucide-react';
 import { toast } from 'sonner';
+import { useUploadDocumentMutation } from '@/hooks/use-document-mutations';
+import type { DocumentWithLease } from '@/types/documents';
+
+void React;
 
 export function UploadDocumentDialog() {
   const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState({
     title: '',
     description: '',
@@ -41,8 +43,26 @@ export function UploadDocumentDialog() {
     expires_at: '',
   });
   const [file, setFile] = useState<File | null>(null);
+  const [optimisticMessage, setOptimisticMessage] = useState<string | null>(null);
   const router = useRouter();
   const permissions = useDocumentPermissions();
+
+  const uploadMutation = useUploadDocumentMutation({
+    onOptimistic: () => {
+      setOptimisticMessage('Document uploaded successfully. Syncing with server...');
+    },
+    onRollback: (error) => {
+      setOptimisticMessage(null);
+      const message =
+        error instanceof Error ? error.message : 'Failed to upload document';
+      toast.error(message);
+    },
+    onConfirmed: () => {
+      setOptimisticMessage('Document upload synced successfully.');
+    },
+  });
+
+  const isSubmitting = uploadMutation.isPending;
 
   // Don't render upload button if user doesn't have permission
   if (!permissions.canUploadDocuments) {
@@ -90,7 +110,6 @@ export function UploadDocumentDialog() {
       return;
     }
 
-    setLoading(true);
     try {
       const submitData = new FormData();
       submitData.append('file', file);
@@ -102,30 +121,37 @@ export function UploadDocumentDialog() {
       submitData.append('requires_signature', formData.requires_signature.toString());
       submitData.append('expires_at', formData.expires_at);
 
-      const result = await uploadDocumentAction(submitData);
+      const optimisticDocument = buildOptimisticDocument({
+        formData,
+        file,
+      });
 
-      if (result.success) {
-        toast.success('Document uploaded successfully');
-        setOpen(false);
-        setFormData({
-          title: '',
-          description: '',
-          document_type: 'other',
-          tenant_id: '',
-          unit_id: '',
-          requires_signature: false,
-          expires_at: '',
-        });
-        setFile(null);
-        router.refresh();
-      } else {
-        toast.error(result.error || 'Failed to upload document');
-      }
+      await uploadMutation.mutateAsync(
+        {
+          formData: submitData,
+          optimisticDocument,
+        },
+        {
+          onSuccess: () => {
+            toast.success('Document uploaded successfully');
+            setOpen(false);
+            setFormData({
+              title: '',
+              description: '',
+              document_type: 'other',
+              tenant_id: '',
+              unit_id: '',
+              requires_signature: false,
+              expires_at: '',
+            });
+            setFile(null);
+            router.refresh();
+            setOptimisticMessage(null);
+          },
+        },
+      );
     } catch (error) {
       console.error('Error uploading document:', error);
-      toast.error('An unexpected error occurred');
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -146,6 +172,12 @@ export function UploadDocumentDialog() {
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {optimisticMessage && (
+            <div className="rounded-md border border-primary/20 bg-primary/10 p-3 text-sm text-primary">
+              {optimisticMessage}
+            </div>
+          )}
+
           {/* File Upload */}
           <div className="space-y-2">
             <Label htmlFor="file">Document File</Label>
@@ -248,16 +280,63 @@ export function UploadDocumentDialog() {
               type="button"
               variant="outline"
               onClick={() => setOpen(false)}
-              disabled={loading}
+              disabled={isSubmitting}
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={loading || !file}>
-              {loading ? 'Uploading...' : 'Upload Document'}
+            <Button type="submit" disabled={isSubmitting || !file}>
+              {isSubmitting ? 'Uploading...' : 'Upload Document'}
             </Button>
           </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>
   );
+}
+
+function buildOptimisticDocument({
+  formData,
+  file,
+}: {
+  formData: {
+    title: string;
+    description: string;
+    document_type: DocumentWithLease['document_type'];
+    tenant_id: string;
+    unit_id: string;
+    requires_signature: boolean;
+    expires_at: string;
+  };
+  file: File;
+}): DocumentWithLease {
+  const timestamp = new Date().toISOString();
+  const optimisticId = `temp-${timestamp}`;
+
+  return {
+    id: optimisticId,
+    created_at: timestamp,
+    updated_at: timestamp,
+    title: formData.title,
+    description: formData.description,
+    document_type: formData.document_type,
+    status: formData.requires_signature ? 'pending_signature' : 'draft',
+    file_url: undefined,
+    documenso_envelope_id: undefined,
+    documenso_template_id: undefined,
+    metadata: {
+      optimistic: true,
+      originalFileName: file.name,
+    },
+    created_by: undefined,
+    property_id: undefined,
+    tenant_id: formData.tenant_id || undefined,
+    unit_id: formData.unit_id || undefined,
+    requires_signature: formData.requires_signature,
+    expires_at: formData.expires_at || undefined,
+    signed_at: undefined,
+    version: 1,
+    parent_document_id: undefined,
+    lease: undefined,
+    signatures: [],
+  };
 }

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -15,6 +15,11 @@ import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { OptimisticContext } from "@/lib/optimistic";
+import { finalizeOptimisticUpdate, rollbackOptimisticUpdate, startOptimisticUpdate } from "@/lib/optimistic";
+
+void React;
 
 const maintenanceRequestSchema = z.object({
   title: z.string().min(5, "Title must be at least 5 characters"),
@@ -25,6 +30,23 @@ const maintenanceRequestSchema = z.object({
 });
 
 type MaintenanceRequestFormData = z.infer<typeof maintenanceRequestSchema>;
+
+type MaintenanceRequestCacheItem = {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  created_at: string;
+};
+
+interface MaintenanceRequestFormProps {
+  initialValues?: Partial<MaintenanceRequestFormData>;
+}
+
+interface MaintenanceMutationContext {
+  optimisticContext: OptimisticContext<MaintenanceRequestCacheItem[]>;
+  optimisticRequest: MaintenanceRequestCacheItem;
+}
 
 const categories = [
   "Plumbing",
@@ -45,37 +67,37 @@ const priorities = [
   { value: "urgent", label: "Urgent - Emergency fix needed" },
 ];
 
-export function MaintenanceRequestForm() {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+export function MaintenanceRequestForm({ initialValues }: MaintenanceRequestFormProps = {}) {
+  const [optimisticMessage, setOptimisticMessage] = useState<string | null>(null);
   const { notifyMaintenanceRequest } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
   const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  const queryClient = useQueryClient();
+
+  const defaultValues = useMemo(
+    () => ({
+      title: initialValues?.title ?? "",
+      description: initialValues?.description ?? "",
+      priority: initialValues?.priority ?? "normal",
+      category: initialValues?.category ?? "",
+      location: initialValues?.location ?? "",
+    }),
+    [initialValues],
+  );
 
   const form = useForm<MaintenanceRequestFormData>({
     resolver: zodResolver(maintenanceRequestSchema),
-    defaultValues: {
-      title: "",
-      description: "",
-      priority: "normal",
-      category: "",
-      location: "",
-    },
+    defaultValues,
   });
 
-  const onSubmit = async (data: MaintenanceRequestFormData) => {
-    setIsSubmitting(true);
-
-    try {
-      // Get current user info
+  const maintenanceMutation = useMutation<any, Error, MaintenanceRequestFormData, MaintenanceMutationContext>({
+    mutationFn: async (data) => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error("Not authenticated");
 
-      // Get user profile
       const profile = await fetchMemberProfile(typedSupabase, user.id);
-
       if (!profile) throw new Error("Profile not found");
-
       if (!profile.unit_id) {
         throw new Error("User is not assigned to a unit");
       }
@@ -88,7 +110,6 @@ export function MaintenanceRequestForm() {
         throw new Error("Property manager not found for this unit");
       }
 
-      // Create maintenance request record
       const { data: request, error: requestError } = await (supabase as any)
         .from('maintenance_requests')
         .insert({
@@ -104,9 +125,10 @@ export function MaintenanceRequestForm() {
         .select()
         .single();
 
-      if (requestError) throw requestError;
+      if (requestError) {
+        throw new Error(requestError.message ?? 'Failed to submit maintenance request');
+      }
 
-      // Send notifications
       await notifyMaintenanceRequest({
         requesterName: profile.full_name || user.email || 'Unknown',
         title: data.title,
@@ -119,27 +141,79 @@ export function MaintenanceRequestForm() {
         },
       });
 
-      toast({
-        title: "Maintenance request submitted",
-        description: "Your maintenance request has been submitted and notifications sent.",
+      return request;
+    },
+    onMutate: (data) => {
+      const optimisticRequest = createOptimisticMaintenanceRequest(data);
+      const optimisticContext = startOptimisticUpdate<MaintenanceRequestCacheItem[]>({
+        queryClient,
+        filters: { queryKey: ['maintenance-requests'] },
+        operation: 'create-maintenance-request',
+        updateFn: (current = []) => [optimisticRequest, ...current],
       });
 
-      form.reset();
-    } catch (error) {
-      console.error('Error submitting maintenance request:', error);
+      setOptimisticMessage('Maintenance request submitted. Syncing with server...');
+
+      return { optimisticContext, optimisticRequest } satisfies MaintenanceMutationContext;
+    },
+    onError: (error, _variables, context) => {
+      rollbackOptimisticUpdate(queryClient, context?.optimisticContext, error);
+      setOptimisticMessage(null);
+
       toast({
         title: "Error",
         description: error instanceof Error ? error.message : "Failed to submit maintenance request",
         variant: "destructive",
       });
-    } finally {
-      setIsSubmitting(false);
+    },
+    onSuccess: (request, _variables, context) => {
+      const cacheItem = toMaintenanceCacheItem(request);
+      finalizeOptimisticUpdate<MaintenanceRequestCacheItem[]>({
+        queryClient,
+        context: context?.optimisticContext,
+        reconcileFn: (current) => {
+          if (!current) return current;
+          const placeholderId = context?.optimisticRequest.id;
+          const hasPlaceholder = current.some(item => item.id === placeholderId);
+          const next = current.map(item => item.id === placeholderId ? cacheItem : item);
+          return hasPlaceholder ? next : [cacheItem, ...current];
+        },
+      });
+
+      setOptimisticMessage('Maintenance request synced successfully.');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['maintenance-requests'] });
+    },
+  });
+
+  const onSubmit = async (data: MaintenanceRequestFormData) => {
+    try {
+      await maintenanceMutation.mutateAsync(data, {
+        onSuccess: () => {
+          toast({
+            title: "Maintenance request submitted",
+            description: "Your maintenance request has been submitted and notifications sent.",
+          });
+          form.reset(defaultValues);
+        },
+      });
+    } catch (error) {
+      console.error('Error submitting maintenance request:', error);
     }
   };
+
+  const isSubmitting = maintenanceMutation.isPending;
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {optimisticMessage && (
+          <div className="rounded-md border border-primary/20 bg-primary/10 p-3 text-sm text-primary">
+            {optimisticMessage}
+          </div>
+        )}
+
         <FormField
           control={form.control}
           name="title"
@@ -244,4 +318,27 @@ export function MaintenanceRequestForm() {
       </form>
     </Form>
   );
+}
+
+function createOptimisticMaintenanceRequest(
+  data: MaintenanceRequestFormData,
+): MaintenanceRequestCacheItem {
+  const created_at = new Date().toISOString();
+  return {
+    id: `temp-maintenance-${created_at}`,
+    title: data.title,
+    status: 'pending',
+    priority: data.priority,
+    created_at,
+  };
+}
+
+function toMaintenanceCacheItem(request: any): MaintenanceRequestCacheItem {
+  return {
+    id: request.id,
+    title: request.title,
+    status: request.status ?? 'pending',
+    priority: request.priority ?? 'normal',
+    created_at: request.created_at ?? new Date().toISOString(),
+  };
 }

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -20,6 +20,11 @@ import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { OptimisticContext } from "@/lib/optimistic";
+import { finalizeOptimisticUpdate, rollbackOptimisticUpdate, startOptimisticUpdate } from "@/lib/optimistic";
+
+void React;
 
 const visitorBookingSchema = z.object({
   guestName: z.string().min(2, "Guest name must be at least 2 characters"),
@@ -38,38 +43,57 @@ const visitorBookingSchema = z.object({
 
 type VisitorBookingFormData = z.infer<typeof visitorBookingSchema>;
 
-export function VisitorBookingForm() {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+type VisitorBookingCacheItem = {
+  id: string;
+  guestName: string;
+  status: string;
+  checkInDate: string;
+  checkOutDate: string;
+};
+
+interface VisitorBookingFormProps {
+  initialValues?: Partial<VisitorBookingFormData>;
+}
+
+interface VisitorMutationContext {
+  optimisticContext: OptimisticContext<VisitorBookingCacheItem[]>;
+  optimisticBooking: VisitorBookingCacheItem;
+}
+
+export function VisitorBookingForm({ initialValues }: VisitorBookingFormProps = {}) {
+  const [optimisticMessage, setOptimisticMessage] = useState<string | null>(null);
   const { notifyVisitorBooking } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
   const typedSupabase = supabase as unknown as TypedSupabaseClient;
+  const queryClient = useQueryClient();
+
+  const defaultValues = useMemo(
+    () => ({
+      guestName: initialValues?.guestName ?? "",
+      guestEmail: initialValues?.guestEmail ?? "",
+      guestPhone: initialValues?.guestPhone ?? "",
+      purpose: initialValues?.purpose ?? "",
+      emergencyContact: initialValues?.emergencyContact ?? "",
+      specialNotes: initialValues?.specialNotes ?? "",
+      checkInDate: initialValues?.checkInDate ?? undefined,
+      checkOutDate: initialValues?.checkOutDate ?? undefined,
+    }),
+    [initialValues],
+  );
 
   const form = useForm<VisitorBookingFormData>({
     resolver: zodResolver(visitorBookingSchema),
-    defaultValues: {
-      guestName: "",
-      guestEmail: "",
-      guestPhone: "",
-      purpose: "",
-      emergencyContact: "",
-      specialNotes: "",
-    },
+    defaultValues,
   });
 
-  const onSubmit = async (data: VisitorBookingFormData) => {
-    setIsSubmitting(true);
-
-    try {
-      // Get current user info
+  const visitorMutation = useMutation<any, Error, VisitorBookingFormData, VisitorMutationContext>({
+    mutationFn: async (data) => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error("Not authenticated");
 
-      // Get user profile
       const profile = await fetchMemberProfile(typedSupabase, user.id);
-
       if (!profile) throw new Error("Profile not found");
-
       if (!profile.unit_id) {
         throw new Error("User is not assigned to a unit");
       }
@@ -87,7 +111,6 @@ export function VisitorBookingForm() {
         throw new Error("Property manager not found for this unit");
       }
 
-      // Create visitor booking record
       const { data: booking, error: bookingError } = await (supabase as any)
         .from('visitor_logs')
         .insert({
@@ -105,9 +128,10 @@ export function VisitorBookingForm() {
         .select()
         .single();
 
-      if (bookingError) throw bookingError;
+      if (bookingError) {
+        throw new Error(bookingError.message ?? 'Failed to submit visitor booking');
+      }
 
-      // Send notifications
       await notifyVisitorBooking({
         guestName: data.guestName,
         hostName: profile.full_name || user.email || 'Unknown',
@@ -126,27 +150,78 @@ export function VisitorBookingForm() {
         },
       });
 
-      toast({
-        title: "Visitor booking submitted",
-        description: "Your visitor booking has been submitted and notifications sent.",
+      return booking;
+    },
+    onMutate: (data) => {
+      const optimisticBooking = createOptimisticVisitorBooking(data);
+      const optimisticContext = startOptimisticUpdate<VisitorBookingCacheItem[]>({
+        queryClient,
+        filters: { queryKey: ['visitor-bookings'] },
+        operation: 'create-visitor-booking',
+        updateFn: (current = []) => [optimisticBooking, ...current],
       });
 
-      form.reset();
-    } catch (error) {
-      console.error('Error submitting visitor booking:', error);
+      setOptimisticMessage('Visitor booking submitted. Syncing with server...');
+
+      return { optimisticContext, optimisticBooking } satisfies VisitorMutationContext;
+    },
+    onError: (error, _variables, context) => {
+      rollbackOptimisticUpdate(queryClient, context?.optimisticContext, error);
+      setOptimisticMessage(null);
+
       toast({
         title: "Error",
         description: error instanceof Error ? error.message : "Failed to submit visitor booking",
         variant: "destructive",
       });
-    } finally {
-      setIsSubmitting(false);
+    },
+    onSuccess: (booking, _variables, context) => {
+      const cacheItem = toVisitorBookingCacheItem(booking);
+      finalizeOptimisticUpdate<VisitorBookingCacheItem[]>({
+        queryClient,
+        context: context?.optimisticContext,
+        reconcileFn: (current) => {
+          if (!current) return current;
+          const placeholderId = context?.optimisticBooking.id;
+          const hasPlaceholder = current.some(item => item.id === placeholderId);
+          const next = current.map(item => item.id === placeholderId ? cacheItem : item);
+          return hasPlaceholder ? next : [cacheItem, ...current];
+        },
+      });
+
+      setOptimisticMessage('Visitor booking synced successfully.');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['visitor-bookings'] });
+    },
+  });
+
+  const onSubmit = async (data: VisitorBookingFormData) => {
+    try {
+      await visitorMutation.mutateAsync(data, {
+        onSuccess: () => {
+          toast({
+            title: "Visitor booking submitted",
+            description: "Your visitor booking has been submitted and notifications sent.",
+          });
+          form.reset(defaultValues);
+        },
+      });
+    } catch (error) {
+      console.error('Error submitting visitor booking:', error);
     }
   };
+
+  const isSubmitting = visitorMutation.isPending;
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {optimisticMessage && (
+          <div className="rounded-md border border-primary/20 bg-primary/10 p-3 text-sm text-primary">
+            {optimisticMessage}
+          </div>
+        )}
         <div className="grid gap-4 md:grid-cols-2">
           <FormField
             control={form.control}
@@ -333,4 +408,27 @@ export function VisitorBookingForm() {
       </form>
     </Form>
   );
+}
+
+function createOptimisticVisitorBooking(
+  data: VisitorBookingFormData,
+): VisitorBookingCacheItem {
+  const created_at = new Date().toISOString();
+  return {
+    id: `temp-visitor-${created_at}`,
+    guestName: data.guestName,
+    status: 'pending',
+    checkInDate: data.checkInDate.toISOString(),
+    checkOutDate: data.checkOutDate.toISOString(),
+  };
+}
+
+function toVisitorBookingCacheItem(booking: any): VisitorBookingCacheItem {
+  return {
+    id: booking.id,
+    guestName: booking.guest_name ?? booking.guestName ?? 'Guest',
+    status: booking.status ?? 'pending',
+    checkInDate: booking.check_in_date ?? booking.checkInDate ?? new Date().toISOString(),
+    checkOutDate: booking.check_out_date ?? booking.checkOutDate ?? new Date().toISOString(),
+  };
 }

--- a/hooks/use-document-mutations.ts
+++ b/hooks/use-document-mutations.ts
@@ -1,0 +1,105 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { uploadDocumentAction } from '@/app/documents/actions'
+import type { Document, DocumentWithLease } from '@/types/documents'
+import {
+  finalizeOptimisticUpdate,
+  rollbackOptimisticUpdate,
+  startOptimisticUpdate,
+} from '@/lib/optimistic'
+import type { OptimisticContext } from '@/lib/optimistic'
+
+interface UploadVariables {
+  formData: FormData
+  optimisticDocument: DocumentWithLease
+}
+
+interface UploadContext {
+  optimisticDocument: DocumentWithLease
+  optimisticContext: OptimisticContext<DocumentWithLease[]>
+}
+
+export interface UploadDocumentCallbacks {
+  onOptimistic?(document: DocumentWithLease): void
+  onRollback?(error: unknown): void
+  onConfirmed?(document: DocumentWithLease): void
+}
+
+function toDocumentWithLease(document: Document): DocumentWithLease {
+  return {
+    ...document,
+    metadata: document.metadata ?? {},
+    lease: (document as DocumentWithLease).lease,
+    signatures: (document as DocumentWithLease).signatures ?? [],
+  }
+}
+
+export function useUploadDocumentMutation(callbacks?: UploadDocumentCallbacks) {
+  const queryClient = useQueryClient()
+
+  return useMutation<DocumentWithLease, Error, UploadVariables, UploadContext>({
+    mutationFn: async ({ formData }) => {
+      const result = await uploadDocumentAction(formData)
+
+      if (!result.success || !result.data) {
+        throw new Error(result.error ?? 'Failed to upload document')
+      }
+
+      return toDocumentWithLease(result.data)
+    },
+    onMutate: (variables) => {
+      const optimisticContext = startOptimisticUpdate<DocumentWithLease[]>({
+        queryClient,
+        filters: { queryKey: ['documents'] },
+        operation: 'upload-document',
+        updateFn: (current = []) => {
+          const withoutDuplicate = current.filter(
+            (doc) => doc.id !== variables.optimisticDocument.id,
+          )
+          return [variables.optimisticDocument, ...withoutDuplicate]
+        },
+      })
+
+      callbacks?.onOptimistic?.(variables.optimisticDocument)
+
+      return {
+        optimisticDocument: variables.optimisticDocument,
+        optimisticContext,
+      }
+    },
+    onError: (error, _variables, context) => {
+      rollbackOptimisticUpdate(queryClient, context?.optimisticContext, error)
+      callbacks?.onRollback?.(error)
+    },
+    onSuccess: (document, _variables, context) => {
+      finalizeOptimisticUpdate<DocumentWithLease[]>({
+        queryClient,
+        context: context?.optimisticContext,
+        reconcileFn: (current) => {
+          if (!current) {
+            return current
+          }
+
+          const placeholderId = context?.optimisticDocument.id
+          const hasPlaceholder = current.some((doc) => doc.id === placeholderId)
+          const reconciled = current.map((doc) =>
+            doc.id === placeholderId ? document : doc,
+          )
+
+          if (!hasPlaceholder) {
+            return [document, ...current]
+          }
+
+          return reconciled
+        },
+      })
+
+      callbacks?.onConfirmed?.(document)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['documents'] })
+    },
+  })
+}

--- a/lib/optimistic.ts
+++ b/lib/optimistic.ts
@@ -1,0 +1,137 @@
+'use client'
+
+import type { QueryClient, QueryFilters, QueryKey } from '@tanstack/react-query'
+
+export type OptimisticStage = 'applied' | 'committed' | 'rolled-back'
+
+export interface OptimisticSnapshot<TData> {
+  queryKey: QueryKey
+  data: TData | undefined
+}
+
+export interface OptimisticContext<TData> {
+  operation: string
+  timestamp: number
+  snapshots: OptimisticSnapshot<TData>[]
+}
+
+interface OptimisticEvent {
+  operation: string
+  stage: OptimisticStage
+  durationMs: number
+  affectedQueries: number
+  error?: unknown
+}
+
+function logEvent(event: OptimisticEvent) {
+  if (process.env.NODE_ENV !== 'production') {
+    const { operation, stage, durationMs, affectedQueries, error } = event
+    const prefix = `[optimistic:${stage}] ${operation}`
+    const details = { durationMs, affectedQueries, error }
+    if (stage === 'rolled-back') {
+      console.warn(prefix, details)
+    } else {
+      console.info(prefix, details)
+    }
+  }
+}
+
+export interface StartOptimisticUpdateOptions<TData> {
+  queryClient: QueryClient
+  filters: QueryFilters
+  operation: string
+  updateFn: (current: TData | undefined, queryKey: QueryKey) => TData
+}
+
+export function startOptimisticUpdate<TData>({
+  queryClient,
+  filters,
+  operation,
+  updateFn,
+}: StartOptimisticUpdateOptions<TData>): OptimisticContext<TData> {
+  const matched = queryClient.getQueriesData<TData>(filters)
+  const snapshots: OptimisticSnapshot<TData>[] = matched.map(([queryKey, data]) => ({
+    queryKey,
+    data,
+  }))
+
+  if (snapshots.length === 0 && filters.queryKey) {
+    const queryKey = filters.queryKey
+    const next = updateFn(undefined, queryKey)
+    queryClient.setQueryData(queryKey, next)
+    snapshots.push({ queryKey, data: undefined })
+  } else {
+    matched.forEach(([queryKey, data]) => {
+      const next = updateFn(data, queryKey)
+      queryClient.setQueryData(queryKey, next)
+    })
+  }
+
+  logEvent({
+    operation,
+    stage: 'applied',
+    durationMs: 0,
+    affectedQueries: snapshots.length,
+  })
+
+  return {
+    operation,
+    timestamp: Date.now(),
+    snapshots,
+  }
+}
+
+export function rollbackOptimisticUpdate<TData>(
+  queryClient: QueryClient,
+  context: OptimisticContext<TData> | undefined,
+  error?: unknown,
+) {
+  if (!context) return
+
+  context.snapshots.forEach(({ queryKey, data }) => {
+    queryClient.setQueryData(queryKey, data)
+  })
+
+  logEvent({
+    operation: context.operation,
+    stage: 'rolled-back',
+    durationMs: Date.now() - context.timestamp,
+    affectedQueries: context.snapshots.length,
+    error,
+  })
+}
+
+export interface FinalizeOptimisticUpdateOptions<TData> {
+  queryClient: QueryClient
+  context: OptimisticContext<TData> | undefined
+  reconcileFn?: (
+    current: TData | undefined,
+    snapshot: OptimisticSnapshot<TData>,
+  ) => TData | undefined
+}
+
+export function finalizeOptimisticUpdate<TData>({
+  queryClient,
+  context,
+  reconcileFn,
+}: FinalizeOptimisticUpdateOptions<TData>) {
+  if (!context) return
+
+  context.snapshots.forEach((snapshot) => {
+    queryClient.setQueryData(snapshot.queryKey, (current: TData | undefined) => {
+      if (!reconcileFn) {
+        return current ?? snapshot.data
+      }
+
+      const reconciled = reconcileFn(current, snapshot)
+      return typeof reconciled === 'undefined' ? current : reconciled
+    })
+  })
+
+  logEvent({
+    operation: context.operation,
+    stage: 'committed',
+    durationMs: Date.now() - context.timestamp,
+    affectedQueries: context.snapshots.length,
+  })
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/user-event": "^14.5.2",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
@@ -85,6 +88,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^24.1.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,15 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^14.2.2
+        version: 14.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@9.3.4)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -225,6 +234,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^24.1.0
+        version: 24.1.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,13 +248,16 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@24.1.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -255,6 +270,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +389,34 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1628,11 +1674,35 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@testing-library/dom@9.3.4':
+    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+    engines: {node: '>=14'}
+
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@14.3.1':
+    resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2012,6 +2082,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2032,6 +2106,9 @@ packages:
   aria-hidden@1.2.3:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
+
+  aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2080,6 +2157,9 @@ packages:
 
   asynciterator.prototype@1.0.0:
     resolution: {integrity: sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   autoprefixer@10.4.16:
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
@@ -2206,6 +2286,10 @@ packages:
   call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
 
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -2314,6 +2398,10 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -2350,16 +2438,27 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2390,6 +2489,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
@@ -2400,6 +2502,10 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-equal@2.2.3:
+    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
+    engines: {node: '>= 0.4'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2416,9 +2522,17 @@ packages:
     resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
     engines: {node: '>= 0.4'}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2454,6 +2568,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2507,6 +2627,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   es-abstract@1.22.3:
     resolution: {integrity: sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==}
     engines: {node: '>= 0.4'}
@@ -2518,6 +2642,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
@@ -2531,6 +2658,10 @@ packages:
 
   es-set-tostringtag@2.0.2:
     resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   es-shim-unscopables@1.0.2:
@@ -2792,6 +2923,10 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
 
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
@@ -2950,6 +3085,9 @@ packages:
   has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
     engines: {node: '>= 0.4'}
@@ -2962,12 +3100,8 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  has-tostringtag@1.0.0:
-    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.0:
-    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -2983,6 +3117,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3128,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3008,6 +3154,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3029,6 +3179,10 @@ packages:
     resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
     engines: {node: '>= 0.4'}
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -3037,6 +3191,10 @@ packages:
 
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
@@ -3117,6 +3275,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
@@ -3201,6 +3362,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3487,9 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3324,6 +3497,10 @@ packages:
     resolution: {integrity: sha512-JZX+1fjpqxvQmEgItvPOAwRlqf0Eg9dSZMxljA2/V2M6dluOhQCPBhewIlSJWgkNu0M36kViOgmTAMnDaAMOFw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -3494,6 +3671,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -3608,6 +3789,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.22:
+    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3621,6 +3805,10 @@ packages:
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
@@ -3671,6 +3859,9 @@ packages:
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -3712,9 +3903,6 @@ packages:
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3806,11 +3994,18 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
@@ -3822,6 +4017,9 @@ packages:
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3868,6 +4066,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
@@ -3945,6 +4146,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
     engines: {node: '>= 0.4'}
@@ -3968,6 +4173,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resend@4.8.0:
     resolution: {integrity: sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==}
@@ -4001,6 +4209,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4227,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4048,6 +4269,10 @@ packages:
 
   set-function-length@1.1.1:
     resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
+    engines: {node: '>= 0.4'}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
 
   set-function-name@2.0.1:
@@ -4152,6 +4377,10 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -4197,6 +4426,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -4261,6 +4494,9 @@ packages:
   svelte@4.2.18:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
@@ -4369,8 +4605,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4476,6 +4720,10 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   update-browserslist-db@1.0.13:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -4496,6 +4744,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
@@ -4622,6 +4873,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4634,6 +4889,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4907,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4970,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4732,6 +5022,8 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.2.1':
@@ -4744,6 +5036,14 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5199,26 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -6195,11 +6515,45 @@ snapshots:
       '@tanstack/query-core': 5.51.9
       react: 18.2.0
 
+  '@testing-library/dom@9.3.4':
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/runtime': 7.23.9
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@14.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@testing-library/dom': 9.3.4
+      '@types/react-dom': 18.3.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@9.3.4)':
+    dependencies:
+      '@testing-library/dom': 9.3.4
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.5
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -6644,6 +6998,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -6660,6 +7016,10 @@ snapshots:
   aria-hidden@1.2.3:
     dependencies:
       tslib: 2.6.2
+
+  aria-query@5.1.3:
+    dependencies:
+      deep-equal: 2.2.3
 
   aria-query@5.3.2: {}
 
@@ -6714,7 +7074,7 @@ snapshots:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
@@ -6727,6 +7087,8 @@ snapshots:
   asynciterator.prototype@1.0.0:
     dependencies:
       has-symbols: 1.0.3
+
+  asynckit@0.4.0: {}
 
   autoprefixer@10.4.16(postcss@8.4.32):
     dependencies:
@@ -6866,8 +7228,15 @@ snapshots:
   call-bind@1.0.5:
     dependencies:
       function-bind: 1.1.2
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       set-function-length: 1.1.1
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
 
   call-bound@1.0.4:
     dependencies:
@@ -6982,6 +7351,10 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
@@ -7012,11 +7385,23 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   date-fns@3.3.1: {}
 
@@ -7032,6 +7417,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   decode-named-character-reference@1.0.2:
     dependencies:
       character-entities: 2.0.2
@@ -7042,6 +7429,27 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deep-equal@2.2.3:
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      call-bind: 1.0.5
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.3.0
+      is-arguments: 1.2.0
+      is-array-buffer: 3.0.2
+      is-date-object: 1.0.5
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      isarray: 2.0.5
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      object.assign: 4.1.5
+      regexp.prototype.flags: 1.5.1
+      side-channel: 1.1.0
+      which-boxed-primitive: 1.0.2
+      which-collection: 1.0.1
+      which-typed-array: 1.1.13
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -7050,15 +7458,23 @@ snapshots:
 
   define-data-property@1.1.1:
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.1
       has-property-descriptors: 1.0.1
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -7089,6 +7505,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -7143,6 +7563,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   es-abstract@1.22.3:
     dependencies:
       array-buffer-byte-length: 1.0.0
@@ -7152,14 +7574,14 @@ snapshots:
       es-set-tostringtag: 2.0.2
       es-to-primitive: 1.2.1
       function.prototype.name: 1.1.6
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.2
       internal-slot: 1.0.6
       is-array-buffer: 3.0.2
       is-callable: 1.2.7
@@ -7189,6 +7611,18 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.5
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.2
+      is-set: 2.0.2
+      is-string: 1.0.7
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
+
   es-iterator-helpers@1.0.15:
     dependencies:
       asynciterator.prototype: 1.0.0
@@ -7214,13 +7648,20 @@ snapshots:
 
   es-set-tostringtag@2.0.2:
     dependencies:
-      get-intrinsic: 1.2.2
-      has-tostringtag: 1.0.0
-      hasown: 2.0.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   es-shim-unscopables@1.0.2:
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   es-to-primitive@1.2.1:
     dependencies:
@@ -7590,6 +8031,14 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fraction.js@4.3.7: {}
 
   framer-motion@10.18.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
@@ -7645,7 +8094,7 @@ snapshots:
       function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -7670,7 +8119,7 @@ snapshots:
   get-symbol-description@1.0.0:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
 
   get-tsconfig@4.7.2:
     dependencies:
@@ -7762,7 +8211,7 @@ snapshots:
 
   gopd@1.0.1:
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
 
   gopd@1.2.0: {}
 
@@ -7786,7 +8235,11 @@ snapshots:
 
   has-property-descriptors@1.0.1:
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-proto@1.0.1: {}
 
@@ -7794,13 +8247,9 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  has-tostringtag@1.0.0:
+  has-tostringtag@1.0.2:
     dependencies:
-      has-symbols: 1.0.3
-
-  hasown@2.0.0:
-    dependencies:
-      function-bind: 1.1.2
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -7851,6 +8300,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8319,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7883,6 +8347,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -7899,9 +8365,15 @@ snapshots:
 
   internal-slot@1.0.6:
     dependencies:
-      get-intrinsic: 1.2.2
-      hasown: 2.0.0
+      get-intrinsic: 1.3.0
+      hasown: 2.0.2
       side-channel: 1.0.4
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
 
   invariant@2.2.4:
     dependencies:
@@ -7914,17 +8386,22 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-array-buffer@3.0.2:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       is-typed-array: 1.1.12
 
   is-arrayish@0.3.2: {}
 
   is-async-function@2.0.0:
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   is-bigint@1.0.4:
     dependencies:
@@ -7937,17 +8414,17 @@ snapshots:
   is-boolean-object@1.1.2:
     dependencies:
       call-bind: 1.0.5
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   is-callable@1.2.7: {}
 
   is-core-module@2.13.1:
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   is-date-object@1.0.5:
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
 
@@ -7961,7 +8438,7 @@ snapshots:
 
   is-generator-function@1.0.10:
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   is-glob@4.0.3:
     dependencies:
@@ -7975,13 +8452,15 @@ snapshots:
 
   is-number-object@1.0.7:
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-reference@3.0.2:
     dependencies:
@@ -7995,7 +8474,7 @@ snapshots:
   is-regex@1.1.4:
     dependencies:
       call-bind: 1.0.5
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   is-set@2.0.2: {}
 
@@ -8007,11 +8486,11 @@ snapshots:
 
   is-string@1.0.7:
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   is-symbol@1.0.4:
     dependencies:
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
 
   is-typed-array@1.1.12:
     dependencies:
@@ -8026,7 +8505,7 @@ snapshots:
   is-weakset@2.0.2:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
 
   is-what@4.1.16: {}
 
@@ -8037,7 +8516,7 @@ snapshots:
   iterator.prototype@1.1.2:
     dependencies:
       define-properties: 1.2.1
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       has-symbols: 1.0.3
       reflect.getprototypeof: 1.0.4
       set-function-name: 2.0.1
@@ -8072,6 +8551,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@24.1.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.4
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.22
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8167,6 +8674,8 @@ snapshots:
 
   lru-cache@10.1.0: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -8174,6 +8683,8 @@ snapshots:
   lucide-react@0.302.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.176.0)(three@0.160.0):
     dependencies:
@@ -8496,7 +9007,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8527,6 +9038,8 @@ snapshots:
       mime-db: 1.52.0
 
   mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -8623,6 +9136,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  nwsapi@2.2.22: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -8630,6 +9145,11 @@ snapshots:
   object-inspect@1.13.1: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -8706,6 +9226,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -8739,8 +9263,6 @@ snapshots:
       is-reference: 3.0.2
 
   picocolors@1.0.0: {}
-
-  picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -8786,7 +9308,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       source-map-js: 1.2.0
 
   postcss@8.4.32:
@@ -8824,6 +9346,12 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8831,6 +9359,10 @@ snapshots:
       react-is: 16.13.1
 
   property-information@6.5.0: {}
+
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
 
   pump@3.0.0:
     dependencies:
@@ -8842,6 +9374,8 @@ snapshots:
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -8885,6 +9419,8 @@ snapshots:
       react: 18.2.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-merge-refs@1.1.0: {}
 
@@ -8961,12 +9497,17 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.4:
     dependencies:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       globalthis: 1.0.3
       which-builtin-type: 1.1.3
 
@@ -9003,6 +9544,8 @@ snapshots:
       vfile: 6.0.2
 
   require-from-string@2.0.2: {}
+
+  requires-port@1.0.0: {}
 
   resend@4.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -9061,6 +9604,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9068,7 +9615,7 @@ snapshots:
   safe-array-concat@1.0.1:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       has-symbols: 1.0.3
       isarray: 2.0.5
 
@@ -9077,8 +9624,14 @@ snapshots:
   safe-regex-test@1.0.0:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9118,9 +9671,18 @@ snapshots:
   set-function-length@1.1.1:
     dependencies:
       define-data-property: 1.1.1
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   set-function-name@2.0.1:
     dependencies:
@@ -9168,7 +9730,7 @@ snapshots:
   side-channel@1.0.4:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       object-inspect: 1.13.1
 
   side-channel@1.1.0:
@@ -9229,6 +9791,11 @@ snapshots:
   stats.js@0.17.0: {}
 
   std-env@3.9.0: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   streamsearch@1.1.0: {}
 
@@ -9300,6 +9867,10 @@ snapshots:
       ansi-regex: 6.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 
@@ -9374,6 +9945,8 @@ snapshots:
       magic-string: 0.30.19
       periscopic: 3.1.0
     optional: true
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.2.0:
     dependencies:
@@ -9508,7 +10081,18 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9563,7 +10147,7 @@ snapshots:
   typed-array-buffer@1.0.0:
     dependencies:
       call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.3.0
       is-typed-array: 1.1.12
 
   typed-array-byte-length@1.0.0:
@@ -9593,7 +10177,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.5
       has-bigints: 1.0.2
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
       which-boxed-primitive: 1.0.2
 
   undici-types@6.21.0: {}
@@ -9640,17 +10224,19 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
+  universalify@0.2.0: {}
+
   update-browserslist-db@1.0.13(browserslist@4.22.2):
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.0(browserslist@4.23.2):
     dependencies:
       browserslist: 4.23.2
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
@@ -9661,6 +10247,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   url-template@2.0.8: {}
 
@@ -9736,7 +10327,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@24.1.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10355,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 24.1.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,6 +10381,10 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -9799,6 +10395,8 @@ snapshots:
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9833,6 +10431,17 @@ snapshots:
       - esbuild
       - uglify-js
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -9849,7 +10458,7 @@ snapshots:
   which-builtin-type@1.1.3:
     dependencies:
       function.prototype.name: 1.1.6
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
       is-async-function: 2.0.0
       is-date-object: 1.0.5
       is-finalizationregistry: 1.0.2
@@ -9874,7 +10483,7 @@ snapshots:
       call-bind: 1.0.5
       for-each: 0.3.3
       gopd: 1.0.1
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:
@@ -9903,6 +10512,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/tests/optimistic-updates.test.tsx
+++ b/tests/optimistic-updates.test.tsx
@@ -1,0 +1,509 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '@testing-library/jest-dom/vitest'
+import type { DocumentWithLease } from '@/types/documents'
+import { DocumentList } from '@/app/documents/components/documents-list'
+import { useUploadDocumentMutation } from '@/hooks/use-document-mutations'
+import { MaintenanceRequestForm } from '@/components/maintenance/maintenance-request-form'
+import { VisitorBookingForm } from '@/components/visitors/visitor-booking-form'
+
+vi.mock('@/app/documents/components/document-actions', () => ({
+  DocumentActions: () => null,
+}));
+
+const mockGetDocumentsAction = vi.fn()
+const mockUploadDocumentAction = vi.fn()
+
+vi.mock('@/app/documents/actions', () => ({
+  getDocumentsAction: (...args: any[]) => mockGetDocumentsAction(...args),
+  uploadDocumentAction: (...args: any[]) => mockUploadDocumentAction(...args),
+}));
+
+const mockNotifyMaintenanceRequest = vi.fn()
+const mockNotifyVisitorBooking = vi.fn()
+
+vi.mock('@/hooks/use-notifications', () => ({
+  useNotifications: () => ({
+    notifyMaintenanceRequest: mockNotifyMaintenanceRequest,
+    notifyVisitorBooking: mockNotifyVisitorBooking,
+  }),
+}));
+
+const mockFetchMemberProfile = vi.fn()
+const mockFetchMembersByUnit = vi.fn()
+
+vi.mock('@/lib/data/members', () => ({
+  fetchMemberProfile: (...args: any[]) => mockFetchMemberProfile(...args),
+  fetchMembersByUnit: (...args: any[]) => mockFetchMembersByUnit(...args),
+}));
+
+const mockToast = vi.fn()
+
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+(globalThis as any).React = React
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+let maintenanceInsertDeferred: Deferred<{ data: any; error: any }>
+let visitorInsertDeferred: Deferred<{ data: any; error: any }>
+
+const supabaseAuthGetUser = vi.fn()
+
+vi.mock('@/utils/supabase-browser', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: supabaseAuthGetUser,
+    },
+    from: (table: string) => {
+      if (table === 'maintenance_requests') {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: () => maintenanceInsertDeferred.promise,
+            }),
+          }),
+        }
+      }
+
+      if (table === 'visitor_logs') {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: () => visitorInsertDeferred.promise,
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    },
+  }),
+}))
+
+function renderWithClient(ui: React.ReactNode, client?: QueryClient) {
+  const queryClient =
+    client ??
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+
+  const result = render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  )
+
+  return { queryClient, ...result }
+}
+
+function createOptimisticDocument(title: string): DocumentWithLease {
+  const now = new Date().toISOString()
+  return {
+    id: `temp-${now}`,
+    created_at: now,
+    updated_at: now,
+    title,
+    description: 'Optimistic document placeholder',
+    document_type: 'other',
+    status: 'draft',
+    file_url: undefined,
+    documenso_envelope_id: undefined,
+    documenso_template_id: undefined,
+    metadata: { optimistic: true },
+    created_by: undefined,
+    property_id: undefined,
+    tenant_id: undefined,
+    unit_id: undefined,
+    requires_signature: false,
+    expires_at: undefined,
+    signed_at: undefined,
+    version: 1,
+    parent_document_id: undefined,
+    lease: undefined,
+    signatures: [],
+  }
+}
+
+function DocumentTestHarness() {
+  const mutation = useUploadDocumentMutation()
+
+  const handleUpload = () => {
+    const file = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('title', 'Optimistic Document')
+    formData.append('description', 'Testing optimistic upload flow')
+    formData.append('document_type', 'other')
+    formData.append('tenant_id', '')
+    formData.append('unit_id', '')
+    formData.append('requires_signature', 'false')
+    formData.append('expires_at', '')
+
+    mutation.mutate({
+      formData,
+      optimisticDocument: createOptimisticDocument('Optimistic Document'),
+    })
+  }
+
+  return (
+    <div>
+      <button onClick={handleUpload}>Trigger Upload</button>
+      <DocumentList filter={{}} />
+      {mutation.isError && <div role="alert">Upload failed</div>}
+    </div>
+  )
+}
+
+beforeEach(() => {
+  maintenanceInsertDeferred = createDeferred()
+  visitorInsertDeferred = createDeferred()
+  supabaseAuthGetUser.mockResolvedValue({
+    data: { user: { id: 'user-1', email: 'user@example.com' } },
+  })
+
+  mockFetchMemberProfile.mockResolvedValue({
+    id: 'user-1',
+    full_name: 'Test User',
+    unit_id: 'unit-1',
+  })
+
+  mockFetchMembersByUnit.mockImplementation(
+    async (_client, _unitId, options?: { roles?: string[]; excludeUserId?: string }) => {
+      if (options?.roles?.includes('property_manager')) {
+        return [
+          {
+            id: 'pm-1',
+            email: 'pm@example.com',
+            full_name: 'PM',
+            role: 'property_manager',
+          },
+        ]
+      }
+
+      return [
+        {
+          id: 'pm-1',
+          email: 'pm@example.com',
+          full_name: 'PM',
+          role: 'property_manager',
+        },
+        {
+          id: 'roommate-1',
+          email: 'roommate@example.com',
+          full_name: 'Roommate',
+          role: 'roommate',
+        },
+      ]
+    },
+  )
+
+  mockGetDocumentsAction.mockReset()
+  mockUploadDocumentAction.mockReset()
+  mockNotifyMaintenanceRequest.mockReset()
+  mockNotifyVisitorBooking.mockReset()
+  mockToast.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('document upload optimistic updates', () => {
+  it('adds documents optimistically and keeps the server response', async () => {
+    const initialDocument: DocumentWithLease = {
+      id: 'doc-1',
+      created_at: '2024-06-01T00:00:00.000Z',
+      updated_at: '2024-06-01T00:00:00.000Z',
+      title: 'Existing Document',
+      description: 'Already synced document',
+      document_type: 'other',
+      status: 'draft',
+      file_url: undefined,
+      documenso_envelope_id: undefined,
+      documenso_template_id: undefined,
+      metadata: {},
+      created_by: undefined,
+      property_id: undefined,
+      tenant_id: undefined,
+      unit_id: undefined,
+      requires_signature: false,
+      expires_at: undefined,
+      signed_at: undefined,
+      version: 1,
+      parent_document_id: undefined,
+      lease: undefined,
+      signatures: [],
+    }
+
+    let serverDocuments: DocumentWithLease[] = [initialDocument]
+
+    mockGetDocumentsAction.mockImplementation(async () => ({
+      success: true,
+      data: serverDocuments,
+    }))
+
+    const deferred = createDeferred<{ success: boolean; data?: any; error?: string }>()
+    mockUploadDocumentAction.mockReturnValue(deferred.promise)
+
+    renderWithClient(<DocumentTestHarness />)
+
+    expect(await screen.findByText('Existing Document')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Trigger Upload'))
+
+    await waitFor(() =>
+      expect(screen.getByText('Optimistic Document')).toBeInTheDocument(),
+    )
+
+    const persistedDocument: DocumentWithLease = {
+      ...initialDocument,
+      id: 'doc-optimistic',
+      title: 'Server Document Title',
+      updated_at: '2024-07-01T00:00:00.000Z',
+    }
+
+    serverDocuments = [persistedDocument, initialDocument]
+    deferred.resolve({ success: true, data: persistedDocument })
+
+    await waitFor(() =>
+      expect(screen.getByText('Server Document Title')).toBeInTheDocument(),
+    )
+  })
+
+  it('rolls back optimistic documents when the upload fails', async () => {
+    const initialDocument: DocumentWithLease = {
+      id: 'doc-1',
+      created_at: '2024-06-01T00:00:00.000Z',
+      updated_at: '2024-06-01T00:00:00.000Z',
+      title: 'Existing Document',
+      description: 'Already synced document',
+      document_type: 'other',
+      status: 'draft',
+      file_url: undefined,
+      documenso_envelope_id: undefined,
+      documenso_template_id: undefined,
+      metadata: {},
+      created_by: undefined,
+      property_id: undefined,
+      tenant_id: undefined,
+      unit_id: undefined,
+      requires_signature: false,
+      expires_at: undefined,
+      signed_at: undefined,
+      version: 1,
+      parent_document_id: undefined,
+      lease: undefined,
+      signatures: [],
+    }
+
+    mockGetDocumentsAction.mockResolvedValue({ success: true, data: [initialDocument] })
+
+    const deferred = createDeferred<{ success: boolean; data?: any; error?: string }>()
+    mockUploadDocumentAction.mockReturnValue(deferred.promise)
+
+    renderWithClient(<DocumentTestHarness />)
+
+    expect(await screen.findByText('Existing Document')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Trigger Upload'))
+
+    await waitFor(() =>
+      expect(screen.getByText('Optimistic Document')).toBeInTheDocument(),
+    )
+
+    deferred.reject(new Error('Upload failed'))
+
+    await waitFor(() =>
+      expect(screen.queryByText('Optimistic Document')).not.toBeInTheDocument(),
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Upload failed')
+  })
+})
+
+describe('maintenance request optimistic messaging', () => {
+  it('shows optimistic success and confirms once persisted', async () => {
+    const requestResult = {
+      id: 'req-1',
+      title: 'Broken sink',
+      status: 'pending',
+      priority: 'high',
+      created_at: '2024-07-01T00:00:00.000Z',
+    }
+
+    renderWithClient(
+      <MaintenanceRequestForm
+        initialValues={{
+          title: 'Broken sink',
+          description: 'Sink has been leaking continuously for three days.',
+          priority: 'high',
+        }}
+      />,
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /submit maintenance request/i }),
+    )
+
+    expect(
+      screen.getByText('Maintenance request submitted. Syncing with server...'),
+    ).toBeInTheDocument()
+
+    maintenanceInsertDeferred.resolve({ data: requestResult, error: null })
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Maintenance request synced successfully.'),
+      ).toBeInTheDocument(),
+    )
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Maintenance request submitted',
+      description:
+        'Your maintenance request has been submitted and notifications sent.',
+    })
+  })
+
+  it('rolls back the optimistic message on failure', async () => {
+    renderWithClient(
+      <MaintenanceRequestForm
+        initialValues={{
+          title: 'Broken sink',
+          description: 'Sink has been leaking continuously for three days.',
+        }}
+      />,
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /submit maintenance request/i }),
+    )
+
+    expect(
+      screen.getByText('Maintenance request submitted. Syncing with server...'),
+    ).toBeInTheDocument()
+
+    maintenanceInsertDeferred.resolve({ data: null, error: { message: 'Insert failed' } })
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Maintenance request submitted. Syncing with server...'),
+      ).not.toBeInTheDocument(),
+    )
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Error',
+      description: 'Insert failed',
+      variant: 'destructive',
+    })
+  })
+})
+
+describe('visitor booking optimistic messaging', () => {
+  it('shows optimistic success state before the booking is saved', async () => {
+    const bookingResult = {
+      id: 'booking-1',
+      guest_name: 'Jamie Guest',
+      status: 'pending',
+      check_in_date: '2024-08-10T00:00:00.000Z',
+      check_out_date: '2024-08-12T00:00:00.000Z',
+    }
+
+    renderWithClient(
+      <VisitorBookingForm
+        initialValues={{
+          guestName: 'Jamie Guest',
+          guestEmail: 'guest@example.com',
+          purpose: 'Weekend stay for out-of-town family member',
+          checkInDate: new Date('2024-08-10T00:00:00.000Z'),
+          checkOutDate: new Date('2024-08-12T00:00:00.000Z'),
+        }}
+      />,
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /submit visitor booking/i }),
+    )
+
+    expect(
+      screen.getByText('Visitor booking submitted. Syncing with server...'),
+    ).toBeInTheDocument()
+
+    visitorInsertDeferred.resolve({ data: bookingResult, error: null })
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Visitor booking synced successfully.'),
+      ).toBeInTheDocument(),
+    )
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Visitor booking submitted',
+      description: 'Your visitor booking has been submitted and notifications sent.',
+    })
+  })
+
+  it('clears the optimistic banner when the booking fails', async () => {
+    renderWithClient(
+      <VisitorBookingForm
+        initialValues={{
+          guestName: 'Jamie Guest',
+          guestEmail: 'guest@example.com',
+          purpose: 'Weekend stay for out-of-town family member',
+          checkInDate: new Date('2024-08-10T00:00:00.000Z'),
+          checkOutDate: new Date('2024-08-12T00:00:00.000Z'),
+        }}
+      />,
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /submit visitor booking/i }),
+    )
+
+    expect(
+      screen.getByText('Visitor booking submitted. Syncing with server...'),
+    ).toBeInTheDocument()
+
+    visitorInsertDeferred.resolve({
+      data: null,
+      error: { message: 'Booking failed' },
+    })
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Visitor booking submitted. Syncing with server...'),
+      ).not.toBeInTheDocument(),
+    )
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Error',
+      description: 'Booking failed',
+      variant: 'destructive',
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a shared optimistic update helper and document upload mutation hook to drive cache updates
- refactor document upload, maintenance request, and visitor booking flows to surface optimistic success and rollback states
- introduce a Vitest suite plus testing-library matchers covering optimistic success and rollback behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b84d70083289ef8e2166dcaab32