### PR TITLE
Add quarterly NPS survey and CSAT feedback instrumentation

### DIFF
--- a/app/dashboard/(dashboard)/components/nps-survey-card.tsx
+++ b/app/dashboard/(dashboard)/components/nps-survey-card.tsx
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+import { getQuarterDateRange, getQuarterInfo, isNpsSurveyDue } from "@/lib/surveys"
+import { readUserSession } from "@/utils/actions"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+
+import { NpsSurveyForm } from "./nps-survey-form"
+
+export default async function NpsSurveyCard() {
+  const [{ data: sessionData }, supabaseClient] = await Promise.all([
+    readUserSession(),
+    createSupbaseServerClientReadOnly(),
+  ])
+
+  const userId = sessionData.session?.user.id
+  if (!userId) {
+    return null
+  }
+
+  const supabase = supabaseClient as SupabaseClient<Database>
+
+  const { data: responses, error } = await supabase
+    .from('nps_responses')
+    .select('survey_period')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  if (error) {
+    console.error('Unable to load NPS responses', error)
+    return null
+  }
+
+  const latestPeriod = responses?.[0]?.survey_period ?? null
+  if (!isNpsSurveyDue(latestPeriod)) {
+    return null
+  }
+
+  const quarterInfo = getQuarterInfo()
+  const range = getQuarterDateRange()
+
+  return (
+    <NpsSurveyForm
+      period={quarterInfo.period}
+      periodLabel={quarterInfo.label}
+      window={range}
+    />
+  )
+}

--- a/app/dashboard/(dashboard)/components/nps-survey-form.tsx
+++ b/app/dashboard/(dashboard)/components/nps-survey-form.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { useEffect, useMemo, useState, useTransition } from "react"
+import { track } from "@vercel/analytics/react"
+
+import { submitNpsResponse } from "@/app/feedback/actions"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+
+const SCORES = Array.from({ length: 11 }, (_, index) => index)
+
+type NpsSurveyFormProps = {
+  period: string
+  periodLabel: string
+  window: {
+    start: string
+    end: string
+  }
+}
+
+export function NpsSurveyForm({ period, periodLabel, window }: NpsSurveyFormProps) {
+  const [selectedScore, setSelectedScore] = useState<number | null>(null)
+  const [comment, setComment] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const { toast } = useToast()
+
+  useEffect(() => {
+    track('nps_survey_shown', { period })
+  }, [period])
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+      }),
+    [],
+  )
+
+  if (dismissed) {
+    return null
+  }
+
+  const formattedWindow = `${dateFormatter.format(new Date(window.start))} – ${dateFormatter.format(new Date(window.end))}`
+
+  const handleScoreSelect = (score: number) => {
+    setSelectedScore(score)
+    setError(null)
+    track('nps_score_selected', { period, score })
+  }
+
+  const handleSubmit = () => {
+    if (selectedScore === null) {
+      setError('Please choose a score to continue.')
+      return
+    }
+
+    startTransition(async () => {
+      const result = await submitNpsResponse({
+        score: selectedScore,
+        comment: comment.trim() ? comment.trim() : undefined,
+      })
+
+      if (result?.error) {
+        setError(result.error)
+        track('nps_submission_failed', { period, score: selectedScore })
+        return
+      }
+
+      setSubmitted(true)
+      track('nps_submission_completed', {
+        period,
+        score: selectedScore,
+        commentLength: comment.trim().length,
+      })
+      toast({
+        title: 'Thanks for the feedback! 💛',
+        description: 'We share every response with the product team.',
+      })
+    })
+  }
+
+  const handleDismiss = (reason: 'skip' | 'complete') => {
+    if (reason === 'skip') {
+      track('nps_survey_dismissed', { period, reason })
+    }
+
+    setDismissed(true)
+  }
+
+  return (
+    <Card className="border-primary/40 bg-primary/5">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle>Quarterly check-in</CardTitle>
+            <CardDescription>
+              How likely are you to recommend Share House Portal to a friend? This survey resets each
+              quarter ({periodLabel}, {formattedWindow}).
+            </CardDescription>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={isPending}
+            onClick={() => handleDismiss('skip')}
+          >
+            Maybe later
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          {SCORES.map((score) => (
+            <Button
+              key={score}
+              type="button"
+              variant={selectedScore === score ? 'default' : 'outline'}
+              size="sm"
+              disabled={isPending || submitted}
+              onClick={() => handleScoreSelect(score)}
+              className={cn(
+                'size-10 rounded-full border-2 font-semibold transition-colors',
+                score <= 6 && 'border-destructive/50 text-destructive hover:bg-destructive/90 hover:text-destructive-foreground',
+                score >= 9 && 'border-emerald-500 text-emerald-600 hover:bg-emerald-500 hover:text-white',
+              )}
+              aria-label={`Score ${score}`}
+            >
+              {score}
+            </Button>
+          ))}
+        </div>
+        <Textarea
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          placeholder="Optional: What’s the biggest reason for your score?"
+          disabled={isPending || submitted}
+        />
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      </CardContent>
+      <CardFooter className="flex items-center justify-between gap-4">
+        {submitted ? (
+          <>
+            <p className="text-sm text-muted-foreground">We appreciate you taking the time to help us improve.</p>
+            <Button type="button" onClick={() => handleDismiss('complete')}>
+              Close
+            </Button>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">0 = Not at all likely, 10 = Extremely likely</p>
+            <Button type="button" onClick={handleSubmit} disabled={isPending}>
+              Submit
+            </Button>
+          </>
+        )}
+      </CardFooter>
+    </Card>
+  )
+}

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -16,10 +16,14 @@ import {
 } from "./components/skeletons"
 
 import InsightsPanel from "./components/insights-panel"
