### PR TITLE
Add optimistic dashboard todo mutations and tests

### DIFF
--- a/app/dashboard/todo/components/CreateForm.tsx
+++ b/app/dashboard/todo/components/CreateForm.tsx
@@ -1,86 +1,113 @@
-"use client";
+"use client"
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import * as z from "zod";
-import { AiOutlineLoading3Quarters } from "react-icons/ai";
+import { useMemo } from "react"
 
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import * as z from "zod"
+import { AiOutlineLoading3Quarters } from "react-icons/ai"
+
+import { Button } from "@/components/ui/button"
 import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { toast } from "@/components/ui/use-toast";
-import { Button } from "@/components/ui/button";
-import { useTransition } from "react";
-import { cn } from "@/lib/utils";
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { toast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+import {
+  createTodoMutationOptions,
+  type CreateTodoContext,
+} from "@/queries/dashboard-todos"
+import { createClient } from "@/utils/supabase-browser"
 
 const FormSchema = z.object({
-	title: z.string().min(1, {
-		message: "Title is required.",
-	}),
-});
+  title: z.string().min(1, {
+    message: "Title is required.",
+  }),
+})
 
 export default function CreateForm() {
-	const [isPending, startTransition] = useTransition();
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      title: "",
+    },
+  })
 
-	const form = useForm<z.infer<typeof FormSchema>>({
-		resolver: zodResolver(FormSchema),
-		defaultValues: {
-			title: "",
-		},
-	});
+  const supabase = useMemo(() => createClient(), [])
+  const queryClient = useQueryClient()
 
-	function onSubmit(data: z.infer<typeof FormSchema>) {
-		toast({
-			title: "You have successfully create todo.",
-			description: (
-				<pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-					<code className="text-white">{data.title} is created</code>
-				</pre>
-			),
-		});
-		form.reset();
-	}
+  const createTodo = useMutation(
+    createTodoMutationOptions({
+      supabase,
+      queryClient,
+      callbacks: {
+        onSuccess: (todo) => {
+          toast({
+            title: "Todo created",
+            description: `${todo.title} added to the dashboard.`,
+          })
+        },
+        onError: (error, context?: CreateTodoContext) => {
+          if (context?.optimisticTodo) {
+            form.setValue("title", context.optimisticTodo.title)
+            form.setFocus("title")
+          }
 
-	return (
-		<Form {...form}>
-			<form
-				onSubmit={form.handleSubmit(onSubmit)}
-				className="w-full space-y-6"
-			>
-				<FormField
-					control={form.control}
-					name="title"
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Title</FormLabel>
-							<FormControl>
-								<Input
-									placeholder="todo title"
-									{...field}
-									onChange={field.onChange}
-								/>
-							</FormControl>
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
-<Button
-				className="flex w-full items-center gap-2"
-				variant="outline"
-			>
-				Create{" "}
-				<AiOutlineLoading3Quarters
-					className={cn(" animate-spin", { hidden: !isPending })}
-				/>
-			</Button>
+          toast({
+            title: "Failed to create todo",
+            description: error.message,
+            variant: "destructive",
+          })
+        },
+      },
+    }),
+  )
 
-			</form>
-		</Form>
-	);
+  function onSubmit(data: z.infer<typeof FormSchema>) {
+    createTodo.mutate(data)
+    form.reset()
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="w-full space-y-6">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Title</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="todo title"
+                  {...field}
+                  onChange={field.onChange}
+                  aria-label="Todo title"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button
+          className="flex w-full items-center gap-2"
+          variant="outline"
+          type="submit"
+          disabled={createTodo.isPending}
+        >
+          Create
+          <AiOutlineLoading3Quarters
+            className={cn("animate-spin", { hidden: !createTodo.isPending })}
+          />
+        </Button>
+      </form>
+    </Form>
+  )
 }

--- a/app/dashboard/todo/components/TodoItems.tsx
+++ b/app/dashboard/todo/components/TodoItems.tsx
@@ -1,26 +1,85 @@
-import { Button } from "@/components/ui/button"
+"use client"
+
+import { useMemo } from "react"
+
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query"
+
+import { Switch } from "@/components/ui/switch"
+import { toast } from "@/components/ui/use-toast"
 import { cn } from "@/lib/utils"
