### PR TITLE
feat(documents): surface curated templates in upload flow

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -18,6 +18,7 @@ import {
   DocumentSigningRequest,
   DocumentStats,
   DocumentVersionSnapshot,
+  DocumentTemplate,
 } from '@/types/documents';
 import type { Database } from '@/lib/supabase';
 
@@ -30,6 +31,7 @@ const documentUploadSchema = z.object({
   unit_id: z.string().optional(),
   requires_signature: z.boolean().default(false),
   expires_at: z.string().datetime().optional(),
+  documenso_template_id: z.string().optional(),
 });
 
 const documentSigningSchema = z.object({
@@ -49,6 +51,104 @@ const documentListFiltersSchema = z.object({
   date_to: z.string().datetime().optional(),
 });
 
+const documentTemplatePrefillSchema = z
+  .object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    document_type: z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other']).optional(),
+    requires_signature: z.boolean().optional(),
+    documenso_template_id: z.string().optional(),
+    expires_at: z.string().optional(),
+    metadata: z.record(z.any()).optional(),
+  })
+  .partial();
+
+const documentTemplateRowSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().nullable().optional(),
+  document_type: z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other']),
+  documenso_template_id: z.string().nullable().optional(),
+  tags: z.array(z.string()).nullable().optional(),
+  recommended_for: z.string().nullable().optional(),
+  preview_url: z.string().url().nullable().optional(),
+  requires_signature: z.boolean().nullable().optional(),
+  metadata: z.record(z.any()).nullable().optional(),
+  prefill_data: z.record(z.any()).nullable().optional(),
+  auto_create_draft: z.boolean().nullable().optional(),
+  source: z.enum(['supabase', 'documenso']).nullable().optional(),
+  updated_at: z.string().nullable().optional(),
+});
+
+const createDraftFromTemplateSchema = z.object({
+  template_id: z.string(),
+  title: z.string().min(1, 'Template title is required'),
+  description: z.string().optional(),
+  document_type: z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other']),
+  requires_signature: z.boolean().default(true),
+  documenso_template_id: z.string().optional(),
+  metadata: z.record(z.any()).optional(),
+  source: z.enum(['supabase', 'documenso']).optional(),
+});
+
+const curatedDocumensoTemplates: DocumentTemplate[] = [
+  {
+    id: 'documenso-standard-lease',
+    title: 'Standard Residential Lease',
+    description: 'Comprehensive lease agreement covering rent, utilities, and roommate expectations.',
+    document_type: 'lease',
+    source: 'documenso',
+    documenso_template_id: 'tmpl_standard_lease',
+    tags: ['Lease', 'Documenso'],
+    recommended_for: 'full-unit lease agreements',
+    requires_signature: true,
+    metadata: {
+      placeholders: ['tenant_name', 'unit_number', 'rent_amount'],
+    },
+    prefill: {
+      title: 'Residential Lease Agreement',
+      description: 'Documenso standard lease template with signature fields for every roommate.',
+      requires_signature: true,
+      documenso_template_id: 'tmpl_standard_lease',
+    },
+    autoCreateDraft: true,
+  },
+  {
+    id: 'documenso-pet-addendum',
+    title: 'Pet Policy Addendum',
+    description: 'Document to outline approved pets, deposits, and roommate responsibilities.',
+    document_type: 'addendum',
+    source: 'documenso',
+    documenso_template_id: 'tmpl_pet_addendum',
+    tags: ['Addendum', 'Pets'],
+    recommended_for: 'pet permission agreements',
+    requires_signature: true,
+    prefill: {
+      title: 'Pet Policy Addendum',
+      description: 'Adds specific pet terms to an existing lease.',
+      requires_signature: true,
+      documenso_template_id: 'tmpl_pet_addendum',
+    },
+    autoCreateDraft: false,
+  },
+  {
+    id: 'documenso-maintenance-authorization',
+    title: 'Maintenance Work Authorization',
+    description: 'Authorize maintenance visits and outline access windows for roommates.',
+    document_type: 'maintenance',
+    source: 'documenso',
+    tags: ['Maintenance', 'Authorization'],
+    recommended_for: 'scheduled maintenance visits',
+    requires_signature: false,
+    prefill: {
+      title: 'Maintenance Work Authorization',
+      description: 'Details scope of work, schedule, and notification requirements.',
+      requires_signature: false,
+    },
+    autoCreateDraft: false,
+  },
+];
+
 // Action result interface
 interface ActionResult<T = any> {
   success: boolean;
@@ -58,6 +158,119 @@ interface ActionResult<T = any> {
 }
 
 type DocumentRow = Database['public']['Tables']['documents']['Row'];
+type DocumentTemplateRow = z.infer<typeof documentTemplateRowSchema>;
+type CreateDraftFromTemplateInput = z.infer<typeof createDraftFromTemplateSchema>;
+
+function normalizeDocumentTemplateRow(row: DocumentTemplateRow): DocumentTemplate {
+  const tags = Array.isArray(row.tags)
+    ? row.tags.filter((tag): tag is string => typeof tag === 'string' && tag.trim().length > 0)
+    : [];
+
+  const prefillResult = documentTemplatePrefillSchema.safeParse(row.prefill_data ?? {});
+  const metadataRecord = row.metadata && typeof row.metadata === 'object' ? (row.metadata as Record<string, any>) : undefined;
+
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description ?? undefined,
+    document_type: row.document_type,
+    source: row.source ?? 'supabase',
+    documenso_template_id: row.documenso_template_id ?? undefined,
+    tags,
+    recommended_for: row.recommended_for ?? undefined,
+    preview_url: row.preview_url ?? undefined,
+    requires_signature: row.requires_signature ?? undefined,
+    metadata: metadataRecord ?? undefined,
+    prefill: prefillResult.success ? prefillResult.data : undefined,
+    autoCreateDraft: row.auto_create_draft ?? undefined,
+    updated_at: row.updated_at ?? undefined,
+  };
+}
+
+function mergeTemplateCollections(
+  ...collections: DocumentTemplate[][]
+): DocumentTemplate[] {
+  const merged = new Map<string, DocumentTemplate>();
+
+  for (const collection of collections) {
+    for (const template of collection) {
+      merged.set(template.id, template);
+    }
+  }
+
+  return Array.from(merged.values()).sort((a, b) => {
+    const aTime = a.updated_at ? new Date(a.updated_at).getTime() : 0;
+    const bTime = b.updated_at ? new Date(b.updated_at).getTime() : 0;
+
+    if (aTime !== bTime) {
+      return bTime - aTime;
+    }
+
+    return a.title.localeCompare(b.title);
+  });
+}
+
+async function fetchSupabaseDocumentTemplates(
+  supabase: TypedSupabaseClient,
+): Promise<DocumentTemplate[]> {
+  try {
+    const { data, error } = await (supabase as any)
+      .from('document_templates')
+      .select('*');
+
+    if (error) {
+      console.warn('Error fetching document templates from Supabase:', error);
+      return [];
+    }
+
+    return (data ?? [])
+      .map((row: unknown) => {
+        const parsed = documentTemplateRowSchema.safeParse(row);
+
+        if (!parsed.success) {
+          console.warn('Skipping invalid document template row', parsed.error);
+          return null;
+        }
+
+        return normalizeDocumentTemplateRow(parsed.data);
+      })
+      .filter((template): template is DocumentTemplate => Boolean(template));
+  } catch (error) {
+    console.warn('Document templates table unavailable', error);
+    return [];
+  }
+}
+
+export async function getDocumentTemplatesAction(): Promise<ActionResult<DocumentTemplate[]>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return {
+        success: false,
+        error: 'You must be logged in to view templates.',
+      };
+    }
+
+    const supabaseTemplates = await fetchSupabaseDocumentTemplates(typedSupabase);
+    const templates = mergeTemplateCollections(supabaseTemplates, curatedDocumensoTemplates);
+
+    return {
+      success: true,
+      data: templates,
+    };
+  } catch (error) {
+    console.error('Unexpected error in getDocumentTemplatesAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to load document templates.',
+    };
+  }
+}
 
 function buildVersionSnapshot(document: DocumentRow): DocumentVersionSnapshot {
   return {
@@ -267,6 +480,7 @@ export async function uploadDocumentAction(
         unit_id: validatedData.unit_id,
         requires_signature: validatedData.requires_signature,
         expires_at: validatedData.expires_at,
+        documenso_template_id: validatedData.documenso_template_id ?? null,
         created_by: user.id,
         state: 'draft',
         published_at: null,
@@ -304,6 +518,102 @@ export async function uploadDocumentAction(
     return {
       success: false,
       error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+    };
+  }
+}
+
+export async function createDocumentDraftFromTemplateAction(
+  input: CreateDraftFromTemplateInput
+): Promise<ActionResult<Document>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return {
+        success: false,
+        error: 'You must be logged in to create documents.',
+      };
+    }
+
+    const validatedData = createDraftFromTemplateSchema.parse(input);
+
+    const metadataPayload: Record<string, any> = {
+      ...(validatedData.metadata ?? {}),
+      template_id: validatedData.template_id,
+    };
+
+    if (validatedData.source) {
+      metadataPayload.template_source = validatedData.source;
+    }
+
+    const { data: document, error: dbError } = await (supabase as any)
+      .from('documents')
+      .insert({
+        title: validatedData.title,
+        description: validatedData.description ?? null,
+        document_type: validatedData.document_type,
+        status: 'draft',
+        state: 'draft',
+        requires_signature: validatedData.requires_signature,
+        documenso_template_id: validatedData.documenso_template_id ?? null,
+        metadata: metadataPayload,
+        created_by: user.id,
+        published_at: null,
+      })
+      .select()
+      .single();
+
+    if (dbError) {
+      console.error('Error creating document draft from template:', dbError);
+      return {
+        success: false,
+        error: 'Failed to create document draft from template.',
+      };
+    }
+
+    try {
+      await insertDocumentVersion(typedSupabase, document as DocumentRow, user.id);
+    } catch (versionError) {
+      console.error('Error creating initial document version for template draft:', versionError);
+      await (supabase as any).from('documents').delete().eq('id', document.id);
+      return {
+        success: false,
+        error: 'Failed to create document draft from template.',
+      };
+    }
+
+    await (supabase as any)
+      .rpc('log_document_access', {
+        p_document_id: document.id,
+        p_action: 'template_draft',
+        p_metadata: {
+          template_id: validatedData.template_id,
+          template_source: validatedData.source ?? 'unknown',
+        },
+      })
+      .catch((error: unknown) => {
+        console.warn('Failed to log template draft creation', error);
+      });
+
+    revalidatePath('/documents');
+
+    return {
+      success: true,
+      data: document as Document,
+      message: 'Document draft created from template.',
+    };
+  } catch (error) {
+    console.error('Unexpected error in createDocumentDraftFromTemplateAction:', error);
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Failed to create document draft from template.',
     };
   }
 }

