### PR TITLE
Group notifications by thread with mute controls

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -154,6 +154,9 @@ async function handleCheckoutSessionCompleted(
                 message: `Your payment of $${paymentData.amount} has been processed successfully.`,
                 type: "success",
                 actionUrl: "/payments",
+                threadId: "payments",
+                threadLabel: "Payments",
+                source: "payments",
               })
             }
           } catch (notificationError) {

--- a/components/notifications/notification-center.tsx
+++ b/components/notifications/notification-center.tsx
@@ -1,177 +1,407 @@
-"use client";
+"use client"
 
-import { useState, useEffect, useCallback, useMemo } from "react";
-import { Bell, X, Check, CheckCheck } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import { useToast } from "@/components/ui/use-toast";
-import { createClient } from "@/utils/supabase-browser";
-import { cn } from "@/lib/utils";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react"
+import { Bell, X, Check, CheckCheck, ChevronDown } from "lucide-react"
 
-interface Notification {
-  id: string;
-  title: string;
-  message: string;
-  type: 'info' | 'success' | 'warning' | 'error';
-  action_url?: string;
-  read: boolean;
-  created_at: string;
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
+import { useToast } from "@/components/ui/use-toast"
+import {
+  buildNotificationGroups,
+  ensureThreadId,
+  ensureThreadSource,
+  formatThreadLabel,
+  type NotificationGroup,
+  type NotificationRow,
+  type ThreadPreferenceSummary,
+} from "@/lib/notifications/thread-utils"
+import { cn } from "@/lib/utils"
+import { createClient } from "@/utils/supabase-browser"
+
+type ThreadPreference = ThreadPreferenceSummary
+
+type NotificationWithMetadata = NotificationRow & {
+  metadata: Record<string, unknown> | null
+  read: boolean
+}
+
+function normalizeNotification(notification: NotificationRow): NotificationWithMetadata {
+  const metadata =
+    notification.metadata &&
+    typeof notification.metadata === "object" &&
+    !Array.isArray(notification.metadata)
+      ? (notification.metadata as Record<string, unknown>)
+      : null
+
+  return {
+    ...notification,
+    metadata,
+    thread_id: ensureThreadId(notification.thread_id),
+    source: ensureThreadSource(notification.source),
+    read: Boolean(notification.read),
+  }
+}
+
+function normalizePreference(preference: ThreadPreference): ThreadPreference {
+  return {
+    thread_id: ensureThreadId(preference.thread_id),
+    muted: Boolean(preference.muted),
+    source: ensureThreadSource(preference.source),
+    thread_label: preference.thread_label ?? null,
+  }
+}
+
+function getTypeColor(type: string) {
+  switch (type) {
+    case "success":
+      return "border-green-200 bg-green-100 text-green-800"
+    case "warning":
+      return "border-yellow-200 bg-yellow-100 text-yellow-800"
+    case "error":
+      return "border-red-200 bg-red-100 text-red-800"
+    default:
+      return "border-blue-200 bg-blue-100 text-blue-800"
+  }
+}
+
+function formatTime(dateString: string | null) {
+  if (!dateString) return "Just now"
+
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / 60000)
+
+  if (Number.isNaN(diffInMinutes) || diffInMinutes < 1) return "Just now"
+  if (diffInMinutes < 60) return `${diffInMinutes}m ago`
+  if (diffInMinutes < 1440) return `${Math.floor(diffInMinutes / 60)}h ago`
+  return date.toLocaleDateString()
 }
 
 export function NotificationCenter() {
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [unreadCount, setUnreadCount] = useState(0);
-  const [isOpen, setIsOpen] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const { toast } = useToast();
-  const supabase = useMemo(() => createClient(), []);
+  const [notifications, setNotifications] = useState<NotificationWithMetadata[]>([])
+  const [preferences, setPreferences] = useState<ThreadPreference[]>([])
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({})
+  const [isOpen, setIsOpen] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [userId, setUserId] = useState<string | null>(null)
+  const [updatingThread, setUpdatingThread] = useState<string | null>(null)
+  const preferencesRef = useRef<ThreadPreference[]>([])
 
-  const fetchNotifications = useCallback(async () => {
-    setLoading(true);
-    try {
-      const { data, error } = await (supabase as any)
-        .from('notifications')
-        .select('*')
-        .order('created_at', { ascending: false })
-        .limit(50);
-
-      if (error) throw error;
-
-      setNotifications(data || []);
-      setUnreadCount(data?.filter((n: any) => !n.read).length || 0);
-    } catch (error) {
-      console.error('Failed to fetch notifications:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [supabase]);
+  const { toast } = useToast()
+  const supabase = useMemo(() => createClient(), [])
 
   useEffect(() => {
-    fetchNotifications();
+    preferencesRef.current = preferences
+  }, [preferences])
 
-    // Subscribe to real-time notifications
+  useEffect(() => {
+    let active = true
+    supabase.auth
+      .getUser()
+      .then(({ data, error }) => {
+        if (!active) return
+        if (error) {
+          console.error("Failed to resolve session user:", error)
+          setUserId(null)
+          return
+        }
+        setUserId(data.user?.id ?? null)
+      })
+      .catch((error) => {
+        if (!active) return
+        console.error("Failed to resolve session user:", error)
+        setUserId(null)
+      })
+    return () => {
+      active = false
+    }
+  }, [supabase])
+
+  const fetchNotifications = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [notificationResponse, preferenceResponse] = await Promise.all([
+        (supabase as any)
+          .from("notifications")
+          .select("*")
+          .order("created_at", { ascending: false })
+          .limit(50),
+        (supabase as any)
+          .from("notification_thread_preferences")
+          .select("thread_id, muted, source, thread_label"),
+      ])
+
+      if (notificationResponse.error) {
+        throw notificationResponse.error
+      }
+
+      if (preferenceResponse.error) {
+        throw preferenceResponse.error
+      }
+
+      const notificationData =
+        (notificationResponse.data as NotificationRow[] | null) ?? []
+      const preferenceData =
+        (preferenceResponse.data as ThreadPreference[] | null) ?? []
+
+      setNotifications(notificationData.map(normalizeNotification))
+      setPreferences(preferenceData.map(normalizePreference))
+    } catch (error) {
+      console.error("Failed to fetch notifications:", error)
+    } finally {
+      setLoading(false)
+    }
+  }, [supabase])
+
+  useEffect(() => {
+    fetchNotifications()
+
     const channel = supabase
-      .channel('notifications')
+      .channel("notifications")
       .on(
-        'postgres_changes',
+        "postgres_changes",
         {
-          event: 'INSERT',
-          schema: 'public',
-          table: 'notifications',
+          event: "INSERT",
+          schema: "public",
+          table: "notifications",
         },
         (payload) => {
-          const newNotification = payload.new as Notification;
-          setNotifications(prev => [newNotification, ...prev]);
-          setUnreadCount(prev => prev + 1);
+          const newNotification = normalizeNotification(
+            payload.new as NotificationRow
+          )
 
-          // Show toast for new notification
-          toast({
-            title: newNotification.title,
-            description: newNotification.message,
-            variant: newNotification.type === 'error' ? 'destructive' :
-                    newNotification.type === 'warning' ? 'default' : 'default',
-          });
+          setNotifications((prev) => {
+            if (prev.some((entry) => entry.id === newNotification.id)) {
+              return prev
+            }
+            return [newNotification, ...prev]
+          })
+
+          const muted = preferencesRef.current.some(
+            (preference) =>
+              preference.muted &&
+              ensureThreadId(preference.thread_id) ===
+                ensureThreadId(newNotification.thread_id)
+          )
+
+          if (!muted) {
+            toast({
+              title: newNotification.title,
+              description: newNotification.message,
+              variant:
+                newNotification.type === "error"
+                  ? "destructive"
+                  : newNotification.type === "warning"
+                  ? "default"
+                  : "default",
+            })
+          }
         }
       )
-      .subscribe();
+      .subscribe()
 
     return () => {
-      supabase.removeChannel(channel);
-    };
-  }, [fetchNotifications, supabase, toast]);
+      supabase.removeChannel(channel)
+    }
+  }, [fetchNotifications, supabase, toast])
+
+  const groups = useMemo<NotificationGroup[]>(() => {
+    return buildNotificationGroups(notifications, preferences)
+  }, [notifications, preferences])
+
+  useEffect(() => {
+    setOpenGroups((prev) => {
+      let changed = false
+      const next: Record<string, boolean> = { ...prev }
+
+      for (const group of groups) {
+        if (next[group.threadId] === undefined) {
+          next[group.threadId] = !group.muted
+          changed = true
+        }
+      }
+
+      for (const key of Object.keys(next)) {
+        if (!groups.some((group) => group.threadId === key)) {
+          delete next[key]
+          changed = true
+        }
+      }
+
+      if (!changed) {
+        return prev
+      }
+
+      return next
+    })
+  }, [groups])
+
+  const unreadCount = useMemo(() => {
+    return notifications.reduce((total, entry) => total + (entry.read ? 0 : 1), 0)
+  }, [notifications])
 
   const markAsRead = async (notificationId: string) => {
     try {
       const { error } = await (supabase as any)
-        .from('notifications')
+        .from("notifications")
         .update({ read: true })
-        .eq('id', notificationId);
+        .eq("id", notificationId)
 
-      if (error) throw error;
+      if (error) throw error
 
-      setNotifications(prev =>
-        prev.map(n =>
-          n.id === notificationId ? { ...n, read: true } : n
+      setNotifications((prev) =>
+        prev.map((notification) =>
+          notification.id === notificationId
+            ? { ...notification, read: true }
+            : notification
         )
-      );
-      setUnreadCount(prev => Math.max(0, prev - 1));
+      )
     } catch (error) {
-      console.error('Failed to mark notification as read:', error);
+      console.error("Failed to mark notification as read:", error)
     }
-  };
+  }
 
   const markAllAsRead = async () => {
+    const unreadIds = notifications
+      .filter((notification) => !notification.read)
+      .map((notification) => notification.id)
+
+    if (unreadIds.length === 0) return
+
     try {
-      const unreadIds = notifications.filter(n => !n.read).map(n => n.id);
-
-      if (unreadIds.length === 0) return;
-
       const { error } = await (supabase as any)
-        .from('notifications')
+        .from("notifications")
         .update({ read: true })
-        .in('id', unreadIds);
+        .in("id", unreadIds)
 
-      if (error) throw error;
+      if (error) throw error
 
-      setNotifications(prev =>
-        prev.map(n => ({ ...n, read: true }))
-      );
-      setUnreadCount(0);
+      const unreadIdSet = new Set(unreadIds)
+      setNotifications((prev) =>
+        prev.map((notification) =>
+          unreadIdSet.has(notification.id)
+            ? { ...notification, read: true }
+            : notification
+        )
+      )
 
       toast({
         title: "All notifications marked as read",
-      });
+      })
     } catch (error) {
-      console.error('Failed to mark all notifications as read:', error);
+      console.error("Failed to mark all notifications as read:", error)
     }
