### PR TITLE
Add document import wizard with CSV preview and tests

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -8,6 +8,13 @@ import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
 import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
+import {
+  applyDocumentImportPlan,
+  buildDocumentImportPlan,
+  parseCsvRecords,
+  type DocumentImportMapping,
+  type DocumentImportPlan,
+} from '@/lib/documents/import';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import { getServiceRoleSupabaseClient } from '@/utils/supabase-service-role';
 import {
@@ -946,6 +953,136 @@ export async function getSigningUrlAction(
   }
 }
 
+export async function previewDocumentImportAction(
+  formData: FormData,
+): Promise<ActionResult<{ headers: string[]; plan: DocumentImportPlan }>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to preview document imports.' };
+    }
+
+    try {
+      await assertDocumentManager(typedSupabase, user.id);
+    } catch (permissionError) {
+      return {
+        success: false,
+        error: permissionError instanceof Error ? permissionError.message : 'Permission denied.',
+      };
+    }
+
+    const prepared = await prepareDocumentImportPlan({ formData, supabase: typedSupabase });
+
+    return {
+      success: true,
+      data: {
+        headers: prepared.headers,
+        plan: prepared.plan,
+      },
+    };
+  } catch (error) {
+    console.error('Unexpected error in previewDocumentImportAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
+    };
+  }
+}
+
+export async function commitDocumentImportAction(
+  formData: FormData,
+): Promise<ActionResult<{ plan: DocumentImportPlan; inserted: number; updated: number }>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to import documents.' };
+    }
+
+    try {
+      await assertDocumentManager(typedSupabase, user.id);
+    } catch (permissionError) {
+      return {
+        success: false,
+        error: permissionError instanceof Error ? permissionError.message : 'Permission denied.',
+      };
+    }
+
+    const prepared = await prepareDocumentImportPlan({ formData, supabase: typedSupabase });
+
+    if (prepared.plan.summary.valid === 0) {
+      return { success: false, error: 'No valid rows found in the uploaded CSV.' };
+    }
+
+    const repository = {
+      insert: async (payload: Record<string, unknown>) => {
+        const { data, error } = await (supabase as any)
+          .from('documents')
+          .insert(payload)
+          .select()
+          .single();
+
+        if (error || !data) {
+          throw new Error(error?.message ?? 'Failed to insert document.');
+        }
+
+        return data as DocumentRow;
+      },
+      update: async (id: string, payload: Record<string, unknown>) => {
+        const { data, error } = await (supabase as any)
+          .from('documents')
+          .update(payload)
+          .eq('id', id)
+          .select()
+          .single();
+
+        if (error || !data) {
+          throw new Error(error?.message ?? 'Failed to update document.');
+        }
+
+        return data as DocumentRow;
+      },
+      recordVersion: (document: DocumentRow, actorId: string, versionOverride?: number) =>
+        insertDocumentVersion(typedSupabase, document, actorId, versionOverride),
+    } satisfies {
+      insert: (payload: Record<string, unknown>) => Promise<DocumentRow>;
+      update: (id: string, payload: Record<string, unknown>) => Promise<DocumentRow>;
+      recordVersion: (document: DocumentRow, actorId: string, versionOverride?: number) => Promise<void>;
+    };
+
+    const execution = await applyDocumentImportPlan({
+      plan: prepared.plan,
+      repository,
+      actorId: user.id,
+    });
+
+    revalidatePath('/documents');
+
+    return {
+      success: true,
+      data: {
+        plan: prepared.plan,
+        inserted: execution.inserted,
+        updated: execution.updated,
+      },
+      message: `Imported ${execution.inserted} new documents and updated ${execution.updated}.`,
+    };
+  } catch (error) {
+    console.error('Unexpected error in commitDocumentImportAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
+    };
+  }
+}
+
 // Get document statistics
 export async function getDocumentStatsAction(): Promise<ActionResult<DocumentStats>> {
   const cookieStore = cookies();
@@ -987,4 +1124,120 @@ export async function getDocumentStatsAction(): Promise<ActionResult<DocumentSta
       error: error instanceof Error ? error.message : 'An unexpected error occurred.'
     };
   }
+}
+
+async function prepareDocumentImportPlan({
+  formData,
+  supabase,
+}: {
+  formData: FormData;
+  supabase: TypedSupabaseClient;
+}): Promise<{ headers: string[]; plan: DocumentImportPlan }> {
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    throw new Error('Please upload a CSV file.');
+  }
+
+  const mapping = parseImportMapping(formData);
+  const csvText = await file.text();
+  const { headers, rows } = parseCsvRecords(csvText);
+
+  if (headers.length === 0) {
+    throw new Error('CSV file must include a header row.');
+  }
+
+  if (rows.length === 0) {
+    throw new Error('CSV file does not contain any data rows.');
+  }
+
+  const { emails, documentIds } = collectImportReferences(rows, mapping);
+
+  const [profilesResult, documentsResult] = await Promise.all([
+    emails.length > 0
+      ? (supabase as any)
+          .from('profiles')
+          .select('id,email')
+          .in('email', emails)
+      : Promise.resolve({ data: [], error: null }),
+    documentIds.length > 0
+      ? (supabase as any)
+          .from('documents')
+          .select('*')
+          .in('id', documentIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (profilesResult.error) {
+    throw new Error(`Failed to load tenant records: ${profilesResult.error.message}`);
+  }
+
+  if (documentsResult.error) {
+    throw new Error(`Failed to load documents for import: ${documentsResult.error.message}`);
+  }
+
+  const plan = buildDocumentImportPlan({
+    headers,
+    rows,
+    mapping,
+    documents: documentsResult.data ?? [],
+    profiles: profilesResult.data ?? [],
+  });
+
+  return { headers, plan };
+}
+
+function parseImportMapping(formData: FormData): DocumentImportMapping {
+  const raw = formData.get('mapping');
+  if (typeof raw !== 'string') {
+    throw new Error('Column mapping payload is required.');
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('Invalid column mapping payload.');
+    }
+    return parsed as DocumentImportMapping;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error('Invalid column mapping payload.');
+    }
+    throw error;
+  }
+}
+
+function collectImportReferences(
+  rows: Record<string, string>[],
+  mapping: DocumentImportMapping,
+) {
+  const emails = new Set<string>();
+  const documentIds = new Set<string>();
+
+  const emailColumn = typeof mapping.tenant_email === 'string' ? mapping.tenant_email : undefined;
+  const documentColumn = typeof mapping.document_id === 'string' ? mapping.document_id : undefined;
+
+  for (const row of rows) {
+    if (emailColumn) {
+      const value = row[emailColumn];
+      if (value && value.trim()) {
+        emails.add(value.trim().toLowerCase());
+      }
+    }
+
+    if (documentColumn) {
+      const value = row[documentColumn];
+      if (value && value.trim()) {
+        documentIds.add(value.trim());
+      }
+    }
+  }
+
+  const validEmails = [...emails].filter((email) => z.string().email().safeParse(email).success);
+  const validDocumentIds = [...documentIds].filter(isUuid);
+
+  return { emails: validEmails, documentIds: validDocumentIds };
+}
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }

