### PR TITLE
Add privacy dashboard with export and deletion workflows

### DIFF
--- a/app/privacy/dashboard/actions.ts
+++ b/app/privacy/dashboard/actions.ts
@@ -1,0 +1,185 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+
+import { createClient } from '@/utils/supa-server-actions'
+
+export type ExportActionState = {
+  status: 'idle' | 'success' | 'error'
+  message: string | null
+  downloadUrl: string | null
+}
+
+export const initialExportState: ExportActionState = {
+  status: 'idle',
+  message: null,
+  downloadUrl: null,
+}
+
+export type DeletionActionState = {
+  status: 'idle' | 'success' | 'error'
+  message: string | null
+}
+
+export const initialDeletionState: DeletionActionState = {
+  status: 'idle',
+  message: null,
+}
+
+function parseCheckboxValue(value: FormDataEntryValue | null): boolean {
+  if (typeof value !== 'string') {
+    return false
+  }
+
+  const normalized = value.trim().toLowerCase()
+  return normalized === 'true' || normalized === '1' || normalized === 'on' || normalized === 'yes'
+}
+
+export async function requestPrivacyExport(
+  _prevState: ExportActionState,
+  formData: FormData,
+): Promise<ExportActionState> {
+  const includeDocuments = parseCheckboxValue(formData.get('includeDocuments'))
+  const includeMessages = parseCheckboxValue(formData.get('includeMessages'))
+  const includeRequests = parseCheckboxValue(formData.get('includeRequests'))
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+  const { data: authData, error: userError } = await supabase.auth.getUser()
+  const user = authData?.user
+
+  if (userError || !user) {
+    return {
+      status: 'error',
+      message: 'You must be signed in to request a data export.',
+      downloadUrl: null,
+    }
+  }
+
+  try {
+    const { data, error } = await supabase.functions.invoke('generate-privacy-export', {
+      body: {
+        user_id: user.id,
+        options: {
+          include_documents: includeDocuments,
+          include_messages: includeMessages,
+          include_requests: includeRequests,
+        },
+      },
+    })
+
+    if (error) {
+      return {
+        status: 'error',
+        message: error.message ?? 'We could not start your export. Please try again.',
+        downloadUrl: null,
+      }
+    }
+
+    await revalidatePath('/privacy/dashboard')
+
+    const downloadUrl =
+      typeof data?.downloadUrl === 'string'
+        ? data.downloadUrl
+        : typeof data?.download_url === 'string'
+          ? data.download_url
+          : null
+
+    const message =
+      typeof data?.message === 'string'
+        ? data.message
+        : "We're compiling your archive. We'll email you when it's ready."
+
+    return {
+      status: 'success',
+      message,
+      downloadUrl,
+    }
+  } catch (_error) {
+    return {
+      status: 'error',
+      message: 'We could not start your export. Please try again.',
+      downloadUrl: null,
+    }
+  }
+}
+
+export async function submitDeletionRequest(
+  _prevState: DeletionActionState,
+  formData: FormData,
+): Promise<DeletionActionState> {
+  const confirmationValue = formData.get('confirmation')
+  if (typeof confirmationValue !== 'string' || confirmationValue.trim().length === 0) {
+    return {
+      status: 'error',
+      message: 'Please type DELETE to confirm account deletion.',
+    }
+  }
+
+  const confirmation = confirmationValue.trim()
+
+  if (confirmation.toUpperCase() !== 'DELETE') {
+    return {
+      status: 'error',
+      message: 'Type DELETE to confirm you understand this action removes all of your data.',
+    }
+  }
+
+  const reasonValue = formData.get('reason')
+  let reason: string | null = null
+  if (typeof reasonValue === 'string') {
+    const trimmed = reasonValue.trim()
+    if (trimmed.length > 0) {
+      reason = trimmed.slice(0, 500)
+    }
+  }
+
+  const exportBackup = parseCheckboxValue(formData.get('exportBackup'))
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+  const { data: authData, error: userError } = await supabase.auth.getUser()
+  const user = authData?.user
+
+  if (userError || !user) {
+    return {
+      status: 'error',
+      message: 'You must be signed in to manage deletion requests.',
+    }
+  }
+
+  try {
+    const { data, error } = await supabase.functions.invoke('schedule-account-deletion', {
+      body: {
+        user_id: user.id,
+        reason,
+        export_backup: exportBackup,
+      },
+    })
+
+    if (error) {
+      return {
+        status: 'error',
+        message: error.message ?? 'Unable to schedule account deletion right now.',
+      }
+    }
+
+    await revalidatePath('/privacy/dashboard')
+
+    const message =
+      typeof data?.message === 'string'
+        ? data.message
+        : "We'll email you once your account deletion has been scheduled."
+
+    return {
+      status: 'success',
+      message,
+    }
+  } catch (_error) {
+    return {
+      status: 'error',
+      message: 'Unable to schedule account deletion right now.',
+    }
+  }
+}

