### PR TITLE
Add recent activity tracking and resume experience

### DIFF
--- a/app/dashboard/(dashboard)/components/dashboard-welcome.tsx
+++ b/app/dashboard/(dashboard)/components/dashboard-welcome.tsx
@@ -1,34 +1,59 @@
 import { Button } from "@/components/ui/button"
 import SmartLink from "@/components/navigation/SmartLink"
+import { loadRecentActivity, type RecentActivityEntry } from "@/lib/recent-activity"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
 import { getWelcomeMessage } from "../data"
+import RecentActivityResume from "./recent-activity-resume"
 
 export async function DashboardWelcome() {
   const message = await getWelcomeMessage()
+  let recentActivity: RecentActivityEntry[] = []
+
+  try {
+    const supabase = (await createSupbaseServerClientReadOnly()) as unknown as TypedSupabaseClient
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (user) {
+      recentActivity = await loadRecentActivity({
+        supabase,
+        userId: user.id,
+      })
+    }
+  } catch (error) {
+    recentActivity = []
+  }
 
   return (
-    <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
-      <div className="space-y-1">
-        <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">
-          Resident dashboard
-        </p>
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
-          {message.title}
-        </h1>
-        <p className="text-sm text-muted-foreground sm:text-base">{message.subtitle}</p>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">
+            Resident dashboard
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            {message.title}
+          </h1>
+          <p className="text-sm text-muted-foreground sm:text-base">{message.subtitle}</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <SmartLink href={message.primaryAction.href} intent="critical">
+            <Button size="sm">{message.primaryAction.label}</Button>
+          </SmartLink>
+          {message.secondaryAction ? (
+            <SmartLink href={message.secondaryAction.href} intent="passive">
+              <Button variant="outline" size="sm">
+                {message.secondaryAction.label}
+              </Button>
+            </SmartLink>
+          ) : null}
+        </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <SmartLink href={message.primaryAction.href} intent="critical">
-          <Button size="sm">{message.primaryAction.label}</Button>
-        </SmartLink>
-        {message.secondaryAction ? (
-          <SmartLink href={message.secondaryAction.href} intent="passive">
-            <Button variant="outline" size="sm">
-              {message.secondaryAction.label}
-            </Button>
-          </SmartLink>
-        ) : null}
-      </div>
+      <RecentActivityResume initialEntries={recentActivity} />
     </div>
   )
 }

