### PR TITLE
Add high-contrast theme support

### DIFF
--- a/app/dashboard/todo/components/ToggleDarkMode.tsx
+++ b/app/dashboard/todo/components/ToggleDarkMode.tsx
@@ -1,40 +1,64 @@
-"use client";
+"use client"
 
-import * as React from "react";
-import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
-import { useTheme } from "next-themes";
+import * as React from "react"
+import { Contrast, Moon, Sun, type LucideIcon } from "lucide-react"
+import { useTheme } from "next-themes"
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
 import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  APP_THEME_LABELS,
+  APP_THEMES,
+  isAppTheme,
+  type AppTheme,
+} from "@/config/themes"
+
+const ICONS: Record<AppTheme, LucideIcon> = {
+  light: Sun,
+  dark: Moon,
+  "high-contrast": Contrast,
+}
 
 export default function ModeToggle() {
-	const { setTheme } = useTheme();
+  const { resolvedTheme, setTheme, theme } = useTheme()
+  const [mounted, setMounted] = React.useState(false)
 
-	return (
-		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="outline" size="icon">
-					<SunIcon className="size-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-					<MoonIcon className="absolute size-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-					<span className="sr-only">Toggle theme</span>
-				</Button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end">
-				<DropdownMenuItem onClick={() => setTheme("light")}>
-					Light
-				</DropdownMenuItem>
-				<DropdownMenuItem onClick={() => setTheme("dark")}>
-					Dark
-				</DropdownMenuItem>
-				<DropdownMenuItem onClick={() => setTheme("system")}>
-					System
-				</DropdownMenuItem>
-			</DropdownMenuContent>
-		</DropdownMenu>
-	);
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const resolved = theme === "system" ? resolvedTheme : theme
+  const activeTheme: AppTheme =
+    mounted && isAppTheme(resolved) ? resolved : "light"
+  const Icon = ICONS[activeTheme]
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label="Toggle theme menu"
+          size="icon"
+          title={`Theme: ${APP_THEME_LABELS[activeTheme]}`}
+          variant="outline"
+        >
+          <Icon aria-hidden className="size-[1.2rem]" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {APP_THEMES.map((option) => (
+          <DropdownMenuItem key={option} onClick={() => setTheme(option)}>
+            {APP_THEME_LABELS[option]}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -55,6 +55,28 @@ body {}
     --input: 217 33% 17%;
     --ring: 210 40% 98%;
   }
+
+  .high-contrast {
+    --background: 0 0% 0%;
+    --foreground: 0 0% 100%;
+    --card: 0 0% 0%;
+    --card-foreground: 0 0% 100%;
+    --popover: 0 0% 0%;
+    --popover-foreground: 0 0% 100%;
+    --primary: 52 100% 50%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 0 0% 20%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 0 0% 18%;
+    --muted-foreground: 0 0% 100%;
+    --accent: 193 100% 41%;
+    --accent-foreground: 0 0% 0%;
+    --destructive: 0 100% 35%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 0 0% 100%;
+    --input: 0 0% 100%;
+    --ring: 52 100% 50%;
+  }
 }
 
 @layer base {

--- a/components/tailwind-indicator.tsx
+++ b/components/tailwind-indicator.tsx
@@ -2,7 +2,7 @@ export function TailwindIndicator() {
   if (process.env.NODE_ENV === "production") return null
 
   return (
-    <div className="fixed bottom-1 left-1 z-50 flex size-6 items-center justify-center rounded-full bg-gray-800 p-3 font-mono text-xs text-white">
+    <div className="fixed bottom-1 left-1 z-50 flex size-6 items-center justify-center rounded-full border border-border bg-background/95 p-3 font-mono text-[10px] text-foreground shadow hc:bg-foreground hc:text-background">
       <div className="block sm:hidden">xs</div>
       <div className="hidden sm:block md:hidden">sm</div>
       <div className="hidden md:block lg:hidden">md</div>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -4,6 +4,21 @@ import * as React from "react"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
 import { type ThemeProviderProps } from "next-themes/dist/types"
 
+import { APP_THEMES } from "@/config/themes"
+
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+  return (
+    <NextThemesProvider
+      storageKey="roomsily-theme"
+      themes={Array.from(APP_THEMES)}
+      value={{
+        light: "light",
+        dark: "dark",
+        "high-contrast": "high-contrast",
+      }}
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  )
 }

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,23 +1,49 @@
 "use client"
 
 import * as React from "react"
-import { Moon, Sun } from "lucide-react"
+import { Contrast, Moon, Sun, type LucideIcon } from "lucide-react"
 import { useTheme } from "next-themes"
 
 import { Button } from "@/components/ui/button"
+import {
+  APP_THEME_LABELS,
+  APP_THEMES,
+  isAppTheme,
+  type AppTheme,
+} from "@/config/themes"
+
+const ICONS: Record<AppTheme, LucideIcon> = {
+  light: Sun,
+  dark: Moon,
+  "high-contrast": Contrast,
+}
 
 export function ThemeToggle() {
-  const { setTheme, theme } = useTheme()
+  const { resolvedTheme, setTheme, theme } = useTheme()
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const resolved = theme === "system" ? resolvedTheme : theme
+  const currentTheme: AppTheme =
+    mounted && isAppTheme(resolved) ? resolved : "light"
+  const themeOrder = APP_THEMES
+  const currentIndex = Math.max(themeOrder.indexOf(currentTheme), 0)
+  const nextTheme = themeOrder[(currentIndex + 1) % themeOrder.length]
+  const Icon = ICONS[currentTheme]
+  const nextThemeLabel = APP_THEME_LABELS[nextTheme]
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+      onClick={() => setTheme(nextTheme)}
+      aria-label={`Switch to the ${nextThemeLabel} theme`}
+      title={`Theme: ${APP_THEME_LABELS[currentTheme]}`}
     >
-      <Sun className="h-6 w-5 dark:hidden" />
-      <Moon className="hidden size-5 dark:block" />
-      <span className="sr-only">Toggle theme</span>
+      <Icon aria-hidden className="size-5" />
     </Button>
   )
 }

--- a/config/themes.ts
+++ b/config/themes.ts
@@ -1,0 +1,12 @@
+export const APP_THEMES = ["light", "dark", "high-contrast"] as const
+
+export type AppTheme = (typeof APP_THEMES)[number]
+
+export const APP_THEME_LABELS: Record<AppTheme, string> = {
+  light: "Light",
+  dark: "Dark",
+  "high-contrast": "High contrast",
+}
+
+export const isAppTheme = (value: unknown): value is AppTheme =>
+  typeof value === "string" && APP_THEMES.includes(value as AppTheme)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss"
+import plugin from "tailwindcss/plugin"
 
 const config = {
   darkMode: ["class"],
@@ -84,7 +85,12 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    require("tailwindcss-animate"),
+    plugin(({ addVariant }) => {
+      addVariant("hc", ".high-contrast &")
+    }),
+  ],
 } satisfies Config
 
 export default config

--- a/tests/visual/themes.visual.test.ts
+++ b/tests/visual/themes.visual.test.ts
@@ -1,0 +1,184 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import postcss from "postcss"
+import { describe, expect, it } from "vitest"
+
+import { APP_THEME_LABELS, APP_THEMES, type AppTheme } from "@/config/themes"
+
+type ThemeSelector = ":root" | ".dark" | ".high-contrast"
+
+const REQUIRED_TOKENS = [
+  "--background",
+  "--foreground",
+  "--card",
+  "--card-foreground",
+  "--popover",
+  "--popover-foreground",
+  "--primary",
+  "--primary-foreground",
+  "--secondary",
+  "--secondary-foreground",
+  "--muted",
+  "--muted-foreground",
+  "--accent",
+  "--accent-foreground",
+  "--destructive",
+  "--destructive-foreground",
+  "--border",
+  "--input",
+  "--ring",
+]
+
+const CONTRAST_PAIRS: Array<[string, string]> = [
+  ["--background", "--foreground"],
+  ["--card", "--card-foreground"],
+  ["--popover", "--popover-foreground"],
+  ["--primary", "--primary-foreground"],
+  ["--secondary", "--secondary-foreground"],
+  ["--accent", "--accent-foreground"],
+  ["--destructive", "--destructive-foreground"],
+]
+
+const cssPath = path.resolve(__dirname, "../../app/globals.css")
+const cssSource = fs.readFileSync(cssPath, "utf8")
+const parsed = postcss.parse(cssSource)
+
+const selectorMap: Record<AppTheme, ThemeSelector> = {
+  light: ":root",
+  dark: ".dark",
+  "high-contrast": ".high-contrast",
+}
+
+const themeVariables: Record<ThemeSelector, Record<string, string>> = {
+  ":root": {},
+  ".dark": {},
+  ".high-contrast": {},
+}
+
+parsed.walkRules((rule) => {
+  const selector = rule.selector as ThemeSelector | undefined
+
+  if (!selector || !(selector in themeVariables)) {
+    return
+  }
+
+  rule.walkDecls((decl) => {
+    if (decl.prop.startsWith("--")) {
+      themeVariables[selector][decl.prop] = decl.value
+    }
+  })
+})
+
+const toThemeTokens = (theme: AppTheme) =>
+  themeVariables[selectorMap[theme]] ?? {}
+
+const parseHsl = (value: string) => {
+  const [hue, saturation, lightness] = value.trim().split(/\s+/)
+
+  const h = Number.parseFloat(hue)
+  const s = Number.parseFloat(saturation.replace("%", "")) / 100
+  const l = Number.parseFloat(lightness.replace("%", "")) / 100
+
+  return { h, s, l }
+}
+
+const hslToRgb = ({ h, s, l }: { h: number; s: number; l: number }) => {
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const hh = h / 60
+  const x = c * (1 - Math.abs((hh % 2) - 1))
+  const m = l - c / 2
+
+  let r = 0
+  let g = 0
+  let b = 0
+
+  if (hh >= 0 && hh < 1) {
+    r = c
+    g = x
+  } else if (hh >= 1 && hh < 2) {
+    r = x
+    g = c
+  } else if (hh >= 2 && hh < 3) {
+    g = c
+    b = x
+  } else if (hh >= 3 && hh < 4) {
+    g = x
+    b = c
+  } else if (hh >= 4 && hh < 5) {
+    r = x
+    b = c
+  } else if (hh >= 5 && hh < 6) {
+    r = c
+    b = x
+  }
+
+  return {
+    r: r + m,
+    g: g + m,
+    b: b + m,
+  }
+}
+
+const relativeLuminance = ({ r, g, b }: { r: number; g: number; b: number }) => {
+  const transform = (value: number) =>
+    value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4)
+
+  const R = transform(r)
+  const G = transform(g)
+  const B = transform(b)
+
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B
+}
+
+const contrastRatio = (first: string, second: string) => {
+  const firstRgb = hslToRgb(parseHsl(first))
+  const secondRgb = hslToRgb(parseHsl(second))
+  const firstLum = relativeLuminance(firstRgb)
+  const secondLum = relativeLuminance(secondRgb)
+  const [bright, dark] = firstLum >= secondLum
+    ? [firstLum, secondLum]
+    : [secondLum, firstLum]
+
+  return (bright + 0.05) / (dark + 0.05)
+}
+
+describe("theme tokens", () => {
+  it("defines a consistent set of CSS variables for each theme", () => {
+    for (const theme of APP_THEMES) {
+      const tokens = toThemeTokens(theme)
+
+      for (const token of REQUIRED_TOKENS) {
+        expect(tokens[token]).toBeDefined()
+      }
+    }
+  })
+
+  it("keeps high-contrast pairs above AAA thresholds", () => {
+    const highContrastTokens = toThemeTokens("high-contrast")
+
+    expect(Object.keys(highContrastTokens).length).toBeGreaterThan(0)
+
+    for (const [backgroundToken, foregroundToken] of CONTRAST_PAIRS) {
+      const background = highContrastTokens[backgroundToken]
+      const foreground = highContrastTokens[foregroundToken]
+
+      expect(background, `${backgroundToken} is missing`).toBeDefined()
+      expect(foreground, `${foregroundToken} is missing`).toBeDefined()
+
+      const ratio = contrastRatio(background, foreground)
+
+      expect(ratio).toBeGreaterThanOrEqual(7)
+    }
+  })
+
+  it("retains human readable labels for reporting", () => {
+    const labels = APP_THEMES.map((theme) => APP_THEME_LABELS[theme])
+
+    expect(labels).toEqual([
+      "Light",
+      "Dark",
+      "High contrast",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- add a high-contrast token set and Tailwind variant so class-based styling can react to the new theme
- centralize theme metadata, persist the chosen theme, and update toggles/indicator to cycle through light, dark, and high-contrast modes
- add a visual regression test that parses the global stylesheet to ensure tokens exist and high-contrast color pairs maintain AAA contrast

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b9704b083289e21fffa86bf8752