### PR TITLE
Add share target handling and sharing helpers

### DIFF
--- a/app/documents/components/document-actions.tsx
+++ b/app/documents/components/document-actions.tsx
@@ -21,6 +21,7 @@ import {
 import { DocumentViewerDialog } from './document-viewer-dialog';
 import { CreateSignatureDialog } from './create-signature-dialog';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
+import { shareDocument } from '@/lib/share/outbound';
 import {
   MoreHorizontal,
   Eye,
@@ -84,16 +85,21 @@ export function DocumentActions({ document }: DocumentActionsProps) {
     }
   };
 
-  const handleShare = () => {
-    if (navigator.share && document.file_url) {
-      navigator.share({
-        title: document.title,
-        url: document.file_url,
-      });
-    } else {
-      // Fallback: copy URL to clipboard
-      navigator.clipboard.writeText(document.file_url || '');
-      toast.success('Document URL copied to clipboard');
+  const handleShare = async () => {
+    const baseUrl = typeof window !== 'undefined' ? window.location.origin : undefined
+    try {
+      const status = await shareDocument(document, { baseUrl })
+
+      if (status === 'shared') {
+        toast.success('Document shared successfully')
+      } else if (status === 'copied') {
+        toast.success('Document URL copied to clipboard')
+      } else if (status === 'unsupported') {
+        toast.error('Sharing is not supported on this device')
+      }
+    } catch (error) {
+      console.error('Error sharing document:', error)
+      toast.error('Unable to share document')
     }
   };
 

--- a/app/messaging/_components/share-thread-button.tsx
+++ b/app/messaging/_components/share-thread-button.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState } from "react"
+import { Share2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { shareThread } from "@/lib/share/outbound"
+
+interface ShareThreadButtonProps {
+  thread: {
+    id: string
+    title: string
+    summary: string
+    category?: string
+    participants?: number
+    lastMessageAt?: string
+    href: string
+  }
+}
+
+export function ShareThreadButton({ thread }: ShareThreadButtonProps) {
+  const [pending, setPending] = useState(false)
+
+  const handleShare = async () => {
+    setPending(true)
+    try {
+      const baseUrl = typeof window !== "undefined" ? window.location.origin : undefined
+      const status = await shareThread(
+        {
+          id: thread.id,
+          title: thread.title,
+          summary: thread.summary,
+          category: thread.category,
+          participants: thread.participants,
+          lastMessageAt: thread.lastMessageAt,
+          href: thread.href,
+        },
+        { baseUrl },
+      )
+
+      if (status === "shared") {
+        toast.success("Thread shared with your device")
+      } else if (status === "copied") {
+        toast.success("Thread link copied to clipboard")
+      } else if (status === "unsupported") {
+        toast.error("Sharing is not supported on this device")
+      }
+    } catch (error) {
+      console.error("Failed to share thread", error)
+      toast.error("Unable to share thread")
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="gap-2"
+      onClick={handleShare}
+      disabled={pending}
+    >
+      <Share2 className="size-4" aria-hidden />
+      {pending ? "Sharing…" : "Share thread"}
+    </Button>
+  )
+}

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -14,6 +14,7 @@ import { Progress } from "@/components/ui/progress"
 import { Separator } from "@/components/ui/separator"
 import { cn } from "@/lib/utils"
 import { Paperclip } from "lucide-react"
+import { ShareThreadButton } from "./_components/share-thread-button"
 
 type ThreadListItem = {
   id: string
@@ -149,6 +150,7 @@ const threadList: ThreadListItem[] = [
 ]
 
 const activeThread = {
+  id: "chore-rotation",
   title: "Q2 chore rotation plan",
   summary:
     "Keep the shared areas sparkling with a rotation everyone can reference — vote on the deep clean weekend and review updated checklists in one place.",
@@ -436,7 +438,20 @@ export default function MessagingPage() {
                   <CardTitle>{activeThread.title}</CardTitle>
                   <CardDescription>{activeThread.summary}</CardDescription>
                 </div>
-                <Badge variant="secondary">{activeThread.category}</Badge>
+                <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
+                  <Badge variant="secondary" className="w-fit">{activeThread.category}</Badge>
+                  <ShareThreadButton
+                    thread={{
+                      id: activeThread.id,
+                      title: activeThread.title,
+                      summary: activeThread.summary,
+                      category: activeThread.category,
+                      participants: activeThread.participants,
+                      lastMessageAt: activeThread.updated,
+                      href: `/messaging?thread=${activeThread.id}`,
+                    }}
+                  />
+                </div>
               </div>
               <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
                 <span>Owner: {activeThread.owner}</span>

--- a/app/payments/_components/receipt-history-card.tsx
+++ b/app/payments/_components/receipt-history-card.tsx
@@ -17,6 +17,7 @@ import {
   createPaymentHistoryCsv,
   summarizeReceiptHistory,
 } from "@/lib/payments/receipts"
+import { ShareReceiptButton } from "./share-receipt-button"
 import type { PaymentReceiptHistoryEntry } from "@/types/payments"
 
 interface ReceiptHistoryCardProps {
@@ -224,6 +225,7 @@ export function ReceiptHistoryCard({ receipts }: ReceiptHistoryCardProps) {
                       </td>
                       <td className="p-4">
                         <div className="flex flex-col items-end gap-2">
+                          <ShareReceiptButton receipt={receipt} />
                           <a
                             href={receipt.receiptUrl}
                             target="_blank"

--- a/app/payments/_components/share-receipt-button.tsx
+++ b/app/payments/_components/share-receipt-button.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useState } from "react"
+import { Share2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { sharePaymentReceipt } from "@/lib/share/outbound"
+import type { PaymentReceiptHistoryEntry } from "@/types/payments"
+
+interface ShareReceiptButtonProps {
+  receipt: PaymentReceiptHistoryEntry
+}
+
+export function ShareReceiptButton({ receipt }: ShareReceiptButtonProps) {
+  const [pending, setPending] = useState(false)
+
+  const handleShare = async () => {
+    setPending(true)
+    try {
+      const baseUrl = typeof window !== "undefined" ? window.location.origin : undefined
+      const status = await sharePaymentReceipt(receipt, { baseUrl })
+
+      if (status === "shared") {
+        toast.success("Receipt shared")
+      } else if (status === "copied") {
+        toast.success("Receipt link copied to clipboard")
+      } else if (status === "unsupported") {
+        toast.error("Sharing is not supported on this device")
+      }
+    } catch (error) {
+      console.error("Failed to share receipt", error)
+      toast.error("Unable to share receipt")
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      disabled={pending}
+      className={cn(buttonVariants({ variant: "ghost", size: "sm" }), "w-full justify-center gap-1")}
+    >
+      <Share2 className="size-4" aria-hidden />
+      <span>{pending ? "Sharing…" : "Share"}</span>
+    </button>
+  )
+}

--- a/app/share/intent/page.tsx
+++ b/app/share/intent/page.tsx
@@ -1,0 +1,176 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowRight, ExternalLink, FileText, Share2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import {
+  SHARE_DESTINATION_META,
+  type ShareDestination,
+  coerceSharePayloadFromParams,
+  determineShareDestination,
+  normalizeShareDestination,
+} from "@/lib/share/intent"
+
+export const metadata: Metadata = {
+  title: "Share intent",
+  description: "Review shared content and jump into the Roomsily workspace that can take action on it.",
+}
+
+interface ShareIntentPageProps {
+  searchParams: Record<string, string | string[] | undefined>
+}
+
+function extractParam(params: ShareIntentPageProps["searchParams"], key: string) {
+  const value = params[key]
+  if (Array.isArray(value)) {
+    return value.length ? value[0] : undefined
+  }
+  return value
+}
+
+function isPayloadEmpty(payload: { title?: string; text?: string; url?: string; fileNames?: string[] }) {
+  return !payload.title && !payload.text && !payload.url && !(payload.fileNames && payload.fileNames.length)
+}
+
+export default function ShareIntentPage({ searchParams }: ShareIntentPageProps) {
+  const payload = coerceSharePayloadFromParams(searchParams)
+  const rawDestination = extractParam(searchParams, "destination")
+  const explicitDestination = normalizeShareDestination(rawDestination)
+  const resolution = determineShareDestination(payload, explicitDestination ?? rawDestination)
+  const activeMeta = SHARE_DESTINATION_META[resolution.destination]
+
+  const declaredReason = extractParam(searchParams, "reason")
+  const shareReason = declaredReason || resolution.reason
+  const source = extractParam(searchParams, "source")
+  const fileNames = payload.fileNames ?? []
+
+  const supportingDestinations = (Object.keys(SHARE_DESTINATION_META) as ShareDestination[])
+    .filter((destination) => destination !== resolution.destination)
+    .map((destination) => ({ destination, meta: SHARE_DESTINATION_META[destination] }))
+
+  return (
+    <div className="container max-w-4xl space-y-10 py-12">
+      <header className="space-y-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <Badge variant={resolution.explicit ? "default" : "outline"}>
+            {resolution.explicit ? "Shortcut selected" : "Smart routing"}
+          </Badge>
+          {source ? <Badge variant="secondary">Shared via {source}</Badge> : null}
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Shared content ready for {activeMeta.label}</h1>
+          <p className="text-base text-muted-foreground sm:text-lg">{shareReason}</p>
+        </div>
+        <Link href={activeMeta.href} className="inline-flex">
+          <Button className="gap-2" size="lg">
+            <ExternalLink className="size-4" aria-hidden />
+            Continue to {activeMeta.label}
+          </Button>
+        </Link>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Share2 className="size-5" aria-hidden />
+            Shared details
+          </CardTitle>
+          <CardDescription>
+            Roomsily captured the payload provided by the originating app. Confirm the context before finalising any actions.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {isPayloadEmpty(payload) ? (
+            <p className="text-sm text-muted-foreground">
+              No text, links, or files were included in this share. You can still continue to {activeMeta.label} to log a note for your housemates.
+            </p>
+          ) : (
+            <dl className="space-y-4 text-sm">
+              {payload.title ? (
+                <div>
+                  <dt className="font-semibold text-foreground">Title</dt>
+                  <dd className="text-muted-foreground">{payload.title}</dd>
+                </div>
+              ) : null}
+              {payload.text ? (
+                <div>
+                  <dt className="font-semibold text-foreground">Notes</dt>
+                  <dd className="whitespace-pre-wrap text-muted-foreground">{payload.text}</dd>
+                </div>
+              ) : null}
+              {payload.url ? (
+                <div>
+                  <dt className="font-semibold text-foreground">Link</dt>
+                  <dd className="break-all text-muted-foreground">{payload.url}</dd>
+                </div>
+              ) : null}
+              {fileNames.length ? (
+                <div>
+                  <dt className="font-semibold text-foreground">Attachments</dt>
+                  <dd className="text-muted-foreground">
+                    <ul className="list-inside list-disc space-y-1">
+                      {fileNames.map((name) => (
+                        <li key={name}>{name}</li>
+                      ))}
+                    </ul>
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="size-5" aria-hidden />
+            Recommended next steps
+          </CardTitle>
+          <CardDescription>{activeMeta.description}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">{activeMeta.helper}</p>
+          <Separator />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Card className="border-dashed">
+              <CardHeader>
+                <CardTitle className="text-sm">Primary destination</CardTitle>
+                <CardDescription className="text-xs text-muted-foreground">
+                  Jump into {activeMeta.label} to continue processing the shared content.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Link href={activeMeta.href} className="inline-flex">
+                  <Button variant="outline" size="sm" className="gap-2">
+                    <ArrowRight className="size-4" aria-hidden />
+                    Open {activeMeta.label}
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+            {supportingDestinations.slice(0, 3).map(({ destination, meta }) => (
+              <Card key={destination} className="border-dashed">
+                <CardHeader>
+                  <CardTitle className="text-sm">Also consider {meta.label}</CardTitle>
+                  <CardDescription className="text-xs text-muted-foreground">{meta.helper}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Link href={meta.href} className="inline-flex">
+                    <Button variant="ghost" size="sm" className="gap-2">
+                      <ArrowRight className="size-4" aria-hidden />
+                      Review {meta.label}
+                    </Button>
+                  </Link>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,22 +1,264 @@
-self.addEventListener('push', function (event) {
-    if (event.data) {
-      const data = event.data.json()
-      const options = {
-        body: data.body,
-        icon: data.icon || '/icon.png',
-        badge: '/badge.png',
-        vibrate: [100, 50, 100],
-        data: {
-          dateOfArrival: Date.now(),
-          primaryKey: '2',
-        },
-      }
-      event.waitUntil(self.registration.showNotification(data.title, options))
+const SHARE_TARGET_ACTION = "/share-target"
+const SHARE_INTENT_PATH = "/share/intent"
+
+const SHARE_KEYWORDS = {
+  payments: [
+    "rent",
+    "payment",
+    "stripe",
+    "invoice",
+    "receipt",
+    "balance",
+    "autopay",
+    "charge",
+  ],
+  visitors: [
+    "guest",
+    "visitor",
+    "overnight",
+    "stay",
+    "host",
+  ],
+  maintenance: [
+    "maintenance",
+    "repair",
+    "fix",
+    "issue",
+    "leak",
+    "broken",
+    "damage",
+    "work order",
+  ],
+  documents: ["document", "lease", "agreement", "attachment", "pdf", "documenso", "file"],
+  bookings: ["booking", "reservation", "calendar", "schedule", "amenity", "cal.com"],
+}
+
+const DOCUMENT_EXTENSIONS = ["pdf", "doc", "docx", "xls", "xlsx", "csv", "txt", "rtf"]
+
+function normalizeValue(value) {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function normalizeDestination(value) {
+  const normalized = normalizeValue(value)
+  if (!normalized) return undefined
+  const lower = normalized.toLowerCase()
+
+  if (lower.startsWith("doc")) return "documents"
+  if (lower.startsWith("pay")) return "payments"
+  if (lower.startsWith("main")) return "maintenance"
+  if (lower.startsWith("visit")) return "visitors"
+  if (lower.startsWith("book")) return "bookings"
+  if (lower.startsWith("message") || lower.startsWith("thread")) return "messaging"
+  return undefined
+}
+
+function containsKeyword(haystack, keywords) {
+  const lower = haystack.toLowerCase()
+  return keywords.some((keyword) => lower.includes(keyword))
+}
+
+function hasDocumentFile(files) {
+  if (!files || !files.length) return false
+  return files.some((name) => {
+    const lower = name.toLowerCase()
+    return DOCUMENT_EXTENSIONS.some((ext) => lower.endsWith(`.${ext}`))
+  })
+}
+
+function collectShareText(payload) {
+  const segments = []
+  if (payload.title) segments.push(payload.title)
+  if (payload.text) segments.push(payload.text)
+  if (payload.url) segments.push(payload.url)
+  return segments.join(" • ")
+}
+
+function determineShareDestination(payload, explicitDestination) {
+  const explicit = normalizeDestination(explicitDestination)
+  if (explicit) {
+    return {
+      destination: explicit,
+      reason: "Explicit share destination selected",
+      explicit: true,
+    }
+  }
+
+  if (payload.fileNames && hasDocumentFile(payload.fileNames)) {
+    return {
+      destination: "documents",
+      reason: "Detected shared files likely suited for document intake",
+      explicit: false,
+    }
+  }
+
+  const shareText = collectShareText(payload)
+  const lowerUrl = payload.url ? payload.url.toLowerCase() : ""
+
+  if (lowerUrl.includes("stripe.com") || containsKeyword(shareText, SHARE_KEYWORDS.payments)) {
+    return {
+      destination: "payments",
+      reason: "Detected payment terminology in shared content",
+      explicit: false,
+    }
+  }
+
+  if (lowerUrl.includes("cal.com") || containsKeyword(shareText, SHARE_KEYWORDS.bookings)) {
+    return {
+      destination: "bookings",
+      reason: "Identified amenity or scheduling details in shared payload",
+      explicit: false,
+    }
+  }
+
+  if (containsKeyword(shareText, SHARE_KEYWORDS.visitors)) {
+    return {
+      destination: "visitors",
+      reason: "Shared content references an overnight guest or visitor",
+      explicit: false,
+    }
+  }
+
+  if (containsKeyword(shareText, SHARE_KEYWORDS.maintenance)) {
+    return {
+      destination: "maintenance",
+      reason: "Shared content references a maintenance issue",
+      explicit: false,
+    }
+  }
+
+  if (
+    (payload.fileNames && payload.fileNames.length) ||
+    lowerUrl.includes("documenso") ||
+    containsKeyword(shareText, SHARE_KEYWORDS.documents)
+  ) {
+    return {
+      destination: "documents",
+      reason: "Shared context aligns with document management",
+      explicit: false,
+    }
+  }
+
+  return {
+    destination: "messaging",
+    reason: "Defaulted to messaging hub for general share content",
+    explicit: false,
+  }
+}
+
+function parseSharedFileNames(formData) {
+  const files = formData.getAll("files")
+  return files
+    .map((entry) => {
+      if (typeof entry === "string") return entry
+      if (entry && typeof entry.name === "string") return entry.name
+      return undefined
+    })
+    .filter((value) => Boolean(value))
+}
+
+function extractSharePayload(formData) {
+  return {
+    title: normalizeValue(formData.get("title")),
+    text: normalizeValue(formData.get("text")),
+    url: normalizeValue(formData.get("url")),
+    fileNames: parseSharedFileNames(formData),
+  }
+}
+
+function buildShareIntentUrl(payload, resolution, additional = {}) {
+  const params = new URLSearchParams()
+  params.set("source", "share-target")
+  params.set("timestamp", Date.now().toString())
+  if (resolution.destination) {
+    params.set("destination", resolution.destination)
+  }
+  if (resolution.reason) {
+    params.set("reason", resolution.reason)
+  }
+  if (payload.title) params.set("title", payload.title)
+  if (payload.text) params.set("text", payload.text)
+  if (payload.url) params.set("url", payload.url)
+  if (payload.fileNames && payload.fileNames.length) {
+    params.set("files", JSON.stringify(payload.fileNames))
+  }
+  Object.entries(additional).forEach(([key, value]) => {
+    if (value != null) {
+      params.set(key, String(value))
     }
   })
-   
-  self.addEventListener('notificationclick', function (event) {
-    console.log('Notification click received.')
-    event.notification.close()
-    event.waitUntil(clients.openWindow('<https://roomsily.app>'))
-  })
+  return `${SHARE_INTENT_PATH}?${params.toString()}`
+}
+
+function parseExplicitDestinationFromRequestUrl(url) {
+  try {
+    const parsed = new URL(url)
+    return parsed.searchParams.get("destination") || undefined
+  } catch (error) {
+    return undefined
+  }
+}
+
+async function handleShareTarget(event) {
+  try {
+    const formData = await event.request.formData()
+    const payload = extractSharePayload(formData)
+    const explicit = parseExplicitDestinationFromRequestUrl(event.request.url)
+    const resolution = determineShareDestination(payload, explicit)
+    const redirectUrl = buildShareIntentUrl(payload, resolution)
+
+    event.waitUntil(
+      (async () => {
+        const clientId = event.resultingClientId || event.clientId
+        if (clientId) {
+          const client = await self.clients.get(clientId)
+          if (client) {
+            client.navigate(redirectUrl)
+            return
+          }
+        }
+        await self.clients.openWindow(redirectUrl)
+      })(),
+    )
+
+    return Response.redirect(redirectUrl, 303)
+  } catch (error) {
+    console.error("Roomsily share target failed", error)
+    return Response.redirect(
+      `${SHARE_INTENT_PATH}?source=share-target&error=share-target`,
+      303,
+    )
+  }
+}
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url)
+  if (url.pathname === SHARE_TARGET_ACTION && event.request.method === "POST") {
+    event.respondWith(handleShareTarget(event))
+  }
+})
+
+self.addEventListener("push", function (event) {
+  if (event.data) {
+    const data = event.data.json()
+    const options = {
+      body: data.body,
+      icon: data.icon || "/icon.png",
+      badge: "/badge.png",
+      vibrate: [100, 50, 100],
+      data: {
+        dateOfArrival: Date.now(),
+        primaryKey: "2",
+      },
+    }
+    event.waitUntil(self.registration.showNotification(data.title, options))
+  }
+})
+
+self.addEventListener("notificationclick", function (event) {
+  console.log("Notification click received.")
+  event.notification.close()
+  event.waitUntil(self.clients.openWindow("https://roomsily.app"))
+})

--- a/lib/share/intent.ts
+++ b/lib/share/intent.ts
@@ -1,0 +1,343 @@
+const SHARE_TARGET_KEYWORDS = {
+  payments: [
+    "rent",
+    "payment",
+    "stripe",
+    "invoice",
+    "receipt",
+    "balance",
+    "autopay",
+    "charge",
+  ],
+  visitors: [
+    "guest",
+    "visitor",
+    "overnight",
+    "stay",
+    "host",
+  ],
+  maintenance: [
+    "maintenance",
+    "repair",
+    "fix",
+    "issue",
+    "leak",
+    "broken",
+    "damage",
+    "work order",
+    "ticket",
+  ],
+  documents: [
+    "document",
+    "lease",
+    "agreement",
+    "attachment",
+    "pdf",
+    "documenso",
+    "file",
+  ],
+  bookings: [
+    "booking",
+    "reservation",
+    "calendar",
+    "schedule",
+    "amenity",
+    "cal.com",
+  ],
+} as const
+
+export const SHARE_TARGET_ACTION = "/share-target"
+export const SHARE_INTENT_PATH = "/share/intent"
+
+export type ShareDestination =
+  | "documents"
+  | "payments"
+  | "messaging"
+  | "maintenance"
+  | "visitors"
+  | "bookings"
+
+export interface SharePayload {
+  title?: string
+  text?: string
+  url?: string
+  fileNames?: string[]
+}
+
+export interface ShareResolution {
+  destination: ShareDestination
+  reason: string
+  explicit: boolean
+}
+
+export interface ShareDestinationMeta {
+  label: string
+  description: string
+  href: string
+  helper: string
+}
+
+export const SHARE_DESTINATION_META: Record<ShareDestination, ShareDestinationMeta> = {
+  documents: {
+    label: "Documents",
+    description:
+      "Capture leases, agreements, and attachments that were shared from other apps into the secure Roomsily vault.",
+    href: "/documents",
+    helper: "Upload or link shared files so roommates and managers can access the latest version.",
+  },
+  payments: {
+    label: "Payments",
+    description:
+      "Attach receipts or payment confirmations to the rent ledger so roommates stay aligned on balances.",
+    href: "/payments",
+    helper: "Log catch-up payments or share proof-of-payment with everyone in the unit.",
+  },
+  messaging: {
+    label: "Messaging",
+    description:
+      "Drop shared notes or links into the message board thread that needs follow-up from your housemates.",
+    href: "/messaging",
+    helper: "Start a discussion or pin the shared context so everyone can weigh in.",
+  },
+  maintenance: {
+    label: "Maintenance",
+    description:
+      "Escalate shared photos or notes about broken items directly into a maintenance request.",
+    href: "/maintenance",
+    helper: "Pre-fill the maintenance form with what was shared so property managers can triage quickly.",
+  },
+  visitors: {
+    label: "Visitors",
+    description:
+      "Turn shared contact cards or travel itineraries into an overnight visitor booking.",
+    href: "/visitors",
+    helper: "Keep roommates and property managers aware of who is staying over and when.",
+  },
+  bookings: {
+    label: "Bookings",
+    description:
+      "Route shared links or screenshots about amenity reservations into your scheduling flow.",
+    href: "/bookings",
+    helper: "Confirm the amenity slot and notify roommates about the reservation details.",
+  },
+}
+
+const DOCUMENT_FILE_EXTENSIONS = [
+  "pdf",
+  "doc",
+  "docx",
+  "xls",
+  "xlsx",
+  "csv",
+  "txt",
+  "rtf",
+]
+
+function normalizeValue(value?: string | null): string | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function toLower(value?: string | null): string | undefined {
+  const normalized = normalizeValue(value)
+  return normalized ? normalized.toLowerCase() : undefined
+}
+
+export function normalizeShareDestination(
+  value?: string | null,
+): ShareDestination | undefined {
+  const normalized = toLower(value)
+  if (!normalized) return undefined
+
+  if (normalized.startsWith("doc")) return "documents"
+  if (normalized.startsWith("pay")) return "payments"
+  if (normalized.startsWith("main")) return "maintenance"
+  if (normalized.startsWith("visit")) return "visitors"
+  if (normalized.startsWith("book")) return "bookings"
+  if (normalized.startsWith("message") || normalized.startsWith("thread")) {
+    return "messaging"
+  }
+
+  return undefined
+}
+
+function containsKeyword(haystack: string, keywords: readonly string[]): boolean {
+  const lowerHaystack = haystack.toLowerCase()
+  return keywords.some((keyword) => lowerHaystack.includes(keyword))
+}
+
+function hasDocumentFile(files: string[] | undefined): boolean {
+  if (!files?.length) return false
+  return files.some((name) => {
+    const lower = name.toLowerCase()
+    return DOCUMENT_FILE_EXTENSIONS.some((ext) => lower.endsWith(`.${ext}`))
+  })
+}
+
+function coalesceText(payload: SharePayload): string {
+  const parts: string[] = []
+  if (payload.title) parts.push(payload.title)
+  if (payload.text) parts.push(payload.text)
+  if (payload.url) parts.push(payload.url)
+  return parts.join(" \u2022 ")
+}
+
+export function determineShareDestination(
+  payload: SharePayload,
+  explicitDestination?: ShareDestination | string | null,
+): ShareResolution {
+  const explicit =
+    typeof explicitDestination === "string"
+      ? normalizeShareDestination(explicitDestination)
+      : explicitDestination
+
+  if (explicit) {
+    return {
+      destination: explicit,
+      reason: "Explicit share destination selected",
+      explicit: true,
+    }
+  }
+
+  if (payload.fileNames?.length && hasDocumentFile(payload.fileNames)) {
+    return {
+      destination: "documents",
+      reason: "Detected shared files likely suited for document intake",
+      explicit: false,
+    }
+  }
+
+  const text = coalesceText(payload)
+  const lowerText = text.toLowerCase()
+  const lowerUrl = payload.url ? payload.url.toLowerCase() : ""
+
+  if (lowerUrl.includes("stripe.com") || containsKeyword(lowerText, SHARE_TARGET_KEYWORDS.payments)) {
+    return {
+      destination: "payments",
+      reason: "Detected payment terminology in shared content",
+      explicit: false,
+    }
+  }
+
+  if (lowerUrl.includes("cal.com") || containsKeyword(lowerText, SHARE_TARGET_KEYWORDS.bookings)) {
+    return {
+      destination: "bookings",
+      reason: "Identified amenity or scheduling details in shared payload",
+      explicit: false,
+    }
+  }
+
+  if (containsKeyword(lowerText, SHARE_TARGET_KEYWORDS.visitors)) {
+    return {
+      destination: "visitors",
+      reason: "Shared content references an overnight guest or visitor",
+      explicit: false,
+    }
+  }
+
+  if (containsKeyword(lowerText, SHARE_TARGET_KEYWORDS.maintenance)) {
+    return {
+      destination: "maintenance",
+      reason: "Shared content references a maintenance issue",
+      explicit: false,
+    }
+  }
+
+  if (
+    payload.fileNames?.length ||
+    lowerUrl.includes("documenso") ||
+    containsKeyword(lowerText, SHARE_TARGET_KEYWORDS.documents)
+  ) {
+    return {
+      destination: "documents",
+      reason: "Shared context aligns with document management",
+      explicit: false,
+    }
+  }
+
+  return {
+    destination: "messaging",
+    reason: "Defaulted to messaging hub for general share content",
+    explicit: false,
+  }
+}
+
+export function buildShareIntentUrl(
+  payload: SharePayload,
+  options: { destination?: ShareDestination; reason?: string } = {},
+): string {
+  const params = new URLSearchParams()
+  params.set("source", "share-target")
+  params.set("timestamp", Date.now().toString())
+
+  if (options.destination) {
+    params.set("destination", options.destination)
+  }
+
+  if (options.reason) {
+    params.set("reason", options.reason)
+  }
+
+  if (payload.title) params.set("title", payload.title)
+  if (payload.text) params.set("text", payload.text)
+  if (payload.url) params.set("url", payload.url)
+  if (payload.fileNames?.length) {
+    params.set("files", JSON.stringify(payload.fileNames))
+  }
+
+  const query = params.toString()
+  return query ? `${SHARE_INTENT_PATH}?${query}` : SHARE_INTENT_PATH
+}
+
+export function parseFileNamesParam(value: string | null | undefined): string[] {
+  if (!value) return []
+
+  try {
+    const parsed = JSON.parse(value)
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((item) => (typeof item === "string" ? item : String(item)))
+        .filter((item) => item.trim().length > 0)
+    }
+  } catch (error) {
+    // Fallback below
+  }
+
+  return value
+    .split(/[|,]/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+export function extractExplicitDestinationFromUrl(url: string): ShareDestination | undefined {
+  try {
+    const parsed = new URL(url)
+    return normalizeShareDestination(parsed.searchParams.get("destination"))
+  } catch (error) {
+    return undefined
+  }
+}
+
+function coerceParamValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value.length ? value[0] : undefined
+  }
+  return typeof value === "string" ? value : undefined
+}
+
+export function coerceSharePayloadFromParams(
+  params: Record<string, string | string[] | undefined>,
+): SharePayload {
+  const title = normalizeValue(coerceParamValue(params.title))
+  const text = normalizeValue(coerceParamValue(params.text))
+  const url = normalizeValue(coerceParamValue(params.url))
+  const filesParam = coerceParamValue(params.files)
+
+  return {
+    title,
+    text,
+    url,
+    fileNames: parseFileNamesParam(filesParam),
+  }
+}

--- a/lib/share/outbound.ts
+++ b/lib/share/outbound.ts
@@ -1,0 +1,215 @@
+import { format } from "date-fns"
+
+import { formatCurrency } from "@/lib/payments/currency"
+import type { DocumentWithLease } from "@/types/documents"
+import type { PaymentReceiptHistoryEntry } from "@/types/payments"
+
+export interface ShareContentPayload {
+  title?: string
+  text?: string
+  url?: string
+}
+
+export type ShareStatus = "shared" | "copied" | "aborted" | "unsupported"
+
+export interface ShareDocumentOptions {
+  baseUrl?: string
+}
+
+export interface SharePaymentOptions {
+  baseUrl?: string
+  shareUrl?: string
+}
+
+export interface ShareThreadDetails {
+  id: string
+  title: string
+  summary: string
+  category?: string
+  participants?: number
+  lastMessageAt?: string
+  href?: string
+  url?: string
+}
+
+export interface ShareThreadOptions {
+  baseUrl?: string
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value)
+}
+
+export function resolveShareUrl(url: string | undefined, baseUrl?: string): string | undefined {
+  if (!url) return undefined
+  if (isAbsoluteUrl(url)) {
+    return url
+  }
+
+  if (!baseUrl) {
+    return url
+  }
+
+  try {
+    return new URL(url, baseUrl).toString()
+  } catch (error) {
+    return url
+  }
+}
+
+export async function shareContent(
+  payload: ShareContentPayload,
+  options: { fallbackText?: string } = {},
+): Promise<ShareStatus> {
+  if (typeof navigator === "undefined") {
+    return "unsupported"
+  }
+
+  if (navigator.share) {
+    try {
+      await navigator.share(payload)
+      return "shared"
+    } catch (error) {
+      if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+        if (error.name === "AbortError") {
+          return "aborted"
+        }
+      }
+      // If the share failed for another reason, fall through to clipboard fallback
+    }
+  }
+
+  const fallbackText = options.fallbackText ?? payload.url ?? payload.text
+  if (fallbackText && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(fallbackText)
+      return "copied"
+    } catch (error) {
+      return "unsupported"
+    }
+  }
+
+  return "unsupported"
+}
+
+export function buildDocumentSharePayload(
+  document: DocumentWithLease,
+  options: ShareDocumentOptions = {},
+): ShareContentPayload {
+  const shareUrl = resolveShareUrl(document.file_url ?? undefined, options.baseUrl)
+  const context: string[] = []
+
+  if (document.description) {
+    context.push(document.description)
+  }
+
+  const lease = document.lease
+  const leaseDetails: string[] = []
+  if (lease?.unit_number) {
+    leaseDetails.push(`Unit ${lease.unit_number}`)
+  }
+  if (lease?.property_address) {
+    leaseDetails.push(lease.property_address)
+  }
+  if (leaseDetails.length) {
+    context.push(leaseDetails.join(" • "))
+  }
+
+  if (document.requires_signature) {
+    context.push("Signature required")
+  }
+
+  const text = context.join("\n")
+
+  return {
+    title: `${document.title} – Roomsily`,
+    text: text || undefined,
+    url: shareUrl,
+  }
+}
+
+export async function shareDocument(
+  document: DocumentWithLease,
+  options: ShareDocumentOptions = {},
+): Promise<ShareStatus> {
+  const payload = buildDocumentSharePayload(document, options)
+  return shareContent(payload, { fallbackText: payload.url })
+}
+
+export function buildPaymentReceiptSharePayload(
+  receipt: PaymentReceiptHistoryEntry,
+  options: SharePaymentOptions = {},
+): ShareContentPayload {
+  const amount = formatCurrency(receipt.amount, receipt.currency)
+  let issuedOn = ""
+  try {
+    issuedOn = format(new Date(receipt.paymentDate), "MMM d, yyyy")
+  } catch (error) {
+    issuedOn = receipt.paymentDate
+  }
+
+  const shareUrl = resolveShareUrl(options.shareUrl ?? receipt.receiptUrl ?? receipt.invoiceUrl, options.baseUrl)
+
+  const summaryLines: string[] = []
+  summaryLines.push(`${amount} on ${issuedOn} • ${receipt.paymentMethod}`)
+  summaryLines.push(`Status: ${receipt.status}`)
+
+  const primaryLineItem = receipt.lineItems[0]?.description
+  if (primaryLineItem) {
+    summaryLines.push(`Key line item: ${primaryLineItem}`)
+  }
+
+  if (receipt.memo) {
+    summaryLines.push(`Memo: ${receipt.memo}`)
+  }
+
+  return {
+    title: `Receipt • ${receipt.issuedTo}`,
+    text: summaryLines.join("\n"),
+    url: shareUrl,
+  }
+}
+
+export async function sharePaymentReceipt(
+  receipt: PaymentReceiptHistoryEntry,
+  options: SharePaymentOptions = {},
+): Promise<ShareStatus> {
+  const payload = buildPaymentReceiptSharePayload(receipt, options)
+  return shareContent(payload, { fallbackText: payload.url })
+}
+
+export function buildThreadSharePayload(
+  thread: ShareThreadDetails,
+  options: ShareThreadOptions = {},
+): ShareContentPayload {
+  const shareUrl = resolveShareUrl(thread.url ?? thread.href, options.baseUrl)
+  const summaryLines: string[] = [thread.summary]
+
+  const meta: string[] = []
+  if (thread.category) {
+    meta.push(thread.category)
+  }
+  if (typeof thread.participants === "number" && thread.participants > 0) {
+    meta.push(`${thread.participants} roommates involved`)
+  }
+  if (meta.length) {
+    summaryLines.push(meta.join(" • "))
+  }
+  if (thread.lastMessageAt) {
+    summaryLines.push(`Last activity: ${thread.lastMessageAt}`)
+  }
+
+  return {
+    title: `${thread.title} – Roomsily thread`,
+    text: summaryLines.join("\n"),
+    url: shareUrl,
+  }
+}
+
+export async function shareThread(
+  thread: ShareThreadDetails,
+  options: ShareThreadOptions = {},
+): Promise<ShareStatus> {
+  const payload = buildThreadSharePayload(thread, options)
+  return shareContent(payload, { fallbackText: payload.url })
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -42,5 +42,83 @@
       "platform": "play",
       "url": "https://play.google.com/store/apps/details?id=yourApp"
     }
+  ],
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url",
+      "files": [
+        {
+          "name": "files",
+          "accept": [
+            "image/*",
+            "application/pdf",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.ms-excel",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "text/plain"
+          ]
+        }
+      ]
+    }
+  },
+  "shortcuts": [
+    {
+      "name": "Log rent receipt",
+      "short_name": "Receipt",
+      "description": "Attach a shared rent or utility receipt to roommate ledgers.",
+      "url": "/share/intent?destination=payments",
+      "icons": [
+        {
+          "src": "images/touch/homescreen96.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "File document",
+      "short_name": "Document",
+      "description": "Route shared agreements and attachments into the Roomsily vault.",
+      "url": "/share/intent?destination=documents",
+      "icons": [
+        {
+          "src": "images/touch/homescreen96.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "Escalate maintenance",
+      "short_name": "Maintenance",
+      "description": "Send shared photos or notes directly to the maintenance intake flow.",
+      "url": "/share/intent?destination=maintenance",
+      "icons": [
+        {
+          "src": "images/touch/homescreen96.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "Coordinate visitor",
+      "short_name": "Visitor",
+      "description": "Turn shared contact cards into overnight visitor bookings.",
+      "url": "/share/intent?destination=visitors",
+      "icons": [
+        {
+          "src": "images/touch/homescreen96.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ]
+    }
   ]
 }

--- a/tests/share-flows.test.ts
+++ b/tests/share-flows.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  SHARE_INTENT_PATH,
+  buildShareIntentUrl,
+  coerceSharePayloadFromParams,
+  determineShareDestination,
+  parseFileNamesParam,
+} from "@/lib/share/intent"
+import {
+  buildDocumentSharePayload,
+  buildPaymentReceiptSharePayload,
+  buildThreadSharePayload,
+  resolveShareUrl,
+} from "@/lib/share/outbound"
+import type { DocumentWithLease } from "@/types/documents"
+import type { PaymentReceiptHistoryEntry } from "@/types/payments"
+
+describe("share target routing", () => {
+  it("routes file based shares to documents", () => {
+    const resolution = determineShareDestination({
+      title: "Signed lease",
+      text: "Latest lease draft",
+      fileNames: ["unit-5a-lease.pdf"],
+    }, null)
+
+    expect(resolution.destination).toBe("documents")
+    expect(resolution.reason).toContain("document")
+  })
+
+  it("detects payment terminology", () => {
+    const resolution = determineShareDestination({
+      text: "Rent payment receipt for April",
+      url: "https://stripe.com/payments/receipt",
+    }, null)
+
+    expect(resolution.destination).toBe("payments")
+  })
+
+  it("detects visitor intents", () => {
+    const resolution = determineShareDestination({
+      text: "Guest stay request for my sister visiting this weekend",
+    }, null)
+
+    expect(resolution.destination).toBe("visitors")
+  })
+
+  it("detects maintenance issues", () => {
+    const resolution = determineShareDestination({
+      text: "Water heater leak needs urgent repair",
+    }, null)
+
+    expect(resolution.destination).toBe("maintenance")
+  })
+
+  it("falls back to messaging when no signals detected", () => {
+    const resolution = determineShareDestination({
+      text: "Check out this idea for our next roommate dinner",
+    }, null)
+
+    expect(resolution.destination).toBe("messaging")
+  })
+
+  it("honours explicit destination overrides", () => {
+    const resolution = determineShareDestination(
+      {
+        text: "Attaching maintenance photos",
+        fileNames: ["leak.jpg"],
+      },
+      "payments",
+    )
+
+    expect(resolution.destination).toBe("payments")
+    expect(resolution.explicit).toBe(true)
+  })
+
+  it("builds a share intent URL with metadata", () => {
+    const url = buildShareIntentUrl(
+      {
+        title: "Lease amendment",
+        text: "Needs signature",
+        url: "https://example.com/documents/123",
+        fileNames: ["amendment.pdf"],
+      },
+      {
+        destination: "documents",
+        reason: "Detected shared files likely suited for document intake",
+      },
+    )
+
+    expect(url).toContain(SHARE_INTENT_PATH)
+    expect(url).toContain("destination=documents")
+    expect(url).toContain("reason=")
+    expect(url).toContain("files=%5B%22amendment.pdf%22%5D")
+  })
+
+  it("coerces payload from query parameters", () => {
+    const payload = coerceSharePayloadFromParams({
+      title: "Unit 5A visitor",
+      text: "Guest arriving Friday",
+      url: "https://roomsily.app",
+      files: JSON.stringify(["guest-pass.pdf"]),
+    })
+
+    expect(payload.title).toBe("Unit 5A visitor")
+    expect(payload.text).toContain("Guest")
+    expect(payload.url).toBe("https://roomsily.app")
+    expect(payload.fileNames).toEqual(["guest-pass.pdf"])
+  })
+
+  it("parses fallback file lists", () => {
+    expect(parseFileNamesParam("one.png|two.jpg")).toEqual(["one.png", "two.jpg"])
+  })
+})
+
+describe("outbound share payloads", () => {
+  const baseDocument: DocumentWithLease = {
+    id: "doc-1",
+    created_at: "2023-01-01",
+    updated_at: "2023-01-02",
+    title: "Lease Agreement",
+    description: "Primary lease for Unit 5A",
+    document_type: "lease",
+    status: "signed",
+    state: "published",
+    metadata: {},
+    requires_signature: false,
+    version: 1,
+    file_url: "/documents/doc-1.pdf",
+  } as DocumentWithLease
+
+  const baseReceipt: PaymentReceiptHistoryEntry = {
+    id: "rec-1",
+    issuedTo: "Alex Tenant",
+    paymentDate: "2024-03-01",
+    currency: "USD",
+    amount: 185000,
+    status: "paid",
+    paymentMethod: "Visa •••• 4242",
+    receiptUrl: "/receipts/rec-1",
+    lineItems: [
+      { id: "item-1", description: "Rent", category: "rent", totalAmount: 185000 },
+    ],
+  }
+
+  it("builds document share payloads with lease context", () => {
+    const payload = buildDocumentSharePayload({
+      ...baseDocument,
+      lease: {
+        id: "lease-1",
+        document_id: "doc-1",
+        created_at: "2023-01-01",
+        updated_at: "2023-01-01",
+        start_date: "2023-01-01",
+        rent_frequency: "monthly",
+        auto_renew: false,
+        renewal_notice_days: 30,
+        tenant_ids: [],
+        status: "signed",
+        unit_number: "5A",
+        property_address: "456 Shared House Ln",
+      },
+    } as DocumentWithLease, { baseUrl: "https://roomsily.test" })
+
+    expect(payload.title).toContain("Lease Agreement")
+    expect(payload.url).toBe("https://roomsily.test/documents/doc-1.pdf")
+    expect(payload.text).toContain("Unit 5A")
+  })
+
+  it("builds payment receipt payloads with formatted context", () => {
+    const payload = buildPaymentReceiptSharePayload(baseReceipt, { baseUrl: "https://roomsily.test" })
+
+    expect(payload.title).toContain("Receipt")
+    expect(payload.text).toContain("Visa")
+    expect(resolveShareUrl(baseReceipt.receiptUrl, "https://roomsily.test")).toBe(
+      "https://roomsily.test/receipts/rec-1",
+    )
+    expect(payload.url).toBe("https://roomsily.test/receipts/rec-1")
+  })
+
+  it("builds messaging thread payloads with metadata", () => {
+    const payload = buildThreadSharePayload(
+      {
+        id: "thread-1",
+        title: "Chore rotation",
+        summary: "Vote on the deep clean weekend",
+        category: "Chores",
+        participants: 4,
+        lastMessageAt: "Today 9:00 AM",
+        href: "/messaging?thread=thread-1",
+      },
+      { baseUrl: "https://roomsily.test" },
+    )
+
+    expect(payload.title).toContain("Chore rotation")
+    expect(payload.text).toContain("4 roommates involved")
+    expect(payload.url).toBe("https://roomsily.test/messaging?thread=thread-1")
+  })
+
+  it("does not alter absolute URLs when resolving", () => {
+    const absolute = resolveShareUrl("https://example.com/path", "https://roomsily.test")
+    expect(absolute).toBe("https://example.com/path")
+  })
+})


### PR DESCRIPTION
## Summary
- configure the PWA manifest with share target metadata and shortcuts for routing inbound shares into a new share intent view
- add share heuristics and service worker handling to extract shared payloads, redirect users, and display contextual next steps
- centralize outbound sharing helpers and wire them into document, payment receipt, and messaging thread actions alongside new tests for share flows

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b9ccba883289140c18179bd04c0