### PR TITLE
feat: add realtime thread presence and collaborative cursors

### DIFF
--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,4 +1,6 @@
 import ModerationControls from "@/components/messaging/moderation-controls"
+import ReplyComposer from "@/components/messaging/reply-composer"
+import ThreadPresenceIndicator from "@/components/messaging/thread-presence-indicator"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -443,6 +445,7 @@ export default function MessagingPage() {
                 <span>{activeThread.participants} roommates involved</span>
                 <span>Updated {activeThread.updated}</span>
               </div>
+              <ThreadPresenceIndicator threadId="chore-rotation" className="pt-2" />
             </CardHeader>
             <CardContent className="space-y-8">
               {threadPosts.map((post, index) => (
@@ -562,6 +565,7 @@ export default function MessagingPage() {
                   {index < threadPosts.length - 1 ? <Separator /> : null}
                 </div>
               ))}
+              <ReplyComposer threadId="chore-rotation" />
             </CardContent>
           </Card>
 

--- a/components/messaging/reply-composer.tsx
+++ b/components/messaging/reply-composer.tsx
@@ -1,0 +1,228 @@
+"use client"
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEventHandler,
+} from "react"
+
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import useThreadPresence from "@/hooks/use-thread-presence"
+import { getReadableTextColor } from "@/lib/color"
+import {
+  type ThreadPresenceCursor,
+  type ThreadPresenceUser,
+} from "@/lib/messaging/thread-presence-manager"
+
+const CONNECTION_COPY: Record<string, string> = {
+  connected: "Synced with Supabase",
+  connecting: "Connecting to Supabase…",
+  error: "Connection lost — retrying",
+  offline: "Offline",
+}
+
+type ReplyComposerProps = {
+  threadId: string
+}
+
+export default function ReplyComposer({ threadId }: ReplyComposerProps) {
+  const { users, status, viewer, setTyping, updateCursor } = useThreadPresence(threadId)
+  const [value, setValue] = useState("")
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const frameRef = useRef<number | null>(null)
+
+  const remoteUsers = useMemo(
+    () => users.filter((user) => !user.isSelf),
+    [users],
+  )
+
+  const remoteCursors = useMemo(
+    () => remoteUsers.filter((user) => user.cursor),
+    [remoteUsers],
+  )
+
+  const typingUsers = useMemo(
+    () => remoteUsers.filter((user) => user.typing),
+    [remoteUsers],
+  )
+
+  const connectionMessage = CONNECTION_COPY[status] ?? CONNECTION_COPY.connecting
+
+  const scheduleCursorBroadcast = useCallback(() => {
+    if (frameRef.current) {
+      cancelAnimationFrame(frameRef.current)
+    }
+
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null
+      const textarea = textareaRef.current
+      if (!textarea) {
+        return
+      }
+
+      const { selectionStart, selectionEnd, value: draft } = textarea
+      const prefix = draft.slice(0, selectionStart)
+      const lineBreaks = prefix.split("\n").length - 1
+      const lastBreak = prefix.lastIndexOf("\n")
+      const column = lastBreak === -1 ? prefix.length : prefix.length - lastBreak - 1
+
+      updateCursor({
+        start: selectionStart,
+        end: selectionEnd,
+        line: lineBreaks,
+        column,
+        textLength: draft.length,
+        timestamp: Date.now(),
+      })
+    })
+  }, [updateCursor])
+
+  useEffect(() => {
+    return () => {
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current)
+      }
+      updateCursor(null)
+      setTyping(false)
+    }
+  }, [setTyping, updateCursor])
+
+  const handleChange = useCallback<ChangeEventHandler<HTMLTextAreaElement>>(
+    (event) => {
+      setValue(event.target.value)
+      setTyping(true)
+      scheduleCursorBroadcast()
+    },
+    [scheduleCursorBroadcast, setTyping],
+  )
+
+  const handleFocus = useCallback(() => {
+    setTyping(true)
+    scheduleCursorBroadcast()
+  }, [scheduleCursorBroadcast, setTyping])
+
+  const handleBlur = useCallback(() => {
+    setTyping(false)
+    updateCursor(null)
+  }, [setTyping, updateCursor])
+
+  const handleSelectionChange = useCallback(() => {
+    scheduleCursorBroadcast()
+  }, [scheduleCursorBroadcast])
+
+  const handleSend = useCallback(() => {
+    setValue("")
+    updateCursor(null)
+    setTyping(false)
+  }, [setTyping, updateCursor])
+
+  const typingAnnouncement = formatTypingAnnouncement(typingUsers)
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border/60 bg-background/90 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">
+          Reply together
+        </span>
+        <span aria-live="polite">{connectionMessage}</span>
+      </div>
+      <div className="relative">
+        <Textarea
+          ref={textareaRef}
+          value={value}
+          onChange={handleChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onSelect={handleSelectionChange}
+          onKeyUp={handleSelectionChange}
+          onMouseUp={handleSelectionChange}
+          placeholder="Share an update for the crew…"
+          className="min-h-[140px] resize-y rounded-lg border-border/70 bg-background/80 text-sm leading-6"
+        />
+        <div className="pointer-events-none absolute inset-0">
+          {remoteCursors.map((user) => (
+            <RemoteCursor
+              key={user.connectionId}
+              name={user.name}
+              color={user.color}
+              cursor={user.cursor!}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span aria-live="polite">{typingAnnouncement}</span>
+        <div className="flex items-center gap-2">
+          {viewer ? (
+            <span className="hidden text-[11px] uppercase tracking-wide text-muted-foreground sm:inline">
+              You are {viewer.name}
+            </span>
+          ) : null}
+          <Button size="sm" className="px-4" onClick={handleSend} type="button">
+            Send update
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type RemoteCursorProps = {
+  name: string
+  color: string
+  cursor: ThreadPresenceCursor
+}
+
+function RemoteCursor({ name, color, cursor }: RemoteCursorProps) {
+  const left = cursorPositionToPercent(cursor)
+  return (
+    <div
+      className="pointer-events-none absolute inset-y-2 flex flex-col items-center"
+      style={{ left: `calc(${left}% - 8px)` }}
+    >
+      <span
+        className="rounded-full px-2 py-0.5 text-[10px] font-semibold shadow"
+        style={{
+          backgroundColor: color,
+          color: getReadableTextColor(color),
+        }}
+      >
+        {name}
+      </span>
+      <div
+        className="mt-1 h-full w-0.5 rounded-full"
+        style={{ backgroundColor: color, opacity: 0.85 }}
+      />
+    </div>
+  )
+}
+
+function cursorPositionToPercent(cursor: Pick<ThreadPresenceCursor, "start" | "textLength">) {
+  if (!cursor.textLength) {
+    return 0
+  }
+
+  const ratio = cursor.start / cursor.textLength
+  const clamped = Math.max(0, Math.min(1, ratio))
+  return clamped * 100
+}
+
+function formatTypingAnnouncement(users: ThreadPresenceUser[]) {
+  if (users.length === 0) {
+    return ""
+  }
+
+  if (users.length === 1) {
+    return `${users[0].name} is typing…`
+  }
+
+  if (users.length === 2) {
+    return `${users[0].name} and ${users[1].name} are typing…`
+  }
+
+  return `${users[0].name}, ${users[1].name}, and ${users.length - 2} others are typing…`
+}

--- a/components/messaging/thread-presence-indicator.tsx
+++ b/components/messaging/thread-presence-indicator.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import useThreadPresence from "@/hooks/use-thread-presence"
+import { getReadableTextColor } from "@/lib/color"
+import { cn } from "@/lib/utils"
+
+const STATUS_LABEL: Record<string, string> = {
+  connected: "Connected",
+  connecting: "Connecting…",
+  error: "Connection issue",
+  offline: "Offline",
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  connected: "bg-emerald-500",
+  connecting: "bg-amber-400",
+  error: "bg-destructive",
+  offline: "bg-muted-foreground/60",
+}
+
+const MAX_VISIBLE_AVATARS = 4
+
+type ThreadPresenceIndicatorProps = {
+  threadId: string
+  className?: string
+}
+
+export default function ThreadPresenceIndicator({
+  threadId,
+  className,
+}: ThreadPresenceIndicatorProps) {
+  const { users, status, viewer } = useThreadPresence(threadId)
+
+  const visibleUsers = users.slice(0, MAX_VISIBLE_AVATARS)
+  const overflow = Math.max(users.length - MAX_VISIBLE_AVATARS, 0)
+  const typingUsers = users.filter((user) => user.typing && !user.isSelf)
+
+  const statusLabel = STATUS_LABEL[status] ?? STATUS_LABEL.connecting
+  const statusColor = STATUS_COLOR[status] ?? STATUS_COLOR.connecting
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="flex items-center gap-2 text-xs sm:text-sm">
+        <span
+          aria-hidden
+          className={cn("inline-flex size-2 rounded-full", statusColor)}
+        />
+        <span className="font-medium text-foreground">Live presence</span>
+        <span className="text-muted-foreground">{statusLabel}</span>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground sm:text-sm">
+        <div className="flex -space-x-2">
+          {visibleUsers.map((user) => (
+            <Avatar
+              key={user.connectionId}
+              className="size-8 border-2 border-background shadow-sm"
+              aria-label={`${user.name} is viewing this thread`}
+            >
+              <AvatarFallback
+                className="text-[11px] font-semibold uppercase"
+                style={{
+                  backgroundColor: user.color,
+                  color: getReadableTextColor(user.color),
+                }}
+              >
+                {user.initials}
+              </AvatarFallback>
+            </Avatar>
+          ))}
+        </div>
+        <div className="flex flex-col leading-tight">
+          <span className="font-medium text-foreground">
+            {users.length} roommate{users.length === 1 ? "" : "s"} here now
+          </span>
+          {typingUsers.length > 0 ? (
+            <span>
+              {typingUsers
+                .map((user) => user.name)
+                .join(", ")}{" "}
+              typing…
+            </span>
+          ) : viewer ? (
+            <span>Signed in as {viewer.name}</span>
+          ) : null}
+        </div>
+        {overflow > 0 ? (
+          <Badge variant="secondary" className="uppercase">
+            +{overflow}
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/hooks/use-thread-presence.ts
+++ b/hooks/use-thread-presence.ts
@@ -1,0 +1,177 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { useLocalStorage } from "@/lib/hooks/use-local-storage"
+import {
+  ThreadPresenceManager,
+  type ThreadPresenceCursor,
+  type ThreadPresenceIdentity,
+  type ThreadPresenceState,
+} from "@/lib/messaging/thread-presence-manager"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+type UseThreadPresenceState = ThreadPresenceState & {
+  viewer: ThreadPresenceIdentity | null
+  setTyping: (typing: boolean) => void
+  updateCursor: (cursor: ThreadPresenceCursor | null) => void
+}
+
+const PRESENCE_IDENTITY_STORAGE_KEY = "share-house-portal.presence.identity"
+
+const COLOR_POOL = [
+  "#0ea5e9",
+  "#f97316",
+  "#6366f1",
+  "#22c55e",
+  "#ec4899",
+  "#14b8a6",
+  "#facc15",
+]
+
+const ADJECTIVES = [
+  "Bright",
+  "Calm",
+  "Cozy",
+  "Friendly",
+  "Lively",
+  "Mindful",
+  "Organized",
+  "Thoughtful",
+]
+
+const NOUNS = [
+  "Alpaca",
+  "Fox",
+  "Heron",
+  "Juniper",
+  "Maple",
+  "Otter",
+  "Pine",
+  "River",
+]
+
+const INITIAL_HOOK_STATE: ThreadPresenceState = {
+  status: "offline",
+  users: [],
+  lastSyncedAt: null,
+}
+
+const managers = new Map<string, ThreadPresenceManager>()
+
+function generateRandomIdentity(): ThreadPresenceIdentity {
+  const adjective = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)]
+  const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)]
+  const name = `${adjective} ${noun}`
+  const initials = name
+    .split(" ")
+    .slice(0, 2)
+    .map((segment) => segment.charAt(0))
+    .join("")
+    .toUpperCase()
+
+  const color = COLOR_POOL[Math.floor(Math.random() * COLOR_POOL.length)]
+  const id = globalThis.crypto?.randomUUID()
+    ?? Math.random().toString(36).slice(2)
+
+  return {
+    id,
+    name,
+    initials,
+    color,
+  }
+}
+
+function getManagerKey(threadId: string) {
+  return threadId
+}
+
+function getOrCreateManager(
+  threadId: string,
+  client: TypedSupabaseClient,
+  identity: ThreadPresenceIdentity,
+) {
+  const key = getManagerKey(threadId)
+  const existing = managers.get(key)
+
+  if (existing) {
+    return existing
+  }
+
+  const manager = new ThreadPresenceManager({
+    client,
+    threadId,
+    identity,
+  })
+
+  managers.set(key, manager)
+  return manager
+}
+
+function usePresenceIdentity() {
+  const [identity, setIdentity] = useLocalStorage<ThreadPresenceIdentity | null>(
+    PRESENCE_IDENTITY_STORAGE_KEY,
+    null,
+  )
+
+  useEffect(() => {
+    if (identity) {
+      return
+    }
+
+    const nextIdentity = generateRandomIdentity()
+    setIdentity(nextIdentity)
+  }, [identity, setIdentity])
+
+  return identity
+}
+
+export default function useThreadPresence(threadId: string): UseThreadPresenceState {
+  const supabase = useSupabaseBrowser()
+  const viewerIdentity = usePresenceIdentity()
+  const managerRef = useRef<ThreadPresenceManager | null>(null)
+  const [state, setState] = useState<ThreadPresenceState>(INITIAL_HOOK_STATE)
+
+  useEffect(() => {
+    if (!viewerIdentity) {
+      return
+    }
+
+    const manager = getOrCreateManager(threadId, supabase, viewerIdentity)
+    managerRef.current = manager
+    setState(manager.snapshot)
+
+    const unsubscribe = manager.subscribe(setState)
+
+    return () => {
+      unsubscribe()
+      if (manager.snapshot.status === "offline") {
+        managers.delete(getManagerKey(threadId))
+      }
+      managerRef.current = null
+    }
+  }, [supabase, threadId, viewerIdentity])
+
+  const setTyping = useCallback((typing: boolean) => {
+    managerRef.current?.setTyping(typing)
+  }, [])
+
+  const updateCursor = useCallback((cursor: ThreadPresenceCursor | null) => {
+    managerRef.current?.updateCursor(cursor)
+  }, [])
+
+  return useMemo(() => {
+    const status = viewerIdentity ? state.status : "connecting"
+
+    return {
+      ...state,
+      status,
+      viewer: viewerIdentity,
+      setTyping: viewerIdentity ? setTyping : noop,
+      updateCursor: viewerIdentity ? updateCursor : noop,
+    }
+  }, [state, viewerIdentity, setTyping, updateCursor])
+}
+
+function noop() {}

--- a/lib/color.ts
+++ b/lib/color.ts
@@ -1,0 +1,18 @@
+export function getReadableTextColor(
+  hex: string,
+  { light = "#f8fafc", dark = "#0f172a" } = {},
+) {
+  const sanitized = hex.replace("#", "")
+
+  if (sanitized.length !== 6) {
+    return dark
+  }
+
+  const r = parseInt(sanitized.slice(0, 2), 16)
+  const g = parseInt(sanitized.slice(2, 4), 16)
+  const b = parseInt(sanitized.slice(4, 6), 16)
+
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+
+  return luminance > 0.6 ? dark : light
+}

--- a/lib/messaging/thread-presence-manager.ts
+++ b/lib/messaging/thread-presence-manager.ts
@@ -1,0 +1,366 @@
+import type {
+  RealtimeChannel,
+  RealtimeChannelStatus,
+  RealtimePresenceState,
+} from "@supabase/supabase-js"
+
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+type PresenceListener = (state: ThreadPresenceState) => void
+
+export type ThreadPresenceIdentity = {
+  id: string
+  name: string
+  initials: string
+  color: string
+}
+
+export type ThreadPresenceCursor = {
+  start: number
+  end: number
+  line: number
+  column: number
+  textLength: number
+  timestamp: number
+}
+
+export type ThreadPresenceUser = ThreadPresenceIdentity & {
+  connectionId: string
+  typing: boolean
+  cursor: ThreadPresenceCursor | null
+  lastActiveAt: number
+  isSelf: boolean
+}
+
+export type ThreadPresenceConnectionStatus =
+  | "offline"
+  | "connecting"
+  | "connected"
+  | "error"
+
+export type ThreadPresenceState = {
+  status: ThreadPresenceConnectionStatus
+  users: ThreadPresenceUser[]
+  lastSyncedAt: number | null
+}
+
+type PresencePayload = {
+  identity: ThreadPresenceIdentity
+  typing: boolean
+  cursor: ThreadPresenceCursor | null
+  lastActiveAt: number
+  sessionId: string
+}
+
+type PresenceEnvelope = PresencePayload & {
+  presence_ref?: string
+}
+
+const INITIAL_STATE: ThreadPresenceState = {
+  status: "offline",
+  users: [],
+  lastSyncedAt: null,
+}
+
+function sortPresenceUsers(users: ThreadPresenceUser[]): ThreadPresenceUser[] {
+  return [...users].sort((a, b) => {
+    if (a.isSelf && !b.isSelf) {
+      return -1
+    }
+    if (!a.isSelf && b.isSelf) {
+      return 1
+    }
+    return a.name.localeCompare(b.name)
+  })
+}
+
+export function derivePresenceUsers(
+  presence: RealtimePresenceState<PresenceEnvelope>,
+  viewerId: string,
+  sessionId: string,
+): ThreadPresenceUser[] {
+  const collected: ThreadPresenceUser[] = []
+
+  for (const entries of Object.values(presence)) {
+    for (const entry of entries) {
+      if (!entry.identity) {
+        continue
+      }
+
+      const lastActiveAt = typeof entry.lastActiveAt === "number"
+        ? entry.lastActiveAt
+        : Date.now()
+
+      collected.push({
+        connectionId: entry.presence_ref ?? `${entry.identity.id}-${entry.sessionId}`,
+        ...entry.identity,
+        typing: Boolean(entry.typing),
+        cursor: entry.cursor ?? null,
+        lastActiveAt,
+        isSelf: entry.identity.id === viewerId && entry.sessionId === sessionId,
+      })
+    }
+  }
+
+  return sortPresenceUsers(collected)
+}
+
+export class ThreadPresenceManager {
+  private channel: RealtimeChannel | null = null
+  private state: ThreadPresenceState = INITIAL_STATE
+  private presencePayload: PresencePayload | null = null
+  private readonly listeners = new Set<PresenceListener>()
+  private readonly sessionId: string
+
+  constructor(
+    private readonly options: {
+      client: TypedSupabaseClient
+      threadId: string
+      identity: ThreadPresenceIdentity
+    },
+  ) {
+    this.sessionId = globalThis.crypto?.randomUUID()
+      ?? Math.random().toString(36).slice(2)
+  }
+
+  get snapshot(): ThreadPresenceState {
+    return this.state
+  }
+
+  subscribe(listener: PresenceListener): () => void {
+    this.listeners.add(listener)
+    listener(this.state)
+    void this.connect()
+
+    return () => {
+      this.listeners.delete(listener)
+      if (this.listeners.size === 0) {
+        void this.disconnect()
+      }
+    }
+  }
+
+  setTyping(typing: boolean) {
+    this.updatePresence({ typing })
+  }
+
+  updateCursor(cursor: ThreadPresenceCursor | null) {
+    this.updatePresence({ cursor })
+  }
+
+  async disconnect() {
+    if (!this.channel) {
+      return
+    }
+
+    try {
+      await this.channel.unsubscribe()
+    } catch (error) {
+      console.error("Failed to unsubscribe from thread presence", error)
+    }
+
+    this.channel = null
+    this.state = {
+      ...INITIAL_STATE,
+      status: "offline",
+    }
+    this.notify()
+  }
+
+  private async connect() {
+    if (this.channel || this.listeners.size === 0) {
+      return
+    }
+
+    this.state = {
+      ...this.state,
+      status: "connecting",
+    }
+    this.notify()
+
+    const { client, threadId, identity } = this.options
+
+    try {
+      const channel = client.channel(`thread-presence:${threadId}`, {
+        config: {
+          presence: {
+            key: identity.id,
+          },
+        },
+      })
+
+      this.channel = channel
+
+      channel
+        .on("presence", { event: "sync" }, () => this.handlePresenceSync())
+        .on("presence", { event: "join" }, () => this.handlePresenceSync())
+        .on("presence", { event: "leave" }, () => this.handlePresenceSync())
+
+      const payload = this.ensurePresencePayload()
+
+      await channel.subscribe(async (status) => {
+        this.handleStatusChange(status)
+
+        if (status === "SUBSCRIBED") {
+          try {
+            await channel.track(payload)
+            this.handlePresenceSync()
+          } catch (error) {
+            console.error("Failed to announce thread presence", error)
+          }
+        }
+      })
+    } catch (error) {
+      console.error("Failed to connect to Supabase presence", error)
+      this.state = {
+        ...this.state,
+        status: "error",
+      }
+      this.notify()
+    }
+  }
+
+  private ensurePresencePayload(): PresencePayload {
+    if (this.presencePayload) {
+      return this.presencePayload
+    }
+
+    const payload: PresencePayload = {
+      identity: this.options.identity,
+      typing: false,
+      cursor: null,
+      lastActiveAt: Date.now(),
+      sessionId: this.sessionId,
+    }
+
+    this.presencePayload = payload
+    return payload
+  }
+
+  private handlePresenceSync() {
+    if (!this.channel) {
+      return
+    }
+
+    const presenceState = this.channel.presenceState<PresenceEnvelope>()
+    const users = derivePresenceUsers(
+      presenceState,
+      this.options.identity.id,
+      this.sessionId,
+    )
+
+    this.state = {
+      ...this.state,
+      users,
+      lastSyncedAt: Date.now(),
+    }
+
+    this.notify()
+  }
+
+  private handleStatusChange(status: RealtimeChannelStatus) {
+    if (status === "SUBSCRIBED") {
+      this.state = {
+        ...this.state,
+        status: "connected",
+      }
+      this.notify()
+      return
+    }
+
+    if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+      this.state = {
+        ...this.state,
+        status: "error",
+        users: [],
+      }
+      this.notify()
+      return
+    }
+
+    if (status === "CLOSED") {
+      this.state = {
+        ...this.state,
+        status: "offline",
+        users: [],
+      }
+      this.notify()
+    }
+  }
+
+  private updatePresence(partial: Partial<PresencePayload>) {
+    const base = this.ensurePresencePayload()
+    const next: PresencePayload = {
+      ...base,
+      ...partial,
+      lastActiveAt: Date.now(),
+    }
+
+    if (this.presencePayload && isPresenceEqual(this.presencePayload, next)) {
+      return
+    }
+
+    this.presencePayload = next
+
+    if (this.channel) {
+      void this.channel.track(next)
+    }
+
+    this.state = {
+      ...this.state,
+      users: this.mergeSelfIntoUsers(next),
+      lastSyncedAt: Date.now(),
+    }
+    this.notify()
+  }
+
+  private mergeSelfIntoUsers(payload: PresencePayload): ThreadPresenceUser[] {
+    const others = this.state.users.filter((user) => !user.isSelf)
+
+    const selfUser: ThreadPresenceUser = {
+      connectionId: `${payload.identity.id}-${payload.sessionId}`,
+      ...payload.identity,
+      typing: payload.typing,
+      cursor: payload.cursor,
+      lastActiveAt: payload.lastActiveAt,
+      isSelf: true,
+    }
+
+    return sortPresenceUsers([...others, selfUser])
+  }
+
+  private notify() {
+    for (const listener of this.listeners) {
+      listener(this.state)
+    }
+  }
+}
+
+function isPresenceEqual(a: PresencePayload, b: PresencePayload) {
+  return (
+    a.identity.id === b.identity.id &&
+    a.typing === b.typing &&
+    areCursorsEqual(a.cursor, b.cursor)
+  )
+}
+
+function areCursorsEqual(
+  a: ThreadPresenceCursor | null,
+  b: ThreadPresenceCursor | null,
+) {
+  if (!a && !b) {
+    return true
+  }
+
+  if (!a || !b) {
+    return false
+  }
+
+  return (
+    a.start === b.start &&
+    a.end === b.end &&
+    a.line === b.line &&
+    a.column === b.column &&
+    a.textLength === b.textLength
+  )
+}

--- a/tests/messaging/thread-presence-manager.test.ts
+++ b/tests/messaging/thread-presence-manager.test.ts
@@ -1,0 +1,235 @@
+import type {
+  RealtimeChannel,
+  RealtimeChannelStatus,
+  RealtimePresenceState,
+} from "@supabase/supabase-js"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  ThreadPresenceManager,
+  derivePresenceUsers,
+  type ThreadPresenceCursor,
+  type ThreadPresenceIdentity,
+  type ThreadPresenceState,
+} from "@/lib/messaging/thread-presence-manager"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+class MockRealtimeChannel
+  implements Partial<RealtimeChannel<unknown, unknown, unknown, unknown>>
+{
+  public readonly trackedPayloads: Array<Record<string, any>> = []
+  public unsubscribed = false
+
+  private readonly statusHandlers: Array<
+    (status: RealtimeChannelStatus) => void | Promise<void>
+  > = []
+  private readonly syncHandlers: Array<() => void> = []
+  private presenceStateValue: RealtimePresenceState<Record<string, any>> = {}
+
+  on(event: "presence", filter: { event: string }, callback: () => void) {
+    if (event === "presence" && filter.event === "sync") {
+      this.syncHandlers.push(callback)
+    }
+
+    return this as unknown as RealtimeChannel
+  }
+
+  async subscribe(callback: (status: RealtimeChannelStatus) => void | Promise<void>) {
+    this.statusHandlers.push(callback)
+    return this as unknown as RealtimeChannel
+  }
+
+  async track(payload: Record<string, any>) {
+    this.trackedPayloads.push(payload)
+    const identity = payload.identity as ThreadPresenceIdentity | undefined
+    if (!identity) {
+      return { data: {}} as any
+    }
+
+    const key = identity.id
+    const entry = {
+      presence_ref: `${key}-${payload.sessionId ?? "session"}`,
+      ...payload,
+    }
+
+    const records = this.presenceStateValue[key] ?? []
+    const existingIndex = records.findIndex(
+      (item) => item.sessionId === payload.sessionId,
+    )
+
+    if (existingIndex >= 0) {
+      records[existingIndex] = entry
+    } else {
+      records.push(entry)
+    }
+
+    this.presenceStateValue[key] = records
+
+    for (const handler of this.syncHandlers) {
+      handler()
+    }
+
+    return { data: {}} as any
+  }
+
+  presenceState<T>() {
+    return this.presenceStateValue as RealtimePresenceState<T>
+  }
+
+  async unsubscribe() {
+    this.unsubscribed = true
+    return "ok"
+  }
+
+  async emitStatus(status: RealtimeChannelStatus) {
+    for (const handler of this.statusHandlers) {
+      await handler(status)
+    }
+  }
+}
+
+describe("ThreadPresenceManager", () => {
+  it("connects to Supabase and tracks the viewer", async () => {
+    const { manager, channel } = createManager()
+    const states: ThreadPresenceState[] = []
+
+    const unsubscribe = manager.subscribe((state) => {
+      states.push(state)
+    })
+
+    expect(states.at(-1)?.status).toBe("connecting")
+
+    await channel.emitStatus("SUBSCRIBED")
+    await flushMicrotasks()
+
+    expect(states.at(-1)?.status).toBe("connected")
+    expect(channel.trackedPayloads).toHaveLength(1)
+
+    unsubscribe()
+    await flushMicrotasks()
+    expect(channel.unsubscribed).toBe(true)
+  })
+
+  it("updates cursor and typing state for the current viewer", async () => {
+    const { manager, channel, identity } = createManager()
+    const states: ThreadPresenceState[] = []
+    manager.subscribe((state) => states.push(state))
+
+    await channel.emitStatus("SUBSCRIBED")
+    await flushMicrotasks()
+
+    const cursor: ThreadPresenceCursor = {
+      start: 5,
+      end: 5,
+      line: 0,
+      column: 5,
+      textLength: 20,
+      timestamp: Date.now(),
+    }
+
+    manager.updateCursor(cursor)
+    manager.setTyping(true)
+    await flushMicrotasks()
+
+    const lastPayload = channel.trackedPayloads.at(-1)
+    expect(lastPayload?.cursor).toEqual(cursor)
+    expect(lastPayload?.typing).toBe(true)
+
+    const selfUser = manager.snapshot.users.find((user) => user.isSelf)
+    expect(selfUser?.id).toBe(identity.id)
+    expect(selfUser?.cursor).toEqual(cursor)
+    expect(selfUser?.typing).toBe(true)
+  })
+
+  it("derives presence state into displayable users", () => {
+    const identity: ThreadPresenceIdentity = {
+      id: "user-1",
+      name: "Jordan",
+      initials: "JL",
+      color: "#f97316",
+    }
+
+    const other: ThreadPresenceIdentity = {
+      id: "user-2",
+      name: "Avery",
+      initials: "AC",
+      color: "#6366f1",
+    }
+
+    const cursor: ThreadPresenceCursor = {
+      start: 2,
+      end: 4,
+      line: 0,
+      column: 2,
+      textLength: 12,
+      timestamp: 100,
+    }
+
+    const state: RealtimePresenceState<any> = {
+      [identity.id]: [
+        {
+          presence_ref: "ref-1",
+          identity,
+          sessionId: "session-1",
+          typing: true,
+          cursor,
+          lastActiveAt: 50,
+        },
+      ],
+      [other.id]: [
+        {
+          presence_ref: "ref-2",
+          identity: other,
+          sessionId: "session-2",
+          typing: false,
+          lastActiveAt: 75,
+        },
+      ],
+    }
+
+    const users = derivePresenceUsers(state, identity.id, "session-1")
+    expect(users).toHaveLength(2)
+    expect(users[0].isSelf).toBe(true)
+    expect(users[0].cursor).toEqual(cursor)
+    expect(users[1].name).toBe("Avery")
+    expect(users[1].typing).toBe(false)
+  })
+
+  it("surfaces connection errors", async () => {
+    const { manager, channel } = createManager()
+    const states: ThreadPresenceState[] = []
+    manager.subscribe((state) => states.push(state))
+
+    await channel.emitStatus("CHANNEL_ERROR")
+    await flushMicrotasks()
+
+    expect(states.at(-1)?.status).toBe("error")
+  })
+})
+
+function createManager() {
+  const channel = new MockRealtimeChannel()
+  const client = {
+    channel: vi.fn(() => channel as unknown as RealtimeChannel),
+  } as unknown as TypedSupabaseClient
+
+  const identity: ThreadPresenceIdentity = {
+    id: "user-1",
+    name: "Jordan",
+    initials: "JL",
+    color: "#f97316",
+  }
+
+  const manager = new ThreadPresenceManager({
+    client,
+    threadId: "thread-1",
+    identity,
+  })
+
+  return { manager, channel, identity }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}


### PR DESCRIPTION
## Summary
- add a reusable Supabase-backed presence manager and hook that publish typing state and cursor metadata per thread
- surface active viewers and connection status inside the messaging thread along with a collaborative reply composer
- cover presence manager behaviours with unit tests built on a mocked realtime channel

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30ba663448328a436714b631e43f6