-  };
+  }
 
   const deleteNotification = async (notificationId: string) => {
     try {
       const { error } = await (supabase as any)
-        .from('notifications')
+        .from("notifications")
         .delete()
-        .eq('id', notificationId);
+        .eq("id", notificationId)
 
-      if (error) throw error;
+      if (error) throw error
 
-      const deletedNotification = notifications.find(n => n.id === notificationId);
-      setNotifications(prev => prev.filter(n => n.id !== notificationId));
-
-      if (deletedNotification && !deletedNotification.read) {
-        setUnreadCount(prev => Math.max(0, prev - 1));
-      }
+      setNotifications((prev) =>
+        prev.filter((notification) => notification.id !== notificationId)
+      )
     } catch (error) {
-      console.error('Failed to delete notification:', error);
+      console.error("Failed to delete notification:", error)
     }
-  };
+  }
 
-  const getTypeColor = (type: string) => {
-    switch (type) {
-      case 'success':
-        return 'border-green-200 bg-green-100 text-green-800';
-      case 'warning':
-        return 'border-yellow-200 bg-yellow-100 text-yellow-800';
-      case 'error':
-        return 'border-red-200 bg-red-100 text-red-800';
-      default:
-        return 'border-blue-200 bg-blue-100 text-blue-800';
+  const handleMuteToggle = async (
+    group: NotificationGroup,
+    nextMuted: boolean
+  ) => {
+    if (!userId) {
+      toast({
+        title: "Unable to update preferences",
+        description: "Please sign in again to manage notification settings.",
+        variant: "destructive",
+      })
+      return
     }
-  };
 
-  const formatTime = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
+    setUpdatingThread(group.threadId)
+    try {
+      const { error } = await (supabase as any)
+        .from("notification_thread_preferences")
+        .upsert(
+          {
+            user_id: userId,
+            thread_id: group.threadId,
+            source: group.source,
+            muted: nextMuted,
+            muted_at: nextMuted ? new Date().toISOString() : null,
+            thread_label: group.title,
+          },
+          { onConflict: "user_id,thread_id" }
+        )
 
-    if (diffInMinutes < 1) return 'Just now';
-    if (diffInMinutes < 60) return `${diffInMinutes}m ago`;
-    if (diffInMinutes < 1440) return `${Math.floor(diffInMinutes / 60)}h ago`;
-    return date.toLocaleDateString();
-  };
+      if (error) throw error
+
+      setPreferences((prev) => {
+        const normalizedThreadId = ensureThreadId(group.threadId)
+        const updatedEntry: ThreadPreference = {
+          thread_id: normalizedThreadId,
+          muted: nextMuted,
+          source: group.source,
+          thread_label: group.title,
+        }
+        const existingIndex = prev.findIndex(
+          (preference) => ensureThreadId(preference.thread_id) === normalizedThreadId
+        )
+        if (existingIndex === -1) {
+          return [...prev, updatedEntry]
+        }
+        const next = prev.slice()
+        next[existingIndex] = updatedEntry
+        return next
+      })
+
+      setOpenGroups((prev) => ({
+        ...prev,
+        [group.threadId]: nextMuted ? false : true,
+      }))
+
+      toast({
+        title: nextMuted ? "Thread muted" : "Thread unmuted",
+        description: nextMuted
+          ? `${group.title} notifications will be hidden going forward.`
+          : `Notifications from ${group.title} are active again.`,
+      })
+    } catch (error) {
+      console.error("Failed to update notification preference:", error)
+      toast({
+        title: "Preference update failed",
+        description: "We couldn't update this thread's mute setting.",
+        variant: "destructive",
+      })
+    } finally {
+      setUpdatingThread(null)
+    }
+  }
+
+  const handleNotificationClick = (notification: NotificationWithMetadata) => {
+    if (!notification.read) {
+      void markAsRead(notification.id)
+    }
+    if (notification.action_url) {
+      window.location.href = notification.action_url
+      setIsOpen(false)
+    }
+  }
 
   return (
     <div className="relative">
@@ -187,7 +417,7 @@ export function NotificationCenter() {
             variant="destructive"
             className="absolute -right-1 -top-1 flex size-5 items-center justify-center p-0 text-xs"
           >
-            {unreadCount > 99 ? '99+' : unreadCount}
+            {unreadCount > 99 ? "99+" : unreadCount}
           </Badge>
         )}
       </Button>
