### PR TITLE
Add quarterly NPS and CSAT feedback surfaces

### DIFF
--- a/app/dashboard/components/quarterly-nps-gate.tsx
+++ b/app/dashboard/components/quarterly-nps-gate.tsx
@@ -1,0 +1,46 @@
+import { cookies } from "next/headers"
+
+import { QuarterlyNpsSurvey } from "@/components/surveys/quarterly-nps-survey"
+import { fetchLatestNpsResponse, type NpsResponseSummary } from "@/lib/data/surveys"
+import { getQuarterWindow, shouldTriggerQuarterlyNps } from "@/lib/surveys"
+import { createClient } from "@/utils/supa-server-actions"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+export async function QuarterlyNpsGate() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    return null
+  }
+
+  let latestResponse: NpsResponseSummary | null = null
+
+  try {
+    latestResponse = await fetchLatestNpsResponse(
+      supabase as unknown as TypedSupabaseClient,
+      user.id
+    )
+  } catch (error) {
+    console.error("Failed to load latest NPS response", error)
+  }
+
+  if (!shouldTriggerQuarterlyNps(latestResponse?.quarter_start ?? null)) {
+    return null
+  }
+
+  const quarter = getQuarterWindow()
+
+  return (
+    <QuarterlyNpsSurvey
+      quarter={quarter}
+      lastCompletedQuarterStart={latestResponse?.quarter_start ?? null}
+      className="border border-dashed"
+    />
+  )
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ import { readUserSession } from "@/utils/actions"
 import MobileSideNav from "./components/MobileSideNav"
 import SideNav from "./components/SideNav"
 import ToggleSidebar from "./components/ToggleSidebar"