+import NpsSurveyCard from "./components/nps-survey-card"
 
 export default function DashboardPage() {
   return (
     <div className="space-y-8">
+      <Suspense fallback={null}>
+        <NpsSurveyCard />
+      </Suspense>
       <Suspense fallback={<DashboardHeaderSkeleton />}>
         <DashboardWelcome />
       </Suspense>

--- a/app/feedback/actions.ts
+++ b/app/feedback/actions.ts
@@ -1,0 +1,107 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { z } from "zod"
+
+import { getCurrentNpsPeriod } from "@/lib/surveys"
+import { createSupbaseServerClient } from "@/utils/supaone"
+import { readUserSession } from "@/utils/actions"
+
+const npsResponseSchema = z.object({
+  score: z.number().int().min(0).max(10),
+  comment: z
+    .string()
+    .trim()
+    .max(1000, "Comment is too long")
+    .optional(),
+})
+
+export type SubmitNpsResponseInput = z.infer<typeof npsResponseSchema>
+
+export async function submitNpsResponse(input: SubmitNpsResponseInput) {
+  const parsed = npsResponseSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      error: parsed.error.flatten().formErrors.join(" ") || "Invalid feedback",
+    }
+  }
+
+  const [{ data: sessionData }, supabase] = await Promise.all([
+    readUserSession(),
+    createSupbaseServerClient(),
+  ])
+
+  const userId = sessionData.session?.user.id
+  if (!userId) {
+    return { error: "You need to be signed in to share feedback." }
+  }
+
+  const surveyPeriod = getCurrentNpsPeriod()
+  const payload = {
+    user_id: userId,
+    score: parsed.data.score,
+    comment: parsed.data.comment ?? null,
+    survey_period: surveyPeriod,
+  }
+
+  const { error } = await supabase
+    .from('nps_responses')
+    .upsert(payload, { onConflict: 'user_id,survey_period' })
+
+  if (error) {
+    console.error('Failed to persist NPS response', error)
+    return { error: "We couldn't save your feedback. Please try again." }
+  }
+
+  revalidatePath("/dashboard")
+
+  return {
+    success: true as const,
+    surveyPeriod,
+  }
+}
+
+const csatResponseSchema = z.object({
+  flow: z.string().min(1, "Flow is required"),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().max(1000).optional(),
+})
+
+export type RecordCsatResponseInput = z.infer<typeof csatResponseSchema>
+
+export async function recordCsatResponse(input: RecordCsatResponseInput) {
+  const parsed = csatResponseSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      error: parsed.error.flatten().formErrors.join(" ") || "Invalid response",
+    }
+  }
+
+  const [{ data: sessionData }, supabase] = await Promise.all([
+    readUserSession(),
+    createSupbaseServerClient(),
+  ])
+
+  const userId = sessionData.session?.user.id ?? null
+
+  const { data, error } = await supabase
+    .from('csat_responses')
+    .insert({
+      user_id: userId,
+      flow: parsed.data.flow,
+      rating: parsed.data.rating,
+      comment: parsed.data.comment ?? null,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    console.error('Failed to persist CSAT response', error)
+    return { error: "We couldn't save your response. Please try again." }
+  }
+
+  return {
+    success: true as const,
+    responseId: data.id,
+  }
+}