--- a/app/privacy/dashboard/page.tsx
+++ b/app/privacy/dashboard/page.tsx
@@ -1,0 +1,87 @@
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supa-server-actions'
+
+import PrivacyDashboard from './privacy-dashboard'
+import type { PrivacyDashboardSummary } from './types'
+
+type SummaryFunctionResponse = {
+  latest_export?: {
+    status?: string | null
+    requested_at?: string | null
+    completed_at?: string | null
+    download_url?: string | null
+  } | null
+  pending_deletion?: {
+    status?: string | null
+    scheduled_for?: string | null
+  } | null
+}
+
+async function loadPrivacyDashboardSummary(
+  supabase: ReturnType<typeof createClient>,
+  userId: string,
+): Promise<PrivacyDashboardSummary> {
+  try {
+    const { data, error } = await supabase.functions.invoke<SummaryFunctionResponse>(
+      'privacy-dashboard-summary',
+      {
+        body: { user_id: userId },
+      },
+    )
+
+    if (error || !data) {
+      return { latestExport: null, pendingDeletion: null }
+    }
+
+    const latestRaw = data.latest_export ?? null
+    const pendingRaw = data.pending_deletion ?? null
+
+    return {
+      latestExport: latestRaw
+        ? {
+            status: typeof latestRaw.status === 'string' ? latestRaw.status : 'pending',
+            requestedAt: typeof latestRaw.requested_at === 'string' ? latestRaw.requested_at : null,
+            completedAt: typeof latestRaw.completed_at === 'string' ? latestRaw.completed_at : null,
+            downloadUrl: typeof latestRaw.download_url === 'string' ? latestRaw.download_url : null,
+          }
+        : null,
+      pendingDeletion: pendingRaw
+        ? {
+            status: typeof pendingRaw.status === 'string' ? pendingRaw.status : 'pending',
+            scheduledFor: typeof pendingRaw.scheduled_for === 'string' ? pendingRaw.scheduled_for : null,
+          }
+        : null,
+    }
+  } catch (_error) {
+    return { latestExport: null, pendingDeletion: null }
+  }
+}
+
+export default async function PrivacyDashboardPage() {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+  const { data: authData } = await supabase.auth.getUser()
+  const user = authData?.user
+
+  if (!user) {
+    redirect('/auth')
+  }
+
+  const summary = await loadPrivacyDashboardSummary(supabase, user.id)
+
+  return (
+    <div className="mt-10 px-2 lg:p-8">
+      <div className="mx-auto flex w-full max-w-5xl flex-col space-y-8 px-2">
+        <div className="space-y-2 text-left">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-5xl">Privacy dashboard</h1>
+          <p className="text-base text-muted-foreground">
+            Manage data exports and deletions directly from the portal. These tools create an audit trail for compliance and tenant peace of mind.
+          </p>
+        </div>
+        <PrivacyDashboard email={user.email ?? null} summary={summary} />
+      </div>
+    </div>
+  )
+}

