### PR TITLE
Instrument SmartLink navigation performance

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
 import { CookieButton } from "@/components/cookie-button"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
+import RouteChangeMonitor from "@/components/navigation/RouteChangeMonitor"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
@@ -124,12 +125,13 @@ export default function RootLayout({ children }: RootLayoutProps) {
             fontSans.variable
           )}
         >
-<ThemeProvider
+          <ThemeProvider
             attribute="class"
             defaultTheme="system"
             enableSystem
             disableTransitionOnChange
           >
+            <RouteChangeMonitor />
              <div className="relative flex min-h-screen flex-col">
               {/* <SiteHeader /> */}
               <div className="flex-1">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,5 @@
 import dynamic from "next/dynamic"
 import Image from "next/image"
-import Link from "next/link"
-
 import SmartLink from "@/components/navigation/SmartLink"
 
 import { redirect } from "next/navigation"
@@ -230,24 +228,26 @@ export default async function IndexPage() {
                 </p>
               </div>
               <div className="flex flex-col justify-center gap-4 sm:flex-row lg:justify-start">
-                <Link
+                <SmartLink
                   href={siteConfig.links.login}
                   className={cn(
                     buttonVariants({ size: "lg" }),
                     "bg-primary px-8 text-base font-semibold shadow-lg shadow-primary/30 transition hover:bg-primary/90"
                   )}
+                  intent="critical"
                 >
                   <span>Sign in</span>
-                </Link>
-                <Link
+                </SmartLink>
+                <SmartLink
                   href={siteConfig.links.signup}
                   className={cn(
                     buttonVariants({ variant: "outline", size: "lg" }),
                     "border-primary/40 bg-background/80 px-8 text-base font-semibold backdrop-blur transition hover:border-primary hover:bg-primary/10"
                   )}
+                  intent="critical"
                 >
                   <span>Create your household</span>
-                </Link>
+                </SmartLink>
               </div>
               <div className="grid gap-4 sm:grid-cols-3">
                 {heroHighlights.map((item) => (
@@ -348,9 +348,13 @@ export default async function IndexPage() {
                 <CardDescription>{feature.description}</CardDescription>
               </CardHeader>
               <CardContent className="mt-auto">
-                <Link href={feature.href} className="text-sm font-medium text-primary hover:underline">
+                <SmartLink
+                  href={feature.href}
+                  className="text-sm font-medium text-primary hover:underline"
+                  intent="navigation"
+                >
                   <span>{feature.ctaLabel}</span>
-                </Link>
+                </SmartLink>
               </CardContent>
             </Card>
           ))}
@@ -420,21 +424,26 @@ export default async function IndexPage() {
                 </li>
               </ul>
               <div className="flex flex-wrap gap-3 pt-2">
-                <Link
+                <SmartLink
                   href={siteConfig.links.contact}
                   className={cn(
                     buttonVariants({ variant: "outline", size: "sm" }),
                     "border-primary/40 bg-background/80 text-primary hover:border-primary hover:bg-primary/10"
                   )}
+                  intent="navigation"
                 >
                   <span>Book a walkthrough</span>
-                </Link>
-                <Link
+                </SmartLink>
+                <SmartLink
                   href={siteConfig.links.signup}
-                  className={cn(buttonVariants({ size: "sm" }), "bg-primary text-primary-foreground hover:bg-primary/90")}
+                  className={cn(
+                    buttonVariants({ size: "sm" }),
+                    "bg-primary text-primary-foreground hover:bg-primary/90"
+                  )}
+                  intent="critical"
                 >
                   <span>Start onboarding</span>
-                </Link>
+                </SmartLink>
               </div>
             </div>
             <div className="relative h-[320px] w-full overflow-hidden rounded-3xl border border-primary/30 bg-background/80 shadow-xl shadow-primary/20 md:h-[420px]">

--- a/components/navigation/RouteChangeMonitor.tsx
+++ b/components/navigation/RouteChangeMonitor.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import * as React from "react"
+import { usePathname } from "next/navigation"
+
+import {
+  SMARTLINK_MEDIAN_BUDGET,
+  SMARTLINK_MODE_EVENT,
+  SMARTLINK_SAMPLE_SIZE,
+  computeMedian,
+  initializeSmartLinkMetrics,
+  resetNavigationStart,
+  type SmartLinkModeChangeDetail,
+  type SmartLinkNavigationMetrics,
+} from "@/components/navigation/smart-link-metrics"
+
+const logNavigationSample = (metrics: SmartLinkNavigationMetrics) => {
+  if (process.env.NODE_ENV !== "development") {
+    return
+  }
+
+  const latest = metrics.durations.at(-1)
+  if (latest === undefined) {
+    return
+  }
+
+  // eslint-disable-next-line no-console -- surfaced only during development to aid tuning.
+  console.debug(
+    `[SmartLink] navigation ${latest.toFixed(1)}ms (median ${
+      metrics.median?.toFixed(1) ?? "n/a"
+    }ms across ${metrics.durations.length} samples)`
+  )
+}
+
+export function RouteChangeMonitor() {
+  const pathname = usePathname()
+  const previousPathRef = React.useRef<string | null>(pathname)
+  const durationsRef = React.useRef<number[]>([])
+
+  React.useEffect(() => {
+    initializeSmartLinkMetrics()
+  }, [])
+
+  React.useEffect(() => {
+    if (previousPathRef.current === pathname) {
+      return
+    }
+
+    previousPathRef.current = pathname
+
+    if (typeof window === "undefined" || typeof performance === "undefined") {
+      return
+    }
+
+    const navigationStart = window.__smartlinkNavigationStart
+    resetNavigationStart()
+
+    if (!navigationStart) {
+      return
+    }
+
+    const duration = performance.now() - navigationStart.startedAt
+
+    if (!Number.isFinite(duration) || duration < 0) {
+      return
+    }
+
+    durationsRef.current = [...durationsRef.current, duration].slice(-SMARTLINK_SAMPLE_SIZE)
+
+    const median = computeMedian(durationsRef.current)
+
+    const metrics = initializeSmartLinkMetrics()
+    const nextMode = median > SMARTLINK_MEDIAN_BUDGET ? "aggressive" : "default"
+    const modeChanged = metrics.mode !== nextMode
+    const medianChanged = metrics.median !== median
+
+    window.__smartlinkNavigationMetrics = {
+      ...metrics,
+      durations: [...durationsRef.current],
+      median,
+      mode: nextMode,
+    }
+
+    if (modeChanged || medianChanged) {
+      const detail: SmartLinkModeChangeDetail = {
+        median,
+        mode: nextMode,
+        sampleSize: durationsRef.current.length,
+      }
+
+      window.dispatchEvent(new CustomEvent(SMARTLINK_MODE_EVENT, { detail }))
+    }
+
+    logNavigationSample(window.__smartlinkNavigationMetrics)
+  }, [pathname])
+
+  return null
+}
+
+export default RouteChangeMonitor

--- a/components/navigation/SmartLink.tsx
+++ b/components/navigation/SmartLink.tsx
@@ -4,6 +4,13 @@ import * as React from "react"
 import NextLink from "next/link"
 import { useRouter } from "next/navigation"
 
+import {
+  SMARTLINK_MODE_EVENT,
+  initializeSmartLinkMetrics,
+  type SmartLinkMode,
+  type SmartLinkModeChangeDetail,
+} from "@/components/navigation/smart-link-metrics"
+
 export type SmartLinkIntent = "standard" | "critical" | "passive" | "navigation"
 
 export interface SmartLinkProps
@@ -34,11 +41,13 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       prefetch: prefetchProp,
       onPointerEnter,
       onFocus,
+      onClick,
       href,
       ...rest
     } = props
 
     const router = useRouter()
+    const [performanceMode, setPerformanceMode] = React.useState<SmartLinkMode>("default")
     const innerRef = React.useRef<HTMLAnchorElement | null>(null)
     const combinedRef = React.useCallback(
       (node: AnchorRef) => {
@@ -65,6 +74,37 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
     const [isVisible, setIsVisible] = React.useState(false)
     const hasPrefetchedRef = React.useRef(false)
 
+    React.useEffect(() => {
+      if (typeof window === "undefined") {
+        return
+      }
+
+      initializeSmartLinkMetrics()
+
+      const handleModeChange = (event: Event) => {
+        const detail = (event as CustomEvent<SmartLinkModeChangeDetail>).detail
+        const nextMode = detail?.mode ?? window.__smartlinkNavigationMetrics?.mode ?? "default"
+        setPerformanceMode(nextMode)
+      }
+
+      const currentMode = window.__smartlinkNavigationMetrics?.mode ?? "default"
+      setPerformanceMode(currentMode)
+
+      window.addEventListener(SMARTLINK_MODE_EVENT, handleModeChange as EventListener)
+
+      return () => {
+        window.removeEventListener(SMARTLINK_MODE_EVENT, handleModeChange as EventListener)
+      }
+    }, [])
+
+    const effectiveIntent = React.useMemo(() => {
+      if (intent === "standard" && performanceMode === "aggressive") {
+        return "critical"
+      }
+
+      return intent
+    }, [intent, performanceMode])
+
     const prefetchHint = React.useMemo<PrefetchHint>(() => {
       if (!isInternalHref) {
         return "never"
@@ -74,7 +114,7 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
         return prefetchProp ? "viewport" : "never"
       }
 
-      switch (intent) {
+      switch (effectiveIntent) {
         case "critical":
           return "immediate"
         case "passive":
@@ -84,7 +124,7 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
         default:
           return "viewport"
       }
-    }, [intent, isInternalHref, prefetchProp])
+    }, [effectiveIntent, isInternalHref, prefetchProp])
 
     const prefetchHref = React.useMemo(() => {
       if (!isInternalHref) {
@@ -154,6 +194,24 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
       }
     }, [isVisible, prefetchHint, prefetchHref])
 
+    const handleClick = React.useCallback(
+      (event: React.MouseEvent<HTMLAnchorElement>) => {
+        if (isInternalHref && typeof window !== "undefined" && typeof performance !== "undefined") {
+          window.__smartlinkNavigationStart = {
+            href: typeof href === "string" ? href : undefined,
+            startedAt: performance.now(),
+          }
+        }
+
+        onClick?.(event)
+
+        if (event.defaultPrevented && typeof window !== "undefined") {
+          window.__smartlinkNavigationStart = undefined
+        }
+      },
+      [href, isInternalHref, onClick]
+    )
+
     const handlePointerEnter = React.useCallback(
       (event: React.PointerEvent<HTMLAnchorElement>) => {
         onPointerEnter?.(event)
@@ -208,6 +266,7 @@ export const SmartLink = React.forwardRef<HTMLAnchorElement, SmartLinkProps>(
         ref={combinedRef}
         href={href}
         prefetch={shouldPrefetch}
+        onClick={handleClick}
         onPointerEnter={handlePointerEnter}
         onFocus={handleFocus}
         {...rest}

--- a/components/navigation/smart-link-metrics.ts
+++ b/components/navigation/smart-link-metrics.ts
@@ -1,0 +1,64 @@
+export const SMARTLINK_MODE_EVENT = "smartlink:modechange" as const
+export const SMARTLINK_MEDIAN_BUDGET = 100
+export const SMARTLINK_SAMPLE_SIZE = 15
+
+export type SmartLinkMode = "default" | "aggressive"
+
+export interface SmartLinkNavigationStart {
+  href?: string
+  startedAt: number
+}
+
+export interface SmartLinkNavigationMetrics {
+  durations: number[]
+  median?: number
+  mode: SmartLinkMode
+}
+
+export interface SmartLinkModeChangeDetail {
+  median: number
+  mode: SmartLinkMode
+  sampleSize: number
+}
+
+declare global {
+  interface Window {
+    __smartlinkNavigationStart?: SmartLinkNavigationStart
+    __smartlinkNavigationMetrics?: SmartLinkNavigationMetrics
+  }
+}
+
+export const computeMedian = (values: readonly number[]): number => {
+  if (!values.length) {
+    return 0
+  }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const midpoint = Math.floor(sorted.length / 2)
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[midpoint - 1] + sorted[midpoint]) / 2
+  }
+
+  return sorted[midpoint]
+}
+
+export const initializeSmartLinkMetrics = (): SmartLinkNavigationMetrics => {
+  if (typeof window === "undefined") {
+    return { durations: [], mode: "default" }
+  }
+
+  if (!window.__smartlinkNavigationMetrics) {
+    window.__smartlinkNavigationMetrics = { durations: [], mode: "default" }
+  }
+
+  return window.__smartlinkNavigationMetrics
+}
+
+export const resetNavigationStart = () => {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  window.__smartlinkNavigationStart = undefined
+}


### PR DESCRIPTION
## Summary
- replace remaining landing page CTA links to use SmartLink with critical or navigation intents
- add a route change monitor and shared SmartLink metrics helpers to watch navigation medians and tune prefetch defaults
- teach SmartLink to record navigation starts, react to performance mode changes, and surface the monitor globally via the root layout

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d30ba209c0832893a102fda92dde2f