### PR TITLE
Add client-side route progress bar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from "next"
-import { Inter } from "next/font/google"
 import { Suspense } from "react"
 
 import { Analytics } from "@vercel/analytics/react"
@@ -7,19 +6,19 @@ import { SpeedInsights } from "@vercel/speed-insights/next"
 
 import "./globals.css"
 
+import { CookieButton } from "@/components/cookie-button"
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
-import { CookieButton } from "@/components/cookie-button"
+import { ReactQueryClientProvider } from "@/components/react-query-client-provider"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
+import { TopProgressBar } from "@/components/top-progress-bar"
+import { siteConfig } from "@/config/site"
 import { fontSans } from "@/lib/font"
 import { cn } from "@/lib/utils"
-import { siteConfig } from "@/config/site"
-import { ReactQueryClientProvider } from "@/components/react-query-client-provider"
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: {
@@ -27,40 +26,60 @@ export const metadata: Metadata = {
     template: `%s - ${siteConfig.name}`,
   },
   description: siteConfig.description,
-    manifest: '/manifest.json',
-  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || 'https://www.roomsily'),
+  manifest: "/manifest.json",
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL || "https://www.roomsily",
+  ),
   alternates: {
-    canonical: '/',
+    canonical: "/",
     languages: {
-      'en-US': '/en-US',
-      'de-DE': '/de-DE',
-      'es-ES': '/es-ES',
-      'fr-FR': '/fr-FR',
-      'jp-JP': '/jp-JP',
-      'ko-KO': '/ko-KP',
-      'zh-ZH': '/zh-ZH',
-      'pt-PT': '/pt-PT',
+      "en-US": "/en-US",
+      "de-DE": "/de-DE",
+      "es-ES": "/es-ES",
+      "fr-FR": "/fr-FR",
+      "jp-JP": "/jp-JP",
+      "ko-KO": "/ko-KP",
+      "zh-ZH": "/zh-ZH",
+      "pt-PT": "/pt-PT",
     },
   },
-  referrer: 'origin-when-cross-origin',
-  keywords: ['Roomsily', 'NextJS 14 TypeScript', 'Supabase SSR', 'TanStack React Query', 'co-living software', 'rent payment portal', 'shadcn/ui', 'Tailwind CSS', 'SaaS', 'NextJS Supabase Postgres Tailwind TanStack', 'NextJS CSP',
-             'PWA', 'NextJS SaaS PWA Template', 'CRUD ops', 'secure headers', 'NextJS templates with user authentication, RBAC, and CRUD ops', 'NextJS templates with data validation and database integration',
-            'Rust API runtime for vercel serverless functions', 'NextJS secure headers', 'NextJS NextMDX'],
-  authors: [{ name: 'Robert Mourey Jr' }],
-  creator: 'Robert Mourey Jr',
-  publisher: 'Robert Mourey Jr', 
+  referrer: "origin-when-cross-origin",
+  keywords: [
+    "Roomsily",
+    "NextJS 14 TypeScript",
+    "Supabase SSR",
+    "TanStack React Query",
+    "co-living software",
+    "rent payment portal",
+    "shadcn/ui",
+    "Tailwind CSS",
+    "SaaS",
+    "NextJS Supabase Postgres Tailwind TanStack",
+    "NextJS CSP",
+    "PWA",
+    "NextJS SaaS PWA Template",
+    "CRUD ops",
+    "secure headers",
+    "NextJS templates with user authentication, RBAC, and CRUD ops",
+    "NextJS templates with data validation and database integration",
+    "Rust API runtime for vercel serverless functions",
+    "NextJS secure headers",
+    "NextJS NextMDX",
+  ],
+  authors: [{ name: "Robert Mourey Jr" }],
+  creator: "Robert Mourey Jr",
+  publisher: "Robert Mourey Jr",
   formatDetection: {
     email: false,
     address: false,
     telephone: false,
   },
-  generator: 'NextJS',
+  generator: "NextJS",
   icons: {
     icon: "/favicon.svg",
     shortcut: "/favicon.svg",
     apple: "/favicon.svg",
   },
-
   robots: {
     index: false,
     follow: true,
@@ -69,9 +88,9 @@ export const metadata: Metadata = {
       index: true,
       follow: false,
       noimageindex: true,
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
     },
   },
   openGraph: {
@@ -81,29 +100,30 @@ export const metadata: Metadata = {
     url: "https://www.roomsily",
     images: [
       {
-        url: '/roomsily-og.svg',
+        url: "/roomsily-og.svg",
         width: 1200,
         height: 630,
-        alt: 'Roomsily — modern co-living hub',
+        alt: "Roomsily — modern co-living hub",
       },
     ],
-    locale: 'en_US',
-    type: 'website',
+    locale: "en_US",
+    type: "website",
   },
-    twitter: {
-         title: siteConfig.name,
-         description: siteConfig.description,
-         site: '@roomsily',
-         creator: '@roomsily',
-         images: ['/roomsily-og.svg'],
-   },
+  twitter: {
+    title: siteConfig.name,
+    description: siteConfig.description,
+    site: "@roomsily",
+    creator: "@roomsily",
+    images: ["/roomsily-og.svg"],
+  },
 }
-export const viewport: Viewport =  {
+
+export const viewport: Viewport = {
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "white" },
     { media: "(prefers-color-scheme: dark)", color: "black" },
   ],
