### PR TITLE
Add session timeout monitoring and auto-save support

### DIFF
--- a/app/account/supa-account-form.tsx
+++ b/app/account/supa-account-form.tsx
@@ -9,6 +9,7 @@ import { buttonVariants } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import useSupabaseBrowser from "@/utils/supabase-browser"
+import { useSessionAutoSave } from "@/hooks/use-session-auto-save"
 
 import Avatar from "./avatar"
 import type { AccountProfile } from "./types"
@@ -41,6 +42,14 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
   const [profileState, setProfileState] = useState(() => createProfileState(user, profile))
   const [isSaving, setIsSaving] = useState(false)
 
+  const { clearDraft } = useSessionAutoSave<ProfileState>({
+    storageKey: "account-profile-draft",
+    getValues: () => profileState,
+    onRestore: (draft) => {
+      setProfileState((previous) => ({ ...previous, ...draft }))
+    },
+  })
+
   const persistProfile = useCallback(
     async (overrides: Partial<ProfileState> = {}) => {
       const payload = { ...profileState, ...overrides }
@@ -66,6 +75,8 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
           title: "Profile updated",
           description: "We saved your latest contact details.",
         })
+
+        clearDraft()
       } catch (error) {
         console.error("Failed to update profile", error)
         toast({
@@ -80,7 +91,7 @@ export default function AccountForm({ user, profile }: AccountFormProps) {
         setIsSaving(false)
       }
     },
-    [profileState, supabase, user.id],
+    [clearDraft, profileState, supabase, user.id],
   )
 
   const handleChange = (field: keyof ProfileState) => (event: ChangeEvent<HTMLInputElement>) => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,7 @@ import { fontSans } from "@/lib/font"
 import { cn } from "@/lib/utils"
 import { siteConfig } from "@/config/site"
 import { ReactQueryClientProvider } from "@/components/react-query-client-provider"
+import { SessionTimeoutProvider } from "@/components/session/session-timeout-provider"
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
@@ -117,51 +118,50 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <ReactQueryClientProvider>
-    <html lang="en" suppressHydrationWarning>
-    <head></head>
-      <body className={cn(
+      <html lang="en" suppressHydrationWarning>
+        <head></head>
+        <body
+          className={cn(
             "min-h-screen bg-background font-sans antialiased",
             fontSans.variable
           )}
         >
-<ThemeProvider
+          <ThemeProvider
             attribute="class"
             defaultTheme="system"
             enableSystem
             disableTransitionOnChange
           >
-             <div className="relative flex min-h-screen flex-col">
-              {/* <SiteHeader /> */}
-              <div className="flex-1">
-                <ErrorBoundary>
-                  <Suspense fallback={<RouteSkeleton />}>
-                    {children}
-                  </Suspense>
-                </ErrorBoundary>
-                <Toaster />
-                <Analytics />
-                <SpeedInsights />
+            <SessionTimeoutProvider>
+              <div className="relative flex min-h-screen flex-col">
+                {/* <SiteHeader /> */}
+                <div className="flex-1">
+                  <ErrorBoundary>
+                    <Suspense fallback={<RouteSkeleton />}>
+                      {children}
+                    </Suspense>
+                  </ErrorBoundary>
+                  <Toaster />
+                  <Analytics />
+                  <SpeedInsights />
+                </div>
               </div>
 
-   </div>
-{/* <SiteFooter/> */}
+              {/* <SiteFooter/> */}
 
+              {/*
+              enter your api info from termly.io or a provider of your choice
+              <Script
+                type="text/javascript"
+                src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
 
-{/*
-enter your api info from termly.io or a provider of your choice
-<Script
-  type="text/javascript"
-  src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
-
- */}
-   <CookieButton />
-   <TailwindIndicator />
+               */}
+              <CookieButton />
+              <TailwindIndicator />
+            </SessionTimeoutProvider>
           </ThemeProvider>
-
-
-
-</body>
-    </html>
+        </body>
+      </html>
     </ReactQueryClientProvider>
   )
 }

