### PR TITLE
Add global favorites system

### DIFF
--- a/app/bookings/components/booking-history.tsx
+++ b/app/bookings/components/booking-history.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FavoriteToggle } from '@/components/navigation/FavoriteToggle';
 
 export function BookingHistory() {
   // Placeholder history list
@@ -11,8 +14,20 @@ export function BookingHistory() {
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
       {items.map((x) => (
         <Card key={x.id}>
-          <CardHeader>
+          <CardHeader className="flex flex-row items-start justify-between gap-2">
             <CardTitle className="text-base">{x.title}</CardTitle>
+            <FavoriteToggle
+              entityType="booking"
+              entityId={x.id}
+              metadata={{
+                title: `${x.title} booking`,
+                subtitle: x.when,
+                description: `Recent reservation for the ${x.title.toLowerCase()}`,
+                href: '/bookings',
+                badge: 'Booking',
+              }}
+              label={`Toggle favorite for ${x.title} booking`}
+            />
           </CardHeader>
           <CardContent>
             <div className="text-sm text-muted-foreground">{x.when}</div>

--- a/app/dashboard/components/SideNav.tsx
+++ b/app/dashboard/components/SideNav.tsx
@@ -4,6 +4,7 @@ import NavLinks from "./NavLinks";
 import { cn } from "@/lib/utils";
 import SignOut from "./SignOut";
 import { ThemeToggle } from "@/components/theme-toggle"
+import FavoritesPanel from "@/components/navigation/FavoritesPanel"
 export default function SideNav() {
 	return (
 		<SideBar className=" dark:bg-gradient-dark hidden flex-1 lg:block" />
@@ -27,7 +28,8 @@ export const SideBar = ({ className }: { className?: string }) => {
 
 						<ThemeToggle />
 					</div>
-					<NavLinks />
+                                        <FavoritesPanel />
+                                        <NavLinks />
 				</div>
 				<div className="">
 					<SignOut />

--- a/app/documents/components/documents-list.tsx
+++ b/app/documents/components/documents-list.tsx
@@ -4,11 +4,33 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { FavoriteToggle } from '@/components/navigation/FavoriteToggle';
 import { DocumentWithLease, DocumentListFilters } from '@/types/documents';
 import { getDocumentsAction } from '../actions';
 import { DocumentActions } from './document-actions';
 import { formatDistanceToNow } from 'date-fns';
 import { FileText, Users, Calendar, Eye } from 'lucide-react';
+
+const documentTypeLabels: Record<string, string> = {
+  lease: 'Lease',
+  addendum: 'Addendum',
+  insurance: 'Insurance',
+  maintenance: 'Maintenance',
+  other: 'Document',
+};
+
+const documentStatusLabels: Record<string, string> = {
+  draft: 'Draft',
+  pending_signature: 'Pending Signature',
+  signed: 'Signed',
+  expired: 'Expired',
+  cancelled: 'Cancelled',
+};
+
+const documentStateLabels: Record<string, string> = {
+  draft: 'Draft',
+  published: 'Published',
+};
 
 interface DocumentsListProps {
   filter: DocumentListFilters;
@@ -51,33 +73,24 @@ export function DocumentsList({ filter }: DocumentsListProps) {
       cancelled: 'secondary',
     } as const;
 
-    const labels = {
-      draft: 'Draft',
-      pending_signature: 'Pending Signature',
-      signed: 'Signed',
-      expired: 'Expired',
-      cancelled: 'Cancelled',
-    };
+    const label = documentStatusLabels[status] ?? status;
 
     return (
       <Badge variant={variants[status as keyof typeof variants] || 'secondary'}>
-        {labels[status as keyof typeof labels] || status}
+        {label}
       </Badge>
     );
   };
 
   const getStateBadge = (state: string) => {
-    const labels = {
-      draft: 'Draft',
-      published: 'Published',
-    } as const;
+    const label = documentStateLabels[state] ?? state;
 
     return (
       <Badge
         variant={state === 'published' ? 'default' : 'secondary'}
         className="uppercase"
       >
-        {labels[state as keyof typeof labels] || state}
+        {label}
       </Badge>
     );
   };
@@ -172,8 +185,23 @@ export function DocumentsList({ filter }: DocumentsListProps) {
 
   return (
     <div className="space-y-4">
-      {documents.map((doc) => (
-        <Card key={doc.id} className="transition-shadow hover:shadow-md">
+      {documents.map((doc) => {
+        const typeLabel = documentTypeLabels[doc.document_type] ?? 'Document';
+        const statusLabel = documentStatusLabels[doc.status] ?? doc.status;
+        const signedSummary =
+          doc.signatures && doc.signatures.length > 0
+            ? `${doc.signatures.filter(s => s.status === 'signed').length}/${doc.signatures.length} signed`
+            : undefined;
+        const tenantSummary = doc.lease?.tenant_ids?.length
+          ? `${doc.lease.tenant_ids.length} tenants`
+          : undefined;
+        const favoriteDescription =
+          [signedSummary, tenantSummary].filter(Boolean).join(' • ') || statusLabel;
+        const favoriteSubtitle =
+          doc.description || `${typeLabel} • ${statusLabel}`;
+
+        return (
+          <Card key={doc.id} className="transition-shadow hover:shadow-md">
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between">
               <div className="flex items-start space-x-3">
@@ -215,6 +243,18 @@ export function DocumentsList({ filter }: DocumentsListProps) {
               <div className="flex items-center space-x-2">
                 {getStateBadge(doc.state)}
                 {getStatusBadge(doc.status)}
+                <FavoriteToggle
+                  entityType="document"
+                  entityId={doc.id}
+                  metadata={{
+                    title: doc.title,
+                    subtitle: favoriteSubtitle,
+                    description: favoriteDescription,
+                    href: '/documents',
+                    badge: typeLabel,
+                  }}
+                  label={`Toggle favorite for ${doc.title}`}
+                />
                 <DocumentActions document={doc} />
               </div>
             </div>
@@ -277,8 +317,9 @@ export function DocumentsList({ filter }: DocumentsListProps) {
               </div>
             </CardContent>
           )}
-        </Card>
-      ))}
+          </Card>
+        )
+      })}
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ import { SiteHeader } from "@/components/site-header"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
+import { FavoritesProvider } from "@/components/navigation/FavoritesProvider"
 import { fontSans } from "@/lib/font"
 import { cn } from "@/lib/utils"
 import { siteConfig } from "@/config/site"
@@ -119,18 +120,20 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <ReactQueryClientProvider>
     <html lang="en" suppressHydrationWarning>
     <head></head>
-      <body className={cn(
-            "min-h-screen bg-background font-sans antialiased",
-            fontSans.variable
-          )}
+      <body
+        className={cn(
+          "min-h-screen bg-background font-sans antialiased",
+          fontSans.variable,
+        )}
+      >
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
         >
-<ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-             <div className="relative flex min-h-screen flex-col">
+          <FavoritesProvider>
+            <div className="relative flex min-h-screen flex-col">
               {/* <SiteHeader /> */}
               <div className="flex-1">
                 <ErrorBoundary>
@@ -142,25 +145,22 @@ export default function RootLayout({ children }: RootLayoutProps) {
                 <Analytics />
                 <SpeedInsights />
               </div>
+            </div>
 
-   </div>
-{/* <SiteFooter/> */}
+            {/* <SiteFooter/> */}
 
+            {/*
+              enter your api info from termly.io or a provider of your choice
+              <Script
+                type="text/javascript"
+                src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
 
-{/*
-enter your api info from termly.io or a provider of your choice
-<Script
-  type="text/javascript"
-  src="https://app.termly.io/resource-blocker/123456789abcdefg"/>
-
- */}
-   <CookieButton />
-   <TailwindIndicator />
-          </ThemeProvider>
-
-
-
-</body>
+            */}
+            <CookieButton />
+            <TailwindIndicator />
+          </FavoritesProvider>
+        </ThemeProvider>
+      </body>
     </html>
     </ReactQueryClientProvider>
   )

--- a/app/messaging/page.tsx
+++ b/app/messaging/page.tsx
@@ -1,4 +1,10 @@
+"use client"
+
+import { useMemo } from "react"
+
 import ModerationControls from "@/components/messaging/moderation-controls"
+import { FavoriteToggle } from "@/components/navigation/FavoriteToggle"
+import { useFavorites } from "@/components/navigation/FavoritesProvider"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -303,6 +309,14 @@ const pollSnapshots: PollSnapshot[] = [
 ]
 
 export default function MessagingPage() {
+  const { favorites } = useFavorites()
+  const pinnedThreadIds = useMemo(() => {
+    const pinned = favorites
+      .filter((favorite) => favorite.entityType === 'thread')
+      .map((favorite) => favorite.entityId)
+    return new Set(pinned)
+  }, [favorites])
+
   return (
     <div className="container max-w-6xl space-y-10 py-12">
       <header className="space-y-4">
@@ -345,51 +359,70 @@ export default function MessagingPage() {
               </div>
             </CardHeader>
             <CardContent className="space-y-3">
-              {threadList.map((thread) => (
-                <div
-                  key={thread.id}
-                  className="space-y-3 rounded-lg border border-border/60 bg-muted/30 p-4 transition hover:border-primary/50 hover:bg-background"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="space-y-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant="secondary">{thread.category}</Badge>
-                        {thread.pinned ? (
-                          <Badge variant="outline" className="uppercase">
-                            Pinned
-                          </Badge>
-                        ) : null}
+              {threadList.map((thread) => {
+                const isPinned = pinnedThreadIds.has(thread.id)
+                const containerClasses = cn(
+                  "space-y-3 rounded-lg border border-border/60 bg-muted/30 p-4 transition hover:border-primary/50 hover:bg-background",
+                  isPinned && "border-primary/70 bg-background shadow-sm",
+                )
+                const subtitle = `${thread.category} • ${thread.lastMessageAt}`
+
+                return (
+                  <div key={thread.id} className={containerClasses}>
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant="secondary">{thread.category}</Badge>
+                          {isPinned ? (
+                            <Badge variant="outline" className="uppercase">
+                              Pinned
+                            </Badge>
+                          ) : null}
+                        </div>
+                        <p className="text-sm font-semibold text-foreground">{thread.title}</p>
+                        <p className="text-xs text-muted-foreground">{thread.summary}</p>
                       </div>
-                      <p className="text-sm font-semibold text-foreground">{thread.title}</p>
-                      <p className="text-xs text-muted-foreground">{thread.summary}</p>
-                    </div>
-                    <div className="flex flex-col items-end gap-2 text-xs">
-                      <span className="text-muted-foreground">{thread.lastMessageAt}</span>
-                      {thread.unreadCount > 0 ? (
-                        <span className="rounded-full bg-primary/10 px-2 py-1 font-medium text-primary">
-                          {thread.unreadCount} new
-                        </span>
-                      ) : null}
-                      <div className="flex gap-1">
-                        {thread.reactions.map((reaction) => (
-                          <span
-                            key={`${thread.id}-${reaction}`}
-                            className="inline-flex size-6 items-center justify-center rounded-full bg-background text-sm"
-                            aria-hidden
-                          >
-                            {reaction}
+                      <div className="flex flex-col items-end gap-2 text-xs">
+                        <FavoriteToggle
+                          entityType="thread"
+                          entityId={thread.id}
+                          metadata={{
+                            title: thread.title,
+                            subtitle,
+                            description: thread.summary,
+                            href: '/messaging',
+                            badge: thread.category,
+                          }}
+                          label={`Toggle favorite for ${thread.title}`}
+                          className="self-end text-muted-foreground"
+                        />
+                        <span className="text-muted-foreground">{thread.lastMessageAt}</span>
+                        {thread.unreadCount > 0 ? (
+                          <span className="rounded-full bg-primary/10 px-2 py-1 font-medium text-primary">
+                            {thread.unreadCount} new
                           </span>
-                        ))}
+                        ) : null}
+                        <div className="flex gap-1">
+                          {thread.reactions.map((reaction) => (
+                            <span
+                              key={`${thread.id}-${reaction}`}
+                              className="inline-flex size-6 items-center justify-center rounded-full bg-background text-sm"
+                              aria-hidden
+                            >
+                              {reaction}
+                            </span>
+                          ))}
+                        </div>
                       </div>
                     </div>
+                    <div className="flex flex-wrap gap-4 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      <span>{thread.participants} participants</span>
+                      <span>{thread.attachments} attachments</span>
+                      <span>{thread.activity}</span>
+                    </div>
                   </div>
-                  <div className="flex flex-wrap gap-4 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    <span>{thread.participants} participants</span>
-                    <span>{thread.attachments} attachments</span>
-                    <span>{thread.activity}</span>
-                  </div>
-                </div>
-              ))}
+                )
+              })}
             </CardContent>
           </Card>
 

--- a/components/navigation/FavoriteToggle.tsx
+++ b/components/navigation/FavoriteToggle.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from 'react';
+import { Bookmark, BookmarkCheck } from 'lucide-react';
+
+import type { FavoriteEntityType, FavoriteMetadata } from '@/types/favorites';
+import { Button } from '@/components/ui/button';
+import { useFavorites } from '@/components/navigation/FavoritesProvider';
+
+interface FavoriteToggleProps {
+  entityType: FavoriteEntityType;
+  entityId: string;
+  metadata: FavoriteMetadata;
+  label?: string;
+  iconOnly?: boolean;
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+  variant?: 'default' | 'secondary' | 'ghost' | 'outline';
+  className?: string;
+}
+
+export function FavoriteToggle({
+  entityType,
+  entityId,
+  metadata,
+  label,
+  iconOnly = true,
+  size,
+  variant,
+  className,
+}: FavoriteToggleProps) {
+  const { isFavorite, pinFavorite, unpinFavorite } = useFavorites();
+  const [pending, setPending] = useState(false);
+
+  const favorite = isFavorite(entityType, entityId);
+  const buttonSize = iconOnly ? 'icon' : size ?? 'sm';
+  const buttonVariant = variant ?? (favorite ? 'secondary' : 'ghost');
+  const ariaLabel = label ?? (favorite ? 'Remove from favorites' : 'Add to favorites');
+
+  return (
+    <Button
+      type="button"
+      variant={buttonVariant}
+      size={buttonSize}
+      className={className}
+      aria-pressed={favorite}
+      aria-label={ariaLabel}
+      disabled={pending}
+      onClick={async () => {
+        if (pending) {
+          return;
+        }
+
+        setPending(true);
+        try {
+          if (favorite) {
+            await unpinFavorite(entityType, entityId);
+          } else {
+            await pinFavorite({ entityType, entityId, metadata });
+          }
+        } catch (toggleError) {
+          console.error('Failed to toggle favorite state', toggleError);
+        } finally {
+          setPending(false);
+        }
+      }}
+    >
+      {favorite ? (
+        <BookmarkCheck className="h-4 w-4" aria-hidden />
+      ) : (
+        <Bookmark className="h-4 w-4" aria-hidden />
+      )}
+      {!iconOnly ? <span className="ml-2 text-sm">{favorite ? 'Pinned' : 'Pin'}</span> : null}
+    </Button>
+  );
+}

--- a/components/navigation/FavoritesPanel.tsx
+++ b/components/navigation/FavoritesPanel.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useMemo } from 'react';
+import { Bookmark, BookmarkMinus } from 'lucide-react';
+
+import { buildFavoritePanelItems } from '@/lib/data/favorites';
+import { useFavorites } from '@/components/navigation/FavoritesProvider';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import SmartLink from '@/components/navigation/SmartLink';
+
+export default function FavoritesPanel() {
+  const { favorites, loading, error, unpinFavorite } = useFavorites();
+
+  const items = useMemo(() => buildFavoritePanelItems(favorites), [favorites]);
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="flex items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <Bookmark className="h-4 w-4" aria-hidden />
+          <span>Pinned shortcuts</span>
+        </div>
+      </div>
+      <div className="border-t">
+        {loading ? (
+          <div className="space-y-2 px-4 py-4">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-10 animate-pulse rounded-md bg-muted/60"
+                aria-hidden
+              />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <div className="space-y-1 px-4 py-6 text-sm text-muted-foreground">
+            <p>No favorites yet.</p>
+            <p>Use the pin icons across documents, threads, or bookings to keep them handy.</p>
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {items.map((item) => (
+              <li key={item.id} className="flex items-start gap-3 px-4 py-3">
+                <div className="min-w-0 flex-1 space-y-1">
+                  {item.href ? (
+                    <SmartLink
+                      href={item.href}
+                      intent="navigation"
+                      className="block truncate text-sm font-medium text-foreground hover:underline"
+                    >
+                      {item.title}
+                    </SmartLink>
+                  ) : (
+                    <span className="block truncate text-sm font-medium text-foreground">
+                      {item.title}
+                    </span>
+                  )}
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <Badge variant="secondary">{item.badge}</Badge>
+                    {item.subtitle ? <span className="truncate">{item.subtitle}</span> : null}
+                  </div>
+                  {item.description ? (
+                    <p className="line-clamp-2 text-xs text-muted-foreground">{item.description}</p>
+                  ) : null}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="mt-1 text-muted-foreground"
+                  onClick={async () => {
+                    try {
+                      await unpinFavorite(item.entityType, item.entityId);
+                    } catch (unpinError) {
+                      console.error('Failed to remove favorite', unpinError);
+                    }
+                  }}
+                  aria-label={`Remove ${item.title} from favorites`}
+                >
+                  <BookmarkMinus className="h-4 w-4" aria-hidden />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {error ? (
+          <div className="border-t px-4 py-2 text-xs text-destructive">{error}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/navigation/FavoritesProvider.tsx
+++ b/components/navigation/FavoritesProvider.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
+import { fetchUserFavorites, removeFavoriteRecord, upsertFavoriteRecord } from '@/lib/data/favorites';
+import type { FavoriteEntityType, FavoriteMetadata, UserFavorite } from '@/types/favorites';
+import { createClient } from '@/utils/supabase-browser';
+
+interface FavoritesContextValue {
+  favorites: UserFavorite[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  pinFavorite: (input: {
+    entityType: FavoriteEntityType;
+    entityId: string;
+    metadata: FavoriteMetadata;
+  }) => Promise<void>;
+  unpinFavorite: (entityType: FavoriteEntityType, entityId: string) => Promise<void>;
+  isFavorite: (entityType: FavoriteEntityType, entityId: string) => boolean;
+}
+
+const FavoritesContext = createContext<FavoritesContextValue | undefined>(undefined);
+
+export function FavoritesProvider({ children }: { children: ReactNode }) {
+  const supabase = useMemo(() => createClient(), []);
+  const [favorites, setFavorites] = useState<UserFavorite[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+
+  const loadFavoritesForUser = useCallback(
+    async (uid: string) => {
+      setLoading(true);
+      try {
+        const items = await fetchUserFavorites(supabase as any, uid);
+        setFavorites(items);
+        setError(null);
+      } catch (loadError) {
+        const message =
+          loadError instanceof Error ? loadError.message : 'Failed to load favorites';
+        setError(message);
+        setFavorites([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [supabase],
+  );
+
+  const refresh = useCallback(async () => {
+    if (!userId) {
+      return;
+    }
+    await loadFavoritesForUser(userId);
+  }, [loadFavoritesForUser, userId]);
+
+  useEffect(() => {
+    let active = true;
+    let channel: RealtimeChannel | null = null;
+
+    const resolveUserAndSubscribe = async () => {
+      const { data, error: authError } = await supabase.auth.getUser();
+
+      if (!active) {
+        return;
+      }
+
+      if (authError || !data.user) {
+        setUserId(null);
+        setFavorites([]);
+        if (authError) {
+          setError(`Failed to resolve user session: ${authError.message}`);
+        }
+        setLoading(false);
+        return;
+      }
+
+      const uid = data.user.id;
+      setUserId(uid);
+      await loadFavoritesForUser(uid);
+
+      channel = supabase
+        .channel(`user_favorites_${uid}`)
+        .on(
+          'postgres_changes',
+          {
+            event: '*',
+            schema: 'public',
+            table: 'user_favorites',
+            filter: `profile_id=eq.${uid}`,
+          },
+          () => {
+            loadFavoritesForUser(uid).catch((subscriptionError) => {
+              console.error('Failed to refresh favorites after realtime update', subscriptionError);
+            });
+          },
+        )
+        .subscribe();
+    };
+
+    resolveUserAndSubscribe();
+
+    return () => {
+      active = false;
+      if (channel) {
+        supabase.removeChannel(channel);
+      }
+    };
+  }, [loadFavoritesForUser, supabase]);
+
+  const pinFavorite = useCallback<
+    FavoritesContextValue['pinFavorite']
+  >(
+    async ({ entityType, entityId, metadata }) => {
+      if (!userId) {
+        const message = 'You need to be signed in to pin favorites';
+        setError(message);
+        throw new Error(message);
+      }
+
+      try {
+        await upsertFavoriteRecord({
+          client: supabase as any,
+          userId,
+          entityType,
+          entityId,
+          metadata,
+        });
+        await loadFavoritesForUser(userId);
+      } catch (mutationError) {
+        const message =
+          mutationError instanceof Error
+            ? mutationError.message
+            : 'Failed to save favorite';
+        setError(message);
+        throw mutationError instanceof Error ? mutationError : new Error(message);
+      }
+    },
+    [loadFavoritesForUser, supabase, userId],
+  );
+
+  const unpinFavorite = useCallback<
+    FavoritesContextValue['unpinFavorite']
+  >(
+    async (entityType, entityId) => {
+      if (!userId) {
+        const message = 'You need to be signed in to remove favorites';
+        setError(message);
+        throw new Error(message);
+      }
+
+      try {
+        await removeFavoriteRecord({
+          client: supabase as any,
+          userId,
+          entityType,
+          entityId,
+        });
+        await loadFavoritesForUser(userId);
+      } catch (mutationError) {
+        const message =
+          mutationError instanceof Error
+            ? mutationError.message
+            : 'Failed to remove favorite';
+        setError(message);
+        throw mutationError instanceof Error ? mutationError : new Error(message);
+      }
+    },
+    [loadFavoritesForUser, supabase, userId],
+  );
+
+  const isFavorite = useCallback<
+    FavoritesContextValue['isFavorite']
+  >(
+    (entityType, entityId) =>
+      favorites.some(
+        (item) => item.entityType === entityType && item.entityId === entityId,
+      ),
+    [favorites],
+  );
+
+  const value = useMemo<FavoritesContextValue>(
+    () => ({
+      favorites,
+      loading,
+      error,
+      refresh,
+      pinFavorite,
+      unpinFavorite,
+      isFavorite,
+    }),
+    [error, favorites, isFavorite, loading, pinFavorite, refresh, unpinFavorite],
+  );
+
+  return <FavoritesContext.Provider value={value}>{children}</FavoritesContext.Provider>;
+}
+
+export function useFavorites(): FavoritesContextValue {
+  const context = useContext(FavoritesContext);
+  if (!context) {
+    throw new Error('useFavorites must be used within a FavoritesProvider');
+  }
+  return context;
+}

--- a/lib/data/favorites.ts
+++ b/lib/data/favorites.ts
@@ -1,0 +1,245 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+
+import type { Database } from '@/lib/supabase';
+import type {
+  FavoriteEntityType,
+  FavoriteMetadata,
+  FavoritePanelItem,
+  UserFavorite,
+} from '@/types/favorites';
+import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+
+type SupabaseClientLike = Pick<TypedSupabaseClient, 'from'>;
+
+type FavoriteRow = Database['public']['Tables']['user_favorites']['Row'];
+
+const ENTITY_LABELS: Record<FavoriteEntityType, string> = {
+  document: 'Document',
+  thread: 'Thread',
+  booking: 'Booking',
+};
+
+function handlePostgrestError(error: PostgrestError | null, context: string) {
+  if (error) {
+    throw new Error(`${context}: ${error.message}`);
+  }
+}
+
+function parseMetadata(value: unknown): FavoriteMetadata {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { title: 'Untitled' };
+  }
+
+  const record = value as Record<string, unknown>;
+  const title = typeof record.title === 'string' && record.title.trim().length > 0
+    ? record.title
+    : 'Untitled';
+
+  const metadata: FavoriteMetadata = { title };
+
+  if (typeof record.subtitle === 'string' && record.subtitle.trim()) {
+    metadata.subtitle = record.subtitle;
+  }
+
+  if (typeof record.description === 'string' && record.description.trim()) {
+    metadata.description = record.description;
+  }
+
+  if (typeof record.href === 'string' && record.href.trim()) {
+    metadata.href = record.href;
+  }
+
+  if (typeof record.badge === 'string' && record.badge.trim()) {
+    metadata.badge = record.badge;
+  }
+
+  return metadata;
+}
+
+function serializeMetadata(metadata: FavoriteMetadata): Record<string, string> {
+  const payload: Record<string, string> = {
+    title: metadata.title?.trim().length ? metadata.title : 'Untitled',
+  };
+
+  if (metadata.subtitle?.trim()) {
+    payload.subtitle = metadata.subtitle;
+  }
+
+  if (metadata.description?.trim()) {
+    payload.description = metadata.description;
+  }
+
+  if (metadata.href?.trim()) {
+    payload.href = metadata.href;
+  }
+
+  if (metadata.badge?.trim()) {
+    payload.badge = metadata.badge;
+  }
+
+  return payload;
+}
+
+function mapFavoriteRow(row: FavoriteRow): UserFavorite {
+  return {
+    id: row.id,
+    profileId: row.profile_id,
+    entityType: row.entity_type,
+    entityId: row.entity_id,
+    position: typeof row.position === 'number' ? row.position : 0,
+    metadata: parseMetadata(row.metadata),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function fetchUserFavorites(
+  client: SupabaseClientLike,
+  userId: string,
+): Promise<UserFavorite[]> {
+  const query = (client as any)
+    .from('user_favorites')
+    .select('id, profile_id, entity_type, entity_id, position, metadata, created_at, updated_at')
+    .eq('profile_id', userId)
+    .order('position', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  const { data, error } = await query;
+  handlePostgrestError(error, 'Failed to load favorites');
+
+  const rows = (data ?? []) as FavoriteRow[];
+
+  return rows
+    .slice()
+    .sort((a, b) => {
+      if (typeof a.position === 'number' && typeof b.position === 'number' && a.position !== b.position) {
+        return a.position - b.position;
+      }
+
+      const createdAtA = a.created_at ?? '';
+      const createdAtB = b.created_at ?? '';
+
+      return createdAtA.localeCompare(createdAtB);
+    })
+    .map((row) => mapFavoriteRow(row));
+}
+
+type UpsertFavoriteParams = {
+  client: SupabaseClientLike;
+  userId: string;
+  entityType: FavoriteEntityType;
+  entityId: string;
+  metadata: FavoriteMetadata;
+};
+
+export async function upsertFavoriteRecord({
+  client,
+  userId,
+  entityType,
+  entityId,
+  metadata,
+}: UpsertFavoriteParams): Promise<void> {
+  const sanitizedMetadata = serializeMetadata(metadata);
+  const timestamp = new Date().toISOString();
+
+  const existingResponse = await (client as any)
+    .from('user_favorites')
+    .select('id, position')
+    .eq('profile_id', userId)
+    .eq('entity_type', entityType)
+    .eq('entity_id', entityId)
+    .maybeSingle();
+
+  handlePostgrestError(existingResponse.error, 'Failed to check existing favorite');
+
+  const existing = existingResponse.data as Pick<FavoriteRow, 'id' | 'position'> | null;
+
+  if (existing) {
+    const { error: updateError } = await (client as any)
+      .from('user_favorites')
+      .update({
+        metadata: sanitizedMetadata,
+        updated_at: timestamp,
+      })
+      .eq('id', existing.id);
+
+    handlePostgrestError(updateError, 'Failed to update favorite');
+    return;
+  }
+
+  const lastPositionResponse = await (client as any)
+    .from('user_favorites')
+    .select('position')
+    .eq('profile_id', userId)
+    .order('position', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  handlePostgrestError(lastPositionResponse.error, 'Failed to determine next favorite position');
+
+  const nextPosition =
+    typeof lastPositionResponse.data?.position === 'number'
+      ? lastPositionResponse.data.position + 1
+      : 0;
+
+  const { error: insertError } = await (client as any)
+    .from('user_favorites')
+    .insert({
+      profile_id: userId,
+      entity_type: entityType,
+      entity_id: entityId,
+      position: nextPosition,
+      metadata: sanitizedMetadata,
+      updated_at: timestamp,
+    });
+
+  handlePostgrestError(insertError, 'Failed to create favorite');
+}
+
+type RemoveFavoriteParams = {
+  client: SupabaseClientLike;
+  userId: string;
+  entityType: FavoriteEntityType;
+  entityId: string;
+};
+
+export async function removeFavoriteRecord({
+  client,
+  userId,
+  entityType,
+  entityId,
+}: RemoveFavoriteParams): Promise<void> {
+  const { error } = await (client as any)
+    .from('user_favorites')
+    .delete()
+    .eq('profile_id', userId)
+    .eq('entity_type', entityType)
+    .eq('entity_id', entityId);
+
+  handlePostgrestError(error, 'Failed to remove favorite');
+}
+
+export function buildFavoritePanelItems(favorites: UserFavorite[]): FavoritePanelItem[] {
+  return favorites
+    .slice()
+    .sort((a, b) => {
+      if (a.position !== b.position) {
+        return a.position - b.position;
+      }
+
+      const createdAtA = a.createdAt ?? '';
+      const createdAtB = b.createdAt ?? '';
+
+      return createdAtA.localeCompare(createdAtB);
+    })
+    .map((favorite) => ({
+      id: favorite.id,
+      entityType: favorite.entityType,
+      entityId: favorite.entityId,
+      title: favorite.metadata.title,
+      subtitle: favorite.metadata.subtitle,
+      description: favorite.metadata.description,
+      href: favorite.metadata.href,
+      badge: favorite.metadata.badge ?? ENTITY_LABELS[favorite.entityType],
+    }));
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -214,6 +214,16 @@ export type Database = {
         created_at: string | null
         updated_at: string | null
       }>
+      user_favorites: SupabaseTable<{
+        id: string
+        profile_id: string
+        entity_type: 'document' | 'thread' | 'booking'
+        entity_id: string
+        position: number
+        metadata: Json | null
+        created_at: string | null
+        updated_at: string | null
+      }>
       notifications: SupabaseTable<{
         id: string
         user_id: string

--- a/supabase/migrations/20250315_user_favorites.sql
+++ b/supabase/migrations/20250315_user_favorites.sql
@@ -1,0 +1,42 @@
+-- Create user_favorites table to track pinned entities for quick access
+CREATE TABLE public.user_favorites (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  profile_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  entity_type TEXT NOT NULL CHECK (entity_type IN ('document', 'thread', 'booking')),
+  entity_id UUID NOT NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- Prevent duplicate favorites per entity for a given user
+CREATE UNIQUE INDEX user_favorites_unique_entity
+  ON public.user_favorites(profile_id, entity_type, entity_id);
+
+-- Support ordered retrieval by user and type
+CREATE INDEX user_favorites_profile_position
+  ON public.user_favorites(profile_id, position ASC);
+
+CREATE INDEX user_favorites_profile_entity_type
+  ON public.user_favorites(profile_id, entity_type);
+
+-- Enable row level security and scope access to the owning user
+ALTER TABLE public.user_favorites ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their favorites" ON public.user_favorites
+  FOR SELECT
+  USING (auth.uid() = profile_id);
+
+CREATE POLICY "Users can insert their favorites" ON public.user_favorites
+  FOR INSERT
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY "Users can update their favorites" ON public.user_favorites
+  FOR UPDATE
+  USING (auth.uid() = profile_id)
+  WITH CHECK (auth.uid() = profile_id);
+
+CREATE POLICY "Users can delete their favorites" ON public.user_favorites
+  FOR DELETE
+  USING (auth.uid() = profile_id);

--- a/tests/lib/data/favorites.test.ts
+++ b/tests/lib/data/favorites.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildFavoritePanelItems,
+  fetchUserFavorites,
+  removeFavoriteRecord,
+  upsertFavoriteRecord,
+} from '@/lib/data/favorites';
+import type { FavoriteMetadata } from '@/types/favorites';
+
+function createQueryBuilder(result: any) {
+  const builder: any = {};
+
+  builder.select = vi.fn().mockImplementation(() => builder);
+  builder.eq = vi.fn().mockImplementation(() => builder);
+  builder.order = vi.fn().mockImplementation(() => builder);
+  builder.limit = vi.fn().mockImplementation(() => builder);
+  builder.maybeSingle = vi.fn().mockResolvedValue(result);
+  builder.insert = vi.fn().mockResolvedValue(result);
+  builder.update = vi.fn().mockImplementation(() => builder);
+  builder.delete = vi.fn().mockImplementation(() => builder);
+  builder.then = (onFulfilled: (value: any) => unknown) =>
+    Promise.resolve(onFulfilled(result));
+
+  return builder;
+}
+
+function createFromStub(...builders: any[]) {
+  let index = 0;
+  return vi.fn((table: string) => {
+    expect(table).toBe('user_favorites');
+    const builder = builders[index];
+    index += 1;
+    return builder;
+  });
+}
+
+describe('fetchUserFavorites', () => {
+  it('returns favorites ordered by position and created_at', async () => {
+    const rows = [
+      {
+        id: 'fav-2',
+        profile_id: 'user-1',
+        entity_type: 'thread',
+        entity_id: 'thread-b',
+        position: 2,
+        metadata: { title: 'Thread B' },
+        created_at: '2024-05-01T00:00:00Z',
+        updated_at: '2024-05-01T00:00:00Z',
+      },
+      {
+        id: 'fav-1',
+        profile_id: 'user-1',
+        entity_type: 'document',
+        entity_id: 'doc-a',
+        position: 0,
+        metadata: { title: 'Document A' },
+        created_at: '2024-04-01T00:00:00Z',
+        updated_at: '2024-04-01T00:00:00Z',
+      },
+    ];
+    const builder = createQueryBuilder({ data: rows, error: null });
+    const supabase = { from: createFromStub(builder) } as any;
+
+    const favorites = await fetchUserFavorites(supabase, 'user-1');
+
+    expect(builder.select).toHaveBeenCalledWith(
+      'id, profile_id, entity_type, entity_id, position, metadata, created_at, updated_at',
+    );
+    expect(builder.eq).toHaveBeenCalledWith('profile_id', 'user-1');
+    expect(favorites).toHaveLength(2);
+    expect(favorites[0].id).toBe('fav-1');
+    expect(favorites[1].id).toBe('fav-2');
+  });
+});
+
+describe('upsertFavoriteRecord', () => {
+  const metadata: FavoriteMetadata = {
+    title: 'Lease Agreement',
+    subtitle: 'Lease • Signed',
+    href: '/documents',
+    badge: 'Document',
+  };
+
+  it('inserts new favorites with the next position', async () => {
+    const existingBuilder = createQueryBuilder({ data: null, error: null });
+    const positionBuilder = createQueryBuilder({ data: { position: 3 }, error: null });
+    const insertBuilder = createQueryBuilder({ error: null });
+    const supabase = {
+      from: createFromStub(existingBuilder, positionBuilder, insertBuilder),
+    } as any;
+
+    await upsertFavoriteRecord({
+      client: supabase,
+      userId: 'user-1',
+      entityType: 'document',
+      entityId: 'doc-123',
+      metadata,
+    });
+
+    expect(existingBuilder.select).toHaveBeenCalledWith('id, position');
+    expect(insertBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile_id: 'user-1',
+        entity_type: 'document',
+        entity_id: 'doc-123',
+        position: 4,
+        metadata: expect.objectContaining({ title: 'Lease Agreement' }),
+      }),
+    );
+  });
+
+  it('updates existing favorites when already pinned', async () => {
+    const existingBuilder = createQueryBuilder({ data: { id: 'fav-1', position: 0 }, error: null });
+    const updateBuilder = createQueryBuilder({ error: null });
+    const supabase = {
+      from: createFromStub(existingBuilder, updateBuilder),
+    } as any;
+
+    await upsertFavoriteRecord({
+      client: supabase,
+      userId: 'user-1',
+      entityType: 'document',
+      entityId: 'doc-123',
+      metadata,
+    });
+
+    expect(updateBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ title: 'Lease Agreement' }) }),
+    );
+    expect(updateBuilder.eq).toHaveBeenCalledWith('id', 'fav-1');
+  });
+});
+
+describe('removeFavoriteRecord', () => {
+  it('removes favorites for the provided entity', async () => {
+    const deleteBuilder = createQueryBuilder({ error: null });
+    const supabase = { from: createFromStub(deleteBuilder) } as any;
+
+    await removeFavoriteRecord({
+      client: supabase,
+      userId: 'user-1',
+      entityType: 'thread',
+      entityId: 'thread-9',
+    });
+
+    expect(deleteBuilder.delete).toHaveBeenCalled();
+    expect(deleteBuilder.eq).toHaveBeenCalledWith('entity_id', 'thread-9');
+  });
+});
+
+describe('buildFavoritePanelItems', () => {
+  it('maps favorites into panel items sorted by position', () => {
+    const items = buildFavoritePanelItems([
+      {
+        id: 'fav-1',
+        profileId: 'user-1',
+        entityType: 'document',
+        entityId: 'doc-1',
+        position: 2,
+        metadata: { title: 'Lease', badge: 'Document' },
+        createdAt: '2024-04-02T00:00:00Z',
+        updatedAt: '2024-04-02T00:00:00Z',
+      },
+      {
+        id: 'fav-2',
+        profileId: 'user-1',
+        entityType: 'thread',
+        entityId: 'thread-1',
+        position: 1,
+        metadata: { title: 'Chore rota', badge: 'Thread' },
+        createdAt: '2024-04-01T00:00:00Z',
+        updatedAt: '2024-04-01T00:00:00Z',
+      },
+    ]);
+
+    expect(items.map((item) => item.id)).toEqual(['fav-2', 'fav-1']);
+    expect(items[0].badge).toBe('Thread');
+    expect(items[1].badge).toBe('Document');
+  });
+});

--- a/types/favorites.ts
+++ b/types/favorites.ts
@@ -1,0 +1,35 @@
+import type { Database } from '@/lib/supabase';
+
+type FavoriteRow = Database['public']['Tables']['user_favorites']['Row'];
+
+export type FavoriteEntityType = FavoriteRow['entity_type'];
+
+export interface FavoriteMetadata {
+  title: string;
+  subtitle?: string;
+  description?: string;
+  href?: string;
+  badge?: string;
+}
+
+export interface UserFavorite {
+  id: FavoriteRow['id'];
+  profileId: FavoriteRow['profile_id'];
+  entityType: FavoriteEntityType;
+  entityId: FavoriteRow['entity_id'];
+  position: FavoriteRow['position'];
+  metadata: FavoriteMetadata;
+  createdAt: FavoriteRow['created_at'];
+  updatedAt: FavoriteRow['updated_at'];
+}
+
+export interface FavoritePanelItem {
+  id: string;
+  entityType: FavoriteEntityType;
+  entityId: string;
+  title: string;
+  subtitle?: string;
+  description?: string;
+  href?: string;
+  badge?: string;
+}


### PR DESCRIPTION
## Summary
- add a `user_favorites` table with indexes and row level security, expose it through the generated Supabase types
- implement reusable favorites data helpers plus provider, toggle control, and panel components wired into the app shell
- surface pin/unpin controls for documents, threads, and bookings so selections appear in the global favorites list

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d30bba67688328a86c8aba11529cfc