### PR TITLE
feat(documents): add filter builder and saved views

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -6,7 +6,12 @@ import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { documensoService } from '@/lib/documenso';
-import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import {
+  fetchDocumentSavedViews,
+  fetchDocumentStats,
+  fetchDocumentsList,
+  upsertDocumentSavedView,
+} from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import { getServiceRoleSupabaseClient } from '@/utils/supabase-service-role';
@@ -14,6 +19,7 @@ import {
   Document,
   DocumentWithLease,
   DocumentListFilters,
+  DocumentSavedView,
   DocumentUploadRequest,
   DocumentSigningRequest,
   DocumentStats,
@@ -40,6 +46,12 @@ const documentSigningSchema = z.object({
   expires_in_days: z.number().min(1).max(365).optional(),
 });
 
+const documentFilterConditionSchema = z.object({
+  field: z.enum(['status', 'type', 'tenant_id', 'unit_id', 'created_at']),
+  operator: z.enum(['eq', 'in', 'gte', 'lte']),
+  value: z.union([z.string(), z.array(z.string())]),
+});
+
 const documentListFiltersSchema = z.object({
   status: z.array(z.enum(['draft', 'pending_signature', 'signed', 'expired', 'cancelled'])).optional(),
   type: z.array(z.enum(['lease', 'addendum', 'insurance', 'maintenance', 'other'])).optional(),
@@ -47,6 +59,13 @@ const documentListFiltersSchema = z.object({
   unit_id: z.string().optional(),
   date_from: z.string().datetime().optional(),
   date_to: z.string().datetime().optional(),
+  conditions: z.array(documentFilterConditionSchema).optional(),
+});
+
+const saveDocumentViewSchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().min(1, 'Name is required').max(120, 'View name is too long'),
+  filters: documentListFiltersSchema,
 });
 
 // Action result interface
@@ -189,6 +208,83 @@ export async function getDocumentsAction(
     return {
       success: false,
       error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+    };
+  }
+}
+
+export async function listDocumentSavedViewsAction(): Promise<ActionResult<DocumentSavedView[]>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to load saved views.' };
+    }
+
+    try {
+      const views = await fetchDocumentSavedViews({
+        client: typedSupabase,
+        userId: user.id,
+      });
+
+      return { success: true, data: views };
+    } catch (error) {
+      console.error('Error fetching document saved views:', error);
+      return { success: false, error: 'Failed to load saved views.' };
+    }
+  } catch (error) {
+    console.error('Unexpected error loading document saved views:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
+    };
+  }
+}
+
+export async function saveDocumentSavedViewAction(
+  input: unknown,
+): Promise<ActionResult<DocumentSavedView>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to save views.' };
+    }
+
+    let payload: z.infer<typeof saveDocumentViewSchema>;
+    try {
+      payload = saveDocumentViewSchema.parse(input);
+    } catch (validationError) {
+      const message =
+        validationError instanceof z.ZodError
+          ? validationError.issues.map((issue) => issue.message).join(', ')
+          : 'Invalid view payload.';
+      return { success: false, error: message };
+    }
+
+    try {
+      const view = await upsertDocumentSavedView({
+        client: typedSupabase,
+        userId: user.id,
+        view: payload,
+      });
+
+      revalidatePath('/documents');
+      return { success: true, data: view };
+    } catch (error) {
+      console.error('Error saving document view:', error);
+      return { success: false, error: 'Failed to save view.' };
+    }
+  } catch (error) {
+    console.error('Unexpected error saving document view:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
     };
   }
 }

--- a/app/documents/components/documents-filters.tsx
+++ b/app/documents/components/documents-filters.tsx
@@ -1,153 +1,518 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState, useTransition } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuCheckboxItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
-import { DocumentListFilters, DocumentStatus, DocumentType } from '@/types/documents';
-import { Filter, X } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from '@/components/ui/use-toast';
+import {
+  cleanDocumentFilters,
+  countActiveDocumentFilters,
+  describeDocumentFilters,
+  normalizeDocumentFilters,
+  serializeDocumentFilters,
+} from '@/lib/documents-filters';
+import {
+  DocumentListFilters,
+  DocumentSavedView,
+  DocumentStatus,
+  DocumentType,
+} from '@/types/documents';
+import { Filter, Save, X } from 'lucide-react';
+import { saveDocumentSavedViewAction } from '../actions';
 
 interface DocumentsFiltersProps {
-  onFiltersChange?: (filters: DocumentListFilters) => void;
+  initialFilters: DocumentListFilters;
+  savedViews: DocumentSavedView[];
+  activeViewId: string | null;
 }
 
-export function DocumentsFilters({ onFiltersChange }: DocumentsFiltersProps) {
-  const [filters, setFilters] = useState<DocumentListFilters>({});
+const statusOptions: { value: DocumentStatus; label: string }[] = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'pending_signature', label: 'Pending Signature' },
+  { value: 'signed', label: 'Signed' },
+  { value: 'expired', label: 'Expired' },
+  { value: 'cancelled', label: 'Cancelled' },
+];
 
-  const statusOptions: { value: DocumentStatus; label: string }[] = [
-    { value: 'draft', label: 'Draft' },
-    { value: 'pending_signature', label: 'Pending Signature' },
-    { value: 'signed', label: 'Signed' },
-    { value: 'expired', label: 'Expired' },
-    { value: 'cancelled', label: 'Cancelled' },
-  ];
+const typeOptions: { value: DocumentType; label: string }[] = [
+  { value: 'lease', label: 'Lease' },
+  { value: 'addendum', label: 'Addendum' },
+  { value: 'insurance', label: 'Insurance' },
+  { value: 'maintenance', label: 'Maintenance' },
+  { value: 'other', label: 'Other' },
+];
 
