### PR TITLE
Add performance budgets and monitoring instrumentation

### DIFF
--- a/app/dashboard/(dashboard)/data.ts
+++ b/app/dashboard/(dashboard)/data.ts
@@ -2,6 +2,8 @@ import "server-only"
 
 import { cache } from "react"
 
+import { measureDataFetch } from "@/lib/performance/server"
+
 type WelcomeMessage = {
   title: string
   subtitle: string
@@ -80,19 +82,27 @@ async function wait(ms: number) {
 }
 
 async function fetchWelcomeMessage(): Promise<WelcomeMessage> {
-  await wait(120)
-  return {
-    title: "Welcome back, Jordan",
-    subtitle: "Here’s what’s happening with Unit 3B today.",
-    primaryAction: {
-      href: "/payments",
-      label: "Settle rent",
+  return measureDataFetch(
+    {
+      route: "/dashboard",
+      detail: "welcome-message",
     },
-    secondaryAction: {
-      href: "/schedule",
-      label: "Book an amenity",
-    },
-  }
+    async () => {
+      await wait(120)
+      return {
+        title: "Welcome back, Jordan",
+        subtitle: "Here’s what’s happening with Unit 3B today.",
+        primaryAction: {
+          href: "/payments",
+          label: "Settle rent",
+        },
+        secondaryAction: {
+          href: "/schedule",
+          label: "Book an amenity",
+        },
+      }
+    }
+  )
 }
 
 export const getWelcomeMessage = cache(fetchWelcomeMessage)
@@ -102,15 +112,23 @@ export function loadWelcomeMessageUncached() {
 }
 
 async function fetchRentSummary(): Promise<RentSummary> {
-  await wait(240)
-  return {
-    amount: 1260,
-    dueDate: "2024-08-01",
-    autopayEnabled: true,
-    balance: 0,
-    lastPaymentDate: "2024-07-01",
-    status: "due_soon",
-  }
+  return measureDataFetch(
+    {
+      route: "/dashboard",
+      detail: "rent-summary",
+    },
+    async () => {
+      await wait(240)
+      return {
+        amount: 1260,
+        dueDate: "2024-08-01",
+        autopayEnabled: true,
+        balance: 0,
+        lastPaymentDate: "2024-07-01",
+        status: "due_soon",
+      }
+    }
+  )
 }
 
 export const getRentSummary = cache(fetchRentSummary)
@@ -120,30 +138,38 @@ export function loadRentSummaryUncached() {
 }
 
 async function fetchRecentDocuments(): Promise<DocumentSummary[]> {
-  await wait(180)
-  return [
+  return measureDataFetch(
     {
-      name: "Lease agreement v2.pdf",
-      href: "/documents",
-      category: "Lease",
-      status: "viewed",
-      updatedAt: "2024-06-15",
+      route: "/dashboard",
+      detail: "recent-documents",
     },
-    {
-      name: "House rules.pdf",
-      href: "/documents",
-      category: "Policies",
-      status: "new",
-      updatedAt: "2024-07-10",
-    },
-    {
-      name: "September chore rotation.pdf",
-      href: "/documents",
-      category: "Chores",
-      status: "action_required",
-      updatedAt: "2024-07-22",
-    },
-  ]
+    async () => {
+      await wait(180)
+      return [
+        {
+          name: "Lease agreement v2.pdf",
+          href: "/documents",
+          category: "Lease",
+          status: "viewed",
+          updatedAt: "2024-06-15",
+        },
+        {
+          name: "House rules.pdf",
+          href: "/documents",
+          category: "Policies",
+          status: "new",
+          updatedAt: "2024-07-10",
+        },
+        {
+          name: "September chore rotation.pdf",
+          href: "/documents",
+          category: "Chores",
+          status: "action_required",
+          updatedAt: "2024-07-22",
+        },
+      ]
+    }
+  )
 }
 
 export const getRecentDocuments = cache(fetchRecentDocuments)
@@ -153,31 +179,39 @@ export function loadRecentDocumentsUncached() {
 }
 
 async function fetchRoommateUpdates(): Promise<RoommateUpdate[]> {
-  await wait(320)
-  const now = new Date()
-  return [
+  return measureDataFetch(
     {
-      id: "1",
-      author: "Jordan",
-      message: "Wi-Fi was down earlier — rebooted the router and it’s stable again.",
-      timestamp: new Date(now.getTime() - 1000 * 60 * 45).toISOString(),
-      topic: "maintenance",
+      route: "/dashboard",
+      detail: "roommate-updates",
     },
-    {
-      id: "2",
-      author: "Avery",
-      message: "Can we swap parking spots this weekend while my guests visit?",
-      timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 5).toISOString(),
-      topic: "logistics",
-    },
-    {
-      id: "3",
-      author: "Property manager",
-      message: "Reminder: fire alarm inspection on Thursday at 10:00 AM.",
-      timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 24).toISOString(),
-      topic: "announcement",
-    },
-  ]
+    async () => {
+      await wait(320)
+      const now = new Date()
+      return [
+        {
+          id: "1",
+          author: "Jordan",
+          message: "Wi-Fi was down earlier — rebooted the router and it’s stable again.",
+          timestamp: new Date(now.getTime() - 1000 * 60 * 45).toISOString(),
+          topic: "maintenance",
+        },
+        {
+          id: "2",
+          author: "Avery",
+          message: "Can we swap parking spots this weekend while my guests visit?",
+          timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 5).toISOString(),
+          topic: "logistics",
+        },
+        {
+          id: "3",
+          author: "Property manager",
+          message: "Reminder: fire alarm inspection on Thursday at 10:00 AM.",
+          timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 24).toISOString(),
+          topic: "announcement",
+        },
+      ]
+    }
+  )
 }
 
 export const getRoommateUpdates = cache(fetchRoommateUpdates)