+import { QuarterlyNpsGate } from "./components/quarterly-nps-gate"
 
 export default async function Layout({ children }: { children: ReactNode }) {
 	const { data: userSession } = await readUserSession();
@@ -24,6 +25,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
 
                         <div className="w-full space-y-5 bg-gray-100 p-5 sm:flex-1 sm:p-10 dark:bg-inherit">
                                 <ToggleSidebar />
+                                <QuarterlyNpsGate />
                                 <ErrorBoundary>
                                         <Suspense fallback={<RouteSkeleton />}>
                                                 {children}

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -15,6 +15,8 @@ import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { CsatQuickPrompt } from "@/components/surveys/csat-quick-prompt";
+import { buildMaintenanceCsatContext, CSAT_FLOW_MAINTENANCE } from "@/lib/surveys";
 
 const maintenanceRequestSchema = z.object({
   title: z.string().min(5, "Title must be at least 5 characters"),
@@ -47,6 +49,9 @@ const priorities = [
 
 export function MaintenanceRequestForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [csatContext, setCsatContext] = useState<string | null>(null);
+  const [csatOpen, setCsatOpen] = useState(false);
+  const [csatMetadata, setCsatMetadata] = useState<Record<string, unknown> | null>(null);
   const { notifyMaintenanceRequest } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
@@ -125,6 +130,15 @@ export function MaintenanceRequestForm() {
       });
 
       form.reset();
+
+      const contextIdentifier = buildMaintenanceCsatContext(request.id);
+      setCsatContext(contextIdentifier);
+      setCsatMetadata({
+        surface: "maintenance_request_submission",
+        request_id: request.id,
+        priority: data.priority,
+      });
+      setCsatOpen(true);
     } catch (error) {
       console.error('Error submitting maintenance request:', error);
       toast({
@@ -242,6 +256,19 @@ export function MaintenanceRequestForm() {
           {isSubmitting ? "Submitting..." : "Submit Maintenance Request"}
         </Button>
       </form>
+      <CsatQuickPrompt
+        open={csatOpen}
+        flow={CSAT_FLOW_MAINTENANCE}
+        contextIdentifier={csatContext}
+        metadata={csatMetadata}
+        onOpenChange={(open) => {
+          setCsatOpen(open);
+          if (!open) {
+            setCsatContext(null);
+            setCsatMetadata(null);
+          }
+        }}
+      />
     </Form>
   );
 }

--- a/components/surveys/csat-quick-prompt.tsx
+++ b/components/surveys/csat-quick-prompt.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import { track } from "@vercel/analytics/react"
+
+import { recordCsatResponse } from "@/lib/data/surveys"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/components/ui/use-toast"
+import { createClient } from "@/utils/supabase-browser"
+
+const SCORES = [1, 2, 3, 4, 5] as const
+
+const SCORE_LABELS: Record<(typeof SCORES)[number], string> = {
+  1: "Very poor",
+  2: "Poor",
+  3: "Okay",
+  4: "Good",
+  5: "Excellent",
+}
+
+export interface CsatQuickPromptProps {
+  open: boolean
+  flow: string
+  contextIdentifier: string | null
+  onOpenChange: (open: boolean) => void
+  metadata?: Record<string, unknown> | null
+  title?: string
+  description?: string
+}
+
+export function CsatQuickPrompt({
+  open,
+  flow,
+  contextIdentifier,
+  onOpenChange,
+  metadata,
+  title = "How was that flow?",
+  description = "Quick rating keeps the experience sharp for every roommate.",
+}: CsatQuickPromptProps) {
+  const [score, setScore] = useState<number | null>(null)
+  const [comment, setComment] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const supabase = createClient()
+  const { toast } = useToast()
+  const promptTrackedRef = useRef(false)
+  const submittedRef = useRef(false)
+
+  useEffect(() => {
+    if (open && contextIdentifier && !promptTrackedRef.current) {
+      track("survey_csat_prompted", {
+        flow,
+        context_identifier: contextIdentifier,
+      })
+      promptTrackedRef.current = true
+    }
+  }, [open, flow, contextIdentifier])
+
+  const resetState = () => {
+    setScore(null)
+    setComment("")
+    setIsSubmitting(false)
+  }
+
+  const handleDialogOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && contextIdentifier) {
+      if (promptTrackedRef.current && !submittedRef.current) {
+        track("survey_csat_dismissed", {
+          flow,
+          context_identifier: contextIdentifier,
+        })
+      }
+
+      promptTrackedRef.current = false
+      submittedRef.current = false
+      resetState()
+    }
+
+    onOpenChange(nextOpen)
+  }
+
+  const handleSubmit = async () => {
+    if (score === null || !contextIdentifier) {
+      toast({
+        title: "Pick a rating",
+        description: "Let us know how the flow felt before submitting.",
+      })
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const {
+        data: { user },
+        error,
+      } = await supabase.auth.getUser()
+
+      if (error || !user) {
+        throw new Error("You need to be signed in to share feedback.")
+      }
+
+      const metadataPayload = { surface: "csat_quick_prompt", ...(metadata ?? {}) }
+
+      await recordCsatResponse({
+        client: supabase,
+        userId: user.id,
+        flow,
+        contextIdentifier,
+        score,
+        comment,
+        metadata: metadataPayload,
+      })
+
+      track("survey_csat_submitted", {
+        flow,
+        context_identifier: contextIdentifier,
+        score,
+      })
+
+      toast({
+        title: "Thanks for the quick rating!",
+        description: "We’ll use it to keep flows smooth for the whole household.",
+      })
+
+      submittedRef.current = true
+      handleDialogOpenChange(false)
+    } catch (error) {
+      console.error("Error submitting CSAT response", error)
+      toast({
+        title: "We couldn’t save that",
+        description: error instanceof Error ? error.message : "Please try again.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const descriptor = useMemo(() => {
+    if (score === null) {
+      return "Tap a score to continue"
+    }
+
+    return SCORE_LABELS[score as (typeof SCORES)[number]]
+  }, [score])
+
+  if (!contextIdentifier) {
+    return null
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {SCORES.map((value) => (
+              <Button
+                key={value}
+                type="button"
+                variant={value === score ? "default" : "outline"}
+                disabled={isSubmitting}
+                onClick={() => setScore(value)}
+                className={cn(
+                  "h-10 w-10 rounded-full border",
+                  value === score
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-muted-foreground/30 text-foreground"
+                )}
+              >
+                {value}
+              </Button>
+            ))}
+          </div>
+          <p className="text-sm font-medium text-muted-foreground">{descriptor}</p>
+
+          <Textarea
+            placeholder="Anything we should know?"
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            rows={3}
+          />
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={isSubmitting}
+              onClick={() => handleDialogOpenChange(false)}
+            >
+              Skip
+            </Button>
+            <Button type="button" onClick={handleSubmit} disabled={isSubmitting}>
+              {isSubmitting ? "Sending..." : "Send"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/surveys/quarterly-nps-survey.tsx
+++ b/components/surveys/quarterly-nps-survey.tsx
@@ -1,0 +1,269 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react"
+
+import { useRouter } from "next/navigation"
+
+import { track } from "@vercel/analytics/react"
+
+import { recordNpsResponse } from "@/lib/data/surveys"
+import { formatQuarterLabel, type QuarterWindow } from "@/lib/surveys"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/components/ui/use-toast"
+import { createClient } from "@/utils/supabase-browser"
+
+const SCORES = Array.from({ length: 11 }, (_, index) => index)
+
+interface ScoreDescriptor {
+  headline: string
+  helper: string
+  className: string
+}
+
+function describeScore(score: number | null): ScoreDescriptor {
+  if (score === null) {
+    return {
+      headline: "Select a score to continue",
+      helper: "0 = not likely, 10 = extremely likely",
+      className: "text-muted-foreground",
+    }
+  }
+
+  if (score <= 6) {
+    return {
+      headline: "We want to do better",
+      helper: "Tell us what felt off so we can fix it quickly.",
+      className: "text-destructive",
+    }
+  }
+
+  if (score <= 8) {
+    return {
+      headline: "Almost there",
+      helper: "What would earn us a 9 or 10 next quarter?",
+      className: "text-amber-600 dark:text-amber-500",
+    }
+  }
+
+  return {
+    headline: "Thanks for the love!",
+    helper: "Share what stood out so we can keep doing it.",
+    className: "text-emerald-600 dark:text-emerald-400",
+  }
+}
+
+function formatDateLabel(isoDate: string | null): string | null {
+  if (!isoDate) {
+    return null
+  }
+
+  const parsed = new Date(`${isoDate}T00:00:00Z`)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed)
+}
+
+export interface QuarterlyNpsSurveyProps {
+  quarter: QuarterWindow
+  lastCompletedQuarterStart: string | null
+  className?: string
+}
+
+export function QuarterlyNpsSurvey({
+  quarter,
+  lastCompletedQuarterStart,
+  className,
+}: QuarterlyNpsSurveyProps) {
+  const [score, setScore] = useState<number | null>(null)
+  const [feedback, setFeedback] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+  const router = useRouter()
+  const supabase = createClient()
+  const { toast } = useToast()
+  const descriptor = useMemo(() => describeScore(score), [score])
+  const lastCompletedLabel = useMemo(
+    () => formatDateLabel(lastCompletedQuarterStart),
+    [lastCompletedQuarterStart]
+  )
+  const promptTrackedRef = useRef(false)
+
+  useEffect(() => {
+    if (!promptTrackedRef.current) {
+      track("survey_nps_prompted", {
+        quarter: quarter.quarter,
+        year: quarter.year,
+        last_completed_quarter_start: lastCompletedQuarterStart,
+      })
+      promptTrackedRef.current = true
+    }
+  }, [quarter.quarter, quarter.year, lastCompletedQuarterStart])
+
+  if (dismissed) {
+    return null
+  }
+
+  const quarterLabel = formatQuarterLabel(quarter)
+
+  const handleDismiss = (reason: "skip" | "completed") => {
+    track("survey_nps_dismissed", {
+      reason,
+      quarter: quarter.quarter,
+      year: quarter.year,
+    })
+    setDismissed(true)
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (score === null) {
+      toast({
+        title: "Choose a score",
+        description: "Please select how likely you are to recommend us before submitting.",
+      })
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const {
+        data: { user },
+        error,
+      } = await supabase.auth.getUser()
+
+      if (error || !user) {
+        throw new Error("You need to be signed in to share feedback.")
+      }
+
+      await recordNpsResponse({
+        client: supabase,
+        userId: user.id,
+        score,
+        feedback,
+        quarter,
+        metadata: {
+          surface: "dashboard_quarterly_prompt",
+          last_completed_quarter_start: lastCompletedQuarterStart,
+        },
+      })
+
+      track("survey_nps_submitted", {
+        score,
+        quarter: quarter.quarter,
+        year: quarter.year,
+      })
+
+      toast({
+        title: "Thanks for the feedback!",
+        description: "We appreciate you taking a moment to help shape the roadmap.",
+      })
+
+      handleDismiss("completed")
+      router.refresh()
+    } catch (error) {
+      console.error("Error submitting NPS response", error)
+      toast({
+        title: "We couldn’t save your score",
+        description:
+          error instanceof Error ? error.message : "Please try again in a moment.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Card className={cn("border-primary/40 shadow-sm", className)}>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <CardTitle>Quarterly check-in</CardTitle>
+            <CardDescription>
+              How likely are you to recommend Share House Portal this {quarterLabel}?
+            </CardDescription>
+            {lastCompletedLabel ? (
+              <p className="text-xs text-muted-foreground">
+                Last response recorded on {lastCompletedLabel}
+              </p>
+            ) : null}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={isSubmitting}
+            onClick={() => handleDismiss("skip")}
+          >
+            Remind me later
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              {SCORES.map((value) => (
+                <Button
+                  type="button"
+                  key={value}
+                  variant={value === score ? "default" : "outline"}
+                  onClick={() => setScore(value)}
+                  className={cn(
+                    "h-10 w-10 rounded-full border",
+                    value === score
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-muted-foreground/30 text-foreground"
+                  )}
+                >
+                  {value}
+                </Button>
+              ))}
+            </div>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>0 — Not likely</span>
+              <span>10 — Extremely likely</span>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <p className={cn("text-sm font-medium", descriptor.className)}>
+              {descriptor.headline}
+            </p>
+            <p className="text-xs text-muted-foreground">{descriptor.helper}</p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="nps-feedback" className="text-sm font-medium text-foreground">
+              Any details to share? (optional)
+            </label>
+            <Textarea
+              id="nps-feedback"
+              placeholder="Tell us about a recent win or something we should improve."
+              value={feedback}
+              onChange={(event) => setFeedback(event.target.value)}
+              rows={4}
+            />
+          </div>
+
+          <div className="flex items-center justify-end gap-2">
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Sending..." : "Submit"}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/data/surveys.ts
+++ b/lib/data/surveys.ts
@@ -1,0 +1,119 @@
+import type { Database } from '@/lib/supabase'
+import { getQuarterWindow, shouldTriggerQuarterlyNps, type QuarterWindow } from '@/lib/surveys'
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+
+type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>
+
+type NpsRow = Database['public']['Tables']['nps_responses']['Row']
+type NpsInsert = Database['public']['Tables']['nps_responses']['Insert']
+type CsatInsert = Database['public']['Tables']['csat_responses']['Insert']
+
+export type NpsResponseSummary = Pick<NpsRow, 'quarter_start' | 'quarter_end' | 'submitted_at' | 'score'>
+
+export async function fetchLatestNpsResponse(
+  client: SupabaseClientLike,
+  userId: string
+): Promise<NpsResponseSummary | null> {
+  const { data, error } = await client
+    .from('nps_responses')
+    .select('quarter_start, quarter_end, submitted_at, score')
+    .eq('user_id', userId)
+    .order('quarter_start', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to load NPS responses: ${error.message}`)
+  }
+
+  return (data as NpsResponseSummary | null) ?? null
+}
+
+export async function hasSubmittedNpsThisQuarter(
+  client: SupabaseClientLike,
+  userId: string,
+  now: Date = new Date()
+): Promise<boolean> {
+  const latest = await fetchLatestNpsResponse(client, userId)
+  return !shouldTriggerQuarterlyNps(latest?.quarter_start ?? null, now)
+}
+
+export interface RecordNpsResponseArgs {
+  client: SupabaseClientLike
+  userId: string
+  score: number
+  feedback?: string | null
+  metadata?: NpsInsert['metadata']
+  quarter?: QuarterWindow
+}
+
+export async function recordNpsResponse({
+  client,
+  userId,
+  score,
+  feedback,
+  metadata,
+  quarter = getQuarterWindow(),
+}: RecordNpsResponseArgs): Promise<void> {
+  if (score < 0 || score > 10) {
+    throw new RangeError('NPS score must be between 0 and 10')
+  }
+
+  const payload: NpsInsert = {
+    user_id: userId,
+    score,
+    feedback: feedback?.trim() ? feedback.trim() : null,
+    quarter_start: quarter.startDate,
+    quarter_end: quarter.endDate,
+    metadata: metadata ?? {},
+  }
+
+  const { error } = await client.from('nps_responses').insert(payload)
+
+  if (error) {
+    throw new Error(`Failed to record NPS response: ${error.message}`)
+  }
+}
+
+export interface RecordCsatResponseArgs {
+  client: SupabaseClientLike
+  userId: string
+  flow: string
+  contextIdentifier: string
+  score: number
+  comment?: string | null
+  metadata?: CsatInsert['metadata']
+}
+
+export async function recordCsatResponse({
+  client,
+  userId,
+  flow,
+  contextIdentifier,
+  score,
+  comment,
+  metadata,
+}: RecordCsatResponseArgs): Promise<void> {
+  if (score < 1 || score > 5) {
+    throw new RangeError('CSAT score must be between 1 and 5')
+  }
+
+  if (!contextIdentifier || contextIdentifier.trim().length < 3) {
+    throw new Error('A valid CSAT context identifier is required')
+  }
+
+  const payload: CsatInsert = {
+    user_id: userId,
+    flow,
+    context_identifier: contextIdentifier,
+    score,
+    comment: comment?.trim() ? comment.trim() : null,
+    metadata: metadata ?? {},
+  }
+
+  const { error } = await client.from('csat_responses').insert(payload)
+
+  if (error) {
+    throw new Error(`Failed to record CSAT response: ${error.message}`)
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -197,6 +197,26 @@ export type Database = {
         attachments: Json | null
         metadata: Json | null
       }>
+      nps_responses: SupabaseTable<{
+        id: string
+        user_id: string
+        score: number
+        feedback: string | null
+        quarter_start: string
+        quarter_end: string
+        submitted_at: string | null
+        metadata: Json | null
+      }>
+      csat_responses: SupabaseTable<{
+        id: string
+        user_id: string
+        flow: string
+        context_identifier: string
+        score: number
+        comment: string | null
+        submitted_at: string | null
+        metadata: Json | null
+      }>
       visitor_logs: SupabaseTable<{
         id: string
         guest_name: string

--- a/lib/surveys.ts
+++ b/lib/surveys.ts
@@ -1,0 +1,55 @@
+export type QuarterNumber = 1 | 2 | 3 | 4
+
+export type QuarterWindow = {
+  year: number
+  quarter: QuarterNumber
+  startDate: string
+  endDate: string
+}
+
+const ISO_DATE_LENGTH = 10
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, ISO_DATE_LENGTH)
+}
+
+export function getQuarterWindow(referenceDate: Date = new Date()): QuarterWindow {
+  const year = referenceDate.getUTCFullYear()
+  const month = referenceDate.getUTCMonth()
+  const quarterIndex = Math.floor(month / 3)
+  const quarter = (quarterIndex + 1) as QuarterNumber
+  const startMonth = quarterIndex * 3
+
+  const start = new Date(Date.UTC(year, startMonth, 1))
+  const end = new Date(Date.UTC(year, startMonth + 3, 0))
+
+  return {
+    year,
+    quarter,
+    startDate: toIsoDate(start),
+    endDate: toIsoDate(end),
+  }
+}
+
+export function shouldTriggerQuarterlyNps(
+  lastCompletedQuarterStart: string | null,
+  now: Date = new Date()
+): boolean {
+  const currentQuarterStart = getQuarterWindow(now).startDate
+
+  if (!lastCompletedQuarterStart) {
+    return true
+  }
+
+  return lastCompletedQuarterStart !== currentQuarterStart
+}
+
+export function formatQuarterLabel(window: QuarterWindow): string {
+  return `Q${window.quarter} ${window.year}`
+}
+
+export const CSAT_FLOW_MAINTENANCE = 'maintenance_request' as const
+
+export function buildMaintenanceCsatContext(requestId: string): string {
+  return `${CSAT_FLOW_MAINTENANCE}:${requestId}`
+}

--- a/supabase/migrations/20250321_feedback_surveys.sql
+++ b/supabase/migrations/20250321_feedback_surveys.sql
@@ -1,0 +1,83 @@
+-- Capture resident feedback via quarterly NPS and flow-specific CSAT prompts
+CREATE TABLE public.nps_responses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  score INTEGER NOT NULL CHECK (score >= 0 AND score <= 10),
+  feedback TEXT,
+  quarter_start DATE NOT NULL,
+  quarter_end DATE NOT NULL,
+  submitted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE UNIQUE INDEX nps_responses_user_quarter_idx
+  ON public.nps_responses(user_id, quarter_start);
+CREATE INDEX nps_responses_quarter_idx
+  ON public.nps_responses(quarter_start);
+CREATE INDEX nps_responses_submitted_at_idx
+  ON public.nps_responses(submitted_at DESC);
+
+ALTER TABLE public.nps_responses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read their own NPS responses"
+  ON public.nps_responses
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Managers can read resident NPS responses"
+  ON public.nps_responses
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Users can create their quarterly NPS response"
+  ON public.nps_responses
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+
+CREATE TABLE public.csat_responses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  flow TEXT NOT NULL CHECK (char_length(flow) >= 3),
+  context_identifier TEXT NOT NULL CHECK (char_length(context_identifier) >= 3),
+  score INTEGER NOT NULL CHECK (score BETWEEN 1 AND 5),
+  comment TEXT,
+  submitted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE UNIQUE INDEX csat_responses_user_context_idx
+  ON public.csat_responses(user_id, flow, context_identifier);
+CREATE INDEX csat_responses_flow_idx
+  ON public.csat_responses(flow);
+CREATE INDEX csat_responses_submitted_at_idx
+  ON public.csat_responses(submitted_at DESC);
+
+ALTER TABLE public.csat_responses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read their own CSAT responses"
+  ON public.csat_responses
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Managers can review CSAT responses"
+  ON public.csat_responses
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE POLICY "Users can submit CSAT feedback"
+  ON public.csat_responses
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);

--- a/tests/lib/data/surveys.test.ts
+++ b/tests/lib/data/surveys.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchLatestNpsResponse,
+  hasSubmittedNpsThisQuarter,
+  recordCsatResponse,
+  recordNpsResponse,
+} from '@/lib/data/surveys'
+import { getQuarterWindow } from '@/lib/surveys'
+
+type MaybeSingleResult<T> = { data: T; error: { message: string } | null }
+
+type NpsBuilder = {
+  select?: ReturnType<typeof vi.fn>
+  eq?: ReturnType<typeof vi.fn>
+  order?: ReturnType<typeof vi.fn>
+  limit?: ReturnType<typeof vi.fn>
+  maybeSingle?: () => Promise<MaybeSingleResult<unknown>>
+  insert?: ReturnType<typeof vi.fn>
+}
+
+type CsatBuilder = {
+  insert: ReturnType<typeof vi.fn>
+}
+
+function createNpsBuilder(options: {
+  selectResult?: MaybeSingleResult<unknown>
+  insertError?: { message: string } | null
+} = {}): NpsBuilder {
+  const builder: Partial<NpsBuilder> = {}
+
+  if (options.selectResult) {
+    builder.select = vi.fn().mockImplementation(() => builder)
+    builder.eq = vi.fn().mockImplementation(() => builder)
+    builder.order = vi.fn().mockImplementation(() => builder)
+    builder.limit = vi.fn().mockImplementation(() => builder)
+    builder.maybeSingle = vi.fn().mockResolvedValue(options.selectResult)
+  }
+
+  if (options.insertError !== undefined) {
+    builder.insert = vi.fn().mockResolvedValue({ data: null, error: options.insertError })
+  }
+
+  return builder as NpsBuilder
+}
+
+function createCsatBuilder(error: { message: string } | null = null): CsatBuilder {
+  return {
+    insert: vi.fn().mockResolvedValue({ data: null, error }),
+  }
+}
+
+function createSurveySupabaseStub({
+  nps,
+  csat,
+}: {
+  nps?: NpsBuilder
+  csat?: CsatBuilder
+}) {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'nps_responses') {
+        if (!nps) {
+          throw new Error('NPS builder not provided')
+        }
+        return nps
+      }
+
+      if (table === 'csat_responses') {
+        if (!csat) {
+          throw new Error('CSAT builder not provided')
+        }
+        return csat
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    }),
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('fetchLatestNpsResponse', () => {
+  it('returns the most recent quarterly response', async () => {
+    const result = {
+      data: {
+        quarter_start: '2025-01-01',
+        quarter_end: '2025-03-31',
+        submitted_at: '2025-02-10T00:00:00Z',
+        score: 9,
+      },
+      error: null,
+    }
+    const npsBuilder = createNpsBuilder({ selectResult: result })
+    const supabase = createSurveySupabaseStub({ nps: npsBuilder })
+
+    const response = await fetchLatestNpsResponse(supabase as any, 'user-1')
+
+    expect(npsBuilder.select).toHaveBeenCalledWith('quarter_start, quarter_end, submitted_at, score')
+    expect(npsBuilder.eq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(npsBuilder.order).toHaveBeenCalledWith('quarter_start', { ascending: false })
+    expect(npsBuilder.limit).toHaveBeenCalledWith(1)
+    expect(response).toEqual(result.data)
+  })
+
+  it('throws when Supabase reports an error', async () => {
+    const npsBuilder = createNpsBuilder({
+      selectResult: { data: null, error: { message: 'boom' } },
+    })
+    const supabase = createSurveySupabaseStub({ nps: npsBuilder })
+
+    await expect(fetchLatestNpsResponse(supabase as any, 'user-2')).rejects.toThrow(
+      /Failed to load NPS responses: boom/
+    )
+  })
+})
+
+describe('hasSubmittedNpsThisQuarter', () => {
+  it('returns true when a response exists for the current quarter', async () => {
+    const now = new Date('2025-02-20T00:00:00Z')
+    const currentQuarter = getQuarterWindow(now)
+    const npsBuilder = createNpsBuilder({
+      selectResult: {
+        data: {
+          quarter_start: currentQuarter.startDate,
+          quarter_end: currentQuarter.endDate,
+          submitted_at: '2025-02-10T00:00:00Z',
+          score: 7,
+        },
+        error: null,
+      },
+    })
+    const supabase = createSurveySupabaseStub({ nps: npsBuilder })
+
+    const result = await hasSubmittedNpsThisQuarter(supabase as any, 'tenant-1', now)
+    expect(result).toBe(true)
+  })
+
+  it('returns false when the last response was in a previous quarter', async () => {
+    const now = new Date('2025-02-20T00:00:00Z')
+    const npsBuilder = createNpsBuilder({
+      selectResult: {
+        data: {
+          quarter_start: '2024-10-01',
+          quarter_end: '2024-12-31',
+          submitted_at: '2024-12-15T00:00:00Z',
+          score: 6,
+        },
+        error: null,
+      },
+    })
+    const supabase = createSurveySupabaseStub({ nps: npsBuilder })
+
+    const result = await hasSubmittedNpsThisQuarter(supabase as any, 'tenant-2', now)
+    expect(result).toBe(false)
+  })
+})
+
+describe('recordNpsResponse', () => {
+  it('persists the score and trims optional feedback', async () => {
+    const quarter = {
+      year: 2025,
+      quarter: 1,
+      startDate: '2025-01-01',
+      endDate: '2025-03-31',
+    }
+    const npsBuilder = createNpsBuilder({ insertError: null })
+    const supabase = createSurveySupabaseStub({ nps: npsBuilder })
+
+    await recordNpsResponse({
+      client: supabase as any,
+      userId: 'user-3',
+      score: 10,
+      feedback: '  love the portal  ',
+      metadata: { source: 'dashboard_prompt' },
+      quarter,
+    })
+
+    expect(npsBuilder.insert).toHaveBeenCalledWith({
+      user_id: 'user-3',
+      score: 10,
+      feedback: 'love the portal',
+      quarter_start: quarter.startDate,
+      quarter_end: quarter.endDate,
+      metadata: { source: 'dashboard_prompt' },
+    })
+  })
+
+  it('throws when the score is outside the allowed range', async () => {
+    const npsBuilder = createNpsBuilder({ insertError: null })
+    const supabase = createSurveySupabaseStub({ nps: npsBuilder })
+
+    await expect(
+      recordNpsResponse({ client: supabase as any, userId: 'user-4', score: 15 })
+    ).rejects.toThrow(/between 0 and 10/)
+    expect(npsBuilder.insert).not.toHaveBeenCalled()
+  })
+
+  it('throws when Supabase rejects the insert', async () => {
+    const npsBuilder = createNpsBuilder({ insertError: { message: 'constraint violation' } })
+    const supabase = createSurveySupabaseStub({ nps: npsBuilder })
+
+    await expect(
+      recordNpsResponse({ client: supabase as any, userId: 'user-5', score: 8 })
+    ).rejects.toThrow(/Failed to record NPS response: constraint violation/)
+  })
+})
+
+describe('recordCsatResponse', () => {
+  it('stores a CSAT response with optional comments', async () => {
+    const csatBuilder = createCsatBuilder()
+    const supabase = createSurveySupabaseStub({ csat: csatBuilder })
+
+    await recordCsatResponse({
+      client: supabase as any,
+      userId: 'user-6',
+      flow: 'maintenance_request',
+      contextIdentifier: 'maintenance_request:req-1',
+      score: 4,
+      comment: '  quick and easy ',
+      metadata: { source: 'maintenance_form' },
+    })
+
+    expect(csatBuilder.insert).toHaveBeenCalledWith({
+      user_id: 'user-6',
+      flow: 'maintenance_request',
+      context_identifier: 'maintenance_request:req-1',
+      score: 4,
+      comment: 'quick and easy',
+      metadata: { source: 'maintenance_form' },
+    })
+  })
+
+  it('throws on invalid scores', async () => {
+    const csatBuilder = createCsatBuilder()
+    const supabase = createSurveySupabaseStub({ csat: csatBuilder })
+
+    await expect(
+      recordCsatResponse({
+        client: supabase as any,
+        userId: 'user-7',
+        flow: 'maintenance_request',
+        contextIdentifier: 'maintenance_request:req-2',
+        score: 0,
+      })
+    ).rejects.toThrow(/between 1 and 5/)
+    expect(csatBuilder.insert).not.toHaveBeenCalled()
+  })
+
+  it('throws when the context identifier is missing', async () => {
+    const csatBuilder = createCsatBuilder()
+    const supabase = createSurveySupabaseStub({ csat: csatBuilder })
+
+    await expect(
+      recordCsatResponse({
+        client: supabase as any,
+        userId: 'user-8',
+        flow: 'maintenance_request',
+        contextIdentifier: '  ',
+        score: 3,
+      })
+    ).rejects.toThrow(/context identifier is required/)
+    expect(csatBuilder.insert).not.toHaveBeenCalled()
+  })
+
+  it('throws when Supabase reports an error', async () => {
+    const csatBuilder = createCsatBuilder({ message: 'duplicate key value' })
+    const supabase = createSurveySupabaseStub({ csat: csatBuilder })
+
+    await expect(
+      recordCsatResponse({
+        client: supabase as any,
+        userId: 'user-9',
+        flow: 'maintenance_request',
+        contextIdentifier: 'maintenance_request:req-3',
+        score: 5,
+      })
+    ).rejects.toThrow(/Failed to record CSAT response: duplicate key value/)
+  })
+})

--- a/tests/lib/surveys.test.ts
+++ b/tests/lib/surveys.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildMaintenanceCsatContext,
+  CSAT_FLOW_MAINTENANCE,
+  formatQuarterLabel,
+  getQuarterWindow,
+  shouldTriggerQuarterlyNps,
+} from '@/lib/surveys'
+
+describe('getQuarterWindow', () => {
+  it('derives the correct window for each quarter', () => {
+    const q1 = getQuarterWindow(new Date('2025-02-10T10:00:00Z'))
+    expect(q1).toEqual({
+      year: 2025,
+      quarter: 1,
+      startDate: '2025-01-01',
+      endDate: '2025-03-31',
+    })
+
+    const q2 = getQuarterWindow(new Date('2025-05-03T05:00:00Z'))
+    expect(q2).toEqual({
+      year: 2025,
+      quarter: 2,
+      startDate: '2025-04-01',
+      endDate: '2025-06-30',
+    })
+
+    const q3 = getQuarterWindow(new Date('2025-08-21T23:00:00Z'))
+    expect(q3).toEqual({
+      year: 2025,
+      quarter: 3,
+      startDate: '2025-07-01',
+      endDate: '2025-09-30',
+    })
+
+    const q4 = getQuarterWindow(new Date('2025-11-05T00:00:00Z'))
+    expect(q4).toEqual({
+      year: 2025,
+      quarter: 4,
+      startDate: '2025-10-01',
+      endDate: '2025-12-31',
+    })
+  })
+})
+
+describe('shouldTriggerQuarterlyNps', () => {
+  it('requests feedback when no prior response exists', () => {
+    expect(shouldTriggerQuarterlyNps(null, new Date('2025-02-01T00:00:00Z'))).toBe(true)
+  })
+
+  it('skips prompting when a response exists for the current quarter', () => {
+    expect(
+      shouldTriggerQuarterlyNps('2025-01-01', new Date('2025-02-15T00:00:00Z'))
+    ).toBe(false)
+  })
+
+  it('re-prompts when the previous quarter is complete', () => {
+    expect(
+      shouldTriggerQuarterlyNps('2024-10-01', new Date('2025-02-15T00:00:00Z'))
+    ).toBe(true)
+  })
+})
+
+describe('formatQuarterLabel', () => {
+  it('produces human readable quarter labels', () => {
+    const label = formatQuarterLabel({
+      year: 2025,
+      quarter: 1,
+      startDate: '2025-01-01',
+      endDate: '2025-03-31',
+    })
+
+    expect(label).toBe('Q1 2025')
+  })
+})
+
+describe('buildMaintenanceCsatContext', () => {
+  it('namespaces maintenance feedback to avoid collisions', () => {
+    expect(buildMaintenanceCsatContext('request-123')).toBe(
+      `${CSAT_FLOW_MAINTENANCE}:request-123`
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add Supabase schema objects and type definitions for quarterly NPS and inline CSAT survey storage
- surface a quarterly NPS prompt after login with scheduling utilities, server gate, and a tracked client experience
- show a lightweight CSAT dialog after maintenance submissions plus supporting data helpers and tests for survey flows

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d2ed6565b88328afa3d41f323f6e6c