@@ -224,76 +454,150 @@ export function NotificationCenter() {
                 <div className="p-4 text-center text-sm text-muted-foreground">
                   Loading notifications...
                 </div>
-              ) : notifications.length === 0 ? (
+              ) : groups.length === 0 ? (
                 <div className="p-4 text-center text-sm text-muted-foreground">
                   No notifications yet
                 </div>
               ) : (
-                <div className="space-y-1">
-                  {notifications.map((notification, index) => (
-                    <div key={notification.id}>
-                      <div
-                        className={cn(
-                          "cursor-pointer p-3 transition-colors hover:bg-muted/50",
-                          !notification.read && "bg-muted/20"
-                        )}
-                        onClick={() => {
-                          if (!notification.read) {
-                            markAsRead(notification.id);
-                          }
-                          if (notification.action_url) {
-                            window.location.href = notification.action_url;
-                            setIsOpen(false);
-                          }
-                        }}
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="flex-1 space-y-1">
-                            <div className="flex items-center gap-2">
-                              <Badge
-                                variant="outline"
-                                className={cn("text-xs", getTypeColor(notification.type))}
-                              >
-                                {notification.type}
-                              </Badge>
-                              <span className="text-xs text-muted-foreground">
-                                {formatTime(notification.created_at)}
+                <div className="divide-y">
+                  {groups.map((group) => {
+                    const isGroupOpen = openGroups[group.threadId] ?? !group.muted
+                    return (
+                      <div key={group.threadId} className="bg-background">
+                        <div className="flex items-center justify-between px-3 py-2">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setOpenGroups((prev) => ({
+                                ...prev,
+                                [group.threadId]: !isGroupOpen,
+                              }))
+                            }
+                            className="flex flex-1 items-center justify-between gap-3 text-left"
+                          >
+                            <span className="flex items-center gap-2">
+                              <ChevronDown
+                                className={cn(
+                                  "size-4 transition-transform",
+                                  isGroupOpen ? "rotate-180" : "-rotate-90"
+                                )}
+                              />
+                              <span className="text-sm font-semibold">
+                                {group.title}
                               </span>
+                              {group.unreadCount > 0 && (
+                                <Badge variant="secondary" className="text-[10px]">
+                                  {group.unreadCount} new
+                                </Badge>
+                              )}
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              {group.notifications.length} {" "}
+                              {group.notifications.length === 1
+                                ? "notification"
+                                : "notifications"}
+                            </span>
+                          </button>
+                          <div className="ml-3 flex items-center gap-2">
+                            <Badge variant="outline" className="text-xs">
+                              {formatThreadLabel(group.source)}
+                            </Badge>
+                            <div className="flex items-center gap-1">
+                              <span className="text-xs text-muted-foreground">
+                                {group.muted ? "Muted" : "Mute"}
+                              </span>
+                              <Switch
+                                checked={group.muted}
+                                onCheckedChange={(value) =>
+                                  handleMuteToggle(group, value)
+                                }
+                                disabled={
+                                  updatingThread === group.threadId || !userId
+                                }
+                                aria-label={`${
+                                  group.muted ? "Unmute" : "Mute"
+                                } ${group.title}`}
+                              />
                             </div>
-                            <p className="text-sm font-medium">{notification.title}</p>
-                            <p className="text-xs text-muted-foreground">{notification.message}</p>
-                          </div>
-                          <div className="flex gap-1">
-                            {!notification.read && (
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  markAsRead(notification.id);
-                                }}
-                                className="size-6"
-                              >
-                                <Check className="size-3" />
-                              </Button>
-                            )}
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                deleteNotification(notification.id);
-                              }}
-                              className="size-6 text-muted-foreground hover:text-destructive"
-                            >
-                              <X className="size-3" />
-                            </Button>
                           </div>
                         </div>
+                        {isGroupOpen && (
+                          <div className="border-t border-border/60">
+                            {group.notifications.map((notification, index) => {
+                              const isUnread = !notification.read
+                              return (
+                                <div key={notification.id}>
+                                  <div
+                                    className={cn(
+                                      "cursor-pointer px-3 py-3 transition-colors hover:bg-muted/50",
+                                      isUnread && "bg-muted/20"
+                                    )}
+                                    onClick={() =>
+                                      handleNotificationClick(notification as NotificationWithMetadata)
+                                    }
+                                  >
+                                    <div className="flex items-start justify-between gap-2">
+                                      <div className="flex-1 space-y-1">
+                                        <div className="flex items-center gap-2">
+                                          <Badge
+                                            variant="outline"
+                                            className={cn(
+                                              "text-xs",
+                                              getTypeColor(notification.type)
+                                            )}
+                                          >
+                                            {notification.type}
+                                          </Badge>
+                                          <span className="text-xs text-muted-foreground">
+                                            {formatTime(notification.created_at)}
+                                          </span>
+                                        </div>
+                                        <p className="text-sm font-medium">
+                                          {notification.title}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                          {notification.message}
+                                        </p>
+                                      </div>
+                                      <div className="flex gap-1">
+                                        {isUnread && (
+                                          <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={(event) => {
+                                              event.stopPropagation()
+                                              void markAsRead(notification.id)
+                                            }}
+                                            className="size-6"
+                                          >
+                                            <Check className="size-3" />
+                                          </Button>
+                                        )}
+                                        <Button
+                                          variant="ghost"
+                                          size="icon"
+                                          onClick={(event) => {
+                                            event.stopPropagation()
+                                            void deleteNotification(notification.id)
+                                          }}
+                                          className="size-6 text-muted-foreground hover:text-destructive"
+                                        >
+                                          <X className="size-3" />
+                                        </Button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  {index < group.notifications.length - 1 && (
+                                    <Separator />
+                                  )}
+                                </div>
+                              )
+                            })}
+                          </div>
+                        )}
                       </div>
-                      {index < notifications.length - 1 && <Separator />}
-                    </div>
-                  ))}
+                    )
+                  })}
                 </div>
               )}
             </ScrollArea>