@@ -187,41 +221,49 @@ export function loadRoommateUpdatesUncached() {
 }
 
 async function fetchDashboardMetrics(): Promise<DashboardMetric[]> {
-  await wait(160)
-  return [
+  return measureDataFetch(
     {
-      id: "rent",
-      label: "This month’s rent",
-      value: "$1,260",
-      helperText: "Due in 5 days",
-      trend: { direction: "neutral", label: "Autopay scheduled" },
-      icon: "rent",
+      route: "/dashboard",
+      detail: "dashboard-metrics",
     },
-    {
-      id: "calendar",
-      label: "Upcoming bookings",
-      value: "3",
-      helperText: "Kitchen, TV room & parking",
-      trend: { direction: "up", label: "+1 vs last week" },
-      icon: "calendar",
-    },
-    {
-      id: "roommates",
-      label: "Roommate updates",
-      value: "4",
-      helperText: "New notes in the last 24h",
-      trend: { direction: "up", label: "Active thread" },
-      icon: "roommates",
-    },
-    {
-      id: "maintenance",
-      label: "Open maintenance",
-      value: "2",
-      helperText: "Both scheduled for this week",
-      trend: { direction: "down", label: "No overdue items" },
-      icon: "maintenance",
-    },
-  ]
+    async () => {
+      await wait(160)
+      return [
+        {
+          id: "rent",
+          label: "This month’s rent",
+          value: "$1,260",
+          helperText: "Due in 5 days",
+          trend: { direction: "neutral", label: "Autopay scheduled" },
+          icon: "rent",
+        },
+        {
+          id: "calendar",
+          label: "Upcoming bookings",
+          value: "3",
+          helperText: "Kitchen, TV room & parking",
+          trend: { direction: "up", label: "+1 vs last week" },
+          icon: "calendar",
+        },
+        {
+          id: "roommates",
+          label: "Roommate updates",
+          value: "4",
+          helperText: "New notes in the last 24h",
+          trend: { direction: "up", label: "Active thread" },
+          icon: "roommates",
+        },
+        {
+          id: "maintenance",
+          label: "Open maintenance",
+          value: "2",
+          helperText: "Both scheduled for this week",
+          trend: { direction: "down", label: "No overdue items" },
+          icon: "maintenance",
+        },
+      ]
+    }
+  )
 }
 
 export const getDashboardMetrics = cache(fetchDashboardMetrics)
@@ -231,27 +273,35 @@ export function loadDashboardMetricsUncached() {
 }
 
 async function fetchQuickActions(): Promise<QuickAction[]> {
-  await wait(140)
-  return [
+  return measureDataFetch(
     {
-      id: "payments",
-      label: "Record a payment",
-      description: "Log an off-platform rent payment",
-      href: "/payments",
+      route: "/dashboard",
+      detail: "quick-actions",
     },
-    {
-      id: "amenity",
-      label: "Reserve an amenity",
-      description: "Kitchen, TV room, parking & more",
-      href: "/schedule",
-    },
-    {
-      id: "visitor",
-      label: "Register a visitor",
-      description: "Stay compliant with overnight policy",
-      href: "/visitors",
-    },
-  ]
+    async () => {
+      await wait(140)
+      return [
+        {
+          id: "payments",
+          label: "Record a payment",
+          description: "Log an off-platform rent payment",
+          href: "/payments",
+        },
+        {
+          id: "amenity",
+          label: "Reserve an amenity",
+          description: "Kitchen, TV room, parking & more",
+          href: "/schedule",
+        },
+        {
+          id: "visitor",
+          label: "Register a visitor",
+          description: "Stay compliant with overnight policy",
+          href: "/visitors",
+        },
+      ]
+    }
+  )
 }
 
 export const getQuickActions = cache(fetchQuickActions)
