### PR TITLE
Add pricing page with Stripe upgrade flows

### DIFF
--- a/app/dashboard/(dashboard)/data.ts
+++ b/app/dashboard/(dashboard)/data.ts
@@ -234,6 +234,12 @@ async function fetchQuickActions(): Promise<QuickAction[]> {
   await wait(140)
   return [
     {
+      id: "upgrade",
+      label: "Upgrade plan",
+      description: "Unlock automations, analytics, and concierge support",
+      href: "/pricing",
+    },
+    {
       id: "payments",
       label: "Record a payment",
       description: "Log an off-platform rent payment",

--- a/app/pricing/_components/upgrade-button.tsx
+++ b/app/pricing/_components/upgrade-button.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import React, { useState } from "react"
+
+import { Button, type ButtonProps } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export type CheckoutSessionParams = {
+  priceId: string
+  planId: string
+  planName: string
+  quantity?: number
+}
+
+export type CheckoutSessionResponse = {
+  id?: string
+  url?: string
+}
+
+export async function createCheckoutSession(
+  { priceId, planId, planName, quantity = 1 }: CheckoutSessionParams,
+  fetchImpl: typeof fetch = fetch
+): Promise<CheckoutSessionResponse> {
+  if (!priceId) {
+    throw new Error("A Stripe price ID is required to start checkout.")
+  }
+
+  const response = await fetchImpl("/api/stripe/checkout", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      priceId,
+      quantity,
+      mode: "subscription",
+      metadata: {
+        plan_id: planId,
+        plan_name: planName,
+      },
+    }),
+  })
+
+  const payload = await response.json().catch(() => ({}))
+
+  if (!response.ok) {
+    const message =
+      typeof payload?.error === "string"
+        ? payload.error
+        : "Unable to create Stripe checkout session."
+    throw new Error(message)
+  }
+
+  return payload as CheckoutSessionResponse
+}
+
+export interface UpgradeButtonProps
+  extends Omit<ButtonProps, "onClick">,
+    CheckoutSessionParams {}
+
+export function UpgradeButton({
+  priceId,
+  planId,
+  planName,
+  quantity = 1,
+  children,
+  className,
+  ...buttonProps
+}: UpgradeButtonProps) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    setError(null)
+    setIsLoading(true)
+
+    try {
+      const session = await createCheckoutSession(
+        { priceId, planId, planName, quantity },
+        fetch
+      )
+
+      if (!session?.url) {
+        throw new Error("Stripe did not return a checkout URL.")
+      }
+
+      window.location.assign(session.url)
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Unable to start Stripe checkout. Please try again."
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        onClick={handleClick}
+        isLoading={isLoading}
+        className={cn("w-full", className)}
+        {...buttonProps}
+      >
+        {children ?? `Upgrade to ${planName}`}
+      </Button>
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,327 @@
+import React, { Fragment } from "react"
+
+import SmartLink from "@/components/navigation/SmartLink"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { buttonVariants } from "@/components/ui/button"
+import { PRICING_FEATURE_MATRIX, PRICING_PLANS } from "@/config/pricing"
+import { formatCurrency } from "@/lib/payments/currency"
+import { cn } from "@/lib/utils"
+import { UpgradeButton } from "./_components/upgrade-button"
+import {
+  CalendarClock,
+  Check,
+  Minus,
+  ShieldCheck,
+  Users,
+  Wallet,
+} from "lucide-react"
+
+const heroHighlights = [
+  {
+    title: "Stripe autopay spine",
+    description:
+      "Collect rent on schedule with roommate-level receipts, catch-up flows, and ledger transparency.",
+    icon: Wallet,
+  },
+  {
+    title: "Amenity governance",
+    description:
+      "Coordinate kitchens, parking, and gaming nooks with conflict-free Cal.com bookings and reminders.",
+    icon: CalendarClock,
+  },
+  {
+    title: "Policy guardrails",
+    description:
+      "Documenso workflows, visitor approvals, and RBAC keep every household compliant by default.",
+    icon: ShieldCheck,
+  },
+  {
+    title: "Roommate accountability",
+    description:
+      "Realtime messaging, polls, and insights drive shared rituals that scale beyond a single unit.",
+    icon: Users,
+  },
+]
+
+const popularPlan = PRICING_PLANS.find((plan) => plan.mostPopular) ?? PRICING_PLANS[1]
+
+export default function PricingPage() {
+  return (
+    <div className="container max-w-6xl space-y-16 py-16">
+      <section className="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
+        <Badge variant="outline" className="border-primary/30 text-primary">
+          Pricing
+        </Badge>
+        <div className="space-y-4">
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+            Plans built for every shared home
+          </h1>
+          <p className="text-base text-muted-foreground sm:text-lg">
+            Roomsily keeps rent, amenities, documents, and visitor policies in
+            sync as your community grows. Choose the plan that matches your
+            operational playbook and upgrade without switching tools.
+          </p>
+        </div>
+        {popularPlan && (
+          <div className="flex w-full flex-col items-center gap-3 sm:w-auto sm:flex-row">
+            <UpgradeButton
+              priceId={popularPlan.priceId}
+              planId={popularPlan.id}
+              planName={popularPlan.name}
+              size="lg"
+              className="sm:w-auto"
+            >
+              {popularPlan.ctaLabel}
+            </UpgradeButton>
+            <SmartLink
+              href="/contact"
+              className={cn(
+                buttonVariants({ variant: "ghost", size: "lg" }),
+                "sm:w-auto"
+              )}
+              intent="navigation"
+            >
+              Talk with a specialist
+            </SmartLink>
+          </div>
+        )}
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {heroHighlights.map((highlight) => (
+          <Card key={highlight.title} className="h-full border-dashed">
+            <CardHeader className="flex flex-row items-start gap-3">
+              <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <highlight.icon className="size-5" />
+              </div>
+              <div className="space-y-1 text-left">
+                <CardTitle className="text-base font-semibold">
+                  {highlight.title}
+                </CardTitle>
+                <CardDescription className="text-sm leading-relaxed">
+                  {highlight.description}
+                </CardDescription>
+              </div>
+            </CardHeader>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        {PRICING_PLANS.map((plan) => {
+          const formattedPrice =
+            plan.priceMonthly === 0
+              ? "Free"
+              : formatCurrency(plan.priceMonthly, plan.currency)
+
+          return (
+            <Card
+              key={plan.id}
+              className={cn(
+                "flex h-full flex-col justify-between border",
+                plan.mostPopular
+                  ? "border-primary shadow-lg shadow-primary/10"
+                  : "border-border"
+              )}
+            >
+              <CardHeader className="space-y-4">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-2xl font-semibold">
+                      {plan.name}
+                    </CardTitle>
+                    {plan.badge && (
+                      <Badge variant="secondary" className="text-xs">
+                        {plan.badge}
+                      </Badge>
+                    )}
+                  </div>
+                  <CardDescription className="text-base">
+                    {plan.tagline}
+                  </CardDescription>
+                </div>
+                <div className="space-y-1 text-left">
+                  <p className="text-4xl font-semibold">{formattedPrice}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {plan.priceSuffix}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {plan.description}
+                  </p>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                <ul className="space-y-3 text-sm">
+                  {plan.perks.map((perk) => (
+                    <li key={perk} className="flex items-start gap-2">
+                      <Check className="mt-0.5 size-4 text-primary" />
+                      <span className="text-muted-foreground">{perk}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="rounded-lg border border-dashed border-primary/20 bg-primary/5 p-4 text-sm">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-primary">
+                    Usage included
+                  </h3>
+                  <dl className="mt-3 grid gap-2">
+                    {plan.usage.map((item) => (
+                      <div
+                        key={item.label}
+                        className="flex items-center justify-between gap-4"
+                      >
+                        <dt className="text-muted-foreground">{item.label}</dt>
+                        <dd className="font-medium text-foreground">
+                          {item.value}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              </CardContent>
+              <CardFooter className="flex flex-col gap-2">
+                <UpgradeButton
+                  priceId={plan.priceId}
+                  planId={plan.id}
+                  planName={plan.name}
+                  variant={plan.mostPopular ? "default" : "outline"}
+                  className="w-full"
+                >
+                  {plan.ctaLabel}
+                </UpgradeButton>
+                <p className="text-xs text-muted-foreground">
+                  Support: {plan.support}
+                </p>
+              </CardFooter>
+            </Card>
+          )
+        })}
+      </section>
+
+      <section className="space-y-6">
+        <div className="max-w-3xl space-y-2">
+          <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+            Feature comparison
+          </h2>
+          <p className="text-muted-foreground">
+            Every plan includes core roommate workflows. Higher tiers unlock
+            advanced automation, analytics, and concierge support.
+          </p>
+        </div>
+        <div className="overflow-hidden rounded-2xl border">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-muted/50">
+              <tr>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-muted-foreground">
+                  Capability
+                </th>
+                {PRICING_PLANS.map((plan) => (
+                  <th
+                    key={plan.id}
+                    className="px-4 py-3 text-left text-sm font-semibold text-foreground"
+                  >
+                    {plan.name}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border bg-background">
+              {PRICING_FEATURE_MATRIX.map((section) => (
+                <Fragment key={section.category}>
+                  <tr className="bg-muted/40">
+                    <th
+                      colSpan={PRICING_PLANS.length + 1}
+                      className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                    >
+                      {section.category}
+                    </th>
+                  </tr>
+                  {section.features.map((feature) => (
+                    <tr key={feature.label} className="align-top">
+                      <td className="px-4 py-4 text-sm">
+                        <div className="font-medium text-foreground">
+                          {feature.label}
+                        </div>
+                        {feature.description && (
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {feature.description}
+                          </p>
+                        )}
+                      </td>
+                      {PRICING_PLANS.map((plan) => {
+                        const value = feature.plans[plan.id]
+                        return (
+                          <td key={plan.id} className="px-4 py-4 text-sm">
+                            {typeof value === "boolean" ? (
+                              value ? (
+                                <span className="inline-flex items-center gap-2 font-medium text-emerald-600">
+                                  <Check className="size-4" />
+                                  Included
+                                </span>
+                              ) : (
+                                <span className="inline-flex items-center gap-2 text-muted-foreground">
+                                  <Minus className="size-4" />
+                                  Not included
+                                </span>
+                              )
+                            ) : (
+                              <span className="font-medium text-foreground">
+                                {value}
+                              </span>
+                            )}
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  ))}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {popularPlan && (
+        <section className="overflow-hidden rounded-3xl border bg-gradient-to-r from-primary/10 via-primary/5 to-transparent p-8 sm:p-12">
+          <div className="grid gap-8 md:grid-cols-[2fr_1fr] md:items-center">
+            <div className="space-y-4">
+              <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+                Ready to upgrade?
+              </h2>
+              <p className="text-base text-muted-foreground">
+                Stripe handles billing while Roomsily centralizes operations.
+                Launch {popularPlan.name} today and give every roommate a calm
+                command centre for rent, amenities, and compliance.
+              </p>
+            </div>
+            <div className="space-y-3">
+              <UpgradeButton
+                priceId={popularPlan.priceId}
+                planId={popularPlan.id}
+                planName={popularPlan.name}
+                size="lg"
+                className="md:w-full"
+              >
+                {popularPlan.ctaLabel}
+              </UpgradeButton>
+              <SmartLink
+                href="/privacy"
+                className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+                intent="navigation"
+              >
+                Review billing & privacy terms
+              </SmartLink>
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -12,6 +12,10 @@ export const docsConfig: DocsConfig = {
       href: "/",
     },
     {
+      title: "Pricing",
+      href: "/pricing",
+    },
+    {
       title: "Dashboard",
       href: "/dashboard",
     },

--- a/config/pricing.ts
+++ b/config/pricing.ts
@@ -1,0 +1,231 @@
+export type PricingPlanId = "starter" | "plus" | "concierge"
+
+export type PricingPlan = {
+  id: PricingPlanId
+  name: string
+  tagline: string
+  priceMonthly: number
+  priceSuffix: string
+  currency: string
+  description: string
+  ctaLabel: string
+  priceId: string
+  badge?: string
+  mostPopular?: boolean
+  perks: string[]
+  usage: Array<{ label: string; value: string }>
+  support: string
+}
+
+const priceIds = {
+  starter:
+    process.env.NEXT_PUBLIC_STRIPE_STARTER_PRICE_ID ??
+    "price_roomsily_starter",
+  plus:
+    process.env.NEXT_PUBLIC_STRIPE_PLUS_PRICE_ID ??
+    "price_roomsily_plus",
+  concierge:
+    process.env.NEXT_PUBLIC_STRIPE_CONCIERGE_PRICE_ID ??
+    "price_roomsily_concierge",
+} satisfies Record<PricingPlanId, string>
+
+export const PRICING_PLANS: PricingPlan[] = [
+  {
+    id: "starter",
+    name: "Starter",
+    badge: "New households",
+    tagline: "Centralize rent, guests, and docs for a single home.",
+    priceMonthly: 0,
+    priceSuffix: "per unit / month",
+    currency: "USD",
+    description:
+      "Launch Roomsily with core rent tracking, visitor policies, and roommate messaging in one hub.",
+    ctaLabel: "Launch for free",
+    priceId: priceIds.starter,
+    perks: [
+      "Stripe-powered rent ledger with receipt history",
+      "Documenso document vault with version tracking",
+      "Visitor approvals and overnight stay guardrails",
+    ],
+    usage: [
+      { label: "Units included", value: "1 property" },
+      { label: "Roommates", value: "Up to 5" },
+    ],
+    support: "Email support during business hours",
+  },
+  {
+    id: "plus",
+    name: "Roommate Plus",
+    badge: "Most popular",
+    tagline: "Automate autopay, amenity usage, and policy enforcement.",
+    priceMonthly: 49,
+    priceSuffix: "per unit / month",
+    currency: "USD",
+    description:
+      "Unlock autopay workflows, unlimited amenity calendars, and realtime community analytics for growing portfolios.",
+    ctaLabel: "Upgrade to Plus",
+    priceId: priceIds.plus,
+    mostPopular: true,
+    perks: [
+      "Autopay cadence builder with late fee automation",
+      "Unlimited Cal.com amenity calendars with conflict prevention",
+      "Realtime roommate feed with polls and escalations",
+    ],
+    usage: [
+      { label: "Units included", value: "Up to 5 properties" },
+      { label: "Roommates", value: "Up to 25 per workspace" },
+    ],
+    support: "Priority in-app chat and next-day onboarding",
+  },
+  {
+    id: "concierge",
+    name: "Community Concierge",
+    tagline: "Dedicated success, analytics, and API extensions for scaled operators.",
+    priceMonthly: 129,
+    priceSuffix: "per unit / month",
+    currency: "USD",
+    description:
+      "Partner with Roomsily experts for white-glove onboarding, SLAs, and data exports that plug into your back office.",
+    ctaLabel: "Upgrade to Concierge",
+    priceId: priceIds.concierge,
+    perks: [
+      "Dedicated success manager with quarterly planning",
+      "Documenso + Cal.com automation playbooks",
+      "BI-ready exports and maintenance SLA tracking",
+    ],
+    usage: [
+      { label: "Units included", value: "Unlimited properties" },
+      { label: "Roommates", value: "Unlimited members" },
+    ],
+    support: "24/7 concierge with on-call escalation",
+  },
+]
+
+export type FeatureMatrixRow = {
+  label: string
+  description?: string
+  plans: Record<PricingPlanId, string | boolean>
+}
+
+export type FeatureMatrixSection = {
+  category: string
+  features: FeatureMatrixRow[]
+}
+
+export const PRICING_FEATURE_MATRIX: FeatureMatrixSection[] = [
+  {
+    category: "Payments & Finance",
+    features: [
+      {
+        label: "Autopay cadence builder",
+        description:
+          "Design rent schedules, grace periods, and automatic late fee nudges.",
+        plans: {
+          starter: false,
+          plus: true,
+          concierge: true,
+        },
+      },
+      {
+        label: "Partial & catch-up payments",
+        plans: {
+          starter: true,
+          plus: true,
+          concierge: true,
+        },
+      },
+      {
+        label: "Stripe Billing seats included",
+        plans: {
+          starter: "Up to 5 roommates",
+          plus: "Up to 25 roommates",
+          concierge: "Unlimited",
+        },
+      },
+      {
+        label: "Automated receipt exports",
+        plans: {
+          starter: "Monthly CSV",
+          plus: "Weekly CSV + PDF",
+          concierge: "Realtime webhooks",
+        },
+      },
+    ],
+  },
+  {
+    category: "Operations & Community",
+    features: [
+      {
+        label: "Amenity calendars",
+        plans: {
+          starter: "2 amenities",
+          plus: "Unlimited amenities",
+          concierge: "Unlimited + VIP slots",
+        },
+      },
+      {
+        label: "Visitor policy automation",
+        plans: {
+          starter: true,
+          plus: true,
+          concierge: true,
+        },
+      },
+      {
+        label: "Documenso workflows",
+        plans: {
+          starter: "3 active templates",
+          plus: "Unlimited templates",
+          concierge: "Unlimited + custom branding",
+        },
+      },
+      {
+        label: "Roommate messaging",
+        description:
+          "Realtime threads, polls, and escalation paths for property teams.",
+        plans: {
+          starter: true,
+          plus: true,
+          concierge: true,
+        },
+      },
+    ],
+  },
+  {
+    category: "Support & Governance",
+    features: [
+      {
+        label: "Support response time",
+        plans: {
+          starter: "24h email",
+          plus: "4h in-app chat",
+          concierge: "1h concierge",
+        },
+      },
+      {
+        label: "Role-based access control",
+        plans: {
+          starter: true,
+          plus: true,
+          concierge: true,
+        },
+      },
+      {
+        label: "Analytics & reporting",
+        plans: {
+          starter: "Rent + booking dashboards",
+          plus: "Payments, amenities & retention",
+          concierge: "Custom SQL + BI exports",
+        },
+      },
+      {
+        label: "Service-level agreements",
+        plans: {
+          starter: false,
+          plus: false,
+          concierge: true,
+        },
+      },
+    ],
+  },
+]

--- a/config/site.ts
+++ b/config/site.ts
@@ -10,6 +10,10 @@ export const siteConfig = {
       href: "/",
     },
     {
+      title: "Pricing",
+      href: "/pricing",
+    },
+    {
       title: "Dashboard",
       href: "/dashboard",
     },

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -5,6 +5,7 @@ import { siteConfig } from "@/config/site"
 
 const expectedEntries = [
   { title: "Payments", href: "/payments" },
+  { title: "Pricing", href: "/pricing" },
   { title: "Documents", href: "/documents" },
   { title: "Messaging", href: "/messaging" },
 ]

--- a/tests/pricing-page.test.ts
+++ b/tests/pricing-page.test.ts
@@ -1,0 +1,87 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+
+vi.mock("@/components/navigation/SmartLink", () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: any) =>
+    React.createElement(
+      "a",
+      {
+        href: typeof href === "string" ? href : String(href),
+        ...rest,
+      },
+      children
+    ),
+}))
+
+import PricingPage from "@/app/pricing/page"
+import {
+  PRICING_FEATURE_MATRIX,
+  PRICING_PLANS,
+} from "@/config/pricing"
+import { createCheckoutSession } from "@/app/pricing/_components/upgrade-button"
+
+describe("pricing experience", () => {
+  it("renders plan copy and feature sections from configuration", () => {
+    const markup = renderToStaticMarkup(PricingPage())
+
+    for (const plan of PRICING_PLANS) {
+      expect(markup).toContain(plan.name)
+      expect(markup).toContain(plan.ctaLabel)
+    }
+
+    for (const section of PRICING_FEATURE_MATRIX) {
+      for (const feature of section.features) {
+        const encodedLabel = feature.label.replace(/&/g, "&amp;")
+        expect(markup).toContain(encodedLabel)
+      }
+    }
+  })
+
+  it("starts a Stripe checkout session with plan metadata", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ url: "https://stripe.test/checkout" }),
+    }))
+
+    const result = await createCheckoutSession(
+      { priceId: "price_test", planId: "plus", planName: "Roommate Plus" },
+      fetchMock as unknown as typeof fetch
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit
+    ]
+
+    expect(url).toBe("/api/stripe/checkout")
+    expect(init?.method).toBe("POST")
+    expect(init?.headers).toEqual({ "Content-Type": "application/json" })
+    expect(JSON.parse((init?.body as string) ?? "{}")).toEqual({
+      priceId: "price_test",
+      quantity: 1,
+      mode: "subscription",
+      metadata: {
+        plan_id: "plus",
+        plan_name: "Roommate Plus",
+      },
+    })
+    expect(result.url).toBe("https://stripe.test/checkout")
+  })
+
+  it("surfaces Stripe errors when checkout cannot be created", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: "Stripe unavailable" }),
+    }))
+
+    await expect(
+      createCheckoutSession(
+        { priceId: "price_bad", planId: "plus", planName: "Roommate Plus" },
+        fetchMock as unknown as typeof fetch
+      )
+    ).rejects.toThrow(/Stripe unavailable/)
+  })
+})


### PR DESCRIPTION
## Summary
- add a dedicated pricing page with plan highlights, feature matrix, and Stripe-powered upgrade CTAs
- centralize pricing metadata and expose upgrade prompts in navigation and dashboard quick actions
- add tests to verify pricing content renders and Stripe checkout requests carry the correct payload

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b8acb108328aa014cb34498ede9