### PR TITLE
feat(payments): automate billing portal and tax receipts

### DIFF
--- a/app/api/stripe/billing-portal/route.ts
+++ b/app/api/stripe/billing-portal/route.ts
@@ -1,13 +1,36 @@
 import { NextRequest } from "next/server"
-import { getStripe, getAppBaseUrl } from "@/lib/stripe"
 
-export async function POST(req: NextRequest) {
+import { getStripe, getAppBaseUrl } from "@/lib/stripe"
+import { createClient } from "@/utils/supabase/server"
+
+export async function POST(_req: NextRequest) {
   try {
     const stripe = getStripe()
-    const { customerId } = await req.json()
-    if (!customerId || typeof customerId !== "string") {
-      return Response.json({ error: "customerId is required" }, { status: 400 })
+    const supabase = createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 })
     }
+
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("stripe_customer_id")
+      .eq("id", user.id)
+      .maybeSingle()
+
+    if (error) {
+      console.error("Unable to load Stripe customer for billing portal", error)
+      return Response.json({ error: "Unable to load billing profile" }, { status: 500 })
+    }
+
+    const customerId = data?.stripe_customer_id
+    if (!customerId) {
+      return Response.json({ error: "No Stripe customer on file" }, { status: 404 })
+    }
+
     const returnUrl = getAppBaseUrl() + "/payments"
     const session = await stripe.billingPortal.sessions.create({
       customer: customerId,

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -4,7 +4,13 @@ import { getStripe, getAppBaseUrl } from "@/lib/stripe"
 export async function POST(req: NextRequest) {
   try {
     const stripe = getStripe()
-    const { priceId, quantity = 1, mode = "payment", metadata } = await req.json()
+    const {
+      priceId,
+      quantity = 1,
+      mode = "payment",
+      metadata,
+      customerId,
+    } = await req.json()
 
     if (!priceId || typeof priceId !== "string") {
       return Response.json({ error: "priceId is required" }, { status: 400 })
@@ -27,6 +33,10 @@ export async function POST(req: NextRequest) {
     // Add metadata if provided
     if (metadata) {
       sessionConfig.metadata = metadata
+    }
+
+    if (typeof customerId === "string" && customerId.trim().length > 0) {
+      sessionConfig.customer = customerId.trim()
     }
 
     const session = await stripe.checkout.sessions.create(sessionConfig)

--- a/app/payments/_components/receipt-history-card.tsx
+++ b/app/payments/_components/receipt-history-card.tsx
@@ -1,5 +1,5 @@
 import { format, parseISO } from "date-fns"
-import { Download, FileText } from "lucide-react"
+import { Download, FileText, ReceiptText } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
@@ -95,8 +95,8 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
         <div className="space-y-1.5">
           <CardTitle>Receipt history</CardTitle>
           <CardDescription>
-            Download itemized receipts and export the full payment ledger for
-            reimbursements, tax season, or dispute resolution.
+            Download itemized receipts, official tax forms, and export the full
+            payment ledger for reimbursements or dispute resolution.
           </CardDescription>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -248,6 +248,20 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
                             >
                               <FileText className="size-4" aria-hidden="true" />
                               <span>Invoice</span>
+                            </a>
+                          ) : null}
+                          {receipt.taxReceiptUrl ? (
+                            <a
+                              href={receipt.taxReceiptUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              className={cn(
+                                buttonVariants({ variant: "ghost", size: "sm" }),
+                                "w-full justify-center gap-1",
+                              )}
+                            >
+                              <ReceiptText className="size-4" aria-hidden="true" />
+                              <span>Tax receipt</span>
                             </a>
                           ) : null}
                         </div>

--- a/app/payments/_components/stripe-actions.tsx
+++ b/app/payments/_components/stripe-actions.tsx
@@ -1,112 +1,123 @@
 "use client"
 
 import { useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 
-export function StripeActions() {
-  const [priceId, setPriceId] = useState("")
-  const [customerId, setCustomerId] = useState("")
-  const [tenantId, setTenantId] = useState("")
-  const [unitId, setUnitId] = useState("")
+import { Button } from "@/components/ui/button"
+import { formatCurrency } from "@/lib/payments/currency"
+import {
+  buildCheckoutSessionPayload,
+  type TenantBillingContext,
+} from "@/lib/payments/billing"
+
+interface StripeActionsProps {
+  billingContext: TenantBillingContext | null
+}
+
+export function StripeActions({ billingContext }: StripeActionsProps) {
   const [loadingCheckout, setLoadingCheckout] = useState(false)
   const [loadingPortal, setLoadingPortal] = useState(false)
 
+  const plan = billingContext?.plan ?? null
+  const tenantId = billingContext?.tenantId ?? null
+  const unitId = billingContext?.unitId ?? null
+  const stripeCustomerId = billingContext?.stripeCustomerId ?? null
+
+  const checkoutLabel = plan
+    ? `Start ${formatCurrency(plan.amount, plan.currency)} checkout`
+    : "Select a plan to checkout"
+
   const startCheckout = async () => {
-    if (!priceId) return
+    if (!plan) return
     setLoadingCheckout(true)
     try {
+      const payload = buildCheckoutSessionPayload({
+        plan,
+        tenantId,
+        unitId,
+        stripeCustomerId,
+      })
+
       const res = await fetch("/api/stripe/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          priceId,
-          quantity: 1,
-          mode: "payment",
-          metadata: {
-            tenant_id: tenantId || undefined,
-            unit_id: unitId || undefined,
-          }
-        }),
+        body: JSON.stringify(payload),
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data?.error || "Unable to create session")
       if (data?.url) window.location.assign(data.url)
-    } catch (e) {
-      console.error(e)
+    } catch (error) {
+      console.error(error)
     } finally {
       setLoadingCheckout(false)
     }
   }
 
   const openBillingPortal = async () => {
-    if (!customerId) return
+    if (!stripeCustomerId) return
     setLoadingPortal(true)
     try {
       const res = await fetch("/api/stripe/billing-portal", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ customerId }),
       })
       const data = await res.json()
-      if (!res.ok) throw new Error(data?.error || "Unable to create billing portal session")
+      if (!res.ok)
+        throw new Error(data?.error || "Unable to create billing portal session")
       if (data?.url) window.location.assign(data.url)
-    } catch (e) {
-      console.error(e)
+    } catch (error) {
+      console.error(error)
     } finally {
       setLoadingPortal(false)
     }
   }
 
+  const checkoutDisabled = !plan || loadingCheckout
+  const portalDisabled = !stripeCustomerId || loadingPortal
+
   return (
     <div className="space-y-4">
-      <div className="grid gap-4">
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="tenant-id">Tenant ID (optional)</Label>
-            <Input
-              id="tenant-id"
-              value={tenantId}
-              onChange={(e) => setTenantId(e.target.value)}
-              placeholder="user-uuid"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="unit-id">Unit ID (optional)</Label>
-            <Input
-              id="unit-id"
-              value={unitId}
-              onChange={(e) => setUnitId(e.target.value)}
-              placeholder="unit-123"
-            />
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Input
-            value={priceId}
-            onChange={(e) => setPriceId(e.target.value)}
-            placeholder="price_123 (test price id)"
-            className="min-w-56 flex-1"
-          />
-          <Button onClick={startCheckout} disabled={!priceId || loadingCheckout} variant="outline">
-            {loadingCheckout ? "Creating..." : "Create Checkout"}
-          </Button>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Input
-            value={customerId}
-            onChange={(e) => setCustomerId(e.target.value)}
-            placeholder="cus_123 (Stripe customer id)"
-            className="min-w-56 flex-1"
-          />
-          <Button onClick={openBillingPortal} disabled={!customerId || loadingPortal} variant="outline">
-            {loadingPortal ? "Opening..." : "Open Billing Portal"}
-          </Button>
+      <div className="space-y-2 rounded-lg border bg-muted/40 p-4">
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-semibold text-foreground">Plan details</p>
+          {plan ? (
+            <>
+              <p className="text-sm text-foreground">{plan.label}</p>
+              <p className="text-xs text-muted-foreground">
+                {formatCurrency(plan.amount, plan.currency)} per {plan.interval}
+              </p>
+              <p className="text-xs text-muted-foreground">{plan.description}</p>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Assign a Roomsily billing plan in account settings to enable Stripe checkout.
+            </p>
+          )}
         </div>
       </div>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Button
+          onClick={startCheckout}
+          disabled={checkoutDisabled}
+          className="sm:flex-1"
+        >
+          {loadingCheckout ? "Redirecting..." : checkoutLabel}
+        </Button>
+        <Button
+          onClick={openBillingPortal}
+          disabled={portalDisabled}
+          variant="outline"
+          className="sm:flex-1"
+        >
+          {loadingPortal ? "Opening..." : "Open Billing Portal"}
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Checkout sessions are prefilled with your tenant and unit metadata for reconciliation.
+      </p>
+      {!stripeCustomerId ? (
+        <p className="text-xs text-muted-foreground">
+          Add a payment method through Stripe to unlock billing portal downloads.
+        </p>
+      ) : null}
     </div>
   )
 }
-
-

--- a/app/payments/loaders.ts
+++ b/app/payments/loaders.ts
@@ -3,6 +3,12 @@
 import "server-only"
 
 import { catchUpBalances, receiptHistory } from "@/lib/payments/mock-data"
+import {
+  buildTenantBillingContext,
+  type BillingProfileRow,
+  type TenantBillingContext,
+} from "@/lib/payments/billing"
+import { createClient } from "@/utils/supabase/server"
 import type {
   CatchUpBalance,
   PaymentReceiptHistoryEntry,
@@ -16,4 +22,34 @@ export async function loadCatchUpBalances(): Promise<CatchUpBalance[]> {
 export async function loadReceiptHistory(): Promise<PaymentReceiptHistoryEntry[]> {
   return receiptHistory
 
+}
+
+export async function loadTenantBillingContext(): Promise<TenantBillingContext | null> {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError) {
+    console.error("Failed to read authenticated user for billing context", authError)
+  }
+
+  if (!user) {
+    return null
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("stripe_customer_id, unit_id, metadata")
+    .eq("id", user.id)
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to load tenant billing profile", error)
+  }
+
+  const profile = (data as BillingProfileRow | null) ?? null
+
+  return buildTenantBillingContext({ userId: user.id, profile })
 }

--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -21,7 +21,11 @@ import {
 import { formatCurrency } from "@/lib/payments/currency"
 import { describeAutopayStatus } from "@/lib/payments/status"
 
-import { loadCatchUpBalances, loadReceiptHistory } from "./loaders"
+import {
+  loadCatchUpBalances,
+  loadReceiptHistory,
+  loadTenantBillingContext,
+} from "./loaders"
 import { ReceiptHistoryCard } from "./_components/receipt-history-card"
 
 
@@ -73,10 +77,10 @@ function formatFullDate(date: string) {
 }
 
 export default async function PaymentsPage() {
-  const [catchUpBalances, receiptHistory] = await Promise.all([
+  const [catchUpBalances, receiptHistory, billingContext] = await Promise.all([
     loadCatchUpBalances(),
     loadReceiptHistory(),
-
+    loadTenantBillingContext(),
   ])
   const outstandingSummaries = catchUpBalances.map((balance) => {
     const outstanding = calculateOutstanding(balance.charges)
@@ -234,10 +238,13 @@ export default async function PaymentsPage() {
           <Card>
             <CardHeader>
               <CardTitle>Pay with Stripe</CardTitle>
-              <CardDescription>Create a quick checkout or open Billing Portal</CardDescription>
+              <CardDescription>
+                Prefill checkout with your Roomsily plan or open the Billing Portal to manage
+                payment methods.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              <StripeActions />
+              <StripeActions billingContext={billingContext} />
             </CardContent>
           </Card>
         </div>

--- a/lib/payments/billing.ts
+++ b/lib/payments/billing.ts
@@ -1,0 +1,157 @@
+import type { Database, Json } from "@/lib/supabase"
+
+export type TenantPlanId = "shared" | "plus" | "premium"
+
+export interface TenantBillingPlan {
+  id: TenantPlanId
+  label: string
+  description: string
+  stripePriceId: string
+  amount: number
+  currency: string
+  interval: "month" | "year"
+}
+
+const PLAN_CATALOG: Record<TenantPlanId, TenantBillingPlan> = {
+  shared: {
+    id: "shared",
+    label: "Shared Living",
+    description: "Standard roommate plan covering shared unit rent and utilities.",
+    stripePriceId: "price_roomsily_shared_monthly",
+    amount: 1260,
+    currency: "USD",
+    interval: "month",
+  },
+  plus: {
+    id: "plus",
+    label: "Shared Living Plus",
+    description: "Enhanced roommate plan with split maintenance and amenity coverage.",
+    stripePriceId: "price_roomsily_plus_monthly",
+    amount: 1390,
+    currency: "USD",
+    interval: "month",
+  },
+  premium: {
+    id: "premium",
+    label: "Premium Suite",
+    description: "Premium plan for private suites with bundled concierge services.",
+    stripePriceId: "price_roomsily_premium_monthly",
+    amount: 1550,
+    currency: "USD",
+    interval: "month",
+  },
+}
+
+const DEFAULT_PLAN_ID: TenantPlanId = "shared"
+
+type ProfilesTable = Database["public"]["Tables"]["profiles"]
+export type BillingProfileRow = Pick<
+  ProfilesTable["Row"],
+  "stripe_customer_id" | "unit_id" | "metadata"
+>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function normalizeCurrency(input: unknown, fallback: string): string {
+  if (typeof input !== "string" || !input.trim()) {
+    return fallback
+  }
+  return input.trim().toUpperCase()
+}
+
+function resolvePlanId(raw: unknown): TenantPlanId {
+  if (typeof raw === "string" && raw in PLAN_CATALOG) {
+    return raw as TenantPlanId
+  }
+  return DEFAULT_PLAN_ID
+}
+
+export function resolveTenantPlan(metadata: Json | null | undefined): TenantBillingPlan {
+  const basePlan = PLAN_CATALOG[DEFAULT_PLAN_ID]
+  if (!metadata || !isRecord(metadata)) {
+    return basePlan
+  }
+
+  const billing = isRecord(metadata.billing) ? metadata.billing : null
+
+  const planId = resolvePlanId(billing?.plan)
+  const catalogPlan = PLAN_CATALOG[planId] ?? basePlan
+
+  const priceId =
+    typeof billing?.price_id === "string" && billing.price_id.trim()
+      ? billing.price_id.trim()
+      : catalogPlan.stripePriceId
+
+  const currency = normalizeCurrency(billing?.currency, catalogPlan.currency)
+
+  return {
+    ...catalogPlan,
+    stripePriceId: priceId,
+    currency,
+  }
+}
+
+export interface TenantBillingContext {
+  tenantId: string
+  unitId: string | null
+  stripeCustomerId: string | null
+  plan: TenantBillingPlan
+}
+
+export function buildTenantBillingContext({
+  userId,
+  profile,
+}: {
+  userId: string
+  profile: BillingProfileRow | null | undefined
+}): TenantBillingContext {
+  return {
+    tenantId: userId,
+    unitId: profile?.unit_id ?? null,
+    stripeCustomerId: profile?.stripe_customer_id ?? null,
+    plan: resolveTenantPlan(profile?.metadata ?? null),
+  }
+}
+
+export interface CheckoutSessionPayload {
+  priceId: string
+  quantity: number
+  mode: "subscription"
+  metadata: Record<string, string>
+  customerId?: string
+}
+
+export function buildCheckoutSessionPayload({
+  plan,
+  tenantId,
+  unitId,
+  stripeCustomerId,
+}: {
+  plan: TenantBillingPlan
+  tenantId?: string | null
+  unitId?: string | null
+  stripeCustomerId?: string | null
+}): CheckoutSessionPayload {
+  const metadata: Record<string, string> = {
+    plan_id: plan.id,
+    plan_interval: plan.interval,
+  }
+
+  if (tenantId) {
+    metadata.tenant_id = tenantId
+  }
+
+  if (unitId) {
+    metadata.unit_id = unitId
+  }
+
+  return {
+    priceId: plan.stripePriceId,
+    quantity: 1,
+    mode: "subscription",
+    metadata,
+    customerId: stripeCustomerId ?? undefined,
+  }
+}

--- a/lib/payments/mock-data.ts
+++ b/lib/payments/mock-data.ts
@@ -186,6 +186,7 @@ export const receiptHistory: PaymentReceiptHistoryEntry[] = [
     paymentMethod: "Visa •••• 4242 (Autopay)",
     receiptUrl: "https://receipts.roomsily.dev/rcpt_avery_2024_06.pdf",
     invoiceUrl: "https://receipts.roomsily.dev/invoice_avery_2024_06",
+    taxReceiptUrl: "https://receipts.roomsily.dev/tax_avery_2024_ytd.pdf",
     memo: "Includes rent share plus reimbursable Wi-Fi and maintenance fees.",
     lineItems: [
       {
@@ -226,6 +227,7 @@ export const receiptHistory: PaymentReceiptHistoryEntry[] = [
     paymentMethod: "ACH checking •••• 1100",
     receiptUrl: "https://receipts.roomsily.dev/rcpt_jordan_2024_05.pdf",
     invoiceUrl: "https://receipts.roomsily.dev/invoice_jordan_2024_05",
+    taxReceiptUrl: "https://receipts.roomsily.dev/tax_jordan_2024_ytd.pdf",
     memo: "Manual catch-up payment covering parking and partial rent.",
     lineItems: [
       {
@@ -258,6 +260,7 @@ export const receiptHistory: PaymentReceiptHistoryEntry[] = [
     paymentMethod: "Visa •••• 3188",
     receiptUrl: "https://receipts.roomsily.dev/rcpt_priya_2024_04.pdf",
     invoiceUrl: "https://receipts.roomsily.dev/invoice_priya_2024_04",
+    taxReceiptUrl: "https://receipts.roomsily.dev/tax_priya_2024_ytd.pdf",
     memo: "Autopay rent receipt for April billing period.",
     lineItems: [
       {

--- a/lib/payments/receipts.ts
+++ b/lib/payments/receipts.ts
@@ -67,6 +67,7 @@ export function createPaymentHistoryCsv(
     "Memo",
     "Receipt URL",
     "Invoice URL",
+    "Tax Document URL",
   ]
 
   const rows = receipts.map((receipt) => {
@@ -91,6 +92,7 @@ export function createPaymentHistoryCsv(
       receipt.memo ?? "",
       receipt.receiptUrl,
       receipt.invoiceUrl ?? "",
+      receipt.taxReceiptUrl ?? "",
     ]
   })
 

--- a/tests/payments-billing.test.ts
+++ b/tests/payments-billing.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildCheckoutSessionPayload,
+  buildTenantBillingContext,
+  resolveTenantPlan,
+  type BillingProfileRow,
+} from "@/lib/payments/billing"
+
+const baseProfile: BillingProfileRow = {
+  stripe_customer_id: "cus_test_123",
+  unit_id: "unit-99",
+  metadata: {
+    billing: {
+      plan: "plus",
+      currency: "usd",
+      price_id: "price_custom_plus",
+    },
+  },
+}
+
+describe("tenant billing context", () => {
+  it("retains the stored Stripe customer id for authenticated tenants", () => {
+    const context = buildTenantBillingContext({ userId: "user-1", profile: baseProfile })
+
+    expect(context.tenantId).toBe("user-1")
+    expect(context.stripeCustomerId).toBe("cus_test_123")
+    expect(context.unitId).toBe("unit-99")
+    expect(context.plan.id).toBe("plus")
+    expect(context.plan.stripePriceId).toBe("price_custom_plus")
+    expect(context.plan.currency).toBe("USD")
+  })
+
+  it("falls back to the default plan when metadata is missing", () => {
+    const context = buildTenantBillingContext({
+      userId: "user-2",
+      profile: { stripe_customer_id: null, unit_id: null, metadata: null },
+    })
+
+    expect(context.plan.id).toBe("shared")
+    expect(context.plan.stripePriceId).toBe("price_roomsily_shared_monthly")
+  })
+})
+
+describe("checkout payload", () => {
+  it("prefills checkout metadata with plan, tenant, and unit details", () => {
+    const plan = resolveTenantPlan(baseProfile.metadata)
+    const payload = buildCheckoutSessionPayload({
+      plan,
+      tenantId: "tenant-123",
+      unitId: "unit-456",
+      stripeCustomerId: "cus_456",
+    })
+
+    expect(payload.priceId).toBe("price_custom_plus")
+    expect(payload.mode).toBe("subscription")
+    expect(payload.metadata).toMatchObject({
+      tenant_id: "tenant-123",
+      unit_id: "unit-456",
+      plan_id: "plus",
+      plan_interval: "month",
+    })
+    expect(payload.customerId).toBe("cus_456")
+  })
+
+  it("omits optional fields when tenant context is unavailable", () => {
+    const plan = resolveTenantPlan(null)
+    const payload = buildCheckoutSessionPayload({ plan })
+
+    expect(payload.metadata).toMatchObject({ plan_id: plan.id })
+    expect(payload.customerId).toBeUndefined()
+  })
+})

--- a/tests/payments-receipts.test.ts
+++ b/tests/payments-receipts.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import { createPaymentHistoryCsv } from "@/lib/payments/receipts"
+import type { PaymentReceiptHistoryEntry } from "@/types/payments"
+
+describe("payment receipts exports", () => {
+  it("includes tax document download URLs in the CSV export", () => {
+    const receipts: PaymentReceiptHistoryEntry[] = [
+      {
+        id: "rcpt_test",
+        issuedTo: "Test Tenant",
+        paymentDate: "2024-01-01",
+        currency: "USD",
+        amount: 1260,
+        status: "paid",
+        paymentMethod: "Visa",
+        receiptUrl: "https://example.com/receipt.pdf",
+        taxReceiptUrl: "https://example.com/tax.pdf",
+        lineItems: [
+          {
+            id: "line-1",
+            description: "Rent",
+            category: "rent",
+            totalAmount: 1260,
+          },
+        ],
+      },
+    ]
+
+    const csv = createPaymentHistoryCsv(receipts)
+    const [header, row] = csv.split("\n")
+
+    expect(header).toContain("Tax Document URL")
+    expect(row).toContain("https://example.com/tax.pdf")
+  })
+})

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -99,6 +99,7 @@ export interface PaymentReceiptHistoryEntry {
   periodEnd?: string
   receiptUrl: string
   invoiceUrl?: string
+  taxReceiptUrl?: string
   memo?: string
   lineItems: PaymentReceiptLineItem[]
 


### PR DESCRIPTION
## Summary
- automatically resolve the authenticated tenant's Stripe customer and plan to drive billing portal access and checkout payloads
- refresh the payments UI to surface plan details, prefilled checkout buttons, and tax receipt downloads
- extend receipt exports and add unit tests covering billing context helpers and CSV tax links

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b8853808328a56b248310a76b28