### PR TITLE
Add consent manager with gated analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,14 +2,16 @@ import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
 import { Suspense } from "react"
 
-import { Analytics } from "@vercel/analytics/react"
-import { SpeedInsights } from "@vercel/speed-insights/next"
-
 import "./globals.css"
 
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
 import { CookieButton } from "@/components/cookie-button"
+import {
+  ConsentManagerModal,
+  ConsentManagerProvider,
+} from "@/components/consent-manager"
+import { ConsentAwareScripts } from "@/components/consent-aware-scripts"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
@@ -117,51 +119,49 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <ReactQueryClientProvider>
-    <html lang="en" suppressHydrationWarning>
-    <head></head>
-      <body className={cn(
-            "min-h-screen bg-background font-sans antialiased",
-            fontSans.variable
-          )}
-        >
-<ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
+      <ConsentManagerProvider>
+        <html lang="en" suppressHydrationWarning>
+          <head></head>
+          <body
+            className={cn(
+              "min-h-screen bg-background font-sans antialiased",
+              fontSans.variable,
+            )}
           >
-             <div className="relative flex min-h-screen flex-col">
-              {/* <SiteHeader /> */}
-              <div className="flex-1">
-                <ErrorBoundary>
-                  <Suspense fallback={<RouteSkeleton />}>
-                    {children}
-                  </Suspense>
-                </ErrorBoundary>
-                <Toaster />
-                <Analytics />
-                <SpeedInsights />
+            <ThemeProvider
+              attribute="class"
+              defaultTheme="system"
+              enableSystem
+              disableTransitionOnChange
+            >
+              <div className="relative flex min-h-screen flex-col">
+                {/* <SiteHeader /> */}
+                <div className="flex-1">
+                  <ErrorBoundary>
+                    <Suspense fallback={<RouteSkeleton />}>
+                      {children}
+                    </Suspense>
+                  </ErrorBoundary>
+                  <Toaster />
+                  <ConsentAwareScripts />
+                </div>
               </div>
+              {/* <SiteFooter/> */}
 
-   </div>
-{/* <SiteFooter/> */}
-
-
-{/*
+              {/*
 enter your api info from termly.io or a provider of your choice
 <Script
   type="text/javascript"
   src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
 
  */}
-   <CookieButton />
-   <TailwindIndicator />
-          </ThemeProvider>
-
-
-
-</body>
-    </html>
+              <ConsentManagerModal />
+              <CookieButton />
+              <TailwindIndicator />
+            </ThemeProvider>
+          </body>
+        </html>
+      </ConsentManagerProvider>
     </ReactQueryClientProvider>
   )
 }

--- a/components/consent-aware-scripts.tsx
+++ b/components/consent-aware-scripts.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import * as React from "react"
+
+import { Analytics } from "@vercel/analytics/react"
+import { SpeedInsights } from "@vercel/speed-insights/next"
+
+import { useConsentManager } from "@/components/consent-manager"
+
+type DeferredCategory = "analytics" | "marketing"
+
+function enableDeferredScripts(category: DeferredCategory) {
+  if (typeof document === "undefined") {
+    return
+  }
+
+  const selector = `script[type="text/plain"][data-consent-category="${category}"]:not([data-consent-loaded="true"])`
+  const scripts = document.querySelectorAll<HTMLScriptElement>(selector)
+
+  scripts.forEach((script) => {
+    const executableScript = document.createElement("script")
+
+    executableScript.type = "text/javascript"
+    executableScript.async = script.async
+    executableScript.defer = script.defer
+
+    if (script.nonce) {
+      executableScript.nonce = script.nonce
+    }
+
+    for (const attribute of Array.from(script.attributes)) {
+      if (
+        attribute.name === "type" ||
+        attribute.name === "data-consent-category" ||
+        attribute.name === "data-consent-loaded"
+      ) {
+        continue
+      }
+
+      executableScript.setAttribute(attribute.name, attribute.value)
+    }
+
+    if (script.src) {
+      executableScript.src = script.src
+    } else {
+      executableScript.textContent = script.textContent
+    }
+
+    executableScript.dataset.consentLoaded = "true"
+    script.dataset.consentLoaded = "true"
+
+    script.parentNode?.insertBefore(executableScript, script.nextSibling)
+  })
+}
+
+export function ConsentAwareScripts() {
+  const { preferences, isReady } = useConsentManager()
+
+  React.useEffect(() => {
+    if (!isReady) {
+      return
+    }
+
+    if (preferences.analytics) {
+      enableDeferredScripts("analytics")
+    }
+
+    if (preferences.marketing) {
+      enableDeferredScripts("marketing")
+    }
+  }, [isReady, preferences.analytics, preferences.marketing])
+
+  if (!isReady) {
+    return null
+  }
+
+  return (
+    <>
+      {preferences.analytics ? (
+        <>
+          <Analytics />
+          <SpeedInsights />
+        </>
+      ) : null}
+    </>
+  )
+}

