### PR TITLE
Create branded recovery experiences for error handling

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { useEffect } from "react"
+import { track } from "@vercel/analytics/react"
 
-import { ErrorFallback } from "@/components/feedback/ErrorBoundary"
+import { RecoveryPage } from "@/components/feedback/recovery-page"
 
 type ErrorProps = {
   error: Error
@@ -11,10 +12,29 @@ type ErrorProps = {
 
 export default function GlobalError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    if (process.env.NODE_ENV !== "production") {
-      console.error(error)
+    console.error("Global application error", error)
+
+    const context = {
+      context: "global_error" as const,
+      message: error?.message ?? "Unknown error",
+      name: error?.name ?? "Error",
+      hasStack: Boolean(error?.stack),
+      stackSnippet: error?.stack?.slice(0, 500) ?? null,
+      path:
+        typeof window !== "undefined" ? window.location.pathname : "unavailable",
+      timestamp: Date.now(),
     }
+
+    track("global_error_viewed", context)
   }, [error])
 
-  return <ErrorFallback error={error} onRetry={reset} />
+  return (
+    <RecoveryPage
+      context="global_error"
+      title="We hit a snag loading that view"
+      subtitle="Our household systems had a hiccup. Try again or jump to another area while we investigate."
+      error={error}
+      onRetry={reset}
+    />
+  )
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { useEffect } from "react"
+import { track } from "@vercel/analytics/react"
+
+import { RecoveryPage } from "@/components/feedback/recovery-page"
+
+export default function NotFound() {
+  useEffect(() => {
+    track("not_found_viewed", {
+      context: "not_found",
+      path: typeof window !== "undefined" ? window.location.pathname : "unavailable",
+      timestamp: Date.now(),
+    })
+  }, [])
+
+  return (
+    <RecoveryPage
+      context="not_found"
+      title="We couldn’t find that page"
+      subtitle="The link might be outdated or the page has moved. Use search or jump back into the portal."
+    />
+  )
+}

--- a/components/feedback/recovery-page.tsx
+++ b/components/feedback/recovery-page.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { FormEvent, useMemo, useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { track } from "@vercel/analytics/react"
+import { Search } from "lucide-react"
+
+import { siteConfig } from "@/config/site"
+import { Button, buttonVariants } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  filterRecoveryResources,
+  type RecoveryResource,
+} from "@/lib/recovery-resources"
+import { cn } from "@/lib/utils"
+
+type RecoveryPageProps = {
+  title: string
+  subtitle: string
+  context: "global_error" | "not_found"
+  error?: Error
+  onRetry?: () => void
+}
+
+const MAX_VISIBLE_RESULTS = 6
+
+export function RecoveryPage({
+  title,
+  subtitle,
+  context,
+  error,
+  onRetry,
+}: RecoveryPageProps) {
+  const router = useRouter()
+  const [query, setQuery] = useState("")
+
+  const results = useMemo<RecoveryResource[]>(() => {
+    return filterRecoveryResources(query).slice(0, MAX_VISIBLE_RESULTS)
+  }, [query])
+
+  const hasQuery = query.trim().length > 0
+  const hasResults = results.length > 0
+
+  const handleSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const nextQuery = query.trim()
+    if (nextQuery.length === 0) {
+      track("recovery_search_skipped", { context })
+      return
+    }
+
+    track("recovery_search_submitted", {
+      context,
+      query: nextQuery,
+      hasResults,
+      destination: hasResults ? results[0]?.href : null,
+    })
+
+    if (hasResults) {
+      router.push(results[0]!.href)
+    }
+  }
+
+  const handleRetry = () => {
+    track("recovery_retry_clicked", { context })
+    onRetry?.()
+  }
+
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_top,theme(colors.primary.DEFAULT)/18%,transparent_60%)] bg-slate-950 px-6 py-16 text-foreground">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_bottom_right,theme(colors.secondary.DEFAULT)/12%,transparent_55%)]" aria-hidden="true" />
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-10 text-center">
+        <div className="space-y-3">
+          <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-primary-foreground/80">
+            Roomsily portal guide
+          </span>
+          <h1 className="bg-gradient-to-r from-primary via-primary/80 to-primary/60 bg-clip-text text-3xl font-semibold text-transparent sm:text-4xl">
+            {title}
+          </h1>
+          <p className="text-base text-muted-foreground sm:text-lg">{subtitle}</p>
+          {error?.message ? (
+            <p className="text-xs text-muted-foreground/80">
+              Reference: <code className="rounded bg-background/60 px-1 py-0.5 font-mono text-[11px]">{error.message}</code>
+            </p>
+          ) : null}
+        </div>
+
+        <form
+          onSubmit={handleSearch}
+          className="flex w-full flex-col gap-3 rounded-2xl border border-white/10 bg-background/80 p-4 shadow-2xl backdrop-blur sm:flex-row sm:items-center"
+        >
+          <div className="relative flex-1">
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search for payments, bookings, visitors…"
+              className="h-12 rounded-xl border-transparent bg-background/60 pl-10 text-base"
+              aria-label="Search the Roomsily portal"
+            />
+          </div>
+          <Button type="submit" className="h-12 rounded-xl px-6 text-base" disabled={!hasQuery}>
+            Run search
+          </Button>
+        </form>
+
+        <div className="w-full space-y-4 rounded-2xl border border-white/10 bg-background/70 p-6 text-left shadow-2xl backdrop-blur">
+          <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground/80">
+            Quick links
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {hasResults ? (
+              results.map((resource) => (
+                <Link
+                  key={resource.href}
+                  href={resource.href}
+                  className="group flex flex-col gap-1 rounded-xl border border-transparent bg-muted/10 p-4 transition hover:border-primary/30 hover:bg-primary/10"
+                >
+                  <span className="font-medium text-foreground transition group-hover:text-primary">
+                    {resource.title}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {resource.description}
+                  </span>
+                </Link>
+              ))
+            ) : (
+              <p className="col-span-full rounded-xl border border-dashed border-muted-foreground/20 bg-muted/10 p-4 text-sm text-muted-foreground">
+                No matches found. Try different keywords or head back to the dashboard for a full overview.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Link
+            href="/dashboard"
+            className={cn(
+              buttonVariants({ variant: "secondary" }),
+              "rounded-xl px-6 text-base"
+            )}
+          >
+            Back to dashboard
+          </Link>
+          <Link
+            href={siteConfig.links.contact}
+            className={cn(
+              buttonVariants({ variant: "outline" }),
+              "rounded-xl px-6 text-base"
+            )}
+          >
+            Contact support
+          </Link>
+          {onRetry ? (
+            <Button type="button" className="rounded-xl px-6 text-base" onClick={handleRetry}>
+              Try again
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/recovery-resources.ts
+++ b/lib/recovery-resources.ts
@@ -1,0 +1,79 @@
+import { siteConfig } from "@/config/site"
+
+export type RecoveryResource = {
+  title: string
+  href: string
+  description: string
+}
+
+export const recoveryResources: RecoveryResource[] = [
+  {
+    title: "Resident dashboard",
+    href: "/dashboard",
+    description: "See rent status, bookings, and household alerts at a glance.",
+  },
+  {
+    title: "Payments",
+    href: "/payments",
+    description: "Review autopay, receipts, and outstanding roommate balances.",
+  },
+  {
+    title: "Bookings",
+    href: "/bookings",
+    description: "Reserve shared amenities with conflict-free Cal.com schedules.",
+  },
+  {
+    title: "Documents",
+    href: "/documents",
+    description: "Access leases, renewals, and shared agreements in one vault.",
+  },
+  {
+    title: "Messaging",
+    href: "/messaging",
+    description: "Catch up on roommate announcements, polls, and repairs threads.",
+  },
+  {
+    title: "Visitors",
+    href: "/visitors",
+    description: "Register overnight guests and check approval status instantly.",
+  },
+  {
+    title: "Maintenance",
+    href: "/maintenance",
+    description: "Track open requests and coordinate updates with the property team.",
+  },
+  {
+    title: "Chores",
+    href: "/chores",
+    description: "Stay aligned on rotating chores and household rituals.",
+  },
+  {
+    title: "Supplies",
+    href: "/supplies",
+    description: "Plan shared shopping lists and restock reminders for the house.",
+  },
+  {
+    title: "Account settings",
+    href: "/account",
+    description: "Update your profile, notifications, and linked integrations.",
+  },
+  {
+    title: "Contact support",
+    href: siteConfig.links.contact,
+    description: "Reach the Roomsily support crew or your property manager.",
+  },
+]
+
+export function filterRecoveryResources(query: string): RecoveryResource[] {
+  const normalized = query.trim().toLowerCase()
+
+  if (!normalized) {
+    return recoveryResources
+  }
+
+  return recoveryResources.filter((resource) =>
+    [resource.title, resource.description].some((value) =>
+      value.toLowerCase().includes(normalized)
+    )
+  )
+}

--- a/tests/recovery-pages.test.tsx
+++ b/tests/recovery-pages.test.tsx
@@ -1,0 +1,85 @@
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+
+vi.mock("@vercel/analytics/react", () => ({
+  track: vi.fn(),
+}))
+
+const pushMock = vi.fn()
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    prefetch: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+  }),
+}))
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: React.forwardRef<
+    HTMLAnchorElement,
+    React.ComponentPropsWithoutRef<"a"> & { href: string | URL }
+  >(({ href, children, ...props }, ref) => {
+    const resolvedHref =
+      typeof href === "string"
+        ? href
+        : href instanceof URL
+          ? href.toString()
+          : (href as { pathname?: string })?.pathname ?? ""
+
+    return (
+      <a ref={ref} href={resolvedHref} {...props}>
+        {children}
+      </a>
+    )
+  }),
+}))
+
+import GlobalError from "@/app/error"
+import NotFound from "@/app/not-found"
+import {
+  filterRecoveryResources,
+  recoveryResources,
+} from "@/lib/recovery-resources"
+
+describe("recovery experience", () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+  })
+
+  it("renders actionable navigation on the global error page", () => {
+    const markup = renderToStaticMarkup(
+      <GlobalError error={new Error("Test failure")} reset={() => {}} />
+    )
+
+    expect(markup).toContain("We hit a snag loading that view")
+    expect(markup).toContain('href="/dashboard"')
+    expect(markup).toContain('href="/contact"')
+    expect(markup).toContain("Try again")
+    expect(markup).toContain('href="/payments"')
+    expect(markup).toContain('href="/documents"')
+  })
+
+  it("renders the not-found page with support options", () => {
+    const markup = renderToStaticMarkup(<NotFound />)
+
+    expect(markup).toContain("We couldn’t find that page")
+    expect(markup).toContain('href="/dashboard"')
+    expect(markup).toContain('href="/contact"')
+  })
+
+  it("filters recovery resources by query", () => {
+    const results = filterRecoveryResources("pay")
+
+    expect(results.some((resource) => resource.href === "/payments")).toBe(true)
+    expect(results.length).toBeLessThanOrEqual(recoveryResources.length)
+  })
+
+  it("returns all recovery resources when no query is provided", () => {
+    expect(filterRecoveryResources("")).toEqual(recoveryResources)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,12 +4,15 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {
       "@": path.resolve(__dirname),
       "server-only": path.resolve(__dirname, "tests/mocks/server-only.ts"),
     },
+  },
+  esbuild: {
+    jsx: "automatic",
   },
 })


### PR DESCRIPTION
## Summary
- replace the global error boundary page with a branded recovery screen that logs analytics context and offers search, retry, dashboard, and support actions
- add a shared recovery component and resource catalog used by a new not-found page to surface quick links and inline search
- expand vitest configuration and add coverage to ensure recovery pages render with expected navigation links

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b92814c83289a9a60ee62404478