### PR TITLE
Add pull-to-refresh support for members dashboard

### DIFF
--- a/app/dashboard/members/components/MembersScrollContainer.tsx
+++ b/app/dashboard/members/components/MembersScrollContainer.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { PropsWithChildren, useCallback, useRef } from "react"
+import { useRouter } from "next/navigation"
+
+import { usePullToRefresh } from "@/hooks/use-pull-to-refresh"
+
+type MembersScrollContainerProps = PropsWithChildren<{
+  className?: string
+}>
+
+export function MembersScrollContainer({ children, className }: MembersScrollContainerProps) {
+  const router = useRouter()
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const handleRefresh = useCallback(() => {
+    router.refresh()
+  }, [router])
+
+  usePullToRefresh({ containerRef, onRefresh: handleRefresh })
+
+  return (
+    <div ref={containerRef} className={className}>
+      {children}
+    </div>
+  )
+}

--- a/app/dashboard/members/loading.tsx
+++ b/app/dashboard/members/loading.tsx
@@ -1,10 +1,11 @@
 import { MemberTableSkeleton } from "./components/skeletons"
+import { MembersScrollContainer } from "./components/MembersScrollContainer"
 
 export default function LoadingMembers() {
         return (
-                <div className="w-full space-y-5 overflow-y-auto px-3">
+                <MembersScrollContainer className="w-full space-y-5 overflow-y-auto px-3">
                         <div className="h-10 w-40 animate-pulse rounded bg-muted/60" />
                         <MemberTableSkeleton />
-                </div>
+                </MembersScrollContainer>
         )
 }

--- a/app/dashboard/members/page.tsx
+++ b/app/dashboard/members/page.tsx
@@ -7,12 +7,13 @@ import MemberTable from "./components/MemberTable"
 import { LegacyMemberTable } from "./components/LegacyMemberTable"
 import { MemberTableSkeleton } from "./components/skeletons"
 import SearchMembers from "./components/SearchMembers"
+import { MembersScrollContainer } from "./components/MembersScrollContainer"
 
 export default function Members() {
         const streamingEnabled = isFeatureEnabled("streamingDashboards")
 
         return (
-                <div className="w-full space-y-5 overflow-y-auto px-3">
+                <MembersScrollContainer className="w-full space-y-5 overflow-y-auto px-3">
                         <h1 className="text-3xl font-bold">Members</h1>
                         <div className="flex gap-2">
                                 <SearchMembers />
@@ -25,6 +26,6 @@ export default function Members() {
                         ) : (
                                 <LegacyMemberTable />
                         )}
-                </div>
+                </MembersScrollContainer>
         )
 }

--- a/docs/manual-qa/pull-to-refresh.md
+++ b/docs/manual-qa/pull-to-refresh.md
@@ -1,0 +1,21 @@
+# Pull-to-refresh manual QA
+
+## Goal
+Verify that the members dashboard list supports mobile pull-to-refresh gestures, refetches data, and provides haptic feedback.
+
+## Prerequisites
+- `pnpm dev` running locally.
+- Mobile device or browser device emulator capable of touch events (e.g., Chrome DevTools with "Toggle device toolbar").
+
+## Steps
+1. Open the app at `http://localhost:3000/dashboard/members` in a mobile viewport (e.g., iPhone 14 size).
+2. Scroll the list to the very top.
+3. Drag downward until you feel a short vibration (or see the simulated pull distance in the emulator). The gesture should not interfere with the normal scroll behavior.
+4. Release the gesture once the vibration fires.
+5. Observe the members table reloading: network tab should show a refreshed request and the list should momentarily show the loading skeleton before rendering the latest data.
+
+## Expected results
+- The drag gesture only activates when starting from the top of the list and scrolling downward.
+- A haptic vibration occurs once the threshold is crossed on supported devices.
+- The list re-renders with fresh data (verified via the network tab or the temporary skeleton state).
+- Desktop browsers without touch input do not trigger the pull-to-refresh behavior.

--- a/hooks/use-pull-to-refresh.ts
+++ b/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,101 @@
+"use client"
+
+import { MutableRefObject, useEffect, useRef } from "react"
+
+type PullToRefreshOptions = {
+  containerRef: MutableRefObject<HTMLElement | null>
+  onRefresh: () => void | Promise<void>
+  threshold?: number
+  disabled?: boolean
+}
+
+const isTouchEnvironment = () => {
+  if (typeof window === "undefined") {
+    return false
+  }
+
+  const coarsePointer = window.matchMedia?.("(pointer: coarse)").matches
+
+  return coarsePointer || "ontouchstart" in window
+}
+
+export function usePullToRefresh({
+  containerRef,
+  onRefresh,
+  threshold = 60,
+  disabled = false,
+}: PullToRefreshOptions) {
+  const startY = useRef<number | null>(null)
+  const reachedThreshold = useRef(false)
+  const isRefreshing = useRef(false)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    if (disabled) return
+    if (!isTouchEnvironment()) return
+
+    const handleTouchStart = (event: TouchEvent) => {
+      if (container.scrollTop > 0) {
+        startY.current = null
+        return
+      }
+
+      const touch = event.touches[0]
+      startY.current = touch?.clientY ?? null
+      reachedThreshold.current = false
+    }
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (startY.current === null) return
+      if (container.scrollTop > 0) return
+
+      const touch = event.touches[0]
+      const delta = (touch?.clientY ?? 0) - startY.current
+
+      if (delta <= 0) {
+        reachedThreshold.current = false
+        return
+      }
+
+      if (delta >= threshold && !reachedThreshold.current) {
+        reachedThreshold.current = true
+        if (typeof navigator !== "undefined" && "vibrate" in navigator) {
+          try {
+            navigator.vibrate?.(10)
+          } catch {
+            // noop - vibration unsupported or blocked
+          }
+        }
+      }
+    }
+
+    const handleTouchEnd = async () => {
+      if (!reachedThreshold.current || isRefreshing.current) {
+        startY.current = null
+        reachedThreshold.current = false
+        return
+      }
+
+      isRefreshing.current = true
+      try {
+        await onRefresh()
+      } finally {
+        isRefreshing.current = false
+      }
+
+      startY.current = null
+      reachedThreshold.current = false
+    }
+
+    container.addEventListener("touchstart", handleTouchStart, { passive: true })
+    container.addEventListener("touchmove", handleTouchMove, { passive: true })
+    container.addEventListener("touchend", handleTouchEnd)
+
+    return () => {
+      container.removeEventListener("touchstart", handleTouchStart)
+      container.removeEventListener("touchmove", handleTouchMove)
+      container.removeEventListener("touchend", handleTouchEnd)
+    }
+  }, [containerRef, disabled, onRefresh, threshold])
+}


### PR DESCRIPTION
## Summary
- add a reusable `usePullToRefresh` client hook that gates on touch devices, triggers haptics, and invokes refresh callbacks
- wrap the members dashboard scroll container (page and loading skeleton) in a client component that refetches data via `router.refresh`
- document manual QA steps for validating the mobile pull-to-refresh gesture and data reload

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30b9dbdc88328bd39e5300bd411af