--- a/app/dashboard/(dashboard)/components/recent-activity-resume.tsx
+++ b/app/dashboard/(dashboard)/components/recent-activity-resume.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { formatDistanceToNow, parseISO } from "date-fns"
+
+import SmartLink from "@/components/navigation/SmartLink"
+import { Button } from "@/components/ui/button"
+import {
+  getResumeEntry,
+  loadRecentActivity,
+  type RecentActivityEntry,
+} from "@/lib/recent-activity"
+
+const DISPLAY_LIMIT = 5
+
+type RecentActivityResumeProps = {
+  initialEntries: RecentActivityEntry[]
+}
+
+function dedupeEntries(entries: RecentActivityEntry[]): RecentActivityEntry[] {
+  const byKey = new Map<string, RecentActivityEntry>()
+
+  for (const entry of entries) {
+    const key = entry.entityId ? `${entry.route}#${entry.entityId}` : entry.route
+    const current = byKey.get(key)
+    if (!current) {
+      byKey.set(key, entry)
+      continue
+    }
+
+    if (
+      new Date(entry.accessedAt).getTime() >
+      new Date(current.accessedAt).getTime()
+    ) {
+      byKey.set(key, entry)
+    }
+  }
+
+  return Array.from(byKey.values()).sort(
+    (a, b) => new Date(b.accessedAt).getTime() - new Date(a.accessedAt).getTime(),
+  )
+}
+
+function safeFormatDistance(value: string) {
+  const parsed = parseISO(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return "just now"
+  }
+
+  try {
+    return formatDistanceToNow(parsed, { addSuffix: true })
+  } catch (error) {
+    return "just now"
+  }
+}
+
+export function RecentActivityResume({
+  initialEntries,
+}: RecentActivityResumeProps) {
+  const [entries, setEntries] = useState(() => dedupeEntries(initialEntries))
+
+  useEffect(() => {
+    let active = true
+
+    if (typeof window === "undefined") {
+      return () => {
+        active = false
+      }
+    }
+
+    const storage = window.localStorage
+
+    loadRecentActivity({ storage }).then((clientEntries) => {
+      if (!active) {
+        return
+      }
+
+      if (initialEntries.length === 0) {
+        setEntries(dedupeEntries(clientEntries))
+        return
+      }
+
+      if (clientEntries.length === 0) {
+        setEntries(dedupeEntries(initialEntries))
+        return
+      }
+
+      setEntries(dedupeEntries([...initialEntries, ...clientEntries]))
+    })
+
+    return () => {
+      active = false
+    }
+  }, [initialEntries])
+
+  const visibleEntries = useMemo(
+    () => entries.slice(0, DISPLAY_LIMIT),
+    [entries],
+  )
+  const resumeEntry = useMemo(() => getResumeEntry(entries), [entries])
+
+  return (
+    <div className="rounded-lg border bg-card p-4 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-foreground">Recent activity</p>
+          <p className="text-xs text-muted-foreground">
+            We keep track of the pages and records you last opened so you can
+            jump back in.
+          </p>
+        </div>
+        {resumeEntry ? (
+          <SmartLink href={resumeEntry.route} intent="navigation">
+            <Button size="sm" variant="secondary">
+              Resume
+            </Button>
+          </SmartLink>
+        ) : null}
+      </div>
+
+      {visibleEntries.length > 0 ? (
+        <ul className="mt-4 space-y-3">
+          {visibleEntries.map((entry) => (
+            <li
+              key={`${entry.route}-${entry.accessedAt}`}
+              className="flex items-center justify-between gap-3"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-foreground">
+                  {entry.label}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {safeFormatDistance(entry.accessedAt)}
+                </p>
+              </div>
+              <SmartLink
+                href={entry.route}
+                intent="navigation"
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                Open
+              </SmartLink>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-4 text-sm text-muted-foreground">
+          We’ll show your recently opened items here once you start exploring
+          the portal.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default RecentActivityResume

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation"
 
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary"
 import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
+import RecentActivityTracker from "@/components/navigation/RecentActivityTracker"
 import { readUserSession } from "@/utils/actions"
 import MobileSideNav from "./components/MobileSideNav"
 import SideNav from "./components/SideNav"
@@ -24,6 +25,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
 
                         <div className="w-full space-y-5 bg-gray-100 p-5 sm:flex-1 sm:p-10 dark:bg-inherit">
                                 <ToggleSidebar />
+                                <RecentActivityTracker />
                                 <ErrorBoundary>
                                         <Suspense fallback={<RouteSkeleton />}>
                                                 {children}

--- a/components/navigation/RecentActivityTracker.tsx
+++ b/components/navigation/RecentActivityTracker.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { useEffect, useMemo, useRef } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+
+import { recordRecentActivity } from "@/lib/recent-activity"
+import { useAuth } from "@/hooks/use-auth"
+import useSupabaseBrowser from "@/utils/supabase-browser"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+type Nullable<T> = T | null | undefined
+
+function deriveLabel(pathname: Nullable<string>) {
+  if (typeof document !== "undefined" && document.title) {
+    const [primary] = document.title.split(" - ")
+    if (primary?.trim()) {
+      return primary.trim()
+    }
+    return document.title.trim()
+  }
+
+  if (!pathname) {
+    return "Dashboard"
+  }
+
+  const segments = pathname
+    .split("/")
+    .filter(Boolean)
+    .map((segment) =>
+      segment
+        .replace(/[-_]/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase()),
+    )
+
+  if (segments.length === 0) {
+    return "Dashboard"
+  }
+
+  return segments.join(" › ")
+}
+
+export function RecentActivityTracker() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const { user } = useAuth()
+  const supabase = useSupabaseBrowser()
+  const lastRecordedRef = useRef<string>("")
+
+  const serializedSearch = useMemo(() => searchParams?.toString() ?? "", [searchParams])
+
+  useEffect(() => {
+    if (!pathname) {
+      return
+    }
+
+    const route = serializedSearch ? `${pathname}?${serializedSearch}` : pathname
+    if (route === lastRecordedRef.current) {
+      return
+    }
+
+    lastRecordedRef.current = route
+
+    const label = deriveLabel(pathname)
+
+    void recordRecentActivity(
+      {
+        route,
+        label,
+      },
+      {
+        supabase: user ? (supabase as unknown as TypedSupabaseClient) : null,
+        userId: user?.id,
+        storage: typeof window !== "undefined" ? window.localStorage : undefined,
+      },
+    )
+  }, [pathname, serializedSearch, supabase, user])
+
+  return null
+}
+
+export default RecentActivityTracker

--- a/lib/recent-activity.ts
+++ b/lib/recent-activity.ts
@@ -1,0 +1,250 @@
+import type { Json } from "@/lib/supabase"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+const RECENT_ACTIVITY_STORAGE_KEY = "share-house-portal:recent-activity"
+const RECENT_ACTIVITY_LIMIT = 15
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">
+
+export type RecentActivityEntry = {
+  route: string
+  label: string
+  entityId?: string
+  entityType?: string
+  accessedAt: string
+}
+
+export type RecordRecentActivityInput = {
+  route: string
+  label: string
+  entityId?: string
+  entityType?: string
+  accessedAt?: string
+}
+
+type RecordOptions = {
+  supabase?: TypedSupabaseClient | null
+  userId?: string | null
+  storage?: StorageLike
+  limit?: number
+}
+
+type LoadOptions = {
+  supabase?: TypedSupabaseClient | null
+  userId?: string | null
+  storage?: StorageLike
+  limit?: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isRecentActivityEntry(value: unknown): value is RecentActivityEntry {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return (
+    typeof value.route === "string" &&
+    typeof value.label === "string" &&
+    typeof value.accessedAt === "string"
+  )
+}
+
+function parseEntries(value: unknown): RecentActivityEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter(isRecentActivityEntry)
+    .map((entry) => ({
+      ...entry,
+      entityId: typeof entry.entityId === "string" ? entry.entityId : undefined,
+      entityType: typeof entry.entityType === "string" ? entry.entityType : undefined,
+    }))
+    .sort((a, b) => new Date(b.accessedAt).getTime() - new Date(a.accessedAt).getTime())
+}
+
+function entryKey(entry: Pick<RecentActivityEntry, "route" | "entityId">) {
+  return entry.entityId ? `${entry.route}#${entry.entityId}` : entry.route
+}
+
+function normalizeLimit(limit?: number) {
+  if (typeof limit === "number" && Number.isFinite(limit) && limit > 0) {
+    return Math.min(Math.floor(limit), RECENT_ACTIVITY_LIMIT)
+  }
+
+  return RECENT_ACTIVITY_LIMIT
+}
+
+function mergeEntries(
+  existing: RecentActivityEntry[],
+  incoming: RecentActivityEntry,
+  limit?: number,
+): RecentActivityEntry[] {
+  const deduped = existing.filter((entry) => entryKey(entry) !== entryKey(incoming))
+
+  return [incoming, ...deduped]
+    .sort((a, b) => new Date(b.accessedAt).getTime() - new Date(a.accessedAt).getTime())
+    .slice(0, normalizeLimit(limit))
+}
+
+function resolveStorage(storage?: StorageLike): StorageLike | undefined {
+  if (storage) {
+    return storage
+  }
+
+  if (typeof window !== "undefined" && window?.localStorage) {
+    return window.localStorage
+  }
+
+  return undefined
+}
+
+function readFromStorage(storage?: StorageLike): RecentActivityEntry[] {
+  if (!storage) {
+    return []
+  }
+
+  const raw = storage.getItem(RECENT_ACTIVITY_STORAGE_KEY)
+  if (!raw) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    return parseEntries(parsed)
+  } catch (error) {
+    return []
+  }
+}
+
+function writeToStorage(entries: RecentActivityEntry[], storage?: StorageLike) {
+  if (!storage) {
+    return
+  }
+
+  storage.setItem(RECENT_ACTIVITY_STORAGE_KEY, JSON.stringify(entries))
+}
+
+async function loadFromSupabase(
+  supabase: TypedSupabaseClient,
+  userId: string,
+): Promise<RecentActivityEntry[]> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("metadata")
+    .eq("id", userId)
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  const metadata = isRecord(data?.metadata) ? data?.metadata : {}
+  const stored = (metadata as { recentActivity?: unknown }).recentActivity
+  return parseEntries(stored)
+}
+
+async function recordWithSupabase(
+  supabase: TypedSupabaseClient,
+  userId: string,
+  entry: RecentActivityEntry,
+  limit?: number,
+): Promise<RecentActivityEntry[]> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("metadata")
+    .eq("id", userId)
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  const metadata = isRecord(data?.metadata) ? data?.metadata : {}
+  const stored = (metadata as { recentActivity?: unknown }).recentActivity
+  const existing = parseEntries(stored)
+  const nextEntries = mergeEntries(existing, entry, limit)
+  const nextMetadata = { ...metadata, recentActivity: nextEntries } as Json
+
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({ metadata: nextMetadata })
+    .eq("id", userId)
+
+  if (updateError) {
+    throw updateError
+  }
+
+  return nextEntries
+}
+
+export function getResumeEntry(
+  entries: RecentActivityEntry[],
+): RecentActivityEntry | null {
+  return entries.length > 0 ? entries[0] : null
+}
+
+export async function recordRecentActivity(
+  input: RecordRecentActivityInput,
+  options: RecordOptions = {},
+): Promise<RecentActivityEntry[]> {
+  const entry: RecentActivityEntry = {
+    route: input.route,
+    label: input.label,
+    entityId: input.entityId,
+    entityType: input.entityType,
+    accessedAt: input.accessedAt ?? new Date().toISOString(),
+  }
+
+  const storage = resolveStorage(options.storage)
+  const limit = options.limit
+
+  if (options.supabase && options.userId) {
+    try {
+      const entries = await recordWithSupabase(
+        options.supabase,
+        options.userId,
+        entry,
+        limit,
+      )
+      writeToStorage(entries, storage)
+      return entries
+    } catch (error) {
+      // fall back to storage
+    }
+  }
+
+  const existing = readFromStorage(storage)
+  const nextEntries = mergeEntries(existing, entry, limit)
+  writeToStorage(nextEntries, storage)
+
+  return nextEntries
+}
+
+export async function loadRecentActivity(
+  options: LoadOptions = {},
+): Promise<RecentActivityEntry[]> {
+  const storage = resolveStorage(options.storage)
+  const limit = options.limit
+
+  if (options.supabase && options.userId) {
+    try {
+      const entries = await loadFromSupabase(options.supabase, options.userId)
+      if (entries.length > 0) {
+        writeToStorage(entries, storage)
+        return entries.slice(0, normalizeLimit(limit))
+      }
+    } catch (error) {
+      // fall back to storage
+    }
+  }
+
+  const entries = readFromStorage(storage)
+  return entries.slice(0, normalizeLimit(limit))
+}
+
+export { RECENT_ACTIVITY_LIMIT, RECENT_ACTIVITY_STORAGE_KEY }

--- a/tests/lib/recent-activity.test.ts
+++ b/tests/lib/recent-activity.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  RECENT_ACTIVITY_STORAGE_KEY,
+  getResumeEntry,
+  loadRecentActivity,
+  recordRecentActivity,
+  type RecentActivityEntry,
+} from "@/lib/recent-activity"
+import type { TypedSupabaseClient } from "@/utils/typed-supabase-client"
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+}
+
+describe("recent activity helper", () => {
+  it("records navigation entries in Supabase and syncs storage", async () => {
+    const existing: RecentActivityEntry = {
+      route: "/documents",
+      label: "Documents",
+      accessedAt: "2024-07-01T10:00:00.000Z",
+    }
+    const storage = new MemoryStorage()
+
+    const single = vi.fn().mockResolvedValue({
+      data: { metadata: { recentActivity: [existing] } },
+      error: null,
+    })
+    const selectEq = vi.fn().mockReturnValue({ single })
+    const select = vi.fn().mockReturnValue({ eq: selectEq })
+    const updateEq = vi.fn().mockResolvedValue({ error: null })
+    const update = vi.fn().mockReturnValue({ eq: updateEq })
+    const from = vi.fn().mockReturnValue({ select, update })
+
+    const supabase = { from } as unknown as TypedSupabaseClient
+
+    const nextEntries = await recordRecentActivity(
+      {
+        route: "/documents/lease",
+        label: "Lease renewal",
+        accessedAt: "2024-07-02T12:00:00.000Z",
+      },
+      { supabase, userId: "user-1", storage },
+    )
+
+    expect(from).toHaveBeenCalledWith("profiles")
+    expect(select).toHaveBeenCalledWith("metadata")
+    expect(selectEq).toHaveBeenCalledWith("id", "user-1")
+    expect(updateEq).toHaveBeenCalledWith("id", "user-1")
+    expect(nextEntries[0]).toMatchObject({ route: "/documents/lease", label: "Lease renewal" })
+
+    const stored = storage.getItem(RECENT_ACTIVITY_STORAGE_KEY)
+    expect(stored).toBeTruthy()
+    expect(JSON.parse(stored as string)).toHaveLength(2)
+  })
+
+  it("falls back to storage when Supabase errors", async () => {
+    const storage = new MemoryStorage()
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: { message: "boom" } }),
+          }),
+        }),
+      }),
+    } as unknown as TypedSupabaseClient
+
+    const entries = await recordRecentActivity(
+      {
+        route: "/payments",
+        label: "Payments",
+        accessedAt: "2024-07-03T09:00:00.000Z",
+      },
+      { supabase, userId: "user-1", storage },
+    )
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].route).toBe("/payments")
+    expect(storage.getItem(RECENT_ACTIVITY_STORAGE_KEY)).toBeTruthy()
+  })
+
+  it("loads from storage when Supabase has no records", async () => {
+    const storage = new MemoryStorage()
+    storage.setItem(
+      RECENT_ACTIVITY_STORAGE_KEY,
+      JSON.stringify([
+        {
+          route: "/schedule",
+          label: "Amenity schedule",
+          accessedAt: "2024-07-05T08:15:00.000Z",
+        },
+      ]),
+    )
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { metadata: {} }, error: null }),
+          }),
+        }),
+      }),
+    } as unknown as TypedSupabaseClient
+
+    const entries = await loadRecentActivity({ supabase, userId: "user-1", storage })
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ route: "/schedule" })
+  })
+
+  it("selects the newest entry for resume", () => {
+    const resume = getResumeEntry([
+      { route: "/payments", label: "Payments", accessedAt: "2024-07-01T12:00:00.000Z" },
+      { route: "/documents", label: "Documents", accessedAt: "2024-06-01T12:00:00.000Z" },
+    ])
+
+    expect(resume?.route).toBe("/payments")
+
+    expect(getResumeEntry([])).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add a recent activity helper that normalizes navigation entries and persists them to Supabase metadata or local storage
- track dashboard navigation events on the client and surface the five most recent items with a resume button in the welcome card
- cover storage fallbacks and resume selection logic with unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30bbb48548328b356ab4961ca078a