--- a/components/consent-manager.tsx
+++ b/components/consent-manager.tsx
@@ -1,0 +1,392 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Button } from "@/components/ui/button"
+import { createClient } from "@/utils/supabase-browser"
+
+const STORAGE_KEY = "roomsily.consent-preferences"
+
+type ConsentCategory = "necessary" | "analytics" | "marketing"
+
+export type ConsentPreferences = Record<ConsentCategory, boolean>
+
+const defaultPreferences: ConsentPreferences = {
+  necessary: true,
+  analytics: false,
+  marketing: false,
+}
+
+interface ConsentManagerContextValue {
+  preferences: ConsentPreferences
+  isReady: boolean
+  isModalOpen: boolean
+  setModalOpen: (open: boolean) => void
+  openManager: () => void
+  savePreferences: (preferences: ConsentPreferences) => Promise<void>
+}
+
+const ConsentManagerContext = React.createContext<ConsentManagerContextValue | null>(
+  null,
+)
+
+function normalizePreferences(
+  preferences: Partial<ConsentPreferences> | null | undefined,
+): ConsentPreferences | null {
+  if (!preferences || typeof preferences !== "object") {
+    return null
+  }
+
+  const hasAnalytics = Object.prototype.hasOwnProperty.call(
+    preferences,
+    "analytics",
+  )
+  const hasMarketing = Object.prototype.hasOwnProperty.call(
+    preferences,
+    "marketing",
+  )
+
+  if (!hasAnalytics && !hasMarketing) {
+    return null
+  }
+
+  return {
+    necessary: true,
+    analytics: Boolean(preferences.analytics),
+    marketing: Boolean(preferences.marketing),
+  }
+}
+
+async function persistPreferencesToSupabase(
+  preferences: ConsentPreferences,
+) {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  try {
+    const supabase = createClient()
+    const { data: userData, error: userError } = await supabase.auth.getUser()
+
+    if (userError || !userData?.user) {
+      return
+    }
+
+    const { data: profileData, error: profileError } = await supabase
+      .from("profiles")
+      .select("metadata")
+      .eq("id", userData.user.id)
+      .maybeSingle()
+
+    if (profileError) {
+      console.error("Failed to load consent preferences", profileError)
+      return
+    }
+
+    const metadata = {
+      ...((profileData?.metadata as Record<string, unknown> | null) ?? {}),
+      consentPreferences: preferences,
+    }
+
+    const { error: upsertError } = await supabase
+      .from("profiles")
+      .upsert({ id: userData.user.id, metadata }, { onConflict: "id" })
+
+    if (upsertError) {
+      console.error("Failed to persist consent preferences", upsertError)
+    }
+  } catch (error) {
+    console.error("Unexpected error while storing consent preferences", error)
+  }
+}
+
+export function ConsentManagerProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [preferences, setPreferences] = React.useState<ConsentPreferences>(
+    defaultPreferences,
+  )
+  const [isReady, setIsReady] = React.useState(false)
+  const [isModalOpen, setIsModalOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    let isMounted = true
+
+    const loadPreferences = async () => {
+      let storedPreferences: ConsentPreferences | null = null
+      let shouldOpenModal = true
+
+      if (typeof window !== "undefined") {
+        const raw = window.localStorage.getItem(STORAGE_KEY)
+        if (raw) {
+          try {
+            const parsed = JSON.parse(raw) as Partial<ConsentPreferences>
+            const normalized = normalizePreferences(parsed)
+            if (normalized) {
+              storedPreferences = normalized
+              shouldOpenModal = false
+            }
+          } catch (error) {
+            console.error("Failed to parse stored consent preferences", error)
+          }
+        }
+      }
+
+      if (typeof window !== "undefined" && !storedPreferences) {
+        try {
+          const supabase = createClient()
+          const { data: userData, error: userError } = await supabase.auth.getUser()
+
+          if (!userError && userData?.user) {
+            const { data: profileData, error: profileError } = await supabase
+              .from("profiles")
+              .select("metadata")
+              .eq("id", userData.user.id)
+              .maybeSingle()
+
+            if (!profileError) {
+              const remote = normalizePreferences(
+                (profileData?.metadata as Record<string, unknown> | null)
+                  ?.consentPreferences as Partial<ConsentPreferences> | null,
+              )
+
+              if (remote) {
+                storedPreferences = remote
+                shouldOpenModal = false
+
+                window.localStorage.setItem(
+                  STORAGE_KEY,
+                  JSON.stringify(remote),
+                )
+              }
+            } else {
+              console.error(
+                "Failed to load consent preferences from Supabase",
+                profileError,
+              )
+            }
+          }
+        } catch (error) {
+          console.error(
+            "Unexpected error while loading consent preferences",
+            error,
+          )
+        }
+      }
+
+      if (!isMounted) {
+        return
+      }
+
+      setPreferences(storedPreferences ?? defaultPreferences)
+      setIsModalOpen(shouldOpenModal)
+      setIsReady(true)
+    }
+
+    void loadPreferences()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const savePreferences = React.useCallback(
+    async (next: ConsentPreferences) => {
+      const normalized: ConsentPreferences = {
+        necessary: true,
+        analytics: Boolean(next.analytics),
+        marketing: Boolean(next.marketing),
+      }
+
+      setPreferences(normalized)
+
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized))
+      }
+
+      await persistPreferencesToSupabase(normalized)
+      setIsModalOpen(false)
+    },
+    [],
+  )
+
+  const value = React.useMemo<ConsentManagerContextValue>(
+    () => ({
+      preferences,
+      isReady,
+      isModalOpen,
+      setModalOpen: setIsModalOpen,
+      openManager: () => setIsModalOpen(true),
+      savePreferences,
+    }),
+    [isModalOpen, isReady, preferences, savePreferences],
+  )
+
+  return (
+    <ConsentManagerContext.Provider value={value}>
+      {children}
+    </ConsentManagerContext.Provider>
+  )
+}
+
+export function useConsentManager() {
+  const context = React.useContext(ConsentManagerContext)
+
+  if (!context) {
+    throw new Error(
+      "useConsentManager must be used within a ConsentManagerProvider",
+    )
+  }
+
+  return context
+}
+
+export function ConsentManagerModal() {
+  const { isReady, preferences, isModalOpen, setModalOpen, savePreferences } =
+    useConsentManager()
+  const [draftPreferences, setDraftPreferences] = React.useState<ConsentPreferences>(
+    preferences,
+  )
+
+  React.useEffect(() => {
+    if (isModalOpen) {
+      setDraftPreferences(preferences)
+    }
+  }, [isModalOpen, preferences])
+
+  const handleSave = React.useCallback(() => {
+    return savePreferences(draftPreferences)
+  }, [draftPreferences, savePreferences])
+
+  const handleAcceptAll = React.useCallback(() => {
+    return savePreferences({
+      necessary: true,
+      analytics: true,
+      marketing: true,
+    })
+  }, [savePreferences])
+
+  const handleRejectNonEssential = React.useCallback(() => {
+    return savePreferences({
+      necessary: true,
+      analytics: false,
+      marketing: false,
+    })
+  }, [savePreferences])
+
+  if (!isReady) {
+    return null
+  }
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={setModalOpen}>
+      <DialogContent data-testid="consent-manager">
+        <DialogHeader>
+          <DialogTitle>Privacy preferences</DialogTitle>
+          <DialogDescription>
+            Choose how we can use cookies and similar technologies to improve
+            your experience. You can update your preferences at any time.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="necessary">Necessary</Label>
+              <p className="text-sm text-muted-foreground">
+                Required for core functionality such as security and network
+                management. Always on.
+              </p>
+            </div>
+            <Switch id="necessary" checked disabled aria-readonly aria-label="Necessary cookies" />
+          </div>
+
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="analytics">Analytics</Label>
+              <p className="text-sm text-muted-foreground">
+                Helps us understand how residents use the portal so we can
+                improve performance and usability.
+              </p>
+            </div>
+            <Switch
+              id="analytics"
+              role="switch"
+              checked={draftPreferences.analytics}
+              onCheckedChange={(value) =>
+                setDraftPreferences((current) => ({
+                  ...current,
+                  analytics: value,
+                }))
+              }
+              aria-label="Analytics cookies"
+            />
+          </div>
+
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="marketing">Marketing</Label>
+              <p className="text-sm text-muted-foreground">
+                Enables personalised offers and communications from trusted
+                partners.
+              </p>
+            </div>
+            <Switch
+              id="marketing"
+              role="switch"
+              checked={draftPreferences.marketing}
+              onCheckedChange={(value) =>
+                setDraftPreferences((current) => ({
+                  ...current,
+                  marketing: value,
+                }))
+              }
+              aria-label="Marketing cookies"
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="space-y-2 sm:space-y-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              void handleRejectNonEssential()
+            }}
+          >
+            Reject non-essential
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              void handleAcceptAll()
+            }}
+          >
+            Accept all
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              void handleSave()
+            }}
+          >
+            Save preferences
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/cookie-button.tsx
+++ b/components/cookie-button.tsx
@@ -1,29 +1,23 @@
-import { siteConfig } from '@/config/site'
-import { Icons } from '@/components/icons'
-import { buttonVariants } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
+"use client"
 
