### PR TITLE
feat: add quick add command parser and UI

### DIFF
--- a/app/dashboard/(dashboard)/actions/quick-add.ts
+++ b/app/dashboard/(dashboard)/actions/quick-add.ts
@@ -1,0 +1,77 @@
+"use server"
+
+import { randomUUID } from "crypto"
+
+import type {
+  ParsedQuickAddCommand,
+  QuickAddIntent,
+} from "@/lib/dashboard/quick-add-parser"
+
+export type QuickAddPayload = Required<
+  Pick<ParsedQuickAddCommand, "intent" | "dueDate" | "description">
+> &
+  Pick<ParsedQuickAddCommand, "amount" | "currency">
+
+export type QuickAddResponse = {
+  status: "success"
+  item: {
+    id: string
+    type: QuickAddIntent
+    description: string
+    amount?: number
+    currency?: string
+    dueDate: string
+    reference: string
+  }
+}
+
+export async function createQuickAddItem(
+  payload: QuickAddPayload
+): Promise<QuickAddResponse> {
+  validatePayload(payload)
+
+  const id = randomUUID()
+  const referencePrefix = payload.intent === "invoice" ? "inv" : "task"
+  const reference = `${referencePrefix}_${id.split("-")[0]}`
+
+  return {
+    status: "success",
+    item: {
+      id,
+      type: payload.intent,
+      description: payload.description,
+      amount: payload.amount,
+      currency: payload.currency,
+      dueDate: payload.dueDate,
+      reference,
+    },
+  }
+}
+
+function validatePayload(payload: QuickAddPayload) {
+  if (!payload.intent) {
+    throw new Error("Missing the intent for this quick add command.")
+  }
+
+  if (!payload.description?.trim()) {
+    throw new Error("Quick add items need a short description.")
+  }
+
+  if (!payload.dueDate) {
+    throw new Error("Provide a due date so everyone stays on track.")
+  }
+
+  const dueDate = new Date(payload.dueDate)
+  if (Number.isNaN(dueDate.getTime())) {
+    throw new Error("Due date must be a valid ISO date string.")
+  }
+
+  if (payload.intent === "invoice") {
+    if (payload.amount === undefined) {
+      throw new Error("Invoices created from quick add require an amount.")
+    }
+    if (!payload.currency) {
+      throw new Error("Invoices created from quick add require a currency.")
+    }
+  }
+}

--- a/app/dashboard/(dashboard)/components/dashboard-quick-actions.tsx
+++ b/app/dashboard/(dashboard)/components/dashboard-quick-actions.tsx
@@ -1,6 +1,7 @@
 import SmartLink from "@/components/navigation/SmartLink"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { QuickAddCommand } from "./quick-add-command"
 import { getQuickActions } from "../data"
 import { ArrowUpRight } from "lucide-react"
 