+import {
+  DASHBOARD_TODO_QUERY_KEY,
+  fetchDashboardTodos,
+  toggleTodoMutationOptions,
+  type DashboardTodo,
+} from "@/queries/dashboard-todos"
+import { createClient } from "@/utils/supabase-browser"
 
-import { getDashboardTodos } from "../data"
+export function TodoItems() {
+  const supabase = useMemo(() => createClient(), [])
+  const queryClient = useQueryClient()
 
-export async function TodoItems() {
-        const todos = await getDashboardTodos()
+  const { data: todos } = useSuspenseQuery({
+    queryKey: DASHBOARD_TODO_QUERY_KEY,
+    queryFn: () => fetchDashboardTodos(supabase),
+  })
 
-        return (
-                <div className="space-y-4">
-                        {todos.map((todo) => (
-                                <div key={todo.id} className="flex items-center gap-6">
-                                        <h1
-                                                className={cn({
-                                                        "line-through": todo.completed,
-                                                })}
-                                        >
-                                                {todo.title}
-                                        </h1>
-                                        <Button variant="outline">Delete</Button>
-                                        <Button>Update</Button>
-                                </div>
-                        ))}
-                </div>
-        )
+  const toggleMutation = useMutation(
+    toggleTodoMutationOptions({
+      supabase,
+      queryClient,
+      callbacks: {
+        onError: (error) => {
+          toast({
+            title: "Failed to update todo",
+            description: error.message,
+            variant: "destructive",
+          })
+        },
+      },
+    }),
+  )
+
+  return (
+    <div className="space-y-4">
+      {todos.map((todo) => (
+        <TodoRow
+          key={todo.id}
+          todo={todo}
+          onToggle={(completed) => toggleMutation.mutate({ id: todo.id, completed })}
+          disabled={toggleMutation.isPending}
+        />
+      ))}
+    </div>
+  )
+}
+
+function TodoRow({
+  todo,
+  onToggle,
+  disabled,
+}: {
+  todo: DashboardTodo
+  onToggle: (completed: boolean) => void
+  disabled?: boolean
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-md border border-border/60 px-4 py-3">
+      <div className="flex items-center gap-3">
+        <Switch
+          checked={todo.completed}
+          onCheckedChange={onToggle}
+          disabled={disabled}
+          aria-label={`Mark ${todo.title} as ${todo.completed ? "incomplete" : "complete"}`}
+        />
+        <h1
+          className={cn("text-base font-medium", {
+            "line-through text-muted-foreground": todo.completed,
+          })}
+        >
+          {todo.title}
+        </h1>
+      </div>
+    </div>
+  )
 }

--- a/app/dashboard/todo/data.ts
+++ b/app/dashboard/todo/data.ts
@@ -2,25 +2,11 @@ import "server-only"
 
 import { cache } from "react"
 
-export type DashboardTodo = {
-        id: string
-        title: string
-        createdBy: string
-        completed: boolean
-}
-
-async function wait(ms: number) {
-        return new Promise((resolve) => setTimeout(resolve, ms))
-}
+import { fetchDashboardTodos, type DashboardTodo } from "@/queries/dashboard-todos"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
 
 export const getDashboardTodos = cache(async (): Promise<DashboardTodo[]> => {
-        await wait(200)
-        return [
-                {
-                        title: "Subscribe",
-                        createdBy: "091832901830",
-                        id: "101981908",
-                        completed: false,
-                },
-        ]
+  const supabase = (await createSupbaseServerClientReadOnly()) as TypedSupabaseClient
+  return fetchDashboardTodos(supabase)
 })

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -29,6 +29,12 @@ export type Database = {
         updated_at: string | null
         metadata: Json | null
       }>
+      todos: SupabaseTable<{
+        id: string
+        title: string
+        completed: boolean
+        created_at: string | null
+      }>
       profiles: SupabaseTable<{
         id: string
         created_at: string | null

--- a/queries/dashboard-todos.ts
+++ b/queries/dashboard-todos.ts
@@ -1,0 +1,178 @@
+import type { QueryClient, UseMutationOptions } from "@tanstack/react-query"
+
+import type { Database } from "@/lib/supabase"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+export type DashboardTodo = Database["public"]["Tables"]["todos"]["Row"]
+
+export const DASHBOARD_TODO_QUERY_KEY = ["dashboard", "todos"] as const
+
+function buildError(message: string) {
+  return new Error(message)
+}
+
+export async function fetchDashboardTodos(
+  supabase: TypedSupabaseClient,
+): Promise<DashboardTodo[]> {
+  const { data, error } = await supabase
+    .from("todos")
+    .select("*")
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    throw buildError(`Failed to load todos: ${error.message}`)
+  }
+
+  return data ?? []
+}
+
+export type CreateTodoVariables = { title: string }
+
+export type CreateTodoContext = {
+  previousTodos: DashboardTodo[]
+  optimisticTodo: DashboardTodo
+}
+
+export type ToggleTodoVariables = { id: string; completed: boolean }
+
+export type ToggleTodoContext = {
+  previousTodos: DashboardTodo[]
+}
+
+type MutationCallbacks<TData, TContext> = {
+  onError?: (error: Error, context: TContext | undefined) => void
+  onSuccess?: (data: TData, context: TContext | undefined) => void
+}
+
+export function createTodoMutationOptions({
+  supabase,
+  queryClient,
+  callbacks = {},
+}: {
+  supabase: TypedSupabaseClient
+  queryClient: QueryClient
+  callbacks?: MutationCallbacks<DashboardTodo, CreateTodoContext>
+}): UseMutationOptions<DashboardTodo, Error, CreateTodoVariables, CreateTodoContext> {
+  return {
+    mutationKey: ["create", ...DASHBOARD_TODO_QUERY_KEY],
+    mutationFn: async ({ title }) => {
+      const { data, error } = await supabase
+        .from("todos")
+        .insert({ title })
+        .select()
+        .single()
+
+      if (error || !data) {
+        throw buildError(error?.message ?? "Failed to create todo")
+      }
+
+      return data
+    },
+    onMutate: async ({ title }) => {
+      await queryClient.cancelQueries({ queryKey: DASHBOARD_TODO_QUERY_KEY })
+
+      const previousTodos =
+        queryClient.getQueryData<DashboardTodo[]>(DASHBOARD_TODO_QUERY_KEY) ?? []
+
+      const optimisticTodo: DashboardTodo = {
+        id: `optimistic-${Date.now()}`,
+        title,
+        completed: false,
+        created_at: new Date().toISOString(),
+      }
+
+      queryClient.setQueryData<DashboardTodo[]>(
+        DASHBOARD_TODO_QUERY_KEY,
+        (current = []) => [optimisticTodo, ...current],
+      )
+
+      return { previousTodos, optimisticTodo }
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousTodos) {
+        queryClient.setQueryData(DASHBOARD_TODO_QUERY_KEY, context.previousTodos)
+      }
+
+      callbacks.onError?.(error, context)
+    },
+    onSuccess: (createdTodo, _variables, context) => {
+      if (context?.optimisticTodo) {
+        queryClient.setQueryData<DashboardTodo[]>(
+          DASHBOARD_TODO_QUERY_KEY,
+          (current = []) =>
+            current.map((todo) =>
+              todo.id === context.optimisticTodo.id ? createdTodo : todo,
+            ),
+        )
+      }
+
+      callbacks.onSuccess?.(createdTodo, context)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_TODO_QUERY_KEY })
+    },
+  }
+}
+
+export function toggleTodoMutationOptions({
+  supabase,
+  queryClient,
+  callbacks = {},
+}: {
+  supabase: TypedSupabaseClient
+  queryClient: QueryClient
+  callbacks?: MutationCallbacks<DashboardTodo, ToggleTodoContext>
+}): UseMutationOptions<DashboardTodo, Error, ToggleTodoVariables, ToggleTodoContext> {
+  return {
+    mutationKey: ["toggle", ...DASHBOARD_TODO_QUERY_KEY],
+    mutationFn: async ({ id, completed }) => {
+      const { data, error } = await supabase
+        .from("todos")
+        .update({ completed })
+        .eq("id", id)
+        .select()
+        .single()
+
+      if (error || !data) {
+        throw buildError(error?.message ?? "Failed to update todo")
+      }
+
+      return data
+    },
+    onMutate: async ({ id, completed }) => {
+      await queryClient.cancelQueries({ queryKey: DASHBOARD_TODO_QUERY_KEY })
+
+      const previousTodos =
+        queryClient.getQueryData<DashboardTodo[]>(DASHBOARD_TODO_QUERY_KEY) ?? []
+
+      queryClient.setQueryData<DashboardTodo[]>(
+        DASHBOARD_TODO_QUERY_KEY,
+        (current = []) =>
+          current.map((todo) =>
+            todo.id === id ? { ...todo, completed } : todo,
+          ),
+      )
+
+      return { previousTodos }
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousTodos) {
+        queryClient.setQueryData(DASHBOARD_TODO_QUERY_KEY, context.previousTodos)
+      }
+
+      callbacks.onError?.(error, context)
+    },
+    onSuccess: (updatedTodo, _variables, context) => {
+      queryClient.setQueryData<DashboardTodo[]>(
+        DASHBOARD_TODO_QUERY_KEY,
+        (current = []) =>
+          current.map((todo) => (todo.id === updatedTodo.id ? updatedTodo : todo)),
+      )
+
+      callbacks.onSuccess?.(updatedTodo, context)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_TODO_QUERY_KEY })
+    },
+  }
+}