@@ -301,5 +605,5 @@ export function NotificationCenter() {
         </Card>
       )}
     </div>
-  );
+  )
 }

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -178,6 +178,9 @@ export function useNotifications() {
       type: "info",
       actionUrl: "/visitors",
       metadata: templateData,
+      threadId: "visitor-bookings",
+      threadLabel: "Visitor Bookings",
+      source: "visitors",
     })
 
     for (const roommate of data.roommates) {
@@ -198,6 +201,9 @@ export function useNotifications() {
         type: "info",
         actionUrl: "/visitors",
         metadata: templateData,
+        threadId: "visitor-bookings",
+        threadLabel: "Visitor Bookings",
+        source: "visitors",
       })
     }
 
@@ -227,6 +233,9 @@ export function useNotifications() {
         message: `${data.requesterName} reported: ${data.title}`,
         type: "warning" as const,
         actionUrl: "/dashboard",
+        threadId: "maintenance-requests",
+        threadLabel: "Maintenance Requests",
+        source: "maintenance",
       },
     ]
 
@@ -257,6 +266,9 @@ export function useNotifications() {
         message: `Your payment of $${data.amount} has been processed.`,
         type: "success" as const,
         actionUrl: "/payments",
+        threadId: "payments",
+        threadLabel: "Payments",
+        source: "payments",
       },
     ]
 
