### PR TITLE
Add messaging link previews using Open Graph metadata

### DIFF
--- a/app/messaging/actions.ts
+++ b/app/messaging/actions.ts
@@ -1,0 +1,32 @@
+"use server"
+
+import { buildFallbackPreview, buildPreviewFromMetadata, rememberLinkPreview } from "@/lib/messaging/link-previews"
+
+const PREVIEW_USER_AGENT =
+  "ShareHousePortal/1.0 (+https://share-house.example.com; link-preview-fetcher)"
+
+export async function fetchLinkPreview(url: string) {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": PREVIEW_USER_AGENT,
+        Accept: "text/html,application/xhtml+xml",
+      },
+      cache: "no-store",
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to load Open Graph metadata (status ${response.status})`)
+    }
+
+    const html = await response.text()
+    const preview = buildPreviewFromMetadata(url, html)
+
+    rememberLinkPreview(preview)
+    return preview
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : "Unknown error"
+    return buildFallbackPreview(url, reason)
+  }
+}
+

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,4 +1,5 @@
 import ModerationControls from "@/components/messaging/moderation-controls"
+import { LinkPreviewCard } from "@/components/messaging/link-preview-card"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -12,8 +13,11 @@ import {
 import { Progress } from "@/components/ui/progress"
 
 import { Separator } from "@/components/ui/separator"
+import { createFallbackPreview, extractUrlsFromText, getLinkPreview } from "@/lib/messaging/link-previews"
+import { ensureMessagingPreviewsSeeded } from "@/lib/messaging/preview-fixtures"
 import { cn } from "@/lib/utils"
 import { Paperclip } from "lucide-react"
+import { Fragment, type ReactNode } from "react"
 
 type ThreadListItem = {
   id: string
@@ -86,6 +90,8 @@ type PollSnapshot = {
   votes: number
   progress: number
 }
+
+ensureMessagingPreviewsSeeded()
 
 const threadFilters = [
   { label: "All topics", active: true },
@@ -171,6 +177,7 @@ const threadPosts: ThreadPost[] = [
     content: [
       "Kicking off the Q2 chore rotation thread so we can stay ahead of the spring deep clean.",
       "Please vote in the poll for when we should tackle the deep clean together. I added the updated checklist and rotation calendar so everyone can review before voting.",
+      "You can review the rotation doc here: https://househandbook.example.com/checklists/spring-deep-clean before you vote.",
     ],
     attachments: [
       {
@@ -214,6 +221,7 @@ const threadPosts: ThreadPost[] = [
     content: [
       "Looks good to me. I left a couple of notes in the sheet about trading weekends because of my travel schedule.",
       "If we go with the Saturday 10 AM block, I can take recycling duty during the week so Sunday stays open.",
+      "Heads up that the installer scheduling board lives at https://communitywifi.example.com/installer-tracker if you need to request a different appointment.",
     ],
     attachments: [
       {
@@ -301,6 +309,47 @@ const pollSnapshots: PollSnapshot[] = [
     progress: 75,
   },
 ]
+
+function renderLinkifiedText(text: string) {
+  const elements: ReactNode[] = []
+  const pattern = /(https?:\/\/[^\s]+)/g
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      elements.push(<Fragment key={`text-${lastIndex}`}>{text.slice(lastIndex, match.index)}</Fragment>)
+    }
+
+    const rawUrl = match[0]
+    const trimmedUrl = rawUrl.replace(/[),.!?:;]+$/, "")
+    const trailing = rawUrl.slice(trimmedUrl.length)
+
+    elements.push(
+      <a
+        key={`link-${match.index}`}
+        href={trimmedUrl}
+        className="text-primary underline underline-offset-4"
+        target="_blank"
+        rel="noreferrer"
+      >
+        {trimmedUrl}
+      </a>
+    )
+
+    if (trailing) {
+      elements.push(<Fragment key={`trail-${match.index}`}>{trailing}</Fragment>)
+    }
+
+    lastIndex = match.index + rawUrl.length
+  }
+
+  if (lastIndex < text.length) {
+    elements.push(<Fragment key={`text-${lastIndex}`}>{text.slice(lastIndex)}</Fragment>)
+  }
+
+  return elements
+}
 
 export default function MessagingPage() {
   return (
@@ -463,12 +512,25 @@ export default function MessagingPage() {
                       </div>
                     </div>
 
-                    <div className="space-y-3 text-sm leading-6 text-foreground">
-                      {post.content.map((paragraph, idx) => (
-                        <p key={`${post.id}-content-${idx}`} className="text-muted-foreground">
-                          {paragraph}
-                        </p>
-                      ))}
+                    <div className="space-y-4 text-sm leading-6 text-foreground">
+                      {post.content.map((paragraph, idx) => {
+                        const urls = extractUrlsFromText(paragraph)
+                        const previews = urls.map((url) =>
+                          getLinkPreview(url) ?? createFallbackPreview(url, "Preview will load once fetched.")
+                        )
+
+                        return (
+                          <div key={`${post.id}-content-${idx}`} className="space-y-3">
+                            <p className="text-muted-foreground">{renderLinkifiedText(paragraph)}</p>
+                            {previews.map((preview, previewIndex) => (
+                              <LinkPreviewCard
+                                key={`${post.id}-preview-${idx}-${previewIndex}`}
+                                preview={preview}
+                              />
+                            ))}
+                          </div>
+                        )
+                      })}
                     </div>
 
                     {post.attachments?.length ? (

--- a/components/messaging/link-preview-card.tsx
+++ b/components/messaging/link-preview-card.tsx
@@ -1,0 +1,67 @@
+import { ExternalLink } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { LinkPreview, safeHostname } from "@/lib/messaging/link-previews"
+
+type LinkPreviewCardProps = {
+  preview: LinkPreview
+}
+
+export function LinkPreviewCard({ preview }: LinkPreviewCardProps) {
+  const host = safeHostname(preview.canonicalUrl || preview.url)
+  const hostInitial = host.charAt(0).toUpperCase()
+  const description =
+    preview.description ?? (preview.status === "error" ? "Preview unavailable — open link to view." : undefined)
+
+  return (
+    <a
+      href={preview.canonicalUrl || preview.url}
+      target="_blank"
+      rel="noreferrer"
+      className={cn(
+        "flex w-full overflow-hidden rounded-lg border bg-background transition",
+        preview.status === "error"
+          ? "border-dashed border-border/70 hover:border-border"
+          : "border-border/70 hover:border-primary/50 hover:shadow-sm"
+      )}
+      data-testid="link-preview-card"
+    >
+      <div className="flex flex-1 flex-col justify-between gap-4 p-4">
+        <div className="flex items-center gap-3">
+          {preview.favicon ? (
+            <img
+              src={preview.favicon}
+              alt={`${host} favicon`}
+              width={24}
+              height={24}
+              className="size-6 rounded"
+            />
+          ) : (
+            <div className="flex size-6 items-center justify-center rounded bg-muted text-xs font-semibold uppercase text-muted-foreground">
+              {hostInitial || "?"}
+            </div>
+          )}
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-foreground">{preview.title ?? host}</p>
+            <p className="truncate text-xs text-muted-foreground">{preview.siteName ?? host}</p>
+          </div>
+          <ExternalLink className="ml-auto size-4 shrink-0 text-muted-foreground" aria-hidden />
+        </div>
+        {description ? (
+          <p className="line-clamp-3 text-sm text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      {preview.image ? (
+        <div className="relative hidden h-full w-36 flex-none overflow-hidden sm:block">
+          <img
+            src={preview.image}
+            alt={preview.title ?? preview.siteName ?? host}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        </div>
+      ) : null}
+    </a>
+  )
+}
+

--- a/lib/messaging/link-previews.ts
+++ b/lib/messaging/link-previews.ts
@@ -1,0 +1,225 @@
+export type LinkPreviewStatus = "ready" | "error"
+
+export type LinkPreview = {
+  url: string
+  canonicalUrl: string
+  title?: string
+  description?: string
+  image?: string
+  favicon?: string
+  siteName?: string
+  status: LinkPreviewStatus
+  fetchedAt: string
+  error?: string
+}
+
+const previewStore = new Map<string, LinkPreview>()
+
+function normaliseUrl(url: string): string | null {
+  try {
+    return new URL(url).toString()
+  } catch (error) {
+    return null
+  }
+}
+
+export function rememberLinkPreview(preview: LinkPreview) {
+  const canonicalUrl = normaliseUrl(preview.canonicalUrl) ?? preview.canonicalUrl
+  const originalUrl = normaliseUrl(preview.url) ?? preview.url
+
+  const record: LinkPreview = {
+    ...preview,
+    canonicalUrl,
+    url: originalUrl,
+  }
+
+  previewStore.set(canonicalUrl, record)
+
+  if (originalUrl !== canonicalUrl) {
+    previewStore.set(originalUrl, record)
+  }
+}
+
+export function getLinkPreview(url: string): LinkPreview | undefined {
+  const key = normaliseUrl(url)
+
+  if (!key) {
+    return undefined
+  }
+
+  return previewStore.get(key)
+}
+
+export function upsertLinkPreview(
+  url: string,
+  data: Partial<Omit<LinkPreview, "url" | "canonicalUrl" | "fetchedAt">> & {
+    status?: LinkPreviewStatus
+    canonicalUrl?: string
+  }
+) {
+  const existing = getLinkPreview(url)
+
+  const fetchedAt = new Date().toISOString()
+  const canonicalUrl =
+    (data.canonicalUrl && normaliseUrl(data.canonicalUrl)) || existing?.canonicalUrl || normaliseUrl(url) || url
+  const record: LinkPreview = {
+    url,
+    canonicalUrl,
+    fetchedAt,
+    title: data.title ?? existing?.title,
+    description: data.description ?? existing?.description,
+    image: data.image ?? existing?.image,
+    favicon: data.favicon ?? existing?.favicon,
+    siteName: data.siteName ?? existing?.siteName,
+    status: data.status ?? existing?.status ?? "ready",
+    error: data.error,
+  }
+
+  rememberLinkPreview(record)
+
+  return record
+}
+
+export function createFallbackPreview(url: string, reason?: string): LinkPreview {
+  const canonicalUrl = normaliseUrl(url) ?? url
+  const host = safeHostname(canonicalUrl)
+
+  return {
+    url,
+    canonicalUrl,
+    title: host,
+    siteName: host,
+    status: "error",
+    description: undefined,
+    favicon: undefined,
+    image: undefined,
+    fetchedAt: new Date().toISOString(),
+    error: reason,
+  }
+}
+
+export function buildFallbackPreview(url: string, reason?: string) {
+  const fallback = createFallbackPreview(url, reason)
+  rememberLinkPreview(fallback)
+  return fallback
+}
+
+export function clearLinkPreviewStore() {
+  previewStore.clear()
+}
+
+export function extractUrlsFromText(text: string) {
+  const urlPattern = /(https?:\/\/[^\s<]+[^\s.,!?<)\]])/gi
+  const matches = text.match(urlPattern) ?? []
+
+  const cleaned = matches.map((match) => match.replace(/[\s"'<>]+$/g, "").replace(/[).,!?:;]+$/g, ""))
+
+  return Array.from(new Set(cleaned))
+}
+
+export function safeHostname(url: string) {
+  try {
+    return new URL(url).hostname
+  } catch (error) {
+    return url
+  }
+}
+
+export function resolveUrl(candidate: string | undefined, base: string) {
+  if (!candidate) return undefined
+
+  try {
+    return new URL(candidate, base).toString()
+  } catch (error) {
+    return undefined
+  }
+}
+
+function decodeHtmlEntities(value: string) {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+}
+
+function extractMetaContent(html: string, keys: string[]) {
+  for (const key of keys) {
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    const regex = new RegExp(`<meta[^>]+(?:property|name)=(?:"${escapedKey}"|'${escapedKey}')[^>]*>`, "gi")
+
+    const match = regex.exec(html)
+    if (match) {
+      const tag = match[0]
+      const contentMatch = tag.match(/content=("([^"]*)"|'([^']*)')/i)
+      if (contentMatch) {
+        return decodeHtmlEntities(contentMatch[2] ?? contentMatch[3] ?? "").trim()
+      }
+    }
+  }
+
+  return undefined
+}
+
+function extractLinkHref(html: string, rels: string[], base: string) {
+  const relPattern = rels.map((rel) => rel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")
+  const regex = new RegExp(`<link[^>]+rel=(?:"(${relPattern})"|'(${relPattern})')[^>]*>`, "gi")
+  const match = regex.exec(html)
+  if (!match) return undefined
+
+  const tag = match[0]
+  const hrefMatch = tag.match(/href=("([^"]*)"|'([^']*)')/i)
+  const href = hrefMatch ? hrefMatch[2] ?? hrefMatch[3] : undefined
+  return resolveUrl(href, base)
+}
+
+export function parseOpenGraph(html: string, url: string) {
+  const base = normaliseUrl(url) ?? url
+
+  const metadata = {
+    url: extractMetaContent(html, ["og:url"]) ?? extractLinkHref(html, ["canonical"], base) ?? base,
+    title: extractMetaContent(html, ["og:title", "twitter:title", "title"]),
+    description: extractMetaContent(html, ["og:description", "twitter:description", "description"]),
+    image: resolveUrl(extractMetaContent(html, ["og:image", "twitter:image", "twitter:image:src"]), base),
+    siteName: extractMetaContent(html, ["og:site_name"]),
+    favicon: extractLinkHref(html, ["icon", "shortcut icon", "apple-touch-icon"], base),
+  }
+
+  if (!metadata.title) {
+    const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i)
+    if (titleMatch) {
+      metadata.title = decodeHtmlEntities(titleMatch[1].trim())
+    }
+  }
+
+  return metadata
+}
+
+export function buildPreviewFromMetadata(url: string, html: string) {
+  const baseUrl = normaliseUrl(url) ?? url
+  const og = parseOpenGraph(html, baseUrl)
+  const canonicalUrl = normaliseUrl(og.url) ?? baseUrl
+  const host = safeHostname(canonicalUrl)
+
+  return {
+    url,
+    canonicalUrl,
+    title: og.title ?? host,
+    description: og.description,
+    image: og.image,
+    favicon: og.favicon,
+    siteName: og.siteName ?? host,
+    status: "ready" as const,
+    fetchedAt: new Date().toISOString(),
+  }
+}
+
+export function seedPreview(preview: LinkPreview) {
+  rememberLinkPreview(preview)
+}
+
+export function previewStoreSnapshot() {
+  return Array.from(new Set(previewStore.values()))
+}
+

--- a/lib/messaging/preview-fixtures.ts
+++ b/lib/messaging/preview-fixtures.ts
@@ -1,0 +1,41 @@
+import { LinkPreview, seedPreview } from "./link-previews"
+
+const defaults: LinkPreview[] = [
+  {
+    url: "https://househandbook.example.com/checklists/spring-deep-clean",
+    canonicalUrl: "https://househandbook.example.com/checklists/spring-deep-clean",
+    title: "Spring deep clean checklist",
+    description:
+      "Room-by-room instructions, supplies, and timing for coordinating the spring reset as a household.",
+    image: "https://househandbook.example.com/assets/deep-clean.jpg",
+    favicon: "https://househandbook.example.com/favicon.ico",
+    siteName: "House Handbook",
+    status: "ready",
+    fetchedAt: new Date("2024-06-01T12:00:00.000Z").toISOString(),
+  },
+  {
+    url: "https://communitywifi.example.com/installer-tracker",
+    canonicalUrl: "https://communitywifi.example.com/installer-tracker",
+    title: "Fiber installer availability",
+    description:
+      "Live calendar showing when the community fiber team can swing by for apartment installs.",
+    image: "https://communitywifi.example.com/assets/tech-setup.jpg",
+    favicon: "https://communitywifi.example.com/favicon.ico",
+    siteName: "Community Wi-Fi",
+    status: "ready",
+    fetchedAt: new Date("2024-06-05T09:30:00.000Z").toISOString(),
+  },
+]
+
+let seeded = false
+
+export function ensureMessagingPreviewsSeeded() {
+  if (seeded) return
+
+  for (const preview of defaults) {
+    seedPreview(preview)
+  }
+
+  seeded = true
+}
+

--- a/tests/messaging-link-previews.test.tsx
+++ b/tests/messaging-link-previews.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import { fetchLinkPreview } from "@/app/messaging/actions"
+import { LinkPreviewCard } from "@/components/messaging/link-preview-card"
+import {
+  clearLinkPreviewStore,
+  createFallbackPreview,
+  getLinkPreview,
+} from "@/lib/messaging/link-previews"
+
+const originalFetch = global.fetch
+
+describe("messaging link previews", () => {
+  beforeEach(() => {
+    clearLinkPreviewStore()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+    clearLinkPreviewStore()
+  })
+
+  it("fetches and stores Open Graph metadata for supported URLs", async () => {
+    const html = `<!doctype html>
+      <html>
+        <head>
+          <meta property="og:title" content="Spring deep clean checklist" />
+          <meta property="og:description" content="Room-by-room instructions, supplies, and timing." />
+          <meta property="og:image" content="https://househandbook.example.com/assets/deep-clean.jpg" />
+          <meta property="og:url" content="https://househandbook.example.com/checklists/spring-deep-clean" />
+          <meta property="og:site_name" content="House Handbook" />
+          <link rel="icon" href="https://househandbook.example.com/favicon.ico" />
+        </head>
+      </html>`
+
+    global.fetch = vi.fn(async () => new Response(html, { status: 200 })) as typeof fetch
+
+    const preview = await fetchLinkPreview("https://househandbook.example.com/checklists/spring-deep-clean")
+
+    expect(preview.status).toBe("ready")
+    expect(preview.title).toBe("Spring deep clean checklist")
+    expect(preview.description).toContain("Room-by-room")
+
+    const stored = getLinkPreview("https://househandbook.example.com/checklists/spring-deep-clean")
+    expect(stored).toEqual(preview)
+
+    const markup = renderToStaticMarkup(<LinkPreviewCard preview={preview} />)
+    expect(markup).toContain("Spring deep clean checklist")
+    expect(markup).toContain("House Handbook")
+    expect(markup).toContain("https://househandbook.example.com/assets/deep-clean.jpg")
+  })
+
+  it("returns a graceful fallback when metadata fetch fails", async () => {
+    global.fetch = vi.fn(async () => new Response("error", { status: 500 })) as typeof fetch
+
+    const preview = await fetchLinkPreview("https://communitywifi.example.com/installer-tracker")
+
+    expect(preview.status).toBe("error")
+    expect(preview.title).toBe("communitywifi.example.com")
+
+    const markup = renderToStaticMarkup(
+      <LinkPreviewCard preview={preview} />
+    )
+
+    expect(markup).toContain("Preview unavailable")
+
+    const fallbackOnly = createFallbackPreview("https://roommates.example.com/no-preview")
+    const fallbackMarkup = renderToStaticMarkup(<LinkPreviewCard preview={fallbackOnly} />)
+    expect(fallbackMarkup).toContain("roommates.example.com")
+    expect(fallbackMarkup).toContain("Preview unavailable")
+  })
+})
+


### PR DESCRIPTION
## Summary
- implement utilities and a server action to fetch Open Graph metadata and persist link preview records with graceful fallbacks
- render link preview cards inside messaging threads, including seeded demo metadata and linkified post content
- cover success and failure scenarios for link previews with new Vitest tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30ba9359c8328872ae123830a1480