@@ -261,30 +311,38 @@ export function loadQuickActionsUncached() {
 }
 
 async function fetchUpcomingBookings(): Promise<UpcomingBooking[]> {
-  await wait(200)
-  return [
+  return measureDataFetch(
     {
-      id: "booking-1",
-      amenity: "Kitchen",
-      date: "2024-07-26",
-      timeframe: "5:00 – 7:00 PM",
-      status: "confirmed",
+      route: "/dashboard",
+      detail: "upcoming-bookings",
     },
-    {
-      id: "booking-2",
-      amenity: "Parking spot",
-      date: "2024-07-27",
-      timeframe: "All day",
-      status: "pending",
-    },
-    {
-      id: "booking-3",
-      amenity: "PlayStation nook",
-      date: "2024-07-28",
-      timeframe: "8:00 – 10:00 PM",
-      status: "confirmed",
-    },
-  ]
+    async () => {
+      await wait(200)
+      return [
+        {
+          id: "booking-1",
+          amenity: "Kitchen",
+          date: "2024-07-26",
+          timeframe: "5:00 – 7:00 PM",
+          status: "confirmed",
+        },
+        {
+          id: "booking-2",
+          amenity: "Parking spot",
+          date: "2024-07-27",
+          timeframe: "All day",
+          status: "pending",
+        },
+        {
+          id: "booking-3",
+          amenity: "PlayStation nook",
+          date: "2024-07-28",
+          timeframe: "8:00 – 10:00 PM",
+          status: "confirmed",
+        },
+      ]
+    }
+  )
 }
 
 export const getUpcomingBookings = cache(fetchUpcomingBookings)
@@ -294,23 +352,31 @@ export function loadUpcomingBookingsUncached() {
 }
 
 async function fetchMaintenanceTickets(): Promise<MaintenanceTicket[]> {
-  await wait(220)
-  return [
+  return measureDataFetch(
     {
-      id: "maintenance-1",
-      title: "Washer door latch replacement",
-      status: "scheduled",
-      priority: "medium",
-      updatedAt: "2024-07-22T14:30:00.000Z",
+      route: "/dashboard",
+      detail: "maintenance-tickets",
     },
-    {
-      id: "maintenance-2",
-      title: "HVAC seasonal tune-up",
-      status: "in_progress",
-      priority: "high",
-      updatedAt: "2024-07-21T09:00:00.000Z",
-    },
-  ]
+    async () => {
+      await wait(220)
+      return [
+        {
+          id: "maintenance-1",
+          title: "Washer door latch replacement",
+          status: "scheduled",
+          priority: "medium",
+          updatedAt: "2024-07-22T14:30:00.000Z",
+        },
+        {
+          id: "maintenance-2",
+          title: "HVAC seasonal tune-up",
+          status: "in_progress",
+          priority: "high",
+          updatedAt: "2024-07-21T09:00:00.000Z",
+        },
+      ]
+    }
+  )
 }
 
 export const getMaintenanceTickets = cache(fetchMaintenanceTickets)

--- a/app/dashboard/members/data.ts
+++ b/app/dashboard/members/data.ts
@@ -2,6 +2,8 @@ import "server-only"
 
 import { cache } from "react"
 