--- a/app/documents/components/import-documents-dialog.tsx
+++ b/app/documents/components/import-documents-dialog.tsx
@@ -1,0 +1,537 @@
+'use client';
+
+import { useEffect, useMemo, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { FileSpreadsheet, Loader2, ArrowLeft, CheckCircle2, AlertTriangle } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useDocumentPermissions } from '@/hooks/use-document-permissions';
+import { cn } from '@/lib/utils';
+import {
+  commitDocumentImportAction,
+  previewDocumentImportAction,
+} from '../actions';
+
+import type {
+  DocumentImportField,
+  DocumentImportPlan,
+} from '@/lib/documents/import';
+
+type Step = 'upload' | 'map' | 'preview';
+
+type FieldConfig = {
+  field: DocumentImportField;
+  label: string;
+  required?: boolean;
+  description?: string;
+};
+
+const FIELD_CONFIGS: FieldConfig[] = [
+  { field: 'title', label: 'Document Title', required: true },
+  { field: 'document_type', label: 'Type', required: true },
+  { field: 'status', label: 'Status', required: true },
+  { field: 'description', label: 'Description' },
+  { field: 'tenant_email', label: 'Tenant Email', description: 'Used to match existing profiles.' },
+  { field: 'unit_id', label: 'Unit ID' },
+  { field: 'requires_signature', label: 'Requires Signature' },
+  { field: 'expires_at', label: 'Expires At', description: 'Accepts ISO or yyyy-mm-dd format.' },
+  { field: 'document_id', label: 'Document ID', description: 'Provide to update an existing record.' },
+  { field: 'file_url', label: 'File URL' },
+];
+
+const FIELD_MATCHES: Record<DocumentImportField, string[]> = {
+  title: ['title', 'document title', 'name'],
+  document_type: ['type', 'document type'],
+  status: ['status', 'document status'],
+  description: ['description', 'notes', 'details'],
+  tenant_email: ['tenant email', 'email', 'tenant'],
+  unit_id: ['unit id', 'unit', 'unit number'],
+  requires_signature: ['requires signature', 'signature', 'sign'],
+  expires_at: ['expires', 'expiration', 'expiry', 'expires at'],
+  document_id: ['id', 'document id'],
+  file_url: ['file url', 'url', 'link'],
+};
+
+type MappingState = Record<DocumentImportField, string | null>;
+
+const createEmptyMapping = (): MappingState => ({
+  title: null,
+  document_type: null,
+  status: null,
+  description: null,
+  tenant_email: null,
+  unit_id: null,
+  requires_signature: null,
+  expires_at: null,
+  document_id: null,
+  file_url: null,
+});
+
+export function ImportDocumentsDialog() {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<Step>('upload');
+  const [file, setFile] = useState<File | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [mapping, setMapping] = useState<MappingState>(() => createEmptyMapping());
+  const [preview, setPreview] = useState<DocumentImportPlan | null>(null);
+  const [previewHeaders, setPreviewHeaders] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isPreviewPending, startPreview] = useTransition();
+  const [isCommitPending, startCommit] = useTransition();
+  const permissions = useDocumentPermissions();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!open) {
+      resetState();
+    }
+  }, [open]);
+
+  if (!permissions.canUploadDocuments) {
+    return null;
+  }
+
+  const mappingOptions = useMemo(() => headers, [headers]);
+
+  const validRowCount = preview?.summary.valid ?? 0;
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0];
+    if (!selected) return;
+
+    try {
+      const text = await selected.text();
+      const extractedHeaders = extractHeadersFromCsv(text);
+      if (extractedHeaders.length === 0) {
+        toast.error('The CSV is missing a header row.');
+        return;
+      }
+
+      setFile(selected);
+      setHeaders(extractedHeaders);
+      setMapping(createInitialMapping(extractedHeaders));
+      setPreview(null);
+      setError(null);
+      setStep('map');
+    } catch (readError) {
+      console.error('Failed to read CSV file:', readError);
+      toast.error('Unable to read the selected file.');
+    }
+  };
+
+  const handlePreview = () => {
+    if (!file) {
+      setError('Select a CSV file to continue.');
+      return;
+    }
+
+    const missingRequired = FIELD_CONFIGS.filter(
+      (config) => config.required && !mapping[config.field]
+    );
+
+    if (missingRequired.length > 0) {
+      setError(`Map required fields: ${missingRequired.map((item) => item.label).join(', ')}.`);
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('mapping', JSON.stringify(mapping));
+
+    startPreview(async () => {
+      setError(null);
+      const result = await previewDocumentImportAction(formData);
+
+      if (!result.success || !result.data) {
+        setError(result.error ?? 'Failed to generate preview.');
+        return;
+      }
+
+      setPreview(result.data.plan);
+      setPreviewHeaders(result.data.headers);
+      setStep('preview');
+    });
+  };
+
+  const handleCommit = () => {
+    if (!file || !preview) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('mapping', JSON.stringify(mapping));
+
+    startCommit(async () => {
+      const result = await commitDocumentImportAction(formData);
+
+      if (!result.success || !result.data) {
+        toast.error(result.error ?? 'Import failed.');
+        return;
+      }
+
+      setPreview(result.data.plan);
+      toast.success(`Imported ${result.data.inserted} new and updated ${result.data.updated} documents.`);
+      setOpen(false);
+      router.refresh();
+    });
+  };
+
+  const resetState = () => {
+    setStep('upload');
+    setFile(null);
+    setHeaders([]);
+    setMapping(createEmptyMapping());
+    setPreview(null);
+    setPreviewHeaders([]);
+    setError(null);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <FileSpreadsheet className="mr-2 size-4" />
+          Import CSV
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Import documents from CSV</DialogTitle>
+          <DialogDescription>
+            Upload a spreadsheet to create or update document records. Map columns to Roomsily fields and review validation feedback before committing changes.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <StepTracker step={step} validRows={validRowCount} />
+
+          {step === 'upload' && (
+            <section className="space-y-4">
+              <div className="rounded-lg border-2 border-dashed border-muted-foreground/30 p-6 text-center">
+                <input
+                  id="documents-import-file"
+                  type="file"
+                  accept=".csv"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+                <label htmlFor="documents-import-file" className="cursor-pointer">
+                  <FileSpreadsheet className="mx-auto mb-3 size-12 text-muted-foreground" />
+                  <p className="text-sm text-muted-foreground">
+                    Click to upload a CSV file or drag and drop.
+                  </p>
+                  <p className="text-xs text-muted-foreground">Include a header row with column names.</p>
+                </label>
+              </div>
+
+              {file && (
+                <div className="rounded-md border bg-muted/40 p-3 text-sm">
+                  <div className="font-medium text-foreground">Selected file</div>
+                  <div className="text-muted-foreground">{file.name}</div>
+                </div>
+              )}
+            </section>
+          )}
+
+          {step === 'map' && (
+            <section className="space-y-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-base font-semibold">Map CSV columns</h3>
+                  <p className="text-sm text-muted-foreground">Match your CSV headers to Roomsily fields.</p>
+                </div>
+                <Button variant="outline" size="sm" onClick={() => setStep('upload')}>
+                  <ArrowLeft className="mr-2 size-4" />
+                  Change file
+                </Button>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                {FIELD_CONFIGS.map((config) => (
+                  <div key={config.field} className="space-y-2">
+                    <Label className="flex items-center gap-2 text-sm font-medium">
+                      {config.label}
+                      {config.required && <Badge className="bg-primary/10 text-primary" variant="secondary">Required</Badge>}
+                    </Label>
+                    <Select
+                      value={mapping[config.field] ?? '___none___'}
+                      onValueChange={(value) =>
+                        setMapping((prev) => ({
+                          ...prev,
+                          [config.field]: value === '___none___' ? null : value,
+                        }))
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Choose a column" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="___none___">No column</SelectItem>
+                        {mappingOptions.map((header) => (
+                          <SelectItem key={header} value={header}>
+                            {header}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {config.description && (
+                      <p className="text-xs text-muted-foreground">{config.description}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {step === 'preview' && preview && (
+            <section className="space-y-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-base font-semibold">Import preview</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Review validation results. Rows with issues stay in draft until corrected.
+                  </p>
+                </div>
+                <Button variant="outline" size="sm" onClick={() => setStep('map')}>
+                  <ArrowLeft className="mr-2 size-4" />
+                  Adjust mapping
+                </Button>
+              </div>
+
+              <SummaryBar plan={preview} />
+
+              <ScrollArea className="max-h-72 rounded-md border">
+                <div className="divide-y">
+                  {preview.rows.map((row) => (
+                    <div key={row.index} className="space-y-3 p-4">
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <div>
+                          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                            <span>Row {row.index + 2}</span>
+                            {row.payload?.title && (
+                              <span className="text-muted-foreground">· {row.payload.title}</span>
+                            )}
+                          </div>
+                          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                            <span>{row.action === 'create' ? 'Create' : 'Update existing document'}</span>
+                            {row.payload?.status && (
+                              <Badge variant="secondary" className="bg-primary/10 text-primary">
+                                Status: {row.payload.status.replace('_', ' ')}
+                              </Badge>
+                            )}
+                            {row.payload?.tenant_email && (
+                              <Badge variant="outline">Tenant: {row.payload.tenant_email}</Badge>
+                            )}
+                          </div>
+                        </div>
+                        <Badge variant={row.errors.length > 0 ? 'destructive' : 'secondary'}>
+                          {row.errors.length > 0 ? 'Needs attention' : 'Ready'}
+                        </Badge>
+                      </div>
+
+                      {row.errors.length > 0 ? (
+                        <ul className="space-y-1 text-sm text-destructive">
+                          {row.errors.map((issue, idx) => (
+                            <li key={idx} className="flex items-start gap-2">
+                              <AlertTriangle className="mt-0.5 size-4" />
+                              <span>{issue}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <div className="text-sm text-muted-foreground">
+                          <CheckCircle2 className="mr-2 inline size-4 text-primary" />
+                          This row will {row.action === 'create' ? 'create a new document.' : 'update the existing document.'}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+
+              <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+                Headers matched: {previewHeaders.join(', ')}
+              </div>
+            </section>
+          )}
+
+          {error && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex items-center justify-between">
+          <div className="text-xs text-muted-foreground">
+            Need help? Ensure your CSV includes a header row and UTF-8 encoding.
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              {step === 'upload' ? 'Close' : 'Cancel'}
+            </Button>
+            {step === 'map' && (
+              <Button onClick={handlePreview} disabled={isPreviewPending || !file}>
+                {isPreviewPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+                Generate preview
+              </Button>
+            )}
+            {step === 'preview' && (
+              <Button
+                onClick={handleCommit}
+                disabled={isCommitPending || !preview || preview.summary.valid === 0}
+              >
+                {isCommitPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+                Confirm import
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StepTracker({ step, validRows }: { step: Step; validRows: number }) {
+  const steps: { id: Step; label: string }[] = [
+    { id: 'upload', label: 'Upload CSV' },
+    { id: 'map', label: 'Map columns' },
+    { id: 'preview', label: 'Review & confirm' },
+  ];
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 text-sm">
+      {steps.map((item, index) => {
+        const isActive = step === item.id;
+        const isComplete = steps.findIndex((s) => s.id === step) > index;
+        return (
+          <div key={item.id} className="flex items-center gap-2">
+            <Badge
+              className={cn(
+                'px-3 py-1 font-medium',
+                isActive && 'bg-primary text-primary-foreground',
+                isComplete && !isActive && 'bg-primary/10 text-primary',
+              )}
+            >
+              {index + 1}
+            </Badge>
+            <span className={cn('text-muted-foreground', isActive && 'text-foreground font-semibold')}>
+              {item.label}
+            </span>
+            {index < steps.length - 1 && <Separator orientation="vertical" className="mx-1 h-6" />}
+          </div>
+        );
+      })}
+      {step === 'preview' && (
+        <Badge variant="outline" className="border-primary/30 text-xs text-primary">
+          {validRows} valid {validRows === 1 ? 'row' : 'rows'}
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+function SummaryBar({ plan }: { plan: DocumentImportPlan }) {
+  const items = [
+    { label: 'Total rows', value: plan.summary.total },
+    { label: 'Ready to create', value: plan.summary.creates },
+    { label: 'Ready to update', value: plan.summary.updates },
+    { label: 'Needs attention', value: plan.summary.invalid },
+  ];
+
+  return (
+    <div className="grid gap-3 rounded-md border bg-muted/40 p-3 text-sm sm:grid-cols-4">
+      {items.map((item) => (
+        <div key={item.label} className="space-y-1">
+          <div className="text-xs text-muted-foreground">{item.label}</div>
+          <div className="text-base font-semibold text-foreground">{item.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function extractHeadersFromCsv(text: string): string[] {
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (lines.length === 0) {
+    return [];
+  }
+
+  return splitCsvLine(lines[0]).map((header) => header.trim());
+}
+
+function splitCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      const next = line[i + 1];
+      if (inQuotes && next === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  result.push(current);
+  return result;
+}
+
+function createInitialMapping(headers: string[]): MappingState {
+  const mapping = createEmptyMapping();
+  const used = new Set<string>();
+
+  headers.forEach((header) => {
+    if (used.has(header)) {
+      return;
+    }
+    const normalised = header.trim().toLowerCase();
+    for (const field of FIELD_CONFIGS) {
+      if (mapping[field.field]) continue;
+      const matches = FIELD_MATCHES[field.field] ?? [];
+      if (matches.some((target) => normalised === target || normalised.includes(target))) {
+        mapping[field.field] = header;
+        used.add(header);
+        break;
+      }
+    }
+  });
+
+  return mapping;
+}

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -4,6 +4,7 @@ import { Separator } from "@/components/ui/separator";
 import { FileText, Users, Clock, Upload } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UploadDocumentDialog } from "./components/upload-document-dialog";
+import { ImportDocumentsDialog } from "./components/import-documents-dialog";
 import { DocumentsStats } from "./components/documents-stats";
 import { DocumentsList } from "./components/documents-list";
 import { DocumentsFilters } from "./components/documents-filters";
@@ -20,7 +21,10 @@ export default function DocumentsPage() {
               Manage leases, agreements, and household documents with secure signing and version control.
             </p>
           </div>
-          <UploadDocumentDialog />
+          <div className="flex items-center gap-2">
+            <ImportDocumentsDialog />
+            <UploadDocumentDialog />
+          </div>
         </div>
         <Separator />
       </header>

--- a/lib/documents/import.ts
+++ b/lib/documents/import.ts
@@ -1,0 +1,597 @@
+import { z } from 'zod';
+
+import type { Database } from '@/lib/supabase';
+
+export type DocumentType = Database['public']['Tables']['documents']['Row']['document_type'];
+export type DocumentStatus = Database['public']['Tables']['documents']['Row']['status'];
+export type DocumentRow = Database['public']['Tables']['documents']['Row'];
+type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
+export const DOCUMENT_IMPORT_FIELDS = [
+  'title',
+  'document_type',
+  'status',
+  'description',
+  'tenant_email',
+  'unit_id',
+  'requires_signature',
+  'expires_at',
+  'document_id',
+  'file_url',
+] as const;
+
+export type DocumentImportField = (typeof DOCUMENT_IMPORT_FIELDS)[number];
+
+export type DocumentImportMapping = Partial<Record<DocumentImportField, string | null | undefined>>;
+
+const REQUIRED_FIELDS: DocumentImportField[] = ['title', 'document_type', 'status'];
+
+const DOCUMENT_TYPES: readonly DocumentType[] = ['lease', 'addendum', 'insurance', 'maintenance', 'other'];
+const DOCUMENT_STATUSES: readonly DocumentStatus[] = [
+  'draft',
+  'pending_signature',
+  'signed',
+  'expired',
+  'cancelled',
+];
+
+export interface CsvParseResult {
+  headers: string[];
+  rows: Record<string, string>[];
+}
+
+export interface DocumentImportRowPayload {
+  title: string;
+  description: string | null;
+  document_type: DocumentType;
+  status: DocumentStatus;
+  tenant_email?: string;
+  tenant_id: string | null;
+  unit_id: string | null;
+  requires_signature: boolean;
+  expires_at: string | null;
+  document_id?: string;
+  file_url: string | null;
+}
+
+export interface DocumentImportPlanRow {
+  index: number;
+  raw: Record<string, string>;
+  action: 'create' | 'update';
+  errors: string[];
+  payload?: DocumentImportRowPayload;
+  existingDocument?: DocumentRow;
+}
+
+export interface DocumentImportPlanSummary {
+  total: number;
+  valid: number;
+  invalid: number;
+  creates: number;
+  updates: number;
+}
+
+export interface DocumentImportPlan {
+  rows: DocumentImportPlanRow[];
+  summary: DocumentImportPlanSummary;
+}
+
+export interface DocumentImportPlanInput {
+  headers: string[];
+  rows: Record<string, string>[];
+  mapping: DocumentImportMapping;
+  documents?: DocumentRow[];
+  profiles?: Pick<ProfileRow, 'id' | 'email'>[];
+}
+
+export interface DocumentImportRepository {
+  insert: (payload: Record<string, unknown>) => Promise<DocumentRow>;
+  update: (id: string, payload: Record<string, unknown>) => Promise<DocumentRow>;
+  recordVersion: (document: DocumentRow, actorId: string, versionOverride?: number) => Promise<void>;
+}
+
+export interface DocumentImportExecutionResult {
+  inserted: number;
+  updated: number;
+}
+
+export function parseCsvRecords(csv: string): CsvParseResult {
+  const lines = csv
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = splitCsvLine(lines[0]).map((header) => header.trim());
+
+  const rows = lines.slice(1).map((line) => {
+    const values = splitCsvLine(line);
+    const record: Record<string, string> = {};
+    headers.forEach((header, index) => {
+      record[header] = (values[index] ?? '').trim();
+    });
+    return record;
+  });
+
+  return { headers, rows };
+}
+
+function splitCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === '"') {
+      const nextChar = line[i + 1];
+      if (inQuotes && nextChar === '"') {
+        current += '"';
+        i += 1;
+        continue;
+      }
+
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  result.push(current);
+  return result;
+}
+
+export function buildDocumentImportPlan(input: DocumentImportPlanInput): DocumentImportPlan {
+  const { headers, rows, mapping, documents = [], profiles = [] } = input;
+
+  const resolvedMapping = normaliseMapping(mapping);
+
+  const missingRequired = REQUIRED_FIELDS.filter((field) => !resolvedMapping[field]);
+  if (missingRequired.length > 0) {
+    throw new Error(`Missing mappings for required fields: ${missingRequired.join(', ')}`);
+  }
+
+  for (const [field, column] of Object.entries(resolvedMapping)) {
+    if (!column) continue;
+    if (!headers.includes(column)) {
+      throw new Error(`Column "${column}" selected for ${field} is not present in the CSV.`);
+    }
+  }
+
+  const documentLookup = new Map<string, DocumentRow>();
+  for (const document of documents) {
+    documentLookup.set(document.id, document);
+  }
+
+  const profileLookup = new Map<string, Pick<ProfileRow, 'id' | 'email'>>();
+  for (const profile of profiles) {
+    if (!profile.email) continue;
+    profileLookup.set(profile.email.toLowerCase(), profile);
+  }
+
+  const planRows: DocumentImportPlanRow[] = [];
+  const documentIdCounts = new Map<string, number>();
+
+  rows.forEach((row, index) => {
+    const result = transformRow({
+      row,
+      index,
+      mapping: resolvedMapping,
+      documentLookup,
+      profileLookup,
+    });
+
+    if (result.payload?.document_id) {
+      const current = documentIdCounts.get(result.payload.document_id) ?? 0;
+      documentIdCounts.set(result.payload.document_id, current + 1);
+    }
+
+    planRows.push(result);
+  });
+
+  for (const row of planRows) {
+    const documentId = row.payload?.document_id;
+    if (!documentId) continue;
+    if ((documentIdCounts.get(documentId) ?? 0) > 1) {
+      row.errors.push(`Duplicate document id ${documentId} detected in upload.`);
+    }
+  }
+
+  const summary = planRows.reduce<DocumentImportPlanSummary>((acc, row) => {
+    acc.total += 1;
+    if (row.errors.length === 0 && row.payload) {
+      acc.valid += 1;
+      if (row.action === 'create') {
+        acc.creates += 1;
+      } else {
+        acc.updates += 1;
+      }
+    } else {
+      acc.invalid += 1;
+    }
+    return acc;
+  }, {
+    total: 0,
+    valid: 0,
+    invalid: 0,
+    creates: 0,
+    updates: 0,
+  });
+
+  return { rows: planRows, summary };
+}
+
+export async function applyDocumentImportPlan(options: {
+  plan: DocumentImportPlan;
+  repository: DocumentImportRepository;
+  actorId: string;
+}): Promise<DocumentImportExecutionResult> {
+  const { plan, repository, actorId } = options;
+  let inserted = 0;
+  let updated = 0;
+
+  for (const row of plan.rows) {
+    if (row.errors.length > 0 || !row.payload) {
+      continue;
+    }
+
+    if (row.action === 'create') {
+      const now = new Date().toISOString();
+      const state = row.payload.status === 'draft' ? 'draft' : 'published';
+
+      const payload = {
+        title: row.payload.title,
+        description: row.payload.description,
+        document_type: row.payload.document_type,
+        status: row.payload.status,
+        state,
+        file_url: row.payload.file_url,
+        documenso_envelope_id: null,
+        documenso_template_id: null,
+        metadata: {},
+        created_by: actorId,
+        tenant_id: row.payload.tenant_id,
+        unit_id: row.payload.unit_id,
+        requires_signature: row.payload.requires_signature,
+        expires_at: row.payload.expires_at,
+        signed_at: row.payload.status === 'signed' ? now : null,
+        version: 1,
+        parent_document_id: null,
+        published_at: state === 'published' ? now : null,
+        created_at: now,
+        updated_at: now,
+      };
+
+      const document = await repository.insert(payload);
+      await repository.recordVersion(document, actorId, 1);
+      inserted += 1;
+    } else {
+      const existing = row.existingDocument;
+      if (!existing) {
+        row.errors.push('Document could not be loaded for update.');
+        continue;
+      }
+
+      const now = new Date().toISOString();
+      const nextVersion = (existing.version ?? 1) + 1;
+      const state = row.payload.status === 'draft' ? 'draft' : 'published';
+      const publishedAt = state === 'published' ? existing.published_at ?? now : null;
+      const signedAt =
+        row.payload.status === 'signed'
+          ? existing.signed_at ?? now
+          : row.payload.status === 'draft'
+            ? null
+            : existing.signed_at;
+
+      const updatePayload = {
+        title: row.payload.title,
+        description: row.payload.description,
+        document_type: row.payload.document_type,
+        status: row.payload.status,
+        state,
+        file_url: row.payload.file_url,
+        tenant_id: row.payload.tenant_id,
+        unit_id: row.payload.unit_id,
+        requires_signature: row.payload.requires_signature,
+        expires_at: row.payload.expires_at,
+        signed_at: signedAt,
+        updated_at: now,
+        version: nextVersion,
+        published_at: publishedAt,
+      };
+
+      const document = await repository.update(existing.id, updatePayload);
+      await repository.recordVersion(document, actorId, nextVersion);
+      updated += 1;
+    }
+  }
+
+  return { inserted, updated };
+}
+
+function normaliseMapping(mapping: DocumentImportMapping) {
+  const resolved: Record<DocumentImportField, string | undefined> = {
+    title: undefined,
+    document_type: undefined,
+    status: undefined,
+    description: undefined,
+    tenant_email: undefined,
+    unit_id: undefined,
+    requires_signature: undefined,
+    expires_at: undefined,
+    document_id: undefined,
+    file_url: undefined,
+  };
+
+  for (const field of DOCUMENT_IMPORT_FIELDS) {
+    const column = mapping[field];
+    if (typeof column === 'string' && column.trim().length > 0) {
+      resolved[field] = column.trim();
+    }
+  }
+
+  return resolved;
+}
+
+function transformRow(options: {
+  row: Record<string, string>;
+  index: number;
+  mapping: Record<DocumentImportField, string | undefined>;
+  documentLookup: Map<string, DocumentRow>;
+  profileLookup: Map<string, Pick<ProfileRow, 'id' | 'email'>>;
+}): DocumentImportPlanRow {
+  const { row, index, mapping, documentLookup, profileLookup } = options;
+
+  const errors: string[] = [];
+  const sanitised = sanitiseRow(row, mapping, errors);
+  const action: 'create' | 'update' = sanitised?.document_id ? 'update' : 'create';
+
+  const result: DocumentImportPlanRow = {
+    index,
+    raw: row,
+    action,
+    errors,
+  };
+
+  if (!sanitised) {
+    return result;
+  }
+
+  const payload: DocumentImportRowPayload = {
+    title: sanitised.title,
+    description: sanitised.description ?? null,
+    document_type: sanitised.document_type,
+    status: sanitised.status,
+    tenant_email: sanitised.tenant_email,
+    tenant_id: null,
+    unit_id: sanitised.unit_id ?? null,
+    requires_signature: sanitised.requires_signature ?? false,
+    expires_at: sanitised.expires_at ?? null,
+    document_id: sanitised.document_id,
+    file_url: sanitised.file_url ?? null,
+  };
+
+  if (payload.document_id) {
+    const existing = documentLookup.get(payload.document_id);
+    if (!existing) {
+      result.errors.push(`Document with id ${payload.document_id} was not found.`);
+    } else {
+      result.existingDocument = existing;
+      payload.description = sanitised.description ?? existing.description ?? null;
+      payload.requires_signature = sanitised.requires_signature ?? existing.requires_signature ?? false;
+      payload.unit_id = sanitised.unit_id ?? existing.unit_id ?? null;
+      payload.expires_at = sanitised.expires_at ?? existing.expires_at ?? null;
+      payload.file_url = sanitised.file_url ?? existing.file_url ?? null;
+      payload.tenant_id = resolveTenantId({
+        sanitisedEmail: sanitised.tenant_email,
+        existingTenantId: existing.tenant_id,
+        profileLookup,
+        errors: result.errors,
+      });
+    }
+  } else {
+    payload.tenant_id = resolveTenantId({
+      sanitisedEmail: sanitised.tenant_email,
+      existingTenantId: null,
+      profileLookup,
+      errors: result.errors,
+    });
+  }
+
+  result.payload = payload;
+  return result;
+}
+
+function resolveTenantId(options: {
+  sanitisedEmail?: string;
+  existingTenantId: string | null;
+  profileLookup: Map<string, Pick<ProfileRow, 'id' | 'email'>>;
+  errors: string[];
+}) {
+  const { sanitisedEmail, existingTenantId, profileLookup, errors } = options;
+
+  if (sanitisedEmail) {
+    const profile = profileLookup.get(sanitisedEmail);
+    if (!profile) {
+      errors.push(`No tenant found for email ${sanitisedEmail}.`);
+      return existingTenantId ?? null;
+    }
+    return profile.id;
+  }
+
+  return existingTenantId ?? null;
+}
+
+type SanitisedRow = {
+  title: string;
+  description?: string | null;
+  document_type: DocumentType;
+  status: DocumentStatus;
+  tenant_email?: string;
+  unit_id?: string | null;
+  requires_signature?: boolean;
+  expires_at?: string | null;
+  document_id?: string;
+  file_url?: string | null;
+};
+
+function sanitiseRow(
+  row: Record<string, string>,
+  mapping: Record<DocumentImportField, string | undefined>,
+  errors: string[],
+): SanitisedRow | null {
+  const getValue = (field: DocumentImportField) => {
+    const column = mapping[field];
+    if (!column) return undefined;
+    return row[column] ?? '';
+  };
+
+  const title = (getValue('title') ?? '').trim();
+  if (!title) {
+    errors.push('Title is required.');
+  }
+
+  const rawType = getValue('document_type');
+  const document_type = normaliseEnum(rawType, DOCUMENT_TYPES);
+  if (!document_type) {
+    errors.push(
+      rawType && rawType.trim().length > 0
+        ? `Invalid document type "${rawType}".`
+        : 'Document type is required.',
+    );
+  }
+
+  const rawStatus = getValue('status');
+  const status = normaliseEnum(rawStatus, DOCUMENT_STATUSES);
+  if (!status) {
+    errors.push(
+      rawStatus && rawStatus.trim().length > 0
+        ? `Invalid status "${rawStatus}".`
+        : 'Status is required.',
+    );
+  }
+
+  const description = (() => {
+    if (!mapping.description) return undefined;
+    const value = getValue('description');
+    if (value === undefined) return undefined;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  })();
+
+  const tenant_email = (() => {
+    if (!mapping.tenant_email) return undefined;
+    const value = getValue('tenant_email');
+    if (value === undefined) return undefined;
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    const lowercase = trimmed.toLowerCase();
+    if (!z.string().email().safeParse(lowercase).success) {
+      errors.push(`Invalid tenant email "${value}".`);
+    }
+    return lowercase;
+  })();
+
+  const unit_id = (() => {
+    if (!mapping.unit_id) return undefined;
+    const value = getValue('unit_id');
+    if (value === undefined) return undefined;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  })();
+
+  const requires_signature = (() => {
+    if (!mapping.requires_signature) return undefined;
+    const value = getValue('requires_signature');
+    if (value === undefined) return undefined;
+    const normalised = value.trim().toLowerCase();
+    if (normalised.length === 0) return undefined;
+    if (['true', '1', 'yes', 'y'].includes(normalised)) return true;
+    if (['false', '0', 'no', 'n'].includes(normalised)) return false;
+    errors.push(`Invalid requires_signature value "${value}". Use yes or no.`);
+    return undefined;
+  })();
+
+  const expires_at = (() => {
+    if (!mapping.expires_at) return undefined;
+    const value = getValue('expires_at');
+    if (value === undefined) return undefined;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+      errors.push(`Invalid expiration date "${value}". Use ISO or yyyy-mm-dd.`);
+      return undefined;
+    }
+    return parsed.toISOString();
+  })();
+
+  const document_id = (() => {
+    if (!mapping.document_id) return undefined;
+    const value = getValue('document_id');
+    if (value === undefined) return undefined;
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    if (!isUuid(trimmed)) {
+      errors.push(`Invalid document id "${value}".`);
+      return undefined;
+    }
+    return trimmed;
+  })();
+
+  const file_url = (() => {
+    if (!mapping.file_url) return undefined;
+    const value = getValue('file_url');
+    if (value === undefined) return undefined;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+      new URL(trimmed);
+      return trimmed;
+    } catch {
+      errors.push(`Invalid file url "${value}".`);
+      return undefined;
+    }
+  })();
+
+  if (errors.length > 0 || !document_type || !status || !title) {
+    return null;
+  }
+
+  return {
+    title,
+    description,
+    document_type,
+    status,
+    tenant_email,
+    unit_id,
+    requires_signature,
+    expires_at,
+    document_id,
+    file_url,
+  };
+}
+
+function normaliseEnum<T extends string>(value: string | undefined, allowed: readonly T[]) {
+  if (!value) return undefined;
+  const normalised = value.trim().toLowerCase().replace(/[\s-]+/g, '_') as T;
+  if (allowed.includes(normalised)) {
+    return normalised;
+  }
+  return undefined;
+}
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}

--- a/tests/documents-import.test.ts
+++ b/tests/documents-import.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  applyDocumentImportPlan,
+  buildDocumentImportPlan,
+  parseCsvRecords,
+  type DocumentImportMapping,
+} from '@/lib/documents/import';
+
+const baseDocument = {
+  id: '11111111-1111-1111-8111-111111111111',
+  created_at: new Date('2024-01-01').toISOString(),
+  updated_at: new Date('2024-01-10').toISOString(),
+  title: 'Signed Lease',
+  description: 'Existing description',
+  document_type: 'lease' as const,
+  status: 'draft' as const,
+  state: 'draft' as const,
+  file_url: null,
+  documenso_envelope_id: null,
+  documenso_template_id: null,
+  metadata: {},
+  created_by: 'manager-1',
+  tenant_id: 'tenant-1',
+  unit_id: 'unit-4b',
+  requires_signature: true,
+  expires_at: null,
+  signed_at: null,
+  version: 2,
+  parent_document_id: null,
+  published_at: null,
+};
+
+describe('buildDocumentImportPlan', () => {
+  it('maps headers and classifies create vs update rows', () => {
+    const csv = `Title,Type,Status,Tenant Email,Document ID\n` +
+      `New Lease,Lease,pending_signature,tenant@example.com,\n` +
+      `Existing Lease,Lease,signed,tenant@example.com,${baseDocument.id}`;
+
+    const { headers, rows } = parseCsvRecords(csv);
+
+    const mapping: DocumentImportMapping = {
+      title: 'Title',
+      document_type: 'Type',
+      status: 'Status',
+      tenant_email: 'Tenant Email',
+      document_id: 'Document ID',
+    };
+
+    const plan = buildDocumentImportPlan({
+      headers,
+      rows,
+      mapping,
+      documents: [baseDocument],
+      profiles: [{ id: 'tenant-1', email: 'tenant@example.com' }],
+    });
+
+    expect(plan.summary.total).toBe(2);
+    expect(plan.summary.creates).toBe(1);
+    expect(plan.summary.updates).toBe(1);
+    expect(plan.rows[0].action).toBe('create');
+    expect(plan.rows[0].payload?.title).toBe('New Lease');
+    expect(plan.rows[1].action).toBe('update');
+    expect(plan.rows[1].payload?.document_id).toBe(baseDocument.id);
+    expect(plan.rows[1].errors).toHaveLength(0);
+  });
+
+  it('surfaces validation feedback for bad rows', () => {
+    const csv = `Title,Type,Status,Tenant Email\n` +
+      `Lease Draft,Lease,invalid status,tenant@example.com\n` +
+      `Pending Lease,Lease,pending_signature,missing@example.com`;
+
+    const { headers, rows } = parseCsvRecords(csv);
+    const mapping: DocumentImportMapping = {
+      title: 'Title',
+      document_type: 'Type',
+      status: 'Status',
+      tenant_email: 'Tenant Email',
+    };
+
+    const plan = buildDocumentImportPlan({
+      headers,
+      rows,
+      mapping,
+      documents: [],
+      profiles: [{ id: 'tenant-1', email: 'tenant@example.com' }],
+    });
+
+    expect(plan.summary.invalid).toBe(2);
+    expect(plan.rows[0].errors.some((msg) => msg.includes('Invalid status'))).toBe(true);
+    expect(plan.rows[1].errors.some((msg) => msg.includes('No tenant found'))).toBe(true);
+  });
+});
+
+describe('applyDocumentImportPlan', () => {
+  it('inserts new documents and updates existing ones', async () => {
+    const csv = `Title,Type,Status,Tenant Email,Document ID\n` +
+      `New Lease,Lease,pending_signature,tenant@example.com,\n` +
+      `Existing Lease,Lease,signed,tenant@example.com,${baseDocument.id}`;
+
+    const { headers, rows } = parseCsvRecords(csv);
+    const mapping: DocumentImportMapping = {
+      title: 'Title',
+      document_type: 'Type',
+      status: 'Status',
+      tenant_email: 'Tenant Email',
+      document_id: 'Document ID',
+    };
+
+    const plan = buildDocumentImportPlan({
+      headers,
+      rows,
+      mapping,
+      documents: [baseDocument],
+      profiles: [{ id: 'tenant-1', email: 'tenant@example.com' }],
+    });
+
+    const insertMock = vi.fn(async (payload: Record<string, unknown>) => ({
+      ...baseDocument,
+      id: '99999999-9999-9999-9999-999999999999',
+      title: payload.title as string,
+      status: payload.status as typeof baseDocument.status,
+      state: payload.state as typeof baseDocument.state,
+      requires_signature: payload.requires_signature as boolean,
+      tenant_id: payload.tenant_id as string | null,
+      unit_id: payload.unit_id as string | null,
+      expires_at: payload.expires_at as string | null,
+      signed_at: payload.signed_at as string | null,
+      version: payload.version as number,
+      published_at: payload.published_at as string | null,
+      created_at: payload.created_at as string,
+      updated_at: payload.updated_at as string,
+      metadata: payload.metadata as Record<string, unknown>,
+    }));
+
+    const updateMock = vi.fn(async (id: string, payload: Record<string, unknown>) => ({
+      ...baseDocument,
+      id,
+      title: payload.title as string,
+      status: payload.status as typeof baseDocument.status,
+      state: payload.state as typeof baseDocument.state,
+      requires_signature: payload.requires_signature as boolean,
+      tenant_id: payload.tenant_id as string | null,
+      unit_id: payload.unit_id as string | null,
+      expires_at: payload.expires_at as string | null,
+      signed_at: payload.signed_at as string | null,
+      version: payload.version as number,
+      updated_at: payload.updated_at as string,
+      published_at: payload.published_at as string | null,
+    }));
+
+    const recordVersionMock = vi.fn(async () => undefined);
+
+    const execution = await applyDocumentImportPlan({
+      plan,
+      repository: {
+        insert: insertMock,
+        update: updateMock,
+        recordVersion: recordVersionMock,
+      },
+      actorId: 'manager-1',
+    });
+
+    expect(execution.inserted).toBe(1);
+    expect(execution.updated).toBe(1);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(recordVersionMock).toHaveBeenCalledTimes(2);
+    expect(recordVersionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: '99999999-9999-9999-9999-999999999999' }),
+      'manager-1',
+      1,
+    );
+    expect(recordVersionMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ id: baseDocument.id }),
+      'manager-1',
+      (baseDocument.version ?? 1) + 1,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a multi-step ImportDocumentsDialog that guides CSV upload, column mapping, preview, and confirmation
- expose previewDocumentImportAction/commitDocumentImportAction with shared planning helpers to validate and apply imports
- extract reusable import planning utilities and cover header mapping, validation, and commit flows with new tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30bacf2dc8328a986979d4dbc623a