### PR TITLE
Add documents workspace with CSV export support

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -1,12 +1,16 @@
 'use server';
 
-import type { PostgrestError } from '@supabase/supabase-js';
+import type { PostgrestError, User } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supa-server-actions';
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
-import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import {
+  exportDocumentsToCsv,
+  fetchDocumentStats,
+  fetchDocumentsList,
+} from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import { getServiceRoleSupabaseClient } from '@/utils/supabase-service-role';
@@ -14,12 +18,17 @@ import {
   Document,
   DocumentWithLease,
   DocumentListFilters,
+  DocumentListSort,
   DocumentUploadRequest,
   DocumentSigningRequest,
   DocumentStats,
   DocumentVersionSnapshot,
 } from '@/types/documents';
 import type { Database } from '@/lib/supabase';
+import {
+  DOCUMENT_COLUMN_IDS,
+  type DocumentColumnId,
+} from '@/lib/documents/csv-columns';
 
 // Validation schemas
 const documentUploadSchema = z.object({
@@ -49,6 +58,13 @@ const documentListFiltersSchema = z.object({
   date_to: z.string().datetime().optional(),
 });
 
+const documentListSortSchema = z.object({
+  column: z.enum(['created_at', 'title', 'status', 'document_type']),
+  direction: z.enum(['asc', 'desc']),
+});
+
+const documentColumnIdSchema = z.enum(DOCUMENT_COLUMN_IDS);
+
 // Action result interface
 interface ActionResult<T = any> {
   success: boolean;
@@ -58,6 +74,14 @@ interface ActionResult<T = any> {
 }
 
 type DocumentRow = Database['public']['Tables']['documents']['Row'];
+type MemberRole = Database['public']['Tables']['profiles']['Row']['role'];
+
+interface DocumentsActionContext {
+  supabase: ReturnType<typeof createClient>;
+  typedSupabase: TypedSupabaseClient;
+  user: User;
+  role: MemberRole | null | undefined;
+}
 
 function buildVersionSnapshot(document: DocumentRow): DocumentVersionSnapshot {
   return {
@@ -136,60 +160,164 @@ function isRowLevelSecurityViolation(error: PostgrestError) {
   return message.includes('row-level security');
 }
 
-// Get documents with optional filters
-export async function getDocumentsAction(
-  filters?: DocumentListFilters
-): Promise<ActionResult<DocumentWithLease[]>> {
+async function resolveDocumentsContext({
+  unauthenticatedMessage,
+  failureMessage,
+}: {
+  unauthenticatedMessage: string;
+  failureMessage: string;
+}): Promise<{ success: true; context: DocumentsActionContext } | { success: false; error: string }> {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
   const typedSupabase = supabase as unknown as TypedSupabaseClient;
 
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, error: unauthenticatedMessage };
+  }
+
   try {
-    // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: 'You must be logged in to view documents.' };
-    }
-
-    // Validate filters
-    const validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
-    let role: Awaited<ReturnType<typeof fetchMemberRole>>;
-    try {
-      role = await fetchMemberRole(typedSupabase, user.id);
-    } catch (roleError) {
-      console.error('Error resolving member role:', roleError);
-      return { success: false, error: 'Failed to fetch documents.' };
-    }
-
-    let documents: DocumentWithLease[];
-    try {
-      documents = await fetchDocumentsList({
-        client: typedSupabase,
-        userId: user.id,
+    const role = await fetchMemberRole(typedSupabase, user.id);
+    return {
+      success: true,
+      context: {
+        supabase,
+        typedSupabase,
+        user,
         role,
-        filters: validatedFilters,
-      });
-    } catch (documentsError) {
-      console.error('Error fetching documents:', documentsError);
-      return { success: false, error: 'Failed to fetch documents.' };
-    }
+      },
+    };
+  } catch (roleError) {
+    console.error('Error resolving member role:', roleError);
+    return { success: false, error: failureMessage };
+  }
+}
 
-    // Log access
+// Get documents with optional filters
+export async function getDocumentsAction({
+  filters,
+  sort,
+}: {
+  filters?: DocumentListFilters;
+  sort?: DocumentListSort;
+} = {}): Promise<ActionResult<DocumentWithLease[]>> {
+  const contextResult = await resolveDocumentsContext({
+    unauthenticatedMessage: 'You must be logged in to view documents.',
+    failureMessage: 'Failed to fetch documents.',
+  });
+
+  if (!contextResult.success) {
+    return { success: false, error: contextResult.error };
+  }
+
+  const { supabase, typedSupabase, user, role } = contextResult.context;
+
+  let validatedFilters: DocumentListFilters = {};
+  let validatedSort: DocumentListSort | undefined;
+
+  try {
+    validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
+    validatedSort = sort ? documentListSortSchema.parse(sort) : undefined;
+  } catch (validationError) {
+    if (validationError instanceof z.ZodError) {
+      return { success: false, error: 'Invalid filter parameters.' };
+    }
+    console.error('Unexpected validation error:', validationError);
+    return { success: false, error: 'Failed to fetch documents.' };
+  }
+
+  try {
+    const documents = await fetchDocumentsList({
+      client: typedSupabase,
+      userId: user.id,
+      role,
+      filters: validatedFilters,
+      sort: validatedSort,
+    });
+
     for (const doc of documents) {
       await (supabase as any).rpc('log_document_access', {
         p_document_id: doc.id,
         p_action: 'view',
-        p_metadata: { source: 'documents_page' }
+        p_metadata: { source: 'documents_page' },
       });
     }
 
     return { success: true, data: documents };
   } catch (error) {
-    console.error('Unexpected error in getDocumentsAction:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'An unexpected error occurred.'
-    };
+    console.error('Error fetching documents:', error);
+    return { success: false, error: 'Failed to fetch documents.' };
+  }
+}
+
+export async function exportDocumentsAction({
+  filters,
+  sort,
+  columns,
+}: {
+  filters?: DocumentListFilters;
+  sort?: DocumentListSort;
+  columns: DocumentColumnId[];
+}): Promise<ActionResult<{ csv: string; filename: string }>> {
+  const contextResult = await resolveDocumentsContext({
+    unauthenticatedMessage: 'You must be logged in to export documents.',
+    failureMessage: 'Failed to export documents.',
+  });
+
+  if (!contextResult.success) {
+    return { success: false, error: contextResult.error };
+  }
+
+  const { supabase, typedSupabase, user, role } = contextResult.context;
+
+  let validatedFilters: DocumentListFilters = {};
+  let validatedSort: DocumentListSort | undefined;
+  let validatedColumns: DocumentColumnId[] = [];
+
+  try {
+    validatedFilters = filters ? documentListFiltersSchema.parse(filters) : {};
+    validatedSort = sort ? documentListSortSchema.parse(sort) : undefined;
+    validatedColumns = z
+      .array(documentColumnIdSchema)
+      .min(1, 'Select at least one column to export.')
+      .parse(columns);
+  } catch (validationError) {
+    if (validationError instanceof z.ZodError) {
+      return { success: false, error: 'Invalid export parameters.' };
+    }
+    console.error('Unexpected validation error in exportDocumentsAction:', validationError);
+    return { success: false, error: 'Failed to export documents.' };
+  }
+
+  try {
+    const { csv, documents } = await exportDocumentsToCsv({
+      client: typedSupabase,
+      userId: user.id,
+      role,
+      filters: validatedFilters,
+      sort: validatedSort,
+      visibleColumns: validatedColumns,
+    });
+
+    for (const document of documents) {
+      await (supabase as any).rpc('log_document_access', {
+        p_document_id: document.id,
+        p_action: 'export',
+        p_metadata: { source: 'documents_page' },
+      });
+    }
+
+    const dateSuffix = new Date().toISOString().slice(0, 10);
+    const filename = `documents-export-${dateSuffix}.csv`;
+
+    return { success: true, data: { csv, filename } };
+  } catch (error) {
+    console.error('Unexpected error in exportDocumentsAction:', error);
+    return { success: false, error: 'Failed to export documents.' };
   }
 }
 

--- a/app/documents/components/documents-filters.tsx
+++ b/app/documents/components/documents-filters.tsx
@@ -1,33 +1,56 @@
-'use client';
+'use client'
 
-import { useState } from 'react';
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
-  DropdownMenuCheckboxItem,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Badge } from "@/components/ui/badge";
-import { DocumentListFilters, DocumentStatus, DocumentType } from '@/types/documents';
-import { Filter, X } from 'lucide-react';
+} from "@/components/ui/dropdown-menu"
+import { Badge } from "@/components/ui/badge"
+import type {
+  DocumentListFilters,
+  DocumentListSort,
+  DocumentStatus,
+  DocumentType,
+} from '@/types/documents'
+import type { DocumentColumnId, DocumentCsvColumn } from '@/lib/documents/csv-columns'
+import { Download, Filter, X } from 'lucide-react'
 
 interface DocumentsFiltersProps {
-  onFiltersChange?: (filters: DocumentListFilters) => void;
+  filters: DocumentListFilters
+  onFiltersChange: (filters: DocumentListFilters) => void
+  sort: DocumentListSort
+  onSortChange: (sort: DocumentListSort) => void
+  columns: DocumentCsvColumn[]
+  columnVisibility: Record<DocumentColumnId, boolean>
+  onColumnVisibilityChange: (columnId: DocumentColumnId, visible: boolean) => void
+  onExport?: () => void
+  exporting?: boolean
 }
 
-export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
-  const [filters, setFilters] = useState<DocumentListFilters>({});
-
+export function DocumentsFilters({
+  filters,
+  onFiltersChange,
+  sort,
+  onSortChange,
+  columns,
+  columnVisibility,
+  onColumnVisibilityChange,
+  onExport,
+  exporting = false,
+}: DocumentsFiltersProps) {
   const statusOptions: { value: DocumentStatus; label: string }[] = [
     { value: 'draft', label: 'Draft' },
     { value: 'pending_signature', label: 'Pending Signature' },
     { value: 'signed', label: 'Signed' },
     { value: 'expired', label: 'Expired' },
     { value: 'cancelled', label: 'Cancelled' },
-  ];
+  ]
 
   const typeOptions: { value: DocumentType; label: string }[] = [
     { value: 'lease', label: 'Lease' },
@@ -35,41 +58,77 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
     { value: 'insurance', label: 'Insurance' },
     { value: 'maintenance', label: 'Maintenance' },
     { value: 'other', label: 'Other' },
-  ];
-
-  const updateFilters = (newFilters: DocumentListFilters) => {
-    setFilters(newFilters);
-    onFiltersChange?.(newFilters);
-  };
+  ]
 
   const toggleStatusFilter = (status: DocumentStatus, checked: boolean) => {
-    const currentStatuses = filters.status || [];
-    const newStatuses = checked
-      ? [...currentStatuses, status]
-      : currentStatuses.filter(s => s !== status);
+    const currentStatuses = filters.status || []
+    const nextStatuses = checked
+      ? Array.from(new Set([...currentStatuses, status]))
+      : currentStatuses.filter((item) => item !== status)
 
-    updateFilters({
+    onFiltersChange({
       ...filters,
-      status: newStatuses.length > 0 ? newStatuses : undefined,
-    });
-  };
+      status: nextStatuses.length > 0 ? nextStatuses : undefined,
+    })
+  }
 
   const toggleTypeFilter = (type: DocumentType, checked: boolean) => {
-    const currentTypes = filters.type || [];
-    const newTypes = checked
-      ? [...currentTypes, type]
-      : currentTypes.filter(t => t !== type);
+    const currentTypes = filters.type || []
+    const nextTypes = checked
+      ? Array.from(new Set([...currentTypes, type]))
+      : currentTypes.filter((item) => item !== type)
 
-    updateFilters({
+    onFiltersChange({
       ...filters,
-      type: newTypes.length > 0 ? newTypes : undefined,
-    });
-  };
+      type: nextTypes.length > 0 ? nextTypes : undefined,
+    })
+  }
 
   const clearFilters = () => {
-    setFilters({});
-    onFiltersChange?.({});
-  };
+    onFiltersChange({})
+  }
+
+  const handleColumnToggle = (columnId: DocumentColumnId, checked: boolean) => {
+    if (!checked && columnId === 'title') {
+      return
+    }
+
+    onColumnVisibilityChange(columnId, checked)
+  }
+
+  const sortOptions: { id: string; label: string; sort: DocumentListSort }[] = [
+    {
+      id: 'created_desc',
+      label: 'Newest first',
+      sort: { column: 'created_at', direction: 'desc' },
+    },
+    {
+      id: 'created_asc',
+      label: 'Oldest first',
+      sort: { column: 'created_at', direction: 'asc' },
+    },
+    {
+      id: 'title_asc',
+      label: 'Title A–Z',
+      sort: { column: 'title', direction: 'asc' },
+    },
+    {
+      id: 'title_desc',
+      label: 'Title Z–A',
+      sort: { column: 'title', direction: 'desc' },
+    },
+    {
+      id: 'status_asc',
+      label: 'Status A–Z',
+      sort: { column: 'status', direction: 'asc' },
+    },
+  ]
+
+  const currentSortId =
+    sortOptions.find(
+      (option) =>
+        option.sort.column === sort.column && option.sort.direction === sort.direction,
+    )?.id ?? 'created_desc'
 
   const activeFilterCount =
     (filters.status?.length || 0) +