@@ -15,26 +16,30 @@ export async function DashboardQuickActions() {
           Jump straight into the tasks residents complete most.
         </p>
       </CardHeader>
-      <CardContent className="space-y-3">
-        {actions.map((action) => (
-          <div
-            key={action.id}
-            className="flex flex-col gap-1 rounded-lg border border-transparent p-3 transition-colors hover:border-border/70 hover:bg-muted/50"
-          >
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <p className="text-sm font-medium text-foreground">{action.label}</p>
-                <p className="text-xs text-muted-foreground">{action.description}</p>
+      <CardContent className="space-y-4">
+        <QuickAddCommand />
+
+        <div className="space-y-3">
+          {actions.map((action) => (
+            <div
+              key={action.id}
+              className="flex flex-col gap-1 rounded-lg border border-transparent p-3 transition-colors hover:border-border/70 hover:bg-muted/50"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">{action.label}</p>
+                  <p className="text-xs text-muted-foreground">{action.description}</p>
+                </div>
+                <SmartLink href={action.href} className="shrink-0" intent="navigation">
+                  <Button variant="ghost" size="icon" className="size-8">
+                    <ArrowUpRight className="size-4" />
+                    <span className="sr-only">{`Go to ${action.label}`}</span>
+                  </Button>
+                </SmartLink>
               </div>
-              <SmartLink href={action.href} className="shrink-0" intent="navigation">
-                <Button variant="ghost" size="icon" className="size-8">
-                  <ArrowUpRight className="size-4" />
-                  <span className="sr-only">{`Go to ${action.label}`}</span>
-                </Button>
-              </SmartLink>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </CardContent>
     </Card>
   )

--- a/app/dashboard/(dashboard)/components/quick-add-command.tsx
+++ b/app/dashboard/(dashboard)/components/quick-add-command.tsx
@@ -1,0 +1,186 @@
+"use client"
+
+import { type FormEvent, useMemo, useState, useTransition } from "react"
+import { format, parseISO } from "date-fns"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  parseQuickAddCommand,
+  type ParsedQuickAddCommand,
+  type QuickAddIssue,
+} from "@/lib/dashboard/quick-add-parser"
+
+import { createQuickAddItem } from "../actions/quick-add"
+
+function formatCurrency(amount: number, currency: string) {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).format(amount)
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`
+  }
+}
+
+function describeSummary(data: Partial<ParsedQuickAddCommand>) {
+  if (!data.intent) {
+    return "We'll show a preview once we understand the intent."
+  }
+
+  const parts: string[] = []
+  parts.push(data.intent === "invoice" ? "Invoice" : "Task")
+
+  if (data.amount !== undefined) {
+    const currency = data.currency ?? "USD"
+    parts.push(formatCurrency(data.amount, currency))
+  }
+
+  if (data.dueDate) {
+    try {
+      const formattedDate = format(parseISO(data.dueDate), "MMM d, yyyy")
+      parts.push(`due ${formattedDate}`)
+    } catch {
+      parts.push(`due ${data.dueDate}`)
+    }
+  }
+
+  return parts.join(" ")
+}
+
+function splitIssues(issues: QuickAddIssue[]) {
+  return {
+    errors: issues.filter((issue) => issue.severity === "error"),
+    warnings: issues.filter((issue) => issue.severity === "warning"),
+  }
+}
+
+export function QuickAddCommand() {
+  const [command, setCommand] = useState("")
+  const [feedback, setFeedback] = useState<
+    | { status: "success"; message: string }
+    | { status: "error"; message: string }
+    | null
+  >(null)
+  const [isPending, startTransition] = useTransition()
+
+  const parsing = useMemo(() => parseQuickAddCommand(command), [command])
+  const { errors, warnings } = useMemo(
+    () => splitIssues(parsing.issues),
+    [parsing.issues]
+  )
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setFeedback(null)
+
+    if (!parsing.isReady || !parsing.data.intent || !parsing.data.dueDate) {
+      setFeedback({
+        status: "error",
+        message: "Add a little more detail so we can create the item.",
+      })
+      return
+    }
+
+    const payload = {
+      intent: parsing.data.intent,
+      description: parsing.data.description ?? command,
+      dueDate: parsing.data.dueDate,
+      amount: parsing.data.amount,
+      currency: parsing.data.currency,
+    }
+
+    startTransition(async () => {
+      try {
+        await createQuickAddItem(payload)
+        setFeedback({
+          status: "success",
+          message:
+            parsing.data.intent === "invoice"
+              ? "Invoice queued — we'll notify roommates once it's ready."
+              : "Task added to the shared list.",
+        })
+        setCommand("")
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Unable to create the quick add item."
+        setFeedback({ status: "error", message })
+      }
+    })
+  }
+
+  const hasInput = command.trim().length > 0
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <div className="space-y-1">
+        <Label htmlFor="quick-add-command" className="text-xs font-medium">
+          Quick add command
+        </Label>
+        <div className="flex items-center gap-2">
+          <Input
+            id="quick-add-command"
+            value={command}
+            onChange={(event) => setCommand(event.target.value)}
+            placeholder="e.g. Invoice $250 due next Friday for utilities"
+            aria-describedby="quick-add-feedback"
+            disabled={isPending}
+          />
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Adding" : "Add"}
+          </Button>
+        </div>
+      </div>
+
+      <div
+        id="quick-add-feedback"
+        className="space-y-2 rounded-md border border-dashed bg-muted/40 p-3 text-xs text-muted-foreground"
+      >
+        {hasInput ? (
+          <div className="space-y-2">
+            <p className="font-medium text-foreground">
+              {describeSummary(parsing.data)}
+            </p>
+
+            {errors.length > 0 && (
+              <ul className="space-y-1 text-destructive">
+                {errors.map((issue, index) => (
+                  <li key={`${issue.field}-${index}`}>{issue.message}</li>
+                ))}
+              </ul>
+            )}
+
+            {warnings.length > 0 && (
+              <ul className="space-y-1 text-amber-600">
+                {warnings.map((issue, index) => (
+                  <li key={`${issue.field}-${index}`}>{issue.message}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ) : (
+          <p>
+            Try phrases like "Invoice $420 due on 8/15 for Jordan" or "Task
+            schedule deep clean due in 3 days".
+          </p>
+        )}
+
+        {feedback && (
+          <p
+            className={
+              feedback.status === "success"
+                ? "text-emerald-600"
+                : "text-destructive"
+            }
+          >
+            {feedback.message}
+          </p>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/lib/dashboard/quick-add-parser.ts
+++ b/lib/dashboard/quick-add-parser.ts
@@ -1,0 +1,354 @@
+import {
+  addDays,
+  addWeeks,
+  format,
+  isAfter,
+  isValid,
+  nextDay,
+  parse,
+  startOfDay,
+} from "date-fns"
+
+export type QuickAddIntent = "invoice" | "task"
+
+export type ParsedQuickAddCommand = {
+  intent: QuickAddIntent
+  description: string
+  amount?: number
+  currency?: string
+  dueDate?: string
+}
+
+export type QuickAddIssue = {
+  field: "intent" | "amount" | "currency" | "dueDate"
+  message: string
+  severity: "error" | "warning"
+}
+
+export type QuickAddParsingResult = {
+  data: Partial<ParsedQuickAddCommand>
+  issues: QuickAddIssue[]
+  isReady: boolean
+}
+
+const WEEKDAY_NAME_TO_INDEX: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+}
+
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  $: "USD",
+  "€": "EUR",
+  "£": "GBP",
+}
+
+const STOP_WORDS = [" for ", " to ", " about ", " on ", " amount", " invoice", " task", " pay "]
+
+function normaliseWhitespace(value: string) {
+  return value.replace(/\s+/g, " ").trim()
+}
+
+function normaliseAmount(value: string) {
+  const compact = value.replace(/\s+/g, "")
+  if (compact.includes(",") && !compact.includes(".")) {
+    return compact.replace(/,/g, ".")
+  }
+
+  return compact.replace(/,/g, "")
+}
+
+export function parseQuickAddCommand(
+  raw: string,
+  options: { now?: Date } = {}
+): QuickAddParsingResult {
+  const now = options.now ?? new Date()
+  const input = normaliseWhitespace(raw)
+
+  if (!input) {
+    return {
+      data: {},
+      issues: [
+        {
+          field: "intent",
+          message: "Start typing to create an invoice or task.",
+          severity: "error",
+        },
+      ],
+      isReady: false,
+    }
+  }
+
+  const lower = input.toLowerCase()
+
+  const issues: QuickAddIssue[] = []
+  const data: Partial<ParsedQuickAddCommand> = {
+    description: input,
+  }
+
+  const intent = detectIntent(lower)
+  if (intent) {
+    data.intent = intent
+  } else {
+    issues.push({
+      field: "intent",
+      message: "Mention whether this is an invoice or task.",
+      severity: "error",
+    })
+  }
+
+  const amountInfo = extractAmount(input)
+  if (amountInfo?.amount !== undefined) {
+    data.amount = amountInfo.amount
+  }
+  if (amountInfo?.currency) {
+    data.currency = amountInfo.currency
+  } else if (data.amount !== undefined && intent === "invoice") {
+    data.currency = "USD"
+    issues.push({
+      field: "currency",
+      message: "Assuming USD — include a currency code to override.",
+      severity: "warning",
+    })
+  }
+
+  const duePhrase = detectDuePhrase(input)
+  if (duePhrase) {
+    const dueDate = parseDueDate(duePhrase, now)
+    if (dueDate) {
+      data.dueDate = format(dueDate, "yyyy-MM-dd")
+    } else {
+      issues.push({
+        field: "dueDate",
+        message: `Couldn't understand the due date from "${duePhrase}".`,
+        severity: "error",
+      })
+    }
+  }
+
+  if (data.intent === "invoice") {
+    if (data.amount === undefined) {
+      issues.push({
+        field: "amount",
+        message: "Invoices need an amount like $250 or 250 USD.",
+        severity: "error",
+      })
+    }
+    if (!data.dueDate) {
+      issues.push({
+        field: "dueDate",
+        message: "Invoices need a clear due date.",
+        severity: "error",
+      })
+    }
+  }
+
+  if (data.intent === "task" && !data.dueDate) {
+    issues.push({
+      field: "dueDate",
+      message: "Tasks work best with a due date.",
+      severity: "error",
+    })
+  }
+
+  const isReady =
+    issues.filter((issue) => issue.severity === "error").length === 0 &&
+    Boolean(data.intent)
+
+  return { data, issues, isReady }
+}
+
+function detectIntent(input: string): QuickAddIntent | undefined {
+  if (/(invoice|payment|charge|bill|rent)/i.test(input)) {
+    return "invoice"
+  }
+
+  if (/(task|todo|remind|follow up|follow-up|assign|schedule)/i.test(input)) {
+    return "task"
+  }
+
+  return undefined
+}
+
+function extractAmount(
+  input: string
+): { amount: number; currency?: string } | undefined {
+  const symbolMatch = /([$€£])\s*(\d+(?:[.,]\d{1,2})?)/.exec(input)
+  if (symbolMatch) {
+    const amount = Number(normaliseAmount(symbolMatch[2]))
+    if (!Number.isNaN(amount)) {
+      const currency = CURRENCY_SYMBOLS[symbolMatch[1]]
+      return {
+        amount,
+        currency,
+      }
+    }
+  }
+
+  const codeMatch = /(\d+(?:[.,]\d{1,2})?)\s*(usd|eur|gbp|cad|aud|nzd|inr|jpy|cny|sgd|mxn|sek|nok|dkk|chf|zar)/i.exec(
+    input
+  )
+  if (codeMatch) {
+    const amount = Number(normaliseAmount(codeMatch[1]))
+    if (!Number.isNaN(amount)) {
+      const currency = codeMatch[2].toUpperCase()
+      return {
+        amount,
+        currency,
+      }
+    }
+  }
+
+  const genericMatch = /(\d+(?:[.,]\d{1,2})?)/.exec(input)
+  if (genericMatch) {
+    const amount = Number(normaliseAmount(genericMatch[1]))
+    if (!Number.isNaN(amount)) {
+      return {
+        amount,
+      }
+    }
+  }
+
+  return undefined
+}
+
+function detectDuePhrase(input: string): string | undefined {
+  const lower = input.toLowerCase()
+
+  const dueTriggers = ["due", "by", "before", "on"]
+  for (const trigger of dueTriggers) {
+    const keyword = `${trigger} `
+    const index = lower.indexOf(keyword)
+    if (index >= 0) {
+      const phrase = input.slice(index + keyword.length)
+      return trimAtStopWord(phrase)
+    }
+  }
+
+  const relativeMatch = /(today|tomorrow|next\s+\w+|in\s+\d+\s+(?:days?|weeks?))/i.exec(input)
+  if (relativeMatch) {
+    return relativeMatch[0]
+  }
+
+  return undefined
+}
+
+function trimAtStopWord(phrase: string) {
+  let candidate = phrase.trim()
+  let cutIndex: number | undefined
+  const lower = candidate.toLowerCase()
+  for (const stopWord of STOP_WORDS) {
+    const index = lower.indexOf(stopWord)
+    if (index > 0) {
+      cutIndex = cutIndex === undefined ? index : Math.min(cutIndex, index)
+    }
+  }
+
+  if (cutIndex !== undefined) {
+    candidate = candidate.slice(0, cutIndex)
+  }
+
+  return candidate.replace(/[.,]$/, "").trim()
+}
+
+function parseDueDate(phrase: string, now: Date): Date | undefined {
+  const normalized = normaliseWhitespace(phrase.toLowerCase())
+
+  if (normalized === "today") {
+    return startOfDay(now)
+  }
+
+  if (normalized === "tomorrow") {
+    return startOfDay(addDays(now, 1))
+  }
+
+  const inMatch = /^in\s+(\d+)\s+(day|days|week|weeks)$/.exec(normalized)
+  if (inMatch) {
+    const value = Number(inMatch[1])
+    if (inMatch[2].startsWith("week")) {
+      return startOfDay(addWeeks(now, value))
+    }
+    return startOfDay(addDays(now, value))
+  }
+
+  const nextWeekdayMatch = /^next\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/.exec(
+    normalized
+  )
+  if (nextWeekdayMatch) {
+    const weekday = WEEKDAY_NAME_TO_INDEX[nextWeekdayMatch[1]]
+    return startOfDay(nextDay(now, weekday))
+  }
+
+  const weekdayMatch = /^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/.exec(
+    normalized
+  )
+  if (weekdayMatch) {
+    const weekday = WEEKDAY_NAME_TO_INDEX[weekdayMatch[1]]
+    const candidate = startOfDay(nextDay(addDays(now, -1), weekday))
+    if (candidate.getTime() === startOfDay(now).getTime()) {
+      return startOfDay(now)
+    }
+    if (!isAfter(candidate, now)) {
+      return startOfDay(nextDay(now, weekday))
+    }
+    return candidate
+  }
+
+  const explicitDate = parseExplicitDate(normalized, now)
+  if (explicitDate) {
+    return explicitDate
+  }
+
+  return undefined
+}
+
+function parseExplicitDate(phrase: string, now: Date): Date | undefined {
+  const formats = [
+    "yyyy-MM-dd",
+    "MMMM d, yyyy",
+    "MMM d, yyyy",
+    "d MMMM yyyy",
+    "d MMM yyyy",
+    "MMMM d yyyy",
+    "MMM d yyyy",
+    "MMMM d",
+    "MMM d",
+    "d MMMM",
+    "d MMM",
+    "MM/dd/yyyy",
+    "M/d/yyyy",
+    "MM/dd",
+    "M/d",
+  ]
+
+  for (const formatString of formats) {
+    const parsed = parse(phrase, formatString, now)
+    if (isValid(parsed)) {
+      let candidate = startOfDay(parsed)
+
+      if (formatString === "MM/dd" || formatString === "M/d" || formatString === "MMMM d" || formatString === "MMM d" || formatString === "d MMMM" || formatString === "d MMM") {
+        candidate = rollForwardToFuture(candidate, now)
+      }
+
+      if (isValid(candidate)) {
+        return candidate
+      }
+    }
+  }
+
+  return undefined
+}
+
+function rollForwardToFuture(date: Date, now: Date) {
+  if (isAfter(date, now) || date.getTime() === startOfDay(now).getTime()) {
+    return date
+  }
+
+  const nextYear = new Date(date)
+  nextYear.setFullYear(now.getFullYear() + 1)
+  return startOfDay(nextYear)
+}