--- a/app/privacy/dashboard/privacy-dashboard.tsx
+++ b/app/privacy/dashboard/privacy-dashboard.tsx
@@ -1,0 +1,272 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useFormState, useFormStatus } from 'react-dom'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+
+import {
+  initialDeletionState,
+  initialExportState,
+  requestPrivacyExport,
+  submitDeletionRequest,
+} from './actions'
+import type { PrivacyDashboardSummary } from './types'
+
+interface PrivacyDashboardProps {
+  email: string | null
+  summary: PrivacyDashboardSummary | null
+}
+
+function formatTimestamp(timestamp: string | null | undefined) {
+  if (!timestamp) {
+    return null
+  }
+
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+function normalizeStatusLabel(status: string | null | undefined) {
+  if (!status) {
+    return 'unknown'
+  }
+
+  return status.replace(/_/g, ' ')
+}
+
+function ExportSubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" isLoading={pending} disabled={pending}>
+      {pending ? 'Generating...' : 'Generate archive'}
+    </Button>
+  )
+}
+
+function DeletionSubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" variant="destructive" isLoading={pending} disabled={pending}>
+      {pending ? 'Submitting...' : 'Schedule deletion'}
+    </Button>
+  )
+}
+
+export default function PrivacyDashboard({ email, summary }: PrivacyDashboardProps) {
+  const [exportState, exportAction] = useFormState(requestPrivacyExport, initialExportState)
+  const [deletionState, deletionAction] = useFormState(submitDeletionRequest, initialDeletionState)
+
+  const latestExport = summary?.latestExport ?? null
+  const pendingDeletion = summary?.pendingDeletion ?? null
+
+  const exportDownloadUrl = useMemo(() => {
+    return exportState.downloadUrl ?? latestExport?.downloadUrl ?? null
+  }, [exportState.downloadUrl, latestExport?.downloadUrl])
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Data export</CardTitle>
+          <CardDescription>
+            Compile a portable archive of your data. We send a download link to{' '}
+            <span className="font-medium text-foreground">{email ?? 'your account email'}</span> when it is ready.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {latestExport ? (
+            <div className="rounded-md border border-dashed p-4 text-sm">
+              <p className="font-medium text-foreground">Last export</p>
+              <dl className="mt-2 space-y-1 text-muted-foreground">
+                <div>
+                  <dt className="inline font-medium text-foreground">Status:</dt>{' '}
+                  <dd className="inline capitalize">{normalizeStatusLabel(latestExport.status)}</dd>
+                </div>
+                {latestExport.requestedAt && (
+                  <div>
+                    <dt className="inline font-medium text-foreground">Requested:</dt>{' '}
+                    <dd className="inline">{formatTimestamp(latestExport.requestedAt)}</dd>
+                  </div>
+                )}
+                {latestExport.completedAt && (
+                  <div>
+                    <dt className="inline font-medium text-foreground">Completed:</dt>{' '}
+                    <dd className="inline">{formatTimestamp(latestExport.completedAt)}</dd>
+                  </div>
+                )}
+              </dl>
+              {latestExport.downloadUrl && (
+                <p className="mt-3">
+                  <a
+                    className="text-sm font-medium text-primary underline underline-offset-4"
+                    href={latestExport.downloadUrl}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Download previous archive
+                  </a>
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              You haven&apos;t generated an export yet. Request one anytime to save your profile, bookings, and documents for your
+              personal records.
+            </p>
+          )}
+          <form action={exportAction} className="space-y-4">
+            <fieldset className="space-y-3">
+              <legend className="text-sm font-medium text-foreground">Include in archive</legend>
+              <label className="flex items-center gap-2 text-sm text-muted-foreground" htmlFor="includeDocuments">
+                <input
+                  className="h-4 w-4 rounded border border-border bg-background"
+                  defaultChecked
+                  id="includeDocuments"
+                  name="includeDocuments"
+                  type="checkbox"
+                />
+                Lease agreements & policy documents
+              </label>
+              <label className="flex items-center gap-2 text-sm text-muted-foreground" htmlFor="includeMessages">
+                <input
+                  className="h-4 w-4 rounded border border-border bg-background"
+                  defaultChecked
+                  id="includeMessages"
+                  name="includeMessages"
+                  type="checkbox"
+                />
+                Message board conversations
+              </label>
+              <label className="flex items-center gap-2 text-sm text-muted-foreground" htmlFor="includeRequests">
+                <input
+                  className="h-4 w-4 rounded border border-border bg-background"
+                  id="includeRequests"
+                  name="includeRequests"
+                  type="checkbox"
+                />
+                Maintenance and amenity requests
+              </label>
+            </fieldset>
+            {exportState.message && (
+              <p
+                className={`rounded-md border p-3 text-sm ${
+                  exportState.status === 'error'
+                    ? 'border-destructive/50 bg-destructive/10 text-destructive'
+                    : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+                }`}
+              >
+                {exportState.message}
+              </p>
+            )}
+            {exportDownloadUrl && (
+              <p className="text-sm">
+                <a
+                  className="font-medium text-primary underline underline-offset-4"
+                  href={exportDownloadUrl}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Download the latest archive
+                </a>
+              </p>
+            )}
+            <CardFooter className="px-0">
+              <ExportSubmitButton />
+            </CardFooter>
+          </form>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Self-service deletion</CardTitle>
+          <CardDescription>
+            Remove your account and associated data once obligations and balances are resolved. You will receive confirmation at{' '}
+            <span className="font-medium text-foreground">{email ?? 'your account email'}</span>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {pendingDeletion ? (
+            <div className="rounded-md border border-dashed p-4 text-sm">
+              <p className="font-medium text-foreground">Deletion status</p>
+              <dl className="mt-2 space-y-1 text-muted-foreground">
+                <div>
+                  <dt className="inline font-medium text-foreground">Status:</dt>{' '}
+                  <dd className="inline capitalize">{normalizeStatusLabel(pendingDeletion.status)}</dd>
+                </div>
+                {pendingDeletion.scheduledFor && (
+                  <div>
+                    <dt className="inline font-medium text-foreground">Scheduled for:</dt>{' '}
+                    <dd className="inline">{formatTimestamp(pendingDeletion.scheduledFor)}</dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Deletions are irreversible. We recommend downloading an export first and ensuring rent or maintenance balances are
+              settled.
+            </p>
+          )}
+          <form action={deletionAction} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="confirmation">Confirmation phrase</Label>
+              <Input id="confirmation" name="confirmation" placeholder="Type DELETE to continue" />
+              <p className="text-xs text-muted-foreground">
+                We only proceed when the phrase matches exactly. This keeps your roommates&apos; records safe from accidental deletions.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="reason">Reason for leaving (optional)</Label>
+              <Textarea id="reason" name="reason" placeholder="We appreciate any feedback you can share." />
+            </div>
+            <label className="flex items-center gap-2 text-sm text-muted-foreground" htmlFor="exportBackup">
+              <input
+                className="h-4 w-4 rounded border border-border bg-background"
+                defaultChecked
+                id="exportBackup"
+                name="exportBackup"
+                type="checkbox"
+              />
+              Generate a fresh export before deletion begins
+            </label>
+            {deletionState.message && (
+              <p
+                className={`rounded-md border p-3 text-sm ${
+                  deletionState.status === 'error'
+                    ? 'border-destructive/50 bg-destructive/10 text-destructive'
+                    : 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400'
+                }`}
+              >
+                {deletionState.message}
+              </p>
+            )}
+            <CardFooter className="px-0">
+              <DeletionSubmitButton />
+            </CardFooter>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/privacy/dashboard/types.ts
+++ b/app/privacy/dashboard/types.ts
@@ -1,0 +1,12 @@
+export type PrivacyDashboardSummary = {
+  latestExport: {
+    status: string
+    requestedAt: string | null
+    completedAt: string | null
+    downloadUrl: string | null
+  } | null
+  pendingDeletion: {
+    status: string
+    scheduledFor: string | null
+  } | null
+}

--- a/tests/privacy-dashboard.test.ts
+++ b/tests/privacy-dashboard.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createClientMock, revalidatePathMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => ({
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  })),
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}))
+
+vi.mock('@/utils/supa-server-actions', () => ({
+  createClient: createClientMock,
+}))
+
+import {
+  initialDeletionState,
+  initialExportState,
+  requestPrivacyExport,
+  submitDeletionRequest,
+} from '@/app/privacy/dashboard/actions'
+
+describe('privacy dashboard actions', () => {
+  beforeEach(() => {
+    createClientMock.mockReset()
+    revalidatePathMock.mockReset()
+  })
+
+  it('invokes the Supabase function to generate an export', async () => {
+    const functionsInvoke = vi.fn(async (fnName: string, { body }: any) => {
+      expect(fnName).toBe('generate-privacy-export')
+      expect(body.user_id).toBe('user-123')
+      expect(body.options).toEqual({
+        include_documents: true,
+        include_messages: true,
+        include_requests: false,
+      })
+
+      return {
+        data: { download_url: 'https://example.com/archive.zip', message: 'Archive ready' },
+        error: null,
+      }
+    })
+
+    const supabaseStub = {
+      auth: {
+        getUser: vi.fn(async () => ({
+          data: { user: { id: 'user-123', email: 'test@example.com' } },
+          error: null,
+        })),
+      },
+      functions: {
+        invoke: functionsInvoke,
+      },
+    }
+
+    createClientMock.mockReturnValue(supabaseStub as any)
+
+    const formData = new FormData()
+    formData.set('includeDocuments', 'on')
+    formData.set('includeMessages', 'true')
+
+    const result = await requestPrivacyExport(initialExportState, formData)
+
+    expect(result.status).toBe('success')
+    expect(result.message).toBe('Archive ready')
+    expect(result.downloadUrl).toBe('https://example.com/archive.zip')
+    expect(functionsInvoke).toHaveBeenCalledTimes(1)
+    expect(revalidatePathMock).toHaveBeenCalledWith('/privacy/dashboard')
+  })
+
+  it('requires the DELETE confirmation phrase before scheduling deletion', async () => {
+    const supabaseStub = {
+      auth: {
+        getUser: vi.fn(),
+      },
+      functions: {
+        invoke: vi.fn(),
+      },
+    }
+
+    createClientMock.mockReturnValue(supabaseStub as any)
+
+    const formData = new FormData()
+    formData.set('confirmation', 'delete my account')
+    formData.set('exportBackup', 'on')
+
+    const result = await submitDeletionRequest(initialDeletionState, formData)
+
+    expect(result.status).toBe('error')
+    expect(result.message).toMatch(/Type DELETE/i)
+    expect(createClientMock).not.toHaveBeenCalled()
+    expect(supabaseStub.functions.invoke).not.toHaveBeenCalled()
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+  })
+
+  it('schedules deletion via Supabase when confirmation matches', async () => {
+    const functionsInvoke = vi.fn(async (fnName: string, { body }: any) => {
+      expect(fnName).toBe('schedule-account-deletion')
+      expect(body.user_id).toBe('user-456')
+      expect(body.export_backup).toBe(true)
+      expect(body.reason).toBe('Moving out')
+
+      return {
+        data: { message: 'Scheduled' },
+        error: null,
+      }
+    })
+
+    const supabaseStub = {
+      auth: {
+        getUser: vi.fn(async () => ({
+          data: { user: { id: 'user-456', email: 'tenant@example.com' } },
+          error: null,
+        })),
+      },
+      functions: {
+        invoke: functionsInvoke,
+      },
+    }
+
+    createClientMock.mockReturnValue(supabaseStub as any)
+
+    const formData = new FormData()
+    formData.set('confirmation', 'DELETE ')
+    formData.set('reason', '  Moving out  ')
+    formData.set('exportBackup', 'on')
+
+    const result = await submitDeletionRequest(initialDeletionState, formData)
+
+    expect(result.status).toBe('success')
+    expect(result.message).toBe('Scheduled')
+    expect(functionsInvoke).toHaveBeenCalledTimes(1)
+    expect(revalidatePathMock).toHaveBeenCalledWith('/privacy/dashboard')
+  })
+})


### PR DESCRIPTION
## Summary
- add server actions that trigger Supabase functions for data exports and account deletion requests
- build a privacy dashboard page with UI for requesting archives, reviewing statuses, and confirming deletions
- cover export invocation and deletion safeguard flows with new vitest cases

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b8d4c008328a6cbc12ec9d65e7e