### PR TITLE
Add voice command button and integrate command palette

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import "./globals.css"
 
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+import { CommandPaletteProvider } from "@/components/command-palette"
 import { CookieButton } from "@/components/cookie-button"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
@@ -117,51 +118,49 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <ReactQueryClientProvider>
-    <html lang="en" suppressHydrationWarning>
-    <head></head>
-      <body className={cn(
+      <html lang="en" suppressHydrationWarning>
+        <head></head>
+        <body
+          className={cn(
             "min-h-screen bg-background font-sans antialiased",
             fontSans.variable
           )}
         >
-<ThemeProvider
+          <ThemeProvider
             attribute="class"
             defaultTheme="system"
             enableSystem
             disableTransitionOnChange
           >
-             <div className="relative flex min-h-screen flex-col">
-              {/* <SiteHeader /> */}
-              <div className="flex-1">
-                <ErrorBoundary>
-                  <Suspense fallback={<RouteSkeleton />}>
-                    {children}
-                  </Suspense>
-                </ErrorBoundary>
-                <Toaster />
-                <Analytics />
-                <SpeedInsights />
+            <CommandPaletteProvider>
+              <div className="relative flex min-h-screen flex-col">
+                {/* <SiteHeader /> */}
+                <div className="flex-1">
+                  <ErrorBoundary>
+                    <Suspense fallback={<RouteSkeleton />}>
+                      {children}
+                    </Suspense>
+                  </ErrorBoundary>
+                  <Toaster />
+                  <Analytics />
+                  <SpeedInsights />
+                </div>
               </div>
+              {/* <SiteFooter/> */}
 
-   </div>
-{/* <SiteFooter/> */}
-
-
-{/*
+              {/*
 enter your api info from termly.io or a provider of your choice
 <Script
   type="text/javascript"
   src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
 
  */}
-   <CookieButton />
-   <TailwindIndicator />
+              <CookieButton />
+              <TailwindIndicator />
+            </CommandPaletteProvider>
           </ThemeProvider>
-
-
-
-</body>
-    </html>
+        </body>
+      </html>
     </ReactQueryClientProvider>
   )
 }

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { siteConfig } from "@/config/site"
+import type { VoiceIntent } from "@/lib/voice/voice-intents"
+
+interface CommandPaletteContextValue {
+  open: boolean
+  setOpen: (open: boolean) => void
+  inputValue: string
+  setInputValue: (value: string) => void
+  runIntent: (intent: VoiceIntent) => void
+}
+
+const CommandPaletteContext = React.createContext<CommandPaletteContextValue | null>(
+  null
+)
+
+export function useCommandPalette(): CommandPaletteContextValue {
+  const context = React.useContext(CommandPaletteContext)
+  if (!context) {
+    throw new Error("useCommandPalette must be used within a CommandPaletteProvider")
+  }
+  return context
+}
+
+interface CommandPaletteProviderProps {
+  children: React.ReactNode
+}
+
+export function CommandPaletteProvider({
+  children,
+}: CommandPaletteProviderProps) {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [inputValue, setInputValue] = React.useState("")
+
+  const navCommands = React.useMemo(
+    () => siteConfig.mainNav.filter((item) => item.href && !item.disabled),
+    []
+  )
+
+  const closePalette = React.useCallback(() => {
+    setOpen(false)
+    setInputValue("")
+  }, [])
+
+  const runIntent = React.useCallback(
+    (intent: VoiceIntent) => {
+      switch (intent.type) {
+        case "navigate": {
+          closePalette()
+          router.push(intent.href)
+          break
+        }
+        case "search": {
+          setInputValue(intent.query)
+          setOpen(true)
+          break
+        }
+        case "unknown": {
+          setInputValue(intent.transcript)
+          setOpen(true)
+          break
+        }
+      }
+    },
+    [closePalette, router]
+  )
+
+  React.useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault()
+        setOpen((prev) => !prev)
+      }
+    }
+
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [])
+
+  const contextValue = React.useMemo(
+    () => ({ open, setOpen, inputValue, setInputValue, runIntent }),
+    [open, inputValue, runIntent]
+  )
+
+  return (
+    <CommandPaletteContext.Provider value={contextValue}>
+      {children}
+      <CommandDialog
+        open={open}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen)
+          if (!nextOpen) {
+            setInputValue("")
+          }
+        }}
+      >
+        <CommandInput
+          value={inputValue}
+          onValueChange={setInputValue}
+          placeholder="Search roomsily or type a command"
+        />
+        <CommandList>
+          <CommandEmpty>No matching commands.</CommandEmpty>
+          <CommandGroup heading="Navigate">
+            {navCommands.map((item) => (
+              <CommandItem
+                key={item.href}
+                value={`${item.title} ${item.href}`}
+                onSelect={() => {
+                  if (item.href) {
+                    closePalette()
+                    router.push(item.href)
+                  }
+                }}
+              >
+                {item.title}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </CommandPaletteContext.Provider>
+  )
+}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -5,6 +5,8 @@ import {
   Menu,
   Linkedin,
   LucideIcon,
+  Mic,
+  MicOff,
 } from "lucide-react"
 
 export type Icon = LucideIcon
@@ -14,6 +16,8 @@ export const Icons = {
   moon: Moon,
   menu: Menu,
   linkedin: Linkedin,
+  mic: Mic,
+  micOff: MicOff,
   twitter: (props: LucideProps) => (
     <svg
       {...props}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -10,6 +10,7 @@ import { MobileNav } from "@/components/mobile-nav"
 import { SignOutButton } from "@/components/sign-out-button"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { NotificationCenter } from "@/components/notifications/notification-center"
+import { VoiceCommandButton } from "@/components/voice-command-button"
 
 export async function SiteHeader() {
   const {
@@ -69,6 +70,7 @@ export async function SiteHeader() {
           </div>
           <nav className="flex items-center space-x-1">
             {isAuthenticated && <NotificationCenter />}
+            <VoiceCommandButton />
             <ThemeToggle />
           </nav>
         </div>

--- a/components/voice-command-button.tsx
+++ b/components/voice-command-button.tsx
@@ -1,0 +1,194 @@
+"use client"
+
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/icons"
+import { useToast } from "@/components/ui/use-toast"
+import { useCommandPalette } from "@/components/command-palette"
+import { siteConfig } from "@/config/site"
+import { cn } from "@/lib/utils"
+import { mapTranscriptToIntent } from "@/lib/voice/voice-intents"
+import {
+  startListening,
+  type SpeechRecognitionLike,
+} from "@/lib/voice/voice-service"
+
+const navItems = siteConfig.mainNav.filter((item) => item.href)
+
+export function VoiceCommandButton() {
+  const { toast } = useToast()
+  const { runIntent } = useCommandPalette()
+  const [isListening, setIsListening] = React.useState(false)
+  const stopRef = React.useRef<(() => void) | null>(null)
+  const statusRef = React.useRef<HTMLSpanElement | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      stopRef.current?.()
+      stopRef.current = null
+    }
+  }, [])
+
+  const handleTranscript = React.useCallback(
+    (transcript: string) => {
+      const intent = mapTranscriptToIntent(transcript, { navItems })
+      runIntent(intent)
+
+      switch (intent.type) {
+        case "navigate": {
+          toast({
+            title: `Navigating to ${intent.label}`,
+            description: intent.href,
+          })
+          break
+        }
+        case "search": {
+          toast({
+            title: "Search ready",
+            description: `Command palette primed for “${intent.query}”.`,
+          })
+          break
+        }
+        case "unknown": {
+          toast({
+            title: "Command palette opened",
+            description: `No direct match for “${intent.transcript}”.`,
+          })
+        }
+      }
+    },
+    [runIntent, toast]
+  )
+
+  const handlePermissionDenied = React.useCallback(() => {
+    toast({
+      variant: "destructive",
+      title: "Microphone blocked",
+      description:
+        "Enable microphone access in your browser to use voice commands.",
+    })
+  }, [toast])
+
+  const handleError = React.useCallback(
+    (error: unknown) => {
+      const description =
+        typeof error === "string"
+          ? error
+          : error && typeof error === "object" && "message" in error
+            ? String((error as { message?: unknown }).message || "")
+            : "Speech recognition is unavailable."
+
+      toast({
+        variant: "destructive",
+        title: "Voice command error",
+        description: description || "Speech recognition is unavailable.",
+      })
+    },
+    [toast]
+  )
+
+  const requestMicrophone = React.useCallback(() => {
+    if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      return Promise.reject(new Error("Microphone access is not supported."))
+    }
+
+    return navigator.mediaDevices.getUserMedia({ audio: true })
+  }, [])
+
+  const recognitionFactory = React.useCallback((): SpeechRecognitionLike | null => {
+    if (typeof window === "undefined") {
+      return null
+    }
+
+    const SpeechRecognitionCtor =
+      (window as typeof window & {
+        webkitSpeechRecognition?: typeof window.SpeechRecognition
+      }).SpeechRecognition ||
+      (window as typeof window & {
+        webkitSpeechRecognition?: typeof window.SpeechRecognition
+      }).webkitSpeechRecognition
+
+    if (!SpeechRecognitionCtor) {
+      return null
+    }
+
+    return new SpeechRecognitionCtor() as unknown as SpeechRecognitionLike
+  }, [])
+
+  const handleToggle = React.useCallback(async () => {
+    if (isListening) {
+      stopRef.current?.()
+      stopRef.current = null
+      setIsListening(false)
+      statusRef.current?.setAttribute("data-status", "idle")
+      return
+    }
+
+    const result = await startListening({
+      recognitionFactory,
+      requestMicrophone,
+      onResult: handleTranscript,
+      onPermissionDenied: handlePermissionDenied,
+      onStart: () => {
+        setIsListening(true)
+        statusRef.current?.setAttribute("data-status", "listening")
+      },
+      onEnd: () => {
+        setIsListening(false)
+        statusRef.current?.setAttribute("data-status", "idle")
+        stopRef.current = null
+      },
+      onError: handleError,
+    })
+
+    if (result.started && result.stop) {
+      stopRef.current = result.stop
+    } else {
+      setIsListening(false)
+      stopRef.current = null
+    }
+  }, [
+    handleError,
+    handlePermissionDenied,
+    handleTranscript,
+    isListening,
+    recognitionFactory,
+    requestMicrophone,
+  ])
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        className={cn(
+          "relative size-9 px-0 text-muted-foreground transition-colors",
+          isListening && "text-primary"
+        )}
+        aria-pressed={isListening}
+        aria-label={isListening ? "Stop voice command" : "Start voice command"}
+        onClick={handleToggle}
+      >
+        <span className="sr-only">
+          {isListening ? "Stop voice command" : "Start voice command"}
+        </span>
+        <Icons.mic className="size-4" aria-hidden />
+        {isListening && (
+          <span
+            className="absolute inset-0 animate-ping rounded-full border border-primary/30"
+            aria-hidden
+          />
+        )}
+      </Button>
+      <span
+        ref={statusRef}
+        aria-live="polite"
+        className="sr-only"
+        data-status="idle"
+      >
+        {isListening ? "Listening for a command" : "Voice command idle"}
+      </span>
+    </>
+  )
+}

--- a/lib/voice/voice-intents.ts
+++ b/lib/voice/voice-intents.ts
@@ -1,0 +1,161 @@
+import type { NavItem } from "@/types/nav"
+
+export type VoiceIntent =
+  | {
+      type: "navigate"
+      href: string
+      label: string
+      transcript: string
+    }
+  | {
+      type: "search"
+      query: string
+      transcript: string
+    }
+  | {
+      type: "unknown"
+      transcript: string
+    }
+
+const DEFAULT_SYNONYMS: Record<string, string[]> = {
+  "/": ["home", "start", "landing"],
+  "/dashboard": ["dashboard", "overview", "home base"],
+  "/payments": ["payments", "pay rent", "rent", "billing"],
+  "/documents": ["documents", "docs", "agreements", "leases"],
+  "/messaging": ["messaging", "messages", "chat", "inbox"],
+  "/visitors": ["visitors", "guest log", "guests", "overnight visitors"],
+  "/maintenance": ["maintenance", "repairs", "fix it", "work orders"],
+  "/account": ["account", "profile", "settings", "my info"],
+  "/contact": ["contact", "support", "help", "help center"],
+}
+
+interface PreparedNavItem {
+  item: Pick<NavItem, "title" | "href">
+  phrases: string[]
+}
+
+export interface MapTranscriptOptions {
+  navItems?: Array<Pick<NavItem, "title" | "href">>
+}
+
+export function mapTranscriptToIntent(
+  transcript: string,
+  options: MapTranscriptOptions = {}
+): VoiceIntent {
+  const trimmed = transcript.trim()
+  if (!trimmed) {
+    return { type: "unknown", transcript: "" }
+  }
+
+  const searchMatch = trimmed.match(
+    /^(search|find|look up|lookup)(?:\s+for)?\s+(.+)$/i
+  )
+  if (searchMatch && searchMatch[2]) {
+    const query = searchMatch[2].trim()
+    if (query.length > 0) {
+      return { type: "search", query, transcript: trimmed }
+    }
+  }
+
+  const navItems = prepareNavItems(options.navItems)
+  const normalizedTranscript = normalize(trimmed)
+
+  for (const prepared of navItems) {
+    const href = prepared.item.href
+    if (!href) {
+      continue
+    }
+
+    for (const phrase of prepared.phrases) {
+      if (phrase && containsPhrase(normalizedTranscript, phrase)) {
+        return {
+          type: "navigate",
+          href,
+          label: prepared.item.title,
+          transcript: trimmed,
+        }
+      }
+    }
+  }
+
+  return { type: "unknown", transcript: trimmed }
+}
+
+function prepareNavItems(
+  items: Array<Pick<NavItem, "title" | "href">> | undefined
+): PreparedNavItem[] {
+  if (!items?.length) {
+    return []
+  }
+
+  return items
+    .filter((item): item is Pick<NavItem, "title" | "href"> & { href: string } =>
+      Boolean(item.href)
+    )
+    .map((item) => {
+      const phrases = new Set<string>()
+      const normalizedTitle = normalize(item.title)
+      if (normalizedTitle) {
+        phrases.add(normalizedTitle)
+      }
+
+      const slug = normalize(item.href.replace(/\//g, " "))
+      if (slug) {
+        phrases.add(slug)
+      }
+
+      const defaults = DEFAULT_SYNONYMS[item.href] ?? []
+      for (const synonym of defaults) {
+        const normalized = normalize(synonym)
+        if (normalized) {
+          phrases.add(normalized)
+        }
+      }
+
+      return {
+        item,
+        phrases: Array.from(phrases),
+      }
+    })
+}
+
+function normalize(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/['"’]/g, "")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function containsPhrase(text: string, phrase: string): boolean {
+  if (!text || !phrase) {
+    return false
+  }
+
+  if (text === phrase) {
+    return true
+  }
+
+  const words = text.split(" ")
+  const phraseWords = phrase.split(" ")
+
+  if (phraseWords.length === 1) {
+    return words.includes(phraseWords[0])
+  }
+
+  for (let i = 0; i <= words.length - phraseWords.length; i++) {
+    let matches = true
+    for (let j = 0; j < phraseWords.length; j++) {
+      if (words[i + j] !== phraseWords[j]) {
+        matches = false
+        break
+      }
+    }
+    if (matches) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/lib/voice/voice-service.ts
+++ b/lib/voice/voice-service.ts
@@ -1,0 +1,112 @@
+export interface SpeechRecognitionLike {
+  start: () => void
+  stop: () => void
+  abort?: () => void
+  lang: string
+  interimResults: boolean
+  maxAlternatives: number
+  onresult: ((event: any) => void) | null
+  onerror: ((event: any) => void) | null
+  onend: (() => void) | null
+}
+
+export interface StartListeningOptions {
+  recognitionFactory: () => SpeechRecognitionLike | null
+  requestMicrophone: () => Promise<unknown>
+  onResult: (transcript: string) => void
+  onPermissionDenied?: () => void
+  onStart?: () => void
+  onEnd?: () => void
+  onError?: (error: unknown) => void
+}
+
+export interface StartListeningResult {
+  started: boolean
+  stop?: () => void
+}
+
+export async function startListening({
+  recognitionFactory,
+  requestMicrophone,
+  onResult,
+  onPermissionDenied,
+  onStart,
+  onEnd,
+  onError,
+}: StartListeningOptions): Promise<StartListeningResult> {
+  try {
+    await requestMicrophone()
+  } catch (error) {
+    const isPermissionError =
+      typeof error === "object" &&
+      error !== null &&
+      "name" in error &&
+      (error as { name?: string }).name === "NotAllowedError"
+
+    if (isPermissionError) {
+      onPermissionDenied?.()
+      return { started: false }
+    }
+
+    onError?.(error)
+    return { started: false }
+  }
+
+  const recognition = recognitionFactory()
+  if (!recognition) {
+    onError?.("Speech recognition not supported.")
+    return { started: false }
+  }
+
+  const cleanup = () => {
+    recognition.onresult = null
+    recognition.onerror = null
+    recognition.onend = null
+  }
+
+  recognition.lang = "en-US"
+  recognition.interimResults = false
+  recognition.maxAlternatives = 1
+
+  recognition.onresult = (event: any) => {
+    const result = event?.results?.[0]?.[0]
+    const transcript = typeof result?.transcript === "string" ? result.transcript : ""
+    if (transcript) {
+      onResult(transcript)
+    }
+  }
+
+  recognition.onerror = (event: any) => {
+    cleanup()
+    onEnd?.()
+    onError?.(event)
+  }
+
+  recognition.onend = () => {
+    cleanup()
+    onEnd?.()
+  }
+
+  try {
+    onStart?.()
+    recognition.start()
+  } catch (error) {
+    cleanup()
+    onEnd?.()
+    onError?.(error)
+    return { started: false }
+  }
+
+  const stop = () => {
+    cleanup()
+    try {
+      recognition.stop()
+    } catch (stopError) {
+      recognition.abort?.()
+      onError?.(stopError)
+    }
+    onEnd?.()
+  }
+
+  return { started: true, stop }
+}

--- a/tests/voice-commands.test.ts
+++ b/tests/voice-commands.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { mapTranscriptToIntent } from "@/lib/voice/voice-intents"
+import {
+  startListening,
+  type SpeechRecognitionLike,
+} from "@/lib/voice/voice-service"
+
+const navItems = [
+  { title: "Payments", href: "/payments" },
+  { title: "Documents", href: "/documents" },
+  { title: "Messaging", href: "/messaging" },
+]
+
+describe("voice command intent mapping", () => {
+  it("detects navigation intents for known destinations", () => {
+    const intent = mapTranscriptToIntent("Open the payments portal", { navItems })
+
+    expect(intent).toMatchObject({ type: "navigate", href: "/payments" })
+  })
+
+  it("detects search intents when prefixed with search verbs", () => {
+    const intent = mapTranscriptToIntent("Search for maintenance updates", { navItems })
+
+    expect(intent).toMatchObject({ type: "search", query: "maintenance updates" })
+  })
+
+  it("returns unknown when no intent can be resolved", () => {
+    const intent = mapTranscriptToIntent("Bring me coffee", { navItems })
+
+    expect(intent).toMatchObject({ type: "unknown" })
+  })
+})
+
+class MockRecognition implements SpeechRecognitionLike {
+  start = vi.fn(() => {
+    // simulate async readiness
+    return undefined
+  })
+  stop = vi.fn(() => {
+    this.onend?.()
+    return undefined
+  })
+  abort = vi.fn()
+  lang = ""
+  interimResults = false
+  maxAlternatives = 0
+  onresult: ((event: any) => void) | null = null
+  onerror: ((event: any) => void) | null = null
+  onend: (() => void) | null = null
+
+  emit(transcript: string) {
+    this.onresult?.({ results: [{ 0: { transcript } }] })
+  }
+}
+
+describe("voice command speech service", () => {
+  it("notifies listeners when microphone permission is denied", async () => {
+    const permissionDenied = vi.fn()
+    const errors = vi.fn()
+
+    const result = await startListening({
+      recognitionFactory: () => new MockRecognition(),
+      requestMicrophone: () => Promise.reject({ name: "NotAllowedError" }),
+      onResult: vi.fn(),
+      onPermissionDenied: permissionDenied,
+      onError: errors,
+    })
+
+    expect(result.started).toBe(false)
+    expect(permissionDenied).toHaveBeenCalledTimes(1)
+    expect(errors).not.toHaveBeenCalled()
+  })
+
+  it("forwards recognition transcripts to the consumer", async () => {
+    const recognition = new MockRecognition()
+    const recognitionFactory = vi.fn(() => recognition)
+    const onResult = vi.fn()
+    const onStart = vi.fn()
+    const onEnd = vi.fn()
+
+    const result = await startListening({
+      recognitionFactory,
+      requestMicrophone: () => Promise.resolve(),
+      onResult,
+      onStart,
+      onEnd,
+      onError: vi.fn(),
+    })
+
+    expect(result.started).toBe(true)
+    expect(recognitionFactory).toHaveBeenCalled()
+    expect(onStart).toHaveBeenCalled()
+    expect(recognition.lang).toBe("en-US")
+
+    recognition.emit("Navigate to messaging")
+    expect(onResult).toHaveBeenCalledWith("Navigate to messaging")
+
+    result.stop?.()
+    expect(recognition.stop).toHaveBeenCalled()
+    expect(onEnd).toHaveBeenCalled()
+  })
+
+  it("reports when speech recognition is unsupported", async () => {
+    const onError = vi.fn()
+
+    const result = await startListening({
+      recognitionFactory: () => null,
+      requestMicrophone: () => Promise.resolve(),
+      onResult: vi.fn(),
+      onError,
+    })
+
+    expect(result.started).toBe(false)
+    expect(onError).toHaveBeenCalledWith("Speech recognition not supported.")
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared command palette provider that exposes navigation execution and keyboard shortcuts
- introduce a client voice command button that requests microphone access, listens via the Web Speech API, and routes intents through the palette
- expand icon set, wire the provider into the app shell, and add unit tests for intent parsing and speech service behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b9447588328ad776c8291c257ae