+import { measureDataFetch } from "@/lib/performance/server"
+
 export type DashboardMember = {
         name: string
         role: "admin" | "user"
@@ -13,32 +15,40 @@ async function wait(ms: number) {
         return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-export const getDashboardMembers = cache(async (): Promise<DashboardMember[]> => {
-        await wait(260)
-        return [
-                {
-                        name: "Admin Member",
-                        role: "admin",
-                        createdAt: new Date().toDateString(),
-                        status: "active",
-                },
-                {
-                        name: "Non Admin User",
-                        role: "user",
-                        createdAt: new Date().toDateString(),
-                        status: "active",
-                },
-                {
-                        name: "Administrator",
-                        role: "admin",
-                        createdAt: new Date().toDateString(),
-                        status: "resigned",
-                },
-                {
-                        name: "Satoshi",
-                        role: "user",
-                        createdAt: new Date().toDateString(),
-                        status: "active",
-                },
-        ]
-})
+export const getDashboardMembers = cache(async (): Promise<DashboardMember[]> =>
+  measureDataFetch(
+    {
+      route: "/dashboard/members",
+      detail: "dashboard-members",
+    },
+    async () => {
+      await wait(260)
+      return [
+        {
+          name: "Admin Member",
+          role: "admin",
+          createdAt: new Date().toDateString(),
+          status: "active",
+        },
+        {
+          name: "Non Admin User",
+          role: "user",
+          createdAt: new Date().toDateString(),
+          status: "active",
+        },
+        {
+          name: "Administrator",
+          role: "admin",
+          createdAt: new Date().toDateString(),
+          status: "resigned",
+        },
+        {
+          name: "Satoshi",
+          role: "user",
+          createdAt: new Date().toDateString(),
+          status: "active",
+        },
+      ]
+    }
+  )
+)

--- a/app/dashboard/todo/data.ts
+++ b/app/dashboard/todo/data.ts
@@ -2,6 +2,8 @@ import "server-only"
 
 import { cache } from "react"
 
+import { measureDataFetch } from "@/lib/performance/server"
+
 export type DashboardTodo = {
         id: string
         title: string
@@ -13,14 +15,22 @@ async function wait(ms: number) {
         return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-export const getDashboardTodos = cache(async (): Promise<DashboardTodo[]> => {
-        await wait(200)
-        return [
-                {
-                        title: "Subscribe",
-                        createdBy: "091832901830",
-                        id: "101981908",
-                        completed: false,
-                },
-        ]
-})
+export const getDashboardTodos = cache(async (): Promise<DashboardTodo[]> =>
+  measureDataFetch(
+    {
+      route: "/dashboard/todo",
+      detail: "dashboard-todos",
+    },
+    async () => {
+      await wait(200)
+      return [
+        {
+          title: "Subscribe",
+          createdBy: "091832901830",
+          id: "101981908",
+          completed: false,
+        },
+      ]
+    }
+  )
+)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import "./globals.css"
 
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+import { PerformanceBudgetMonitor } from "@/components/performance-budget-monitor"
 import { CookieButton } from "@/components/cookie-button"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
@@ -141,6 +142,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
                 <Toaster />
                 <Analytics />
                 <SpeedInsights />
+                <PerformanceBudgetMonitor />
               </div>
 
    </div>

--- a/components/performance-budget-monitor.tsx
+++ b/components/performance-budget-monitor.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import { usePathname } from "next/navigation"
+
+import { DEFAULT_DEVICE } from "@/config/performance"
+import { recordClientDuration } from "@/lib/performance/client"
+
+const ROUTE_START_EVENT = "roomsily:performance-route-start"
+
+const getLatestNavigationStart = (): number | undefined => {
+  if (typeof performance === "undefined") {
+    return undefined
+  }
+
+  const entries = performance.getEntriesByType("navigation")
+  if (entries.length === 0) {
+    return undefined
+  }
+
+  const latest = entries[entries.length - 1] as PerformanceNavigationTiming | undefined
+  return latest?.startTime
+}
+
+const now = () => (typeof performance !== "undefined" ? performance.now() : 0)
+
+const scheduleIdle = (callback: () => void) => {
+  const idleCallback = (window as typeof window & { requestIdleCallback?: any })
+    .requestIdleCallback as
+    | ((handler: IdleRequestCallback, options?: IdleRequestOptions) => number)
+    | undefined
+
+  if (typeof idleCallback === "function") {
+    const handle = idleCallback(callback, { timeout: 3000 })
+    return () => {
+      const cancelIdle = (window as typeof window & { cancelIdleCallback?: any })
+        .cancelIdleCallback as ((handle: number) => void) | undefined
+      if (typeof cancelIdle === "function") {
+        cancelIdle(handle)
+      }
+    }
+  }
+
+  const timeout = window.setTimeout(callback, 3000)
+  return () => window.clearTimeout(timeout)
+}
+
+export const PerformanceBudgetMonitor = () => {
+  const pathname = usePathname()
+  const navigationStartRef = useRef<number | undefined>(getLatestNavigationStart())
+  const activeRunRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const dispatchRouteStart = (target?: string | URL | null, force = false) => {
+      if (typeof window === "undefined") return
+
+      let resolvedHref: string | undefined
+
+      if (target instanceof URL) {
+        resolvedHref = target.href
+      } else if (typeof target === "string" && target.length > 0) {
+        try {
+          resolvedHref = new URL(target, window.location.href).href
+        } catch {
+          resolvedHref = target
+        }
+      }
+
+      if (!force && resolvedHref && resolvedHref === window.location.href) {
+        return
+      }
+
+      const timestamp = now()
+      window.dispatchEvent(
+        new CustomEvent(ROUTE_START_EVENT, {
+          detail: { timestamp },
+        })
+      )
+    }
+
+    const originalPushState = history.pushState
+    const originalReplaceState = history.replaceState
+
+    history.pushState = function pushState(...args) {
+      dispatchRouteStart(args[2])
+      return originalPushState.apply(this, args as Parameters<typeof originalPushState>)
+    }
+
+    history.replaceState = function replaceState(...args) {
+      dispatchRouteStart(args[2])
+      return originalReplaceState.apply(this, args as Parameters<typeof originalReplaceState>)
+    }
+
+    const handlePopState = () => dispatchRouteStart(window.location.href, true)
+    window.addEventListener("popstate", handlePopState)
+
+    return () => {
+      history.pushState = originalPushState
+      history.replaceState = originalReplaceState
+      window.removeEventListener("popstate", handlePopState)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const handleRouteStart = (event: Event) => {
+      const custom = event as CustomEvent<{ timestamp?: number }>
+      const timestamp = custom.detail?.timestamp
+      navigationStartRef.current = typeof timestamp === "number" ? timestamp : now()
+    }
+
+    window.addEventListener(ROUTE_START_EVENT, handleRouteStart)
+
+    if (navigationStartRef.current === undefined) {
+      navigationStartRef.current = getLatestNavigationStart() ?? 0
+    }
+
+    return () => {
+      window.removeEventListener(ROUTE_START_EVENT, handleRouteStart)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!pathname || typeof window === "undefined" || typeof performance === "undefined") {
+      return
+    }
+
+    const navigationStart = navigationStartRef.current ?? getLatestNavigationStart() ?? 0
+    const runKey = `${pathname}:${navigationStart}`
+    activeRunRef.current = runKey
+    let lastLongTaskEnd = navigationStart
+
+    let observer: PerformanceObserver | null = null
+    if (typeof PerformanceObserver !== "undefined") {
+      try {
+        observer = new PerformanceObserver((entryList) => {
+          for (const entry of entryList.getEntries()) {
+            const candidate = entry.startTime + entry.duration
+            if (candidate > lastLongTaskEnd) {
+              lastLongTaskEnd = candidate
+            }
+          }
+        })
+        observer.observe({ type: "longtask", buffered: true })
+      } catch (error) {
+        observer = null
+      }
+    }
+
+    const finalize = () => {
+      if (activeRunRef.current !== runKey) {
+        return
+      }
+
+      const end = Math.max(lastLongTaskEnd, now())
+      const duration = end - navigationStart
+      recordClientDuration(pathname, "tti", duration, "time-to-interactive", DEFAULT_DEVICE)
+      activeRunRef.current = null
+    }
+
+    const cancelIdle = scheduleIdle(finalize)
+
+    return () => {
+      activeRunRef.current = null
+      if (observer) {
+        observer.disconnect()
+      }
+      cancelIdle()
+    }
+  }, [pathname])
+
+  return null
+}

--- a/config/performance.ts
+++ b/config/performance.ts
@@ -1,0 +1,273 @@
+export type PerformanceMetric = "tti" | "dataFetch"
+
+export type DeviceProfile = "mid-tier-mobile" | "desktop"
+
+export interface PerformanceBudgetMetric {
+  thresholdMs: number
+  percentile: number
+  description?: string
+  objective?: string
+}
+
+export interface RoutePerformanceBudget {
+  /**
+   * Route matcher supports dynamic segments using Next.js syntax (e.g. `/documents/[id]`).
+   * Wildcards using `*` are also supported for prefix matches.
+   */
+  route: string
+  device: DeviceProfile
+  metrics: Partial<Record<PerformanceMetric, PerformanceBudgetMetric>>
+  owner?: string
+  notes?: string
+}
+
+export type ResolvedPerformanceBudget = PerformanceBudgetMetric & {
+  route: string
+  device: DeviceProfile
+  matcher: string
+}
+
+export const DEFAULT_DEVICE: DeviceProfile = "mid-tier-mobile"
+
+const mobileTtiBudget: PerformanceBudgetMetric = {
+  thresholdMs: 2500,
+  percentile: 95,
+  description: "P95 TTI on mid-tier mobile stays below 2.5 s",
+  objective: "Ensure interactive tenant dashboard experience",
+}
+
+const desktopTtiBudget: PerformanceBudgetMetric = {
+  thresholdMs: 1800,
+  percentile: 95,
+  description: "Desktop TTI should feel instant for admins",
+}
+
+export const performanceBudgets: RoutePerformanceBudget[] = [
+  {
+    route: "/",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 800,
+        percentile: 95,
+        description: "Landing hero data and feature flags hydrate quickly",
+      },
+    },
+    notes: "Homepage introduces the product — keep it snappy to reduce bounce.",
+  },
+  {
+    route: "/dashboard",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 1200,
+        percentile: 95,
+        description: "Dashboard aggregates rent, bookings, and roommate feed",
+      },
+    },
+    owner: "foundations",
+  },
+  {
+    route: "/payments",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 1400,
+        percentile: 95,
+        description: "Stripe ledger summaries and invoices",
+      },
+    },
+  },
+  {
+    route: "/documents",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 1500,
+        percentile: 95,
+        description: "Documenso envelopes and Supabase metadata",
+      },
+    },
+  },
+  {
+    route: "/messaging",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 1100,
+        percentile: 95,
+        description: "Realtime room data should hydrate under 1.1s",
+      },
+    },
+  },
+  {
+    route: "/visitors",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 1000,
+        percentile: 95,
+        description: "Visitor log pull from Supabase",
+      },
+    },
+  },
+  {
+    route: "/maintenance",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 1300,
+        percentile: 95,
+        description: "Maintenance queue and vendor ETA aggregation",
+      },
+    },
+  },
+  {
+    route: "/schedule",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 1250,
+        percentile: 95,
+        description: "Cal.com slot availability hydration",
+      },
+    },
+  },
+  {
+    route: "/dashboard/todo",
+    device: "mid-tier-mobile",
+    metrics: {
+      dataFetch: {
+        thresholdMs: 900,
+        percentile: 95,
+        description: "Dashboard task widget should feel instant",
+      },
+    },
+  },
+  {
+    route: "/dashboard/members",
+    device: "mid-tier-mobile",
+    metrics: {
+      dataFetch: {
+        thresholdMs: 900,
+        percentile: 95,
+        description: "Member list hydration",
+      },
+    },
+  },
+  {
+    route: "*",
+    device: "mid-tier-mobile",
+    metrics: {
+      tti: mobileTtiBudget,
+      dataFetch: {
+        thresholdMs: 1500,
+        percentile: 95,
+        description: "Fallback mobile budget for unclassified routes",
+      },
+    },
+  },
+  {
+    route: "*",
+    device: "desktop",
+    metrics: {
+      tti: desktopTtiBudget,
+      dataFetch: {
+        thresholdMs: 1000,
+        percentile: 95,
+        description: "Desktop fallback budget",
+      },
+    },
+  },
+]
+
+const routeMatcherCache = new Map<string, RegExp>()
+
+const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+const buildRouteMatcher = (pattern: string) => {
+  if (routeMatcherCache.has(pattern)) {
+    return routeMatcherCache.get(pattern) as RegExp
+  }
+
+  const escaped = escapeRegex(pattern)
+    .replace(/\\\[[^/]+?\\\]/g, "[^/]+")
+    .replace(/\\\*/g, ".*")
+
+  const matcher = new RegExp(`^${escaped}$`)
+  routeMatcherCache.set(pattern, matcher)
+  return matcher
+}
+
+export const normalizeRoute = (route: string): string => {
+  if (!route) return "/"
+  if (route === "/") return "/"
+
+  const sanitized = route.trim()
+  const withoutHash = sanitized.split("#")[0] ?? sanitized
+  const withoutQuery = withoutHash.split("?")[0] ?? withoutHash
+  const normalized = withoutQuery.length > 0 ? withoutQuery : "/"
+  return normalized.endsWith("/") && normalized !== "/"
+    ? normalized.slice(0, -1)
+    : normalized
+}
+
+export const matchesBudgetRoute = (matcher: string, route: string): boolean => {
+  const normalizedRoute = normalizeRoute(route)
+  const normalizedMatcher = normalizeRoute(matcher)
+
+  if (normalizedMatcher === "*") {
+    return true
+  }
+
+  const regex = buildRouteMatcher(normalizedMatcher)
+  return regex.test(normalizedRoute)
+}
+
+export const findPerformanceBudget = (
+  route: string,
+  device: DeviceProfile = DEFAULT_DEVICE
+): RoutePerformanceBudget | undefined => {
+  const normalizedRoute = normalizeRoute(route)
+
+  for (const budget of performanceBudgets) {
+    if (budget.device !== device) continue
+    if (matchesBudgetRoute(budget.route, normalizedRoute)) {
+      return budget
+    }
+  }
+
+  return undefined
+}
+
+export const getPerformanceMetricBudget = (
+  route: string,
+  metric: PerformanceMetric,
+  device: DeviceProfile = DEFAULT_DEVICE
+): ResolvedPerformanceBudget | undefined => {
+  const budget = findPerformanceBudget(route, device)
+  const metricBudget = budget?.metrics[metric]
+
+  if (metricBudget) {
+    return {
+      ...metricBudget,
+      route,
+      device,
+      matcher: budget.route,
+    }
+  }
+
+  if (device !== DEFAULT_DEVICE) {
+    return getPerformanceMetricBudget(route, metric, DEFAULT_DEVICE)
+  }
+
+  return undefined
+}

