### PR TITLE
feat: add documents bulk selection and actions

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -49,6 +49,23 @@ const documentListFiltersSchema = z.object({
   date_to: z.string().datetime().optional(),
 });
 
+const bulkDocumentIdsSchema = z.array(z.string().uuid()).min(1, 'Select at least one document.');
+
+const bulkTagPayloadSchema = z
+  .object({
+    documentIds: bulkDocumentIdsSchema,
+    tag: z
+      .string()
+      .min(1, 'Tag cannot be empty.')
+      .max(64, 'Tags must be fewer than 64 characters.')
+      .optional(),
+    unitId: z.string().uuid('Unit ID must be a valid UUID.').optional(),
+  })
+  .refine(
+    (value) => Boolean(value.tag) || Boolean(value.unitId),
+    { message: 'Provide a tag or destination unit to update.', path: ['tag'] },
+  );
+
 // Action result interface
 interface ActionResult<T = any> {
   success: boolean;
@@ -58,6 +75,12 @@ interface ActionResult<T = any> {
 }
 
 type DocumentRow = Database['public']['Tables']['documents']['Row'];
+
+type BulkTagInput = {
+  documentIds: string[];
+  tag?: string;
+  unitId?: string;
+};
 
 function buildVersionSnapshot(document: DocumentRow): DocumentVersionSnapshot {
   return {
@@ -635,6 +658,206 @@ export async function rollbackDocumentAction({
     return {
       success: false,
       error: error instanceof Error ? error.message : 'An unexpected error occurred.'
+    };
+  }
+}
+
+export async function bulkDeleteDocumentsAction(
+  documentIds: string[],
+): Promise<ActionResult<{ deleted_ids: string[] }>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to manage documents.' };
+    }
+
+    try {
+      await assertDocumentManager(typedSupabase, user.id);
+    } catch (permissionError) {
+      return {
+        success: false,
+        error:
+          permissionError instanceof Error ? permissionError.message : 'Permission denied.',
+      };
+    }
+
+    let validatedIds: string[];
+    try {
+      validatedIds = bulkDocumentIdsSchema.parse(documentIds);
+    } catch (validationError) {
+      if (validationError instanceof z.ZodError) {
+        return { success: false, error: validationError.errors[0]?.message ?? 'Invalid request.' };
+      }
+      throw validationError;
+    }
+
+    const { data, error } = await supabase.rpc('documents_bulk_delete', {
+      document_ids: validatedIds,
+    });
+
+    if (error) {
+      console.error('Error deleting documents in bulk:', error);
+      return { success: false, error: 'Failed to delete documents.' };
+    }
+
+    revalidatePath('/documents');
+    return {
+      success: true,
+      data: (data as { deleted_ids: string[] } | null) ?? { deleted_ids: validatedIds },
+      message: `Deleted ${validatedIds.length} document${validatedIds.length === 1 ? '' : 's'}.`,
+    };
+  } catch (error) {
+    console.error('Unexpected error in bulkDeleteDocumentsAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
+    };
+  }
+}
+
+export async function bulkTagDocumentsAction(
+  input: BulkTagInput,
+): Promise<
+  ActionResult<{
+    updated_ids: string[];
+    applied_tag?: string;
+    destination_unit_id?: string | null;
+  }>
+> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to manage documents.' };
+    }
+
+    try {
+      await assertDocumentManager(typedSupabase, user.id);
+    } catch (permissionError) {
+      return {
+        success: false,
+        error:
+          permissionError instanceof Error ? permissionError.message : 'Permission denied.',
+      };
+    }
+
+    let parsedInput: z.infer<typeof bulkTagPayloadSchema>;
+    try {
+      parsedInput = bulkTagPayloadSchema.parse({
+        documentIds: input.documentIds,
+        tag: input.tag?.trim() || undefined,
+        unitId: input.unitId?.trim() || undefined,
+      });
+    } catch (validationError) {
+      if (validationError instanceof z.ZodError) {
+        return { success: false, error: validationError.errors[0]?.message ?? 'Invalid request.' };
+      }
+      throw validationError;
+    }
+
+    const { data, error } = await supabase.rpc('documents_bulk_tag', {
+      document_ids: parsedInput.documentIds,
+      tag: parsedInput.tag ?? null,
+      destination_unit_id: parsedInput.unitId ?? null,
+    });
+
+    if (error) {
+      console.error('Error applying bulk document updates:', error);
+      return { success: false, error: 'Failed to update documents.' };
+    }
+
+    revalidatePath('/documents');
+    return {
+      success: true,
+      data:
+        (data as {
+          updated_ids: string[];
+          applied_tag?: string | null;
+          destination_unit_id?: string | null;
+        } | null) ?? {
+          updated_ids: parsedInput.documentIds,
+          applied_tag: parsedInput.tag,
+          destination_unit_id: parsedInput.unitId ?? null,
+        },
+      message: 'Bulk updates applied to selected documents.',
+    };
+  } catch (error) {
+    console.error('Unexpected error in bulkTagDocumentsAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
+    };
+  }
+}
+
+export async function bulkExportDocumentsAction(
+  documentIds: string[],
+): Promise<ActionResult<{ export_url?: string; signed_url?: string }>> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const typedSupabase = supabase as unknown as TypedSupabaseClient;
+
+  try {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: 'You must be logged in to export documents.' };
+    }
+
+    try {
+      await assertDocumentManager(typedSupabase, user.id);
+    } catch (permissionError) {
+      return {
+        success: false,
+        error:
+          permissionError instanceof Error ? permissionError.message : 'Permission denied.',
+      };
+    }
+
+    let validatedIds: string[];
+    try {
+      validatedIds = bulkDocumentIdsSchema.parse(documentIds);
+    } catch (validationError) {
+      if (validationError instanceof z.ZodError) {
+        return { success: false, error: validationError.errors[0]?.message ?? 'Invalid request.' };
+      }
+      throw validationError;
+    }
+
+    const { data, error } = await supabase.rpc('documents_bulk_export', {
+      document_ids: validatedIds,
+    });
+
+    if (error) {
+      console.error('Error exporting documents in bulk:', error);
+      return { success: false, error: 'Failed to export documents.' };
+    }
+
+    return {
+      success: true,
+      data: (data as { export_url?: string; signed_url?: string } | null) ?? undefined,
+      message: 'Export started for selected documents.',
+    };
+  } catch (error) {
+    console.error('Unexpected error in bulkExportDocumentsAction:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'An unexpected error occurred.',
     };
   }
 }

