### PR TITLE
Add referral program schema, APIs, UI, and tests

### DIFF
--- a/app/api/referrals/accept/route.ts
+++ b/app/api/referrals/accept/route.ts
@@ -1,0 +1,105 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { z } from "zod"
+
+import {
+  SupabaseReferralRepository,
+  mapSignupToReferrer,
+} from "@/lib/referrals"
+import type { Database } from "@/lib/supabase"
+import { createClient } from "@/utils/supa-server-actions"
+import { getServiceRoleSupabaseClient } from "@/utils/supabase-service-role"
+
+const acceptRequestSchema = z.object({
+  token: z.string().min(16, { message: "Invalid referral token" }),
+})
+
+export async function POST(request: Request) {
+  let payload: unknown
+
+  try {
+    payload = await request.json()
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 })
+  }
+
+  const parsed = acceptRequestSchema.safeParse(payload)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Unable to accept invitation",
+        details: parsed.error.flatten(),
+      },
+      { status: 400 }
+    )
+  }
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore) as SupabaseClient<Database>
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const serviceClient = getServiceRoleSupabaseClient()
+
+  if (!serviceClient) {
+    return NextResponse.json(
+      { error: "Referral service is not available" },
+      { status: 500 }
+    )
+  }
+
+  const repository = new SupabaseReferralRepository(serviceClient)
+  const { token } = parsed.data
+
+  try {
+    const rawRewardAmount = process.env.REFERRAL_REWARD_AMOUNT
+    const rewardAmount =
+      rawRewardAmount !== undefined && rawRewardAmount !== null
+        ? Number.parseFloat(rawRewardAmount)
+        : 50
+
+    const { invitation, reward } = await mapSignupToReferrer({
+      repository,
+      inviteToken: token,
+      inviteeId: user.id,
+      inviteeEmail: user.email ?? undefined,
+      rewardAmount: Number.isFinite(rewardAmount) ? rewardAmount : 50,
+      currency: process.env.REFERRAL_REWARD_CURRENCY ?? "USD",
+      description: `Referral reward for ${user.email ?? "new roommate"}`,
+    })
+
+    if (invitation.household_id) {
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("unit_id")
+        .eq("id", user.id)
+        .maybeSingle()
+
+      if (!profile?.unit_id) {
+        await serviceClient
+          .from("profiles")
+          .update({ unit_id: invitation.household_id })
+          .eq("id", user.id)
+      }
+    }
+
+    return NextResponse.json({ invitation, reward })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to accept referral invitation"
+
+    const status = message.includes("not found") || message.includes("expired") ? 400 : 500
+
+    console.error("Failed to accept referral invitation", error)
+
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/referrals/invitations/route.ts
+++ b/app/api/referrals/invitations/route.ts
@@ -1,0 +1,125 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { z } from "zod"
+import { Resend } from "resend"
+
+import { ReferralInviteEmail } from "@/components/emails/referral-invite"
+import {
+  SupabaseReferralRepository,
+  createReferralInvitationFlow,
+  resolveReferralBaseUrl,
+} from "@/lib/referrals"
+import type { Database } from "@/lib/supabase"
+import { createClient } from "@/utils/supa-server-actions"
+
+const inviteRequestSchema = z.object({
+  email: z.string().email({ message: "Please provide a valid email address." }),
+  name: z
+    .string()
+    .trim()
+    .min(1, { message: "Name cannot be empty" })
+    .max(120, { message: "Name is too long" })
+    .optional(),
+})
+
+export async function POST(request: Request) {
+  let payload: unknown
+
+  try {
+    payload = await request.json()
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 })
+  }
+
+  const parsed = inviteRequestSchema.safeParse(payload)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Unable to send invite",
+        details: parsed.error.flatten(),
+      },
+      { status: 400 }
+    )
+  }
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore) as SupabaseClient<Database>
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { email, name } = parsed.data
+
+  try {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("full_name, unit_id")
+      .eq("id", user.id)
+      .maybeSingle()
+
+    const repository = new SupabaseReferralRepository(supabase)
+    const now = new Date()
+    const baseUrl = resolveReferralBaseUrl()
+
+    const { invitation, inviteLink } = await createReferralInvitationFlow({
+      repository,
+      inviterId: user.id,
+      inviteeEmail: email,
+      inviteeName: name,
+      householdId: profile?.unit_id ?? null,
+      baseUrl,
+      now,
+      metadata: {
+        inviter_name: profile?.full_name ?? null,
+        created_via: "email_invite",
+      },
+    })
+
+    const resendApiKey = process.env.RESEND_API_KEY
+
+    if (!resendApiKey) {
+      return NextResponse.json(
+        { error: "Email service is not configured" },
+        { status: 500 }
+      )
+    }
+
+    const resend = new Resend(resendApiKey)
+    const fromAddress =
+      process.env.REFERRAL_EMAIL_FROM ?? "Roomsily Referrals <invitations@roomsily.com>"
+
+    const rawRewardAmount = process.env.REFERRAL_REWARD_AMOUNT
+    const rewardAmount =
+      rawRewardAmount !== undefined && rawRewardAmount !== null
+        ? Number.parseFloat(rawRewardAmount)
+        : undefined
+
+    await resend.emails.send({
+      from: fromAddress,
+      to: [email],
+      subject: `${profile?.full_name ?? "A roommate"} invited you to Roomsily`,
+      react: ReferralInviteEmail({
+        inviterName: profile?.full_name ?? null,
+        inviteLink,
+        householdName: profile?.unit_id ? "your shared home" : null,
+        rewardAmount: Number.isFinite(rewardAmount) ? rewardAmount : undefined,
+        currency: process.env.REFERRAL_REWARD_CURRENCY ?? "USD",
+      }),
+    })
+
+    return NextResponse.json({ invitation, inviteLink })
+  } catch (error) {
+    console.error("Failed to send referral invite", error)
+    return NextResponse.json(
+      { error: "Failed to send referral invite" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/dashboard/components/NavLinks.tsx
+++ b/app/dashboard/components/NavLinks.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { PersonIcon, CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { Gift } from "lucide-react";
 import SmartLink from "@/components/navigation/SmartLink";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
@@ -38,20 +39,22 @@ export default function NavLinks() {
 
 	const isLandlord = role === 'property_manager' || role === 'admin' || role === 'landlord';
 
-	const links = isLandlord
-		? [
-			{ href: "/dashboard/members", text: "Members", Icon: PersonIcon },
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-		]
-		: [
-			{ href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
-			{ href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
-			{ href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
-			{ href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
-			{ href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
-		];
+        const links = isLandlord
+                ? [
+                        { href: "/dashboard/members", text: "Members", Icon: PersonIcon },
+                        { href: "/dashboard/referrals", text: "Referrals", Icon: Gift },
+                        { href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
+                        { href: "/documents", text: "Documents", Icon: CrumpledPaperIcon },
+                        { href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
+                ]
+                : [
+                        { href: "/dashboard/referrals", text: "Referrals", Icon: Gift },
+                        { href: "/payments", text: "Payments", Icon: CrumpledPaperIcon },
+                        { href: "/documents", text: "My Lease", Icon: CrumpledPaperIcon },
+                        { href: "/messaging", text: "Message Board", Icon: CrumpledPaperIcon },
+                        { href: "/chores", text: "Chores", Icon: CrumpledPaperIcon },
+                        { href: "/supplies", text: "Supplies", Icon: CrumpledPaperIcon },
+                ];
 
 	return (
 		<div className="space-y-5">

--- a/app/dashboard/referrals/components/copy-button.tsx
+++ b/app/dashboard/referrals/components/copy-button.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { Check, Copy } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { useToast } from "@/components/ui/use-toast"
+
+type CopyButtonProps = {
+  value: string
+}
+
+export function CopyButton({ value }: CopyButtonProps) {
+  const { toast } = useToast()
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+        throw new Error("Clipboard access is not available")
+      }
+
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      toast({ title: "Link copied", description: "Invite link copied to your clipboard." })
+      setTimeout(() => setCopied(false), 2000)
+    } catch (error) {
+      console.error("Failed to copy text", error)
+      toast({
+        title: "Unable to copy",
+        description: "Copy the link manually if clipboard access is blocked.",
+        variant: "destructive",
+      })
+    }
+  }, [toast, value])
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      onClick={handleCopy}
+      className="flex items-center gap-1"
+    >
+      {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+      <span>{copied ? "Copied" : "Copy link"}</span>
+    </Button>
+  )
+}

--- a/app/dashboard/referrals/components/invitations-table.tsx
+++ b/app/dashboard/referrals/components/invitations-table.tsx
@@ -1,0 +1,108 @@
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+import type { ReferralInvitation } from "@/lib/referrals"
+
+import { CopyButton } from "./copy-button"
+
+type InvitationWithLink = ReferralInvitation & { inviteLink: string }
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+})
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "—"
+  }
+
+  const parsed = new Date(value)
+
+  if (Number.isNaN(parsed.getTime())) {
+    return "—"
+  }
+
+  return dateFormatter.format(parsed)
+}
+
+function getStatusVariant(status: ReferralInvitation["status"]) {
+  switch (status) {
+    case "accepted":
+      return "complete" as const
+    case "expired":
+      return "destructive" as const
+    case "revoked":
+      return "outline" as const
+    default:
+      return "secondary" as const
+  }
+}
+
+const statusLabel: Record<ReferralInvitation["status"], string> = {
+  pending: "Pending",
+  accepted: "Accepted",
+  expired: "Expired",
+  revoked: "Revoked",
+}
+
+export function InvitationsTable({ invitations }: { invitations: InvitationWithLink[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Invite activity</CardTitle>
+        <CardDescription>Monitor every invite and copy the shareable link when needed.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {invitations.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            You haven&apos;t sent any invites yet. Send one above to generate your first referral link.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[600px] text-left text-sm">
+              <thead className="border-b">
+                <tr className="text-muted-foreground">
+                  <th className="py-3 pr-4 font-medium">Invitee</th>
+                  <th className="py-3 pr-4 font-medium">Status</th>
+                  <th className="py-3 pr-4 font-medium">Sent</th>
+                  <th className="py-3 pr-4 font-medium">Accepted</th>
+                  <th className="py-3 font-medium">Link</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {invitations.map((invitation) => (
+                  <tr key={invitation.id} className="align-top">
+                    <td className="py-3 pr-4">
+                      <div className="font-medium">{invitation.invitee_email}</div>
+                      {invitation.invitee_name ? (
+                        <div className="text-xs text-muted-foreground">
+                          {invitation.invitee_name}
+                        </div>
+                      ) : null}
+                    </td>
+                    <td className="py-3 pr-4">
+                      <Badge variant={getStatusVariant(invitation.status)}>
+                        {statusLabel[invitation.status]}
+                      </Badge>
+                    </td>
+                    <td className="py-3 pr-4 text-muted-foreground">
+                      {formatDate(invitation.sent_at ?? invitation.created_at)}
+                    </td>
+                    <td className="py-3 pr-4 text-muted-foreground">
+                      {formatDate(invitation.accepted_at)}
+                    </td>
+                    <td className="py-3">
+                      <CopyButton value={invitation.inviteLink} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/referrals/components/invite-email-form.tsx
+++ b/app/dashboard/referrals/components/invite-email-form.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { FormEvent, useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/components/ui/use-toast"
+
+import { CopyButton } from "./copy-button"
+
+type InviteEmailFormProps = {
+  inviterName?: string
+  latestPendingInviteLink?: string
+}
+
+export function InviteEmailForm({ inviterName, latestPendingInviteLink }: InviteEmailFormProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [email, setEmail] = useState("")
+  const [name, setName] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    setIsSubmitting(true)
+
+    try {
+      const response = await fetch("/api/referrals/invitations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: email.trim(),
+          name: name.trim() ? name.trim() : undefined,
+        }),
+      })
+
+      if (!response.ok) {
+        const result = await response.json().catch(() => ({}))
+        throw new Error(result?.error ?? "Failed to send referral invite")
+      }
+
+      await response.json()
+
+      toast({
+        title: "Invite sent",
+        description: `We emailed ${email.trim()} with your referral link.`,
+      })
+
+      setEmail("")
+      setName("")
+      router.refresh()
+    } catch (error) {
+      toast({
+        title: "Unable to send invite",
+        description: error instanceof Error ? error.message : "Please try again shortly.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Send a roommate invite</CardTitle>
+        <CardDescription>
+          {inviterName
+            ? `${inviterName}, send a quick email and we’ll generate a trackable link.`
+            : "Email a roommate-to-be and we'll generate a trackable link."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form
+          onSubmit={handleSubmit}
+          className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end"
+        >
+          <div className="sm:col-span-1">
+            <label htmlFor="invite-email" className="mb-2 block text-sm font-medium">
+              Invitee email
+            </label>
+            <Input
+              id="invite-email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="roommate@example.com"
+            />
+          </div>
+
+          <div className="sm:col-span-1">
+            <label htmlFor="invite-name" className="mb-2 block text-sm font-medium">
+              Invitee name <span className="text-muted-foreground">(optional)</span>
+            </label>
+            <Input
+              id="invite-name"
+              autoComplete="name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Jamie Roommate"
+            />
+          </div>
+
+          <div className="sm:col-span-1">
+            <Button
+              type="submit"
+              className="w-full sm:w-auto"
+              isLoading={isSubmitting}
+              disabled={!email.trim() || isSubmitting}
+            >
+              Send invite
+            </Button>
+          </div>
+        </form>
+
+        {latestPendingInviteLink ? (
+          <div className="rounded-lg border border-dashed border-primary/40 p-4">
+            <p className="text-sm font-medium">Latest shareable invite link</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Copy this link to drop in texts or group chats.
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <code className="max-w-full flex-1 truncate rounded-md bg-muted px-3 py-2 text-sm">
+                {latestPendingInviteLink}
+              </code>
+              <CopyButton value={latestPendingInviteLink} />
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Once you send an invite we&apos;ll generate a link you can share anywhere.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/referrals/components/referral-summary.tsx
+++ b/app/dashboard/referrals/components/referral-summary.tsx
@@ -1,0 +1,64 @@
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+type ReferralSummaryProps = {
+  totalInvites: number
+  acceptedInvites: number
+  pendingInvites: number
+  totalRewards: number
+  currency: string
+}
+
+const numberFormatter = new Intl.NumberFormat("en-US")
+
+function formatCurrency(amount: number, currency: string) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: amount % 1 === 0 ? 0 : 2,
+  }).format(amount)
+}
+
+export function ReferralSummary({
+  totalInvites,
+  acceptedInvites,
+  pendingInvites,
+  totalRewards,
+  currency,
+}: ReferralSummaryProps) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardHeader>
+          <CardDescription>Total invites</CardDescription>
+          <CardTitle className="text-3xl">
+            {numberFormatter.format(totalInvites)}
+          </CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardDescription>Accepted invites</CardDescription>
+          <CardTitle className="text-3xl">
+            {numberFormatter.format(acceptedInvites)}
+          </CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardDescription>Pending invites</CardDescription>
+          <CardTitle className="text-3xl">
+            {numberFormatter.format(pendingInvites)}
+          </CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardDescription>Total rewards</CardDescription>
+          <CardTitle className="text-3xl">
+            {formatCurrency(totalRewards, currency)}
+          </CardTitle>
+        </CardHeader>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/referrals/components/rewards-table.tsx
+++ b/app/dashboard/referrals/components/rewards-table.tsx
@@ -1,0 +1,128 @@
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+import type { ReferralInvitation, ReferralRewardEntry } from "@/lib/referrals"
+
+type InvitationLookup = Map<string, ReferralInvitation & { inviteLink: string }>
+
+type RewardsTableProps = {
+  rewards: ReferralRewardEntry[]
+  invitationLookup: InvitationLookup
+  currency: string
+}
+
+const rewardStatusLabels: Record<ReferralRewardEntry["status"], string> = {
+  pending: "Pending",
+  earned: "Earned",
+  paid: "Paid",
+  reversed: "Reversed",
+}
+
+function getRewardVariant(status: ReferralRewardEntry["status"]) {
+  switch (status) {
+    case "earned":
+    case "paid":
+      return "complete" as const
+    case "reversed":
+      return "destructive" as const
+    default:
+      return "secondary" as const
+  }
+}
+
+const postedFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+})
+
+function formatPostedDate(value: string | null) {
+  if (!value) {
+    return "—"
+  }
+
+  const parsed = new Date(value)
+
+  if (Number.isNaN(parsed.getTime())) {
+    return "—"
+  }
+
+  return postedFormatter.format(parsed)
+}
+
+function formatAmount(amount: ReferralRewardEntry["amount"], status: ReferralRewardEntry["status"], currency: string) {
+  const numericAmount = typeof amount === "number" ? amount : Number(amount ?? 0)
+  const signed = status === "reversed" ? -Math.abs(numericAmount) : numericAmount
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    signDisplay: "auto",
+  }).format(signed)
+}
+
+export function RewardsTable({ rewards, invitationLookup, currency }: RewardsTableProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Reward ledger</CardTitle>
+        <CardDescription>
+          Track when referral bonuses are earned, paid, or reversed.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {rewards.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Rewards will appear here after someone uses your invite link and completes onboarding.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-left text-sm">
+              <thead className="border-b">
+                <tr className="text-muted-foreground">
+                  <th className="py-3 pr-4 font-medium">Reward</th>
+                  <th className="py-3 pr-4 font-medium">Invitee</th>
+                  <th className="py-3 pr-4 font-medium">Status</th>
+                  <th className="py-3 pr-4 font-medium">Amount</th>
+                  <th className="py-3 font-medium">Posted</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rewards.map((reward) => {
+                  const relatedInvitation = reward.invitation_id
+                    ? invitationLookup.get(reward.invitation_id)
+                    : undefined
+
+                  return (
+                    <tr key={reward.id} className="align-top">
+                      <td className="py-3 pr-4">
+                        <div className="font-medium">{reward.reward_type.replace(/_/g, " ")}</div>
+                        {reward.description ? (
+                          <div className="text-xs text-muted-foreground">{reward.description}</div>
+                        ) : null}
+                      </td>
+                      <td className="py-3 pr-4 text-muted-foreground">
+                        {relatedInvitation?.invitee_email ?? "—"}
+                      </td>
+                      <td className="py-3 pr-4">
+                        <Badge variant={getRewardVariant(reward.status)}>
+                          {rewardStatusLabels[reward.status]}
+                        </Badge>
+                      </td>
+                      <td className="py-3 pr-4 font-medium">
+                        {formatAmount(reward.amount, reward.status, currency)}
+                      </td>
+                      <td className="py-3 text-muted-foreground">
+                        {formatPostedDate(reward.posted_at ?? null)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/dashboard/referrals/page.tsx
+++ b/app/dashboard/referrals/page.tsx
@@ -1,0 +1,109 @@
+import { redirect } from "next/navigation"
+
+import {
+  ReferralInvitation,
+  ReferralRewardEntry,
+  resolveReferralBaseUrl,
+} from "@/lib/referrals"
+import { createSupbaseServerClient } from "@/utils/supaone"
+
+import { InviteEmailForm } from "./components/invite-email-form"
+import { InvitationsTable } from "./components/invitations-table"
+import { ReferralSummary } from "./components/referral-summary"
+import { RewardsTable } from "./components/rewards-table"
+
+type InvitationRow = ReferralInvitation & { inviteLink: string }
+
+export default async function ReferralDashboardPage() {
+  const supabase = await createSupbaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const [profileResult, invitationsResult, rewardsResult] = await Promise.all([
+    supabase.from("profiles").select("full_name, unit_id").eq("id", user.id).maybeSingle(),
+    supabase
+      .from("referral_invitations")
+      .select("*")
+      .eq("inviter_id", user.id)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("referral_reward_ledger")
+      .select("*")
+      .eq("inviter_id", user.id)
+      .order("posted_at", { ascending: false }),
+  ])
+
+  if (profileResult.error) {
+    console.error("Failed to load profile for referral dashboard", profileResult.error)
+  }
+
+  if (invitationsResult.error) {
+    console.error("Failed to load referral invitations", invitationsResult.error)
+  }
+
+  if (rewardsResult.error) {
+    console.error("Failed to load referral rewards", rewardsResult.error)
+  }
+
+  const profile = profileResult.data ?? null
+  const invitationsData = invitationsResult.data ?? []
+  const rewardsData = rewardsResult.data ?? []
+
+  const baseUrl = resolveReferralBaseUrl()
+  const invitations: InvitationRow[] = (invitationsData ?? []).map((invitation) => ({
+    ...invitation,
+    inviteLink: `${baseUrl}/referrals/accept?token=${invitation.invite_token}`,
+  }))
+
+  const rewards: ReferralRewardEntry[] = rewardsData ?? []
+  const invitationLookup = new Map(invitations.map((inv) => [inv.id, inv]))
+
+  const totalInvites = invitations.length
+  const acceptedInvites = invitations.filter((inv) => inv.status === "accepted").length
+  const pendingInvites = invitations.filter((inv) => inv.status === "pending").length
+
+  const totalRewardsValue = rewards.reduce((sum, reward) => {
+    const amount = typeof reward.amount === "number" ? reward.amount : Number(reward.amount ?? 0)
+    const signedAmount = reward.status === "reversed" ? -Math.abs(amount) : amount
+    return sum + signedAmount
+  }, 0)
+
+  const latestPendingInvite = invitations.find((inv) => inv.status === "pending")
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-semibold">Referral dashboard</h1>
+        <p className="mt-2 text-muted-foreground">
+          Invite roommates, keep track of invite status, and monitor your earned rewards.
+        </p>
+      </div>
+
+      <ReferralSummary
+        totalInvites={totalInvites}
+        acceptedInvites={acceptedInvites}
+        pendingInvites={pendingInvites}
+        totalRewards={totalRewardsValue}
+        currency={process.env.REFERRAL_REWARD_CURRENCY ?? "USD"}
+      />
+
+      <InviteEmailForm
+        inviterName={profile?.full_name ?? undefined}
+        latestPendingInviteLink={latestPendingInvite?.inviteLink}
+      />
+
+      <InvitationsTable invitations={invitations} />
+
+      <RewardsTable
+        rewards={rewards}
+        invitationLookup={invitationLookup}
+        currency={process.env.REFERRAL_REWARD_CURRENCY ?? "USD"}
+      />
+    </div>
+  )
+}

--- a/components/emails/referral-invite.tsx
+++ b/components/emails/referral-invite.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+
+type ReferralInviteEmailProps = {
+  inviterName?: string | null
+  inviteLink: string
+  householdName?: string | null
+  rewardAmount?: number
+  currency?: string
+}
+
+export function ReferralInviteEmail({
+  inviterName,
+  inviteLink,
+  householdName,
+  rewardAmount,
+  currency = "USD",
+}: ReferralInviteEmailProps) {
+  const formattedReward =
+    typeof rewardAmount === "number"
+      ? new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency,
+          minimumFractionDigits: 0,
+        }).format(rewardAmount)
+      : null
+
+  return (
+    <div style={{ fontFamily: "Inter, Arial, sans-serif", lineHeight: 1.6 }}>
+      <h2 style={{ color: "#111827" }}>You&apos;re invited to Roomsily!</h2>
+      <p>
+        {inviterName ? `${inviterName} has invited you` : "A roommate has invited you"} to
+        join {householdName ? `${householdName} on Roomsily` : "the Roomsily household portal"}.
+      </p>
+      <p>
+        Roomsily keeps rent, chores, documents, and amenity bookings tidy for every roommate. Use the
+        secure button below to claim your spot and finish setting up your account.
+      </p>
+      {formattedReward ? (
+        <p style={{ backgroundColor: "#F3F4F6", padding: "12px 16px", borderRadius: 8 }}>
+          Join now and {inviterName ? `${inviterName} will earn` : "your roommate will earn"}{" "}
+          <strong>{formattedReward}</strong> once you complete onboarding.
+        </p>
+      ) : null}
+      <a
+        href={inviteLink}
+        style={{
+          display: "inline-block",
+          backgroundColor: "#111827",
+          color: "#ffffff",
+          padding: "12px 24px",
+          borderRadius: 9999,
+          textDecoration: "none",
+          fontWeight: 600,
+        }}
+      >
+        Accept invitation
+      </a>
+      <p style={{ fontSize: 12, color: "#6B7280", marginTop: 24 }}>
+        If the button doesn&apos;t work, copy and paste this link into your browser:
+        <br />
+        <span style={{ wordBreak: "break-all" }}>{inviteLink}</span>
+      </p>
+    </div>
+  )
+}

--- a/lib/referrals.ts
+++ b/lib/referrals.ts
@@ -1,0 +1,288 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type {
+  Database,
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from "@/lib/supabase"
+
+export type ReferralInvitation = Tables<"referral_invitations">
+export type ReferralRewardEntry = Tables<"referral_reward_ledger">
+export type ReferralInvitationInsert = TablesInsert<"referral_invitations">
+export type ReferralInvitationUpdate = TablesUpdate<"referral_invitations">
+export type ReferralRewardInsert = TablesInsert<"referral_reward_ledger">
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function defaultTokenGenerator() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function normalizeBaseUrl(explicitBaseUrl?: string | null) {
+  const envUrl =
+    explicitBaseUrl ?? process.env.NEXT_PUBLIC_APP_URL ?? process.env.VERCEL_URL
+
+  if (!envUrl) {
+    return "http://localhost:3000"
+  }
+
+  if (envUrl.startsWith("http")) {
+    return envUrl
+  }
+
+  return `https://${envUrl}`
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase()
+}
+
+export interface ReferralRepository {
+  createInvitation(values: ReferralInvitationInsert): Promise<ReferralInvitation>
+  findInvitationByToken(token: string): Promise<ReferralInvitation | null>
+  updateInvitation(
+    id: string,
+    updates: ReferralInvitationUpdate
+  ): Promise<ReferralInvitation>
+  createRewardEntry(values: ReferralRewardInsert): Promise<ReferralRewardEntry>
+}
+
+export class SupabaseReferralRepository implements ReferralRepository {
+  constructor(private readonly supabase: SupabaseClient<Database>) {}
+
+  async createInvitation(values: ReferralInvitationInsert) {
+    const { data, error } = await this.supabase
+      .from("referral_invitations")
+      .insert(values)
+      .select("*")
+      .single()
+
+    if (error || !data) {
+      throw new Error(error?.message ?? "Failed to create referral invitation")
+    }
+
+    return data
+  }
+
+  async findInvitationByToken(token: string) {
+    const { data, error } = await this.supabase
+      .from("referral_invitations")
+      .select("*")
+      .eq("invite_token", token)
+      .maybeSingle()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    return data ?? null
+  }
+
+  async updateInvitation(id: string, updates: ReferralInvitationUpdate) {
+    const { data, error } = await this.supabase
+      .from("referral_invitations")
+      .update(updates)
+      .eq("id", id)
+      .select("*")
+      .single()
+
+    if (error || !data) {
+      throw new Error(error?.message ?? "Failed to update referral invitation")
+    }
+
+    return data
+  }
+
+  async createRewardEntry(values: ReferralRewardInsert) {
+    const { data, error } = await this.supabase
+      .from("referral_reward_ledger")
+      .insert(values)
+      .select("*")
+      .single()
+
+    if (error || !data) {
+      throw new Error(error?.message ?? "Failed to create referral reward entry")
+    }
+
+    return data
+  }
+}
+
+export interface CreateReferralInvitationOptions {
+  repository: ReferralRepository
+  inviterId: string
+  inviteeEmail: string
+  inviteeName?: string | null
+  householdId?: string | null
+  baseUrl?: string
+  expiresInDays?: number
+  metadata?: Record<string, unknown>
+  now?: Date
+  generateToken?: () => string
+}
+
+export async function createReferralInvitationFlow({
+  repository,
+  inviterId,
+  inviteeEmail,
+  inviteeName,
+  householdId,
+  baseUrl,
+  expiresInDays = 14,
+  metadata,
+  now = new Date(),
+  generateToken = defaultTokenGenerator,
+}: CreateReferralInvitationOptions) {
+  const normalizedEmail = normalizeEmail(inviteeEmail)
+  const token = generateToken()
+  const invitationExpiresAt =
+    typeof expiresInDays === "number" && Number.isFinite(expiresInDays)
+      ? new Date(now.getTime() + expiresInDays * MS_PER_DAY)
+      : null
+
+  const invitation = await repository.createInvitation({
+    inviter_id: inviterId,
+    invitee_email: normalizedEmail,
+    invitee_name: inviteeName ?? null,
+    invite_token: token,
+    status: "pending",
+    sent_at: now.toISOString(),
+    expires_at: invitationExpiresAt ? invitationExpiresAt.toISOString() : null,
+    household_id: householdId ?? null,
+    metadata: metadata ?? null,
+  })
+
+  return {
+    invitation,
+    inviteLink: `${normalizeBaseUrl(baseUrl)}/referrals/accept?token=${token}`,
+  }
+}
+
+export interface MapSignupToReferrerOptions {
+  repository: ReferralRepository
+  inviteToken: string
+  inviteeId: string
+  inviteeEmail?: string | null
+  rewardAmount?: number
+  currency?: string
+  rewardType?: string
+  description?: string
+  now?: Date
+}
+
+export async function mapSignupToReferrer({
+  repository,
+  inviteToken,
+  inviteeId,
+  inviteeEmail,
+  rewardAmount = 50,
+  currency = "USD",
+  rewardType = "referral_bonus",
+  description,
+  now = new Date(),
+}: MapSignupToReferrerOptions) {
+  const invitation = await repository.findInvitationByToken(inviteToken)
+
+  if (!invitation) {
+    throw new Error("Invitation not found")
+  }
+
+  if (invitation.status !== "pending") {
+    throw new Error(`Invitation is not pending (current status: ${invitation.status})`)
+  }
+
+  if (invitation.expires_at) {
+    const expiresAt = new Date(invitation.expires_at)
+    if (Number.isFinite(expiresAt.getTime()) && expiresAt.getTime() < now.getTime()) {
+      await repository.updateInvitation(invitation.id, {
+        status: "expired",
+      })
+      throw new Error("Invitation has expired")
+    }
+  }
+
+  const updatedInvitation = await repository.updateInvitation(invitation.id, {
+    status: "accepted",
+    accepted_at: now.toISOString(),
+    accepted_by: inviteeId,
+    invitee_email: inviteeEmail ? normalizeEmail(inviteeEmail) : invitation.invitee_email,
+  })
+
+  let reward: ReferralRewardEntry | null = null
+
+  if (rewardAmount > 0) {
+    reward = await repository.createRewardEntry({
+      invitation_id: invitation.id,
+      inviter_id: invitation.inviter_id,
+      invitee_id: inviteeId,
+      household_id: invitation.household_id ?? null,
+      amount: rewardAmount,
+      currency,
+      reward_type: rewardType,
+      status: "earned",
+      description:
+        description ??
+        `Referral bonus for inviting ${inviteeEmail ?? invitation.invitee_email}`,
+      posted_at: now.toISOString(),
+    })
+  }
+
+  return { invitation: updatedInvitation, reward }
+}
+
+export interface PostReferralRewardOptions {
+  repository: ReferralRepository
+  invitationId: string | null
+  inviterId: string
+  inviteeId?: string | null
+  householdId?: string | null
+  amount: number
+  currency?: string
+  rewardType?: string
+  status?: ReferralRewardEntry["status"]
+  description?: string
+  metadata?: Record<string, unknown>
+  now?: Date
+}
+
+export async function postReferralReward({
+  repository,
+  invitationId,
+  inviterId,
+  inviteeId = null,
+  householdId = null,
+  amount,
+  currency = "USD",
+  rewardType = "referral_bonus",
+  status = "earned",
+  description,
+  metadata,
+  now = new Date(),
+}: PostReferralRewardOptions) {
+  if (amount === 0) {
+    throw new Error("Reward amount must be non-zero")
+  }
+
+  const reward = await repository.createRewardEntry({
+    invitation_id: invitationId,
+    inviter_id: inviterId,
+    invitee_id: inviteeId,
+    household_id: householdId,
+    amount,
+    currency,
+    reward_type: rewardType,
+    status,
+    description: description ?? "Referral reward posted",
+    metadata: metadata ?? null,
+    posted_at: now.toISOString(),
+  })
+
+  return reward
+}
+
+export { normalizeBaseUrl as resolveReferralBaseUrl }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -237,6 +237,38 @@ export type Database = {
         error_message: string | null
         metadata: Json | null
       }>
+      referral_invitations: SupabaseTable<{
+        id: string
+        inviter_id: string
+        invitee_email: string
+        invitee_name: string | null
+        invite_token: string
+        status: 'pending' | 'accepted' | 'expired' | 'revoked'
+        sent_at: string | null
+        accepted_at: string | null
+        expires_at: string | null
+        accepted_by: string | null
+        household_id: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
+      referral_reward_ledger: SupabaseTable<{
+        id: string
+        invitation_id: string | null
+        inviter_id: string
+        invitee_id: string | null
+        household_id: string | null
+        reward_type: string
+        amount: number
+        currency: string
+        status: 'pending' | 'earned' | 'paid' | 'reversed'
+        description: string | null
+        posted_at: string | null
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
       meetings: SupabaseTable<{
         id: string
         user_id: string

--- a/supabase/migrations/20250310_referrals_schema.sql
+++ b/supabase/migrations/20250310_referrals_schema.sql
@@ -1,0 +1,77 @@
+-- Referral invitations and rewards schema
+CREATE TABLE public.referral_invitations (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  inviter_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  invitee_email TEXT NOT NULL,
+  invitee_name TEXT,
+  invite_token TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'expired', 'revoked')),
+  sent_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  accepted_at TIMESTAMP WITH TIME ZONE,
+  expires_at TIMESTAMP WITH TIME ZONE,
+  accepted_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  household_id UUID REFERENCES public.households(id) ON DELETE SET NULL,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE public.referral_reward_ledger (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  invitation_id UUID REFERENCES public.referral_invitations(id) ON DELETE SET NULL,
+  inviter_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  invitee_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  household_id UUID REFERENCES public.households(id) ON DELETE SET NULL,
+  reward_type TEXT NOT NULL,
+  amount NUMERIC(10, 2) NOT NULL DEFAULT 0,
+  currency TEXT NOT NULL DEFAULT 'USD',
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'earned', 'paid', 'reversed')),
+  description TEXT,
+  posted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_referral_invitations_inviter_id ON public.referral_invitations(inviter_id);
+CREATE INDEX idx_referral_invitations_invitee_email ON public.referral_invitations(invitee_email);
+CREATE INDEX idx_referral_invitations_token ON public.referral_invitations(invite_token);
+CREATE INDEX idx_referral_invitations_status ON public.referral_invitations(status);
+
+CREATE INDEX idx_referral_reward_ledger_inviter_id ON public.referral_reward_ledger(inviter_id);
+CREATE INDEX idx_referral_reward_ledger_invitee_id ON public.referral_reward_ledger(invitee_id);
+CREATE INDEX idx_referral_reward_ledger_status ON public.referral_reward_ledger(status);
+CREATE INDEX idx_referral_reward_ledger_posted_at ON public.referral_reward_ledger(posted_at DESC);
+
+ALTER TABLE public.referral_invitations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.referral_reward_ledger ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their referral invitations" ON public.referral_invitations
+  FOR SELECT
+  USING (
+    inviter_id = auth.uid() OR accepted_by = auth.uid()
+  );
+
+CREATE POLICY "Users can create referral invitations" ON public.referral_invitations
+  FOR INSERT
+  WITH CHECK (
+    inviter_id = auth.uid()
+  );
+
+CREATE POLICY "Inviters can update their referral invitations" ON public.referral_invitations
+  FOR UPDATE
+  USING (inviter_id = auth.uid());
+
+CREATE POLICY "Users can view their referral rewards" ON public.referral_reward_ledger
+  FOR SELECT
+  USING (
+    inviter_id = auth.uid() OR invitee_id = auth.uid()
+  );
+
+CREATE TRIGGER update_referral_invitations_updated_at
+  BEFORE UPDATE ON public.referral_invitations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_referral_reward_ledger_updated_at
+  BEFORE UPDATE ON public.referral_reward_ledger
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/tests/referrals.test.ts
+++ b/tests/referrals.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createReferralInvitationFlow,
+  mapSignupToReferrer,
+  postReferralReward,
+  type ReferralInvitation,
+  type ReferralInvitationInsert,
+  type ReferralInvitationUpdate,
+  type ReferralRepository,
+  type ReferralRewardEntry,
+  type ReferralRewardInsert,
+} from "@/lib/referrals"
+
+class InMemoryReferralRepository implements ReferralRepository {
+  private invitationStore = new Map<string, ReferralInvitation>()
+  private rewardStore = new Map<string, ReferralRewardEntry>()
+  private invitationIndexByToken = new Map<string, string>()
+  private invitationSequence = 0
+  private rewardSequence = 0
+
+  async createInvitation(values: ReferralInvitationInsert) {
+    const nowIso = new Date().toISOString()
+    const id = values.id ?? `inv_${++this.invitationSequence}`
+
+    const record: ReferralInvitation = {
+      id,
+      inviter_id: values.inviter_id ?? "",
+      invitee_email: values.invitee_email ?? "",
+      invitee_name: values.invitee_name ?? null,
+      invite_token: values.invite_token ?? "",
+      status: (values.status as ReferralInvitation["status"]) ?? "pending",
+      sent_at: values.sent_at ?? nowIso,
+      accepted_at: values.accepted_at ?? null,
+      expires_at: values.expires_at ?? null,
+      accepted_by: values.accepted_by ?? null,
+      household_id: values.household_id ?? null,
+      metadata: (values.metadata as ReferralInvitation["metadata"]) ?? null,
+      created_at: values.created_at ?? nowIso,
+      updated_at: values.updated_at ?? nowIso,
+    }
+
+    this.invitationStore.set(record.id, record)
+    this.invitationIndexByToken.set(record.invite_token, record.id)
+
+    return record
+  }
+
+  async findInvitationByToken(token: string) {
+    const id = this.invitationIndexByToken.get(token)
+    if (!id) {
+      return null
+    }
+    return this.invitationStore.get(id) ?? null
+  }
+
+  async updateInvitation(id: string, updates: ReferralInvitationUpdate) {
+    const existing = this.invitationStore.get(id)
+    if (!existing) {
+      throw new Error("Invitation not found")
+    }
+
+    const updated: ReferralInvitation = {
+      ...existing,
+      ...updates,
+      metadata: (updates.metadata as ReferralInvitation["metadata"]) ?? existing.metadata,
+      updated_at: updates.updated_at ?? new Date().toISOString(),
+    }
+
+    this.invitationStore.set(id, updated)
+    this.invitationIndexByToken.set(updated.invite_token, id)
+
+    return updated
+  }
+
+  async createRewardEntry(values: ReferralRewardInsert) {
+    const nowIso = new Date().toISOString()
+    const id = values.id ?? `rew_${++this.rewardSequence}`
+
+    const record: ReferralRewardEntry = {
+      id,
+      invitation_id: values.invitation_id ?? null,
+      inviter_id: values.inviter_id ?? "",
+      invitee_id: values.invitee_id ?? null,
+      household_id: values.household_id ?? null,
+      reward_type: values.reward_type ?? "referral_bonus",
+      amount: typeof values.amount === "number" ? values.amount : Number(values.amount ?? 0),
+      currency: values.currency ?? "USD",
+      status: (values.status as ReferralRewardEntry["status"]) ?? "pending",
+      description: values.description ?? null,
+      posted_at: values.posted_at ?? nowIso,
+      metadata: (values.metadata as ReferralRewardEntry["metadata"]) ?? null,
+      created_at: values.created_at ?? nowIso,
+      updated_at: values.updated_at ?? nowIso,
+    }
+
+    this.rewardStore.set(record.id, record)
+
+    return record
+  }
+
+  get invitations() {
+    return this.invitationStore
+  }
+
+  get rewards() {
+    return this.rewardStore
+  }
+}
+
+describe("referral flows", () => {
+  it("creates a referral invitation with a shareable link", async () => {
+    const repository = new InMemoryReferralRepository()
+    const now = new Date("2025-03-10T12:00:00.000Z")
+
+    const { invitation, inviteLink } = await createReferralInvitationFlow({
+      repository,
+      inviterId: "user_referrer",
+      inviteeEmail: "FutureRoomie@example.com",
+      householdId: "household-1",
+      baseUrl: "https://roomsily.test",
+      now,
+      generateToken: () => "token-xyz",
+    })
+
+    expect(invitation.invite_token).toBe("token-xyz")
+    expect(invitation.invitee_email).toBe("futureroomie@example.com")
+    expect(invitation.status).toBe("pending")
+    expect(invitation.expires_at).toBe("2025-03-24T12:00:00.000Z")
+    expect(inviteLink).toBe("https://roomsily.test/referrals/accept?token=token-xyz")
+    expect(repository.invitations.size).toBe(1)
+  })
+
+  it("maps a signup to the correct referrer and posts a reward", async () => {
+    const repository = new InMemoryReferralRepository()
+    const now = new Date("2025-04-01T00:00:00.000Z")
+
+    const { invitation } = await createReferralInvitationFlow({
+      repository,
+      inviterId: "user_referrer",
+      inviteeEmail: "new-roommate@example.com",
+      baseUrl: "https://roomsily.test",
+      now,
+      generateToken: () => "token-map",
+    })
+
+    const result = await mapSignupToReferrer({
+      repository,
+      inviteToken: "token-map",
+      inviteeId: "user_new",
+      inviteeEmail: "new-roommate@example.com",
+      rewardAmount: 75,
+      currency: "USD",
+      now: new Date("2025-04-03T10:30:00.000Z"),
+    })
+
+    expect(result.invitation.status).toBe("accepted")
+    expect(result.invitation.accepted_by).toBe("user_new")
+    expect(result.reward).not.toBeNull()
+    expect(result.reward?.amount).toBe(75)
+    expect(result.reward?.invitation_id).toBe(invitation.id)
+    expect(repository.rewards.size).toBe(1)
+  })
+
+  it("marks invitations as expired when the token is stale", async () => {
+    const repository = new InMemoryReferralRepository()
+
+    await createReferralInvitationFlow({
+      repository,
+      inviterId: "user_referrer",
+      inviteeEmail: "late@example.com",
+      baseUrl: "https://roomsily.test",
+      now: new Date("2024-12-01T00:00:00.000Z"),
+      generateToken: () => "token-expired",
+      expiresInDays: 7,
+    })
+
+    await expect(
+      mapSignupToReferrer({
+        repository,
+        inviteToken: "token-expired",
+        inviteeId: "late_user",
+        now: new Date("2025-02-01T00:00:00.000Z"),
+      })
+    ).rejects.toThrow("Invitation has expired")
+
+    const invitation = repository.invitations.values().next().value
+    expect(invitation.status).toBe("expired")
+  })
+
+  it("allows manually posting rewards to the ledger", async () => {
+    const repository = new InMemoryReferralRepository()
+
+    const { invitation } = await createReferralInvitationFlow({
+      repository,
+      inviterId: "user_referrer",
+      inviteeEmail: "ledger@example.com",
+      baseUrl: "https://roomsily.test",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+      generateToken: () => "token-ledger",
+    })
+
+    const reward = await postReferralReward({
+      repository,
+      invitationId: invitation.id,
+      inviterId: invitation.inviter_id,
+      inviteeId: "ledger_user",
+      amount: 120,
+      currency: "USD",
+      rewardType: "referral_bonus",
+      status: "paid",
+      description: "Referral payout processed",
+      now: new Date("2025-01-15T12:00:00.000Z"),
+    })
+
+    expect(reward.status).toBe("paid")
+    expect(reward.amount).toBe(120)
+    expect(repository.rewards.size).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add referral invitation and reward ledger tables with RLS and triggers
- implement invite sending and acceptance API routes with Resend emails
- build dashboard referral UI to manage invites, copy links, and review rewards
- create reusable referral service helpers and Vitest coverage for invites, signup mapping, and reward posting

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d30b871c548328852702b7694e3dc2