--- a/lib/performance/client.ts
+++ b/lib/performance/client.ts
@@ -1,0 +1,77 @@
+import type { DeviceProfile, PerformanceMetric } from "@/config/performance"
+
+import {
+  type BudgetReportOptions,
+  type BudgetReportResult,
+  reportBudgetResult,
+} from "./reporting"
+
+const CLIENT_SOURCE = "client"
+
+const maybeSendBeacon = (result: BudgetReportResult) => {
+  if (!result.exceeded || typeof navigator === "undefined") {
+    return
+  }
+
+  const beaconUrl = process.env.NEXT_PUBLIC_PERFORMANCE_ALERT_URL
+  if (!beaconUrl) {
+    return
+  }
+
+  const payload = JSON.stringify({
+    route: result.normalizedRoute,
+    metric: result.metric,
+    durationMs: result.duration,
+    thresholdMs: result.budget?.thresholdMs ?? null,
+    percentile: result.budget?.percentile ?? null,
+    differenceMs: result.differenceMs ?? null,
+    device: result.device,
+    detail: result.detail ?? null,
+    timestamp: result.timestamp,
+    source: CLIENT_SOURCE,
+  })
+
+  if (typeof navigator.sendBeacon === "function") {
+    navigator.sendBeacon(beaconUrl, payload)
+    return
+  }
+
+  if (typeof fetch === "function") {
+    fetch(beaconUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: payload,
+      keepalive: true,
+    }).catch(() => {})
+  }
+}
+
+export interface ClientMetricOptions
+  extends Omit<BudgetReportOptions, "source"> {
+  device?: DeviceProfile
+}
+
+export const reportClientMetric = (
+  options: ClientMetricOptions
+): BudgetReportResult => {
+  const result = reportBudgetResult({ ...options, source: CLIENT_SOURCE })
+  maybeSendBeacon(result)
+  return result
+}
+
+export const recordClientDuration = (
+  route: string,
+  metric: PerformanceMetric,
+  duration: number,
+  detail?: string,
+  device?: DeviceProfile
+) =>
+  reportClientMetric({
+    route,
+    metric,
+    duration,
+    detail,
+    device,
+  })

