### PR TITLE
feat: surface roadmap and status links in footer

### DIFF
--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,22 +1,144 @@
-import SmartLink from "@/components/navigation/SmartLink"
-import { siteConfig } from "@/config/site"
-import { buttonVariants } from "@/components/ui/button"
-import { Icons } from "@/components/icons"
+"use client"
 
-export function SiteFooter() {
+import * as React from "react"
+
+import SmartLink from "@/components/navigation/SmartLink"
+import { Badge, type BadgeProps } from "@/components/ui/badge"
+import { Icons } from "@/components/icons"
+import { siteConfig, type SiteConfig } from "@/config/site"
+
+type StatusSummary = {
+  status?: {
+    description?: string
+    indicator?: string
+  }
+  incidents?: Array<{
+    id: string
+    name?: string
+    status?: string
+    impact?: string
+  }>
+  scheduled_maintenances?: Array<{
+    id: string
+    name?: string
+    status?: string
+  }>
+}
+
+const INDICATOR_VARIANTS: Record<string, BadgeProps["variant"]> = {
+  none: "complete",
+  maintenance: "outline",
+  minor: "secondary",
+  major: "destructive",
+  critical: "destructive",
+}
+
+function getIndicatorVariant(indicator?: string): BadgeProps["variant"] {
+  if (!indicator) {
+    return "secondary"
+  }
+
+  return INDICATOR_VARIANTS[indicator] ?? "secondary"
+}
+
+function useStatusSummary(summaryUrl?: string) {
+  const [summary, setSummary] = React.useState<StatusSummary | null>(null)
+
+  React.useEffect(() => {
+    if (!summaryUrl) {
+      setSummary(null)
+      return
+    }
+
+    let cancelled = false
+    const controller = new AbortController()
+
+    async function load() {
+      try {
+        const response = await fetch(summaryUrl, { signal: controller.signal })
+        if (!response.ok) {
+          throw new Error(`Failed to fetch status summary (${response.status})`)
+        }
+
+        const json = (await response.json()) as StatusSummary
+        if (!cancelled) {
+          setSummary(json)
+        }
+      } catch (error) {
+        if (
+          cancelled ||
+          (error instanceof Error && error.name === "AbortError")
+        ) {
+          return
+        }
+
+        setSummary(null)
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [summaryUrl])
+
+  return summary
+}
+
+type SiteFooterProps = {
+  config?: SiteConfig
+}
+
+export function SiteFooter({ config = siteConfig }: SiteFooterProps) {
+  const statusSummary = useStatusSummary(config.status?.summaryUrl)
+
+  const activeIncidents = React.useMemo(() => {
+    if (!statusSummary?.incidents?.length) {
+      return []
+    }
+
+    return statusSummary.incidents.filter((incident) => {
+      const status = incident.status?.toLowerCase()
+      return status && !["resolved", "completed", "postmortem"].includes(status)
+    })
+  }, [statusSummary?.incidents])
+
+  const scheduledMaintenances = React.useMemo(() => {
+    if (!statusSummary?.scheduled_maintenances?.length) {
+      return 0
+    }
+
+    return statusSummary.scheduled_maintenances.filter((maintenance) => {
+      const status = maintenance.status?.toLowerCase()
+      return status && status !== "completed"
+    }).length
+  }, [statusSummary?.scheduled_maintenances])
+
+  const roadmapUrl = config.links.roadmap
+  const statusPageUrl = config.links.status
+
+  const statusDescription = statusSummary?.status?.description
+  const indicatorVariant = getIndicatorVariant(
+    statusSummary?.status?.indicator?.toLowerCase()
+  )
+
   return (
     <footer className="z-40 border-t">
       <div className="container flex flex-col gap-8 py-8 md:flex-row md:py-12">
         <div className="flex-1 space-y-4">
-        <SmartLink className="ml-0 inline-flex" href="/" intent="navigation">
-          <span className="flex items-center gap-2">
-            <Icons.logo className="size-6" />
-            <div className="flex flex-col leading-tight">
-              <span className="inline-block font-semibold">{siteConfig.name}</span>
-              <span className="text-xs font-medium text-muted-foreground">www.roomsily</span>
-            </div>
-          </span>
-        </SmartLink>
+          <SmartLink className="ml-0 inline-flex" href="/" intent="navigation">
+            <span className="flex items-center gap-2">
+              <Icons.logo className="size-6" />
+              <div className="flex flex-col leading-tight">
+                <span className="inline-block font-semibold">{config.name}</span>
+                <span className="text-xs font-medium text-muted-foreground">
+                  www.roomsily
+                </span>
+              </div>
+            </span>
+          </SmartLink>
           <p className="text-sm text-muted-foreground">
             Manage rent, roommates, and shared amenities from a single, secure Roomsily HQ.
           </p>
@@ -95,11 +217,58 @@ export function SiteFooter() {
               </li>
             </ul>
           </div>
+          <div className="space-y-4">
+            <h3 className="text-sm font-medium">Resources</h3>
+            <ul className="space-y-3 text-sm">
+              {roadmapUrl ? (
+                <li>
+                  <SmartLink
+                    href={roadmapUrl}
+                    className="text-muted-foreground transition-colors hover:text-primary"
+                    intent="navigation"
+                  >
+                    Public roadmap
+                  </SmartLink>
+                </li>
+              ) : null}
+              {statusPageUrl ? (
+                <li>
+                  <SmartLink
+                    href={statusPageUrl}
+                    className="text-muted-foreground transition-colors hover:text-primary"
+                    intent="navigation"
+                  >
+                    Status
+                  </SmartLink>
+                </li>
+              ) : null}
+            </ul>
+            {statusPageUrl && statusSummary ? (
+              <div className="flex flex-wrap gap-2">
+                {statusDescription ? (
+                  <Badge variant={indicatorVariant}>{statusDescription}</Badge>
+                ) : null}
+                <Badge
+                  variant={
+                    activeIncidents.length > 0 || scheduledMaintenances > 0
+                      ? "destructive"
+                      : "secondary"
+                  }
+                >
+                  {activeIncidents.length > 0
+                    ? `${activeIncidents.length} active incident${activeIncidents.length > 1 ? "s" : ""}`
+                    : scheduledMaintenances > 0
+                      ? `${scheduledMaintenances} scheduled maintenance${scheduledMaintenances > 1 ? "s" : ""}`
+                      : "No active incidents"}
+                </Badge>
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
       <div className="container border-t py-6">
         <p className="text-center text-sm text-muted-foreground">
-          © {new Date().getFullYear()} Roomsily. All rights reserved.
+          © {new Date().getFullYear()} {config.name}. All rights reserved.
         </p>
       </div>
     </footer>

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,6 +1,29 @@
-export type SiteConfig = typeof siteConfig
+export type SiteNavItem = {
+  title: string
+  href: string
+}
 
-export const siteConfig = {
+export type SiteLinks = {
+  login: string
+  signup: string
+  contact: string
+  roadmap?: string
+  status?: string
+}
+
+export type SiteStatusConfig = {
+  summaryUrl?: string
+}
+
+export type SiteConfig = {
+  name: string
+  description: string
+  mainNav: SiteNavItem[]
+  links: SiteLinks
+  status?: SiteStatusConfig
+}
+
+export const siteConfig: SiteConfig = {
   name: "Roomsily",
   description:
     "www.roomsily is the modern co-living HQ for effortless rent, amenities, and roommate communication.",
@@ -46,5 +69,10 @@ export const siteConfig = {
     login: "/auth",
     signup: "/onboarding",
     contact: "/contact",
+    roadmap: "https://feedback.roomsily.example/roadmap",
+    status: "https://status.roomsily.example",
+  },
+  status: {
+    summaryUrl: "https://status.roomsily.example/api/v2/summary.json",
   },
 }

--- a/tests/site-footer.test.tsx
+++ b/tests/site-footer.test.tsx
@@ -1,0 +1,69 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import type { SiteConfig } from "@/config/site"
+
+vi.mock("@/components/navigation/SmartLink", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: { children?: React.ReactNode; href?: string }) => (
+    <a href={typeof href === "string" ? href : "#"} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock("@/components/icons", () => ({
+  Icons: {
+    logo: () => null,
+  },
+}))
+
+let SiteFooter: (props: { config?: SiteConfig }) => JSX.Element
+let defaultConfig: SiteConfig
+
+beforeAll(async () => {
+  const [{ SiteFooter: FooterComponent }, { siteConfig }] = await Promise.all([
+    import("@/components/site-footer"),
+    import("@/config/site"),
+  ])
+
+  SiteFooter = FooterComponent
+  defaultConfig = siteConfig
+})
+
+describe("SiteFooter", () => {
+  it("renders roadmap and status links from default configuration", () => {
+    const markup = renderToStaticMarkup(<SiteFooter />)
+
+    expect(defaultConfig.links.roadmap).toBeTruthy()
+    expect(defaultConfig.links.status).toBeTruthy()
+    expect(markup).toContain(defaultConfig.links.roadmap as string)
+    expect(markup).toContain(defaultConfig.links.status as string)
+  })
+
+  it("supports overriding roadmap and status links", () => {
+    const customConfig: SiteConfig = {
+      ...defaultConfig,
+      links: {
+        ...defaultConfig.links,
+        roadmap: "https://example.com/roadmap",
+        status: "https://status.example.com",
+      },
+      status: undefined,
+    }
+
+    const markup = renderToStaticMarkup(<SiteFooter config={customConfig} />)
+
+    expect(markup).toContain(customConfig.links.roadmap as string)
+    expect(markup).toContain(customConfig.links.status as string)
+
+    if (defaultConfig.links.roadmap) {
+      expect(markup).not.toContain(defaultConfig.links.roadmap)
+    }
+
+    if (defaultConfig.links.status) {
+      expect(markup).not.toContain(defaultConfig.links.status)
+    }
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- extend the site configuration with roadmap/status links and optional status API settings
- update the SiteFooter to accept configurable links and render status badges from the status summary endpoint when available
- cover the new configuration with footer tests and enable Vitest to discover TSX test files

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b8f05748328ad9d77929601105a