--- a/app/documents/components/document-bulk-actions-toolbar.tsx
+++ b/app/documents/components/document-bulk-actions-toolbar.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+interface DocumentBulkActionsToolbarProps {
+  selectedCount: number;
+  selectableCount: number;
+  onClearSelection: () => void;
+  onDelete: () => void;
+  onMoveTag: () => void;
+  onExport: () => void;
+  busyAction: 'delete' | 'update' | 'export' | null;
+}
+
+export function DocumentBulkActionsToolbar({
+  selectedCount,
+  selectableCount,
+  onClearSelection,
+  onDelete,
+  onMoveTag,
+  onExport,
+  busyAction,
+}: DocumentBulkActionsToolbarProps) {
+  const selectionLabel = `${selectedCount} ${selectedCount === 1 ? 'document' : 'documents'} selected`;
+  const manageableLabel = selectableCount === selectedCount
+    ? `You can manage ${selectableCount} ${selectableCount === 1 ? 'document' : 'documents'} in this list.`
+    : `Bulk actions apply to ${selectableCount} ${selectableCount === 1 ? 'document you can manage' : 'documents you can manage'}.`;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-border bg-muted/40 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium">{selectionLabel}</p>
+        <p className="text-xs text-muted-foreground">{manageableLabel}</p>
+      </div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClearSelection}
+          className="justify-start sm:justify-center"
+        >
+          Clear selection
+        </Button>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={onDelete}
+            disabled={busyAction !== null && busyAction !== 'delete'}
+          >
+            {busyAction === 'delete' ? 'Deleting…' : 'Delete'}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onMoveTag}
+            disabled={busyAction === 'update'}
+          >
+            {busyAction === 'update' ? 'Applying…' : 'Move / Tag'}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onExport}
+            disabled={busyAction !== null && busyAction !== 'export'}
+          >
+            {busyAction === 'export' ? 'Exporting…' : 'Export'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -1,14 +1,43 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
-import { getDocumentsAction } from '../actions';
+import {
+  bulkDeleteDocumentsAction,
+  bulkExportDocumentsAction,
+  bulkTagDocumentsAction,
+  getDocumentsAction,
+} from '../actions';
 import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
 import { FileText, Users, Calendar, Eye } from 'lucide-react';
+import { toast } from 'sonner';
+import { useDocumentPermissions } from '@/hooks/use-document-permissions';
+import { useTableSelection } from '@/components/table/use-table-selection';
+import { DocumentBulkActionsToolbar } from './document-bulk-actions-toolbar';
+import { cn } from '@/lib/utils';
 
 interface DocumentsListProps {
   filter: DocumentListFilters;
@@ -18,6 +47,12 @@ export function DocumentsList({ filter }: DocumentsListProps) {
   const [documents, setDocuments] = useState<DocumentWithLease[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [bulkAction, setBulkAction] = useState<'delete' | 'update' | 'export' | null>(null);
+  const [showBulkDialog, setShowBulkDialog] = useState(false);
+  const [bulkForm, setBulkForm] = useState({ unitId: '', tag: '' });
+  const permissions = useDocumentPermissions();
+  const unitFieldId = useId();
+  const tagFieldId = useId();
 
   useEffect(() => {
     const fetchDocuments = async () => {
@@ -42,7 +77,7 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     fetchDocuments();
   }, [filter]);
 
-  const getStatusBadge = (status: string) => {
+  const getStatusBadge = useCallback((status: string) => {
     const variants = {
       draft: 'secondary',
       pending_signature: 'outline',
@@ -64,9 +99,9 @@ export function DocumentsList({ filter }: DocumentsListProps) {
         {labels[status as keyof typeof labels] || status}
       </Badge>
     );
-  };
+  }, []);
 
-  const getStateBadge = (state: string) => {
+  const getStateBadge = useCallback((state: string) => {
     const labels = {
       draft: 'Draft',
       published: 'Published',
@@ -80,9 +115,9 @@ export function DocumentsList({ filter }: DocumentsListProps) {
         {labels[state as keyof typeof labels] || state}
       </Badge>
     );
-  };
+  }, []);
 
-  const versionStatusLabel = (status: string) => {
+  const versionStatusLabel = useCallback((status: string) => {
     const labels = {
       draft: 'Draft Saved',
       pending_signature: 'Sent for Signature',
@@ -92,9 +127,9 @@ export function DocumentsList({ filter }: DocumentsListProps) {
     } as const;
 
     return labels[status as keyof typeof labels] || status;
-  };
+  }, []);
 
-  const getTypeIcon = (type: string) => {
+  const getTypeIcon = useCallback((type: string) => {
     switch (type) {
       case 'lease':
         return <FileText className="size-4" />;
@@ -105,7 +140,165 @@ export function DocumentsList({ filter }: DocumentsListProps) {
       default:
         return <FileText className="size-4" />;
     }
-  };
+  }, []);
+
+  const getDocumentId = useCallback((doc: DocumentWithLease) => doc.id, []);
+  const isDocumentSelectable = useCallback(
+    (doc: DocumentWithLease) => permissions.canEditDocument(doc),
+    [permissions],
+  );
+
+  const {
+    selectedIds,
+    toggleItem,
+    toggleAll,
+    isSelected,
+    isAllSelected,
+    isIndeterminate,
+    clearSelection,
+    selectableCount,
+  } = useTableSelection<DocumentWithLease>({
+    items: documents,
+    getId: getDocumentId,
+    isItemSelectable: isDocumentSelectable,
+  });
+
+  const selectedCount = selectedIds.length;
+  const headerCheckboxState: boolean | 'indeterminate' = isAllSelected
+    ? true
+    : isIndeterminate
+      ? 'indeterminate'
+      : false;
+
+  useEffect(() => {
+    if (selectedCount === 0 && showBulkDialog) {
+      setShowBulkDialog(false);
+    }
+  }, [selectedCount, showBulkDialog]);
+
+  const handleBulkDelete = useCallback(async () => {
+    if (selectedIds.length === 0) {
+      toast.error('Select at least one document to delete.');
+      return;
+    }
+
+    const ids = [...selectedIds];
+    setBulkAction('delete');
+    try {
+      const result = await bulkDeleteDocumentsAction(ids);
+      if (result.success) {
+        setDocuments((previous) => previous.filter((doc) => !ids.includes(doc.id)));
+        clearSelection();
+        toast.success(result.message ?? `Deleted ${ids.length} document${ids.length === 1 ? '' : 's'}.`);
+      } else {
+        toast.error(result.error || 'Failed to delete documents.');
+      }
+    } catch (err) {
+      console.error('Error deleting documents:', err);
+      toast.error('An unexpected error occurred while deleting documents.');
+    } finally {
+      setBulkAction(null);
+    }
+  }, [selectedIds, clearSelection]);
+
+  const handleBulkExport = useCallback(async () => {
+    if (selectedIds.length === 0) {
+      toast.error('Select at least one document to export.');
+      return;
+    }
+
+    const ids = [...selectedIds];
+    setBulkAction('export');
+    try {
+      const result = await bulkExportDocumentsAction(ids);
+      if (result.success) {
+        const url = result.data?.export_url ?? result.data?.signed_url;
+        if (url && typeof window !== 'undefined') {
+          window.open(url, '_blank', 'noopener,noreferrer');
+        }
+        toast.success(result.message ?? 'Export started for selected documents.');
+      } else {
+        toast.error(result.error || 'Failed to export documents.');
+      }
+    } catch (err) {
+      console.error('Error exporting documents:', err);
+      toast.error('An unexpected error occurred while exporting documents.');
+    } finally {
+      setBulkAction(null);
+    }
+  }, [selectedIds]);
+
+  const handleBulkUpdate = useCallback(async () => {
+    if (selectedIds.length === 0) {
+      toast.error('Select at least one document to update.');
+      return;
+    }
+
+    const normalizedTag = bulkForm.tag.trim();
+    const normalizedUnitId = bulkForm.unitId.trim();
+
+    if (!normalizedTag && !normalizedUnitId) {
+      toast.error('Enter a destination unit or tag to apply.');
+      return;
+    }
+
+    const ids = [...selectedIds];
+    setBulkAction('update');
+    try {
+      const result = await bulkTagDocumentsAction({
+        documentIds: ids,
+        tag: normalizedTag || undefined,
+        unitId: normalizedUnitId || undefined,
+      });
+
+      if (result.success) {
+        setDocuments((previous) =>
+          previous.map((doc) => {
+            if (!ids.includes(doc.id)) {
+              return doc;
+            }
+
+            const nextMetadata = (() => {
+              const currentMetadata = (doc.metadata ?? {}) as Record<string, any>;
+              if (!normalizedTag) {
+                return currentMetadata;
+              }
+
+              const existingTags = Array.isArray(currentMetadata.tags)
+                ? (currentMetadata.tags as string[])
+                : [];
+
+              if (existingTags.includes(normalizedTag)) {
+                return currentMetadata;
+              }
+
+              return {
+                ...currentMetadata,
+                tags: [...existingTags, normalizedTag],
+              };
+            })();
+
+            return {
+              ...doc,
+              unit_id: normalizedUnitId ? normalizedUnitId : doc.unit_id,
+              metadata: nextMetadata,
+            };
+          }),
+        );
+        clearSelection();
+        setBulkForm({ tag: '', unitId: '' });
+        setShowBulkDialog(false);
+        toast.success(result.message ?? 'Updates applied to selected documents.');
+      } else {
+        toast.error(result.error || 'Failed to update documents.');
+      }
+    } catch (err) {
+      console.error('Error applying bulk updates:', err);
+      toast.error('An unexpected error occurred while updating documents.');
+    } finally {
+      setBulkAction(null);
+    }
+  }, [bulkForm.tag, bulkForm.unitId, clearSelection, selectedIds]);
 
   if (loading) {
     return (
@@ -115,18 +308,18 @@ export function DocumentsList({ filter }: DocumentsListProps) {
             <CardHeader>
               <div className="flex items-center justify-between">
                 <div className="space-y-2">
-                  <div className="h-5 w-48 rounded bg-muted"></div>
-                  <div className="h-4 w-32 rounded bg-muted"></div>
+                  <div className="h-5 w-48 rounded bg-muted" />
+                  <div className="h-4 w-32 rounded bg-muted" />
                 </div>
-                <div className="h-6 w-20 rounded bg-muted"></div>
+                <div className="h-6 w-20 rounded bg-muted" />
               </div>
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between">
-                <div className="h-4 w-24 rounded bg-muted"></div>
+                <div className="h-4 w-24 rounded bg-muted" />
                 <div className="flex space-x-2">
-                  <div className="h-8 w-16 rounded bg-muted"></div>
-                  <div className="h-8 w-16 rounded bg-muted"></div>
+                  <div className="h-8 w-16 rounded bg-muted" />
+                  <div className="h-8 w-16 rounded bg-muted" />
                 </div>
               </div>
             </CardContent>
@@ -162,123 +355,270 @@ export function DocumentsList({ filter }: DocumentsListProps) {
           <h3 className="mb-2 text-lg font-medium">No documents found</h3>
           <p className="text-sm text-muted-foreground">
             {Object.keys(filter).length > 0
-              ? "No documents match your current filters."
-              : "Get started by uploading your first document."}
+              ? 'No documents match your current filters.'
+              : 'Get started by uploading your first document.'}
           </p>
         </div>
       </Card>
     );
   }
 
+  const selectionDescription = selectedCount === 1 ? 'selected document' : `${selectedCount} selected documents`;
+
   return (
     <div className="space-y-4">
-      {documents.map((doc) => (
-        <Card key={doc.id} className="transition-shadow hover:shadow-md">
-          <CardHeader className="pb-3">
-            <div className="flex items-start justify-between">
-              <div className="flex items-start space-x-3">
-                <div className="mt-1">
-                  {getTypeIcon(doc.document_type)}
-                </div>
-                <div className="space-y-1">
-                  <h3 className="font-medium leading-none">{doc.title}</h3>
-                  {doc.description && (
-                    <p className="text-sm text-muted-foreground">
-                      {doc.description}
-                    </p>
-                  )}
-                  <div className="flex items-center space-x-4 text-xs text-muted-foreground">
-                    <div className="flex items-center space-x-1">
-                      <Calendar className="size-3" />
-                      <span>
-                        {formatDistanceToNow(new Date(doc.created_at), { addSuffix: true })}
-                      </span>
-                    </div>
-                    {doc.lease && (
-                      <div className="flex items-center space-x-1">
-                        <Users className="size-3" />
-                        <span>Lease • {doc.lease.tenant_ids?.length || 0} tenants</span>
-                      </div>
-                    )}
-                    {doc.signatures && doc.signatures.length > 0 && (
-                      <div className="flex items-center space-x-1">
-                        <Eye className="size-3" />
-                        <span>
-                          {doc.signatures.filter(s => s.status === 'signed').length}/
-                          {doc.signatures.length} signed
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                {getStateBadge(doc.state)}
-                {getStatusBadge(doc.status)}
-                <DocumentActions document={doc} />
-              </div>
-            </div>
-          </CardHeader>
-          {(doc.signatures && doc.signatures.length > 0) && (
-            <CardContent className="pt-0">
-              <div className="flex items-center space-x-2">
-                <span className="text-xs text-muted-foreground">Signers:</span>
-                {doc.signatures.slice(0, 3).map((signature) => (
-                  <Badge
-                    key={signature.id}
-                    variant={signature.status === 'signed' ? 'default' : 'outline'}
-                    className="text-xs"
-                  >
-                    {signature.signer_name || signature.signer_email.split('@')[0]}
-                  </Badge>
-                ))}
-                {doc.signatures.length > 3 && (
-                  <Badge variant="secondary" className="text-xs">
-                    +{doc.signatures.length - 3} more
-                  </Badge>
-                )}
-              </div>
-            </CardContent>
-          )}
+      {selectedCount > 0 && (
+        <DocumentBulkActionsToolbar
+          selectedCount={selectedCount}
+          selectableCount={selectableCount}
+          onClearSelection={clearSelection}
+          onDelete={() => {
+            void handleBulkDelete();
+          }}
+          onMoveTag={() => setShowBulkDialog(true)}
+          onExport={() => {
+            void handleBulkExport();
+          }}
+          busyAction={bulkAction}
+        />
+      )}
 
-          {doc.versions && doc.versions.length > 0 && (
-            <CardContent className="pt-3">
-              <div className="border-t pt-3">
-                <div className="text-xs font-medium uppercase text-muted-foreground">
-                  Version history
-                </div>
-                <div className="mt-2 space-y-2">
-                  {doc.versions.slice(0, 5).map((version) => (
-                    <div
-                      key={version.id}
-                      className="flex items-center justify-between text-xs text-muted-foreground"
-                    >
-                      <div className="flex items-center space-x-2">
-                        <Badge
-                          variant={version.version === doc.version ? 'default' : 'outline'}
-                          className="text-[10px] uppercase"
-                        >
-                          v{version.version}
-                        </Badge>
-                        <Badge
-                          variant={version.state === 'published' ? 'default' : 'secondary'}
-                          className="text-[10px] uppercase"
-                        >
-                          {version.state}
-                        </Badge>
-                        <span>{versionStatusLabel(version.status)}</span>
+      <div className="overflow-hidden rounded-md border">
+        <table className="min-w-full divide-y divide-border text-sm">
+          <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th scope="col" className="w-[48px] px-3 py-3 text-left">
+                <Checkbox
+                  aria-label="Select all documents"
+                  checked={headerCheckboxState}
+                  onCheckedChange={() => toggleAll()}
+                  disabled={selectableCount === 0}
+                />
+              </th>
+              <th scope="col" className="px-3 py-3 text-left font-medium text-foreground">
+                Document
+              </th>
+              <th scope="col" className="w-[160px] px-3 py-3 text-left font-medium text-foreground">
+                Status
+              </th>
+              <th scope="col" className="w-[80px] px-3 py-3 text-right font-medium text-foreground">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border bg-background">
+            {documents.map((doc) => {
+              const canManage = permissions.canEditDocument(doc);
+              const selected = isSelected(doc.id);
+
+              const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>) => {
+                if ((event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') && canManage) {
+                  event.preventDefault();
+                  toggleItem(doc.id);
+                  return;
+                }
+
+                if ((event.key === 'a' || event.key === 'A') && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  toggleAll();
+                }
+              };
+
+              return (
+                <tr
+                  key={doc.id}
+                  className={cn(
+                    'align-top transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+                    selected ? 'bg-muted/60' : 'hover:bg-muted/30',
+                  )}
+                  tabIndex={0}
+                  aria-selected={selected}
+                  onKeyDown={handleRowKeyDown}
+                >
+                  <td className="px-3 py-4 align-top">
+                    <Checkbox
+                      aria-label={`Select document ${doc.title}`}
+                      checked={selected}
+                      onCheckedChange={() => toggleItem(doc.id)}
+                      disabled={!canManage}
+                    />
+                  </td>
+                  <td className="px-3 py-4">
+                    <div className="flex items-start gap-3">
+                      <div className="mt-1 text-muted-foreground">{getTypeIcon(doc.document_type)}</div>
+                      <div className="space-y-2">
+                        <div className="flex flex-col gap-1">
+                          <span className="font-medium text-foreground">{doc.title}</span>
+                          {doc.description && (
+                            <span className="text-xs text-muted-foreground">{doc.description}</span>
+                          )}
+                        </div>
+                        <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                          <div className="flex items-center gap-1">
+                            <Calendar className="size-3" />
+                            <span>
+                              {formatDistanceToNow(new Date(doc.created_at), { addSuffix: true })}
+                            </span>
+                          </div>
+                          {doc.lease && (
+                            <div className="flex items-center gap-1">
+                              <Users className="size-3" />
+                              <span>Lease • {doc.lease.tenant_ids?.length || 0} tenants</span>
+                            </div>
+                          )}
+                          {doc.signatures && doc.signatures.length > 0 && (
+                            <div className="flex items-center gap-1">
+                              <Eye className="size-3" />
+                              <span>
+                                {doc.signatures.filter((s) => s.status === 'signed').length}/
+                                {doc.signatures.length} signed
+                              </span>
+                            </div>
+                          )}
+                        </div>
+
+                        {doc.signatures && doc.signatures.length > 0 && (
+                          <div className="flex flex-wrap items-center gap-2 text-xs">
+                            <span className="text-muted-foreground">Signers:</span>
+                            {doc.signatures.slice(0, 3).map((signature) => (
+                              <Badge
+                                key={signature.id}
+                                variant={signature.status === 'signed' ? 'default' : 'outline'}
+                                className="text-[11px]"
+                              >
+                                {signature.signer_name || signature.signer_email.split('@')[0]}
+                              </Badge>
+                            ))}
+                            {doc.signatures.length > 3 && (
+                              <Badge variant="secondary" className="text-[11px]">
+                                +{doc.signatures.length - 3} more
+                              </Badge>
+                            )}
+                          </div>
+                        )}
+
+                        {doc.versions && doc.versions.length > 0 && (
+                          <div className="space-y-2 rounded-md border border-dashed border-border/60 p-2">
+                            <div className="text-[11px] font-medium uppercase text-muted-foreground">
+                              Version history
+                            </div>
+                            <div className="space-y-1">
+                              {doc.versions.slice(0, 5).map((version) => (
+                                <div
+                                  key={version.id}
+                                  className="flex items-center justify-between text-[11px] text-muted-foreground"
+                                >
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <Badge
+                                      variant={version.version === doc.version ? 'default' : 'outline'}
+                                      className="text-[10px] uppercase"
+                                    >
+                                      v{version.version}
+                                    </Badge>
+                                    <Badge
+                                      variant={version.state === 'published' ? 'default' : 'secondary'}
+                                      className="text-[10px] uppercase"
+                                    >
+                                      {version.state}
+                                    </Badge>
+                                    <span>{versionStatusLabel(version.status)}</span>
+                                  </div>
+                                  <span>
+                                    {formatDistanceToNow(new Date(version.created_at), { addSuffix: true })}
+                                  </span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
                       </div>
-                      <span>
-                        {formatDistanceToNow(new Date(version.created_at), { addSuffix: true })}
-                      </span>
                     </div>
-                  ))}
-                </div>
-              </div>
-            </CardContent>
-          )}
-        </Card>
-      ))}
+                  </td>
+                  <td className="px-3 py-4">
+                    <div className="flex flex-col gap-2">
+                      {getStateBadge(doc.state)}
+                      {getStatusBadge(doc.status)}
+                    </div>
+                  </td>
+                  <td className="px-3 py-4 text-right">
+                    <DocumentActions document={doc} />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <Dialog
+        open={showBulkDialog}
+        onOpenChange={(open) => {
+          setShowBulkDialog(open);
+          if (!open) {
+            setBulkForm({ tag: '', unitId: '' });
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Move or tag documents</DialogTitle>
+            <DialogDescription>
+              Apply updates to the {selectionDescription}.
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            onSubmit={(event: FormEvent<HTMLFormElement>) => {
+              event.preventDefault();
+              void handleBulkUpdate();
+            }}
+            className="space-y-4"
+          >
+            <div className="space-y-2">
+              <Label htmlFor={unitFieldId}>Move to unit</Label>
+              <Input
+                id={unitFieldId}
+                placeholder="Enter destination unit ID"
+                value={bulkForm.unitId}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  setBulkForm((previous) => ({ ...previous, unitId: event.target.value }))
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                Leave blank to keep the current unit assignment.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={tagFieldId}>Apply tag</Label>
+              <Input
+                id={tagFieldId}
+                placeholder="e.g. renewal, compliance"
+                value={bulkForm.tag}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  setBulkForm((previous) => ({ ...previous, tag: event.target.value }))
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                Tags are stored in each document&apos;s metadata.
+              </p>
+            </div>
+            <DialogFooter className="sm:space-x-2">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  setShowBulkDialog(false);
+                  setBulkForm({ tag: '', unitId: '' });
+                }}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={selectedCount === 0 || bulkAction === 'update'}>
+                {bulkAction === 'update' ? 'Applying…' : 'Apply updates'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/components/table/use-table-selection.ts
+++ b/components/table/use-table-selection.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface UseTableSelectionOptions<T> {
+  items: T[];
+  getId: (item: T) => string;
+  isItemSelectable?: (item: T) => boolean;
+}
+
+export interface TableSelectionController {
+  selectedIds: string[];
+  toggleItem: (id: string) => void;
+  toggleAll: () => void;
+  isSelected: (id: string) => boolean;
+  isAllSelected: boolean;
+  isIndeterminate: boolean;
+  clearSelection: () => void;
+  selectableCount: number;
+}
+
+export function useTableSelection<T>({
+  items,
+  getId,
+  isItemSelectable,
+}: UseTableSelectionOptions<T>): TableSelectionController {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const selectableItems = useMemo(() => {
+    if (!isItemSelectable) {
+      return items;
+    }
+
+    return items.filter((item) => isItemSelectable(item));
+  }, [items, isItemSelectable]);
+
+  const selectableIds = useMemo(() => selectableItems.map((item) => getId(item)), [
+    selectableItems,
+    getId,
+  ]);
+
+  const selectableIdSet = useMemo(() => new Set(selectableIds), [selectableIds]);
+
+  useEffect(() => {
+    setSelectedIds((previous) => previous.filter((id) => selectableIdSet.has(id)));
+  }, [selectableIdSet]);
+
+  const toggleItem = useCallback(
+    (id: string) => {
+      if (!selectableIdSet.has(id)) {
+        return;
+      }
+
+      setSelectedIds((previous) => {
+        if (previous.includes(id)) {
+          return previous.filter((value) => value !== id);
+        }
+
+        return [...previous, id];
+      });
+    },
+    [selectableIdSet],
+  );
+
+  const toggleAll = useCallback(() => {
+    setSelectedIds((previous) => {
+      if (selectableIds.length === 0) {
+        return [];
+      }
+
+      const hasAllSelected = previous.length === selectableIds.length;
+      return hasAllSelected ? [] : selectableIds;
+    });
+  }, [selectableIds]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds([]);
+  }, []);
+
+  const isSelected = useCallback(
+    (id: string) => selectedIds.includes(id),
+    [selectedIds],
+  );
+
+  const { isAllSelected, isIndeterminate } = useMemo(() => {
+    if (selectableIds.length === 0) {
+      return { isAllSelected: false, isIndeterminate: false };
+    }
+
+    if (selectedIds.length === 0) {
+      return { isAllSelected: false, isIndeterminate: false };
+    }
+
+    if (selectedIds.length === selectableIds.length) {
+      return { isAllSelected: true, isIndeterminate: false };
+    }
+
+    return { isAllSelected: false, isIndeterminate: true };
+  }, [selectedIds, selectableIds]);
+
+  return {
+    selectedIds,
+    toggleItem,
+    toggleAll,
+    isSelected,
+    isAllSelected,
+    isIndeterminate,
+    clearSelection,
+    selectableCount: selectableIds.length,
+  };
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -284,6 +284,26 @@ export type Database = {
         }
         Returns: Json
       }
+      documents_bulk_delete: {
+        Args: { document_ids: string[] }
+        Returns: { deleted_ids: string[] }
+      }
+      documents_bulk_export: {
+        Args: { document_ids: string[] }
+        Returns: { export_url?: string | null; signed_url?: string | null }
+      }
+      documents_bulk_tag: {
+        Args: {
+          document_ids: string[]
+          tag?: string | null
+          destination_unit_id?: string | null
+        }
+        Returns: {
+          updated_ids: string[]
+          applied_tag?: string | null
+          destination_unit_id?: string | null
+        }
+      }
       get_unread_notification_count: {
         Args: { user_uuid?: string | null }
         Returns: number

--- a/tests/documents-bulk-actions.test.ts
+++ b/tests/documents-bulk-actions.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createClientMock, fetchMemberRoleMock, revalidatePathMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  fetchMemberRoleMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => ({ get: vi.fn() })),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock('@/utils/supa-server-actions', () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock('@/lib/data/members', () => ({
+  fetchMemberRole: fetchMemberRoleMock,
+}));
+
+import {
+  bulkDeleteDocumentsAction,
+  bulkExportDocumentsAction,
+  bulkTagDocumentsAction,
+} from '@/app/documents/actions';
+
+function createSupabaseStub(
+  rpcHandlers: Record<string, (args: any) => Promise<{ data: any; error: any }>> = {},
+) {
+  const rpcMock = vi.fn(async (fnName: string, args: any) => {
+    const handler = rpcHandlers[fnName];
+    if (handler) {
+      return handler(args);
+    }
+
+    return { data: null, error: null };
+  });
+
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: { id: 'manager-1' } },
+        error: null,
+      })),
+    },
+    rpc: rpcMock,
+  };
+}
+
+beforeEach(() => {
+  createClientMock.mockReset();
+  fetchMemberRoleMock.mockReset();
+  revalidatePathMock.mockReset();
+});
+
+describe('documents bulk actions', () => {
+  it('deletes all selected documents via batch endpoint', async () => {
+    const ids = [
+      '11111111-2222-3333-4444-555555555551',
+      '11111111-2222-3333-4444-555555555552',
+    ];
+
+    const rpcSpy = vi.fn(async (args: any) => ({
+      data: { deleted_ids: args.document_ids },
+      error: null,
+    }));
+
+    const supabaseStub = createSupabaseStub({
+      documents_bulk_delete: rpcSpy,
+    });
+
+    createClientMock.mockReturnValue(supabaseStub as any);
+    fetchMemberRoleMock.mockResolvedValue('property_manager');
+
+    const result = await bulkDeleteDocumentsAction(ids);
+
+    expect(supabaseStub.rpc).toHaveBeenCalledWith('documents_bulk_delete', {
+      document_ids: ids,
+    });
+    expect(rpcSpy).toHaveBeenCalledWith({ document_ids: ids });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ deleted_ids: ids });
+    expect(revalidatePathMock).toHaveBeenCalledWith('/documents');
+  });
+
+  it('applies tags and moves selected documents', async () => {
+    const ids = [
+      '11111111-2222-3333-4444-555555555553',
+      '11111111-2222-3333-4444-555555555554',
+    ];
+
+    const rpcSpy = vi.fn(async (args: any) => ({
+      data: {
+        updated_ids: args.document_ids,
+        applied_tag: args.tag,
+        destination_unit_id: args.destination_unit_id,
+      },
+      error: null,
+    }));
+
+    const supabaseStub = createSupabaseStub({
+      documents_bulk_tag: rpcSpy,
+    });
+
+    createClientMock.mockReturnValue(supabaseStub as any);
+    fetchMemberRoleMock.mockResolvedValue('admin');
+
+    const payload = {
+      documentIds: ids,
+      tag: 'renewal',
+      unitId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    };
+
+    const result = await bulkTagDocumentsAction(payload);
+
+    expect(supabaseStub.rpc).toHaveBeenCalledWith('documents_bulk_tag', {
+      document_ids: ids,
+      tag: 'renewal',
+      destination_unit_id: payload.unitId,
+    });
+    expect(rpcSpy).toHaveBeenCalledWith({
+      document_ids: ids,
+      tag: 'renewal',
+      destination_unit_id: payload.unitId,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      updated_ids: ids,
+      applied_tag: 'renewal',
+      destination_unit_id: payload.unitId,
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith('/documents');
+  });
+
+  it('exports all selected documents', async () => {
+    const ids = [
+      '11111111-2222-3333-4444-555555555555',
+      '11111111-2222-3333-4444-555555555556',
+    ];
+
+    const rpcSpy = vi.fn(async (args: any) => ({
+      data: { export_url: 'https://example.com/export.zip' },
+      error: null,
+    }));
+
+    const supabaseStub = createSupabaseStub({
+      documents_bulk_export: rpcSpy,
+    });
+
+    createClientMock.mockReturnValue(supabaseStub as any);
+    fetchMemberRoleMock.mockResolvedValue('property_manager');
+
+    const result = await bulkExportDocumentsAction(ids);
+
+    expect(supabaseStub.rpc).toHaveBeenCalledWith('documents_bulk_export', {
+      document_ids: ids,
+    });
+    expect(rpcSpy).toHaveBeenCalledWith({ document_ids: ids });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ export_url: 'https://example.com/export.zip' });
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- convert the documents list into a selectable table with a bulk action toolbar and move/tag dialog wired to Supabase
- add a shared table selection hook plus new bulk delete/tag/export server actions and Supabase function types
- cover the new batch actions with dedicated tests to ensure every selected document is processed

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30bb536908328a002fedf0e445420