### PR TITLE
Add notification preferences settings and scheduler logic

### DIFF
--- a/app/account/notifications/preferences/loaders.ts
+++ b/app/account/notifications/preferences/loaders.ts
@@ -1,0 +1,51 @@
+"use server"
+
+import "server-only"
+
+import { cookies } from "next/headers"
+
+import type { User } from "@supabase/supabase-js"
+
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  normalizePreferencesRow,
+  type NotificationPreferences,
+} from "@/lib/notification-preferences"
+import { createClient } from "@/utils/supa-server-actions"
+
+export interface NotificationPreferencesPageData {
+  user: User | null
+  preferences: NotificationPreferences
+}
+
+export async function loadNotificationPreferencesPage(): Promise<NotificationPreferencesPageData> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      user: null,
+      preferences: { ...DEFAULT_NOTIFICATION_PREFERENCES },
+    }
+  }
+
+  const { data, error } = await supabase
+    .from("notification_preferences")
+    .select("digest_frequency, quiet_hours_start, quiet_hours_end")
+    .eq("user_id", user.id)
+    .maybeSingle()
+
+  if (error && error.code !== "PGRST116") {
+    console.error("Failed to load notification preferences", error)
+  }
+
+  const preferences = data
+    ? normalizePreferencesRow(data)
+    : { ...DEFAULT_NOTIFICATION_PREFERENCES }
+
+  return { user, preferences }
+}