-  const typeOptions: { value: DocumentType; label: string }[] = [
-    { value: 'lease', label: 'Lease' },
-    { value: 'addendum', label: 'Addendum' },
-    { value: 'insurance', label: 'Insurance' },
-    { value: 'maintenance', label: 'Maintenance' },
-    { value: 'other', label: 'Other' },
-  ];
+function toDateInputValue(value?: string) {
+  return value ? value.slice(0, 10) : '';
+}
 
-  const updateFilters = (newFilters: DocumentListFilters) => {
-    setFilters(newFilters);
-    onFiltersChange?.(newFilters);
-  };
+function fromDateInputValue(value: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
 
-  const toggleStatusFilter = (status: DocumentStatus, checked: boolean) => {
-    const currentStatuses = filters.status || [];
-    const newStatuses = checked
-      ? [...currentStatuses, status]
-      : currentStatuses.filter(s => s !== status);
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
 
-    updateFilters({
-      ...filters,
-      status: newStatuses.length > 0 ? newStatuses : undefined,
+  return date.toISOString();
+}
+
+export function DocumentsFilters({ initialFilters, savedViews, activeViewId }: DocumentsFiltersProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { toast } = useToast();
+
+  const [filters, setFilters] = useState<DocumentListFilters>(() =>
+    normalizeDocumentFilters(initialFilters),
+  );
+  const [draftFilters, setDraftFilters] = useState<DocumentListFilters>(() =>
+    normalizeDocumentFilters(initialFilters),
+  );
+  const [views, setViews] = useState<DocumentSavedView[]>(() => savedViews);
+  const [selectedViewId, setSelectedViewId] = useState<string | null>(activeViewId);
+  const [isFilterDialogOpen, setIsFilterDialogOpen] = useState(false);
+  const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
+  const [newViewName, setNewViewName] = useState('');
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isSaving, startSaving] = useTransition();
+
+  useEffect(() => {
+    const normalized = normalizeDocumentFilters(initialFilters);
+    setFilters(normalized);
+    if (!isFilterDialogOpen) {
+      setDraftFilters(normalized);
+    }
+  }, [initialFilters, isFilterDialogOpen]);
+
+  useEffect(() => {
+    setViews(savedViews);
+  }, [savedViews]);
+
+  useEffect(() => {
+    setSelectedViewId(activeViewId);
+  }, [activeViewId]);
+
+  const normalizedDraft = useMemo(
+    () => normalizeDocumentFilters(draftFilters),
+    [draftFilters],
+  );
+
+  const activeFilterCount = useMemo(
+    () => countActiveDocumentFilters(filters),
+    [filters],
+  );
+
+  const filterDescriptions = useMemo(
+    () => describeDocumentFilters(filters),
+    [filters],
+  );
+
+  const updateDraftStatus = (status: DocumentStatus, checked: boolean) => {
+    setDraftFilters((current) => {
+      const statuses = current.status ?? [];
+      const nextStatuses = checked
+        ? Array.from(new Set([...statuses, status]))
+        : statuses.filter((value) => value !== status);
+
+      const next: DocumentListFilters = {
+        ...current,
+        status: nextStatuses.length > 0 ? nextStatuses : undefined,
+      };
+
+      return normalizeDocumentFilters(next);
     });
   };
 
-  const toggleTypeFilter = (type: DocumentType, checked: boolean) => {
-    const currentTypes = filters.type || [];
-    const newTypes = checked
-      ? [...currentTypes, type]
-      : currentTypes.filter(t => t !== type);
+  const updateDraftType = (type: DocumentType, checked: boolean) => {
+    setDraftFilters((current) => {
+      const types = current.type ?? [];
+      const nextTypes = checked
+        ? Array.from(new Set([...types, type]))
+        : types.filter((value) => value !== type);
 
-    updateFilters({
-      ...filters,
-      type: newTypes.length > 0 ? newTypes : undefined,
+      const next: DocumentListFilters = {
+        ...current,
+        type: nextTypes.length > 0 ? nextTypes : undefined,
+      };
+
+      return normalizeDocumentFilters(next);
     });
   };
 
-  const clearFilters = () => {
-    setFilters({});
-    onFiltersChange?.({});
+  const applyFilters = (nextFilters: DocumentListFilters, viewId: string | null) => {
+    const normalized = normalizeDocumentFilters(nextFilters);
+    setFilters(normalized);
+    setDraftFilters(normalized);
+    const cleaned = cleanDocumentFilters(normalized);
+
+    const params = new URLSearchParams(searchParams.toString());
+    const serialized = serializeDocumentFilters(cleaned);
+
+    if (serialized) {
+      params.set('filters', serialized);
+    } else {
+      params.delete('filters');
+    }
+
+    if (viewId) {
+      params.set('view', viewId);
+    } else {
+      params.delete('view');
+    }
+
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    setSelectedViewId(viewId);
   };
 
-  const activeFilterCount =
-    (filters.status?.length || 0) +
-    (filters.type?.length || 0) +
-    (filters.tenant_id ? 1 : 0) +
-    (filters.unit_id ? 1 : 0) +
-    (filters.date_from ? 1 : 0) +
-    (filters.date_to ? 1 : 0);
+  const handleSelectView = (value: string) => {
+    if (value === '__clear__') {
+      applyFilters({}, null);
+      return;
+    }
+
+    const view = views.find((item) => item.id === value);
+    if (!view) {
+      return;
+    }
+
+    applyFilters(view.filters, view.id);
+  };
+
+  const handleOpenSaveDialog = () => {
+    const selectedView = selectedViewId
+      ? views.find((view) => view.id === selectedViewId)
+      : undefined;
+
+    setNewViewName(selectedView?.name ?? '');
+    setSaveError(null);
+    setIsSaveDialogOpen(true);
+  };
+
+  const handleSaveView = () => {
+    const trimmedName = newViewName.trim();
+    if (!trimmedName) {
+      setSaveError('Please provide a name for this view.');
+      return;
+    }
+
+    const existingSelected = selectedViewId
+      ? views.find((view) => view.id === selectedViewId)
+      : undefined;
+
+    const payload = {
+      id:
+        existingSelected && existingSelected.name === trimmedName
+          ? existingSelected.id
+          : undefined,
+      name: trimmedName,
+      filters,
+    };
+
+    setSaveError(null);
+
+    startSaving(async () => {
+      const result = await saveDocumentSavedViewAction(payload);
+      if (result.success && result.data) {
+        const cleaned = cleanDocumentFilters(result.data.filters);
+        const updatedView: DocumentSavedView = {
+          ...result.data,
+          filters: cleaned,
+        };
+
+        setViews((current) => {
+          const withoutCurrent = current.filter((view) => view.id !== updatedView.id);
+          return [...withoutCurrent, updatedView].sort((a, b) =>
+            a.name.localeCompare(b.name),
+          );
+        });
+
+        applyFilters(updatedView.filters, updatedView.id);
+        setIsSaveDialogOpen(false);
+        toast({
+          title: 'View saved',
+          description: `“${updatedView.name}” is available in your saved views.`,
+        });
+      } else {
+        const message = result.error ?? 'Unable to save this view. Please try again.';
+        setSaveError(message);
+        toast({
+          variant: 'destructive',
+          title: 'Failed to save view',
+          description: message,
+        });
+      }
+    });
+  };
+
+  const handleClearFilters = () => {
+    applyFilters({}, null);
+  };
+
+  const handleApplyDraft = () => {
+    applyFilters(draftFilters, null);
+    setIsFilterDialogOpen(false);
+  };
 
   return (
-    <div className="flex items-center space-x-2">
-      {/* Status Filter */}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm">
-            <Filter className="mr-2 size-4" />
-            Status
-            {filters.status && filters.status.length > 0 && (
-              <Badge variant="secondary" className="ml-2 size-4 p-0 text-xs">
-                {filters.status.length}
-              </Badge>
-            )}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-48">
-          <DropdownMenuLabel>Filter by Status</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          {statusOptions.map((option) => (
-            <DropdownMenuCheckboxItem
-              key={option.value}
-              checked={filters.status?.includes(option.value) || false}
-              onCheckedChange={(checked) => toggleStatusFilter(option.value, checked)}
-            >
-              {option.label}
-            </DropdownMenuCheckboxItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      {/* Type Filter */}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm">
-            Type
-            {filters.type && filters.type.length > 0 && (
-              <Badge variant="secondary" className="ml-2 size-4 p-0 text-xs">
-                {filters.type.length}
-              </Badge>
-            )}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-48">
-          <DropdownMenuLabel>Filter by Type</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          {typeOptions.map((option) => (
-            <DropdownMenuCheckboxItem
-              key={option.value}
-              checked={filters.type?.includes(option.value) || false}
-              onCheckedChange={(checked) => toggleTypeFilter(option.value, checked)}
-            >
-              {option.label}
-            </DropdownMenuCheckboxItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      {/* Clear Filters */}
-      {activeFilterCount > 0 && (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={clearFilters}
-          className="text-muted-foreground hover:text-foreground"
+    <div className="flex flex-col space-y-2 text-left sm:items-end sm:text-right">
+      <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+        <Select
+          value={selectedViewId ?? undefined}
+          onValueChange={handleSelectView}
         >
-          <X className="mr-2 size-4" />
-          Clear ({activeFilterCount})
+          <SelectTrigger className="w-[220px]" disabled={views.length === 0}>
+            <SelectValue placeholder={views.length ? 'Saved views' : 'No saved views'} />
+          </SelectTrigger>
+          <SelectContent>
+            {views.length === 0 && (
+              <SelectItem value="__empty" disabled>
+                No saved views yet
+              </SelectItem>
+            )}
+            {views.map((view) => (
+              <SelectItem key={view.id} value={view.id}>
+                {view.name}
+              </SelectItem>
+            ))}
+            <SelectSeparator />
+            <SelectItem value="__clear__">Clear selection</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleOpenSaveDialog}
+        >
+          <Save className="mr-2 size-4" />
+          Save view
         </Button>
+
+        <Dialog
+          open={isFilterDialogOpen}
+          onOpenChange={(open) => {
+            setIsFilterDialogOpen(open);
+            if (open) {
+              setDraftFilters(filters);
+            }
+          }}
+        >
+          <DialogTrigger asChild>
+            <Button variant="outline" size="sm">
+              <Filter className="mr-2 size-4" />
+              Filters
+              {activeFilterCount > 0 && (
+                <Badge variant="secondary" className="ml-2 size-5 px-1">
+                  {activeFilterCount}
+                </Badge>
+              )}
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Build filters</DialogTitle>
+              <DialogDescription>
+                Combine conditions to narrow down documents by status, type, tenant, unit, and date.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-6 py-2">
+              <div className="space-y-3">
+                <Label className="text-xs uppercase text-muted-foreground">Status</Label>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {statusOptions.map((option) => (
+                    <label
+                      key={option.value}
+                      className="flex items-center space-x-2 rounded-md border border-border/60 px-3 py-2 text-sm"
+                    >
+                      <Checkbox
+                        checked={normalizedDraft.status?.includes(option.value) ?? false}
+                        onCheckedChange={(checked) =>
+                          updateDraftStatus(option.value, Boolean(checked))
+                        }
+                      />
+                      <span>{option.label}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <Label className="text-xs uppercase text-muted-foreground">Type</Label>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {typeOptions.map((option) => (
+                    <label
+                      key={option.value}
+                      className="flex items-center space-x-2 rounded-md border border-border/60 px-3 py-2 text-sm"
+                    >
+                      <Checkbox
+                        checked={normalizedDraft.type?.includes(option.value) ?? false}
+                        onCheckedChange={(checked) =>
+                          updateDraftType(option.value, Boolean(checked))
+                        }
+                      />
+                      <span>{option.label}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="tenant-filter">Tenant ID</Label>
+                  <Input
+                    id="tenant-filter"
+                    value={normalizedDraft.tenant_id ?? ''}
+                    onChange={(event) =>
+                      setDraftFilters((current) => ({
+                        ...current,
+                        tenant_id: event.target.value ? event.target.value : undefined,
+                      }))
+                    }
+                    placeholder="e.g. UUID"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="unit-filter">Unit</Label>
+                  <Input
+                    id="unit-filter"
+                    value={normalizedDraft.unit_id ?? ''}
+                    onChange={(event) =>
+                      setDraftFilters((current) => ({
+                        ...current,
+                        unit_id: event.target.value ? event.target.value : undefined,
+                      }))
+                    }
+                    placeholder="Unit identifier"
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="date-from">Created after</Label>
+                  <Input
+                    id="date-from"
+                    type="date"
+                    value={toDateInputValue(normalizedDraft.date_from)}
+                    onChange={(event) =>
+                      setDraftFilters((current) => ({
+                        ...current,
+                        date_from: fromDateInputValue(event.target.value),
+                      }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="date-to">Created before</Label>
+                  <Input
+                    id="date-to"
+                    type="date"
+                    value={toDateInputValue(normalizedDraft.date_to)}
+                    onChange={(event) =>
+                      setDraftFilters((current) => ({
+                        ...current,
+                        date_to: fromDateInputValue(event.target.value),
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+
+            <DialogFooter className="gap-2">
+              <Button variant="ghost" onClick={() => setDraftFilters(filters)}>
+                Reset changes
+              </Button>
+              <Button variant="outline" onClick={handleClearFilters}>
+                <X className="mr-2 size-4" />
+                Clear all
+              </Button>
+              <Button onClick={handleApplyDraft}>Apply filters</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {activeFilterCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClearFilters}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="mr-2 size-4" />
+            Clear ({activeFilterCount})
+          </Button>
+        )}
+      </div>
+
+      {filterDescriptions.length > 0 && (
+        <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+          {filterDescriptions.map((description) => (
+            <Badge key={description} variant="outline">
+              {description}
+            </Badge>
+          ))}
+        </div>
       )}
+
+      <Dialog open={isSaveDialogOpen} onOpenChange={setIsSaveDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Save current view</DialogTitle>
+            <DialogDescription>
+              Give this filter configuration a memorable name to reuse it later.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="view-name">View name</Label>
+            <Input
+              id="view-name"
+              value={newViewName}
+              onChange={(event) => setNewViewName(event.target.value)}
+              placeholder="e.g. Pending renewals"
+              autoFocus
+            />
+            {saveError && (
+              <p className="text-sm text-destructive">{saveError}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsSaveDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSaveView} disabled={isSaving}>
+              {isSaving ? 'Saving…' : 'Save view'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -7,9 +7,54 @@ import { UploadDocumentDialog } from "./components/upload-document-dialog";
 import { DocumentsStats } from "./components/documents-stats";
 import { DocumentsList } from "./components/documents-list";
 import { DocumentsFilters } from "./components/documents-filters";
-import { DocumentListFilters } from '@/types/documents';
+import { DocumentListFilters, DocumentSavedView } from '@/types/documents';
+import { parseDocumentFilters, cleanDocumentFilters, mergeDocumentFilters } from '@/lib/documents-filters';
+import { cookies } from 'next/headers';
+import { createClient } from '@/utils/supa-server-actions';
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+import { fetchDocumentSavedViews } from '@/lib/data/documents';
 
-export default function DocumentsPage() {
+type DocumentsPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+async function loadSavedViews(): Promise<DocumentSavedView[]> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error || !user) {
+    return [];
+  }
+
+  try {
+    const views = await fetchDocumentSavedViews({
+      client: typedSupabase,
+      userId: user.id,
+    });
+
+    return views;
+  } catch (err) {
+    console.error('Failed to load document saved views:', err);
+    return [];
+  }
+}
+
+export default async function DocumentsPage({ searchParams = {} }: DocumentsPageProps) {
+  const filtersFromParams = cleanDocumentFilters(parseDocumentFilters(searchParams.filters));
+  const activeViewId = typeof searchParams.view === 'string' ? searchParams.view : null;
+  const savedViews = await loadSavedViews();
+
+  let initialFilters: DocumentListFilters = filtersFromParams;
+
+  if ((!initialFilters || Object.keys(initialFilters).length === 0) && activeViewId) {
+    const matchingView = savedViews.find((view) => view.id === activeViewId);
+    if (matchingView) {
+      initialFilters = cleanDocumentFilters(matchingView.filters);
+    }
+  }
+
   return (
     <div className="container max-w-7xl space-y-8 py-8">
       <header className="space-y-4">
@@ -50,30 +95,34 @@ export default function DocumentsPage() {
             <TabsTrigger value="pending">Pending</TabsTrigger>
             <TabsTrigger value="signed">Signed</TabsTrigger>
           </TabsList>
-          <DocumentsFilters />
+          <DocumentsFilters
+            initialFilters={initialFilters}
+            savedViews={savedViews}
+            activeViewId={activeViewId}
+          />
         </div>
 
         <TabsContent value="all" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{}} />
+            <DocumentsList filter={initialFilters} />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="leases" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ type: ['lease'] }} />
+            <DocumentsList filter={mergeDocumentFilters({ type: ['lease'] }, initialFilters)} />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="pending" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['pending_signature'] }} />
+            <DocumentsList filter={mergeDocumentFilters({ status: ['pending_signature'] }, initialFilters)} />
           </Suspense>
         </TabsContent>
 
         <TabsContent value="signed" className="space-y-6">
           <Suspense fallback={<DocumentsListSkeleton />}>
-            <DocumentsList filter={{ status: ['signed'] }} />
+            <DocumentsList filter={mergeDocumentFilters({ status: ['signed'] }, initialFilters)} />
           </Suspense>
         </TabsContent>
       </Tabs>

--- a/lib/data/documents.ts
+++ b/lib/data/documents.ts
@@ -1,11 +1,16 @@
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
 import type {
   DocumentListFilters,
+  DocumentSavedView,
   DocumentStats,
   DocumentVersion,
   DocumentWithLease,
 } from '@/types/documents';
 import type { Database } from '@/lib/supabase';
+import {
+  cleanDocumentFilters,
+  normalizeDocumentFilters,
+} from '@/lib/documents-filters';
 
 type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
 
@@ -54,6 +59,7 @@ export async function fetchDocumentsList({
   role,
   filters = {},
 }: FetchDocumentsParams): Promise<DocumentWithLease[]> {
+  const normalizedFilters = normalizeDocumentFilters(filters);
   let query = (client as any)
     .from('documents')
     .select(DOCUMENT_SELECT)
@@ -63,28 +69,28 @@ export async function fetchDocumentsList({
     query = query.or(`tenant_id.eq.${userId},signatures.signer_id.eq.${userId}`);
   }
 
-  if (filters.status?.length) {
-    query = query.in('status', filters.status);
+  if (normalizedFilters.status?.length) {
+    query = query.in('status', normalizedFilters.status);
   }
 
-  if (filters.type?.length) {
-    query = query.in('document_type', filters.type);
+  if (normalizedFilters.type?.length) {
+    query = query.in('document_type', normalizedFilters.type);
   }
 
-  if (filters.tenant_id) {
-    query = query.eq('tenant_id', filters.tenant_id);
+  if (normalizedFilters.tenant_id) {
+    query = query.eq('tenant_id', normalizedFilters.tenant_id);
   }
 
-  if (filters.unit_id) {
-    query = query.eq('unit_id', filters.unit_id);
+  if (normalizedFilters.unit_id) {
+    query = query.eq('unit_id', normalizedFilters.unit_id);
   }
 
-  if (filters.date_from) {
-    query = query.gte('created_at', filters.date_from);
+  if (normalizedFilters.date_from) {
+    query = query.gte('created_at', normalizedFilters.date_from);
   }
 
-  if (filters.date_to) {
-    query = query.lte('created_at', filters.date_to);
+  if (normalizedFilters.date_to) {
+    query = query.lte('created_at', normalizedFilters.date_to);
   }
 
   const { data, error } = await query;
@@ -101,6 +107,73 @@ export async function fetchDocumentsList({
       .slice()
       .sort((a, b) => b.version - a.version),
   }));
+}
+
+type FetchDocumentSavedViewsParams = {
+  client: SupabaseClientLike;
+  userId: string;
+};
+
+type UpsertDocumentSavedViewParams = {
+  client: SupabaseClientLike;
+  userId: string;
+  view: {
+    id?: string;
+    name: string;
+    filters: DocumentListFilters;
+  };
+};
+
+export async function fetchDocumentSavedViews({
+  client,
+  userId,
+}: FetchDocumentSavedViewsParams): Promise<DocumentSavedView[]> {
+  const { data, error } = await (client as any)
+    .from('document_saved_views')
+    .select('*')
+    .eq('user_id', userId)
+    .order('name', { ascending: true });
+
+  handlePostgrestError(error, 'Failed to fetch document saved views');
+
+  return ((data ?? []) as DocumentSavedView[]).map((view) => ({
+    ...view,
+    filters: cleanDocumentFilters(view.filters as DocumentListFilters),
+  }));
+}
+
+export async function upsertDocumentSavedView({
+  client,
+  userId,
+  view,
+}: UpsertDocumentSavedViewParams): Promise<DocumentSavedView> {
+  const payload: Record<string, unknown> = {
+    user_id: userId,
+    name: view.name,
+    filters: cleanDocumentFilters(view.filters),
+  };
+
+  if (view.id) {
+    payload.id = view.id;
+  }
+
+  const { data, error } = await (client as any)
+    .from('document_saved_views')
+    .upsert(payload, {
+      onConflict: 'user_id,name',
+      ignoreDuplicates: false,
+    })
+    .select('*')
+    .single();
+
+  handlePostgrestError(error, 'Failed to save document view');
+
+  const savedView = data as DocumentSavedView;
+
+  return {
+    ...savedView,
+    filters: cleanDocumentFilters(savedView.filters as DocumentListFilters),
+  };
 }
 
 export async function fetchDocumentStats({

--- a/lib/documents-filters.ts
+++ b/lib/documents-filters.ts
@@ -1,0 +1,282 @@
+import {
+  DocumentFilterCondition,
+  DocumentListFilters,
+  DocumentStatus,
+  DocumentType,
+} from '@/types/documents';
+
+function uniqueArray<T>(values: T[] | undefined): T[] | undefined {
+  if (!values || values.length === 0) {
+    return undefined;
+  }
+
+  return Array.from(new Set(values));
+}
+
+function hasAnyFilter(filters: DocumentListFilters): boolean {
+  return Boolean(
+    filters.status?.length ||
+    filters.type?.length ||
+    filters.tenant_id ||
+    filters.unit_id ||
+    filters.date_from ||
+    filters.date_to
+  );
+}
+
+export function normalizeDocumentFilters(
+  filters?: DocumentListFilters | null,
+): DocumentListFilters {
+  if (!filters) {
+    return {};
+  }
+
+  const normalized: DocumentListFilters = {};
+
+  if (filters.status?.length) {
+    normalized.status = uniqueArray<DocumentStatus>(filters.status);
+  }
+
+  if (filters.type?.length) {
+    normalized.type = uniqueArray<DocumentType>(filters.type);
+  }
+
+  if (filters.tenant_id) {
+    normalized.tenant_id = filters.tenant_id;
+  }
+
+  if (filters.unit_id) {
+    normalized.unit_id = filters.unit_id;
+  }
+
+  if (filters.date_from) {
+    normalized.date_from = filters.date_from;
+  }
+
+  if (filters.date_to) {
+    normalized.date_to = filters.date_to;
+  }
+
+  if (filters.conditions?.length) {
+    for (const condition of filters.conditions) {
+      switch (condition.field) {
+        case 'status': {
+          const value = Array.isArray(condition.value)
+            ? condition.value
+            : [condition.value];
+          if (condition.operator === 'in' || condition.operator === 'eq') {
+            normalized.status = uniqueArray(
+              [...(normalized.status ?? []), ...value] as DocumentStatus[],
+            );
+          }
+          break;
+        }
+        case 'type': {
+          const value = Array.isArray(condition.value)
+            ? condition.value
+            : [condition.value];
+          if (condition.operator === 'in' || condition.operator === 'eq') {
+            normalized.type = uniqueArray(
+              [...(normalized.type ?? []), ...value] as DocumentType[],
+            );
+          }
+          break;
+        }
+        case 'tenant_id': {
+          if (typeof condition.value === 'string') {
+            normalized.tenant_id = condition.value;
+          }
+          break;
+        }
+        case 'unit_id': {
+          if (typeof condition.value === 'string') {
+            normalized.unit_id = condition.value;
+          }
+          break;
+        }
+        case 'created_at': {
+          if (typeof condition.value === 'string') {
+            if (condition.operator === 'gte') {
+              normalized.date_from = condition.value;
+            }
+
+            if (condition.operator === 'lte') {
+              normalized.date_to = condition.value;
+            }
+          }
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    }
+  }
+
+  return normalized;
+}
+
+export function filtersToConditions(
+  filters: DocumentListFilters,
+): DocumentFilterCondition[] {
+  const normalized = normalizeDocumentFilters(filters);
+  const conditions: DocumentFilterCondition[] = [];
+
+  if (normalized.status?.length) {
+    conditions.push({
+      field: 'status',
+      operator: 'in',
+      value: normalized.status,
+    });
+  }
+
+  if (normalized.type?.length) {
+    conditions.push({
+      field: 'type',
+      operator: 'in',
+      value: normalized.type,
+    });
+  }
+
+  if (normalized.tenant_id) {
+    conditions.push({
+      field: 'tenant_id',
+      operator: 'eq',
+      value: normalized.tenant_id,
+    });
+  }
+
+  if (normalized.unit_id) {
+    conditions.push({
+      field: 'unit_id',
+      operator: 'eq',
+      value: normalized.unit_id,
+    });
+  }
+
+  if (normalized.date_from) {
+    conditions.push({
+      field: 'created_at',
+      operator: 'gte',
+      value: normalized.date_from,
+    });
+  }
+
+  if (normalized.date_to) {
+    conditions.push({
+      field: 'created_at',
+      operator: 'lte',
+      value: normalized.date_to,
+    });
+  }
+
+  return conditions;
+}
+
+export function cleanDocumentFilters(
+  filters?: DocumentListFilters | null,
+): DocumentListFilters {
+  const normalized = normalizeDocumentFilters(filters);
+  if (!hasAnyFilter(normalized)) {
+    return {};
+  }
+
+  const conditions = filtersToConditions(normalized);
+  return conditions.length > 0
+    ? { ...normalized, conditions }
+    : { ...normalized };
+}
+
+export function serializeDocumentFilters(
+  filters: DocumentListFilters,
+): string | null {
+  const cleaned = cleanDocumentFilters(filters);
+  if (!hasAnyFilter(cleaned)) {
+    return null;
+  }
+
+  return encodeURIComponent(JSON.stringify(cleaned));
+}
+
+export function parseDocumentFilters(
+  value: string | string[] | null | undefined,
+): DocumentListFilters {
+  if (!value || (Array.isArray(value) && value.length === 0)) {
+    return {};
+  }
+
+  const firstValue = Array.isArray(value) ? value[0] : value;
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(firstValue));
+    return cleanDocumentFilters(parsed);
+  } catch (error) {
+    console.warn('Failed to parse document filters from query string', error);
+    return {};
+  }
+}
+
+export function countActiveDocumentFilters(filters: DocumentListFilters): number {
+  const normalized = normalizeDocumentFilters(filters);
+  return [
+    normalized.status?.length ?? 0,
+    normalized.type?.length ?? 0,
+    normalized.tenant_id ? 1 : 0,
+    normalized.unit_id ? 1 : 0,
+    normalized.date_from ? 1 : 0,
+    normalized.date_to ? 1 : 0,
+  ].reduce((total, count) => total + count, 0);
+}
+
+export function mergeDocumentFilters(
+  base: DocumentListFilters,
+  override: DocumentListFilters,
+): DocumentListFilters {
+  const normalizedBase = normalizeDocumentFilters(base);
+  const normalizedOverride = normalizeDocumentFilters(override);
+
+  const combined: DocumentListFilters = {
+    status: normalizedOverride.status ?? normalizedBase.status,
+    type: normalizedOverride.type ?? normalizedBase.type,
+    tenant_id: normalizedOverride.tenant_id ?? normalizedBase.tenant_id,
+    unit_id: normalizedOverride.unit_id ?? normalizedBase.unit_id,
+    date_from: normalizedOverride.date_from ?? normalizedBase.date_from,
+    date_to: normalizedOverride.date_to ?? normalizedBase.date_to,
+  };
+
+  const conditions = filtersToConditions(combined);
+  return conditions.length > 0 ? { ...combined, conditions } : combined;
+}
+
+export function describeDocumentFilters(
+  filters: DocumentListFilters,
+): string[] {
+  const normalized = normalizeDocumentFilters(filters);
+  const descriptions: string[] = [];
+
+  if (normalized.status?.length) {
+    descriptions.push(`Status is ${normalized.status.join(', ')}`);
+  }
+
+  if (normalized.type?.length) {
+    descriptions.push(`Type is ${normalized.type.join(', ')}`);
+  }
+
+  if (normalized.tenant_id) {
+    descriptions.push(`Tenant matches ${normalized.tenant_id}`);
+  }
+
+  if (normalized.unit_id) {
+    descriptions.push(`Unit matches ${normalized.unit_id}`);
+  }
+
+  if (normalized.date_from) {
+    descriptions.push(`Created after ${normalized.date_from}`);
+  }
+
+  if (normalized.date_to) {
+    descriptions.push(`Created before ${normalized.date_to}`);
+  }
+
+  return descriptions;
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -108,6 +108,14 @@ export type Database = {
         user_agent: string | null
         metadata: Json | null
       }>
+      document_saved_views: SupabaseTable<{
+        id: string
+        user_id: string
+        name: string
+        filters: Json
+        created_at: string | null
+        updated_at: string | null
+      }>
       leases: SupabaseTable<{
         id: string
         document_id: string

--- a/supabase/migrations/20250315_document_saved_views.sql
+++ b/supabase/migrations/20250315_document_saved_views.sql
@@ -1,0 +1,47 @@
+-- Saved views for document filters per user
+CREATE TABLE public.document_saved_views (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  filters JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX document_saved_views_user_id_name_idx
+  ON public.document_saved_views(user_id, name);
+
+ALTER TABLE public.document_saved_views ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their document saved views"
+  ON public.document_saved_views
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Admins can manage any document saved view"
+  ON public.document_saved_views
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role IN ('property_manager', 'admin')
+    )
+  );
+
+CREATE FUNCTION public.set_document_saved_views_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER document_saved_views_updated_at
+  BEFORE UPDATE ON public.document_saved_views
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_document_saved_views_updated_at();

--- a/tests/lib/data/documents.test.ts
+++ b/tests/lib/data/documents.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
+import {
+  fetchDocumentSavedViews,
+  fetchDocumentStats,
+  fetchDocumentsList,
+  upsertDocumentSavedView,
+} from '@/lib/data/documents';
+import {
+  parseDocumentFilters,
+  serializeDocumentFilters,
+} from '@/lib/documents-filters';
 import type { DocumentListFilters } from '@/types/documents';
 
 type QueryResult<T> = { data: T; error: { message: string } | null };
@@ -12,6 +21,8 @@ type QueryBuilder<T> = {
   eq: ReturnType<typeof vi.fn>;
   gte: ReturnType<typeof vi.fn>;
   lte: ReturnType<typeof vi.fn>;
+  upsert: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
   then: (onFulfilled: (value: QueryResult<T>) => unknown) => Promise<unknown>;
 };
 
@@ -24,6 +35,8 @@ function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
     eq: ReturnType<typeof vi.fn>;
     gte: ReturnType<typeof vi.fn>;
     lte: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+    single: ReturnType<typeof vi.fn>;
   } = {
     select: vi.fn().mockImplementation(() => builder),
     order: vi.fn().mockImplementation(() => builder),
@@ -32,6 +45,8 @@ function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
     eq: vi.fn().mockImplementation(() => builder),
     gte: vi.fn().mockImplementation(() => builder),
     lte: vi.fn().mockImplementation(() => builder),
+    upsert: vi.fn().mockImplementation(() => builder),
+    single: vi.fn().mockImplementation(() => builder),
   };
 
   (builder as QueryBuilder<T>).then = (onFulfilled) =>
@@ -40,10 +55,13 @@ function createDocumentsQuery<T extends unknown[]>(result: QueryResult<T>) {
   return builder as QueryBuilder<T>;
 }
 
-function createSupabaseStub<T extends unknown[]>(query: QueryBuilder<T>) {
+function createSupabaseStub<T extends unknown[]>(
+  query: QueryBuilder<T>,
+  expectedTable = 'documents',
+) {
   return {
     from: vi.fn((table: string) => {
-      expect(table).toBe('documents');
+      expect(table).toBe(expectedTable);
       return query;
     }),
   };
@@ -78,6 +96,26 @@ describe('fetchDocumentsList', () => {
     expect(query.eq).toHaveBeenCalledWith('unit_id', filters.unit_id);
     expect(query.gte).toHaveBeenCalledWith('created_at', filters.date_from);
     expect(query.lte).toHaveBeenCalledWith('created_at', filters.date_to);
+  });
+
+  it('normalizes condition based filters', async () => {
+    const query = createDocumentsQuery({ data: [], error: null });
+    const supabase = createSupabaseStub(query);
+
+    await fetchDocumentsList({
+      client: supabase,
+      userId: 'user-123',
+      role: 'tenant',
+      filters: {
+        conditions: [
+          { field: 'status', operator: 'in', value: ['draft'] },
+          { field: 'created_at', operator: 'gte', value: '2024-01-01T00:00:00.000Z' },
+        ],
+      },
+    });
+
+    expect(query.in).toHaveBeenCalledWith('status', ['draft']);
+    expect(query.gte).toHaveBeenCalledWith('created_at', '2024-01-01T00:00:00.000Z');
   });
 
   it('skips scoping for property managers and admins', async () => {
@@ -147,5 +185,132 @@ describe('fetchDocumentStats', () => {
     await expect(
       fetchDocumentStats({ client: supabase, userId: 'user-1', role: 'tenant' })
     ).rejects.toThrow(/Failed to fetch document statistics: stats failed/);
+  });
+});
+
+describe('document saved views', () => {
+  it('fetches saved views for a user', async () => {
+    const query = createDocumentsQuery({
+      data: [
+        {
+          id: 'view-1',
+          user_id: 'user-1',
+          name: 'Pending signatures',
+          filters: { status: ['pending_signature'] },
+          created_at: null,
+          updated_at: null,
+        },
+      ] as any,
+      error: null,
+    });
+    const supabase = createSupabaseStub(query, 'document_saved_views');
+
+    const views = await fetchDocumentSavedViews({ client: supabase, userId: 'user-1' });
+
+    expect(query.select).toHaveBeenCalledWith('*');
+    expect(query.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(query.order).toHaveBeenCalledWith('name', { ascending: true });
+    expect(views).toEqual([
+      {
+        id: 'view-1',
+        user_id: 'user-1',
+        name: 'Pending signatures',
+        filters: {
+          status: ['pending_signature'],
+          conditions: [
+            {
+              field: 'status',
+              operator: 'in',
+              value: ['pending_signature'],
+            },
+          ],
+        },
+        created_at: null,
+        updated_at: null,
+      },
+    ]);
+  });
+
+  it('saves a view and returns the normalized payload', async () => {
+    const query = createDocumentsQuery({
+      data: {
+        id: 'view-2',
+        user_id: 'user-1',
+        name: 'Leases only',
+        filters: { type: ['lease'] },
+        created_at: null,
+        updated_at: null,
+      } as any,
+      error: null,
+    });
+    const supabase = createSupabaseStub(query, 'document_saved_views');
+
+    const view = await upsertDocumentSavedView({
+      client: supabase,
+      userId: 'user-1',
+      view: {
+        name: 'Leases only',
+        filters: { type: ['lease'] },
+      },
+    });
+
+    expect(query.upsert).toHaveBeenCalled();
+    expect(query.select).toHaveBeenCalledWith('*');
+    expect(query.single).toHaveBeenCalled();
+
+    const upsertPayload = query.upsert.mock.calls[0][0];
+    expect(upsertPayload.user_id).toBe('user-1');
+    expect(upsertPayload.name).toBe('Leases only');
+    expect(upsertPayload.filters).toEqual({
+      type: ['lease'],
+      conditions: [
+        { field: 'type', operator: 'in', value: ['lease'] },
+      ],
+    });
+
+    expect(view).toEqual({
+      id: 'view-2',
+      user_id: 'user-1',
+      name: 'Leases only',
+      filters: {
+        type: ['lease'],
+        conditions: [
+          { field: 'type', operator: 'in', value: ['lease'] },
+        ],
+      },
+      created_at: null,
+      updated_at: null,
+    });
+  });
+});
+
+describe('document filter serialization', () => {
+  it('round trips filters through the query string', () => {
+    const filters: DocumentListFilters = {
+      status: ['draft'],
+      type: ['lease'],
+      date_from: '2024-01-01T00:00:00.000Z',
+    };
+
+    const serialized = serializeDocumentFilters(filters);
+    expect(serialized).toBeTruthy();
+
+    const parsed = parseDocumentFilters(serialized);
+
+    expect(parsed).toEqual({
+      status: ['draft'],
+      type: ['lease'],
+      date_from: '2024-01-01T00:00:00.000Z',
+      conditions: [
+        { field: 'status', operator: 'in', value: ['draft'] },
+        { field: 'type', operator: 'in', value: ['lease'] },
+        { field: 'created_at', operator: 'gte', value: '2024-01-01T00:00:00.000Z' },
+      ],
+    });
+  });
+
+  it('handles invalid payloads gracefully', () => {
+    const parsed = parseDocumentFilters('%');
+    expect(parsed).toEqual({});
   });
 });

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -143,6 +143,21 @@ export interface DocumentUploadRequest {
   expires_at?: string;
 }
 
+export type DocumentFilterField =
+  | 'status'
+  | 'type'
+  | 'tenant_id'
+  | 'unit_id'
+  | 'created_at';
+
+export type DocumentFilterOperator = 'eq' | 'in' | 'gte' | 'lte';
+
+export interface DocumentFilterCondition {
+  field: DocumentFilterField;
+  operator: DocumentFilterOperator;
+  value: string | string[];
+}
+
 export interface DocumentListFilters {
   status?: DocumentStatus[];
   type?: DocumentType[];
@@ -150,6 +165,16 @@ export interface DocumentListFilters {
   unit_id?: string;
   date_from?: string;
   date_to?: string;
+  conditions?: DocumentFilterCondition[];
+}
+
+export interface DocumentSavedView {
+  id: string;
+  name: string;
+  user_id: string;
+  filters: DocumentListFilters;
+  created_at: string | null;
+  updated_at: string | null;
 }
 
 export interface DocumentStats {


### PR DESCRIPTION
## Summary
- add a reusable document filter normalization/serialization helper
- implement a modal-based filter builder with saved view management backed by Supabase
- persist filter state to the URL, hydrate on load, and extend unit tests for saved view/serialization flows

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30bb2d6e08328b0d9cff8664a7c49