--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -15,6 +15,7 @@ import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { useSessionAutoSave } from "@/hooks/use-session-auto-save";
 
 const maintenanceRequestSchema = z.object({
   title: z.string().min(5, "Title must be at least 5 characters"),
@@ -60,6 +61,17 @@ export function MaintenanceRequestForm() {
       priority: "normal",
       category: "",
       location: "",
+    },
+  });
+
+  const { clearDraft } = useSessionAutoSave<MaintenanceRequestFormData>({
+    storageKey: "maintenance-request-draft",
+    getValues: form.getValues,
+    onRestore: (draft) => {
+      form.reset({
+        ...form.getValues(),
+        ...draft,
+      });
     },
   });
 
@@ -124,6 +136,7 @@ export function MaintenanceRequestForm() {
         description: "Your maintenance request has been submitted and notifications sent.",
       });
 
+      clearDraft();
       form.reset();
     } catch (error) {
       console.error('Error submitting maintenance request:', error);

--- a/components/session/session-timeout-provider.tsx
+++ b/components/session/session-timeout-provider.tsx
@@ -1,0 +1,322 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type {
+  AutoSaveCallback,
+  SessionTimeoutSettings,
+} from "@/lib/session/session-timeout"
+import {
+  calculateSessionStatus,
+  extendSessionWithAutoSave,
+  resolveSessionTimeoutSettings,
+  toSeconds,
+} from "@/lib/session/session-timeout"
+import { toast } from "@/components/ui/use-toast"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+interface SessionTimeoutContextValue {
+  showWarning: boolean
+  remainingSeconds: number | null
+  idleSecondsRemaining: number | null
+  isExtending: boolean
+  extendSession: () => Promise<void>
+  dismissWarning: () => void
+  registerAutoSaveCallback: (callback: AutoSaveCallback) => () => void
+}
+
+const SessionTimeoutContext = createContext<SessionTimeoutContextValue | null>(null)
+
+const DEFAULT_SETTINGS = resolveSessionTimeoutSettings(null)
+const WINDOW_ACTIVITY_EVENTS: Array<keyof WindowEventMap> = [
+  "focus",
+  "keydown",
+  "mousedown",
+  "mousemove",
+  "touchstart",
+  "scroll",
+]
+const VISIBILITY_EVENT: keyof DocumentEventMap = "visibilitychange"
+
+export function SessionTimeoutProvider({ children }: { children: React.ReactNode }) {
+  const supabase = useSupabaseBrowser()
+  const autoSaveCallbacks = useRef(new Set<AutoSaveCallback>())
+  const [expiresAtMs, setExpiresAtMs] = useState<number | null>(null)
+  const [settings, setSettings] = useState<SessionTimeoutSettings>(DEFAULT_SETTINGS)
+  const [lastActivityMs, setLastActivityMs] = useState(() => Date.now())
+  const [showWarning, setShowWarning] = useState(false)
+  const [isExtending, setIsExtending] = useState(false)
+
+  const [status, setStatus] = useState(() =>
+    calculateSessionStatus({
+      expiresAtMs,
+      lastActivityMs,
+      nowMs: Date.now(),
+      settings,
+    }),
+  )
+
+  useEffect(() => {
+    let mounted = true
+
+    async function bootstrapSession() {
+      const { data } = await supabase.auth.getSession()
+      if (!mounted) {
+        return
+      }
+
+      const session = data.session ?? null
+      setExpiresAtMs(session?.expires_at ? session.expires_at * 1000 : null)
+      setSettings(resolveSessionTimeoutSettings(session))
+      setLastActivityMs(Date.now())
+    }
+
+    bootstrapSession()
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setExpiresAtMs(session?.expires_at ? session.expires_at * 1000 : null)
+      setSettings(resolveSessionTimeoutSettings(session))
+      setLastActivityMs(Date.now())
+    })
+
+    return () => {
+      mounted = false
+      subscription.unsubscribe()
+    }
+  }, [supabase])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const markActivity = () => {
+      setLastActivityMs(Date.now())
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        markActivity()
+      }
+    }
+
+    for (const event of WINDOW_ACTIVITY_EVENTS) {
+      if (event === "focus") {
+        window.addEventListener(event, markActivity)
+      } else if (event === "touchstart" || event === "scroll") {
+        window.addEventListener(event, markActivity, { passive: true })
+      } else {
+        window.addEventListener(event, markActivity)
+      }
+    }
+
+    document.addEventListener(VISIBILITY_EVENT, handleVisibility)
+
+    return () => {
+      for (const event of WINDOW_ACTIVITY_EVENTS) {
+        if (event === "focus") {
+          window.removeEventListener(event, markActivity)
+        } else if (event === "touchstart" || event === "scroll") {
+          window.removeEventListener(event, markActivity)
+        } else {
+          window.removeEventListener(event, markActivity)
+        }
+      }
+      document.removeEventListener(VISIBILITY_EVENT, handleVisibility)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const updateStatus = () => {
+      setStatus(
+        calculateSessionStatus({
+          expiresAtMs,
+          lastActivityMs,
+          nowMs: Date.now(),
+          settings,
+        }),
+      )
+    }
+
+    updateStatus()
+
+    const interval = window.setInterval(updateStatus, 1000)
+
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [expiresAtMs, lastActivityMs, settings])
+
+  useEffect(() => {
+    setShowWarning(status.shouldWarn)
+  }, [status.shouldWarn])
+
+  const extendSession = useCallback(async () => {
+    if (isExtending) {
+      return
+    }
+
+    setIsExtending(true)
+    try {
+      const result = await extendSessionWithAutoSave(autoSaveCallbacks.current, () =>
+        supabase.auth.refreshSession(),
+      )
+
+      const { data, error } = result as Awaited<ReturnType<typeof supabase.auth.refreshSession>>
+
+      if (error) {
+        throw error
+      }
+
+      const session = data.session ?? null
+      setExpiresAtMs(session?.expires_at ? session.expires_at * 1000 : null)
+      setSettings(resolveSessionTimeoutSettings(session))
+      setLastActivityMs(Date.now())
+      setShowWarning(false)
+      toast({
+        title: "Session extended",
+        description: "We saved your changes and refreshed your session.",
+      })
+    } catch (error) {
+      console.error("Failed to extend session", error)
+      toast({
+        variant: "destructive",
+        title: "Unable to extend session",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Refreshing your session failed. Please sign in again.",
+      })
+    } finally {
+      setIsExtending(false)
+    }
+  }, [isExtending, supabase])
+
+  const dismissWarning = useCallback(() => {
+    setShowWarning(false)
+    setLastActivityMs(Date.now())
+  }, [])
+
+  const registerAutoSaveCallback = useCallback((callback: AutoSaveCallback) => {
+    autoSaveCallbacks.current.add(callback)
+    return () => {
+      autoSaveCallbacks.current.delete(callback)
+    }
+  }, [])
+
+  const remainingSeconds = toSeconds(status.msUntilExpiry)
+  const idleSecondsRemaining = toSeconds(status.msUntilIdleLogout)
+
+  const secondsUntilTimeout = Math.min(
+    idleSecondsRemaining ?? Number.POSITIVE_INFINITY,
+    remainingSeconds ?? Number.POSITIVE_INFINITY,
+  )
+
+  const normalizedSeconds =
+    Number.isFinite(secondsUntilTimeout) &&
+    secondsUntilTimeout !== Number.POSITIVE_INFINITY
+      ? Math.max(Math.floor(secondsUntilTimeout), 0)
+      : null
+  const safeSeconds = normalizedSeconds !== null ? Math.max(normalizedSeconds, 1) : null
+
+  let formattedTime: string | null = null
+  if (safeSeconds !== null) {
+    if (safeSeconds >= 60) {
+      const minutes = Math.ceil(safeSeconds / 60)
+      formattedTime = `${minutes} minute${minutes === 1 ? "" : "s"}`
+    } else {
+      formattedTime = `${safeSeconds} second${safeSeconds === 1 ? "" : "s"}`
+    }
+  }
+
+  const dialogDescription = formattedTime
+    ? `You've been idle for a while. We'll sign you out in ${formattedTime}. Select Extend session so we can save your changes and refresh your access.`
+    : "Your session is about to expire due to inactivity. Select Extend session so we can save your changes and refresh your access."
+
+  const contextValue = useMemo<SessionTimeoutContextValue>(
+    () => ({
+      showWarning,
+      remainingSeconds,
+      idleSecondsRemaining,
+      isExtending,
+      extendSession,
+      dismissWarning,
+      registerAutoSaveCallback,
+    }),
+    [
+      dismissWarning,
+      extendSession,
+      idleSecondsRemaining,
+      isExtending,
+      registerAutoSaveCallback,
+      remainingSeconds,
+      showWarning,
+    ],
+  )
+
+  return (
+    <SessionTimeoutContext.Provider value={contextValue}>
+      {children}
+      <AlertDialog open={showWarning} onOpenChange={(open) => (!open ? dismissWarning() : null)}>
+        <AlertDialogContent
+          className={cn(
+            "sm:max-w-[420px]",
+            "bg-background text-foreground",
+            "border border-border",
+          )}
+          onEscapeKeyDown={(event) => event.preventDefault()}
+          onInteractOutside={(event) => event.preventDefault()}
+        >
+          <AlertDialogTitle>We&apos;ll sign you out soon</AlertDialogTitle>
+          <AlertDialogDescription>{dialogDescription}</AlertDialogDescription>
+          <AlertDialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button
+              variant="outline"
+              onClick={dismissWarning}
+              disabled={isExtending}
+              type="button"
+            >
+              Keep working
+            </Button>
+            <Button onClick={extendSession} disabled={isExtending} type="button">
+              {isExtending ? "Extending…" : "Extend session"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </SessionTimeoutContext.Provider>
+  )
+}
+
+export function useSessionTimeoutContext() {
+  const context = useContext(SessionTimeoutContext)
+
+  if (!context) {
+    throw new Error("useSessionTimeoutContext must be used within SessionTimeoutProvider")
+  }
+
+  return context
+}