--- a/lib/performance/reporting.ts
+++ b/lib/performance/reporting.ts
@@ -1,0 +1,85 @@
+import {
+  DEFAULT_DEVICE,
+  getPerformanceMetricBudget,
+  normalizeRoute,
+  type DeviceProfile,
+  type PerformanceMetric,
+  type ResolvedPerformanceBudget,
+} from "@/config/performance"
+
+export interface BudgetReportOptions {
+  route: string
+  metric: PerformanceMetric
+  duration: number
+  detail?: string
+  device?: DeviceProfile
+  source?: "client" | "server" | string
+  silent?: boolean
+}
+
+export interface BudgetReportResult {
+  route: string
+  normalizedRoute: string
+  metric: PerformanceMetric
+  duration: number
+  device: DeviceProfile
+  detail?: string
+  source?: string
+  timestamp: number
+  budget?: ResolvedPerformanceBudget
+  exceeded: boolean
+  differenceMs?: number
+}
+
+const clampDuration = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return value < 0 ? 0 : value
+}
+
+const formatMetric = (metric: PerformanceMetric) => metric.toUpperCase()
+
+export const reportBudgetResult = (
+  options: BudgetReportOptions
+): BudgetReportResult => {
+  const normalizedRoute = normalizeRoute(options.route)
+  const device = options.device ?? DEFAULT_DEVICE
+  const duration = clampDuration(options.duration)
+  const budget = getPerformanceMetricBudget(normalizedRoute, options.metric, device)
+  const exceeded = budget ? duration > budget.thresholdMs : false
+  const differenceMs = budget ? Number((duration - budget.thresholdMs).toFixed(2)) : undefined
+  const timestamp = Date.now()
+
+  const prefix = `[performance]${options.source ? ` [${options.source}]` : ""}`
+  const detailSuffix = options.detail ? ` – ${options.detail}` : ""
+  const budgetLabel = budget
+    ? `budget ${budget.thresholdMs}ms (P${budget.percentile})`
+    : "no budget"
+  const message = `${prefix} ${formatMetric(options.metric)} ${duration.toFixed(
+    1
+  )}ms on ${normalizedRoute} (${device} ${budgetLabel})${detailSuffix}`
+
+  if (!options.silent) {
+    if (exceeded) {
+      console.warn(message)
+    } else {
+      console.info(message)
+    }
+  }
+
+  return {
+    route: options.route,
+    normalizedRoute,
+    metric: options.metric,
+    duration,
+    device,
+    detail: options.detail,
+    source: options.source,
+    timestamp,
+    budget,
+    exceeded,
+    differenceMs,
+  }
+}