--- a/app/documents/components/document-template-gallery.tsx
+++ b/app/documents/components/document-template-gallery.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { Sparkles, FileText } from 'lucide-react';
+
+import { getDocumentTemplatesAction } from '../actions';
+import type { DocumentTemplate } from '@/types/documents';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+type DocumentTemplateGalleryProps = {
+  onTemplateSelect: (templateId: string) => void;
+  selectedTemplateId?: string | null;
+  disabled?: boolean;
+  onTemplatesLoaded?: (templates: DocumentTemplate[]) => void;
+  className?: string;
+};
+
+export function DocumentTemplateGallery({
+  onTemplateSelect,
+  selectedTemplateId,
+  disabled = false,
+  onTemplatesLoaded,
+  className,
+}: DocumentTemplateGalleryProps) {
+  const [templates, setTemplates] = useState<DocumentTemplate[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    startTransition(() => {
+      getDocumentTemplatesAction()
+        .then((result) => {
+          if (!isMounted) {
+            return;
+          }
+
+          if (result.success && Array.isArray(result.data)) {
+            setTemplates(result.data);
+            setError(null);
+            onTemplatesLoaded?.(result.data);
+          } else {
+            setTemplates([]);
+            setError(result.error ?? 'Unable to load document templates.');
+            onTemplatesLoaded?.([]);
+          }
+        })
+        .catch((err) => {
+          if (!isMounted) {
+            return;
+          }
+
+          console.error('Failed to load document templates', err);
+          setTemplates([]);
+          setError('Unable to load document templates.');
+          onTemplatesLoaded?.([]);
+        });
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [startTransition, onTemplatesLoaded]);
+
+  const loading = isPending && templates.length === 0;
+  const isEmpty = !loading && templates.length === 0 && !error;
+
+  return (
+    <section className={cn('space-y-3', className)} aria-label="Document templates">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="flex items-center gap-1 text-sm font-medium text-foreground">
+            <Sparkles className="size-4 text-primary" />
+            Start from a template
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Reuse curated Documenso and Supabase templates to move faster.
+          </p>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div
+              key={`template-skeleton-${index}`}
+              className="h-32 animate-pulse rounded-xl border border-dashed border-muted bg-muted/40"
+            />
+          ))}
+        </div>
+      ) : isEmpty ? (
+        <p className="text-sm text-muted-foreground">
+          No templates available yet. Upload a document to create your first template.
+        </p>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {templates.map((template) => {
+            const isSelected = selectedTemplateId === template.id;
+            const tags = template.tags?.length ? template.tags : [];
+
+            return (
+              <button
+                key={template.id}
+                type="button"
+                onClick={() => onTemplateSelect(template.id)}
+                disabled={disabled}
+                className="text-left"
+                aria-pressed={isSelected}
+              >
+                <Card
+                  className={cn(
+                    'h-full transition-all',
+                    disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:border-primary/40 hover:shadow-sm',
+                    isSelected ? 'border-primary shadow-sm ring-2 ring-primary/40' : 'border-muted'
+                  )}
+                >
+                  <CardHeader className="space-y-3 pb-4">
+                    <div className="flex items-center justify-between gap-2">
+                      <CardTitle className="flex items-center gap-2 text-base">
+                        <FileText className="size-4 text-muted-foreground" />
+                        {template.title}
+                      </CardTitle>
+                      <Badge variant="outline" className="uppercase tracking-wide text-[10px]">
+                        {template.source}
+                      </Badge>
+                    </div>
+                    <CardDescription className="line-clamp-3">
+                      {template.description ?? 'Reusable document template.'}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="flex flex-col gap-2 pb-4">
+                    <div className="text-xs font-medium text-muted-foreground">
+                      Type: <span className="capitalize text-foreground">{template.document_type}</span>
+                    </div>
+                    {template.recommended_for ? (
+                      <div className="text-xs text-muted-foreground">
+                        Ideal for {template.recommended_for}
+                      </div>
+                    ) : null}
+                    {tags.length > 0 ? (
+                      <div className="flex flex-wrap gap-1 pt-1">
+                        {tags.map((tag) => (
+                          <Badge key={tag} variant="secondary" className="text-[10px]">
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : null}
+                    {template.autoCreateDraft ? (
+                      <div className="text-xs font-medium text-primary">
+                        Selecting this template will create a draft automatically.
+                      </div>
+                    ) : (
+                      <div className="text-xs text-muted-foreground">
+                        Selecting this template will prefill the upload form.
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/documents/components/template-helpers.ts
+++ b/app/documents/components/template-helpers.ts
@@ -1,0 +1,115 @@
+import type { DocumentTemplate } from '@/types/documents';
+import type { DocumentType } from '@/types/documents';
+
+type MetadataRecord = Record<string, any>;
+
+export interface UploadDocumentFormState {
+  title: string;
+  description: string;
+  document_type: DocumentType;
+  tenant_id: string;
+  unit_id: string;
+  requires_signature: boolean;
+  expires_at: string;
+  documenso_template_id: string;
+}
+
+export const createEmptyUploadDocumentFormState = (): UploadDocumentFormState => ({
+  title: '',
+  description: '',
+  document_type: 'other',
+  tenant_id: '',
+  unit_id: '',
+  requires_signature: false,
+  expires_at: '',
+  documenso_template_id: '',
+});
+
+export function resolveTemplateSelection(
+  templates: DocumentTemplate[],
+  templateId: string,
+): DocumentTemplate {
+  if (!templateId) {
+    throw new Error('Template id is required');
+  }
+
+  const template = templates.find((item) => item.id === templateId);
+
+  if (!template) {
+    throw new Error(`Template '${templateId}' not found`);
+  }
+
+  return template;
+}
+
+export function applyTemplateToFormState({
+  template,
+  currentForm,
+}: {
+  template: DocumentTemplate;
+  currentForm: UploadDocumentFormState;
+}): UploadDocumentFormState {
+  const prefill = template.prefill ?? {};
+  const requiresSignature =
+    typeof prefill.requires_signature === 'boolean'
+      ? prefill.requires_signature
+      : typeof template.requires_signature === 'boolean'
+        ? template.requires_signature
+        : currentForm.requires_signature;
+
+  return {
+    ...currentForm,
+    title: prefill.title ?? template.title ?? currentForm.title,
+    description: prefill.description ?? template.description ?? currentForm.description,
+    document_type: prefill.document_type ?? template.document_type ?? currentForm.document_type,
+    requires_signature: requiresSignature,
+    expires_at: prefill.expires_at ?? currentForm.expires_at,
+    documenso_template_id:
+      prefill.documenso_template_id ??
+      template.documenso_template_id ??
+      currentForm.documenso_template_id ??
+      '',
+  };
+}
+
+export interface DraftFromTemplatePayload {
+  template_id: string;
+  title: string;
+  description?: string;
+  document_type: DocumentType;
+  requires_signature: boolean;
+  documenso_template_id?: string;
+  metadata?: MetadataRecord;
+  source?: DocumentTemplate['source'];
+}
+
+export function buildDraftPayloadFromTemplate(
+  template: DocumentTemplate,
+): DraftFromTemplatePayload {
+  const prefill = template.prefill ?? {};
+  const metadata: MetadataRecord = {
+    ...(template.metadata ?? {}),
+    ...(prefill.metadata ?? {}),
+  };
+
+  const documensoTemplateId =
+    prefill.documenso_template_id ?? template.documenso_template_id ?? undefined;
+
+  const requiresSignature =
+    typeof prefill.requires_signature === 'boolean'
+      ? prefill.requires_signature
+      : typeof template.requires_signature === 'boolean'
+        ? template.requires_signature
+        : true;
+
+  return {
+    template_id: template.id,
+    title: prefill.title ?? template.title,
+    description: prefill.description ?? template.description ?? '',
+    document_type: prefill.document_type ?? template.document_type,
+    requires_signature: requiresSignature,
+    documenso_template_id: documensoTemplateId,
+    metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+    source: template.source,
+  };
+}

--- a/app/documents/components/upload-document-dialog.tsx
+++ b/app/documents/components/upload-document-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from "@/components/ui/button";
 import {
@@ -23,31 +23,106 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
-import { uploadDocumentAction } from '../actions';
+import { uploadDocumentAction, createDocumentDraftFromTemplateAction } from '../actions';
 import { useDocumentPermissions } from '@/hooks/use-document-permissions';
 import { Upload, FileText } from 'lucide-react';
 import { toast } from 'sonner';
+import { DocumentTemplateGallery } from './document-template-gallery';
+import {
+  applyTemplateToFormState,
+  buildDraftPayloadFromTemplate,
+  createEmptyUploadDocumentFormState,
+  resolveTemplateSelection,
+  type UploadDocumentFormState,
+} from './template-helpers';
+import type { DocumentTemplate } from '@/types/documents';
 
 export function UploadDocumentDialog() {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [formData, setFormData] = useState({
-    title: '',
-    description: '',
-    document_type: 'other' as const,
-    tenant_id: '',
-    unit_id: '',
-    requires_signature: false,
-    expires_at: '',
-  });
+  const [formData, setFormData] = useState<UploadDocumentFormState>(
+    () => createEmptyUploadDocumentFormState()
+  );
   const [file, setFile] = useState<File | null>(null);
+  const [templates, setTemplates] = useState<DocumentTemplate[]>([]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
   const router = useRouter();
   const permissions = useDocumentPermissions();
+
+  const handleDialogOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+
+    if (!nextOpen) {
+      setFormData(createEmptyUploadDocumentFormState());
+      setSelectedTemplateId(null);
+      setFile(null);
+    }
+  }, []);
+
+  const handleTemplatesLoaded = useCallback((items: DocumentTemplate[]) => {
+    setTemplates(items);
+  }, []);
+
+  const selectedTemplate = useMemo(() => {
+    if (!selectedTemplateId) {
+      return null;
+    }
+
+    return templates.find((template) => template.id === selectedTemplateId) ?? null;
+  }, [selectedTemplateId, templates]);
 
   // Don't render upload button if user doesn't have permission
   if (!permissions.canUploadDocuments) {
     return null;
   }
+
+  const handleTemplateSelect = async (templateId: string) => {
+    let shouldResetLoading = false;
+
+    try {
+      const template = resolveTemplateSelection(templates, templateId);
+
+      if (template.autoCreateDraft) {
+        shouldResetLoading = true;
+        setLoading(true);
+
+        const payload = buildDraftPayloadFromTemplate(template);
+
+        try {
+          const result = await createDocumentDraftFromTemplateAction(payload);
+
+          if (result.success) {
+            toast.success('Draft created from template');
+            handleDialogOpenChange(false);
+            router.refresh();
+          } else {
+            toast.error(result.error ?? 'Failed to create draft from template');
+          }
+        } catch (error) {
+          console.error('Failed to create draft from template', error);
+          toast.error('Unable to create draft from the selected template');
+        }
+
+        return;
+      }
+
+      const nextForm = applyTemplateToFormState({
+        template,
+        currentForm: formData,
+      });
+
+      setFormData(nextForm);
+      setSelectedTemplateId(templateId);
+      toast.success(`Applied "${template.title}" template`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to apply template';
+      toast.error(message);
+    } finally {
+      if (shouldResetLoading) {
+        setLoading(false);
+      }
+    }
+  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
@@ -101,22 +176,15 @@ export function UploadDocumentDialog() {
       submitData.append('unit_id', formData.unit_id);
       submitData.append('requires_signature', formData.requires_signature.toString());
       submitData.append('expires_at', formData.expires_at);
+      if (formData.documenso_template_id) {
+        submitData.append('documenso_template_id', formData.documenso_template_id);
+      }
 
       const result = await uploadDocumentAction(submitData);
 
       if (result.success) {
         toast.success('Document uploaded successfully');
-        setOpen(false);
-        setFormData({
-          title: '',
-          description: '',
-          document_type: 'other',
-          tenant_id: '',
-          unit_id: '',
-          requires_signature: false,
-          expires_at: '',
-        });
-        setFile(null);
+        handleDialogOpenChange(false);
         router.refresh();
       } else {
         toast.error(result.error || 'Failed to upload document');
@@ -130,7 +198,7 @@ export function UploadDocumentDialog() {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogTrigger asChild>
         <Button>
           <Upload className="mr-2 size-4" />
@@ -146,6 +214,19 @@ export function UploadDocumentDialog() {
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          <DocumentTemplateGallery
+            disabled={loading}
+            selectedTemplateId={selectedTemplateId}
+            onTemplateSelect={handleTemplateSelect}
+            onTemplatesLoaded={handleTemplatesLoaded}
+          />
+
+          {selectedTemplate ? (
+            <div className="rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs text-primary">
+              Prefilling from "{selectedTemplate.title}". You can adjust the fields before uploading.
+            </div>
+          ) : null}
+
           {/* File Upload */}
           <div className="space-y-2">
             <Label htmlFor="file">Document File</Label>
@@ -247,7 +328,7 @@ export function UploadDocumentDialog() {
             <Button
               type="button"
               variant="outline"
-              onClick={() => setOpen(false)}
+              onClick={() => handleDialogOpenChange(false)}
               disabled={loading}
             >
               Cancel

--- a/tests/document-templates.test.ts
+++ b/tests/document-templates.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyTemplateToFormState,
+  buildDraftPayloadFromTemplate,
+  createEmptyUploadDocumentFormState,
+  resolveTemplateSelection,
+} from '@/app/documents/components/template-helpers';
+import type { DocumentTemplate } from '@/types/documents';
+
+const templates: DocumentTemplate[] = [
+  {
+    id: 'tmpl-lease',
+    title: 'Lease Template',
+    description: 'A reusable lease agreement',
+    document_type: 'lease',
+    source: 'documenso',
+    documenso_template_id: 'doc-lease-001',
+    tags: ['Lease', 'Documenso'],
+    requires_signature: true,
+    metadata: { base: 'value' },
+    prefill: {
+      title: 'Residential Lease Agreement',
+      description: 'Prefilled lease draft',
+      requires_signature: true,
+      documenso_template_id: 'doc-lease-001',
+      metadata: { extra: 'field' },
+    },
+    autoCreateDraft: true,
+  },
+  {
+    id: 'tmpl-maintenance',
+    title: 'Maintenance Authorization',
+    description: 'Consent for scheduled maintenance visits',
+    document_type: 'maintenance',
+    source: 'supabase',
+    tags: ['Maintenance'],
+    requires_signature: false,
+  },
+];
+
+describe('document template selection', () => {
+  it('applies template prefill to upload form state', () => {
+    const currentForm = createEmptyUploadDocumentFormState();
+    const template = templates[0];
+
+    const result = applyTemplateToFormState({ template, currentForm });
+
+    expect(result.title).toBe(template.prefill?.title);
+    expect(result.description).toBe(template.prefill?.description);
+    expect(result.document_type).toBe('lease');
+    expect(result.requires_signature).toBe(true);
+    expect(result.documenso_template_id).toBe(template.prefill?.documenso_template_id);
+    expect(result.expires_at).toBe(currentForm.expires_at);
+  });
+
+  it('throws when a template id does not exist', () => {
+    expect(() => resolveTemplateSelection(templates, 'missing-template')).toThrow(
+      "Template 'missing-template' not found",
+    );
+  });
+
+  it('builds a draft payload with merged metadata', () => {
+    const payload = buildDraftPayloadFromTemplate(templates[0]);
+
+    expect(payload.template_id).toBe('tmpl-lease');
+    expect(payload.documenso_template_id).toBe('doc-lease-001');
+    expect(payload.metadata).toMatchObject({ base: 'value', extra: 'field' });
+    expect(payload.requires_signature).toBe(true);
+  });
+});

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -159,3 +159,32 @@ export interface DocumentStats {
   expired_documents: number;
   draft_documents: number;
 }
+
+export type DocumentTemplateSource = 'supabase' | 'documenso';
+
+export interface DocumentTemplatePrefill {
+  title?: string;
+  description?: string;
+  document_type?: DocumentType;
+  requires_signature?: boolean;
+  documenso_template_id?: string;
+  expires_at?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface DocumentTemplate {
+  id: string;
+  title: string;
+  description?: string | null;
+  document_type: DocumentType;
+  source: DocumentTemplateSource;
+  documenso_template_id?: string | null;
+  tags: string[];
+  updated_at?: string | null;
+  recommended_for?: string | null;
+  preview_url?: string | null;
+  requires_signature?: boolean | null;
+  metadata?: Record<string, any>;
+  prefill?: DocumentTemplatePrefill;
+  autoCreateDraft?: boolean;
+}


### PR DESCRIPTION
## Summary
- add document template typing plus curated Documenso defaults and Supabase fetch helpers
- build a DocumentTemplateGallery component and integrate it into the document upload flow with draft creation support
- extend document actions to handle template-aware uploads and cover selection logic with new vitest specs

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30ba84c908328b05872cdeb692f47