--- a/tests/quick-add-command.test.ts
+++ b/tests/quick-add-command.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest"
+
+import { createQuickAddItem } from "@/app/dashboard/(dashboard)/actions/quick-add"
+import { parseQuickAddCommand } from "@/lib/dashboard/quick-add-parser"
+
+describe("quick add command parsing", () => {
+  it("understands invoice commands with relative dates", () => {
+    const now = new Date("2024-07-15T12:00:00Z")
+    const result = parseQuickAddCommand(
+      "Invoice roommate B $450 due next Friday",
+      { now }
+    )
+
+    expect(result.isReady).toBe(true)
+    expect(result.data.intent).toBe("invoice")
+    expect(result.data.amount).toBe(450)
+    expect(result.data.currency).toBe("USD")
+    expect(result.data.dueDate).toBe("2024-07-19")
+    expect(result.issues).toHaveLength(0)
+  })
+
+  it("handles explicit currency codes and natural language dates", () => {
+    const now = new Date("2024-07-01T00:00:00Z")
+    const result = parseQuickAddCommand(
+      "Create invoice 560 eur due 15 Aug for garage space",
+      { now }
+    )
+
+    expect(result.isReady).toBe(true)
+    expect(result.data.intent).toBe("invoice")
+    expect(result.data.amount).toBe(560)
+    expect(result.data.currency).toBe("EUR")
+    expect(result.data.dueDate).toBe("2024-08-15")
+  })
+
+  it("parses task commands with offsets", () => {
+    const now = new Date("2024-07-10T08:00:00Z")
+    const result = parseQuickAddCommand(
+      "Task schedule deep clean due in 3 days",
+      { now }
+    )
+
+    expect(result.isReady).toBe(true)
+    expect(result.data.intent).toBe("task")
+    expect(result.data.dueDate).toBe("2024-07-13")
+  })
+
+  it("supports mixed commands with currency codes", () => {
+    const now = new Date("2024-08-20T00:00:00Z")
+    const result = parseQuickAddCommand(
+      "Remind me to collect utilities 120 cad by 9/5",
+      { now }
+    )
+
+    expect(result.isReady).toBe(true)
+    expect(result.data.intent).toBe("task")
+    expect(result.data.amount).toBe(120)
+    expect(result.data.currency).toBe("CAD")
+    expect(result.data.dueDate).toBe("2024-09-05")
+  })
+
+  it("surfaces validation feedback when context is missing", () => {
+    const now = new Date("2024-07-01T00:00:00Z")
+    const result = parseQuickAddCommand("Invoice 230", { now })
+
+    expect(result.isReady).toBe(false)
+    expect(result.issues.some((issue) => issue.field === "dueDate")).toBe(true)
+    expect(result.issues.some((issue) => issue.field === "amount")).toBe(false)
+    expect(result.issues.some((issue) => issue.field === "currency")).toBe(true)
+  })
+})
+
+describe("quick add server action", () => {
+  it("creates invoice payloads", async () => {
+    const response = await createQuickAddItem({
+      intent: "invoice",
+      description: "Invoice roommate B $450 due next Friday",
+      amount: 450,
+      currency: "USD",
+      dueDate: "2024-07-19",
+    })
+
+    expect(response.status).toBe("success")
+    expect(response.item.type).toBe("invoice")
+    expect(response.item.amount).toBe(450)
+    expect(response.item.currency).toBe("USD")
+    expect(response.item.reference.startsWith("inv_")).toBe(true)
+  })
+
+  it("creates task payloads", async () => {
+    const response = await createQuickAddItem({
+      intent: "task",
+      description: "Task schedule deep clean due in 3 days",
+      dueDate: "2024-07-13",
+    })
+
+    expect(response.status).toBe("success")
+    expect(response.item.type).toBe("task")
+    expect(response.item.reference.startsWith("task_")).toBe(true)
+  })
+
+  it("rejects invoices that are missing financial fields", async () => {
+    await expect(
+      createQuickAddItem({
+        intent: "invoice",
+        description: "Invoice 180",
+        dueDate: "2024-07-15",
+      })
+    ).rejects.toThrow("Invoices created from quick add require an amount.")
+  })
+})


### PR DESCRIPTION
## Summary
- implement a deterministic quick add parser that extracts intent, amounts, currencies, and due dates from free-form text
- add a QuickAddCommand client control that surfaces parsing feedback, calls a server action, and renders alongside dashboard quick actions
- cover invoices and tasks with vitest cases exercising multiple phrase formats and server action validation

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30bb0ef908328b65e239ba3eb03f2