### PR TITLE
Remove onboarding hero testimonial

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,10 +1,8 @@
 import { Metadata } from "next"
-import Image from "next/image"
 import SmartLink from "@/components/navigation/SmartLink"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
-import AuthForm from "@/app/auth/components/AuthForm"
 import { AuthFormLegacy } from '@/app/auth-server-action/components/AuthFormLegacy'
 
 export const metadata: Metadata = {
@@ -15,23 +13,7 @@ export const metadata: Metadata = {
 export default function OnboardingPage() {
   return (
     <>
-      <div className="hidden">
-        <Image
-          src="/images/house-portal-1.jpg"
-          width={1280}
-          height={843}
-          alt="Roomsily household workspace"
-          className="block dark:hidden"
-        />
-        <Image
-          src="/images/house-portal-2.jpg"
-          width={1280}
-          height={843}
-          alt="Roommate Collaboration"
-          className="hidden"
-        />
-      </div>
-      <div className="container relative mx-auto grid h-[640px] grid-cols-1 flex-col items-center justify-center md:grid-cols-2 lg:max-w-none lg:px-0">
+      <div className="container relative mx-auto grid h-[640px] grid-cols-1 flex-col items-center justify-center lg:max-w-none lg:px-0">
         <SmartLink
           href="/auth"
           className={cn(
@@ -41,42 +23,6 @@ export default function OnboardingPage() {
         >
           Login
         </SmartLink>
-        <div className="relative hidden h-full flex-col bg-muted p-10 text-white md:flex dark:border-r">
-          <div className="absolute inset-0 bg-gradient-to-r from-gray-700 via-gray-900 to-black">
-          <Image
-          src="/images/house-portal-2.jpg"
-          width={2048}
-          height={2048}
-          alt="Roommate Collaboration"
-          style={{objectFit: "contain"}}
-          
-        />
-          </div>
-          <div className="relative z-20 flex items-center text-lg font-medium">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="mr-2 size-6"
-            >
-              <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
-            </svg>
-            
-          </div>
-          <div className="relative z-20 mt-auto">
-            <blockquote className="space-y-2">
-              <p className="text-lg">
-                &ldquo;In 6 months, Roomsily has increased our conversions and NPS by 68%
-                and 58% respectively.&rdquo;
-              </p>
-              <footer className="text-sm">Sofia Davis</footer>
-            </blockquote>
-          </div>
-        </div>
         <div className="lg:p-8">
           <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
             <div className="flex flex-col space-y-2 text-center">


### PR DESCRIPTION
## Summary
- simplify the onboarding page layout by removing the left hero testimonial block and unused image imports
- keep the authentication form centered in a single-column grid

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d218c638c483289759b3c5d0868ba6