### PR TITLE
Enhance document empty state guidance

### DIFF
--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -8,7 +8,11 @@ import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
 import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
-import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import { FilePlus, FileText, Users, Calendar, Eye } from 'lucide-react';
+import {
+  buildEmptyStateSuggestions,
+  hasActiveFilters,
+} from './empty-state-suggestions';
 
 interface DocumentsListProps {
   filter: DocumentListFilters;
@@ -18,6 +22,11 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const activeFilters = useMemo(() => hasActiveFilters(filter), [filter]);
+  const emptyStateSuggestions = useMemo(
+    () => buildEmptyStateSuggestions(filter),
+    [filter],
+  );
 
   useEffect(() => {
     const fetchDocuments = async () => {
@@ -155,16 +164,78 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   }
 
   if (documents.length === 0) {
+    const handleCreateFromTemplate = () => {
+      const templateUrl = 'https://documenso.com/templates?ref=roomsily';
+      window.open(templateUrl, '_blank', 'noopener,noreferrer');
+    };
+
     return (
       <Card className="p-12">
-        <div className="text-center">
-          <FileText className="mx-auto mb-4 size-12 text-muted-foreground" />
-          <h3 className="mb-2 text-lg font-medium">No documents found</h3>
-          <p className="text-sm text-muted-foreground">
-            {Object.keys(filter).length > 0
-              ? "No documents match your current filters."
-              : "Get started by uploading your first document."}
-          </p>
+        <div className="mx-auto max-w-2xl space-y-6 text-center">
+          <FileText className="mx-auto size-12 text-muted-foreground" />
+          <div className="space-y-2">
+            <h3 className="text-lg font-medium">No documents found</h3>
+            <p className="text-sm text-muted-foreground">
+              {activeFilters
+                ? 'No documents match your current filters. Try relaxing them or start fresh below.'
+                : 'Get started by creating your first document from a template or exploring sample data.'}
+            </p>
+          </div>
+
+          <div className="space-y-4 text-left">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Recommended next steps
+            </p>
+            <ul className="space-y-3">
+              {emptyStateSuggestions.map((suggestion, index) => (
+                <li
+                  key={`${suggestion.title}-${index}`}
+                  className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/10 p-4"
+                >
+                  <div className="space-y-2">
+                    <p className="font-medium text-foreground">{suggestion.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {suggestion.description}
+                      {suggestion.link && (
+                        <>
+                          {' '}
+                          <a
+                            href={suggestion.link.href}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="font-medium text-primary underline-offset-4 hover:underline"
+                          >
+                            {suggestion.link.label}
+                          </a>
+                          .
+                        </>
+                      )}
+                    </p>
+                    {suggestion.chips && suggestion.chips.length > 0 && (
+                      <div className="flex flex-wrap gap-2 pt-1">
+                        {suggestion.chips.map((chip) => (
+                          <Badge
+                            key={chip}
+                            variant="outline"
+                            className="border-primary/40 bg-primary/5 text-xs font-medium text-primary"
+                          >
+                            {chip}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Button onClick={handleCreateFromTemplate} className="min-w-[200px]">
+              <FilePlus className="mr-2 size-4" />
+              Create from template
+            </Button>
+          </div>
         </div>
       </Card>
     );

--- a/app/documents/components/empty-state-suggestions.ts
+++ b/app/documents/components/empty-state-suggestions.ts
@@ -1,0 +1,116 @@
+import { DocumentListFilters, DocumentStatus, DocumentType } from '@/types/documents';
+
+export interface EmptyStateSuggestionLink {
+  href: string;
+  label: string;
+}
+
+export interface EmptyStateSuggestion {
+  title: string;
+  description: string;
+  chips?: string[];
+  link?: EmptyStateSuggestionLink;
+}
+
+export const DOCS_URL = 'https://documenso.com/docs/templates';
+export const SAMPLE_DATA_URL = 'https://github.com/documenso/documenso/tree/main/examples';
+
+const STATUS_LABELS: Record<DocumentStatus, string> = {
+  draft: 'Draft',
+  pending_signature: 'Pending Signature',
+  signed: 'Signed',
+  expired: 'Expired',
+  cancelled: 'Cancelled',
+};
+
+const TYPE_LABELS: Record<DocumentType, string> = {
+  lease: 'Lease',
+  addendum: 'Addendum',
+  insurance: 'Insurance',
+  maintenance: 'Maintenance',
+  other: 'Other',
+};
+
+function formatDateLabel(value: string) {
+  if (!value) return value;
+  const [datePart] = value.split('T');
+  return datePart ?? value;
+}
+
+export function getActiveFilterChipLabels(filter: DocumentListFilters): string[] {
+  const chips: string[] = [];
+
+  if (filter.status?.length) {
+    for (const status of filter.status) {
+      chips.push(`Status: ${STATUS_LABELS[status] ?? status}`);
+    }
+  }
+
+  if (filter.type?.length) {
+    for (const type of filter.type) {
+      chips.push(`Type: ${TYPE_LABELS[type] ?? type}`);
+    }
+  }
+
+  if (filter.tenant_id) {
+    chips.push('Tenant filter active');
+  }
+
+  if (filter.unit_id) {
+    chips.push(`Unit: ${filter.unit_id}`);
+  }
+
+  if (filter.date_from || filter.date_to) {
+    const from = filter.date_from ? formatDateLabel(filter.date_from) : 'Any';
+    const to = filter.date_to ? formatDateLabel(filter.date_to) : 'Any';
+    chips.push(`Date range: ${from} → ${to}`);
+  }
+
+  return chips;
+}
+
+export function hasActiveFilters(filter: DocumentListFilters) {
+  return getActiveFilterChipLabels(filter).length > 0;
+}
+
+export function buildEmptyStateSuggestions(filter: DocumentListFilters): EmptyStateSuggestion[] {
+  const chips = getActiveFilterChipLabels(filter);
+  const suggestions: EmptyStateSuggestion[] = [];
+
+  if (chips.length > 0) {
+    suggestions.push({
+      title: 'Relax active filters',
+      description: 'Clear or adjust the filters above to broaden your results.',
+      chips,
+    });
+    suggestions.push({
+      title: 'Still need the document?',
+      description: 'Use Create from template to spin up a fresh copy without modifying your saved filters.',
+    });
+  } else {
+    suggestions.push({
+      title: 'Jump-start your workspace',
+      description: 'Use Create from template to generate your first lease or addendum in seconds.',
+    });
+  }
+
+  suggestions.push({
+    title: 'Review Documenso template workflows',
+    description: 'Learn how Roomsily automates lease distribution and renewals.',
+    link: {
+      href: DOCS_URL,
+      label: 'Documenso templates documentation',
+    },
+  });
+
+  suggestions.push({
+    title: 'Import sample roommate paperwork',
+    description: 'Download a pack of example leases, addenda, and insurance forms to experiment with.',
+    link: {
+      href: SAMPLE_DATA_URL,
+      label: 'Download sample data',
+    },
+  });
+
+  return suggestions;
+}

--- a/tests/documents-empty-state.test.ts
+++ b/tests/documents-empty-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DOCS_URL,
+  SAMPLE_DATA_URL,
+  buildEmptyStateSuggestions,
+  getActiveFilterChipLabels,
+  hasActiveFilters,
+} from '@/app/documents/components/empty-state-suggestions';
+import type { DocumentListFilters } from '@/types/documents';
+
+describe('document empty state suggestions', () => {
+  it('includes filter relaxation guidance and chips when filters are active', () => {
+    const filters: DocumentListFilters = {
+      status: ['pending_signature', 'signed'],
+      type: ['lease'],
+      tenant_id: '123e4567-e89b-12d3-a456-426614174000',
+      date_from: '2024-01-01T00:00:00Z',
+      date_to: '2024-01-31T00:00:00Z',
+    };
+
+    const chips = getActiveFilterChipLabels(filters);
+    expect(chips).toContain('Status: Pending Signature');
+    expect(chips).toContain('Status: Signed');
+    expect(chips).toContain('Type: Lease');
+    expect(chips).toContain('Date range: 2024-01-01 → 2024-01-31');
+    expect(hasActiveFilters(filters)).toBe(true);
+
+    const suggestions = buildEmptyStateSuggestions(filters);
+    const relaxationSuggestion = suggestions.find((item) => item.title === 'Relax active filters');
+    expect(relaxationSuggestion).toBeDefined();
+    expect(relaxationSuggestion?.chips).toEqual(chips);
+  });
+
+  it('provides documentation and sample data links when no filters are applied', () => {
+    const filters: DocumentListFilters = {};
+
+    expect(hasActiveFilters(filters)).toBe(false);
+    expect(getActiveFilterChipLabels(filters)).toHaveLength(0);
+
+    const suggestions = buildEmptyStateSuggestions(filters);
+    const linkHrefs = suggestions
+      .map((item) => item.link?.href)
+      .filter((href): href is string => Boolean(href));
+
+    expect(linkHrefs).toContain(DOCS_URL);
+    expect(linkHrefs).toContain(SAMPLE_DATA_URL);
+    expect(suggestions.every((item) => (item.chips?.length ?? 0) === 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the documents empty state with recommended next steps, filter awareness, and a template creation CTA
- factor suggestion-building helpers into their own module for reuse and verification
- add unit coverage ensuring filtered and empty datasets surface the right guidance and links

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30bb191388328894b96a37afb9ffc