--- a/components/visitors/visitor-booking-form.tsx
+++ b/components/visitors/visitor-booking-form.tsx
@@ -20,6 +20,7 @@ import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
+import { useSessionAutoSave } from "@/hooks/use-session-auto-save";
 
 const visitorBookingSchema = z.object({
   guestName: z.string().min(2, "Guest name must be at least 2 characters"),
@@ -38,6 +39,11 @@ const visitorBookingSchema = z.object({
 
 type VisitorBookingFormData = z.infer<typeof visitorBookingSchema>;
 
+type VisitorBookingDraft = Omit<VisitorBookingFormData, "checkInDate" | "checkOutDate"> & {
+  checkInDate?: string | null
+  checkOutDate?: string | null
+};
+
 export function VisitorBookingForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { notifyVisitorBooking } = useNotifications();
@@ -54,6 +60,35 @@ export function VisitorBookingForm() {
       purpose: "",
       emergencyContact: "",
       specialNotes: "",
+    },
+  });
+
+  const { clearDraft } = useSessionAutoSave<VisitorBookingDraft>({
+    storageKey: "visitor-booking-draft",
+    getValues: () => {
+      const values = form.getValues();
+      return {
+        ...values,
+        checkInDate: values.checkInDate ? values.checkInDate.toISOString() : null,
+        checkOutDate: values.checkOutDate ? values.checkOutDate.toISOString() : null,
+      };
+    },
+    onRestore: (draft) => {
+      const current = form.getValues();
+      const parsedCheckIn = draft.checkInDate ? new Date(draft.checkInDate) : undefined;
+      const parsedCheckOut = draft.checkOutDate ? new Date(draft.checkOutDate) : undefined;
+      form.reset({
+        ...current,
+        ...draft,
+        checkInDate:
+          parsedCheckIn && !Number.isNaN(parsedCheckIn.getTime())
+            ? parsedCheckIn
+            : current.checkInDate,
+        checkOutDate:
+          parsedCheckOut && !Number.isNaN(parsedCheckOut.getTime())
+            ? parsedCheckOut
+            : current.checkOutDate,
+      });
     },
   });
 
@@ -131,6 +166,7 @@ export function VisitorBookingForm() {
         description: "Your visitor booking has been submitted and notifications sent.",
       });
 
+      clearDraft();
       form.reset();
     } catch (error) {
       console.error('Error submitting visitor booking:', error);

--- a/hooks/use-session-auto-save.ts
+++ b/hooks/use-session-auto-save.ts
@@ -1,0 +1,72 @@
+"use client"
+
+import { useCallback, useEffect, useRef } from "react"
+
+import { useSessionTimeout } from "@/hooks/use-session-timeout"
+
+interface UseSessionAutoSaveOptions<T> {
+  storageKey: string
+  getValues: () => T
+  onRestore?: (values: Partial<T>) => void
+}
+
+export function useSessionAutoSave<T>({
+  storageKey,
+  getValues,
+  onRestore,
+}: UseSessionAutoSaveOptions<T>) {
+  const { registerAutoSaveCallback } = useSessionTimeout()
+  const latestGetValues = useRef(getValues)
+  const latestOnRestore = useRef(onRestore)
+
+  useEffect(() => {
+    latestGetValues.current = getValues
+  }, [getValues])
+
+  useEffect(() => {
+    latestOnRestore.current = onRestore
+  }, [onRestore])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const draft = window.localStorage.getItem(storageKey)
+    if (!draft) {
+      return
+    }
+
+    try {
+      const parsed = JSON.parse(draft) as Partial<T>
+      latestOnRestore.current?.(parsed)
+    } catch (error) {
+      console.warn("Failed to restore form draft", error)
+    }
+  }, [storageKey])
+
+  useEffect(() => {
+    return registerAutoSaveCallback(async () => {
+      if (typeof window === "undefined") {
+        return
+      }
+
+      try {
+        const values = latestGetValues.current()
+        window.localStorage.setItem(storageKey, JSON.stringify(values))
+      } catch (error) {
+        console.warn("Failed to persist form draft", error)
+      }
+    })
+  }, [registerAutoSaveCallback, storageKey])
+
+  const clearDraft = useCallback(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    window.localStorage.removeItem(storageKey)
+  }, [storageKey])
+
+  return { clearDraft }
+}

