### PR TITLE
Add maintenance request versioning and publish workflow

### DIFF
--- a/components/maintenance/maintenance-request-form.tsx
+++ b/components/maintenance/maintenance-request-form.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -14,6 +14,14 @@ import { useNotifications } from "@/hooks/use-notifications";
 import { createClient } from "@/utils/supabase-browser";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchMemberProfile, fetchMembersByUnit } from "@/lib/data/members";
+import {
+  createMaintenanceRequestDraft,
+  fetchMaintenanceRequests,
+  publishMaintenanceRequest,
+  unpublishMaintenanceRequest,
+  type MaintenanceRequestWithVersions,
+} from "@/lib/maintenance/requests";
+import { cn } from "@/lib/utils";
 import type { TypedSupabaseClient } from "@/utils/typed-supabase-client";
 
 const maintenanceRequestSchema = z.object({
@@ -26,6 +34,14 @@ const maintenanceRequestSchema = z.object({
 
 type MaintenanceRequestFormData = z.infer<typeof maintenanceRequestSchema>;
 
+type PropertyManagerInfo = {
+  id: string;
+  email: string;
+  name: string;
+};
+
+type MaintenanceRequestVersion = MaintenanceRequestWithVersions['versions'][number];
+
 const categories = [
   "Plumbing",
   "Electrical",
@@ -35,7 +51,7 @@ const categories = [
   "Pest Control",
   "Cleaning",
   "Security",
-  "Other"
+  "Other",
 ];
 
 const priorities = [
@@ -45,154 +61,317 @@ const priorities = [
   { value: "urgent", label: "Urgent - Emergency fix needed" },
 ];
 
+const defaultValues: MaintenanceRequestFormData = {
+  title: "",
+  description: "",
+  priority: "normal",
+  category: "",
+  location: "",
+};
+
+function formatVersionTimestamp(version: MaintenanceRequestVersion) {
+  const timestamp = version.published_at ?? version.created_at;
+  if (!timestamp) return "—";
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+
+  return date.toLocaleString();
+}
+
 export function MaintenanceRequestForm() {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSavingDraft, setIsSavingDraft] = useState(false);
+  const [isLoadingRequests, setIsLoadingRequests] = useState(true);
+  const [requests, setRequests] = useState<MaintenanceRequestWithVersions[]>([]);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [unitId, setUnitId] = useState<string | null>(null);
+  const [requesterName, setRequesterName] = useState<string>("Unknown requester");
+  const [propertyManager, setPropertyManager] = useState<PropertyManagerInfo | null>(null);
+  const [publishingRequestId, setPublishingRequestId] = useState<string | null>(null);
+  const [unpublishingRequestId, setUnpublishingRequestId] = useState<string | null>(null);
+  const [activeRequestId, setActiveRequestId] = useState<string | null>(null);
+
   const { notifyMaintenanceRequest } = useNotifications();
   const { toast } = useToast();
-  const supabase = createClient();
-  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  const supabase = useMemo(() => createClient(), []);
+  const typedSupabase = useMemo(
+    () => supabase as unknown as TypedSupabaseClient,
+    [supabase],
+  );
 
   const form = useForm<MaintenanceRequestFormData>({
     resolver: zodResolver(maintenanceRequestSchema),
-    defaultValues: {
-      title: "",
-      description: "",
-      priority: "normal",
-      category: "",
-      location: "",
-    },
+    defaultValues,
   });
 
+  const loadRequests = useCallback(
+    async (targetUserId: string, targetUnitId: string | null) => {
+      try {
+        const result = await fetchMaintenanceRequests({
+          client: typedSupabase,
+          userId: targetUserId,
+          unitId: targetUnitId,
+        });
+        setRequests(result);
+      } catch (error) {
+        console.error('Error fetching maintenance requests:', error);
+        toast({
+          title: "Error",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Failed to load maintenance requests.",
+          variant: "destructive",
+        });
+      }
+    },
+    [typedSupabase, toast],
+  );
+
+  const refreshRequests = useCallback(async () => {
+    if (!userId) return;
+    setIsLoadingRequests(true);
+    try {
+      await loadRequests(userId, unitId ?? null);
+    } finally {
+      setIsLoadingRequests(false);
+    }
+  }, [loadRequests, unitId, userId]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const bootstrap = async () => {
+      setIsLoadingRequests(true);
+
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        if (!isMounted) return;
+
+        if (!user) {
+          setIsLoadingRequests(false);
+          toast({
+            title: "Authentication required",
+            description: "Please sign in to submit maintenance requests.",
+            variant: "destructive",
+          });
+          return;
+        }
+
+        setUserId(user.id);
+        setRequesterName(user.email ?? "Unknown requester");
+
+        const profile = await fetchMemberProfile(typedSupabase, user.id);
+        if (!isMounted) return;
+
+        if (profile?.unit_id) {
+          setUnitId(profile.unit_id);
+          setRequesterName(profile.full_name || user.email || "Unknown requester");
+
+          const [manager] = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
+            roles: ['property_manager'],
+          });
+
+          if (isMounted && manager) {
+            setPropertyManager({
+              id: manager.id,
+              email: manager.email || '',
+              name: manager.full_name || manager.email || 'Property manager',
+            });
+          }
+        }
+
+        await loadRequests(user.id, profile?.unit_id ?? null);
+      } catch (error) {
+        if (!isMounted) return;
+        console.error('Error loading maintenance request context:', error);
+        toast({
+          title: "Error",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Failed to initialize maintenance requests.",
+          variant: "destructive",
+        });
+      } finally {
+        if (isMounted) {
+          setIsLoadingRequests(false);
+        }
+      }
+    };
+
+    bootstrap();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [supabase, typedSupabase, loadRequests, toast]);
+
   const onSubmit = async (data: MaintenanceRequestFormData) => {
-    setIsSubmitting(true);
+    if (!userId) {
+      toast({
+        title: "Unable to submit",
+        description: "You must be signed in to submit a maintenance request.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!unitId) {
+      toast({
+        title: "Missing unit",
+        description: "We could not determine your assigned unit to file this request.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSavingDraft(true);
 
     try {
-      // Get current user info
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
-
-      // Get user profile
-      const profile = await fetchMemberProfile(typedSupabase, user.id);
-
-      if (!profile) throw new Error("Profile not found");
-
-      if (!profile.unit_id) {
-        throw new Error("User is not assigned to a unit");
-      }
-
-      const [propertyManager] = await fetchMembersByUnit(typedSupabase, profile.unit_id, {
-        roles: ['property_manager'],
+      const request = await createMaintenanceRequestDraft({
+        client: typedSupabase,
+        payload: data,
+        userId,
+        unitId,
       });
 
-      if (!propertyManager) {
-        throw new Error("Property manager not found for this unit");
-      }
-
-      // Create maintenance request record
-      const { data: request, error: requestError } = await (supabase as any)
-        .from('maintenance_requests')
-        .insert({
-          title: data.title,
-          description: data.description,
-          priority: data.priority,
-          category: data.category || null,
-          location: data.location || null,
-          requested_by: user.id,
-          unit_id: profile.unit_id,
-          status: 'pending',
-        })
-        .select()
-        .single();
-
-      if (requestError) throw requestError;
-
-      // Send notifications
-      await notifyMaintenanceRequest({
-        requesterName: profile.full_name || user.email || 'Unknown',
-        title: data.title,
-        description: data.description,
-        priority: data.priority,
-        propertyManager: {
-          id: propertyManager.id,
-          email: propertyManager.email || '',
-          name: propertyManager.full_name || propertyManager.email || 'Unknown',
-        },
-      });
+      setActiveRequestId(request.id);
+      await refreshRequests();
 
       toast({
-        title: "Maintenance request submitted",
-        description: "Your maintenance request has been submitted and notifications sent.",
+        title: "Draft saved",
+        description: "Your maintenance request has been saved as a draft. Publish it when you're ready to notify your property manager.",
       });
 
-      form.reset();
+      form.reset(defaultValues);
     } catch (error) {
-      console.error('Error submitting maintenance request:', error);
+      console.error('Error saving maintenance request draft:', error);
       toast({
         title: "Error",
-        description: error instanceof Error ? error.message : "Failed to submit maintenance request",
+        description:
+          error instanceof Error ? error.message : "Failed to save maintenance request draft.",
         variant: "destructive",
       });
     } finally {
-      setIsSubmitting(false);
+      setIsSavingDraft(false);
+    }
+  };
+
+  const handlePublish = async (request: MaintenanceRequestWithVersions) => {
+    if (!userId) {
+      toast({
+        title: "Publish failed",
+        description: "Sign in again to publish maintenance requests.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!propertyManager) {
+      toast({
+        title: "No property manager found",
+        description: "We couldn't find a property manager for your unit. Please contact support before publishing.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setPublishingRequestId(request.id);
+
+    try {
+      const updatedRequest = await publishMaintenanceRequest({
+        client: typedSupabase,
+        request,
+        userId,
+      });
+
+      setActiveRequestId(updatedRequest.id);
+      await refreshRequests();
+
+      await notifyMaintenanceRequest({
+        requesterName,
+        title: updatedRequest.title,
+        description: updatedRequest.description,
+        priority: updatedRequest.priority,
+        propertyManager,
+      });
+
+      toast({
+        title: "Request published",
+        description: "Your property manager has been notified about this issue.",
+      });
+    } catch (error) {
+      console.error('Error publishing maintenance request:', error);
+      toast({
+        title: "Publish failed",
+        description:
+          error instanceof Error ? error.message : "Failed to publish maintenance request.",
+        variant: "destructive",
+      });
+    } finally {
+      setPublishingRequestId(null);
+    }
+  };
+
+  const handleUnpublish = async (request: MaintenanceRequestWithVersions) => {
+    if (!userId) {
+      toast({
+        title: "Unpublish failed",
+        description: "Sign in again to manage maintenance requests.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setUnpublishingRequestId(request.id);
+
+    try {
+      const updatedRequest = await unpublishMaintenanceRequest({
+        client: typedSupabase,
+        request,
+        userId,
+      });
+
+      setActiveRequestId(updatedRequest.id);
+      await refreshRequests();
+
+      toast({
+        title: "Moved back to draft",
+        description: "You can edit the request and publish again when ready.",
+      });
+    } catch (error) {
+      console.error('Error unpublishing maintenance request:', error);
+      toast({
+        title: "Unpublish failed",
+        description:
+          error instanceof Error ? error.message : "Failed to unpublish maintenance request.",
+        variant: "destructive",
+      });
+    } finally {
+      setUnpublishingRequestId(null);
     }
   };
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <FormField
-          control={form.control}
-          name="title"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Issue Title *</FormLabel>
-              <FormControl>
-                <Input placeholder="Brief description of the issue" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="description"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Detailed Description *</FormLabel>
-              <FormControl>
-                <Textarea
-                  placeholder="Please provide detailed information about the issue, including when it started, what you've observed, and any steps you've taken..."
-                  className="min-h-[100px]"
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-8">
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
           <FormField
             control={form.control}
-            name="priority"
+            name="title"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Priority Level *</FormLabel>
-                <Select onValueChange={field.onChange} defaultValue={field.value}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select priority level" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {priorities.map((priority) => (
-                      <SelectItem key={priority.value} value={priority.value}>
-                        {priority.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormLabel>Issue Title *</FormLabel>
+                <FormControl>
+                  <Input placeholder="Brief description of the issue" {...field} />
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}
@@ -200,48 +379,200 @@ export function MaintenanceRequestForm() {
 
           <FormField
             control={form.control}
-            name="category"
+            name="description"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Category (Optional)</FormLabel>
-                <Select onValueChange={field.onChange} defaultValue={field.value}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select category" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {categories.map((category) => (
-                      <SelectItem key={category} value={category}>
-                        {category}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormLabel>Detailed Description *</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Please provide detailed information about the issue, including when it started, what you've observed, and any steps you've taken..."
+                    className="min-h-[100px]"
+                    {...field}
+                  />
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}
           />
-        </div>
 
-        <FormField
-          control={form.control}
-          name="location"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Location (Optional)</FormLabel>
-              <FormControl>
-                <Input placeholder="e.g., Kitchen, Bedroom 1, Common Area" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="priority"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Priority Level *</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select priority level" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {priorities.map((priority) => (
+                        <SelectItem key={priority.value} value={priority.value}>
+                          {priority.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="category"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Category (Optional)</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select category" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {categories.map((category) => (
+                        <SelectItem key={category} value={category}>
+                          {category}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <FormField
+            control={form.control}
+            name="location"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Location (Optional)</FormLabel>
+                <FormControl>
+                  <Input placeholder="e.g., Kitchen, Bedroom 1, Common Area" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit" disabled={isSavingDraft} className="w-full">
+            {isSavingDraft ? "Saving draft..." : "Save Draft"}
+          </Button>
+        </form>
+
+        <section className="space-y-4">
+          <div>
+            <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+              Maintenance requests
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Drafts are only visible to you until you publish them. Published requests are shared with your property manager and household.
+            </p>
+          </div>
+
+          {isLoadingRequests ? (
+            <p className="text-sm text-muted-foreground">Loading your maintenance requests...</p>
+          ) : requests.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              You haven't created any maintenance requests yet. Save a draft to get started.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {requests.map((request) => {
+                const isOwner = userId === request.requested_by;
+                const isDraft = request.state === 'draft';
+                const isPublished = request.state === 'published';
+                const isPublishing = publishingRequestId === request.id;
+                const isUnpublishing = unpublishingRequestId === request.id;
+
+                return (
+                  <div
+                    key={request.id}
+                    className={cn(
+                      "space-y-3 rounded-lg border p-4",
+                      activeRequestId === request.id && "border-primary"
+                    )}
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-medium">{request.title}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Priority: {request.priority} • Status: {request.status}
+                        </p>
+                      </div>
+                      <Badge variant={isPublished ? 'default' : 'secondary'}>
+                        {isPublished ? 'Published' : 'Draft'}
+                      </Badge>
+                    </div>
+
+                    {request.description && (
+                      <p className="text-sm text-muted-foreground">{request.description}</p>
+                    )}
+
+                    <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                      {request.location && <span>Location: {request.location}</span>}
+                      {request.category && <span>Category: {request.category}</span>}
+                      <span>
+                        Version: v{request.version ?? request.versions[0]?.version ?? 1}
+                      </span>
+                    </div>
+
+                    {isOwner && (
+                      <div className="flex flex-wrap gap-2">
+                        {isDraft ? (
+                          <Button
+                            size="sm"
+                            onClick={() => handlePublish(request)}
+                            disabled={isPublishing}
+                          >
+                            {isPublishing ? 'Publishing...' : 'Publish request'}
+                          </Button>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleUnpublish(request)}
+                            disabled={isUnpublishing}
+                          >
+                            {isUnpublishing ? 'Reverting...' : 'Unpublish to edit'}
+                          </Button>
+                        )}
+                      </div>
+                    )}
+
+                    {request.versions.length > 0 && (
+                      <div className="space-y-2">
+                        <p className="text-xs font-semibold uppercase text-muted-foreground">
+                          Version history
+                        </p>
+                        <ul className="space-y-1">
+                          {request.versions.map((version) => (
+                            <li
+                              key={version.id}
+                              className="flex items-center justify-between text-xs text-muted-foreground"
+                            >
+                              <span>
+                                v{version.version} • {version.state}
+                              </span>
+                              <span>{formatVersionTimestamp(version)}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
           )}
-        />
-
-        <Button type="submit" disabled={isSubmitting} className="w-full">
-          {isSubmitting ? "Submitting..." : "Submit Maintenance Request"}
-        </Button>
-      </form>
+        </section>
+      </div>
     </Form>
   );
 }

--- a/lib/maintenance/requests.ts
+++ b/lib/maintenance/requests.ts
@@ -1,0 +1,247 @@
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
+import type { Database, Json } from '@/lib/supabase'
+
+type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>
+
+type MaintenanceRequestRow = Database['public']['Tables']['maintenance_requests']['Row']
+type MaintenanceRequestVersionRow = Database['public']['Tables']['maintenance_request_versions']['Row']
+
+export type MaintenanceRequestWithVersions = MaintenanceRequestRow & {
+  versions: MaintenanceRequestVersionRow[]
+}
+
+type MaintenanceRequestPayload = {
+  title: string
+  description: string
+  priority: MaintenanceRequestRow['priority']
+  category?: string | null
+  location?: string | null
+}
+
+type FetchMaintenanceRequestsParams = {
+  client: SupabaseClientLike
+  userId: string
+  unitId?: string | null
+}
+
+type CreateDraftParams = {
+  client: SupabaseClientLike
+  payload: MaintenanceRequestPayload
+  userId: string
+  unitId: string
+}
+
+type PublishParams = {
+  client: SupabaseClientLike
+  request: MaintenanceRequestRow
+  userId: string
+}
+
+type AppendVersionParams = {
+  client: SupabaseClientLike
+  request: MaintenanceRequestRow
+  userId: string
+  versionOverride?: number
+  publishedAt?: string | null
+}
+
+function normalizeSnapshot(request: MaintenanceRequestRow): Json {
+  return {
+    title: request.title,
+    description: request.description,
+    priority: request.priority,
+    status: request.status,
+    state: request.state,
+    category: request.category,
+    location: request.location,
+    requested_by: request.requested_by,
+    assigned_to: request.assigned_to,
+    unit_id: request.unit_id,
+    notes: request.notes,
+    attachments: request.attachments ?? [],
+    metadata: request.metadata ?? {},
+    version: request.version,
+  }
+}
+
+async function appendMaintenanceRequestVersion({
+  client,
+  request,
+  userId,
+  versionOverride,
+  publishedAt,
+}: AppendVersionParams) {
+  const version = versionOverride ?? request.version ?? 1
+  const payload = {
+    request_id: request.id,
+    version,
+    state: request.state,
+    status: request.status,
+    snapshot: normalizeSnapshot(request),
+    created_by: userId,
+    published_at: publishedAt ?? (request.state === 'published' ? new Date().toISOString() : null),
+  }
+
+  const { error } = await (client as any)
+    .from('maintenance_request_versions')
+    .insert(payload)
+
+  if (error) {
+    throw new Error(`Failed to append maintenance request version: ${error.message}`)
+  }
+}
+
+export async function fetchMaintenanceRequests({
+  client,
+  userId,
+  unitId,
+}: FetchMaintenanceRequestsParams): Promise<MaintenanceRequestWithVersions[]> {
+  let query = (client as any)
+    .from('maintenance_requests')
+    .select(`
+      *,
+      versions:maintenance_request_versions(
+        id,
+        request_id,
+        version,
+        state,
+        status,
+        snapshot,
+        created_at,
+        created_by,
+        published_at
+      )
+    `)
+
+  if (unitId) {
+    query = query.or(
+      [
+        `requested_by.eq.${userId}`,
+        `and(state.eq.published,unit_id.eq.${unitId})`,
+      ].join(',')
+    )
+  } else {
+    query = query.eq('requested_by', userId)
+  }
+
+  const { data, error } = await query.order('created_at', { ascending: false })
+
+  if (error) {
+    throw new Error(`Failed to fetch maintenance requests: ${error.message}`)
+  }
+
+  const requests = (data ?? []) as Array<MaintenanceRequestRow & { versions?: MaintenanceRequestVersionRow[] | null }>
+
+  return requests.map((request) => ({
+    ...request,
+    versions: (request.versions ?? [])
+      .filter((version): version is MaintenanceRequestVersionRow => Boolean(version))
+      .slice()
+      .sort((a, b) => b.version - a.version),
+  }))
+}
+
+export async function createMaintenanceRequestDraft({
+  client,
+  payload,
+  userId,
+  unitId,
+}: CreateDraftParams): Promise<MaintenanceRequestRow> {
+  const insertPayload = {
+    title: payload.title,
+    description: payload.description,
+    priority: payload.priority,
+    category: payload.category ?? null,
+    location: payload.location ?? null,
+    status: 'pending' as MaintenanceRequestRow['status'],
+    state: 'draft' as MaintenanceRequestRow['state'],
+    requested_by: userId,
+    unit_id: unitId,
+    version: 1,
+  }
+
+  const { data, error } = await (client as any)
+    .from('maintenance_requests')
+    .insert(insertPayload)
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    throw new Error(
+      `Failed to create maintenance request draft: ${error?.message ?? 'Unknown error'}`
+    )
+  }
+
+  const request = data as MaintenanceRequestRow
+  await appendMaintenanceRequestVersion({ client, request, userId, versionOverride: request.version ?? 1 })
+
+  return request
+}
+
+export async function publishMaintenanceRequest({
+  client,
+  request,
+  userId,
+}: PublishParams): Promise<MaintenanceRequestRow> {
+  const nextVersion = (request.version ?? 1) + 1
+
+  const { data, error } = await (client as any)
+    .from('maintenance_requests')
+    .update({
+      state: 'published',
+      version: nextVersion,
+    })
+    .eq('id', request.id)
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    throw new Error(`Failed to publish maintenance request: ${error?.message ?? 'Unknown error'}`)
+  }
+
+  const updatedRequest = data as MaintenanceRequestRow
+
+  await appendMaintenanceRequestVersion({
+    client,
+    request: updatedRequest,
+    userId,
+    versionOverride: updatedRequest.version ?? nextVersion,
+    publishedAt: new Date().toISOString(),
+  })
+
+  return updatedRequest
+}
+
+export async function unpublishMaintenanceRequest({
+  client,
+  request,
+  userId,
+}: PublishParams): Promise<MaintenanceRequestRow> {
+  const nextVersion = (request.version ?? 1) + 1
+
+  const { data, error } = await (client as any)
+    .from('maintenance_requests')
+    .update({
+      state: 'draft',
+      version: nextVersion,
+    })
+    .eq('id', request.id)
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    throw new Error(`Failed to unpublish maintenance request: ${error?.message ?? 'Unknown error'}`)
+  }
+
+  const updatedRequest = data as MaintenanceRequestRow
+
+  await appendMaintenanceRequestVersion({
+    client,
+    request: updatedRequest,
+    userId,
+    versionOverride: updatedRequest.version ?? nextVersion,
+    publishedAt: null,
+  })
+
+  return updatedRequest
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -185,6 +185,7 @@ export type Database = {
         description: string
         priority: 'low' | 'normal' | 'high' | 'urgent'
         status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+        state: 'draft' | 'published'
         category: string | null
         location: string | null
         requested_by: string
@@ -196,6 +197,18 @@ export type Database = {
         notes: string | null
         attachments: Json | null
         metadata: Json | null
+        version: number
+      }>
+      maintenance_request_versions: SupabaseTable<{
+        id: string
+        request_id: string
+        version: number
+        state: 'draft' | 'published'
+        status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+        snapshot: Json
+        created_at: string | null
+        created_by: string | null
+        published_at: string | null
       }>
       visitor_logs: SupabaseTable<{
         id: string

--- a/supabase/migrations/20250427_maintenance_versioning.sql
+++ b/supabase/migrations/20250427_maintenance_versioning.sql
@@ -1,0 +1,125 @@
+-- Add state/version columns and version history for maintenance requests
+ALTER TABLE public.maintenance_requests
+  ADD COLUMN state TEXT NOT NULL DEFAULT 'draft' CHECK (state IN ('draft', 'published')),
+  ADD COLUMN version INTEGER NOT NULL DEFAULT 1;
+
+-- Create version history table for maintenance requests
+CREATE TABLE public.maintenance_request_versions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  request_id UUID NOT NULL REFERENCES public.maintenance_requests(id) ON DELETE CASCADE,
+  version INTEGER NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('draft', 'published')),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'in_progress', 'completed', 'cancelled')),
+  snapshot JSONB NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  published_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE UNIQUE INDEX maintenance_request_versions_request_id_version_idx
+  ON public.maintenance_request_versions(request_id, version);
+CREATE INDEX maintenance_request_versions_request_id_idx
+  ON public.maintenance_request_versions(request_id);
+
+-- Backfill initial version entries for existing requests
+INSERT INTO public.maintenance_request_versions (
+  request_id,
+  version,
+  state,
+  status,
+  snapshot,
+  created_at,
+  created_by,
+  published_at
+)
+SELECT
+  r.id,
+  COALESCE(r.version, 1),
+  r.state,
+  r.status,
+  jsonb_build_object(
+    'title', r.title,
+    'description', r.description,
+    'priority', r.priority,
+    'status', r.status,
+    'state', r.state,
+    'category', r.category,
+    'location', r.location,
+    'requested_by', r.requested_by,
+    'assigned_to', r.assigned_to,
+    'unit_id', r.unit_id,
+    'notes', r.notes,
+    'attachments', COALESCE(r.attachments, '[]'::jsonb),
+    'metadata', COALESCE(r.metadata, '{}'::jsonb)
+  ),
+  COALESCE(r.created_at, NOW()),
+  r.requested_by,
+  CASE WHEN r.state = 'published' THEN COALESCE(r.updated_at, NOW()) ELSE NULL END
+FROM public.maintenance_requests r
+ON CONFLICT (request_id, version) DO NOTHING;
+
+-- Refresh RLS policy to ensure drafts remain private to their authors
+DROP POLICY IF EXISTS "Users can view maintenance requests for their unit" ON public.maintenance_requests;
+
+CREATE POLICY "Users can view maintenance requests"
+  ON public.maintenance_requests
+  FOR SELECT
+  USING (
+    requested_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+    OR (
+      state = 'published'
+      AND EXISTS (
+        SELECT 1 FROM public.profiles p1
+        JOIN public.profiles p2 ON p1.unit_id = p2.unit_id
+        WHERE p1.id = auth.uid() AND p2.id = maintenance_requests.requested_by
+      )
+    )
+  );
+
+ALTER TABLE public.maintenance_request_versions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view maintenance request versions"
+  ON public.maintenance_request_versions
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.maintenance_requests req
+      WHERE req.id = maintenance_request_versions.request_id
+        AND (
+          req.requested_by = auth.uid()
+          OR EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+          )
+          OR (
+            req.state = 'published'
+            AND EXISTS (
+              SELECT 1 FROM public.profiles p1
+              JOIN public.profiles p2 ON p1.unit_id = p2.unit_id
+              WHERE p1.id = auth.uid() AND p2.id = req.requested_by
+            )
+          )
+        )
+    )
+  );
+
+CREATE POLICY "Authors can insert maintenance request versions"
+  ON public.maintenance_request_versions
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.maintenance_requests req
+      WHERE req.id = maintenance_request_versions.request_id
+        AND (
+          req.requested_by = auth.uid()
+          OR EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+          )
+        )
+    )
+  );

--- a/tests/maintenance-requests.test.ts
+++ b/tests/maintenance-requests.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchMaintenanceRequests,
+  publishMaintenanceRequest,
+  type MaintenanceRequestWithVersions,
+} from '@/lib/maintenance/requests'
+
+type MaintenanceRequestRow = MaintenanceRequestWithVersions
+
+type QueryBuilder = {
+  select: ReturnType<typeof vi.fn>
+  or: ReturnType<typeof vi.fn>
+  eq: ReturnType<typeof vi.fn>
+  order: ReturnType<typeof vi.fn>
+}
+
+type SupabaseFetchStub = {
+  from: ReturnType<typeof vi.fn>
+  builder: QueryBuilder
+}
+
+type PublishSupabaseStub = {
+  supabase: { from: ReturnType<typeof vi.fn> }
+  getCurrentRequest: () => MaintenanceRequestRow
+  getInsertedVersions: () => any[]
+}
+
+function createFetchSupabaseStub(data: MaintenanceRequestRow[]): SupabaseFetchStub {
+  const builder: Partial<QueryBuilder> = {}
+
+  const promiseLike = {
+    then(onFulfilled: (value: { data: MaintenanceRequestRow[]; error: null }) => unknown) {
+      onFulfilled({ data, error: null })
+      return Promise.resolve({ data, error: null })
+    },
+    catch() {
+      return Promise.resolve({ data, error: null })
+    },
+    finally(onFinally?: () => unknown) {
+      onFinally?.()
+      return Promise.resolve()
+    },
+  }
+
+  builder.select = vi.fn(() => builder as QueryBuilder)
+  builder.or = vi.fn(() => builder as QueryBuilder)
+  builder.eq = vi.fn(() => builder as QueryBuilder)
+  builder.order = vi.fn(() => promiseLike)
+
+  const from = vi.fn(() => builder)
+
+  return { from, builder: builder as QueryBuilder }
+}
+
+function createPublishSupabaseStub(request: MaintenanceRequestRow): PublishSupabaseStub {
+  let currentRequest: MaintenanceRequestRow = { ...request }
+  const insertedVersions: any[] = []
+
+  const maintenanceRequestsBuilder = {
+    update: vi.fn((payload: Partial<MaintenanceRequestRow>) => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(async () => {
+            currentRequest = { ...currentRequest, ...payload }
+            return { data: currentRequest, error: null }
+          }),
+        })),
+      })),
+    })),
+  }
+
+  const versionsBuilder = {
+    insert: vi.fn(async (payload: any) => {
+      insertedVersions.push(payload)
+      return { data: null, error: null }
+    }),
+  }
+
+  const supabase = {
+    from: vi.fn((table: string) => {
+      if (table === 'maintenance_requests') {
+        return maintenanceRequestsBuilder
+      }
+
+      if (table === 'maintenance_request_versions') {
+        return versionsBuilder
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    }),
+  }
+
+  return {
+    supabase,
+    getCurrentRequest: () => currentRequest,
+    getInsertedVersions: () => insertedVersions,
+  }
+}
+
+describe('maintenance request data helpers', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('only includes drafts for the author while sharing published requests within a unit', async () => {
+    const sampleRequests: MaintenanceRequestRow[] = [
+      {
+        id: 'req-1',
+        title: 'Leaky faucet',
+        description: 'The kitchen faucet is leaking steadily.',
+        priority: 'normal',
+        status: 'pending',
+        state: 'draft',
+        category: null,
+        location: 'Kitchen',
+        requested_by: 'user-1',
+        assigned_to: null,
+        unit_id: 'unit-1',
+        created_at: new Date('2024-03-01T10:00:00Z').toISOString(),
+        updated_at: new Date('2024-03-01T10:00:00Z').toISOString(),
+        completed_at: null,
+        notes: null,
+        attachments: [],
+        metadata: {},
+        version: 1,
+        versions: [
+          {
+            id: 'ver-1',
+            request_id: 'req-1',
+            version: 1,
+            state: 'draft',
+            status: 'pending',
+            snapshot: {},
+            created_at: new Date('2024-03-01T10:00:00Z').toISOString(),
+            created_by: 'user-1',
+            published_at: null,
+          },
+          {
+            id: 'ver-2',
+            request_id: 'req-1',
+            version: 3,
+            state: 'published',
+            status: 'pending',
+            snapshot: {},
+            created_at: new Date('2024-03-02T10:00:00Z').toISOString(),
+            created_by: 'user-1',
+            published_at: new Date('2024-03-02T12:00:00Z').toISOString(),
+          },
+          {
+            id: 'ver-3',
+            request_id: 'req-1',
+            version: 2,
+            state: 'draft',
+            status: 'pending',
+            snapshot: {},
+            created_at: new Date('2024-03-01T18:00:00Z').toISOString(),
+            created_by: 'user-1',
+            published_at: null,
+          },
+        ],
+      },
+      {
+        id: 'req-2',
+        title: 'HVAC noise',
+        description: 'Loud rattling noise when the heater starts.',
+        priority: 'high',
+        status: 'pending',
+        state: 'published',
+        category: 'HVAC',
+        location: 'Hallway',
+        requested_by: 'user-2',
+        assigned_to: null,
+        unit_id: 'unit-1',
+        created_at: new Date('2024-02-15T09:00:00Z').toISOString(),
+        updated_at: new Date('2024-02-15T09:15:00Z').toISOString(),
+        completed_at: null,
+        notes: null,
+        attachments: [],
+        metadata: {},
+        version: 4,
+        versions: [
+          {
+            id: 'ver-4',
+            request_id: 'req-2',
+            version: 4,
+            state: 'published',
+            status: 'pending',
+            snapshot: {},
+            created_at: new Date('2024-02-15T09:15:00Z').toISOString(),
+            created_by: 'user-2',
+            published_at: new Date('2024-02-15T09:16:00Z').toISOString(),
+          },
+        ],
+      },
+    ]
+
+    const supabaseStub = createFetchSupabaseStub(sampleRequests)
+
+    const results = await fetchMaintenanceRequests({
+      client: supabaseStub as unknown as { from: SupabaseFetchStub['from'] },
+      userId: 'user-1',
+      unitId: 'unit-1',
+    })
+
+    expect(supabaseStub.builder.or).toHaveBeenCalledWith(
+      'requested_by.eq.user-1,and(state.eq.published,unit_id.eq.unit-1)'
+    )
+    expect(results).toHaveLength(2)
+    expect(results[0].versions.map((version) => version.version)).toEqual([3, 2, 1])
+    expect(results[1].versions.map((version) => version.version)).toEqual([4])
+  })
+
+  it('increments version history when publishing a request', async () => {
+    const request: MaintenanceRequestRow = {
+      id: 'req-1',
+      title: 'Fix broken window',
+      description: 'Window latch snapped during storm.',
+      priority: 'normal',
+      status: 'pending',
+      state: 'draft',
+      category: null,
+      location: 'Bedroom 2',
+      requested_by: 'user-1',
+      assigned_to: null,
+      unit_id: 'unit-1',
+      created_at: new Date('2024-01-10T11:00:00Z').toISOString(),
+      updated_at: new Date('2024-01-10T11:00:00Z').toISOString(),
+      completed_at: null,
+      notes: null,
+      attachments: [],
+      metadata: {},
+      version: 1,
+      versions: [],
+    }
+
+    const { supabase, getCurrentRequest, getInsertedVersions } = createPublishSupabaseStub(request)
+
+    const result = await publishMaintenanceRequest({
+      client: supabase as unknown as { from: PublishSupabaseStub['supabase']['from'] },
+      request,
+      userId: 'user-1',
+    })
+
+    expect(result.state).toBe('published')
+    expect(result.version).toBe(2)
+
+    const insertedVersions = getInsertedVersions()
+    expect(insertedVersions).toHaveLength(1)
+    expect(insertedVersions[0]).toMatchObject({
+      request_id: 'req-1',
+      version: 2,
+      state: 'published',
+      created_by: 'user-1',
+    })
+    expect(insertedVersions[0].published_at).toBeTruthy()
+
+    const updatedRequest = getCurrentRequest()
+    expect(updatedRequest.state).toBe('published')
+    expect(updatedRequest.version).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add a migration introducing state/version tracking and a version history table for maintenance requests with updated RLS
- implement typed helpers to create drafts, publish/unpublish, and fetch maintenance requests with version snapshots
- refresh the maintenance request form to save drafts by default, list accessible requests, and expose publish/unpublish controls with notifications
- cover the new behaviors with Vitest cases for visibility filtering and version increments

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30ba755d083289c32f1d4c1b24bfb