--- a/components/feedback/csat-prompt.tsx
+++ b/components/feedback/csat-prompt.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { track } from "@vercel/analytics/react"
+
+import { recordCsatResponse } from "@/app/feedback/actions"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/components/ui/use-toast"
+
+const RATINGS = [
+  { value: 1, label: "1" },
+  { value: 2, label: "2" },
+  { value: 3, label: "3" },
+  { value: 4, label: "4" },
+  { value: 5, label: "5" },
+] as const
+
+type CsatPromptProps = {
+  flow: string
+  onDismiss?: () => void
+}
+
+export function CsatPrompt({ flow, onDismiss }: CsatPromptProps) {
+  const [rating, setRating] = useState<number | null>(null)
+  const [comment, setComment] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [showComment, setShowComment] = useState(false)
+  const { toast } = useToast()
+
+  useEffect(() => {
+    track('csat_prompt_viewed', { flow })
+  }, [flow])
+
+  const handleDismiss = (reason: 'skip' | 'complete') => {
+    if (reason === 'skip') {
+      track('csat_prompt_skipped', { flow })
+    }
+
+    onDismiss?.()
+  }
+
+  const handleSubmit = async () => {
+    if (!rating) {
+      return
+    }
+
+    setIsSubmitting(true)
+    const trimmedComment = comment.trim()
+
+    try {
+      const result = await recordCsatResponse({
+        flow,
+        rating,
+        comment: trimmedComment ? trimmedComment : undefined,
+      })
+
+      if (result?.error) {
+        toast({
+          title: "We couldn't save that",
+          description: result.error,
+          variant: "destructive",
+        })
+        return
+      }
+
+      setSubmitted(true)
+      track('csat_response_submitted', {
+        flow,
+        rating,
+        commentLength: trimmedComment.length,
+      })
+      toast({
+        title: "Thanks for the quick rating!",
+        description: "We read every response to keep the experience smooth.",
+      })
+    } catch (error) {
+      console.error('Failed to submit CSAT response', error)
+      toast({
+        title: "Submission failed",
+        description: "Please try again in a moment.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Card className="border-muted bg-muted/20">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle>How did that go?</CardTitle>
+            <CardDescription>Rate this experience on a five-point scale.</CardDescription>
+          </div>
+          <Button type="button" variant="ghost" size="sm" onClick={() => handleDismiss('skip')}>
+            Skip
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          {RATINGS.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              variant={rating === option.value ? 'default' : 'outline'}
+              size="sm"
+              disabled={isSubmitting || submitted}
+              onClick={() => {
+                setRating(option.value)
+                track('csat_rating_selected', { flow, rating: option.value })
+              }}
+              aria-label={`Rate ${option.value} out of 5`}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground">1 = Very dissatisfied · 5 = Very satisfied</p>
+          {!showComment && !submitted ? (
+            <Button type="button" variant="ghost" size="sm" onClick={() => setShowComment(true)}>
+              Add comment
+            </Button>
+          ) : null}
+        </div>
+        {showComment || comment ? (
+          <Textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            placeholder="Optional: what could we improve?"
+            disabled={isSubmitting || submitted}
+          />
+        ) : null}
+      </CardContent>
+      <CardFooter className="flex items-center justify-end gap-2">
+        {submitted ? (
+          <Button type="button" onClick={() => handleDismiss('complete')}>
+            Close
+          </Button>
+        ) : (
+          <Button type="button" onClick={handleSubmit} disabled={!rating || isSubmitting}>
+            Share feedback
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  )
+}

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -10,6 +10,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { CsatPrompt } from "@/components/feedback/csat-prompt";
 import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
@@ -47,6 +48,7 @@ const priorities = [
 
 export function MaintenanceRequestForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showCsatPrompt, setShowCsatPrompt] = useState(false);
   const { notifyMaintenanceRequest } = useNotifications();
   const { toast } = useToast();
   const supabase = createClient();
@@ -125,6 +127,7 @@ export function MaintenanceRequestForm() {
       });
 
       form.reset();
+      setShowCsatPrompt(true);
     } catch (error) {
       console.error('Error submitting maintenance request:', error);
       toast({
@@ -138,11 +141,12 @@ export function MaintenanceRequestForm() {
   };
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <FormField
-          control={form.control}
-          name="title"
+    <div className="space-y-6">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="title"
           render={({ field }) => (
             <FormItem>
               <FormLabel>Issue Title *</FormLabel>
@@ -241,7 +245,11 @@ export function MaintenanceRequestForm() {
         <Button type="submit" disabled={isSubmitting} className="w-full">
           {isSubmitting ? "Submitting..." : "Submit Maintenance Request"}
         </Button>
-      </form>
-    </Form>
+        </form>
+      </Form>
+      {showCsatPrompt ? (
+        <CsatPrompt flow="maintenance_request" onDismiss={() => setShowCsatPrompt(false)} />
+      ) : null}
+    </div>
   );
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -197,6 +197,24 @@ export type Database = {
         attachments: Json | null
         metadata: Json | null
       }>
+      nps_responses: SupabaseTable<{
+        id: string
+        user_id: string
+        score: number
+        comment: string | null
+        survey_period: string
+        metadata: Json | null
+        created_at: string | null
+      }>
+      csat_responses: SupabaseTable<{
+        id: string
+        user_id: string | null
+        flow: string
+        rating: number
+        comment: string | null
+        metadata: Json | null
+        created_at: string | null
+      }>
       visitor_logs: SupabaseTable<{
         id: string
         guest_name: string

--- a/lib/surveys.ts
+++ b/lib/surveys.ts
@@ -1,0 +1,82 @@
+export type QuarterInfo = {
+  period: string
+  label: string
+  start: Date
+  end: Date
+}
+
+const QUARTER_LABELS = [
+  'Q1',
+  'Q2',
+  'Q3',
+  'Q4',
+] as const
+
+type QuarterTuple = [year: number, quarter: number]
+
+function getQuarterTuple(date: Date): QuarterTuple {
+  const year = date.getUTCFullYear()
+  const quarter = Math.floor(date.getUTCMonth() / 3) + 1
+  return [year, quarter]
+}
+
+export function getQuarterInfo(date: Date = new Date()): QuarterInfo {
+  const [year, quarter] = getQuarterTuple(date)
+  const startMonth = (quarter - 1) * 3
+  const start = new Date(Date.UTC(year, startMonth, 1))
+  const end = new Date(Date.UTC(year, startMonth + 3, 0, 23, 59, 59, 999))
+
+  return {
+    period: `${year}-Q${quarter}`,
+    label: `${QUARTER_LABELS[quarter - 1]} ${year}`,
+    start,
+    end,
+  }
+}
+
+export function getCurrentNpsPeriod(date: Date = new Date()): string {
+  return getQuarterInfo(date).period
+}
+
+export function getQuarterDateRange(date: Date = new Date()): {
+  start: string
+  end: string
+} {
+  const info = getQuarterInfo(date)
+  return {
+    start: info.start.toISOString(),
+    end: info.end.toISOString(),
+  }
+}
+
+export function parseSurveyPeriod(period: string): QuarterTuple {
+  const match = period.match(/^(\d{4})-Q([1-4])$/)
+  if (!match) {
+    throw new Error(`Invalid survey period: ${period}`)
+  }
+
+  return [Number.parseInt(match[1], 10), Number.parseInt(match[2], 10)]
+}
+
+export function compareSurveyPeriods(a: string, b: string): number {
+  const [aYear, aQuarter] = parseSurveyPeriod(a)
+  const [bYear, bQuarter] = parseSurveyPeriod(b)
+
+  if (aYear !== bYear) {
+    return aYear - bYear
+  }
+
+  return aQuarter - bQuarter
+}
+
+export function isNpsSurveyDue(
+  lastCompletedPeriod: string | null,
+  date: Date = new Date(),
+): boolean {
+  if (!lastCompletedPeriod) {
+    return true
+  }
+
+  const currentPeriod = getCurrentNpsPeriod(date)
+  return compareSurveyPeriods(lastCompletedPeriod, currentPeriod) < 0
+}

--- a/supabase/migrations/20250315_nps_csat_feedback.sql
+++ b/supabase/migrations/20250315_nps_csat_feedback.sql
@@ -1,0 +1,31 @@
+-- Create tables for NPS and CSAT feedback collection
+CREATE TABLE IF NOT EXISTS public.nps_responses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  score INTEGER NOT NULL CHECK (score BETWEEN 0 AND 10),
+  comment TEXT,
+  survey_period TEXT NOT NULL,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS nps_responses_user_period_idx
+  ON public.nps_responses (user_id, survey_period);
+
+COMMENT ON TABLE public.nps_responses IS 'Quarterly Net Promoter Score responses keyed by survey period.';
+COMMENT ON COLUMN public.nps_responses.survey_period IS 'Format: YYYY-Q#, e.g. 2025-Q1';
+
+CREATE TABLE IF NOT EXISTS public.csat_responses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  flow TEXT NOT NULL,
+  rating INTEGER NOT NULL CHECK (rating BETWEEN 1 AND 5),
+  comment TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS csat_responses_flow_idx
+  ON public.csat_responses (flow, created_at DESC);
+
+COMMENT ON TABLE public.csat_responses IS 'Lightweight post-flow CSAT responses (1-5 scale).';

--- a/tests/surveys.test.ts
+++ b/tests/surveys.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  createClientMock,
+  readUserSessionMock,
+  revalidatePathMock,
+  upsertMock,
+  insertMock,
+} = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  readUserSessionMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+  upsertMock: vi.fn(),
+  insertMock: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}))
+
+vi.mock('@/utils/actions', () => ({
+  readUserSession: readUserSessionMock,
+}))
+
+vi.mock('@/utils/supaone', () => ({
+  createSupbaseServerClient: createClientMock,
+}))
+
+import { recordCsatResponse, submitNpsResponse } from '@/app/feedback/actions'
+import {
+  compareSurveyPeriods,
+  getCurrentNpsPeriod,
+  getQuarterInfo,
+  isNpsSurveyDue,
+} from '@/lib/surveys'
+
+describe('survey scheduling helpers', () => {
+  it('computes quarter metadata deterministically', () => {
+    const info = getQuarterInfo(new Date('2025-05-10T12:00:00Z'))
+    expect(info.period).toBe('2025-Q2')
+    expect(info.label).toBe('Q2 2025')
+    expect(info.start.toISOString()).toBe('2025-04-01T00:00:00.000Z')
+    expect(info.end.toISOString()).toBe('2025-06-30T23:59:59.999Z')
+  })
+
+  it('identifies when a new quarterly NPS survey is due', () => {
+    expect(isNpsSurveyDue(null, new Date('2025-01-15T00:00:00Z'))).toBe(true)
+    expect(isNpsSurveyDue('2025-Q1', new Date('2025-02-10T00:00:00Z'))).toBe(false)
+    expect(isNpsSurveyDue('2024-Q4', new Date('2025-02-10T00:00:00Z'))).toBe(true)
+  })
+
+  it('compares survey periods chronologically', () => {
+    expect(compareSurveyPeriods('2024-Q4', '2025-Q1')).toBeLessThan(0)
+    expect(compareSurveyPeriods('2025-Q2', '2025-Q1')).toBeGreaterThan(0)
+    expect(compareSurveyPeriods('2025-Q3', '2025-Q3')).toBe(0)
+  })
+
+  it('derives the current period from the provided date', () => {
+    expect(getCurrentNpsPeriod(new Date('2025-11-01T00:00:00Z'))).toBe('2025-Q4')
+  })
+})
+
+describe('survey actions', () => {
+  let csatSingleMock: ReturnType<typeof vi.fn>
+  let csatSelectMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    upsertMock.mockResolvedValue({ data: null, error: null })
+    csatSingleMock = vi.fn(async () => ({ data: { id: 'csat-1' }, error: null }))
+    csatSelectMock = vi.fn(() => ({ single: csatSingleMock }))
+    insertMock.mockReturnValue({ select: csatSelectMock })
+
+    createClientMock.mockResolvedValue({
+      from: (table: string) => {
+        if (table === 'nps_responses') {
+          return { upsert: upsertMock }
+        }
+        if (table === 'csat_responses') {
+          return { insert: insertMock }
+        }
+        throw new Error(`Unexpected table access: ${table}`)
+      },
+    })
+
+    readUserSessionMock.mockResolvedValue({
+      data: { session: { user: { id: 'user-123' } } },
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('persists NPS responses and revalidates the dashboard view', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-02-10T12:00:00Z'))
+
+    const result = await submitNpsResponse({ score: 9, comment: 'Love the new updates' })
+
+    expect(result).toEqual({ success: true, surveyPeriod: '2025-Q1' })
+    expect(upsertMock).toHaveBeenCalledWith(
+      {
+        user_id: 'user-123',
+        score: 9,
+        comment: 'Love the new updates',
+        survey_period: '2025-Q1',
+      },
+      { onConflict: 'user_id,survey_period' },
+    )
+    expect(revalidatePathMock).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('records CSAT responses with optional comments', async () => {
+    const result = await recordCsatResponse({
+      flow: 'maintenance_request',
+      rating: 5,
+      comment: 'Super fast turnaround!',
+    })
+
+    expect(result).toEqual({ success: true, responseId: 'csat-1' })
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: 'user-123',
+      flow: 'maintenance_request',
+      rating: 5,
+      comment: 'Super fast turnaround!',
+    })
+    expect(csatSelectMock).toHaveBeenCalledWith('id')
+    expect(csatSingleMock).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add Supabase schema for storing quarterly NPS results and CSAT flow ratings
- surface an after-login NPS card with analytics + server actions for recording responses
- show lightweight CSAT prompt after maintenance submission and cover flows with unit tests

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b86241c83288a2057e0825c9cdb