--- a/tests/dashboard-todos.test.ts
+++ b/tests/dashboard-todos.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+
+import {
+  DASHBOARD_TODO_QUERY_KEY,
+  createTodoMutationOptions,
+  toggleTodoMutationOptions,
+  type DashboardTodo,
+} from "@/queries/dashboard-todos"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+describe("dashboard todo optimistic workflows", () => {
+  it("shows newly created todos immediately while awaiting Supabase", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(DASHBOARD_TODO_QUERY_KEY, [])
+
+    const serverTodo: DashboardTodo = {
+      id: "server-1",
+      title: "Schedule chore rotation",
+      completed: false,
+      created_at: new Date().toISOString(),
+    }
+
+    const supabase = {
+      from: () => ({
+        insert: () => ({
+          select: () => ({
+            single: async () => ({ data: serverTodo, error: null }),
+          }),
+        }),
+      }),
+    } as unknown as TypedSupabaseClient
+
+    const options = createTodoMutationOptions({ supabase, queryClient })
+
+    const context = await options.onMutate?.({ title: serverTodo.title })
+
+    const optimistic = queryClient.getQueryData<DashboardTodo[]>(
+      DASHBOARD_TODO_QUERY_KEY,
+    )
+
+    expect(optimistic?.[0]?.title).toBe(serverTodo.title)
+    expect(optimistic?.[0]?.id.startsWith("optimistic-")).toBe(true)
+
+    options.onSuccess?.(serverTodo, { title: serverTodo.title }, context)
+
+    const finalTodos = queryClient.getQueryData<DashboardTodo[]>(
+      DASHBOARD_TODO_QUERY_KEY,
+    )
+
+    expect(finalTodos).toEqual([serverTodo])
+    queryClient.clear()
+  })
+
+  it("reverts switch toggles when Supabase rejects the update", async () => {
+    const queryClient = new QueryClient()
+    const originalTodo: DashboardTodo = {
+      id: "todo-1",
+      title: "Replace air filters",
+      completed: false,
+      created_at: new Date().toISOString(),
+    }
+
+    queryClient.setQueryData(DASHBOARD_TODO_QUERY_KEY, [originalTodo])
+
+    const supabase = {
+      from: () => ({
+        update: () => ({
+          eq: () => ({
+            select: () => ({
+              single: async () => ({
+                data: null,
+                error: { message: "Permission denied" },
+              }),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as TypedSupabaseClient
+
+    const options = toggleTodoMutationOptions({ supabase, queryClient })
+
+    const context = await options.onMutate?.({
+      id: originalTodo.id,
+      completed: true,
+    })
+
+    const optimistic = queryClient.getQueryData<DashboardTodo[]>(
+      DASHBOARD_TODO_QUERY_KEY,
+    )
+    expect(optimistic?.[0]?.completed).toBe(true)
+
+    options.onError?.(
+      new Error("Permission denied"),
+      { id: originalTodo.id, completed: true },
+      context,
+    )
+
+    const reconciled = queryClient.getQueryData<DashboardTodo[]>(
+      DASHBOARD_TODO_QUERY_KEY,
+    )
+    expect(reconciled?.[0]).toEqual(originalTodo)
+
+    queryClient.clear()
+  })
+})


### PR DESCRIPTION
## Summary
- wire dashboard todo creation to React Query mutations with optimistic cache updates, Supabase persistence, and user toasts
- replace the todo list with a client component that fetches from Supabase and optimistically toggles completion states via switches
- define typed todo helpers for Supabase access and add tests covering optimistic creation and rollback on failure

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d30ba5419083288853c5b63e6dc758