### PR TITLE
Fix payments receipt history action links

### DIFF
--- a/app/payments/_components/receipt-history-card.tsx
+++ b/app/payments/_components/receipt-history-card.tsx
@@ -2,7 +2,7 @@ import { format, parseISO } from "date-fns"
 import { Download, FileText } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -100,12 +100,17 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
           </CardDescription>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <Button asChild variant="outline" size="sm" className="gap-2">
-            <a href={csvDownloadHref} download="roomsily-payment-history.csv">
-              <Download className="size-4" aria-hidden="true" />
-              Export CSV
-            </a>
-          </Button>
+          <a
+            className={cn(
+              buttonVariants({ variant: "outline", size: "sm" }),
+              "gap-2",
+            )}
+            href={csvDownloadHref}
+            download="roomsily-payment-history.csv"
+          >
+            <Download className="size-4" aria-hidden="true" />
+            Export CSV
+          </a>
         </div>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -219,37 +224,31 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
                       </td>
                       <td className="p-4">
                         <div className="flex flex-col items-end gap-2">
-                          <Button
-                            asChild
-                            variant="outline"
-                            size="sm"
-                            className="w-full gap-1"
+                          <a
+                            className={cn(
+                              buttonVariants({ variant: "outline", size: "sm" }),
+                              "w-full justify-center gap-1",
+                            )}
+                            href={receipt.receiptUrl}
+                            target="_blank"
+                            rel="noreferrer"
                           >
+                            <Download className="size-4" aria-hidden="true" />
+                            Receipt
+                          </a>
+                          {receipt.invoiceUrl ? (
                             <a
-                              href={receipt.receiptUrl}
+                              className={cn(
+                                buttonVariants({ variant: "ghost", size: "sm" }),
+                                "w-full justify-center gap-1",
+                              )}
+                              href={receipt.invoiceUrl}
                               target="_blank"
                               rel="noreferrer"
                             >
-                              <Download className="size-4" aria-hidden="true" />
-                              Receipt
+                              <FileText className="size-4" aria-hidden="true" />
+                              Invoice
                             </a>
-                          </Button>
-                          {receipt.invoiceUrl ? (
-                            <Button
-                              asChild
-                              variant="ghost"
-                              size="sm"
-                              className="w-full gap-1"
-                            >
-                              <a
-                                href={receipt.invoiceUrl}
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                <FileText className="size-4" aria-hidden="true" />
-                                Invoice
-                              </a>
-                            </Button>
                           ) : null}
                         </div>
                       </td>


### PR DESCRIPTION
## Summary
- replace `Button` components configured with `asChild` in the payments receipt history card with anchor elements styled via `buttonVariants`
- prevent the React.Children.only runtime error so the payments page renders successfully

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d21edbeef483289372026570740ff2