### PR TITLE
Add breadcrumbs to resource pages

### DIFF
--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Breadcrumbs } from "@/components/navigation/breadcrumbs"
 
 import { AmenityBookingForm } from "./components/amenity-booking-form"
 import { BookingHistory } from "./components/booking-history"
@@ -69,6 +70,7 @@ export default function BookingsPage() {
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
+        <Breadcrumbs />
         <div className="space-y-2">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
             Amenity Bookings

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -8,11 +8,13 @@ import { DocumentsStats } from "./components/documents-stats";
 import { DocumentsList } from "./components/documents-list";
 import { DocumentsFilters } from "./components/documents-filters";
 import { DocumentListFilters } from '@/types/documents';
+import { Breadcrumbs } from "@/components/navigation/breadcrumbs";
 
 export default function DocumentsPage() {
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
+        <Breadcrumbs />
         <div className="flex items-center justify-between">
           <div className="space-y-2">
             <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Documents</h1>

--- a/app/maintenance/page.tsx
+++ b/app/maintenance/page.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MaintenanceRequestForm } from "@/components/maintenance/maintenance-request-form";
+import { Breadcrumbs } from "@/components/navigation/breadcrumbs";
 
 const maintenanceHighlights = [
   {
@@ -20,6 +21,7 @@ export default function MaintenancePage() {
   return (
     <div className="container max-w-6xl space-y-10 py-12">
       <header className="space-y-4">
+        <Breadcrumbs />
         <div className="space-y-2">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Maintenance Requests</h1>
           <p className="text-base text-muted-foreground sm:text-lg">

--- a/components/navigation/breadcrumbs.tsx
+++ b/components/navigation/breadcrumbs.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import * as React from "react"
+import Link from "next/link"
+import { usePathname, useSelectedLayoutSegments } from "next/navigation"
+import { ChevronRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+interface BreadcrumbItem {
+  href: string
+  label: string
+  isCurrent: boolean
+}
+
+const SEGMENT_LABEL_OVERRIDES: Record<string, string> = {
+  account: "Account",
+  bookings: "Bookings",
+  contact: "Contact",
+  dashboard: "Dashboard",
+  documents: "Documents",
+  history: "History",
+  leases: "Leases",
+  maintenance: "Maintenance",
+  messaging: "Messaging",
+  onboarding: "Onboarding",
+  payments: "Payments",
+  schedule: "Schedule",
+  supplies: "Supplies",
+  visitors: "Visitors",
+}
+
+const formatSegmentLabel = (segment: string) => {
+  const normalized = segment.toLowerCase()
+  const override = SEGMENT_LABEL_OVERRIDES[normalized]
+  if (override) {
+    return override
+  }
+
+  return segment
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+export const createBreadcrumbItems = (segments: string[]): BreadcrumbItem[] => {
+  const sanitizedSegments = segments
+    .map((segment) => decodeURIComponent(segment))
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+
+  const crumbs = sanitizedSegments.map<BreadcrumbItem>((segment, index) => ({
+    href: `/${sanitizedSegments.slice(0, index + 1).join("/")}`,
+    label: formatSegmentLabel(segment),
+    isCurrent: index === sanitizedSegments.length - 1,
+  }))
+
+  return [
+    {
+      href: "/",
+      label: "Home",
+      isCurrent: sanitizedSegments.length === 0,
+    },
+    ...crumbs,
+  ]
+}
+
+export interface BreadcrumbsProps {
+  className?: string
+}
+
+export function Breadcrumbs({ className }: BreadcrumbsProps) {
+  const pathname = usePathname()
+  const selectedSegments = useSelectedLayoutSegments()
+
+  const segments = React.useMemo(() => {
+    const fallback = pathname?.split("/").filter(Boolean) ?? []
+    if (selectedSegments.length > fallback.length) {
+      return selectedSegments
+    }
+    return fallback
+  }, [pathname, selectedSegments])
+
+  const items = React.useMemo(() => createBreadcrumbItems(segments), [segments])
+
+  if (items.length <= 1) {
+    return null
+  }
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn("text-sm text-muted-foreground", className)}
+    >
+      <ol className="flex flex-wrap items-center gap-1">
+        {items.map((item, index) => (
+          <li key={item.href} className="flex items-center gap-1">
+            {index > 0 ? (
+              <ChevronRight
+                aria-hidden="true"
+                className="size-3 text-muted-foreground"
+              />
+            ) : null}
+            {item.isCurrent ? (
+              <span className="font-medium text-foreground">{item.label}</span>
+            ) : (
+              <Link
+                href={item.href}
+                className="transition-colors hover:text-foreground"
+              >
+                {item.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
+}

--- a/tests/breadcrumbs.test.tsx
+++ b/tests/breadcrumbs.test.tsx
@@ -1,0 +1,53 @@
+import { createElement } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+
+const usePathnameMock = vi.fn(() => "/")
+const useSelectedLayoutSegmentsMock = vi.fn(() => [] as string[])
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => usePathnameMock(),
+  useSelectedLayoutSegments: () => useSelectedLayoutSegmentsMock(),
+}))
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: any) =>
+    createElement(
+      "a",
+      { ...props, href: typeof href === "string" ? href : "" },
+      children,
+    ),
+}))
+
+import { Breadcrumbs } from "@/components/navigation/breadcrumbs"
+
+describe("Breadcrumbs", () => {
+  it("renders a breadcrumb trail for top-level routes", () => {
+    usePathnameMock.mockReturnValue("/documents")
+    useSelectedLayoutSegmentsMock.mockReturnValue(["documents"])
+
+    const markup = renderToStaticMarkup(createElement(Breadcrumbs))
+
+    expect(markup).toContain('aria-label="Breadcrumb"')
+    expect(markup).toMatch(/<a[^>]+href="\/">Home<\/a>/)
+    expect(markup).toMatch(/<span[^>]*>Documents<\/span>/)
+    expect(markup).not.toMatch(/<a[^>]+href="\/documents"[^>]*>Documents<\/a>/)
+  })
+
+  it("links intermediate crumbs to their parent routes", () => {
+    usePathnameMock.mockReturnValue("/documents/leases/lease-123")
+    useSelectedLayoutSegmentsMock.mockReturnValue([
+      "documents",
+      "leases",
+      "lease-123",
+    ])
+
+    const markup = renderToStaticMarkup(createElement(Breadcrumbs))
+
+    expect(markup).toMatch(/<a[^>]+href="\/">Home<\/a>/)
+    expect(markup).toMatch(/<a[^>]+href="\/documents"[^>]*>Documents<\/a>/)
+    expect(markup).toMatch(/<a[^>]+href="\/documents\/leases"[^>]*>Leases<\/a>/)
+    expect(markup).toMatch(/<span[^>]*>Lease 123<\/span>/)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a breadcrumb component that derives labels from the current App Router segments
- surface the breadcrumb trail on the documents, bookings, and maintenance resource pages
- cover the breadcrumb behaviour with unit tests and enable Vitest to discover `.test.tsx` files

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30baf13ac8328b409b0bc2de3425e