--- a/app/account/notifications/preferences/page.tsx
+++ b/app/account/notifications/preferences/page.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation"
+
+import { Separator } from "@/components/ui/separator"
+
+import { NotificationPreferencesForm } from "./preferences-form"
+import { loadNotificationPreferencesPage } from "./loaders"
+
+export default async function NotificationPreferencesPage() {
+  const { user, preferences } = await loadNotificationPreferencesPage()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  return (
+    <div className="mt-10 px-2 lg:p-8">
+      <div className="mx-auto flex w-full max-w-3xl flex-col space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-5xl">
+            Notification Preferences
+          </h1>
+          <p className="text-base text-muted-foreground">
+            Choose how often we bundle updates and set quiet hours when push
+            alerts should pause.
+          </p>
+        </div>
+        <Separator />
+        <NotificationPreferencesForm
+          userId={user.id}
+          initialPreferences={preferences}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/account/notifications/preferences/preferences-form.tsx
+++ b/app/account/notifications/preferences/preferences-form.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import type { FormEvent, ChangeEvent } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
+import {
+  normalizePreferencesRow,
+  normalizeTimeInput,
+  type NotificationPreferences,
+} from "@/lib/notification-preferences"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+
+interface NotificationPreferencesFormProps {
+  userId: string
+  initialPreferences: NotificationPreferences
+}
+
+type FormState = {
+  digestFrequency: NotificationPreferences["digestFrequency"]
+  quietHoursStart: string
+  quietHoursEnd: string
+}
+
+export function NotificationPreferencesForm({
+  userId,
+  initialPreferences,
+}: NotificationPreferencesFormProps) {
+  const supabase = useSupabaseBrowser()
+  const [formState, setFormState] = useState<FormState>(() => ({
+    digestFrequency: initialPreferences.digestFrequency,
+    quietHoursStart: initialPreferences.quietHoursStart ?? "",
+    quietHoursEnd: initialPreferences.quietHoursEnd ?? "",
+  }))
+  const [isSaving, setIsSaving] = useState(false)
+
+  const updateField = useCallback(
+    (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value
+      setFormState((previous) => ({ ...previous, [field]: value }))
+    },
+    [],
+  )
+
+  const handleClearQuietHours = useCallback(() => {
+    setFormState((previous) => ({
+      ...previous,
+      quietHoursStart: "",
+      quietHoursEnd: "",
+    }))
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      setIsSaving(true)
+
+      try {
+        const quietHoursStart = normalizeTimeInput(formState.quietHoursStart)
+        const quietHoursEnd = normalizeTimeInput(formState.quietHoursEnd)
+
+        const { data, error } = await (supabase as any)
+          .from("notification_preferences")
+          .upsert(
+            {
+              user_id: userId,
+              digest_frequency: formState.digestFrequency,
+              quiet_hours_start: quietHoursStart ?? null,
+              quiet_hours_end: quietHoursEnd ?? null,
+            },
+            { onConflict: "user_id" },
+          )
+          .select("digest_frequency, quiet_hours_start, quiet_hours_end")
+          .maybeSingle()
+
+        if (error) {
+          throw error
+        }
+
+        const next = data
+          ? normalizePreferencesRow(data)
+          : {
+              digestFrequency: formState.digestFrequency,
+              quietHoursStart,
+              quietHoursEnd,
+            }
+
+        setFormState({
+          digestFrequency: next.digestFrequency,
+          quietHoursStart: next.quietHoursStart ?? "",
+          quietHoursEnd: next.quietHoursEnd ?? "",
+        })
+
+        toast({
+          title: "Notification preferences updated",
+          description:
+            next.digestFrequency === "daily"
+              ? "We will bundle alerts into a daily digest and keep nights quiet."
+              : "Weekly digest scheduled. Quiet hours respected for immediate alerts.",
+        })
+      } catch (error) {
+        console.error("Failed to save notification preferences", error)
+        toast({
+          variant: "destructive",
+          title: "Unable to save notification preferences",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Something went wrong while saving your notification settings.",
+        })
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [formState, supabase, userId],
+  )
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <div className="space-y-2">
+        <Label htmlFor="digestFrequency">Digest cadence</Label>
+        <Select
+          value={formState.digestFrequency}
+          onValueChange={(value) =>
+            setFormState((previous) => ({
+              ...previous,
+              digestFrequency: value as FormState["digestFrequency"],
+            }))
+          }
+        >
+          <SelectTrigger id="digestFrequency">
+            <SelectValue placeholder="Choose a cadence" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="daily">Daily summary</SelectItem>
+            <SelectItem value="weekly">Weekly round-up</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-sm text-muted-foreground">
+          Digests collect unread alerts and send them once per period instead of
+          real-time emails.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="quietHoursStart">Quiet hours start</Label>
+          <Input
+            id="quietHoursStart"
+            type="time"
+            step={900}
+            value={formState.quietHoursStart}
+            onChange={updateField("quietHoursStart")}
+          />
+          <p className="text-sm text-muted-foreground">
+            Set when silence begins. Leave blank to disable quiet hours.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="quietHoursEnd">Quiet hours end</Label>
+          <Input
+            id="quietHoursEnd"
+            type="time"
+            step={900}
+            value={formState.quietHoursEnd}
+            onChange={updateField("quietHoursEnd")}
+          />
+          <p className="text-sm text-muted-foreground">
+            Notifications resume after this time. Use 24-hour format.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="submit"
+          variant="default"
+          disabled={isSaving}
+        >
+          {isSaving ? "Saving preferences..." : "Save preferences"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleClearQuietHours}
+          disabled={isSaving}
+        >
+          Clear quiet hours
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/components/notifications/notification-center.tsx
+++ b/components/notifications/notification-center.tsx
@@ -10,6 +10,12 @@ import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/use-toast";
 import { createClient } from "@/utils/supabase-browser";
 import { cn } from "@/lib/utils";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  normalizePreferencesRow,
+  shouldSuppressPush,
+  type NotificationPreferences,
+} from "@/lib/notification-preferences";
 
 interface Notification {
   id: string;
@@ -19,6 +25,7 @@ interface Notification {
   action_url?: string;
   read: boolean;
   created_at: string;
+  metadata?: Record<string, any> | null;
 }
 
 export function NotificationCenter() {
@@ -26,6 +33,9 @@ export function NotificationCenter() {
   const [unreadCount, setUnreadCount] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [preferences, setPreferences] = useState<NotificationPreferences>(() => ({
+    ...DEFAULT_NOTIFICATION_PREFERENCES,
+  }));
   const { toast } = useToast();
   const supabase = useMemo(() => createClient(), []);
 
@@ -50,9 +60,66 @@ export function NotificationCenter() {
   }, [supabase]);
 
   useEffect(() => {
+    let isMounted = true;
+
+    const applyPreferences = (next: NotificationPreferences) => {
+      if (!isMounted) {
+        return;
+      }
+
+      setPreferences((previous) => {
+        if (
+          previous.digestFrequency === next.digestFrequency &&
+          previous.quietHoursStart === next.quietHoursStart &&
+          previous.quietHoursEnd === next.quietHoursEnd
+        ) {
+          return previous;
+        }
+
+        return next;
+      });
+    };
+
+    const loadPreferences = async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        if (!user) {
+          applyPreferences({ ...DEFAULT_NOTIFICATION_PREFERENCES });
+          return;
+        }
+
+        const { data, error } = await (supabase as any)
+          .from('notification_preferences')
+          .select('digest_frequency, quiet_hours_start, quiet_hours_end')
+          .eq('user_id', user.id)
+          .maybeSingle();
+
+        if (error && error.code !== 'PGRST116') {
+          console.error('Failed to load notification preferences:', error);
+          applyPreferences({ ...DEFAULT_NOTIFICATION_PREFERENCES });
+          return;
+        }
+
+        applyPreferences(normalizePreferencesRow(data));
+      } catch (error) {
+        console.error('Failed to load notification preferences:', error);
+        applyPreferences({ ...DEFAULT_NOTIFICATION_PREFERENCES });
+      }
+    };
+
+    loadPreferences();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [supabase]);
+
+  useEffect(() => {
     fetchNotifications();
 
-    // Subscribe to real-time notifications
     const channel = supabase
       .channel('notifications')
       .on(
@@ -64,24 +131,38 @@ export function NotificationCenter() {
         },
         (payload) => {
           const newNotification = payload.new as Notification;
-          setNotifications(prev => [newNotification, ...prev]);
-          setUnreadCount(prev => prev + 1);
+          setNotifications((prev) => [newNotification, ...prev]);
+          setUnreadCount((prev) => prev + 1);
 
-          // Show toast for new notification
+          const metadata = (newNotification.metadata ?? {}) as {
+            quietHours?: { suppressed?: boolean };
+          };
+          const metadataSuppressed = Boolean(metadata.quietHours?.suppressed);
+          const quietWindowActive = shouldSuppressPush(
+            new Date(),
+            preferences,
+          );
+
+          if (metadataSuppressed || quietWindowActive) {
+            return;
+          }
+
           toast({
             title: newNotification.title,
             description: newNotification.message,
-            variant: newNotification.type === 'error' ? 'destructive' :
-                    newNotification.type === 'warning' ? 'default' : 'default',
+            variant:
+              newNotification.type === 'error'
+                ? 'destructive'
+                : 'default',
           });
-        }
+        },
       )
       .subscribe();
 
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [fetchNotifications, supabase, toast]);
+  }, [fetchNotifications, preferences, supabase, toast]);
 
   const markAsRead = async (notificationId: string) => {
     try {

--- a/lib/notification-preferences-repository.ts
+++ b/lib/notification-preferences-repository.ts
@@ -1,0 +1,97 @@
+import type { Tables } from "@/lib/supabase"
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  normalizePreferencesRow,
+  normalizeTimeInput,
+  type NotificationPreferences,
+} from "@/lib/notification-preferences"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+const PREFERENCE_COLUMNS = "digest_frequency, quiet_hours_start, quiet_hours_end"
+const PREFERENCE_COLUMNS_WITH_USER = `user_id, ${PREFERENCE_COLUMNS}`
+
+type NotificationPreferencesTableRow = Tables<"notification_preferences">
+
+export async function fetchNotificationPreferences(
+  client: TypedSupabaseClient,
+  userId: string,
+): Promise<NotificationPreferences> {
+  const { data, error } = await client
+    .from("notification_preferences")
+    .select(PREFERENCE_COLUMNS)
+    .eq("user_id", userId)
+    .maybeSingle<Pick<
+      NotificationPreferencesTableRow,
+      "digest_frequency" | "quiet_hours_start" | "quiet_hours_end"
+    >>()
+
+  if (error && error.code !== "PGRST116") {
+    throw error
+  }
+
+  return normalizePreferencesRow(data)
+}
+
+export async function saveNotificationPreferences(
+  client: TypedSupabaseClient,
+  userId: string,
+  input: NotificationPreferences,
+): Promise<NotificationPreferences> {
+  const payload = {
+    user_id: userId,
+    digest_frequency: input.digestFrequency,
+    quiet_hours_start: normalizeTimeInput(input.quietHoursStart) ?? null,
+    quiet_hours_end: normalizeTimeInput(input.quietHoursEnd) ?? null,
+  }
+
+  const { data, error } = await client
+    .from("notification_preferences")
+    .upsert(payload, { onConflict: "user_id" })
+    .select(PREFERENCE_COLUMNS)
+    .maybeSingle<Pick<
+      NotificationPreferencesTableRow,
+      "digest_frequency" | "quiet_hours_start" | "quiet_hours_end"
+    >>()
+
+  if (error) {
+    throw error
+  }
+
+  return normalizePreferencesRow(data ?? payload)
+}
+
+export interface UserNotificationPreferences {
+  userId: string
+  preferences: NotificationPreferences
+}
+
+export async function fetchAllNotificationPreferences(
+  client: TypedSupabaseClient,
+): Promise<UserNotificationPreferences[]> {
+  const { data, error } = await client
+    .from("notification_preferences")
+    .select(PREFERENCE_COLUMNS_WITH_USER)
+
+  if (error) {
+    throw error
+  }
+
+  if (!data || data.length === 0) {
+    return []
+  }
+
+  return data.map((row) => ({
+    userId: row.user_id,
+    preferences: normalizePreferencesRow(row),
+  }))
+}
+
+export function withDefaultPreferences(
+  preferences: NotificationPreferences | null | undefined,
+): NotificationPreferences {
+  if (!preferences) {
+    return { ...DEFAULT_NOTIFICATION_PREFERENCES }
+  }
+
+  return preferences
+}

--- a/lib/notification-preferences.ts
+++ b/lib/notification-preferences.ts
@@ -1,0 +1,180 @@
+export type DigestFrequency = "daily" | "weekly"
+
+export interface NotificationPreferences {
+  digestFrequency: DigestFrequency
+  quietHoursStart: string | null
+  quietHoursEnd: string | null
+}
+
+export interface NotificationPreferencesRow {
+  digest_frequency: string | null
+  quiet_hours_start: string | null
+  quiet_hours_end: string | null
+}
+
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  digestFrequency: "daily",
+  quietHoursStart: null,
+  quietHoursEnd: null,
+}
+
+const MINUTES_IN_DAY = 24 * 60
+
+function clampTimeComponent(value: number, max: number) {
+  if (Number.isNaN(value)) {
+    return 0
+  }
+  return Math.min(Math.max(value, 0), max)
+}
+
+export function normalizeTimeInput(value: string | null | undefined): string | null {
+  if (!value) {
+    return null
+  }
+
+  const cleaned = value.trim()
+  if (cleaned.length === 0) {
+    return null
+  }
+
+  const parts = cleaned.split(":")
+  if (parts.length < 2) {
+    return null
+  }
+
+  const hours = clampTimeComponent(Number.parseInt(parts[0] ?? "", 10), 23)
+  const minutes = clampTimeComponent(Number.parseInt(parts[1] ?? "", 10), 59)
+
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}`
+}
+
+export function parseDbTime(value: string | null | undefined): string | null {
+  if (!value) {
+    return null
+  }
+
+  const parts = value.split(":")
+  if (parts.length < 2) {
+    return null
+  }
+
+  const hours = clampTimeComponent(Number.parseInt(parts[0] ?? "", 10), 23)
+  const minutes = clampTimeComponent(Number.parseInt(parts[1] ?? "", 10), 59)
+
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}`
+}
+
+export function coerceDigestFrequency(
+  value: string | null | undefined,
+): DigestFrequency {
+  return value === "weekly" ? "weekly" : "daily"
+}
+
+function timeStringToMinutes(value: string): number | null {
+  const normalized = normalizeTimeInput(value)
+  if (!normalized) {
+    return null
+  }
+
+  const [hours, minutes] = normalized.split(":")
+  if (hours === undefined || minutes === undefined) {
+    return null
+  }
+
+  const totalMinutes = Number.parseInt(hours, 10) * 60 + Number.parseInt(minutes, 10)
+  return clampTimeComponent(totalMinutes, MINUTES_IN_DAY)
+}
+
+export function normalizePreferencesRow(
+  row: Partial<NotificationPreferencesRow> | null | undefined,
+): NotificationPreferences {
+  if (!row) {
+    return { ...DEFAULT_NOTIFICATION_PREFERENCES }
+  }
+
+  return {
+    digestFrequency: coerceDigestFrequency(row.digest_frequency),
+    quietHoursStart: parseDbTime(row.quiet_hours_start),
+    quietHoursEnd: parseDbTime(row.quiet_hours_end),
+  }
+}
+
+export function isWithinQuietHours(
+  date: Date,
+  preferences: NotificationPreferences,
+): boolean {
+  const startMinutes = preferences.quietHoursStart
+    ? timeStringToMinutes(preferences.quietHoursStart)
+    : null
+  const endMinutes = preferences.quietHoursEnd
+    ? timeStringToMinutes(preferences.quietHoursEnd)
+    : null
+
+  if (
+    startMinutes === null ||
+    endMinutes === null ||
+    startMinutes === endMinutes
+  ) {
+    return false
+  }
+
+  const currentMinutes = date.getHours() * 60 + date.getMinutes()
+
+  if (startMinutes < endMinutes) {
+    return currentMinutes >= startMinutes && currentMinutes < endMinutes
+  }
+
+  return currentMinutes >= startMinutes || currentMinutes < endMinutes
+}
+
+export function shouldSuppressPush(
+  date: Date,
+  preferences: NotificationPreferences | null | undefined,
+): boolean {
+  if (!preferences) {
+    return false
+  }
+
+  return isWithinQuietHours(date, preferences)
+}
+
+export function getQuietHoursResume(
+  date: Date,
+  preferences: NotificationPreferences,
+): Date | null {
+  if (!isWithinQuietHours(date, preferences)) {
+    return null
+  }
+
+  const startMinutes = timeStringToMinutes(preferences.quietHoursStart ?? "")
+  const endMinutes = timeStringToMinutes(preferences.quietHoursEnd ?? "")
+
+  if (startMinutes === null || endMinutes === null) {
+    return null
+  }
+
+  const currentMinutes = date.getHours() * 60 + date.getMinutes()
+  const resume = new Date(date)
+  resume.setSeconds(0, 0)
+
+  if (startMinutes < endMinutes) {
+    const diff = endMinutes - currentMinutes
+    resume.setMinutes(resume.getMinutes() + diff)
+    return resume
+  }
+
+  if (currentMinutes >= startMinutes) {
+    const minutesUntilMidnight = MINUTES_IN_DAY - currentMinutes
+    const total = minutesUntilMidnight + endMinutes
+    resume.setMinutes(resume.getMinutes() + total)
+    return resume
+  }
+
+  const diff = endMinutes - currentMinutes
+  resume.setMinutes(resume.getMinutes() + diff)
+  return resume
+}

--- a/lib/notification-scheduler.ts
+++ b/lib/notification-scheduler.ts
@@ -1,0 +1,114 @@
+import type { Tables } from "@/lib/supabase"
+import {
+  type DigestFrequency,
+  type NotificationPreferences,
+} from "@/lib/notification-preferences"
+import {
+  fetchAllNotificationPreferences,
+  withDefaultPreferences,
+} from "@/lib/notification-preferences-repository"
+import { getServiceRoleSupabaseClient } from "@/utils/supabase-service-role"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+interface NotificationDigestItem {
+  id: string
+  title: string
+  message: string
+  createdAt: string
+  metadata: Tables<"notifications">["metadata"]
+}
+
+export interface NotificationDigestBatch {
+  userId: string
+  frequency: DigestFrequency
+  notifications: NotificationDigestItem[]
+}
+
+function calculateWindowStart(frequency: DigestFrequency, now: Date): string {
+  const start = new Date(now)
+  if (frequency === "weekly") {
+    start.setDate(start.getDate() - 7)
+  } else {
+    start.setDate(start.getDate() - 1)
+  }
+  return start.toISOString()
+}
+
+function selectColumns() {
+  return "id, title, message, created_at, metadata"
+}
+
+async function fetchUnreadNotifications(
+  client: TypedSupabaseClient,
+  userId: string,
+  preferences: NotificationPreferences,
+  now: Date,
+) {
+  const since = calculateWindowStart(preferences.digestFrequency, now)
+  const { data, error } = await client
+    .from("notifications")
+    .select(selectColumns())
+    .eq("user_id", userId)
+    .eq("read", false)
+    .gte("created_at", since)
+    .order("created_at", { ascending: true })
+
+  if (error) {
+    throw error
+  }
+
+  return data ?? []
+}
+
+export async function buildNotificationDigests(
+  client: TypedSupabaseClient,
+  now: Date = new Date(),
+): Promise<NotificationDigestBatch[]> {
+  const preferenceRecords = await fetchAllNotificationPreferences(client)
+
+  if (preferenceRecords.length === 0) {
+    return []
+  }
+
+  const batches: NotificationDigestBatch[] = []
+
+  for (const record of preferenceRecords) {
+    const preferences = withDefaultPreferences(record.preferences)
+    const notifications = await fetchUnreadNotifications(
+      client,
+      record.userId,
+      preferences,
+      now,
+    )
+
+    if (notifications.length === 0) {
+      continue
+    }
+
+    batches.push({
+      userId: record.userId,
+      frequency: preferences.digestFrequency,
+      notifications: notifications.map((notification) => ({
+        id: notification.id,
+        title: notification.title,
+        message: notification.message,
+        createdAt: notification.created_at ?? now.toISOString(),
+        metadata: notification.metadata ?? null,
+      })),
+    })
+  }
+
+  return batches
+}
+
+export async function generateNotificationDigests(
+  now: Date = new Date(),
+): Promise<NotificationDigestBatch[]> {
+  const client = getServiceRoleSupabaseClient()
+
+  if (!client) {
+    return []
+  }
+
+  return buildNotificationDigests(client, now)
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,6 +1,17 @@
 "use server"
 
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  getQuietHoursResume,
+  shouldSuppressPush,
+} from "@/lib/notification-preferences"
+import { fetchNotificationPreferences } from "@/lib/notification-preferences-repository"
+import {
+  generateNotificationDigests,
+  type NotificationDigestBatch,
+} from "@/lib/notification-scheduler"
 import { createSupbaseServerClient } from "@/utils/supaone"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
 import { Resend } from "resend"
 
 export interface NotificationData {
@@ -89,6 +100,34 @@ class NotificationService {
   async sendInAppNotification(notification: InAppNotification) {
     try {
       const supabase = await createSupbaseServerClient()
+      const typedSupabase = supabase as unknown as TypedSupabaseClient
+
+      let preferences = { ...DEFAULT_NOTIFICATION_PREFERENCES }
+      try {
+        preferences = await fetchNotificationPreferences(
+          typedSupabase,
+          notification.userId,
+        )
+      } catch (prefError) {
+        console.error("Failed to load notification preferences:", prefError)
+      }
+
+      const now = new Date()
+      const quietHoursSuppressed = shouldSuppressPush(now, preferences)
+      const quietHoursResume = quietHoursSuppressed
+        ? getQuietHoursResume(now, preferences)
+        : null
+
+      const metadata = {
+        ...notification.metadata,
+        digestFrequency: preferences.digestFrequency,
+        quietHours: {
+          suppressed: quietHoursSuppressed,
+          resumeAt: quietHoursResume ? quietHoursResume.toISOString() : null,
+          start: preferences.quietHoursStart,
+          end: preferences.quietHoursEnd,
+        },
+      }
 
       const { data, error } = await (supabase as any)
         .from("notifications")
@@ -98,9 +137,9 @@ class NotificationService {
           message: notification.message,
           type: notification.type,
           action_url: notification.actionUrl,
-          metadata: notification.metadata,
+          metadata,
           read: false,
-          created_at: new Date().toISOString(),
+          created_at: now.toISOString(),
         })
 
       if (error) {
@@ -262,3 +301,6 @@ export async function sendBulkNotifications(
 ) {
   return notificationService.sendBulkNotification(notifications)
 }
+
+export { generateNotificationDigests }
+export type { NotificationDigestBatch }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -237,6 +237,14 @@ export type Database = {
         error_message: string | null
         metadata: Json | null
       }>
+      notification_preferences: SupabaseTable<{
+        user_id: string
+        digest_frequency: 'daily' | 'weekly'
+        quiet_hours_start: string | null
+        quiet_hours_end: string | null
+        created_at: string | null
+        updated_at: string | null
+      }>
       meetings: SupabaseTable<{
         id: string
         user_id: string

--- a/supabase/migrations/20250315_notification_preferences.sql
+++ b/supabase/migrations/20250315_notification_preferences.sql
@@ -1,0 +1,28 @@
+-- Create notification_preferences table for user notification settings
+CREATE TABLE public.notification_preferences (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  digest_frequency TEXT NOT NULL DEFAULT 'daily' CHECK (digest_frequency IN ('daily', 'weekly')),
+  quiet_hours_start TIME,
+  quiet_hours_end TIME,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_notification_preferences_digest_frequency
+  ON public.notification_preferences(digest_frequency);
+
+ALTER TABLE public.notification_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their notification preferences" ON public.notification_preferences
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their notification preferences" ON public.notification_preferences
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their notification preferences" ON public.notification_preferences
+  FOR UPDATE USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER update_notification_preferences_updated_at
+  BEFORE UPDATE ON public.notification_preferences
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/tests/notification-preferences.test.ts
+++ b/tests/notification-preferences.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  saveNotificationPreferences,
+} from "@/lib/notification-preferences-repository"
+import {
+  shouldSuppressPush,
+  type NotificationPreferences,
+} from "@/lib/notification-preferences"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+describe("notification preferences", () => {
+  it("persists preferences through supabase upsert", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        digest_frequency: "weekly",
+        quiet_hours_start: "22:00:00",
+        quiet_hours_end: "06:30:00",
+      },
+      error: null,
+    })
+
+    const select = vi.fn().mockReturnValue({ maybeSingle })
+    const upsert = vi.fn().mockReturnValue({ select })
+    const from = vi.fn().mockReturnValue({ upsert })
+
+    const supabase = { from } as unknown as TypedSupabaseClient
+
+    const result = await saveNotificationPreferences(supabase, "user-123", {
+      digestFrequency: "weekly",
+      quietHoursStart: "22:00",
+      quietHoursEnd: "06:30",
+    })
+
+    expect(from).toHaveBeenCalledWith("notification_preferences")
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        user_id: "user-123",
+        digest_frequency: "weekly",
+        quiet_hours_start: "22:00",
+        quiet_hours_end: "06:30",
+      },
+      { onConflict: "user_id" },
+    )
+    expect(result.digestFrequency).toBe("weekly")
+    expect(result.quietHoursStart).toBe("22:00")
+    expect(result.quietHoursEnd).toBe("06:30")
+  })
+
+  it("recognises quiet hours that cross midnight", () => {
+    const preferences: NotificationPreferences = {
+      digestFrequency: "daily",
+      quietHoursStart: "22:00",
+      quietHoursEnd: "06:30",
+    }
+
+    const createDate = (hours: number, minutes = 0) => {
+      const date = new Date()
+      date.setHours(hours, minutes, 0, 0)
+      return date
+    }
+
+    expect(shouldSuppressPush(createDate(23, 45), preferences)).toBe(true)
+    expect(shouldSuppressPush(createDate(5, 45), preferences)).toBe(true)
+    expect(shouldSuppressPush(createDate(14, 0), preferences)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add a dedicated `/account/notifications/preferences` page that loads/saves digest cadence and quiet hours
- update notification delivery to honor quiet-hour settings, annotate metadata, and expose digest batches for the scheduler
- create Supabase schema/types plus helpers and tests covering notification preference persistence and quiet-hour logic

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b99c9dc83289cd2f52d3dd9da3b