@@ -286,6 +298,9 @@ export function useNotifications() {
         message: `You have successfully signed "${data.documentTitle}"`,
         type: "success" as const,
         actionUrl: "/documents",
+        threadId: "documents",
+        threadLabel: "Documents",
+        source: "documents",
       },
     ]
 

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,7 +1,14 @@
 "use server"
 
-import { createSupbaseServerClient } from "@/utils/supaone"
 import { Resend } from "resend"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import {
+  ensureThreadId,
+  ensureThreadSource,
+  formatThreadLabel,
+} from "@/lib/notifications/thread-utils"
+import { createSupbaseServerClient } from "@/utils/supaone"
 
 export interface NotificationData {
   to: string | string[]
@@ -18,6 +25,9 @@ export interface InAppNotification {
   type: "info" | "success" | "warning" | "error"
   actionUrl?: string
   metadata?: Record<string, any>
+  threadId?: string
+  threadLabel?: string
+  source?: string
 }
 
 class NotificationService {
@@ -90,6 +100,34 @@ class NotificationService {
     try {
       const supabase = await createSupbaseServerClient()
 
+      const threadId = ensureThreadId(notification.threadId)
+      const source = ensureThreadSource(notification.source)
+      const metadataLabel =
+        notification.metadata &&
+        typeof notification.metadata === "object" &&
+        !Array.isArray(notification.metadata) &&
+        typeof (notification.metadata as Record<string, unknown>).threadLabel ===
+          "string"
+          ? String(
+              (notification.metadata as Record<string, unknown>).threadLabel
+            )
+          : undefined
+
+      const threadLabel = formatThreadLabel(
+        source,
+        notification.threadLabel ?? metadataLabel
+      )
+
+      const isMuted = await this.isThreadMuted(
+        supabase as SupabaseClient,
+        notification.userId,
+        threadId
+      )
+
+      if (isMuted) {
+        return { success: true, skipped: true as const }
+      }
+
       const { data, error } = await (supabase as any)
         .from("notifications")
         .insert({
@@ -101,6 +139,9 @@ class NotificationService {
           metadata: notification.metadata,
           read: false,
           created_at: new Date().toISOString(),
+          thread_id: threadId,
+          source,
+          thread_label: threadLabel,
         })
 
       if (error) {
@@ -115,6 +156,31 @@ class NotificationService {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",
       }
+    }
+  }
+
+  private async isThreadMuted(
+    supabase: SupabaseClient,
+    userId: string,
+    threadId: string
+  ): Promise<boolean> {
+    try {
+      const { data, error } = await (supabase as any)
+        .from("notification_thread_preferences")
+        .select("muted")
+        .eq("user_id", userId)
+        .eq("thread_id", threadId)
+        .maybeSingle()
+
+      if (error) {
+        console.error("Failed to read notification preference:", error)
+        return false
+      }
+
+      return Boolean(data?.muted)
+    } catch (error) {
+      console.error("Notification preference lookup failed:", error)
+      return false
     }
   }
 

--- a/lib/notifications/thread-utils.ts
+++ b/lib/notifications/thread-utils.ts
@@ -1,0 +1,174 @@
+import type { Database } from "@/lib/supabase"
+
+export type NotificationRow =
+  Database["public"]["Tables"]["notifications"]["Row"]
+export type NotificationThreadPreferenceRow =
+  Database["public"]["Tables"]["notification_thread_preferences"]["Row"]
+export type ThreadPreferenceSummary = Pick<
+  NotificationThreadPreferenceRow,
+  "thread_id" | "muted" | "source" | "thread_label"
+>
+
+export interface NotificationGroup {
+  threadId: string
+  source: string
+  title: string
+  muted: boolean
+  notifications: NotificationRow[]
+  unreadCount: number
+  lastActivity: string
+}
+
+export const GENERAL_THREAD_ID = "general"
+export const GENERAL_SOURCE = "general"
+
+const SOURCE_LABELS: Record<string, string> = {
+  documents: "Documents",
+  maintenance: "Maintenance",
+  payments: "Payments",
+  visitors: "Visitor Bookings",
+}
+
+function extractThreadLabelFromMetadata(
+  metadata: NotificationRow["metadata"]
+): string | undefined {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined
+  }
+
+  const record = metadata as Record<string, unknown>
+  const candidates = [
+    record.threadLabel,
+    record.thread_label,
+    record.threadTitle,
+    record.sourceLabel,
+  ]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+  }
+
+  return undefined
+}
+
+export function ensureThreadId(value?: string | null): string {
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (trimmed.length > 0) {
+      return trimmed
+    }
+  }
+  return GENERAL_THREAD_ID
+}
+
+export function ensureThreadSource(value?: string | null): string {
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (trimmed.length > 0) {
+      return trimmed
+    }
+  }
+  return GENERAL_SOURCE
+}
+
+export function formatThreadLabel(
+  source: string,
+  providedLabel?: string | null
+): string {
+  if (providedLabel && providedLabel.trim().length > 0) {
+    return providedLabel.trim()
+  }
+
+  const normalizedSource = source.trim().toLowerCase()
+  if (SOURCE_LABELS[normalizedSource]) {
+    return SOURCE_LABELS[normalizedSource]
+  }
+
+  const cleaned = source.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim()
+  if (cleaned.length === 0) {
+    return "General"
+  }
+
+  return cleaned.replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+export function buildNotificationGroups(
+  notifications: NotificationRow[],
+  preferences: ThreadPreferenceSummary[] = []
+): NotificationGroup[] {
+  const preferenceMap = new Map<string, ThreadPreferenceSummary>()
+  for (const preference of preferences) {
+    preferenceMap.set(ensureThreadId(preference.thread_id), preference)
+  }
+
+  const groups = new Map<string, NotificationGroup>()
+
+  for (const notification of notifications) {
+    const threadId = ensureThreadId(notification.thread_id)
+    const source = ensureThreadSource(notification.source)
+    const preference = preferenceMap.get(threadId)
+
+    const explicitLabel =
+      notification.thread_label ??
+      preference?.thread_label ??
+      extractThreadLabelFromMetadata(notification.metadata)
+
+    const label = formatThreadLabel(source, explicitLabel)
+
+    let group = groups.get(threadId)
+    if (!group) {
+      group = {
+        threadId,
+        source,
+        title: label,
+        muted: preference?.muted ?? false,
+        notifications: [],
+        unreadCount: 0,
+        lastActivity: new Date(0).toISOString(),
+      }
+      groups.set(threadId, group)
+    } else if (group.title !== label) {
+      const hasCustomTitle =
+        group.title !== formatThreadLabel(group.source) ||
+        Boolean(preference?.thread_label)
+      if (!hasCustomTitle) {
+        group.title = label
+      }
+    }
+
+    group.notifications.push(notification)
+  }
+
+  const sortedGroups: NotificationGroup[] = []
+  for (const group of groups.values()) {
+    const sortedNotifications = group.notifications
+      .slice()
+      .sort((a, b) => {
+        const aTime = a.created_at ? new Date(a.created_at).getTime() : 0
+        const bTime = b.created_at ? new Date(b.created_at).getTime() : 0
+        return bTime - aTime
+      })
+
+    const unreadCount = sortedNotifications.reduce((total, entry) => {
+      return total + (entry.read ? 0 : 1)
+    }, 0)
+
+    const latestCreatedAt =
+      sortedNotifications[0]?.created_at ?? new Date(0).toISOString()
+
+    sortedGroups.push({
+      ...group,
+      notifications: sortedNotifications,
+      unreadCount,
+      lastActivity: latestCreatedAt,
+    })
+  }
+
+  return sortedGroups.sort((a, b) => {
+    const aTime = a.lastActivity ? new Date(a.lastActivity).getTime() : 0
+    const bTime = b.lastActivity ? new Date(b.lastActivity).getTime() : 0
+    return bTime - aTime
+  })
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -225,6 +225,20 @@ export type Database = {
         read: boolean | null
         created_at: string | null
         updated_at: string | null
+        thread_id: string
+        source: string
+        thread_label: string | null
+      }>
+      notification_thread_preferences: SupabaseTable<{
+        id: string
+        user_id: string
+        thread_id: string
+        source: string
+        muted: boolean
+        muted_at: string | null
+        thread_label: string | null
+        created_at: string | null
+        updated_at: string | null
       }>
       email_notifications: SupabaseTable<{
         id: string

--- a/supabase/migrations/20250316000000_notification_threads.sql
+++ b/supabase/migrations/20250316000000_notification_threads.sql
@@ -1,0 +1,62 @@
+-- Add thread metadata to notifications and introduce per-thread preferences
+ALTER TABLE public.notifications
+  ADD COLUMN thread_id TEXT NOT NULL DEFAULT 'general',
+  ADD COLUMN source TEXT NOT NULL DEFAULT 'general',
+  ADD COLUMN thread_label TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_thread_id ON public.notifications(thread_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_source ON public.notifications(source);
+
+CREATE TABLE IF NOT EXISTS public.notification_thread_preferences (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  thread_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  muted BOOLEAN NOT NULL DEFAULT FALSE,
+  muted_at TIMESTAMP WITH TIME ZONE,
+  thread_label TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_notification_thread_preferences_user_thread
+  ON public.notification_thread_preferences(user_id, thread_id);
+
+ALTER TABLE public.notification_thread_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their thread preferences"
+  ON public.notification_thread_preferences
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can manage their thread preferences"
+  ON public.notification_thread_preferences
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their thread preferences"
+  ON public.notification_thread_preferences
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their thread preferences"
+  ON public.notification_thread_preferences
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+CREATE OR REPLACE FUNCTION public.set_notification_thread_preferences_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_notification_thread_preferences_updated_at
+  ON public.notification_thread_preferences;
+
+CREATE TRIGGER update_notification_thread_preferences_updated_at
+  BEFORE UPDATE ON public.notification_thread_preferences
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_notification_thread_preferences_updated_at();

--- a/tests/notifications/grouping.test.ts
+++ b/tests/notifications/grouping.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildNotificationGroups,
+  type NotificationRow,
+  type ThreadPreferenceSummary,
+} from "@/lib/notifications/thread-utils"
+
+describe("notification grouping", () => {
+  it("groups notifications by thread and applies mute preferences", () => {
+    const notifications: NotificationRow[] = [
+      {
+        id: "n1",
+        user_id: "user-1",
+        title: "Payment posted",
+        message: "Your rent payment cleared.",
+        type: "success",
+        action_url: "/payments",
+        metadata: null,
+        read: false,
+        created_at: "2025-03-15T12:00:00.000Z",
+        updated_at: "2025-03-15T12:00:00.000Z",
+        thread_id: "payments",
+        source: "payments",
+        thread_label: "Payments",
+      },
+      {
+        id: "n2",
+        user_id: "user-1",
+        title: "Earlier receipt",
+        message: "Thanks for paying on time!",
+        type: "info",
+        action_url: null,
+        metadata: null,
+        read: true,
+        created_at: "2025-03-14T09:00:00.000Z",
+        updated_at: "2025-03-14T09:00:00.000Z",
+        thread_id: "payments",
+        source: "payments",
+        thread_label: "Payments",
+      },
+      {
+        id: "n3",
+        user_id: "user-1",
+        title: "Maintenance update",
+        message: "The leaky sink fix is scheduled.",
+        type: "warning",
+        action_url: "/maintenance",
+        metadata: { threadLabel: "Maintenance" },
+        read: false,
+        created_at: "2025-03-16T08:30:00.000Z",
+        updated_at: "2025-03-16T08:30:00.000Z",
+        thread_id: "maintenance-requests",
+        source: "maintenance",
+        thread_label: null,
+      },
+    ]
+
+    const preferences: ThreadPreferenceSummary[] = [
+      {
+        thread_id: "maintenance-requests",
+        muted: true,
+        source: "maintenance",
+        thread_label: "Maintenance",
+      },
+    ]
+
+    const groups = buildNotificationGroups(notifications, preferences)
+
+    expect(groups).toHaveLength(2)
+
+    expect(groups[0].threadId).toBe("maintenance-requests")
+    expect(groups[0].muted).toBe(true)
+    expect(groups[0].unreadCount).toBe(1)
+    expect(groups[0].notifications[0].id).toBe("n3")
+
+    expect(groups[1].threadId).toBe("payments")
+    expect(groups[1].muted).toBe(false)
+    expect(groups[1].unreadCount).toBe(1)
+    expect(groups[1].notifications.map((entry) => entry.id)).toEqual(["n1", "n2"])
+  })
+
+  it("derives human-friendly labels when none are supplied", () => {
+    const notifications: NotificationRow[] = [
+      {
+        id: "n4",
+        user_id: "user-2",
+        title: "Guest arrival",
+        message: "Alex arrives tomorrow night.",
+        type: "info",
+        action_url: "/visitors",
+        metadata: null,
+        read: false,
+        created_at: "2025-03-10T18:45:00.000Z",
+        updated_at: "2025-03-10T18:45:00.000Z",
+        thread_id: "visitor-thread",
+        source: "visitor-updates",
+        thread_label: null,
+      },
+    ]
+
+    const groups = buildNotificationGroups(notifications, [])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].title).toBe("Visitor Updates")
+    expect(groups[0].muted).toBe(false)
+  })
+})

--- a/tests/notifications/send-in-app.test.ts
+++ b/tests/notifications/send-in-app.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { sendInAppNotification } from "@/lib/notifications"
+
+const { supabaseModuleMock } = vi.hoisted(() => ({
+  supabaseModuleMock: {
+    createSupbaseServerClient: vi.fn(),
+  },
+}))
+
+vi.mock("@/utils/supaone", () => supabaseModuleMock)
+
+const createClientMock = supabaseModuleMock.createSupbaseServerClient
+
+type MutedConfig = Record<string, boolean>
+
+function createSupabaseStub(mutedThreads: MutedConfig = {}) {
+  const inserted: any[] = []
+  const preferenceFilters: Record<string, string> = {}
+
+  const preferencesBuilder = {
+    eq: vi.fn((column: string, value: string) => {
+      preferenceFilters[column] = value
+      return preferencesBuilder
+    }),
+    maybeSingle: vi.fn(async () => {
+      const key = `${preferenceFilters.user_id}:${preferenceFilters.thread_id}`
+      Object.keys(preferenceFilters).forEach((key) => delete preferenceFilters[key])
+
+      if (mutedThreads[key]) {
+        return { data: { muted: true }, error: null }
+      }
+
+      return { data: null, error: null }
+    }),
+  }
+
+  const notificationsBuilder = {
+    insert: vi.fn(async (payload: any) => {
+      const rows = Array.isArray(payload) ? payload : [payload]
+      inserted.push(...rows)
+      return { data: rows, error: null }
+    }),
+  }
+
+  const supabaseStub = {
+    from: vi.fn((table: string) => {
+      if (table === "notification_thread_preferences") {
+        return {
+          select: vi.fn(() => preferencesBuilder),
+        }
+      }
+
+      if (table === "notifications") {
+        return notificationsBuilder
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    }),
+  }
+
+  return {
+    supabase: supabaseStub,
+    inserted,
+    notificationsBuilder,
+    preferencesBuilder,
+  }
+}
+
+describe("sendInAppNotification", () => {
+  beforeEach(() => {
+    createClientMock.mockReset()
+  })
+
+  it("persists notifications when the thread is not muted", async () => {
+    const stub = createSupabaseStub()
+    createClientMock.mockResolvedValue(stub.supabase)
+
+    const result = await sendInAppNotification({
+      userId: "user-1",
+      title: "Payment Successful",
+      message: "Your rent payment has been posted.",
+      type: "success",
+      threadId: "payments",
+      threadLabel: "Payments",
+      source: "payments",
+    })
+
+    expect(result.success).toBe(true)
+    expect(stub.notificationsBuilder.insert).toHaveBeenCalledTimes(1)
+    expect(stub.inserted).toHaveLength(1)
+    expect(stub.inserted[0]).toMatchObject({
+      user_id: "user-1",
+      thread_id: "payments",
+      source: "payments",
+      thread_label: "Payments",
+    })
+  })
+
+  it("skips insertion when the target thread is muted", async () => {
+    const stub = createSupabaseStub({ "user-1:payments": true })
+    createClientMock.mockResolvedValue(stub.supabase)
+
+    const result = await sendInAppNotification({
+      userId: "user-1",
+      title: "Payment Successful",
+      message: "Your rent payment has been posted.",
+      type: "success",
+      threadId: "payments",
+      threadLabel: "Payments",
+      source: "payments",
+    })
+
+    expect(result.success).toBe(true)
+    expect((result as { skipped?: boolean }).skipped).toBe(true)
+    expect(stub.notificationsBuilder.insert).not.toHaveBeenCalled()
+    expect(stub.inserted).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add thread metadata columns and per-thread preference table for notifications
- group notifications by thread in the notification center with collapsible UI and mute toggles
- persist mute settings in Supabase and skip muted notifications when sending
- cover grouping logic and mute persistence with new Vitest suites

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b9a36e483289f393bde9b17685c