### PR TITLE
Refine account profile experience

### DIFF
--- a/app/account/avatar.tsx
+++ b/app/account/avatar.tsx
@@ -1,96 +1,190 @@
-'use client'
-import React, { useEffect, useState } from 'react'
-import useSupabaseBrowser from '@/utils/supabase-browser'
-import Image from 'next/image'
+"use client"
 
-export default function Avatar({
+import { ChangeEvent, useEffect, useId, useRef, useState } from "react"
+import { UploadCloud } from "lucide-react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { toast } from "@/components/ui/use-toast"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+interface ProfileAvatarProps {
+  uid: string
+  url: string | null
+  size: number
+  onUpload: (url: string) => void
+  name?: string | null
+}
+
+export default function ProfileAvatar({
   uid,
   url,
   size,
   onUpload,
-}: {
-  uid: string | null
-  url: string | null
-  size: number
-  onUpload: (url: string) => void
-}) {
+  name,
+}: ProfileAvatarProps) {
   const supabase = useSupabaseBrowser()
-  const [avatarUrl, setAvatarUrl] = useState<string | null>(url)
+  const inputId = useId()
+  const helperId = `${inputId}-helper`
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
   const [uploading, setUploading] = useState(false)
 
   useEffect(() => {
+    let isMounted = true
+    let objectUrl: string | undefined
+
     async function downloadImage(path: string) {
       try {
-        const { data, error } = await supabase.storage.from('avatars').download(path)
+        const { data, error } = await supabase.storage.from("avatars").download(path)
         if (error) {
           throw error
         }
 
-        const url = URL.createObjectURL(data)
-        setAvatarUrl(url)
+        objectUrl = URL.createObjectURL(data)
+        if (isMounted) {
+          setAvatarUrl(objectUrl)
+        }
       } catch (error) {
-        console.log('Error downloading image: ', error)
+        console.error("Error downloading profile image", error)
+        toast({
+          variant: "destructive",
+          title: "Could not load your profile photo",
+          description: "Try refreshing the page or uploading a new image.",
+        })
       }
     }
 
-    if (url) downloadImage(url)
-  }, [url, supabase])
+    if (url) {
+      downloadImage(url)
+    } else {
+      setAvatarUrl(null)
+    }
 
-  const uploadAvatar: React.ChangeEventHandler<HTMLInputElement> = async (event) => {
+    return () => {
+      isMounted = false
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [supabase, url])
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files
+    if (!files || files.length === 0) {
+      return
+    }
+
+    const file = files[0]
+    const maxSizeBytes = 2 * 1024 * 1024
+
+    if (file.size > maxSizeBytes) {
+      toast({
+        variant: "destructive",
+        title: "Image too large",
+        description: "Please upload an image smaller than 2 MB.",
+      })
+      event.target.value = ""
+      return
+    }
+
+    const fileExt = file.name.split(".").pop()?.toLowerCase()
+    const sanitizedExt = fileExt && fileExt.length <= 5 ? fileExt : "png"
+    const fileName = `${uid}/${crypto.randomUUID()}.${sanitizedExt}`
+
+    setUploading(true)
     try {
-      setUploading(true)
+      const { error } = await supabase.storage.from("avatars").upload(fileName, file, {
+        cacheControl: "3600",
+        upsert: true,
+      })
 
-      if (!event.target.files || event.target.files.length === 0) {
-        throw new Error('You must select an image to upload.')
+      if (error) {
+        throw error
       }
 
-      const file = event.target.files[0]
-      const fileExt = file.name.split('.').pop()
-      const filePath = `${uid}-${Math.random()}.${fileExt}`
-
-      const { error: uploadError } = await supabase.storage.from('avatars').upload(filePath, file)
-
-      if (uploadError) {
-        throw uploadError
-      }
-
-      onUpload(filePath)
+      onUpload(fileName)
     } catch (error) {
-      alert('Error uploading avatar!')
+      console.error("Error uploading avatar", error)
+      toast({
+        variant: "destructive",
+        title: "Upload failed",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Something went wrong while uploading your photo.",
+      })
     } finally {
       setUploading(false)
+      if (event.target) {
+        event.target.value = ""
+      }
     }
   }
 
+  const handleUploadClick = () => {
+    inputRef.current?.click()
+  }
+
+  const displayName = name?.trim() || "Your profile"
+  const initials = displayName
+    .split(/\s+/)
+    .map((segment) => segment.charAt(0).toUpperCase())
+    .join("")
+    .slice(0, 2)
+  const fallbackInitials = initials || "SH"
+
   return (
-    <div>
-      {avatarUrl ? (
-        <Image
-          width={size}
-          height={size}
-          src={avatarUrl}
-          alt="Avatar"
-          className="relative flex size-10 shrink-0 overflow-hidden rounded-full"
-          style={{ height: size, width: size }}
-        />
-      ) : (
-        <div className="avatar no-image" style={{ height: size, width: size }} />
-      )}
-      <div style={{ width: size }}>
-        <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" htmlFor="single">
-          {uploading ? 'Uploading ...' : 'Upload Image'}
-        </label>
-        <input
-          style={{
-            visibility: 'hidden',
-            position: 'absolute',
-          }}
-          type="file"
-          id="single"
-          accept="image/*"
-          onChange={uploadAvatar}
-          disabled={uploading}
-        />
+    <div className="flex flex-col items-center gap-4 lg:w-72 lg:items-start">
+      <Avatar
+        className="border border-border/60 shadow-sm"
+        style={{ height: size, width: size }}
+      >
+        {avatarUrl ? (
+          <AvatarImage
+            alt={`${displayName}'s avatar`}
+            src={avatarUrl}
+            className="object-cover"
+          />
+        ) : (
+          <AvatarFallback className="bg-muted text-lg font-semibold uppercase">
+            {fallbackInitials}
+          </AvatarFallback>
+        )}
+      </Avatar>
+
+      <input
+        ref={inputRef}
+        accept="image/*"
+        className="hidden"
+        id={inputId}
+        onChange={handleFileChange}
+        type="file"
+        disabled={uploading}
+      />
+
+      <div className="space-y-3 text-center lg:text-left">
+        <div className="space-y-1">
+          <Label htmlFor={inputId}>Profile photo</Label>
+          <p id={helperId} className="text-sm text-muted-foreground">
+            Upload a clear, square PNG or JPG under 2 MB so roommates recognise you instantly.
+          </p>
+        </div>
+        <div className="flex flex-col items-center gap-2 lg:flex-row lg:items-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleUploadClick}
+            isLoading={uploading}
+            aria-describedby={helperId}
+          >
+            <UploadCloud aria-hidden="true" className="mr-2 size-4" />
+            {uploading ? "Uploading..." : "Upload photo"}
+          </Button>
+          <span className="text-xs text-muted-foreground">Recommended: 400×400px</span>
+        </div>
       </div>
     </div>
   )

--- a/app/account/loaders.ts
+++ b/app/account/loaders.ts
@@ -14,7 +14,7 @@ import type { AccountProfile } from "./types"
 
 type ProfileRow = Pick<
   Database["public"]["Tables"]["profiles"]["Row"],
-  "full_name" | "username" | "website" | "avatar_url" | "email"
+  "full_name" | "username" | "website" | "avatar_url" | "email" | "updated_at"
 >
 
 export interface AccountPageData {
@@ -36,7 +36,7 @@ export async function loadAccountPageData(): Promise<AccountPageData> {
 
   const { data, error } = await supabase
     .from("profiles")
-    .select("full_name, username, website, avatar_url, email")
+    .select("full_name, username, website, avatar_url, email, updated_at")
     .eq("id", user.id)
     .maybeSingle<ProfileRow>()
 
@@ -51,6 +51,7 @@ export async function loadAccountPageData(): Promise<AccountPageData> {
         website: data.website,
         avatarUrl: data.avatar_url,
         email: data.email,
+        updatedAt: data.updated_at,
       }
     : null
 

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -13,17 +13,16 @@ export default async function SettingsAccountPage() {
   }
 
   return (
-    <div className="mt-10 px-2 lg:p-8">
-      <div className="mx-auto flex w-full flex-col justify-center space-y-6 px-2">
-        <div className="flex flex-col space-y-2 text-left">
-          <h1 className="text-3xl font-bold tracking-tighter sm:text-5xl">Account Profile</h1>
-          <p className="text-base text-muted-foreground">
-            Keep your contact details current so rent reminders, booking updates, and document alerts reach you without delay.
-          </p>
-        </div>
-        <Separator />
-        <AccountForm profile={profile} user={user} />
+    <div className="mx-auto w-full max-w-5xl space-y-10 px-4 py-10 lg:px-8">
+      <div className="flex flex-col gap-3">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Profile &amp; preferences</h1>
+        <p className="text-base text-muted-foreground sm:max-w-2xl">
+          Keep your information polished so rent reminders, amenity bookings, and document alerts reach the right roommate every
+          time.
+        </p>
       </div>
+      <Separator />
+      <AccountForm profile={profile} user={user} />
     </div>
   )
 }

--- a/app/account/supa-account-form.tsx
+++ b/app/account/supa-account-form.tsx
@@ -1,16 +1,27 @@
 "use client"
 
-import { useCallback, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import type { ChangeEvent, FormEvent } from "react"
 
+import { format, formatDistanceToNow } from "date-fns"
 import type { User } from "@supabase/supabase-js"
 
-import { buttonVariants } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { toast } from "@/components/ui/use-toast"
 import useSupabaseBrowser from "@/utils/supabase-browser"
 
-import Avatar from "./avatar"
+import ProfileAvatar from "./avatar"
 import type { AccountProfile } from "./types"
 
 interface AccountFormProps {
@@ -24,6 +35,11 @@ type ProfileState = {
   website: string
   avatarUrl: string
   email: string
+}
+
+type DateDescriptor = {
+  absolute: string | null
+  relative: string | null
 }
 
 function createProfileState(user: User, profile: AccountProfile | null): ProfileState {
@@ -40,6 +56,44 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
   const supabase = useSupabaseBrowser()
   const [profileState, setProfileState] = useState(() => createProfileState(user, profile))
   const [isSaving, setIsSaving] = useState(false)
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(profile?.updatedAt ?? null)
+
+  const joinedAt = useMemo<DateDescriptor>(() => {
+    if (!user.created_at) {
+      return { absolute: null, relative: null }
+    }
+
+    try {
+      const createdAt = new Date(user.created_at)
+      return {
+        absolute: format(createdAt, "PPP"),
+        relative: formatDistanceToNow(createdAt, { addSuffix: true }),
+      }
+    } catch (error) {
+      console.error("Failed to parse created_at", error)
+      return { absolute: null, relative: null }
+    }
+  }, [user.created_at])
+
+  const lastUpdatedAt = useMemo<DateDescriptor>(() => {
+    if (!lastSavedAt) {
+      return { absolute: null, relative: null }
+    }
+
+    try {
+      const updatedAt = new Date(lastSavedAt)
+      return {
+        absolute: format(updatedAt, "PPP p"),
+        relative: formatDistanceToNow(updatedAt, { addSuffix: true }),
+      }
+    } catch (error) {
+      console.error("Failed to parse updated_at", error)
+      return { absolute: null, relative: null }
+    }
+  }, [lastSavedAt])
+
+  const emailVerified = Boolean(user.email_confirmed_at)
+  const displayName = profileState.fullName || profileState.email || user.email || "Your profile"
 
   const persistProfile = useCallback(
     async (overrides: Partial<ProfileState> = {}) => {
@@ -48,6 +102,7 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
 
       setIsSaving(true)
       try {
+        const timestamp = new Date().toISOString()
         const { error } = await supabase.from("profiles").upsert({
           id: user.id,
           full_name: payload.fullName || null,
@@ -55,13 +110,14 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
           website: payload.website || null,
           avatar_url: payload.avatarUrl || null,
           email: payload.email || null,
-          updated_at: new Date().toISOString(),
+          updated_at: timestamp,
         })
 
         if (error) {
           throw error
         }
 
+        setLastSavedAt(timestamp)
         toast({
           title: "Profile updated",
           description: "We saved your latest contact details.",
@@ -80,7 +136,7 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
         setIsSaving(false)
       }
     },
-    [profileState, supabase, user.id],
+    [profileState, supabase, user.id]
   )
 
   const handleChange = (field: keyof ProfileState) => (event: ChangeEvent<HTMLInputElement>) => {
@@ -98,81 +154,149 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
   }
 
   return (
-    <div className="w-full space-y-8 px-2 py-8">
-      <Avatar
-        uid={user.id}
-        url={profileState.avatarUrl}
-        size={144}
-        onUpload={handleAvatarUpload}
-      />
-      <form className="grid gap-6" onSubmit={handleSubmit}>
-        <div className="flex flex-col">
-          <label
-            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-            htmlFor="email"
-          >
-            Email
-          </label>
-          <Input id="email" value={profileState.email} disabled />
-        </div>
-        <div className="flex flex-col">
-          <label
-            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-            htmlFor="fullName"
-          >
-            Full name
-          </label>
-          <Input
-            id="fullName"
-            value={profileState.fullName}
-            onChange={handleChange("fullName")}
-            placeholder="Jordan Blake"
-          />
-        </div>
-        <div className="flex flex-col">
-          <label
-            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-            htmlFor="username"
-          >
-            Username
-          </label>
-          <Input
-            id="username"
-            value={profileState.username}
-            onChange={handleChange("username")}
-            placeholder="jordy"
-          />
-        </div>
-        <div className="flex flex-col">
-          <label
-            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-            htmlFor="website"
-          >
-            Website
-          </label>
-          <Input
-            id="website"
-            type="url"
-            value={profileState.website}
-            onChange={handleChange("website")}
-            placeholder="https://sharehouse.example"
-          />
-        </div>
-        <button
-          className={buttonVariants({ variant: "outline" })}
-          disabled={isSaving}
-          type="submit"
-        >
-          {isSaving ? "Saving..." : "Update account"}
-        </button>
+    <div className="space-y-8">
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle>Account snapshot</CardTitle>
+          <CardDescription>
+            A quick overview of the key details your roommates and property manager rely on.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-lg border bg-background/40 p-4">
+              <dt className="text-sm text-muted-foreground">Primary email</dt>
+              <dd className="mt-2 flex flex-wrap items-center gap-2 text-base font-medium">
+                <span className="break-all">{profileState.email || "—"}</span>
+                <Badge variant={emailVerified ? "complete" : "outline"}>
+                  {emailVerified ? "Verified" : "Awaiting verification"}
+                </Badge>
+              </dd>
+              <p className="mt-3 text-sm text-muted-foreground">
+                We use this address for rent receipts, booking confirmations, and important notices.
+              </p>
+            </div>
+            <div className="rounded-lg border bg-background/40 p-4">
+              <dt className="text-sm text-muted-foreground">Member since</dt>
+              <dd className="mt-2 text-base font-medium">{joinedAt.absolute ?? "Not available"}</dd>
+              <p className="mt-3 text-sm text-muted-foreground">
+                {joinedAt.relative ? `Active ${joinedAt.relative}.` : "We'll keep this up to date once your account is confirmed."}
+              </p>
+            </div>
+            <div className="rounded-lg border bg-background/40 p-4">
+              <dt className="text-sm text-muted-foreground">Last profile update</dt>
+              <dd className="mt-2 text-base font-medium">
+                {lastUpdatedAt.relative ?? "Not saved yet"}
+              </dd>
+              <p className="mt-3 text-sm text-muted-foreground">
+                {lastUpdatedAt.absolute
+                  ? `Last confirmed ${lastUpdatedAt.absolute}.`
+                  : "Save your details below so everyone stays coordinated."}
+              </p>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Personal information</CardTitle>
+            <CardDescription>
+              Introduce yourself and share how we should reach you around the house.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col gap-8 lg:flex-row">
+              <ProfileAvatar
+                uid={user.id}
+                url={profileState.avatarUrl}
+                size={144}
+                name={displayName}
+                onUpload={handleAvatarUpload}
+              />
+              <div className="grid flex-1 gap-6">
+                <div className="grid gap-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input id="email" value={profileState.email} disabled aria-readonly />
+                  <p className="text-sm text-muted-foreground">
+                    Your email is managed through Supabase Auth. Contact the property team if it needs updating.
+                  </p>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="fullName">Full name</Label>
+                  <Input
+                    id="fullName"
+                    value={profileState.fullName}
+                    onChange={handleChange("fullName")}
+                    placeholder="Jordan Blake"
+                    autoComplete="name"
+                  />
+                  <p className="text-sm text-muted-foreground">
+                    Displayed on rent receipts, maintenance follow-ups, and visitor logs.
+                  </p>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="username">Username</Label>
+                  <Input
+                    id="username"
+                    value={profileState.username}
+                    onChange={handleChange("username")}
+                    placeholder="jordy"
+                    autoComplete="nickname"
+                  />
+                  <p className="text-sm text-muted-foreground">
+                    Roommates see this name when you comment on the board or book amenities.
+                  </p>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="website">Website</Label>
+                  <Input
+                    id="website"
+                    type="url"
+                    value={profileState.website}
+                    onChange={handleChange("website")}
+                    placeholder="https://sharehouse.example"
+                    autoComplete="url"
+                  />
+                  <p className="text-sm text-muted-foreground">
+                    Optional. Perfect for linking a portfolio, calendar, or roommate handbook.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col-reverse gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              {lastUpdatedAt.relative
+                ? `Last saved ${lastUpdatedAt.relative}.`
+                : "Changes are stored the moment you press \"Save changes\"."}
+            </p>
+            <Button type="submit" isLoading={isSaving}>
+              Save changes
+            </Button>
+          </CardFooter>
+        </Card>
       </form>
-      <div className="mb-2 flex w-full flex-col">
-        <form action="/auth/signout" className="items-center space-y-8" method="post">
-          <button className={buttonVariants({ variant: "outline" })} type="submit">
-            Sign out
-          </button>
-        </form>
-      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Sign out</CardTitle>
+          <CardDescription>Log out of the Share House Portal on this device.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Signing out keeps communal devices secure. You can always hop back in with your email link.
+          </p>
+        </CardContent>
+        <CardFooter className="flex justify-end">
+          <form action="/auth/signout" method="post">
+            <Button variant="destructive" type="submit">
+              Sign out
+            </Button>
+          </form>
+        </CardFooter>
+      </Card>
     </div>
   )
 }

--- a/app/account/types.ts
+++ b/app/account/types.ts
@@ -4,4 +4,5 @@ export interface AccountProfile {
   website: string | null
   avatarUrl: string | null
   email: string | null
+  updatedAt: string | null
 }


### PR DESCRIPTION
## Summary
- redesign the account settings layout with a professional header and structured sections
- surface profile metadata such as email verification, join date, and last update time in a snapshot card
- refresh the editable form and avatar uploader with shadcn/ui cards, helpful guidance, and Supabase-backed persistence feedback

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d21ec69cb083289e7f59806574281c