--- a/hooks/use-session-timeout.ts
+++ b/hooks/use-session-timeout.ts
@@ -1,0 +1,9 @@
+"use client"
+
+import { useSessionTimeoutContext } from "@/components/session/session-timeout-provider"
+
+export function useSessionTimeout() {
+  return useSessionTimeoutContext()
+}
+
+export { useSessionTimeoutContext } from "@/components/session/session-timeout-provider"

--- a/lib/session/session-timeout.ts
+++ b/lib/session/session-timeout.ts
@@ -1,0 +1,211 @@
+import type { Session } from "@supabase/supabase-js"
+
+export type AutoSaveCallback = () => Promise<unknown> | unknown
+
+export interface SessionTimeoutSettings {
+  idleThresholdMs: number
+  warningWindowMs: number
+}
+
+export interface SessionStatusInput {
+  expiresAtMs: number | null
+  lastActivityMs: number
+  nowMs: number
+  settings: SessionTimeoutSettings
+}
+
+export interface SessionStatus {
+  msUntilExpiry: number | null
+  msUntilIdleLogout: number
+  shouldWarn: boolean
+}
+
+const DEFAULT_IDLE_THRESHOLD_MS = 30 * 60 * 1000
+const DEFAULT_WARNING_WINDOW_MS = 5 * 60 * 1000
+
+const SECOND_KEYS = [
+  "session_idle_timeout_seconds",
+  "session_idle_timeout",
+  "session_idle_limit_seconds",
+  "session_idle_limit",
+  "sessionIdleTimeoutSeconds",
+  "sessionIdleSeconds",
+  "idle_timeout_seconds",
+  "idleTimeoutSeconds",
+  "idle_seconds",
+  "idleSeconds",
+]
+
+const MINUTE_KEYS = [
+  "session_idle_timeout_minutes",
+  "session_idle_timeout_mins",
+  "session_idle_minutes",
+  "sessionIdleTimeoutMinutes",
+  "sessionIdleMinutes",
+  "idle_timeout_minutes",
+  "idle_minutes",
+  "idleTimeoutMinutes",
+]
+
+const WARNING_SECOND_KEYS = [
+  "session_idle_warning_seconds",
+  "session_warning_seconds",
+  "session_idle_warning",
+  "sessionIdleWarningSeconds",
+  "warning_seconds",
+  "idle_warning_seconds",
+]
+
+const WARNING_MINUTE_KEYS = [
+  "session_idle_warning_minutes",
+  "session_idle_warning_mins",
+  "sessionWarningMinutes",
+  "warning_minutes",
+  "idle_warning_minutes",
+]
+
+const NESTED_METADATA_KEYS = [
+  "session_idle",
+  "sessionIdle",
+  "session_settings",
+  "sessionSettings",
+  "session",
+]
+
+function parseNumeric(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return null
+    }
+    const parsed = Number.parseFloat(trimmed)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+function pickDurationFromSources(
+  sources: Array<Record<string, unknown>>,
+  secondKeys: string[],
+  minuteKeys: string[],
+  fallbackMs: number,
+) {
+  for (const source of sources) {
+    for (const key of secondKeys) {
+      const candidate = parseNumeric(source[key])
+      if (candidate !== null) {
+        return Math.max(candidate, 0) * 1000
+      }
+    }
+
+    for (const key of minuteKeys) {
+      const candidate = parseNumeric(source[key])
+      if (candidate !== null) {
+        return Math.max(candidate, 0) * 60 * 1000
+      }
+    }
+  }
+
+  return fallbackMs
+}
+
+function collectMetadataSources(session: Session | null) {
+  const sources: Array<Record<string, unknown>> = []
+  const metadata = session?.user?.user_metadata
+
+  if (metadata && typeof metadata === "object") {
+    sources.push(metadata as Record<string, unknown>)
+
+    for (const key of NESTED_METADATA_KEYS) {
+      const candidate = metadata[key]
+      if (candidate && typeof candidate === "object" && !Array.isArray(candidate)) {
+        sources.push(candidate as Record<string, unknown>)
+      }
+    }
+  }
+
+  return sources
+}
+
+export function resolveSessionTimeoutSettings(session: Session | null): SessionTimeoutSettings {
+  const sources = collectMetadataSources(session)
+
+  const idleThresholdMs = pickDurationFromSources(
+    sources,
+    SECOND_KEYS,
+    MINUTE_KEYS,
+    DEFAULT_IDLE_THRESHOLD_MS,
+  )
+
+  const warningWindowMs = pickDurationFromSources(
+    sources,
+    WARNING_SECOND_KEYS,
+    WARNING_MINUTE_KEYS,
+    DEFAULT_WARNING_WINDOW_MS,
+  )
+
+  const safeWarningWindow = Math.min(Math.max(warningWindowMs, 30 * 1000), idleThresholdMs)
+
+  return {
+    idleThresholdMs,
+    warningWindowMs: safeWarningWindow,
+  }
+}
+
+export function calculateSessionStatus({
+  expiresAtMs,
+  lastActivityMs,
+  nowMs,
+  settings,
+}: SessionStatusInput): SessionStatus {
+  const msUntilExpiry =
+    typeof expiresAtMs === "number" ? Math.max(expiresAtMs - nowMs, 0) : null
+  const msSinceActivity = Math.max(nowMs - lastActivityMs, 0)
+  const msUntilIdleLogout = Math.max(settings.idleThresholdMs - msSinceActivity, 0)
+
+  const warnDueToIdle = msUntilIdleLogout <= settings.warningWindowMs && settings.warningWindowMs > 0
+  const warnDueToExpiry =
+    msUntilExpiry !== null && msUntilExpiry <= settings.warningWindowMs && settings.warningWindowMs > 0
+
+  return {
+    msUntilExpiry,
+    msUntilIdleLogout,
+    shouldWarn: (warnDueToIdle || warnDueToExpiry) && msSinceActivity > 0,
+  }
+}
+
+export async function extendSessionWithAutoSave<T>(
+  callbacks: Iterable<AutoSaveCallback>,
+  refreshSession: () => Promise<T>,
+): Promise<T> {
+  const autoSaveTasks = Array.from(callbacks, (callback) => {
+    try {
+      return Promise.resolve(callback())
+    } catch (error) {
+      return Promise.reject(error)
+    }
+  })
+
+  await Promise.allSettled(autoSaveTasks)
+
+  return refreshSession()
+}
+
+export function toSeconds(ms: number | null) {
+  if (typeof ms !== "number" || Number.isNaN(ms)) {
+    return null
+  }
+
+  return Math.max(Math.floor(ms / 1000), 0)
+}
+
+export const __internal = {
+  parseNumeric,
+  collectMetadataSources,
+  pickDurationFromSources,
+}

