### PR TITLE
Expand messaging new thread flow

### DIFF
--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,3 +1,10 @@
+"use client"
+
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import * as z from "zod"
+
 import ModerationControls from "@/components/messaging/moderation-controls"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -9,9 +16,37 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
 import { Progress } from "@/components/ui/progress"
-
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/components/ui/use-toast"
 import { cn } from "@/lib/utils"
 import { Paperclip } from "lucide-react"
 
@@ -27,6 +62,7 @@ type ThreadListItem = {
   activity: string
   reactions: string[]
   pinned?: boolean
+  draft?: boolean
 }
 
 type Attachment = {
@@ -87,15 +123,32 @@ type PollSnapshot = {
   progress: number
 }
 
+const threadCategoryValues = [
+  "Chores",
+  "Logistics",
+  "Maintenance",
+  "Social",
+  "House rules",
+] as const
+
+const pollDurationValues = ["24_hours", "48_hours", "end_of_week"] as const
+
+const pollDurations = [
+  { value: "24_hours", label: "24 hours" },
+  { value: "48_hours", label: "48 hours" },
+  { value: "end_of_week", label: "End of week" },
+] as const
+
 const threadFilters = [
   { label: "All topics", active: true },
   { label: "Chores", active: false },
   { label: "Logistics", active: false },
   { label: "Maintenance", active: false },
+  { label: "House rules", active: false },
   { label: "Social", active: false },
 ]
 
-const threadList: ThreadListItem[] = [
+const initialThreadList: ThreadListItem[] = [
   {
     id: "chore-rotation",
     title: "Q2 chore rotation plan",
@@ -272,7 +325,7 @@ const attachmentSummary: AttachmentSummary[] = [
   },
 ]
 
-const pollSnapshots: PollSnapshot[] = [
+const initialPollSnapshots: PollSnapshot[] = [
   {
     id: "deep-clean",
     title: "Deep clean weekend",
@@ -302,7 +355,540 @@ const pollSnapshots: PollSnapshot[] = [
   },
 ]
 
+const newThreadSchema = z
+  .object({
+    title: z.string().min(4, "Thread title must be at least 4 characters"),
+    category: z.enum(threadCategoryValues, {
+      required_error: "Select a category for the thread",
+    }),
+    summary: z
+      .string()
+      .min(20, "Share a short summary so everyone understands the context"),
+    kickoffMessage: z
+      .string()
+      .min(30, "Give roommates context and outline the next steps"),
+    includePoll: z.boolean(),
+    pollQuestion: z.string().optional(),
+    pollOptionOne: z.string().optional(),
+    pollOptionTwo: z.string().optional(),
+    pollOptionThree: z.string().optional(),
+    pollDeadline: z.enum(pollDurationValues).optional(),
+    pinThread: z.boolean(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.includePoll) {
+      return
+    }
+
+    if (!data.pollQuestion || data.pollQuestion.trim().length < 10) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pollQuestion"],
+        message: "Poll question must be at least 10 characters",
+      })
+    }
+
+    if (!data.pollOptionOne || data.pollOptionOne.trim().length < 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pollOptionOne"],
+        message: "Add a first poll option",
+      })
+    }
+
+    if (!data.pollOptionTwo || data.pollOptionTwo.trim().length < 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pollOptionTwo"],
+        message: "Add a second poll option",
+      })
+    }
+
+    if (
+      data.pollOptionThree &&
+      data.pollOptionThree.trim().length > 0 &&
+      data.pollOptionThree.trim().length < 2
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pollOptionThree"],
+        message: "Poll option must be at least 2 characters",
+      })
+    }
+
+    if (!data.pollDeadline) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pollDeadline"],
+        message: "Select when the poll should close",
+      })
+    }
+  })
+
+type NewThreadFormValues = z.infer<typeof newThreadSchema>
+
+const createNewThreadDefaults = (): NewThreadFormValues => ({
+  title: "",
+  category: threadCategoryValues[0],
+  summary: "",
+  kickoffMessage: "",
+  includePoll: false,
+  pollQuestion: "",
+  pollOptionOne: "",
+  pollOptionTwo: "",
+  pollOptionThree: "",
+  pollDeadline: "48_hours",
+  pinThread: false,
+})
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+
+type NewThreadDialogProps = {
+  existingThreadIds: string[]
+  onCreate: (payload: { thread: ThreadListItem; poll?: PollSnapshot }) => void
+}
+
+function NewThreadDialog({ existingThreadIds, onCreate }: NewThreadDialogProps) {
+  const [open, setOpen] = useState(false)
+  const { toast } = useToast()
+
+  const form = useForm<NewThreadFormValues>({
+    resolver: zodResolver(newThreadSchema),
+    defaultValues: createNewThreadDefaults(),
+    mode: "onSubmit",
+  })
+
+  const includePoll = form.watch("includePoll")
+  const titleValue = form.watch("title")
+  const categoryValue = form.watch("category")
+  const summaryValue = form.watch("summary")
+  const kickoffMessageValue = form.watch("kickoffMessage")
+  const pollQuestionValue = form.watch("pollQuestion")
+  const pollOptionOneValue = form.watch("pollOptionOne")
+  const pollOptionTwoValue = form.watch("pollOptionTwo")
+  const pollOptionThreeValue = form.watch("pollOptionThree")
+  const pollDeadlineValue = form.watch("pollDeadline")
+  const pinThreadValue = form.watch("pinThread")
+
+  const resetForm = () => form.reset(createNewThreadDefaults())
+
+  const pollOptionsPreview = [
+    pollOptionOneValue,
+    pollOptionTwoValue,
+    pollOptionThreeValue,
+  ].filter((option): option is string => Boolean(option && option.trim()))
+
+  const closingPreviewLabel = pollDurations.find(
+    (duration) => duration.value === pollDeadlineValue,
+  )?.label
+
+  const onSubmit = (values: NewThreadFormValues) => {
+    const trimmedTitle = values.title.trim()
+    const trimmedSummary = values.summary.trim()
+    const baseId = slugify(trimmedTitle)
+    const preferredId = baseId.length ? baseId : `thread-${Date.now()}`
+    const uniqueId = existingThreadIds.includes(preferredId)
+      ? `${preferredId}-${Date.now()}`
+      : preferredId
+
+    const closingLabel = pollDurations.find(
+      (duration) => duration.value === values.pollDeadline,
+    )?.label
+    const closingCopy = closingLabel ? closingLabel.toLowerCase() : "soon"
+
+    const newThread: ThreadListItem = {
+      id: uniqueId,
+      title: trimmedTitle,
+      category: values.category,
+      summary: trimmedSummary,
+      lastMessageAt: "Drafted just now",
+      unreadCount: 0,
+      participants: 5,
+      attachments: 0,
+      activity: values.includePoll
+        ? `Poll closes in ${closingCopy}`
+        : "Draft ready to publish",
+      reactions: values.includePoll ? ["📊"] : [],
+      pinned: values.pinThread ? true : undefined,
+      draft: true,
+    }
+
+    const pollOptions = [
+      values.pollOptionOne,
+      values.pollOptionTwo,
+      values.pollOptionThree,
+    ]
+      .map((option) => option?.trim())
+      .filter((option): option is string => Boolean(option && option.length > 0))
+
+    const pollSnapshot: PollSnapshot | undefined = values.includePoll
+      ? {
+          id: uniqueId,
+          title: values.pollQuestion?.trim() ?? "",
+          thread: trimmedTitle,
+          closesAt: `Closes in ${closingCopy}`,
+          leadingOption: pollOptions[0] ?? "",
+          votes: 0,
+          progress: 0,
+        }
+      : undefined
+
+    onCreate({ thread: newThread, poll: pollSnapshot })
+    toast({
+      title: "Thread draft saved",
+      description: values.includePoll
+        ? "Your poll will launch once the thread is published to roommates."
+        : "Publish the thread when you're ready to notify roommates.",
+    })
+
+    setOpen(false)
+    resetForm()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen)
+        if (!nextOpen) {
+          resetForm()
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button size="sm">New thread</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Start a new thread</DialogTitle>
+          <DialogDescription>
+            Draft a focused update, attach context, and optionally launch a poll to gather roommate feedback.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <div className="grid gap-6 lg:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="title"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Thread title</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Ex: Meal prep rotation for July"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Titles appear in the thread list and activity digest.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="category"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Category</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Choose a category" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {threadCategoryValues.map((category) => (
+                          <SelectItem key={category} value={category}>
+                            {category}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      Organize the conversation alongside similar topics.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormField
+              control={form.control}
+              name="summary"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Summary</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Share the TL;DR so everyone knows what decisions you need."
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    This short summary appears under the thread title and in daily recaps.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="kickoffMessage"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Kickoff message</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Provide background, what you need from roommates, and any deadlines."
+                      rows={4}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    This becomes the first post in the thread when you publish.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="pinThread"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between rounded-lg border border-dashed border-border/60 p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel>Pin thread on publish</FormLabel>
+                      <FormDescription>
+                        Keep this conversation above others until you unpin it.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="includePoll"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between rounded-lg border border-dashed border-border/60 p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel>Launch a poll</FormLabel>
+                      <FormDescription>
+                        Collect votes directly in the thread to speed up decisions.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {includePoll ? (
+              <div className="space-y-4 rounded-lg border border-primary/30 bg-primary/5 p-4">
+                <p className="text-sm font-semibold text-primary">
+                  Poll details
+                </p>
+                <FormField
+                  control={form.control}
+                  name="pollQuestion"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Poll question</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="Ex: Which deep clean weekend works best for everyone?"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="grid gap-4 md:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="pollOptionOne"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Option one</FormLabel>
+                        <FormControl>
+                          <Input placeholder="First choice" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="pollOptionTwo"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Option two</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Second choice" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="pollOptionThree"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Option three</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Optional third choice" {...field} />
+                        </FormControl>
+                        <FormDescription>
+                          Leave blank if you only need two options.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="pollDeadline"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Poll closes in</FormLabel>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Choose when to close" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {pollDurations.map((duration) => (
+                              <SelectItem key={duration.value} value={duration.value}>
+                                {duration.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            <div className="space-y-3 rounded-lg border border-dashed border-border/60 bg-muted/40 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Thread preview
+              </p>
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-foreground">
+                  {titleValue || "Thread title"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {(categoryValue && categoryValue.length > 0
+                    ? categoryValue
+                    : "Category TBD") +
+                    " • " +
+                    (pinThreadValue ? "Pinned on publish" : "Draft")}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {summaryValue || "Summaries help roommates understand why this thread matters."}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Kickoff message
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {kickoffMessageValue ||
+                    "Use the kickoff message to outline context, desired actions, and timing."}
+                </p>
+              </div>
+              {includePoll ? (
+                <div className="space-y-2 rounded-lg border border-primary/30 bg-primary/10 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                    Poll draft
+                  </p>
+                  <p className="text-sm font-semibold text-foreground">
+                    {pollQuestionValue || "Poll question will appear here"}
+                  </p>
+                  <ul className="space-y-1 text-xs text-muted-foreground">
+                    {pollOptionsPreview.length > 0 ? (
+                      pollOptionsPreview.map((option) => (
+                        <li key={option}>• {option}</li>
+                      ))
+                    ) : (
+                      <li>Populate options to preview the choices roommates will see.</li>
+                    )}
+                  </ul>
+                  {closingPreviewLabel ? (
+                    <p className="text-xs text-muted-foreground">
+                      Closes in {closingPreviewLabel.toLowerCase()}
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  setOpen(false)
+                  resetForm()
+                }}
+              >
+                Cancel
+              </Button>
+              <Button type="submit">Save draft</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 export default function MessagingPage() {
+  const [threads, setThreads] = useState<ThreadListItem[]>(initialThreadList)
+  const [polls, setPolls] = useState<PollSnapshot[]>(initialPollSnapshots)
+
+  const handleCreateThread = ({
+    thread,
+    poll,
+  }: {
+    thread: ThreadListItem
+    poll?: PollSnapshot
+  }) => {
+    setThreads((previous) => [thread, ...previous])
+    if (poll) {
+      setPolls((previous) => [poll, ...previous])
+    }
+  }
+
   return (
     <div className="container max-w-6xl space-y-10 py-12">
       <header className="space-y-4">
@@ -326,7 +912,10 @@ export default function MessagingPage() {
                     Keep every roommate topic in its own thread so updates, reactions, and attachments stay in context.
                   </CardDescription>
                 </div>
-                <Button size="sm">New thread</Button>
+                <NewThreadDialog
+                  existingThreadIds={threads.map((thread) => thread.id)}
+                  onCreate={handleCreateThread}
+                />
               </div>
               <div className="flex flex-wrap gap-2">
                 {threadFilters.map((filter) => (
@@ -345,10 +934,13 @@ export default function MessagingPage() {
               </div>
             </CardHeader>
             <CardContent className="space-y-3">
-              {threadList.map((thread) => (
+              {threads.map((thread) => (
                 <div
                   key={thread.id}
-                  className="space-y-3 rounded-lg border border-border/60 bg-muted/30 p-4 transition hover:border-primary/50 hover:bg-background"
+                  className={cn(
+                    "space-y-3 rounded-lg border border-border/60 bg-muted/30 p-4 transition hover:border-primary/50 hover:bg-background",
+                    thread.draft && "border-primary/60 bg-primary/5"
+                  )}
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="space-y-2">
@@ -357,6 +949,14 @@ export default function MessagingPage() {
                         {thread.pinned ? (
                           <Badge variant="outline" className="uppercase">
                             Pinned
+                          </Badge>
+                        ) : null}
+                        {thread.draft ? (
+                          <Badge
+                            variant="outline"
+                            className="border-primary/40 text-primary"
+                          >
+                            Draft
                           </Badge>
                         ) : null}
                       </div>
@@ -402,7 +1002,7 @@ export default function MessagingPage() {
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="space-y-3">
-                {pollSnapshots.map((poll) => (
+                {polls.map((poll) => (
                   <div
                     key={poll.id}
                     className="space-y-3 rounded-lg border border-border/60 bg-background/80 p-4"


### PR DESCRIPTION
## Summary
- convert the messaging workspace into a client component that tracks thread and poll state
- add a rich new-thread dialog with validation, poll configuration, and preview so drafts can be saved visually
- update the thread list and poll snapshot cards to surface newly created drafts with contextual badges

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d21f45194883288ad01d3ec3628331