### PR TITLE
Fix documents list fetch for non privileged users

### DIFF
--- a/lib/data/documents.ts
+++ b/lib/data/documents.ts
@@ -11,6 +11,12 @@ type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
 
 type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
 
+type DocumentIdRow = Pick<Database['public']['Tables']['documents']['Row'], 'id'>;
+type DocumentSignatureRow = Pick<
+  Database['public']['Tables']['document_signatures']['Row'],
+  'document_id'
+>;
+
 type FetchDocumentsParams = {
   client: SupabaseClientLike;
   userId: string;
@@ -54,13 +60,50 @@ export async function fetchDocumentsList({
   role,
   filters = {},
 }: FetchDocumentsParams): Promise<DocumentWithLease[]> {
-  let query = (client as any)
+  const supabase = client as unknown as TypedSupabaseClient;
+
+  let query = supabase
     .from('documents')
     .select(DOCUMENT_SELECT)
     .order('created_at', { ascending: false });
 
   if (role !== 'property_manager' && role !== 'admin') {
-    query = query.or(`tenant_id.eq.${userId},signatures.signer_id.eq.${userId}`);
+    const accessibleDocumentIds = new Set<string>();
+
+    const { data: tenantDocuments, error: tenantDocumentsError } = await supabase
+      .from('documents')
+      .select('id')
+      .eq('tenant_id', userId);
+
+    handlePostgrestError(tenantDocumentsError, 'Failed to fetch documents for tenant');
+
+    for (const document of (tenantDocuments ?? []) as DocumentIdRow[]) {
+      if (document?.id) {
+        accessibleDocumentIds.add(document.id);
+      }
+    }
+
+    const { data: signatureDocuments, error: signatureDocumentsError } = await supabase
+      .from('document_signatures')
+      .select('document_id')
+      .eq('signer_id', userId);
+
+    handlePostgrestError(
+      signatureDocumentsError,
+      'Failed to fetch documents available for signature'
+    );
+
+    for (const signature of (signatureDocuments ?? []) as DocumentSignatureRow[]) {
+      if (signature?.document_id) {
+        accessibleDocumentIds.add(signature.document_id);
+      }
+    }
+
+    if (!accessibleDocumentIds.size) {
+      return [];
+    }
+
+    query = query.in('id', Array.from(accessibleDocumentIds));
   }
 
   if (filters.status?.length) {

--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -7,7 +7,6 @@ type QueryResult<T> = { data: T; error: { message: string } | null };
 type QueryBuilder<T> = {
   select: ReturnType<typeof vi.fn>;
   order: ReturnType<typeof vi.fn>;
-  or: ReturnType<typeof vi.fn>;
   in: ReturnType<typeof vi.fn>;
   eq: ReturnType<typeof vi.fn>;
   gte: ReturnType<typeof vi.fn>;
@@ -15,11 +14,10 @@ type QueryBuilder<T> = {
   then: (onFulfilled: (value: QueryResult<T>) => unknown) => Promise<unknown>;
 };
 
-function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
+function createQueryBuilder<T extends unknown[]>(result: QueryResult<T>) {
   const builder: Partial<QueryBuilder<T>> & {
     select: ReturnType<typeof vi.fn>;
     order: ReturnType<typeof vi.fn>;
-    or: ReturnType<typeof vi.fn>;
     in: ReturnType<typeof vi.fn>;
     eq: ReturnType<typeof vi.fn>;
     gte: ReturnType<typeof vi.fn>;
@@ -27,7 +25,6 @@ function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
   } = {
     select: vi.fn().mockImplementation(() => builder),
     order: vi.fn().mockImplementation(() => builder),
-    or: vi.fn().mockImplementation(() => builder),
     in: vi.fn().mockImplementation(() => builder),
     eq: vi.fn().mockImplementation(() => builder),
     gte: vi.fn().mockImplementation(() => builder),
@@ -40,19 +37,47 @@ function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
   return builder as QueryBuilder<T>;
 }
 
-function createSupabaseStub<T extends unknown[]>(query: QueryBuilder<T>) {
+function createSupabaseStub(options: {
+  documentsResult: QueryResult<unknown[]>;
+  tenantDocumentsResult: QueryResult<unknown[]>;
+  signatureDocumentsResult: QueryResult<unknown[]>;
+}) {
+  const documentsQuery = createQueryBuilder(options.documentsResult);
+  const tenantDocumentsQuery = createQueryBuilder(options.tenantDocumentsResult);
+  const signatureDocumentsQuery = createQueryBuilder(options.signatureDocumentsResult);
+
+  let documentCallCount = 0;
+
+  const from = vi.fn((table: string) => {
+    if (table === 'documents') {
+      documentCallCount += 1;
+      return documentCallCount === 1 ? documentsQuery : tenantDocumentsQuery;
+    }
+
+    if (table === 'document_signatures') {
+      return signatureDocumentsQuery;
+    }
+
+    throw new Error(`Unexpected table queried: ${table}`);
+  });
+
   return {
-    from: vi.fn((table: string) => {
-      expect(table).toBe('documents');
-      return query;
-    }),
+    from,
+    queries: {
+      documentsQuery,
+      tenantDocumentsQuery,
+      signatureDocumentsQuery,
+    },
   };
 }
 
 describe('fetchDocumentsList', () => {
   it('applies role scoping and filters for non privileged members', async () => {
-    const query = createDocumentsQuery({ data: [{ id: 'doc-1' }] as any, error: null });
-    const supabase = createSupabaseStub(query);
+    const supabase = createSupabaseStub({
+      documentsResult: { data: [{ id: 'doc-1' }] as any, error: null },
+      tenantDocumentsResult: { data: [{ id: 'doc-1' }] as any, error: null },
+      signatureDocumentsResult: { data: [{ document_id: 'doc-2' }] as any, error: null },
+    });
 
     const filters: DocumentListFilters = {
       status: ['draft', 'signed'],
@@ -64,48 +89,86 @@ describe('fetchDocumentsList', () => {
     };
 
     const documents = await fetchDocumentsList({
-      client: supabase,
+      client: supabase as any,
       userId: 'user-123',
       role: 'tenant',
       filters,
     });
 
     expect(documents).toEqual([{ id: 'doc-1', versions: [] }]);
-    expect(query.or).toHaveBeenCalledWith('tenant_id.eq.user-123,signatures.signer_id.eq.user-123');
-    expect(query.in).toHaveBeenCalledWith('status', filters.status);
-    expect(query.in).toHaveBeenCalledWith('document_type', filters.type);
-    expect(query.eq).toHaveBeenCalledWith('tenant_id', filters.tenant_id);
-    expect(query.eq).toHaveBeenCalledWith('unit_id', filters.unit_id);
-    expect(query.gte).toHaveBeenCalledWith('created_at', filters.date_from);
-    expect(query.lte).toHaveBeenCalledWith('created_at', filters.date_to);
+    const { documentsQuery, tenantDocumentsQuery, signatureDocumentsQuery } = supabase.queries;
+    expect(tenantDocumentsQuery.select).toHaveBeenCalledWith('id');
+    expect(tenantDocumentsQuery.eq).toHaveBeenCalledWith('tenant_id', 'user-123');
+    expect(signatureDocumentsQuery.select).toHaveBeenCalledWith('document_id');
+    expect(signatureDocumentsQuery.eq).toHaveBeenCalledWith('signer_id', 'user-123');
+    expect(documentsQuery.in).toHaveBeenCalledWith(
+      'id',
+      expect.arrayContaining(['doc-1', 'doc-2'])
+    );
+    const idFilterCall = documentsQuery.in.mock.calls.find(([column]) => column === 'id');
+    expect(idFilterCall?.[1]).toHaveLength(2);
+    expect(documentsQuery.in).toHaveBeenCalledWith('status', filters.status);
+    expect(documentsQuery.in).toHaveBeenCalledWith('document_type', filters.type);
+    expect(documentsQuery.eq).toHaveBeenCalledWith('tenant_id', filters.tenant_id);
+    expect(documentsQuery.eq).toHaveBeenCalledWith('unit_id', filters.unit_id);
+    expect(documentsQuery.gte).toHaveBeenCalledWith('created_at', filters.date_from);
+    expect(documentsQuery.lte).toHaveBeenCalledWith('created_at', filters.date_to);
   });
 
   it('skips scoping for property managers and admins', async () => {
-    const query = createDocumentsQuery({ data: [], error: null });
-    const supabase = createSupabaseStub(query);
+    const supabase = createSupabaseStub({
+      documentsResult: { data: [], error: null },
+      tenantDocumentsResult: { data: [], error: null },
+      signatureDocumentsResult: { data: [], error: null },
+    });
 
     await fetchDocumentsList({
-      client: supabase,
+      client: supabase as any,
       userId: 'manager-1',
       role: 'property_manager',
     });
 
-    expect(query.or).not.toHaveBeenCalled();
+    const { documentsQuery, tenantDocumentsQuery, signatureDocumentsQuery } = supabase.queries;
+    expect(documentsQuery.in).not.toHaveBeenCalledWith('id', expect.anything());
+    expect(tenantDocumentsQuery.select).not.toHaveBeenCalled();
+    expect(signatureDocumentsQuery.select).not.toHaveBeenCalled();
   });
 
   it('throws when Supabase returns an error', async () => {
-    const query = createDocumentsQuery({ data: null as any, error: { message: 'boom' } });
-    const supabase = createSupabaseStub(query);
+    const supabase = createSupabaseStub({
+      documentsResult: { data: null as any, error: { message: 'boom' } },
+      tenantDocumentsResult: { data: [{ id: 'doc-1' }] as any, error: null },
+      signatureDocumentsResult: { data: [], error: null },
+    });
 
     await expect(
-      fetchDocumentsList({ client: supabase, userId: 'user-1', role: 'tenant' })
+      fetchDocumentsList({ client: supabase as any, userId: 'user-1', role: 'tenant' })
     ).rejects.toThrow(/Failed to fetch documents: boom/);
+  });
+
+  it('returns an empty array when no accessible documents exist', async () => {
+    const supabase = createSupabaseStub({
+      documentsResult: { data: [{ id: 'doc-1' }] as any, error: null },
+      tenantDocumentsResult: { data: [], error: null },
+      signatureDocumentsResult: { data: [], error: null },
+    });
+
+    const documents = await fetchDocumentsList({
+      client: supabase as any,
+      userId: 'user-123',
+      role: 'tenant',
+    });
+
+    expect(documents).toEqual([]);
+    const { documentsQuery } = supabase.queries;
+    const idFilterCall = documentsQuery.in.mock.calls.find(([column]) => column === 'id');
+    expect(idFilterCall).toBeUndefined();
   });
 });
 
 describe('fetchDocumentStats', () => {
   it('computes stats for scoped users', async () => {
-    const query = createDocumentsQuery({
+    const query = createQueryBuilder({
       data: [
         { status: 'draft' },
         { status: 'signed' },
@@ -113,10 +176,15 @@ describe('fetchDocumentStats', () => {
       ] as any,
       error: null,
     });
-    const supabase = createSupabaseStub(query);
+    const supabase = {
+      from: vi.fn((table: string) => {
+        expect(table).toBe('documents');
+        return query;
+      }),
+    };
 
     const stats = await fetchDocumentStats({
-      client: supabase,
+      client: supabase as any,
       userId: 'tenant-1',
       role: 'tenant',
     });
@@ -132,20 +200,30 @@ describe('fetchDocumentStats', () => {
   });
 
   it('omits tenant filter for admins', async () => {
-    const query = createDocumentsQuery({ data: [], error: null });
-    const supabase = createSupabaseStub(query);
+    const query = createQueryBuilder({ data: [], error: null });
+    const supabase = {
+      from: vi.fn((table: string) => {
+        expect(table).toBe('documents');
+        return query;
+      }),
+    };
 
-    await fetchDocumentStats({ client: supabase, userId: 'admin-1', role: 'admin' });
+    await fetchDocumentStats({ client: supabase as any, userId: 'admin-1', role: 'admin' });
 
     expect(query.eq).not.toHaveBeenCalled();
   });
 
   it('throws when Supabase returns an error', async () => {
-    const query = createDocumentsQuery({ data: null as any, error: { message: 'stats failed' } });
-    const supabase = createSupabaseStub(query);
+    const query = createQueryBuilder({ data: null as any, error: { message: 'stats failed' } });
+    const supabase = {
+      from: vi.fn((table: string) => {
+        expect(table).toBe('documents');
+        return query;
+      }),
+    };
 
     await expect(
-      fetchDocumentStats({ client: supabase, userId: 'user-1', role: 'tenant' })
+      fetchDocumentStats({ client: supabase as any, userId: 'user-1', role: 'tenant' })
     ).rejects.toThrow(/Failed to fetch document statistics: stats failed/);
   });
 });


### PR DESCRIPTION
## Summary
- ensure document queries gather accessible document ids for tenants before loading data
- extend document data tests to cover new access scoping and adjust stats helpers

## Testing
- pnpm test -- tests/lib/data/documents.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d21eee64d883288ea88169fca8e84f