+import { Icons } from "@/components/icons"
+import { useConsentManager } from "@/components/consent-manager"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
 export function CookieButton() {
+  const { openManager } = useConsentManager()
 
-return (
-<div className="fixed bottom-0 right-0 z-50">
-
-              <div
-                className={buttonVariants({
-                  size: "icon",
-                  variant: "ghost",
-                })}
-              >
-
-       <a href="#" className={cn("yourConsentManager")}>
-
-                <Icons.cookie className="size-5" />
-</a>
-                <span className="sr-only">Cookie Preferences</span>
-              </div>
-
-</div>
-
- )
+  return (
+    <div className="fixed bottom-6 right-6 z-50">
+      <button
+        type="button"
+        onClick={openManager}
+        className={cn(buttonVariants({ size: "icon", variant: "ghost" }))}
+        aria-label="Cookie preferences"
+      >
+        <Icons.cookie className="size-5" />
+      </button>
+    </div>
+  )
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.2",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.3",
@@ -85,6 +86,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^3.7.2
         version: 3.7.2(@vue/compiler-sfc@3.4.35)(prettier@2.8.8)
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -225,6 +228,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,7 +242,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
@@ -255,6 +261,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@4.0.5':
+    resolution: {integrity: sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==}
+
+  '@asamuzakjp/dom-selector@6.5.6':
+    resolution: {integrity: sha512-Mj3Hu9ymlsERd7WOsUKNUZnJYL4IZ/I9wVVYgtvOsWYiEFbkQ4G7VRIh2USxTVW4BBDIsLG+gBUgqOqf2Kvqow==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +386,40 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1628,11 +1677,33 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2012,6 +2083,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2032,6 +2107,9 @@ packages:
   aria-hidden@1.2.3:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2350,16 +2428,28 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2389,6 +2479,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -2455,6 +2548,9 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -2505,6 +2601,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.22.3:
@@ -2983,6 +3083,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3094,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3118,6 +3230,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
@@ -3201,6 +3316,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3441,10 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.2.2:
+    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3324,6 +3452,10 @@ packages:
     resolution: {integrity: sha512-JZX+1fjpqxvQmEgItvPOAwRlqf0Eg9dSZMxljA2/V2M6dluOhQCPBhewIlSJWgkNu0M36kViOgmTAMnDaAMOFw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -3374,6 +3506,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
@@ -3671,6 +3806,9 @@ packages:
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -3806,6 +3944,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3868,6 +4010,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
@@ -4001,6 +4146,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4161,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4262,6 +4417,9 @@ packages:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
 
@@ -4361,6 +4519,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4369,8 +4534,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4622,6 +4795,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4634,6 +4811,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4829,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4892,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4744,6 +4956,24 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@4.0.5':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.2
+
+  '@asamuzakjp/dom-selector@6.5.6':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.2
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5129,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.4.32)':
+    dependencies:
+      postcss: 8.4.32
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -6195,11 +6449,34 @@ snapshots:
       '@tanstack/query-core': 5.51.9
       react: 18.2.0
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/runtime': 7.23.9
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@testing-library/dom': 10.4.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.5
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -6644,6 +6921,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -6660,6 +6939,10 @@ snapshots:
   aria-hidden@1.2.3:
     dependencies:
       tslib: 2.6.2
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7012,11 +7295,29 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.1(postcss@8.4.32):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.5
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.4.32)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   date-fns@3.3.1: {}
 
@@ -7031,6 +7332,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -7090,6 +7393,8 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -7142,6 +7447,8 @@ snapshots:
       tapable: 2.2.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.22.3:
     dependencies:
@@ -7851,6 +8158,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8177,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7983,6 +8305,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.2:
     dependencies:
       '@types/estree': 1.0.5
@@ -8072,6 +8396,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.6
+      cssstyle: 5.3.1(postcss@8.4.32)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8167,6 +8519,8 @@ snapshots:
 
   lru-cache@10.1.0: {}
 
+  lru-cache@11.2.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -8174,6 +8528,8 @@ snapshots:
   lucide-react@0.302.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.176.0)(three@0.160.0):
     dependencies:
@@ -8294,6 +8650,8 @@ snapshots:
 
   mdn-data@2.0.30:
     optional: true
+
+  mdn-data@2.12.2: {}
 
   merge-anything@5.1.7:
     dependencies:
@@ -8496,7 +8854,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8706,6 +9064,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -8824,6 +9186,12 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8885,6 +9253,8 @@ snapshots:
       react: 18.2.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-merge-refs@1.1.0: {}
 
@@ -9061,6 +9431,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9079,6 +9451,12 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9375,6 +9753,8 @@ snapshots:
       periscopic: 3.1.0
     optional: true
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@2.2.0:
     dependencies:
       '@babel/runtime': 7.23.7
@@ -9502,13 +9882,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9736,7 +10130,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10158,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,6 +10184,10 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -9799,6 +10198,8 @@ snapshots:
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9832,6 +10233,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9903,6 +10315,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/tests/consent-manager.test.tsx
+++ b/tests/consent-manager.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
+
+import {
+  ConsentManagerModal,
+  ConsentManagerProvider,
+  type ConsentPreferences,
+  useConsentManager,
+} from "@/components/consent-manager"
+import { ConsentAwareScripts } from "@/components/consent-aware-scripts"
+
+const {
+  createClientMock,
+  supabaseClientStub,
+  getUserMock,
+  selectMock,
+  eqMock,
+  maybeSingleMock,
+  upsertMock,
+  fromMock,
+} = vi.hoisted(() => {
+  const getUserMock = vi.fn()
+  const selectMock = vi.fn()
+  const eqMock = vi.fn()
+  const maybeSingleMock = vi.fn()
+  const upsertMock = vi.fn()
+  const fromMock = vi.fn()
+  const createClientMock = vi.fn()
+
+  const supabaseClientStub = {
+    auth: { getUser: getUserMock },
+    from: fromMock,
+  }
+
+  fromMock.mockImplementation(() => ({
+    select: selectMock,
+    eq: eqMock,
+    maybeSingle: maybeSingleMock,
+    upsert: upsertMock,
+  }))
+
+  selectMock.mockImplementation(() => ({ eq: eqMock }))
+  eqMock.mockImplementation(() => ({ maybeSingle: maybeSingleMock }))
+  maybeSingleMock.mockResolvedValue({ data: null, error: null })
+  upsertMock.mockResolvedValue({ data: null, error: null })
+
+  return {
+    createClientMock,
+    supabaseClientStub,
+    getUserMock,
+    selectMock,
+    eqMock,
+    maybeSingleMock,
+    upsertMock,
+    fromMock,
+  }
+})
+
+vi.mock("@/utils/supabase-browser", () => ({
+  createClient: createClientMock,
+}))
+
+vi.mock("@vercel/analytics/react", () => ({
+  Analytics: () => <div data-testid="analytics" />,
+}))
+
+vi.mock("@vercel/speed-insights/next", () => ({
+  SpeedInsights: () => <div data-testid="speed-insights" />,
+}))
+
+type ConsentControllerHandle = {
+  save: (preferences: ConsentPreferences) => Promise<void>
+  isReady: () => boolean
+}
+
+const ConsentController = React.forwardRef<ConsentControllerHandle>((_, ref) => {
+  const manager = useConsentManager()
+
+  React.useImperativeHandle(ref, () => ({
+    save: manager.savePreferences,
+    isReady: () => manager.isReady,
+  }))
+
+  return <ConsentManagerModal />
+})
+ConsentController.displayName = "ConsentController"
+
+describe("consent manager", () => {
+  beforeEach(() => {
+    createClientMock.mockClear()
+    createClientMock.mockReturnValue(supabaseClientStub)
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null })
+    selectMock.mockClear()
+    eqMock.mockClear()
+    fromMock.mockClear()
+    maybeSingleMock.mockClear()
+    maybeSingleMock.mockResolvedValue({ data: null, error: null })
+    upsertMock.mockClear()
+    upsertMock.mockResolvedValue({ data: null, error: null })
+    localStorage.clear()
+    document.body.innerHTML = ""
+    delete (window as Record<string, unknown>).__analyticsExecuted
+    delete (window as Record<string, unknown>).__marketingExecuted
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("blocks analytics and marketing scripts until consent is granted", async () => {
+    const analyticsScript = document.createElement("script")
+    analyticsScript.type = "text/plain"
+    analyticsScript.dataset.consentCategory = "analytics"
+    analyticsScript.textContent =
+      "window.__analyticsExecuted = (window.__analyticsExecuted || 0) + 1"
+    document.body.appendChild(analyticsScript)
+
+    const marketingScript = document.createElement("script")
+    marketingScript.type = "text/plain"
+    marketingScript.dataset.consentCategory = "marketing"
+    marketingScript.textContent =
+      "window.__marketingExecuted = (window.__marketingExecuted || 0) + 1"
+    document.body.appendChild(marketingScript)
+
+    const controllerRef = React.createRef<ConsentControllerHandle>()
+
+    render(
+      <ConsentManagerProvider>
+        <ConsentController ref={controllerRef} />
+        <ConsentAwareScripts />
+      </ConsentManagerProvider>,
+    )
+
+    await waitFor(() => expect(controllerRef.current).not.toBeNull())
+    await waitFor(() => expect(controllerRef.current?.isReady()).toBe(true))
+
+    expect(analyticsScript.dataset.consentLoaded).toBeUndefined()
+    expect(marketingScript.dataset.consentLoaded).toBeUndefined()
+
+    await act(async () => {
+      await controllerRef.current?.save({
+        necessary: true,
+        analytics: true,
+        marketing: false,
+      })
+    })
+
+    await waitFor(() =>
+      expect(analyticsScript.dataset.consentLoaded).toBe("true"),
+    )
+    expect(marketingScript.dataset.consentLoaded).toBeUndefined()
+
+    await act(async () => {
+      await controllerRef.current?.save({
+        necessary: true,
+        analytics: true,
+        marketing: true,
+      })
+    })
+
+    await waitFor(() =>
+      expect(marketingScript.dataset.consentLoaded).toBe("true"),
+    )
+  })
+
+  it("persists consent preferences across sessions", async () => {
+    const controllerRef = React.createRef<ConsentControllerHandle>()
+
+    const { unmount } = render(
+      <ConsentManagerProvider>
+        <ConsentController ref={controllerRef} />
+        <ConsentAwareScripts />
+      </ConsentManagerProvider>,
+    )
+
+    await waitFor(() => expect(controllerRef.current).not.toBeNull())
+    await waitFor(() => expect(controllerRef.current?.isReady()).toBe(true))
+
+    await act(async () => {
+      await controllerRef.current?.save({
+        necessary: true,
+        analytics: true,
+        marketing: false,
+      })
+    })
+
+    const storedPreferences = localStorage.getItem(
+      "roomsily.consent-preferences",
+    )
+    expect(storedPreferences).toContain('"analytics":true')
+
+    unmount()
+
+    const secondControllerRef = React.createRef<ConsentControllerHandle>()
+    render(
+      <ConsentManagerProvider>
+        <ConsentController ref={secondControllerRef} />
+        <ConsentAwareScripts />
+      </ConsentManagerProvider>,
+    )
+
+    await waitFor(() => expect(secondControllerRef.current).not.toBeNull())
+    await waitFor(() => expect(secondControllerRef.current?.isReady()).toBe(true))
+
+    await waitFor(() => expect(screen.getByTestId("analytics")).toBeDefined())
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a consent manager provider and modal that persists analytics and marketing selections to localStorage and Supabase metadata
- gate analytics execution and deferred marketing scripts on stored consent while updating the global layout and cookie trigger
- expand the Vitest config and add consent tests to ensure scripts stay blocked until opted-in and choices persist across reloads

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b8dd2ac8328a6b4945e5918c7b0