-  width: 'device-width',
+  width: "device-width",
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
@@ -113,55 +133,50 @@ interface RootLayoutProps {
   children: React.ReactNode
 }
 
-
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <ReactQueryClientProvider>
-    <html lang="en" suppressHydrationWarning>
-    <head></head>
-      <body className={cn(
+      <html lang="en" suppressHydrationWarning>
+        <head />
+        <body
+          className={cn(
             "min-h-screen bg-background font-sans antialiased",
-            fontSans.variable
+            fontSans.variable,
           )}
         >
-<ThemeProvider
+          <ThemeProvider
             attribute="class"
             defaultTheme="system"
             enableSystem
             disableTransitionOnChange
           >
-             <div className="relative flex min-h-screen flex-col">
+            <TopProgressBar />
+            <div className="relative flex min-h-screen flex-col">
               {/* <SiteHeader /> */}
               <div className="flex-1">
                 <ErrorBoundary>
-                  <Suspense fallback={<RouteSkeleton />}>
-                    {children}
-                  </Suspense>
+                  <Suspense fallback={<RouteSkeleton />}>{children}</Suspense>
                 </ErrorBoundary>
                 <Toaster />
                 <Analytics />
                 <SpeedInsights />
               </div>
+              {/* <SiteFooter /> */}
+            </div>
 
-   </div>
-{/* <SiteFooter/> */}
+            {/*
+            enter your api info from termly.io or a provider of your choice
+            <Script
+              type="text/javascript"
+              src="https://app.termly.io/resource-blocker/123456789abcdefg"
+            />
 
-
-{/*
-enter your api info from termly.io or a provider of your choice
-<Script
-  type="text/javascript"
-  src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
-
- */}
-   <CookieButton />
-   <TailwindIndicator />
+            */}
+            <CookieButton />
+            <TailwindIndicator />
           </ThemeProvider>
-
-
-
-</body>
-    </html>
+        </body>
+      </html>
     </ReactQueryClientProvider>
   )
 }

--- a/components/top-progress-bar.tsx
+++ b/components/top-progress-bar.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { AppProgressBar as ProgressBar } from "next-nprogress-bar"
+
+export function TopProgressBar() {
+  return (
+    <ProgressBar
+      height="3px"
+      color="hsl(var(--primary))"
+      options={{ showSpinner: false }}
+      shallowRouting
+      delay={200}
+    />
+  )
+}

--- a/docs/engineering/manual-qa/top-progress-bar.md
+++ b/docs/engineering/manual-qa/top-progress-bar.md
@@ -1,0 +1,23 @@
+# Manual QA - Route Progress Bar
+
+## Goal
+Verify that the top progress bar appears during client-side route transitions and hides once navigation completes in both light and dark themes.
+
+## Prerequisites
+- Development server running via `pnpm dev`.
+- Browser with devtools available.
+
+## Steps
+1. Open the app at `http://localhost:3000`.
+2. Toggle between light and dark modes using the theme switcher (if available) or system preference to observe the bar color adapting to the active theme.
+3. Click a navigation link that triggers a client-side route change (e.g., between dashboard sections).
+4. Confirm a slim bar animates across the top of the viewport immediately after clicking the link.
+5. Wait for the new page content to finish loading.
+6. Ensure the bar completes the animation and disappears once the transition is done.
+7. Repeat step 3 using the browser back/forward buttons to verify the bar appears for history-based navigations as well.
+
+## Expected Results
+- Progress bar color respects the current theme tokens.
+- Bar becomes visible within ~200ms of initiating navigation.
+- Bar smoothly reaches 100% width and then fades out after content loads.
+- Bar does not remain stuck on screen when navigation completes.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lucide-react": "0.302.0",
     "next": "14.2.4",
     "next-compose-plugins": "^2.2.1",
+    "next-nprogress-bar": "^2.4.7",
     "next-themes": "^0.2.1",
     "prettier": "^2.8.8",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
+      next-nprogress-bar:
+        specifier: ^2.4.7
+        version: 2.4.7
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -3546,6 +3549,9 @@ packages:
   next-compose-plugins@2.2.1:
     resolution: {integrity: sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==}
 
+  next-nprogress-bar@2.4.7:
+    resolution: {integrity: sha512-OeveNQYFBhQhZ+RgrDnvHNUEQfHCmipymmD4AfAVE9pFV4jeWi7/nNK5f0lIk7ODRrtjyyr/n2YpkRbs5kUoMg==}
+
   next-themes@0.2.1:
     resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}
     peerDependencies:
@@ -3607,6 +3613,9 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  nprogress-v2@1.1.10:
+    resolution: {integrity: sha512-MypWLNIPIM07SS0bAc/oac0vhVFz9vAHm7d1sj//Pnf3J03LQ3CuWrlDteIu6exq0fIvkDJ6tUDRWLaifsIt5w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -8568,6 +8577,10 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
+  next-nprogress-bar@2.4.7:
+    dependencies:
+      nprogress-v2: 1.1.10
+
   next-themes@0.2.1(next@14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       next: 14.2.4(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -8622,6 +8635,8 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  nprogress-v2@1.1.10: {}
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
## Summary
- add a themed top progress bar component powered by `next-nprogress-bar`
- mount the progress indicator in the root layout so route transitions surface loading feedback
- document manual QA coverage for validating the progress bar behaviour

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d30ba10ad08328a98174b01b2fdc51