--- a/tests/session-timeout.test.ts
+++ b/tests/session-timeout.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  calculateSessionStatus,
+  extendSessionWithAutoSave,
+  resolveSessionTimeoutSettings,
+  type SessionTimeoutSettings,
+} from "@/lib/session/session-timeout"
+
+const baseSettings: SessionTimeoutSettings = {
+  idleThresholdMs: 30 * 60 * 1000,
+  warningWindowMs: 5 * 60 * 1000,
+}
+
+describe("session timeout calculations", () => {
+  it("flags a warning when idle time is close to the limit", () => {
+    const now = Date.now()
+    const status = calculateSessionStatus({
+      expiresAtMs: now + 4 * 60 * 1000,
+      lastActivityMs: now - 27 * 60 * 1000,
+      nowMs: now,
+      settings: baseSettings,
+    })
+
+    expect(status.shouldWarn).toBe(true)
+    expect(status.msUntilIdleLogout).toBeLessThanOrEqual(baseSettings.warningWindowMs)
+  })
+
+  it("does not warn when the user is active and within the idle window", () => {
+    const now = Date.now()
+    const status = calculateSessionStatus({
+      expiresAtMs: now + 15 * 60 * 1000,
+      lastActivityMs: now - 60 * 1000,
+      nowMs: now,
+      settings: baseSettings,
+    })
+
+    expect(status.shouldWarn).toBe(false)
+    expect(status.msUntilIdleLogout).toBeGreaterThan(baseSettings.warningWindowMs)
+  })
+
+  it("derives idle settings from Supabase user metadata", () => {
+    const session = {
+      user: {
+        user_metadata: {
+          session_idle_timeout_minutes: 12,
+          session_idle_warning_minutes: 3,
+        },
+      },
+    } as unknown as Parameters<typeof resolveSessionTimeoutSettings>[0]
+
+    const settings = resolveSessionTimeoutSettings(session)
+
+    expect(settings.idleThresholdMs).toBe(12 * 60 * 1000)
+    expect(settings.warningWindowMs).toBe(3 * 60 * 1000)
+  })
+})
+
+describe("session extension", () => {
+  it("runs auto-saves before refreshing the session", async () => {
+    const order: string[] = []
+    const firstSave = vi.fn().mockImplementation(async () => {
+      order.push("auto-1")
+    })
+    const secondSave = vi.fn().mockImplementation(() => {
+      order.push("auto-2")
+    })
+    const refresh = vi.fn().mockImplementation(async () => {
+      order.push("refresh")
+      return { data: { session: null }, error: null }
+    })
+
+    const result = await extendSessionWithAutoSave([firstSave, secondSave], refresh)
+
+    expect(order).toEqual(["auto-1", "auto-2", "refresh"])
+    expect(firstSave).toHaveBeenCalledOnce()
+    expect(secondSave).toHaveBeenCalledOnce()
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(result).toEqual({ data: { session: null }, error: null })
+  })
+
+  it("still refreshes the session when an auto-save fails", async () => {
+    const order: string[] = []
+    const failingSave = vi.fn().mockImplementation(() => {
+      order.push("auto-fail")
+      throw new Error("boom")
+    })
+    const succeedingSave = vi.fn().mockImplementation(() => {
+      order.push("auto-pass")
+    })
+    const refresh = vi.fn().mockImplementation(async () => {
+      order.push("refresh")
+      return "refreshed"
+    })
+
+    const result = await extendSessionWithAutoSave([failingSave, succeedingSave], refresh)
+
+    expect(order).toEqual(["auto-fail", "auto-pass", "refresh"])
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(result).toBe("refreshed")
+  })
+})


### PR DESCRIPTION
## Summary
- add a session timeout provider that reads Supabase metadata, tracks idle activity, surfaces extension modal, and runs auto-save callbacks before refreshing tokens
- expose session timeout utilities and hooks, wire the provider into the root layout, and add a reusable session auto-save helper
- register maintenance, visitor booking, and account profile forms to persist drafts and clear them once submission succeeds

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b8c1e908328bfeb6678f14aee20