--- a/lib/performance/server.ts
+++ b/lib/performance/server.ts
@@ -1,0 +1,91 @@
+import { performance } from "node:perf_hooks"
+
+import type { DeviceProfile, PerformanceMetric } from "@/config/performance"
+
+import {
+  type BudgetReportOptions,
+  type BudgetReportResult,
+  reportBudgetResult,
+} from "./reporting"
+
+const SERVER_SOURCE = "server"
+
+const maybeSendAlert = async (result: BudgetReportResult) => {
+  if (!result.exceeded) {
+    return
+  }
+
+  const webhookUrl = process.env.PERFORMANCE_ALERT_WEBHOOK_URL
+  if (!webhookUrl || typeof fetch !== "function") {
+    return
+  }
+
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        route: result.normalizedRoute,
+        metric: result.metric,
+        durationMs: result.duration,
+        thresholdMs: result.budget?.thresholdMs ?? null,
+        percentile: result.budget?.percentile ?? null,
+        differenceMs: result.differenceMs ?? null,
+        device: result.device,
+        detail: result.detail ?? null,
+        timestamp: result.timestamp,
+        source: SERVER_SOURCE,
+      }),
+      keepalive: true,
+    })
+  } catch (error) {
+    console.error("[performance] Failed to send performance alert", error)
+  }
+}
+
+export interface MeasureOptions {
+  route: string
+  detail?: string
+  device?: DeviceProfile
+  metric?: PerformanceMetric
+  silent?: boolean
+  alertOnExceed?: boolean
+}
+
+export const reportServerMetric = (
+  options: Omit<BudgetReportOptions, "source">,
+  config?: { alertOnExceed?: boolean }
+): BudgetReportResult => {
+  const result = reportBudgetResult({ ...options, source: SERVER_SOURCE })
+  if (config?.alertOnExceed !== false) {
+    void maybeSendAlert(result)
+  }
+  return result
+}
+
+export const measureDataFetch = async <T>(
+  options: MeasureOptions,
+  task: () => Promise<T>
+): Promise<T> => {
+  const metric = options.metric ?? "dataFetch"
+  const start = performance.now()
+
+  try {
+    return await task()
+  } finally {
+    const duration = performance.now() - start
+    reportServerMetric(
+      {
+        route: options.route,
+        metric,
+        duration,
+        detail: options.detail,
+        device: options.device,
+        silent: options.silent,
+      },
+      { alertOnExceed: options.alertOnExceed }
+    )
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,8 @@ import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
 export async function middleware(request: NextRequest) {
+  request.headers.set("x-performance-route", request.nextUrl.pathname)
+
   let response = NextResponse.next({
     request: {
       headers: request.headers,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "css:purge": "node scripts/check-css-size.mjs"
+    "css:purge": "node scripts/check-css-size.mjs",
+    "perf:check": "node scripts/check-performance-budgets.cjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/scripts/check-performance-budgets.cjs
+++ b/scripts/check-performance-budgets.cjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs")
+const path = require("node:path")
+const vm = require("node:vm")
+const ts = require("typescript")
+
+const budgetsPath = path.resolve(__dirname, "../config/performance.ts")
+
+const source = fs.readFileSync(budgetsPath, "utf8")
+const transpiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2019,
+    esModuleInterop: true,
+  },
+})
+
+const sandbox = {
+  module: { exports: {} },
+  exports: {},
+  require,
+  __dirname: path.dirname(budgetsPath),
+  __filename: budgetsPath,
+  console,
+  process,
+}
+
+sandbox.exports = sandbox.module.exports
+
+vm.runInNewContext(transpiled.outputText, sandbox, {
+  filename: budgetsPath,
+})
+
+const performanceBudgets = sandbox.module.exports.performanceBudgets
+const defaultDevice = sandbox.module.exports.DEFAULT_DEVICE ?? "mid-tier-mobile"
+
+if (!Array.isArray(performanceBudgets)) {
+  console.error("[perf-check] Unable to load performance budgets from config/performance.ts")
+  process.exit(1)
+}
+
+const midTierBudgets = performanceBudgets.filter((budget) => budget?.device === "mid-tier-mobile")
+
+const ttiBudgets = midTierBudgets.filter((budget) => budget.metrics?.tti)
+
+if (ttiBudgets.length === 0) {
+  console.error("[perf-check] No TTI budgets defined for mid-tier mobile device profile")
+  process.exit(1)
+}
+
+const exceedingThreshold = ttiBudgets.filter(
+  (budget) => typeof budget.metrics.tti.thresholdMs === "number" && budget.metrics.tti.thresholdMs > 2500
+)
+
+const belowPercentile = ttiBudgets.filter(
+  (budget) => typeof budget.metrics.tti.percentile === "number" && budget.metrics.tti.percentile < 95
+)
+
+if (exceedingThreshold.length > 0 || belowPercentile.length > 0) {
+  if (exceedingThreshold.length > 0) {
+    console.error("[perf-check] The following routes exceed the 2.5s P95 TTI budget on mid-tier mobile:")
+    for (const budget of exceedingThreshold) {
+      console.error(
+        `  - ${budget.route} (threshold ${budget.metrics.tti.thresholdMs}ms)`
+      )
+    }
+  }
+
+  if (belowPercentile.length > 0) {
+    console.error("[perf-check] The following routes target a percentile below P95 for TTI:")
+    for (const budget of belowPercentile) {
+      console.error(
+        `  - ${budget.route} (percentile P${budget.metrics.tti.percentile})`
+      )
+    }
+  }
+
+  process.exit(1)
+}
+
+const fallbackBudget = ttiBudgets.find((budget) => budget.route === "*")
+
+if (!fallbackBudget) {
+  console.error("[perf-check] Missing wildcard mid-tier mobile TTI budget; add a '*' entry to config/performance.ts")
+  process.exit(1)
+}
+
+console.log(
+  `[perf-check] ${ttiBudgets.length} mid-tier mobile TTI budgets verified (default device: ${defaultDevice})`
+)


### PR DESCRIPTION
## Summary
- define route-specific performance budgets with helper utilities for matching routes and metrics
- instrument dashboard data fetching and client-side TTI tracking to log and alert when budgets are exceeded
- add a CI performance budget check script and surface the monitor in layout/middleware

## Testing
- pnpm lint
- pnpm test
- pnpm perf:check

------
https://chatgpt.com/codex/tasks/task_e_68d30ba020bc8328aea912b607e4f661