@@ -77,11 +136,10 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
     (filters.tenant_id ? 1 : 0) +
     (filters.unit_id ? 1 : 0) +
     (filters.date_from ? 1 : 0) +
-    (filters.date_to ? 1 : 0);
+    (filters.date_to ? 1 : 0)
 
   return (
-    <div className="flex items-center space-x-2">
-      {/* Status Filter */}
+    <div className="flex w-full flex-wrap items-center gap-2">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" size="sm">
@@ -101,7 +159,9 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
             <DropdownMenuCheckboxItem
               key={option.value}
               checked={filters.status?.includes(option.value) || false}
-              onCheckedChange={(checked) => toggleStatusFilter(option.value, checked)}
+              onCheckedChange={(checked) =>
+                toggleStatusFilter(option.value, checked === true)
+              }
             >
               {option.label}
             </DropdownMenuCheckboxItem>
@@ -109,7 +169,6 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Type Filter */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" size="sm">
@@ -128,7 +187,9 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
             <DropdownMenuCheckboxItem
               key={option.value}
               checked={filters.type?.includes(option.value) || false}
-              onCheckedChange={(checked) => toggleTypeFilter(option.value, checked)}
+              onCheckedChange={(checked) =>
+                toggleTypeFilter(option.value, checked === true)
+              }
             >
               {option.label}
             </DropdownMenuCheckboxItem>
@@ -136,7 +197,33 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Clear Filters */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            Sort: {sortOptions.find((option) => option.id === currentSortId)?.label}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup
+            value={currentSortId}
+            onValueChange={(value) => {
+              const option = sortOptions.find((item) => item.id === value)
+              if (option) {
+                onSortChange(option.sort)
+              }
+            }}
+          >
+            {sortOptions.map((option) => (
+              <DropdownMenuRadioItem key={option.id} value={option.id}>
+                {option.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
       {activeFilterCount > 0 && (
         <Button
           variant="ghost"
@@ -148,6 +235,55 @@ export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
           Clear ({activeFilterCount})
         </Button>
       )}
+
+      <div className="ml-auto flex flex-wrap items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm">
+              Columns
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {columns.map((column) => {
+              const checked = columnVisibility[column.id] ?? true
+              const disabled = column.id === 'title'
+
+              return (
+                <DropdownMenuCheckboxItem
+                  key={column.id}
+                  checked={checked}
+                  disabled={disabled}
+                  onCheckedChange={(checked) =>
+                    handleColumnToggle(column.id, checked === true)
+                  }
+                >
+                  {column.label}
+                  {disabled ? (
+                    <span className="ml-auto text-[10px] uppercase text-muted-foreground">
+                      Required
+                    </span>
+                  ) : null}
+                </DropdownMenuCheckboxItem>
+              )
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {onExport ? (
+          <Button
+            variant="default"
+            size="sm"
+            onClick={onExport}
+            disabled={exporting}
+            className="inline-flex items-center gap-2"
+          >
+            <Download className="size-4" />
+            {exporting ? 'Preparing…' : 'Export CSV'}
+          </Button>
+        ) : null}
+      </div>
     </div>
-  );
+  )
 }

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,284 +1,315 @@
-'use client';
+'use client'
 
-import { useEffect, useState } from 'react';
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
-import { getDocumentsAction } from '../actions';
-import { DocumentActions } from './document-actions';
-import { formatDistanceToNow } from 'date-fns';
-import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react'
+import { format, formatDistanceToNow, parseISO } from 'date-fns'
+import { FileText } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import type { DocumentListFilters, DocumentListSort, DocumentWithLease } from '@/types/documents'
+import type { DocumentColumnId } from '@/lib/documents/csv-columns'
+import { DOCUMENT_CSV_COLUMNS_MAP } from '@/lib/documents/csv-columns'
+import { getDocumentsAction } from '../actions'
+import { DocumentActions } from './document-actions'
 
 interface DocumentsListProps {
-  filter: DocumentListFilters;
+  filters: DocumentListFilters
+  sort?: DocumentListSort
+  visibleColumns: DocumentColumnId[]
 }
 
-export function DocumentsList({ filter }: DocumentsListProps) {
-  const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+const statusVariants: Record<string, 'default' | 'outline' | 'secondary' | 'destructive'> = {
+  draft: 'secondary',
+  pending_signature: 'outline',
+  signed: 'default',
+  expired: 'destructive',
+  cancelled: 'secondary',
+}
 
-  useEffect(() => {
-    const fetchDocuments = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const result = await getDocumentsAction(filter);
-        if (result.success && result.data) {
-          setDocuments(result.data);
-          setError(null);
-        } else {
-          setError(result.error || 'Failed to fetch documents');
-        }
-      } catch (err) {
-        console.error('Error fetching documents:', err);
-        setError('An unexpected error occurred');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchDocuments();
-  }, [filter]);
-
-  const getStatusBadge = (status: string) => {
-    const variants = {
-      draft: 'secondary',
-      pending_signature: 'outline',
-      signed: 'default',
-      expired: 'destructive',
-      cancelled: 'secondary',
-    } as const;
-
-    const labels = {
-      draft: 'Draft',
-      pending_signature: 'Pending Signature',
-      signed: 'Signed',
-      expired: 'Expired',
-      cancelled: 'Cancelled',
-    };
+const columnRenderers: Record<
+  DocumentColumnId,
+  (document: DocumentWithLease) => React.ReactNode
+> = {
+  title: (document) => {
+    const lastUpdated = document.updated_at ?? document.created_at
 
     return (
-      <Badge variant={variants[status as keyof typeof variants] || 'secondary'}>
-        {labels[status as keyof typeof labels] || status}
-      </Badge>
-    );
-  };
+      <div className="space-y-1">
+        <p className="font-medium text-foreground">{document.title}</p>
+        {document.description ? (
+          <p className="text-sm text-muted-foreground">{document.description}</p>
+        ) : null}
+        <p className="text-xs text-muted-foreground">
+          Updated {formatDistanceToNow(new Date(lastUpdated), { addSuffix: true })}
+        </p>
+      </div>
+    )
+  },
+  document_type: (document) => {
+    const label =
+      DOCUMENT_CSV_COLUMNS_MAP.get('document_type')?.getValue(document) ??
+      document.document_type
 
-  const getStateBadge = (state: string) => {
-    const labels = {
-      draft: 'Draft',
-      published: 'Published',
-    } as const;
+    return <Badge variant="outline">{label}</Badge>
+  },
+  status: (document) => {
+    const label =
+      DOCUMENT_CSV_COLUMNS_MAP.get('status')?.getValue(document) ??
+      document.status
+    const variant = statusVariants[document.status] ?? 'secondary'
+
+    return <Badge variant={variant}>{label}</Badge>
+  },
+  created_at: (document) => {
+    const createdAt = parseISO(document.created_at)
+
+    return (
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{format(createdAt, 'MMM d, yyyy')}</p>
+        <p className="text-xs text-muted-foreground">
+          {formatDistanceToNow(createdAt, { addSuffix: true })}
+        </p>
+      </div>
+    )
+  },
+  signature_progress: (document) => {
+    const value =
+      DOCUMENT_CSV_COLUMNS_MAP.get('signature_progress')?.getValue(document) ??
+      '—'
+
+    return <span className="text-sm text-muted-foreground">{value}</span>
+  },
+  tenant_count: (document) => {
+    const value =
+      DOCUMENT_CSV_COLUMNS_MAP.get('tenant_count')?.getValue(document) ?? '—'
+    const numeric = Number.parseInt(value, 10)
+
+    if (!Number.isNaN(numeric)) {
+      return (
+        <span className="text-sm text-muted-foreground">
+          {numeric} {numeric === 1 ? 'tenant' : 'tenants'}
+        </span>
+      )
+    }
+
+    return <span className="text-sm text-muted-foreground">{value}</span>
+  },
+  rent: (document) => {
+    const value = DOCUMENT_CSV_COLUMNS_MAP.get('rent')?.getValue(document) ?? '—'
+
+    return <span className="text-sm text-muted-foreground">{value}</span>
+  },
+  requires_signature: (document) => {
+    const value =
+      DOCUMENT_CSV_COLUMNS_MAP.get('requires_signature')?.getValue(document) ??
+      (document.requires_signature ? 'Yes' : 'No')
 
     return (
       <Badge
-        variant={state === 'published' ? 'default' : 'secondary'}
+        variant={document.requires_signature ? 'default' : 'secondary'}
         className="uppercase"
       >
-        {labels[state as keyof typeof labels] || state}
+        {value}
       </Badge>
-    );
-  };
+    )
+  },
+  expires_at: (document) => {
+    const value =
+      DOCUMENT_CSV_COLUMNS_MAP.get('expires_at')?.getValue(document) ?? '—'
 
-  const versionStatusLabel = (status: string) => {
-    const labels = {
-      draft: 'Draft Saved',
-      pending_signature: 'Sent for Signature',
-      signed: 'Signed',
-      expired: 'Expired',
-      cancelled: 'Cancelled',
-    } as const;
+    return <span className="text-sm text-muted-foreground">{value}</span>
+  },
+}
 
-    return labels[status as keyof typeof labels] || status;
-  };
+export function DocumentsList({
+  filters,
+  sort,
+  visibleColumns,
+}: DocumentsListProps) {
+  const [documents, setDocuments] = useState<DocumentWithLease[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
 
-  const getTypeIcon = (type: string) => {
-    switch (type) {
-      case 'lease':
-        return <FileText className="size-4" />;
-      case 'addendum':
-        return <FileText className="size-4" />;
-      case 'insurance':
-        return <Users className="size-4" />;
-      default:
-        return <FileText className="size-4" />;
+  const serializedFilters = useMemo(
+    () => JSON.stringify(filters ?? {}),
+    [filters],
+  )
+  const serializedSort = useMemo(
+    () => JSON.stringify(sort ?? null),
+    [sort],
+  )
+  const hasActiveFilters = useMemo(() => {
+    const parsed = serializedFilters ? JSON.parse(serializedFilters) : {}
+    return Object.keys(parsed as Record<string, unknown>).length > 0
+  }, [serializedFilters])
+
+  const orderedVisibleColumns = useMemo(
+    () =>
+      visibleColumns.filter((columnId) =>
+        DOCUMENT_CSV_COLUMNS_MAP.has(columnId),
+      ),
+    [visibleColumns],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchDocuments = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+
+        const parsedFilters: DocumentListFilters = serializedFilters
+          ? (JSON.parse(serializedFilters) as DocumentListFilters)
+          : {}
+        const parsedSort: DocumentListSort | undefined = serializedSort
+          ? (JSON.parse(serializedSort) as DocumentListSort)
+          : undefined
+
+        const result = await getDocumentsAction({
+          filters: parsedFilters,
+          sort: parsedSort,
+        })
+
+        if (cancelled) {
+          return
+        }
+
+        if (result.success && result.data) {
+          setDocuments(result.data)
+        } else {
+          setError(result.error || 'Failed to fetch documents')
+        }
+      } catch (fetchError) {
+        console.error('Error fetching documents:', fetchError)
+        if (!cancelled) {
+          setError('An unexpected error occurred')
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
     }
-  };
+
+    fetchDocuments()
+
+    return () => {
+      cancelled = true
+    }
+  }, [serializedFilters, serializedSort, reloadKey])
+
+  const columnCount = orderedVisibleColumns.length + 1
 
   if (loading) {
-    return (
-      <div className="space-y-4">
-        {[...Array(3)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <div className="space-y-2">
-                  <div className="h-5 w-48 rounded bg-muted"></div>
-                  <div className="h-4 w-32 rounded bg-muted"></div>
-                </div>
-                <div className="h-6 w-20 rounded bg-muted"></div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center justify-between">
-                <div className="h-4 w-24 rounded bg-muted"></div>
-                <div className="flex space-x-2">
-                  <div className="h-8 w-16 rounded bg-muted"></div>
-                  <div className="h-8 w-16 rounded bg-muted"></div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    );
+    return <DocumentsTableSkeleton columnCount={columnCount} />
   }
 
   if (error) {
     return (
-      <Card className="p-6">
-        <div className="text-center">
-          <p className="mb-2 text-destructive">Error loading documents</p>
-          <p className="text-sm text-muted-foreground">{error}</p>
-          <Button
-            variant="outline"
-            className="mt-4"
-            onClick={() => window.location.reload()}
-          >
-            Try Again
-          </Button>
-        </div>
-      </Card>
-    );
+      <div className="rounded-lg border p-6 text-center">
+        <p className="text-sm font-medium text-destructive">Error loading documents</p>
+        <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-4"
+          onClick={() => setReloadKey((key) => key + 1)}
+        >
+          Try again
+        </Button>
+      </div>
+    )
+  }
+
+  if (orderedVisibleColumns.length === 0) {
+    return (
+      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
+        Select at least one column to display.
+      </div>
+    )
   }
 
   if (documents.length === 0) {
     return (
-      <Card className="p-12">
-        <div className="text-center">
-          <FileText className="mx-auto mb-4 size-12 text-muted-foreground" />
-          <h3 className="mb-2 text-lg font-medium">No documents found</h3>
-          <p className="text-sm text-muted-foreground">
-            {Object.keys(filter).length > 0
-              ? "No documents match your current filters."
-              : "Get started by uploading your first document."}
-          </p>
-        </div>
-      </Card>
-    );
+      <div className="rounded-lg border p-12 text-center">
+        <FileText className="mx-auto mb-4 size-12 text-muted-foreground" />
+        <h3 className="text-lg font-medium">No documents found</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {hasActiveFilters
+            ? 'No documents match your current filters.'
+            : 'Get started by uploading your first document.'}
+        </p>
+      </div>
+    )
   }
 
   return (
-    <div className="space-y-4">
-      {documents.map((doc) => (
-        <Card key={doc.id} className="transition-shadow hover:shadow-md">
-          <CardHeader className="pb-3">
-            <div className="flex items-start justify-between">
-              <div className="flex items-start space-x-3">
-                <div className="mt-1">
-                  {getTypeIcon(doc.document_type)}
-                </div>
-                <div className="space-y-1">
-                  <h3 className="font-medium leading-none">{doc.title}</h3>
-                  {doc.description && (
-                    <p className="text-sm text-muted-foreground">
-                      {doc.description}
-                    </p>
-                  )}
-                  <div className="flex items-center space-x-4 text-xs text-muted-foreground">
-                    <div className="flex items-center space-x-1">
-                      <Calendar className="size-3" />
-                      <span>
-                        {formatDistanceToNow(new Date(doc.created_at), { addSuffix: true })}
-                      </span>
-                    </div>
-                    {doc.lease && (
-                      <div className="flex items-center space-x-1">
-                        <Users className="size-3" />
-                        <span>Lease • {doc.lease.tenant_ids?.length || 0} tenants</span>
-                      </div>
-                    )}
-                    {doc.signatures && doc.signatures.length > 0 && (
-                      <div className="flex items-center space-x-1">
-                        <Eye className="size-3" />
-                        <span>
-                          {doc.signatures.filter(s => s.status === 'signed').length}/
-                          {doc.signatures.length} signed
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                {getStateBadge(doc.state)}
-                {getStatusBadge(doc.status)}
-                <DocumentActions document={doc} />
-              </div>
-            </div>
-          </CardHeader>
-          {(doc.signatures && doc.signatures.length > 0) && (
-            <CardContent className="pt-0">
-              <div className="flex items-center space-x-2">
-                <span className="text-xs text-muted-foreground">Signers:</span>
-                {doc.signatures.slice(0, 3).map((signature) => (
-                  <Badge
-                    key={signature.id}
-                    variant={signature.status === 'signed' ? 'default' : 'outline'}
-                    className="text-xs"
-                  >
-                    {signature.signer_name || signature.signer_email.split('@')[0]}
-                  </Badge>
-                ))}
-                {doc.signatures.length > 3 && (
-                  <Badge variant="secondary" className="text-xs">
-                    +{doc.signatures.length - 3} more
-                  </Badge>
-                )}
-              </div>
-            </CardContent>
-          )}
-
-          {doc.versions && doc.versions.length > 0 && (
-            <CardContent className="pt-3">
-              <div className="border-t pt-3">
-                <div className="text-xs font-medium uppercase text-muted-foreground">
-                  Version history
-                </div>
-                <div className="mt-2 space-y-2">
-                  {doc.versions.slice(0, 5).map((version) => (
-                    <div
-                      key={version.id}
-                      className="flex items-center justify-between text-xs text-muted-foreground"
-                    >
-                      <div className="flex items-center space-x-2">
-                        <Badge
-                          variant={version.version === doc.version ? 'default' : 'outline'}
-                          className="text-[10px] uppercase"
-                        >
-                          v{version.version}
-                        </Badge>
-                        <Badge
-                          variant={version.state === 'published' ? 'default' : 'secondary'}
-                          className="text-[10px] uppercase"
-                        >
-                          {version.state}
-                        </Badge>
-                        <span>{versionStatusLabel(version.status)}</span>
-                      </div>
-                      <span>
-                        {formatDistanceToNow(new Date(version.created_at), { addSuffix: true })}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </CardContent>
-          )}
-        </Card>
-      ))}
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[760px] divide-y rounded-lg border">
+        <thead className="bg-muted/40">
+          <tr className="text-xs uppercase tracking-wide text-muted-foreground">
+            {orderedVisibleColumns.map((columnId) => {
+              const label =
+                DOCUMENT_CSV_COLUMNS_MAP.get(columnId)?.label ?? columnId
+              return (
+                <th key={columnId} className="px-4 py-3 text-left font-medium">
+                  {label}
+                </th>
+              )
+            })}
+            <th className="px-4 py-3 text-right font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {documents.map((document) => (
+            <tr key={document.id} className="bg-background hover:bg-muted/40">
+              {orderedVisibleColumns.map((columnId) => (
+                <td key={columnId} className="px-4 py-3 align-top text-sm">
+                  {columnRenderers[columnId]?.(document)}
+                </td>
+              ))}
+              <td className="px-4 py-3 align-top text-right">
+                <DocumentActions document={document} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
-  );
+  )
+}
+
+function DocumentsTableSkeleton({
+  columnCount,
+}: {
+  columnCount: number
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <table className="w-full min-w-[720px]">
+        <thead className="bg-muted/40">
+          <tr>
+            {Array.from({ length: columnCount }).map((_, index) => (
+              <th key={index} className="px-4 py-3 text-left">
+                <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 5 }).map((_, rowIndex) => (
+            <tr key={rowIndex} className="border-t">
+              {Array.from({ length: columnCount }).map((_, cellIndex) => (
+                <td key={cellIndex} className="px-4 py-4">
+                  <div className="h-4 w-full max-w-[200px] animate-pulse rounded bg-muted" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
 }

--- a/app/documents/components/documents-workspace.tsx
+++ b/app/documents/components/documents-workspace.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import { Suspense, useCallback, useMemo, useState } from 'react'
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { DocumentsFilters } from "./documents-filters"
+import { DocumentsList } from "./documents-list"
+import { exportDocumentsAction } from "../actions"
+import { DOCUMENT_CSV_COLUMNS, type DocumentColumnId } from '@/lib/documents/csv-columns'
+import type { DocumentListFilters, DocumentListSort } from '@/types/documents'
+
+const LEASES_FILTER: DocumentListFilters = { type: ['lease'] }
+const PENDING_FILTER: DocumentListFilters = { status: ['pending_signature'] }
+const SIGNED_FILTER: DocumentListFilters = { status: ['signed'] }
+
+export function DocumentsWorkspace() {
+  const [filters, setFilters] = useState<DocumentListFilters>({})
+  const [sort, setSort] = useState<DocumentListSort>({
+    column: 'created_at',
+    direction: 'desc',
+  })
+  const [columnVisibility, setColumnVisibility] = useState<Record<DocumentColumnId, boolean>>(() => {
+    const initial: Record<DocumentColumnId, boolean> = {}
+    for (const column of DOCUMENT_CSV_COLUMNS) {
+      initial[column.id] = true
+    }
+    initial.title = true
+    return initial
+  })
+  const [exporting, setExporting] = useState(false)
+
+  const visibleColumns = useMemo(
+    () =>
+      DOCUMENT_CSV_COLUMNS.map((column) => column.id).filter(
+        (columnId) => columnVisibility[columnId] !== false,
+      ),
+    [columnVisibility],
+  )
+
+  const handleColumnVisibilityChange = useCallback(
+    (columnId: DocumentColumnId, visible: boolean) => {
+      if (!visible && columnId === 'title') {
+        return
+      }
+
+      setColumnVisibility((previous) => ({
+        ...previous,
+        [columnId]: visible,
+      }))
+    },
+    [],
+  )
+
+  const handleExport = useCallback(async () => {
+    if (visibleColumns.length === 0) {
+      return
+    }
+
+    try {
+      setExporting(true)
+      const result = await exportDocumentsAction({
+        filters,
+        sort,
+        columns: visibleColumns,
+      })
+
+      if (result.success && result.data) {
+        const blob = new Blob([result.data.csv], {
+          type: 'text/csv;charset=utf-8;',
+        })
+        const url = URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = result.data.filename
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+        URL.revokeObjectURL(url)
+      } else if (result.error) {
+        console.error('Failed to export documents:', result.error)
+      }
+    } catch (error) {
+      console.error('Unexpected error exporting documents:', error)
+    } finally {
+      setExporting(false)
+    }
+  }, [filters, sort, visibleColumns])
+
+  const baseFilters = filters
+  const leasesFilters = useMemo(() => ({ ...filters, ...LEASES_FILTER }), [filters])
+  const pendingFilters = useMemo(() => ({ ...filters, ...PENDING_FILTER }), [filters])
+  const signedFilters = useMemo(() => ({ ...filters, ...SIGNED_FILTER }), [filters])
+
+  return (
+    <Tabs defaultValue="all" className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <TabsList className="grid w-full max-w-md grid-cols-4">
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="leases">Leases</TabsTrigger>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="signed">Signed</TabsTrigger>
+        </TabsList>
+        <DocumentsFilters
+          filters={filters}
+          onFiltersChange={setFilters}
+          sort={sort}
+          onSortChange={setSort}
+          columns={DOCUMENT_CSV_COLUMNS}
+          columnVisibility={columnVisibility}
+          onColumnVisibilityChange={handleColumnVisibilityChange}
+          onExport={handleExport}
+          exporting={exporting}
+        />
+      </div>
+
+      <TabsContent value="all" className="space-y-6">
+        <Suspense fallback={<DocumentsListSkeleton />}>
+          <DocumentsList
+            filters={baseFilters}
+            sort={sort}
+            visibleColumns={visibleColumns}
+          />
+        </Suspense>
+      </TabsContent>
+
+      <TabsContent value="leases" className="space-y-6">
+        <Suspense fallback={<DocumentsListSkeleton />}>
+          <DocumentsList
+            filters={leasesFilters}
+            sort={sort}
+            visibleColumns={visibleColumns}
+          />
+        </Suspense>
+      </TabsContent>
+
+      <TabsContent value="pending" className="space-y-6">
+        <Suspense fallback={<DocumentsListSkeleton />}>
+          <DocumentsList
+            filters={pendingFilters}
+            sort={sort}
+            visibleColumns={visibleColumns}
+          />
+        </Suspense>
+      </TabsContent>
+
+      <TabsContent value="signed" className="space-y-6">
+        <Suspense fallback={<DocumentsListSkeleton />}>
+          <DocumentsList
+            filters={signedFilters}
+            sort={sort}
+            visibleColumns={visibleColumns}
+          />
+        </Suspense>
+      </TabsContent>
+    </Tabs>
+  )
+}
+
+function DocumentsListSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <table className="w-full min-w-[760px]">
+        <thead className="bg-muted/40">
+          <tr>
+            {Array.from({ length: 6 }).map((_, index) => (
+              <th key={index} className="px-4 py-3 text-left">
+                <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 5 }).map((_, rowIndex) => (
+            <tr key={rowIndex} className="border-t">
+              {Array.from({ length: 6 }).map((_, cellIndex) => (
+                <td key={cellIndex} className="px-4 py-4">
+                  <div className="h-4 w-full max-w-[200px] animate-pulse rounded bg-muted" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -2,12 +2,9 @@ import { Suspense } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { FileText, Users, Clock, Upload } from 'lucide-react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UploadDocumentDialog } from "./components/upload-document-dialog";
 import { DocumentsStats } from "./components/documents-stats";
-import { DocumentsList } from "./components/documents-list";
-import { DocumentsFilters } from "./components/documents-filters";
-import { DocumentListFilters } from '@/types/documents';
+import { DocumentsWorkspace } from "./components/documents-workspace";
 
 export default function DocumentsPage() {
   return (
@@ -42,41 +39,7 @@ export default function DocumentsPage() {
       </Suspense>
 
       {/* Main Content Tabs */}
-      <Tabs defaultValue="all" className="space-y-6">
-        <div className="flex items-center justify-between">
-          <TabsList className="grid w-full max-w-md grid-cols-4">
-            <TabsTrigger value="all">All</TabsTrigger>
-            <TabsTrigger value="leases">Leases</TabsTrigger>
-            <TabsTrigger value="pending">Pending</TabsTrigger>
-            <TabsTrigger value="signed">Signed</TabsTrigger>
-          </TabsList>
-          <DocumentsFilters />
-        </div>
-
-        <TabsContent value="all" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{}} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="leases" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ type: ['lease'] }} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="pending" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['pending_signature'] }} />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="signed" className="space-y-6">
-          <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['signed'] }} />
-          </Suspense>
-        </TabsContent>
-      </Tabs>
+      <DocumentsWorkspace />
 
       {/* Feature Highlights */}
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
@@ -140,31 +103,3 @@ export default function DocumentsPage() {
   );
 }
 
-function DocumentsListSkeleton() {
-  return (
-    <div className="space-y-4">
-      {[...Array(5)].map((_, i) => (
-        <Card key={i} className="animate-pulse">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <div className="space-y-2">
-                <div className="h-5 w-48 rounded bg-muted"></div>
-                <div className="h-4 w-32 rounded bg-muted"></div>
-              </div>
-              <div className="h-6 w-20 rounded bg-muted"></div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between">
-              <div className="h-4 w-24 rounded bg-muted"></div>
-              <div className="flex space-x-2">
-                <div className="h-8 w-16 rounded bg-muted"></div>
-                <div className="h-8 w-16 rounded bg-muted"></div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
-}

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -1,0 +1,58 @@
+import type { DocumentColumnId } from "./documents/csv-columns"
+
+export interface CsvColumn<T> {
+  id: DocumentColumnId | string
+  label: string
+  getValue: (row: T) => unknown
+}
+
+function escapeCsvValue(value: string): string {
+  if (value.includes("\"")) {
+    value = value.replace(/"/g, '""')
+  }
+
+  if (/[",\n\r]/.test(value)) {
+    return `"${value}"`
+  }
+
+  return value
+}
+
+export function convertRowsToCsv<T>({
+  rows,
+  columns,
+  visibleColumnIds,
+}: {
+  rows: T[]
+  columns: CsvColumn<T>[]
+  visibleColumnIds: string[]
+}): string {
+  if (columns.length === 0 || visibleColumnIds.length === 0) {
+    return ""
+  }
+
+  const columnSet = new Set(visibleColumnIds)
+  const visibleColumns = columns.filter((column) => columnSet.has(column.id))
+
+  if (visibleColumns.length === 0) {
+    return ""
+  }
+
+  const header = visibleColumns.map((column) => escapeCsvValue(column.label)).join(",")
+
+  const dataLines = rows.map((row) =>
+    visibleColumns
+      .map((column) => {
+        const rawValue = column.getValue(row)
+        if (rawValue === null || rawValue === undefined) {
+          return ""
+        }
+
+        const stringValue = String(rawValue)
+        return escapeCsvValue(stringValue)
+      })
+      .join(","),
+  )
+
+  return [header, ...dataLines].join("\n")
+}

--- a/lib/data/documents.ts
+++ b/lib/data/documents.ts
@@ -1,11 +1,17 @@
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import type {
   DocumentListFilters,
+  DocumentListSort,
   DocumentStats,
   DocumentVersion,
   DocumentWithLease,
 } from '@/types/documents';
 import type { Database } from '@/lib/supabase';
+import { convertRowsToCsv } from '@/lib/csv';
+import {
+  DOCUMENT_CSV_COLUMNS,
+  type DocumentColumnId,
+} from '@/lib/documents/csv-columns';
 
 type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
 
@@ -16,6 +22,7 @@ type FetchDocumentsParams = {
   userId: string;
   role: MemberRole | null | undefined;
   filters?: DocumentListFilters;
+  sort?: DocumentListSort;
 };
 
 type FetchDocumentStatsParams = {
@@ -53,11 +60,19 @@ export async function fetchDocumentsList({
   userId,
   role,
   filters = {},
+  sort,
 }: FetchDocumentsParams): Promise<DocumentWithLease[]> {
+  const sortColumn = sort?.column ?? 'created_at';
+  const ascending = sort?.direction === 'asc';
+
   let query = (client as any)
     .from('documents')
     .select(DOCUMENT_SELECT)
-    .order('created_at', { ascending: false });
+    .order(sortColumn, { ascending });
+
+  if (sortColumn !== 'created_at') {
+    query = query.order('created_at', { ascending: false });
+  }
 
   if (role !== 'property_manager' && role !== 'admin') {
     query = query.or(`tenant_id.eq.${userId},signatures.signer_id.eq.${userId}`);
@@ -101,6 +116,34 @@ export async function fetchDocumentsList({
       .slice()
       .sort((a, b) => b.version - a.version),
   }));
+}
+
+export async function exportDocumentsToCsv({
+  client,
+  userId,
+  role,
+  filters,
+  sort,
+  visibleColumns,
+}: FetchDocumentsParams & { visibleColumns: DocumentColumnId[] }): Promise<{
+  csv: string;
+  documents: DocumentWithLease[];
+}> {
+  const documents = await fetchDocumentsList({
+    client,
+    userId,
+    role,
+    filters,
+    sort,
+  });
+
+  const csv = convertRowsToCsv({
+    rows: documents,
+    columns: DOCUMENT_CSV_COLUMNS,
+    visibleColumnIds: visibleColumns,
+  });
+
+  return { csv, documents };
 }
 
 export async function fetchDocumentStats({

--- a/lib/documents/csv-columns.ts
+++ b/lib/documents/csv-columns.ts
@@ -1,0 +1,141 @@
+import { formatDate } from "@/lib/utils"
+import { formatCurrency } from "@/lib/payments/currency"
+import type { DocumentWithLease } from "@/types/documents"
+
+const TYPE_LABELS: Record<string, string> = {
+  lease: "Lease",
+  addendum: "Addendum",
+  insurance: "Insurance",
+  maintenance: "Maintenance",
+  other: "Other",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: "Draft",
+  pending_signature: "Pending Signature",
+  signed: "Signed",
+  expired: "Expired",
+  cancelled: "Cancelled",
+}
+
+export const DOCUMENT_COLUMN_IDS = [
+  "title",
+  "document_type",
+  "status",
+  "created_at",
+  "signature_progress",
+  "tenant_count",
+  "rent",
+  "requires_signature",
+  "expires_at",
+] as const
+
+export type DocumentColumnId = (typeof DOCUMENT_COLUMN_IDS)[number]
+
+export interface DocumentCsvColumn {
+  id: DocumentColumnId
+  label: string
+  getValue: (document: DocumentWithLease) => string
+}
+
+function resolveCurrency(document: DocumentWithLease): string {
+  const metadataCurrency = typeof document.metadata?.currency === "string" ? document.metadata.currency : null
+  if (metadataCurrency) {
+    return metadataCurrency.toUpperCase()
+  }
+  if (document.lease && (document.lease as any).currency) {
+    return String((document.lease as any).currency)
+  }
+  return "USD"
+}
+
+function formatRent(document: DocumentWithLease): string {
+  const rentAmount = document.lease?.rent_amount
+  if (rentAmount === null || rentAmount === undefined) {
+    return "—"
+  }
+
+  const currency = resolveCurrency(document)
+  const dollars = rentAmount / 100
+  const formatted = formatCurrency(dollars, currency)
+  const frequency = document.lease?.rent_frequency
+  return frequency ? `${formatted} / ${frequency}` : formatted
+}
+
+function formatSignatureProgress(document: DocumentWithLease): string {
+  const total = document.signatures?.length ?? 0
+  if (total === 0) {
+    return "No signatures"
+  }
+
+  const signed = document.signatures?.filter((signature) => signature?.status === "signed").length ?? 0
+  return `${signed}/${total} signed`
+}
+
+function formatTenantCount(document: DocumentWithLease): string {
+  const tenantIds = document.lease?.tenant_ids
+  if (tenantIds && tenantIds.length > 0) {
+    return `${tenantIds.length}`
+  }
+
+  const metadataTenants = Array.isArray(document.metadata?.tenant_ids)
+    ? (document.metadata?.tenant_ids as unknown[])
+    : null
+  if (metadataTenants && metadataTenants.length > 0) {
+    return `${metadataTenants.length}`
+  }
+
+  return "—"
+}
+
+export const DOCUMENT_CSV_COLUMNS: DocumentCsvColumn[] = [
+  {
+    id: "title",
+    label: "Title",
+    getValue: (document) => document.title,
+  },
+  {
+    id: "document_type",
+    label: "Type",
+    getValue: (document) => TYPE_LABELS[document.document_type] ?? document.document_type,
+  },
+  {
+    id: "status",
+    label: "Status",
+    getValue: (document) => STATUS_LABELS[document.status] ?? document.status,
+  },
+  {
+    id: "created_at",
+    label: "Created",
+    getValue: (document) => formatDate(document.created_at),
+  },
+  {
+    id: "signature_progress",
+    label: "Signature progress",
+    getValue: (document) => formatSignatureProgress(document),
+  },
+  {
+    id: "tenant_count",
+    label: "Tenants",
+    getValue: (document) => formatTenantCount(document),
+  },
+  {
+    id: "rent",
+    label: "Rent",
+    getValue: (document) => formatRent(document),
+  },
+  {
+    id: "requires_signature",
+    label: "Requires signature",
+    getValue: (document) => (document.requires_signature ? "Yes" : "No"),
+  },
+  {
+    id: "expires_at",
+    label: "Expires",
+    getValue: (document) => (document.expires_at ? formatDate(document.expires_at) : "—"),
+  },
+]
+
+export const DOCUMENT_CSV_COLUMNS_MAP = new Map(
+  DOCUMENT_CSV_COLUMNS.map((column) => [column.id, column] as const),
+)

--- a/tests/lib/data/documents-export.test.ts
+++ b/tests/lib/data/documents-export.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { exportDocumentsToCsv } from '@/lib/data/documents'
+import type { DocumentListFilters } from '@/types/documents'
+import type { DocumentWithLease } from '@/types/documents'
+
+type QueryResult<T> = { data: T; error: { message: string } | null }
+
+type QueryBuilder<T> = {
+  select: ReturnType<typeof vi.fn>
+  order: ReturnType<typeof vi.fn>
+  or: ReturnType<typeof vi.fn>
+  in: ReturnType<typeof vi.fn>
+  eq: ReturnType<typeof vi.fn>
+  gte: ReturnType<typeof vi.fn>
+  lte: ReturnType<typeof vi.fn>
+  then: (onFulfilled: (value: QueryResult<T>) => unknown) => Promise<unknown>
+}
+
+function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
+  const builder: Partial<QueryBuilder<T>> & {
+    select: ReturnType<typeof vi.fn>
+    order: ReturnType<typeof vi.fn>
+    or: ReturnType<typeof vi.fn>
+    in: ReturnType<typeof vi.fn>
+    eq: ReturnType<typeof vi.fn>
+    gte: ReturnType<typeof vi.fn>
+    lte: ReturnType<typeof vi.fn>
+  } = {
+    select: vi.fn().mockImplementation(() => builder),
+    order: vi.fn().mockImplementation(() => builder),
+    or: vi.fn().mockImplementation(() => builder),
+    in: vi.fn().mockImplementation(() => builder),
+    eq: vi.fn().mockImplementation(() => builder),
+    gte: vi.fn().mockImplementation(() => builder),
+    lte: vi.fn().mockImplementation(() => builder),
+  }
+
+  ;(builder as QueryBuilder<T>).then = (onFulfilled) =>
+    Promise.resolve(onFulfilled(result))
+
+  return builder as QueryBuilder<T>
+}
+
+function createSupabaseStub<T extends unknown[]>(query: QueryBuilder<T>) {
+  return {
+    from: vi.fn((table: string) => {
+      expect(table).toBe('documents')
+      return query
+    }),
+  }
+}
+
+const baseDocument: DocumentWithLease = {
+  id: 'doc-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-02T00:00:00Z',
+  title: 'Lease Agreement',
+  description: 'Primary lease for unit 501',
+  document_type: 'lease',
+  status: 'signed',
+  state: 'published',
+  file_url: null,
+  documenso_envelope_id: null,
+  documenso_template_id: null,
+  created_by: 'manager-1',
+  tenant_id: 'tenant-1',
+  unit_id: 'unit-501',
+  requires_signature: true,
+  expires_at: '2025-01-01T00:00:00Z',
+  signed_at: '2024-01-05T00:00:00Z',
+  version: 1,
+  parent_document_id: null,
+  published_at: '2024-01-02T00:00:00Z',
+  lease: {
+    id: 'lease-1',
+    document_id: 'doc-1',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    start_date: '2024-01-01',
+    end_date: '2024-12-31',
+    rent_amount: 250000,
+    rent_frequency: 'monthly',
+    security_deposit: 50000,
+    tenant_ids: ['tenant-1', 'tenant-2'],
+    property_address: '123 Main St',
+    unit_number: '501',
+    landlord_name: 'Property Manager',
+    landlord_email: 'pm@example.com',
+    auto_renew: false,
+    renewal_notice_days: 60,
+    special_terms: null,
+    status: 'active',
+  },
+  signatures: [
+    {
+      id: 'sig-1',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      document_id: 'doc-1',
+      signer_id: 'tenant-1',
+      signer_email: 'tenant1@example.com',
+      signer_name: 'Tenant One',
+      status: 'signed',
+      signed_at: '2024-01-03T00:00:00Z',
+      declined_at: null,
+      decline_reason: null,
+      documenso_signature_id: null,
+      ip_address: null,
+      user_agent: null,
+      signature_data: null,
+      signing_order: 1,
+    },
+    {
+      id: 'sig-2',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      document_id: 'doc-1',
+      signer_id: 'tenant-2',
+      signer_email: 'tenant2@example.com',
+      signer_name: 'Tenant Two',
+      status: 'pending',
+      signed_at: null,
+      declined_at: null,
+      decline_reason: null,
+      documenso_signature_id: null,
+      ip_address: null,
+      user_agent: null,
+      signature_data: null,
+      signing_order: 2,
+    },
+  ],
+  access_logs: [],
+  versions: [],
+}
+
+describe('exportDocumentsToCsv', () => {
+  it('honors filters and column visibility when generating CSV', async () => {
+    const query = createDocumentsQuery({
+      data: [baseDocument] as DocumentWithLease[],
+      error: null,
+    })
+    const supabase = createSupabaseStub(query)
+
+    const filters: DocumentListFilters = { status: ['signed'], type: ['lease'] }
+
+    const { csv, documents } = await exportDocumentsToCsv({
+      client: supabase,
+      userId: 'tenant-1',
+      role: 'tenant',
+      filters,
+      sort: { column: 'title', direction: 'asc' },
+      visibleColumns: ['title', 'status', 'rent'],
+    })
+
+    expect(query.in).toHaveBeenCalledWith('status', filters.status)
+    expect(query.in).toHaveBeenCalledWith('document_type', filters.type)
+    expect(query.order).toHaveBeenNthCalledWith(
+      1,
+      'title',
+      expect.objectContaining({ ascending: true }),
+    )
+    expect(csv.split('\n')[0]).toBe('Title,Status,Rent')
+    expect(csv.split('\n')[1]).toContain('Lease Agreement')
+    expect(csv.split('\n')[1]).toContain('$2,500.00 / monthly')
+    expect(documents).toHaveLength(1)
+  })
+})

--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -93,6 +93,29 @@ describe('fetchDocumentsList', () => {
     expect(query.or).not.toHaveBeenCalled();
   });
 
+  it('applies custom sorting when provided', async () => {
+    const query = createDocumentsQuery({ data: [], error: null });
+    const supabase = createSupabaseStub(query);
+
+    await fetchDocumentsList({
+      client: supabase,
+      userId: 'user-123',
+      role: 'tenant',
+      sort: { column: 'title', direction: 'asc' },
+    });
+
+    expect(query.order).toHaveBeenNthCalledWith(
+      1,
+      'title',
+      expect.objectContaining({ ascending: true }),
+    );
+    expect(query.order).toHaveBeenNthCalledWith(
+      2,
+      'created_at',
+      expect.objectContaining({ ascending: false }),
+    );
+  });
+
   it('throws when Supabase returns an error', async () => {
     const query = createDocumentsQuery({ data: null as any, error: { message: 'boom' } });
     const supabase = createSupabaseStub(query);

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -152,6 +152,17 @@ export interface DocumentListFilters {
   date_to?: string;
 }
 
+export type DocumentListSortColumn =
+  | 'created_at'
+  | 'title'
+  | 'status'
+  | 'document_type'
+
+export interface DocumentListSort {
+  column: DocumentListSortColumn;
+  direction: 'asc' | 'desc';
+}
+
 export interface DocumentStats {
   total_documents: number;
   pending_signatures: number;


### PR DESCRIPTION
## Summary
- add a documents workspace component that coordinates filters, column visibility, sorting, and CSV exports on the documents page
- implement reusable CSV conversion utilities and document export server action backed by shared column definitions
- cover document exports with tests ensuring filters and column visibility are respected

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30badc63c83288b153c64c58847ed