### PR TITLE
Add multi-step onboarding flow with progress tracking

### DIFF
--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -1,0 +1,239 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { cookies } from "next/headers"
+import { z } from "zod"
+
+import {
+  OnboardingActionResult,
+  OnboardingStepKey,
+  markStepComplete,
+} from "@/lib/onboarding/steps"
+import type { Database } from "@/lib/supabase"
+import { createClient } from "@/utils/supa-server-actions"
+
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"]
+
+type MinimalProfile = Pick<
+  ProfileRow,
+  "metadata" | "onboarding_steps" | "rent_share" | "unit_id"
+>
+
+const unitAssignmentSchema = z.object({
+  unitId: z
+    .string()
+    .trim()
+    .min(1, "Please provide your assigned unit."),
+})
+
+const rentShareSchema = z.object({
+  rentShare: z.coerce
+    .number({ invalid_type_error: "Enter a valid rent share amount." })
+    .min(0, "Rent share cannot be negative."),
+})
+
+const emergencyContactSchema = z.object({
+  contactName: z
+    .string()
+    .trim()
+    .min(1, "Contact name is required."),
+  contactPhone: z
+    .string()
+    .trim()
+    .min(5, "Contact phone is required."),
+})
+
+async function getAuthenticatedUserId(): Promise<{ userId?: string; error?: string }> {
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    return { error: "Please sign in to continue." }
+  }
+
+  return { userId: user.id }
+}
+
+async function fetchProfile(
+  supabase: ReturnType<typeof createClient>,
+  userId: string,
+): Promise<{ profile?: MinimalProfile; error?: string }> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("unit_id, rent_share, metadata, onboarding_steps")
+    .eq("id", userId)
+    .single()
+
+  if (error) {
+    return { error: "We couldn't load your profile. Please try again." }
+  }
+
+  return { profile: data as MinimalProfile }
+}
+
+function getSupabaseForUser() {
+  const cookieStore = cookies()
+  return createClient(cookieStore)
+}
+
+function normalizeMetadata(metadata: MinimalProfile["metadata"]) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return {}
+  }
+
+  return { ...(metadata as Record<string, unknown>) }
+}
+
+async function persistStepUpdate(
+  supabase: ReturnType<typeof createClient>,
+  userId: string,
+  payload: Partial<MinimalProfile>,
+  step: OnboardingStepKey,
+): Promise<OnboardingActionResult> {
+  const { profile, error } = await fetchProfile(supabase, userId)
+  if (error) {
+    return { success: false, error }
+  }
+
+  const updatedSteps = markStepComplete(profile?.onboarding_steps, step)
+
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({
+      ...payload,
+      onboarding_steps: updatedSteps,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", userId)
+    .select("id")
+    .single()
+
+  if (updateError) {
+    return { success: false, error: "Unable to update your onboarding progress." }
+  }
+
+  revalidatePath("/onboarding")
+  return { success: true }
+}
+
+export async function submitUnitAssignment(
+  formData: FormData,
+): Promise<OnboardingActionResult> {
+  const parsed = unitAssignmentSchema.safeParse({
+    unitId: formData.get("unitId"),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Please provide your assigned unit.",
+    }
+  }
+
+  const { userId, error } = await getAuthenticatedUserId()
+  if (error || !userId) {
+    return { success: false, error: error ?? "Please sign in to continue." }
+  }
+
+  const supabase = getSupabaseForUser()
+
+  return persistStepUpdate(
+    supabase,
+    userId,
+    { unit_id: parsed.data.unitId.trim() },
+    "unitAssignment",
+  )
+}
+
+export async function submitRentShare(
+  formData: FormData,
+): Promise<OnboardingActionResult> {
+  const parsed = rentShareSchema.safeParse({
+    rentShare: formData.get("rentShare"),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Enter your monthly rent share.",
+    }
+  }
+
+  const { userId, error } = await getAuthenticatedUserId()
+  if (error || !userId) {
+    return { success: false, error: error ?? "Please sign in to continue." }
+  }
+
+  const supabase = getSupabaseForUser()
+
+  return persistStepUpdate(
+    supabase,
+    userId,
+    { rent_share: parsed.data.rentShare },
+    "rentShare",
+  )
+}
+
+export async function submitEmergencyContact(
+  formData: FormData,
+): Promise<OnboardingActionResult> {
+  const parsed = emergencyContactSchema.safeParse({
+    contactName: formData.get("contactName"),
+    contactPhone: formData.get("contactPhone"),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error:
+        parsed.error.issues[0]?.message ??
+        "Please provide your emergency contact's name and phone number.",
+    }
+  }
+
+  const { userId, error } = await getAuthenticatedUserId()
+  if (error || !userId) {
+    return { success: false, error: error ?? "Please sign in to continue." }
+  }
+
+  const supabase = getSupabaseForUser()
+  const { profile, error: profileError } = await fetchProfile(supabase, userId)
+  if (profileError) {
+    return { success: false, error: profileError }
+  }
+
+  const metadata = normalizeMetadata(profile?.metadata)
+  metadata.emergencyContacts = [
+    {
+      name: parsed.data.contactName.trim(),
+      phone: parsed.data.contactPhone.trim(),
+    },
+  ]
+
+  const updatedSteps = markStepComplete(profile?.onboarding_steps, "emergencyContacts")
+
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({
+      metadata,
+      onboarding_steps: updatedSteps,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", userId)
+    .select("id")
+    .single()
+
+  if (updateError) {
+    return {
+      success: false,
+      error: "Unable to update your emergency contact right now.",
+    }
+  }
+
+  revalidatePath("/onboarding")
+  return { success: true }
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,59 +1,75 @@
 import { Metadata } from "next"
-import SmartLink from "@/components/navigation/SmartLink"
+import { redirect } from "next/navigation"
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
-import { AuthFormLegacy } from '@/app/auth-server-action/components/AuthFormLegacy'
+import ChecklistProgress from "@/components/onboarding/ChecklistProgress"
+import OnboardingFlow from "@/components/onboarding/OnboardingFlow"
+import {
+  getChecklistStateFromProfile,
+  getNextIncompleteStepIndex,
+} from "@/lib/onboarding/steps"
+import type { Database } from "@/lib/supabase"
+import { createClient } from "@/utils/supabase/server"
+
+import {
+  submitEmergencyContact,
+  submitRentShare,
+  submitUnitAssignment,
+} from "./actions"
 
 export const metadata: Metadata = {
   title: "Onboarding",
   description: "Roomsily household onboarding",
 }
 
-export default function OnboardingPage() {
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"]
+
+type OnboardingProfile = Pick<
+  ProfileRow,
+  "unit_id" | "rent_share" | "metadata" | "onboarding_steps"
+>
+
+export default async function OnboardingPage() {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/auth")
+  }
+
+  const { data: profileData } = await supabase
+    .from("profiles")
+    .select("unit_id, rent_share, metadata, onboarding_steps")
+    .eq("id", user.id)
+    .single()
+
+  const profile = (profileData as OnboardingProfile) ?? null
+  const initialSteps = getChecklistStateFromProfile(profile)
+  const nextStepIndex = getNextIncompleteStepIndex(initialSteps)
+
   return (
-    <>
-      <div className="container relative mx-auto grid h-[640px] grid-cols-1 flex-col items-center justify-center lg:max-w-none lg:px-0">
-        <SmartLink
-          href="/auth"
-          className={cn(
-            buttonVariants({ variant: "ghost" }),
-            "absolute right-4 top-4 md:right-8 md:top-8"
-          )}
-        >
-          Login
-        </SmartLink>
-        <div className="lg:p-8">
-          <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
-            <div className="flex flex-col space-y-2 text-center">
-              <h1 className="text-2xl font-semibold tracking-tight">
-                Create an account
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                Enter your email below to create your account
-              </p>
-            </div>
-            <AuthFormLegacy />
-            <p className="px-8 text-center text-sm text-muted-foreground">
-              By clicking continue, you agree to our{" "}
-              <SmartLink
-                href="#"
-                className="underline underline-offset-4 hover:text-primary"
-              >
-                Terms of Service
-              </SmartLink>{" "}
-              and{" "}
-              <SmartLink
-                href="#"
-                className="underline underline-offset-4 hover:text-primary"
-              >
-                Privacy Policy
-              </SmartLink>
-              .
+    <div className="container pb-16 pt-10">
+      <div className="grid gap-10 lg:grid-cols-[2fr_1fr]">
+        <OnboardingFlow
+          initialProfile={profile}
+          initialSteps={initialSteps}
+          initialStepIndex={nextStepIndex}
+          submitUnitAssignment={submitUnitAssignment}
+          submitRentShare={submitRentShare}
+          submitEmergencyContact={submitEmergencyContact}
+        />
+
+        <aside className="space-y-6">
+          <ChecklistProgress />
+          <div className="rounded-2xl border bg-card p-6 shadow-sm">
+            <h2 className="text-lg font-semibold">Need assistance?</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              If anything looks incorrect, reach out to your property manager so we can get it fixed before move-in.
             </p>
           </div>
-        </div>
+        </aside>
       </div>
-    </>
+    </div>
   )
 }

--- a/components/onboarding/ChecklistProgress.tsx
+++ b/components/onboarding/ChecklistProgress.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { CheckCircle2, Circle } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Progress } from "@/components/ui/progress"
+import {
+  EMPTY_ONBOARDING_STEPS_STATE,
+  ONBOARDING_PROGRESS_EVENT,
+  ONBOARDING_STEPS,
+  OnboardingStepsState,
+  computeOnboardingCompletion,
+  getChecklistStateFromProfile,
+} from "@/lib/onboarding/steps"
+import type { Database } from "@/lib/supabase"
+import { cn } from "@/lib/utils"
+import { createClient } from "@/utils/supabase-browser"
+
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"]
+
+async function fetchProfileProgress(
+  supabase: ReturnType<typeof createClient>,
+): Promise<{ state: OnboardingStepsState; error?: string }> {
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    return {
+      state: { ...EMPTY_ONBOARDING_STEPS_STATE },
+      error: "Unable to load your profile. Please try again.",
+    }
+  }
+
+  if (!user) {
+    return {
+      state: { ...EMPTY_ONBOARDING_STEPS_STATE },
+      error: "Sign in to see your onboarding progress.",
+    }
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("unit_id, rent_share, metadata, onboarding_steps")
+    .eq("id", user.id)
+    .single()
+
+  if (error) {
+    return {
+      state: { ...EMPTY_ONBOARDING_STEPS_STATE },
+      error: "We couldn't fetch your onboarding progress.",
+    }
+  }
+
+  return {
+    state: getChecklistStateFromProfile(data as ProfileRow),
+  }
+}
+
+export default function ChecklistProgress() {
+  const [steps, setSteps] = useState<OnboardingStepsState>(
+    EMPTY_ONBOARDING_STEPS_STATE,
+  )
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const supabase = createClient()
+    let isMounted = true
+
+    const load = async () => {
+      setLoading(true)
+      const result = await fetchProfileProgress(supabase)
+      if (!isMounted) {
+        return
+      }
+      setSteps(result.state)
+      setError(result.error ?? null)
+      setLoading(false)
+    }
+
+    void load()
+
+    const handleRefresh = () => {
+      void load()
+    }
+
+    window.addEventListener(ONBOARDING_PROGRESS_EVENT, handleRefresh)
+
+    return () => {
+      isMounted = false
+      window.removeEventListener(ONBOARDING_PROGRESS_EVENT, handleRefresh)
+    }
+  }, [])
+
+  const completion = computeOnboardingCompletion(steps)
+  const allComplete = completion.total > 0 && completion.completed === completion.total
+
+  return (
+    <section className="rounded-2xl border bg-card p-6 shadow-sm">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Onboarding checklist</h2>
+          <p className="text-sm text-muted-foreground">
+            Track the setup tasks your property manager needs before move-in day.
+          </p>
+        </div>
+        {allComplete ? (
+          <Badge variant="outline" className="border-emerald-500 text-emerald-600">
+            Complete
+          </Badge>
+        ) : (
+          <Badge variant="secondary" className="bg-primary/5 text-primary">
+            {completion.completed} / {completion.total}
+          </Badge>
+        )}
+      </header>
+
+      <div className="mt-5 space-y-2">
+        <Progress value={completion.percentage} aria-label="Onboarding progress" />
+        <p className="text-sm text-muted-foreground">
+          {loading
+            ? "Loading your progress..."
+            : `${completion.completed} of ${completion.total} steps complete`}
+        </p>
+        {error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : null}
+      </div>
+
+      <ul className="mt-6 space-y-3">
+        {ONBOARDING_STEPS.map((step) => {
+          const complete = steps[step.key]
+
+          return (
+            <li
+              key={step.key}
+              className={cn(
+                "flex items-start gap-3 rounded-xl border px-3 py-3",
+                complete
+                  ? "border-emerald-200 bg-emerald-50/60"
+                  : "border-border bg-background",
+              )}
+            >
+              {complete ? (
+                <CheckCircle2 className="mt-0.5 h-5 w-5 text-emerald-500" aria-hidden="true" />
+              ) : (
+                <Circle className="mt-0.5 h-5 w-5 text-muted-foreground" aria-hidden="true" />
+              )}
+              <div>
+                <p className="text-sm font-medium">{step.title}</p>
+                <p className="text-xs text-muted-foreground">{step.description}</p>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+
+      {allComplete && !error && !loading ? (
+        <div className="mt-6 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          All onboarding steps complete. You're ready for move-in!
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/components/onboarding/OnboardingFlow.tsx
+++ b/components/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,363 @@
+"use client"
+
+import { useEffect, useMemo, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { CheckCircle2, Circle } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  EmergencyContact,
+  ONBOARDING_PROGRESS_EVENT,
+  ONBOARDING_STEPS,
+  OnboardingActionResult,
+  OnboardingStepKey,
+  OnboardingStepsState,
+  extractEmergencyContacts,
+  getNextIncompleteStepIndex,
+} from "@/lib/onboarding/steps"
+import type { Database } from "@/lib/supabase"
+import { cn } from "@/lib/utils"
+
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"]
+
+type OnboardingFlowProps = {
+  initialProfile: Pick<ProfileRow, "unit_id" | "rent_share" | "metadata" | "onboarding_steps"> | null
+  initialSteps: OnboardingStepsState
+  initialStepIndex: number
+  submitUnitAssignment: (formData: FormData) => Promise<OnboardingActionResult>
+  submitRentShare: (formData: FormData) => Promise<OnboardingActionResult>
+  submitEmergencyContact: (formData: FormData) => Promise<OnboardingActionResult>
+}
+
+function clampStepIndex(index: number) {
+  return Math.min(Math.max(index, 0), ONBOARDING_STEPS.length - 1)
+}
+
+export default function OnboardingFlow({
+  initialProfile,
+  initialSteps,
+  initialStepIndex,
+  submitUnitAssignment,
+  submitRentShare,
+  submitEmergencyContact,
+}: OnboardingFlowProps) {
+  const router = useRouter()
+  const [stepsState, setStepsState] = useState<OnboardingStepsState>({
+    ...initialSteps,
+  })
+  const [currentStep, setCurrentStep] = useState(() => {
+    if (ONBOARDING_STEPS.length === 0) {
+      return 0
+    }
+    const fallback =
+      initialStepIndex === -1 ? ONBOARDING_STEPS.length - 1 : initialStepIndex
+    return clampStepIndex(fallback)
+  })
+  const [unitId, setUnitId] = useState(initialProfile?.unit_id ?? "")
+  const [rentShare, setRentShare] = useState(
+    initialProfile?.rent_share !== null && initialProfile?.rent_share !== undefined
+      ? initialProfile.rent_share.toString()
+      : "",
+  )
+  const [contactName, setContactName] = useState("")
+  const [contactPhone, setContactPhone] = useState("")
+  const [formError, setFormError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const initialContacts = useMemo(() => {
+    return extractEmergencyContacts(initialProfile?.metadata)
+  }, [initialProfile?.metadata])
+
+  useEffect(() => {
+    const primaryContact: EmergencyContact | undefined = initialContacts[0]
+    setContactName(primaryContact?.name ?? "")
+    setContactPhone(primaryContact?.phone ?? "")
+  }, [initialContacts])
+
+  useEffect(() => {
+    setStepsState({ ...initialSteps })
+    if (ONBOARDING_STEPS.length > 0) {
+      const fallback =
+        initialStepIndex === -1 ? ONBOARDING_STEPS.length - 1 : initialStepIndex
+      setCurrentStep(clampStepIndex(fallback))
+    }
+    setUnitId(initialProfile?.unit_id ?? "")
+    setRentShare(
+      initialProfile?.rent_share !== null && initialProfile?.rent_share !== undefined
+        ? initialProfile.rent_share.toString()
+        : "",
+    )
+    setFormError(null)
+  }, [initialProfile, initialStepIndex, initialSteps])
+
+  const allComplete = useMemo(
+    () => ONBOARDING_STEPS.every((step) => stepsState[step.key]),
+    [stepsState],
+  )
+
+  const nextIncomplete = useMemo(
+    () => getNextIncompleteStepIndex(stepsState),
+    [stepsState],
+  )
+
+  const activeStep = ONBOARDING_STEPS[currentStep]
+  const isLastStep = currentStep === ONBOARDING_STEPS.length - 1
+
+  const handleSelectStep = (index: number) => {
+    if (index < 0 || index >= ONBOARDING_STEPS.length) {
+      return
+    }
+    const isLocked =
+      nextIncomplete !== -1 && index > nextIncomplete && !stepsState[ONBOARDING_STEPS[index].key]
+    if (isLocked) {
+      return
+    }
+    setCurrentStep(index)
+    setFormError(null)
+  }
+
+  const moveToNextStep = (stepKey: OnboardingStepKey, updatedState: OnboardingStepsState) => {
+    const nextIndex = getNextIncompleteStepIndex(updatedState)
+    setCurrentStep((current) => {
+      if (nextIndex === -1) {
+        return ONBOARDING_STEPS.length - 1
+      }
+      if (ONBOARDING_STEPS[current]?.key === stepKey) {
+        return nextIndex
+      }
+      return current
+    })
+  }
+
+  const executeAction = (
+    stepKey: OnboardingStepKey,
+    formData: FormData,
+    action: (formData: FormData) => Promise<OnboardingActionResult>,
+    defaultError: string,
+  ) => {
+    setFormError(null)
+    startTransition(() => {
+      action(formData)
+        .then((result) => {
+          if (!result.success) {
+            setFormError(result.error ?? defaultError)
+            return
+          }
+
+          setStepsState((previous) => {
+            const updated: OnboardingStepsState = { ...previous, [stepKey]: true }
+            moveToNextStep(stepKey, updated)
+            return updated
+          })
+
+          window.dispatchEvent(new CustomEvent(ONBOARDING_PROGRESS_EVENT))
+          router.refresh()
+        })
+        .catch(() => {
+          setFormError(defaultError)
+        })
+    })
+  }
+
+  const handleUnitSubmit = (formData: FormData) => {
+    const value = (formData.get("unitId")?.toString() ?? "").trim()
+    formData.set("unitId", value)
+    setUnitId(value)
+    executeAction(
+      "unitAssignment",
+      formData,
+      submitUnitAssignment,
+      "Unable to save your unit assignment.",
+    )
+  }
+
+  const handleRentSubmit = (formData: FormData) => {
+    const value = (formData.get("rentShare")?.toString() ?? "").trim()
+    formData.set("rentShare", value)
+    setRentShare(value)
+    executeAction("rentShare", formData, submitRentShare, "Unable to save your rent share.")
+  }
+
+  const handleEmergencySubmit = (formData: FormData) => {
+    const name = (formData.get("contactName")?.toString() ?? "").trim()
+    const phone = (formData.get("contactPhone")?.toString() ?? "").trim()
+    formData.set("contactName", name)
+    formData.set("contactPhone", phone)
+    setContactName(name)
+    setContactPhone(phone)
+    executeAction(
+      "emergencyContacts",
+      formData,
+      submitEmergencyContact,
+      "Unable to save your emergency contact.",
+    )
+  }
+
+  const formAction = activeStep
+    ? activeStep.key === "unitAssignment"
+      ? handleUnitSubmit
+      : activeStep.key === "rentShare"
+        ? handleRentSubmit
+        : handleEmergencySubmit
+    : undefined
+
+  const submitLabel = isLastStep
+    ? allComplete
+      ? "Save changes"
+      : "Finish onboarding"
+    : "Save and continue"
+
+  return (
+    <section className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">Complete your onboarding</h1>
+        <p className="text-sm text-muted-foreground">
+          We use these details to make sure rent, roommates, and emergencies are covered from day one.
+        </p>
+      </div>
+
+      {allComplete ? (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          All onboarding tasks are complete. You can update any step below if something changes.
+        </div>
+      ) : null}
+
+      <ol className="grid gap-3 md:grid-cols-3">
+        {ONBOARDING_STEPS.map((step, index) => {
+          const isActive = index === currentStep
+          const isComplete = stepsState[step.key]
+          const isLocked =
+            nextIncomplete !== -1 && index > nextIncomplete && !isComplete
+
+          return (
+            <li key={step.key}>
+              <button
+                type="button"
+                onClick={() => handleSelectStep(index)}
+                disabled={isLocked}
+                className={cn(
+                  "h-full w-full rounded-xl border p-4 text-left transition disabled:cursor-not-allowed disabled:opacity-50",
+                  isActive ? "border-primary shadow-sm" : "border-border",
+                  isComplete ? "bg-primary/5" : "bg-background",
+                )}
+              >
+                <div className="flex items-center justify-between gap-3 text-sm font-medium">
+                  <span>
+                    {index + 1}. {step.title}
+                  </span>
+                  {isComplete ? (
+                    <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden="true" />
+                  ) : (
+                    <Circle className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                  )}
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">{step.description}</p>
+              </button>
+            </li>
+          )
+        })}
+      </ol>
+
+      <div className="rounded-2xl border bg-card p-6 shadow-sm">
+        {activeStep ? (
+          <form action={formAction} className="space-y-5">
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-muted-foreground">
+                Step {currentStep + 1} of {ONBOARDING_STEPS.length}
+              </p>
+              <h2 className="text-xl font-semibold">{activeStep.title}</h2>
+              <p className="text-sm text-muted-foreground">{activeStep.description}</p>
+            </div>
+
+            {activeStep.key === "unitAssignment" ? (
+              <div className="space-y-2">
+                <Label htmlFor="unitId">Unit identifier</Label>
+                <Input
+                  id="unitId"
+                  name="unitId"
+                  placeholder="e.g. Unit 3B"
+                  value={unitId}
+                  onChange={(event) => setUnitId(event.target.value)}
+                  required
+                />
+                <p className="text-xs text-muted-foreground">
+                  Property managers use this to map rent payments, roommates, and amenity access.
+                </p>
+              </div>
+            ) : null}
+
+            {activeStep.key === "rentShare" ? (
+              <div className="space-y-2">
+                <Label htmlFor="rentShare">Monthly rent share</Label>
+                <Input
+                  id="rentShare"
+                  name="rentShare"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="800"
+                  value={rentShare}
+                  onChange={(event) => setRentShare(event.target.value)}
+                  required
+                />
+                <p className="text-xs text-muted-foreground">
+                  We use this to calculate autopay amounts and split rent fairly across roommates.
+                </p>
+              </div>
+            ) : null}
+
+            {activeStep.key === "emergencyContacts" ? (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="contactName">Contact name</Label>
+                  <Input
+                    id="contactName"
+                    name="contactName"
+                    placeholder="Alex Rivera"
+                    value={contactName}
+                    onChange={(event) => setContactName(event.target.value)}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="contactPhone">Contact phone</Label>
+                  <Input
+                    id="contactPhone"
+                    name="contactPhone"
+                    placeholder="555-123-4567"
+                    value={contactPhone}
+                    onChange={(event) => setContactPhone(event.target.value)}
+                    required
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  We'll only reach out if there's an emergency affecting your household.
+                </p>
+              </div>
+            ) : null}
+
+            {formError ? (
+              <p className="text-sm text-destructive">{formError}</p>
+            ) : null}
+
+            <div className="flex items-center justify-end gap-3">
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "Saving..." : submitLabel}
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <div className="space-y-2 text-center">
+            <CheckCircle2 className="mx-auto h-10 w-10 text-primary" aria-hidden="true" />
+            <h2 className="text-lg font-semibold">You're all set</h2>
+            <p className="text-sm text-muted-foreground">
+              All onboarding tasks are complete. We'll keep things updated as you make changes.
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/lib/onboarding/steps.ts
+++ b/lib/onboarding/steps.ts
@@ -1,0 +1,139 @@
+import type { Database } from "@/lib/supabase"
+
+export type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"]
+
+export type OnboardingStepKey =
+  | "unitAssignment"
+  | "rentShare"
+  | "emergencyContacts"
+
+export type OnboardingStepsState = Record<OnboardingStepKey, boolean>
+
+export type EmergencyContact = {
+  name: string
+  phone: string
+}
+
+export type OnboardingActionResult = {
+  success: boolean
+  error?: string
+}
+
+export const ONBOARDING_PROGRESS_EVENT = "onboarding:step-updated" as const
+
+export const ONBOARDING_STEPS: ReadonlyArray<{
+  key: OnboardingStepKey
+  title: string
+  description: string
+}> = [
+  {
+    key: "unitAssignment",
+    title: "Confirm your unit",
+    description:
+      "Let us know which unit you're moving into so we can map rent, roommates, and amenity access.",
+  },
+  {
+    key: "rentShare",
+    title: "Set your rent share",
+    description:
+      "Tell us how much of the monthly rent you're responsible for so autopay and ledgers stay accurate.",
+  },
+  {
+    key: "emergencyContacts",
+    title: "Add an emergency contact",
+    description:
+      "Provide a contact person so property managers can reach someone quickly if there's an urgent issue.",
+  },
+]
+
+export const EMPTY_ONBOARDING_STEPS_STATE: OnboardingStepsState = {
+  unitAssignment: false,
+  rentShare: false,
+  emergencyContacts: false,
+}
+
+export function normalizeOnboardingSteps(input: unknown): OnboardingStepsState {
+  const normalized: OnboardingStepsState = { ...EMPTY_ONBOARDING_STEPS_STATE }
+
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    const record = input as Record<string, unknown>
+
+    for (const key of Object.keys(normalized) as OnboardingStepKey[]) {
+      normalized[key] = record[key] === true
+    }
+  }
+
+  return normalized
+}
+
+export function markStepComplete(
+  input: unknown,
+  step: OnboardingStepKey,
+): OnboardingStepsState {
+  const normalized = normalizeOnboardingSteps(input)
+  normalized[step] = true
+  return normalized
+}
+
+export function extractEmergencyContacts(
+  metadata: ProfileRow["metadata"] | null | undefined,
+): EmergencyContact[] {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return []
+  }
+
+  const rawContacts = (metadata as Record<string, unknown>).emergencyContacts
+  if (!Array.isArray(rawContacts)) {
+    return []
+  }
+
+  return rawContacts
+    .filter((contact): contact is Record<string, unknown> =>
+      Boolean(contact && typeof contact === "object" && !Array.isArray(contact)),
+    )
+    .map((contact) => ({
+      name: typeof contact.name === "string" ? contact.name : "",
+      phone: typeof contact.phone === "string" ? contact.phone : "",
+    }))
+    .filter((contact) => contact.name.trim().length > 0 && contact.phone.trim().length > 0)
+}
+
+export function getChecklistStateFromProfile(
+  profile:
+    | (Pick<ProfileRow, "unit_id" | "rent_share" | "metadata" | "onboarding_steps"> & {
+        onboarding_steps: ProfileRow["onboarding_steps"]
+      })
+    | null,
+): OnboardingStepsState {
+  const normalized = normalizeOnboardingSteps(profile?.onboarding_steps)
+
+  if (profile?.unit_id && profile.unit_id.trim().length > 0) {
+    normalized.unitAssignment = true
+  }
+
+  if (profile?.rent_share !== null && profile?.rent_share !== undefined) {
+    normalized.rentShare = true
+  }
+
+  const contacts = extractEmergencyContacts(profile?.metadata)
+  if (contacts.length > 0) {
+    normalized.emergencyContacts = true
+  }
+
+  return normalized
+}
+
+export function computeOnboardingCompletion(state: OnboardingStepsState) {
+  const total = ONBOARDING_STEPS.length
+  const completed = (Object.keys(state) as OnboardingStepKey[]).reduce(
+    (count, key) => count + (state[key] ? 1 : 0),
+    0,
+  )
+  const percentage = total === 0 ? 0 : Math.round((completed / total) * 100)
+
+  return { completed, total, percentage }
+}
+
+export function getNextIncompleteStepIndex(state: OnboardingStepsState): number {
+  return ONBOARDING_STEPS.findIndex((step) => !state[step.key])
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -45,6 +45,7 @@ export type Database = {
         stripe_customer_id: string | null
         rent_share: number | null
         metadata: Json | null
+        onboarding_steps: Json | null
       }>
       documents: SupabaseTable<{
         id: string

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-tailwindcss": "^3.14.2",
+    "jsdom": "^27.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.14.2
         version: 3.14.2(tailwindcss@3.4.0)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -236,7 +239,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0)
 
 packages:
 
@@ -255,6 +258,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@4.0.5':
+    resolution: {integrity: sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==}
+
+  '@asamuzakjp/dom-selector@6.5.6':
+    resolution: {integrity: sha512-Mj3Hu9ymlsERd7WOsUKNUZnJYL4IZ/I9wVVYgtvOsWYiEFbkQ4G7VRIh2USxTVW4BBDIsLG+gBUgqOqf2Kvqow==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.23.5':
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -371,6 +383,40 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -2350,16 +2396,28 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   date-fns@3.3.1:
     resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
@@ -2389,6 +2447,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -2505,6 +2566,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.22.3:
@@ -2983,6 +3048,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2990,9 +3059,17 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3118,6 +3195,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
@@ -3201,6 +3281,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3317,6 +3406,10 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.2.2:
+    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3374,6 +3467,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
@@ -3670,6 +3766,9 @@ packages:
 
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -4001,6 +4100,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4013,6 +4115,13 @@ packages:
 
   safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
@@ -4262,6 +4371,9 @@ packages:
     resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
     engines: {node: '>=16'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@2.2.0:
     resolution: {integrity: sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==}
 
@@ -4361,6 +4473,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4369,8 +4488,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4622,6 +4749,10 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -4634,6 +4765,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -4648,6 +4783,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4699,6 +4846,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xregexp@5.1.1:
     resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
 
@@ -4744,6 +4910,24 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     optional: true
+
+  '@asamuzakjp/css-color@4.0.5':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.2
+
+  '@asamuzakjp/dom-selector@6.5.6':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.2
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.23.5':
     dependencies:
@@ -4899,6 +5083,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.4.32)':
+    dependencies:
+      postcss: 8.4.32
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -7012,11 +7220,29 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.1(postcss@8.4.32):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.5
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.4.32)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   date-fns@3.3.1: {}
 
@@ -7031,6 +7257,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -7142,6 +7370,8 @@ snapshots:
       tapable: 2.2.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.22.3:
     dependencies:
@@ -7851,6 +8081,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7866,12 +8100,23 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7983,6 +8228,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.2:
     dependencies:
       '@types/estree': 1.0.5
@@ -8072,6 +8319,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.6
+      cssstyle: 5.3.1(postcss@8.4.32)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -8166,6 +8441,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.1.0: {}
+
+  lru-cache@11.2.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -8294,6 +8571,8 @@ snapshots:
 
   mdn-data@2.0.30:
     optional: true
+
+  mdn-data@2.12.2: {}
 
   merge-anything@5.1.7:
     dependencies:
@@ -8496,7 +8775,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -8705,6 +8984,10 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseley@0.12.1:
     dependencies:
@@ -9061,6 +9344,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9079,6 +9364,12 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.21.0:
     dependencies:
@@ -9375,6 +9666,8 @@ snapshots:
       periscopic: 3.1.0
     optional: true
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@2.2.0:
     dependencies:
       '@babel/runtime': 7.23.7
@@ -9502,13 +9795,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9736,7 +10043,7 @@ snapshots:
       jiti: 1.21.0
       terser: 5.44.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.17)(jiti@1.21.0)(jsdom@27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10))(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9764,6 +10071,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.17
+      jsdom: 27.0.0(bufferutil@4.0.8)(postcss@8.4.32)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9789,6 +10097,10 @@ snapshots:
       typescript: 5.5.4
     optional: true
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -9799,6 +10111,8 @@ snapshots:
   webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.0: {}
 
   webpack-sources@3.3.3: {}
 
@@ -9832,6 +10146,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9903,6 +10228,15 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xregexp@5.1.1:
     dependencies:

--- a/tests/onboarding.test.tsx
+++ b/tests/onboarding.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act } from "react-dom/test-utils"
+import { createRoot } from "react-dom/client"
+
+const {
+  createServerClientMock,
+  createBrowserClientMock,
+  cookiesMock,
+  revalidatePathMock,
+} = vi.hoisted(() => ({
+  createServerClientMock: vi.fn(),
+  createBrowserClientMock: vi.fn(),
+  cookiesMock: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), delete: vi.fn() })),
+  revalidatePathMock: vi.fn(),
+}))
+
+vi.mock("@/utils/supa-server-actions", () => ({
+  createClient: (cookieStore: unknown) => createServerClientMock(cookieStore),
+}))
+
+vi.mock("@/utils/supabase-browser", () => ({
+  createClient: () => createBrowserClientMock(),
+}))
+
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
+}))
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}))
+
+import ChecklistProgress from "@/components/onboarding/ChecklistProgress"
+import { submitUnitAssignment } from "@/app/onboarding/actions"
+
+function createServerSupabaseStub(initialProfile?: Partial<{
+  unit_id: string | null
+  rent_share: number | null
+  metadata: Record<string, unknown> | null
+  onboarding_steps: Record<string, boolean> | null
+}>) {
+  let currentProfile = {
+    unit_id: initialProfile?.unit_id ?? null,
+    rent_share: initialProfile?.rent_share ?? null,
+    metadata: initialProfile?.metadata ?? null,
+    onboarding_steps:
+      initialProfile?.onboarding_steps ??
+      {
+        unitAssignment: false,
+        rentShare: false,
+        emergencyContacts: false,
+      },
+  }
+
+  const selectResponse = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      single: vi.fn(async () => ({
+        data: { ...currentProfile },
+        error: null,
+      })),
+    })),
+  }))
+
+  const updateResponse = vi.fn((payload: Record<string, unknown>) => ({
+    eq: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(async () => {
+          currentProfile = { ...currentProfile, ...payload }
+          return { data: { ...currentProfile }, error: null }
+        }),
+      })),
+    })),
+  }))
+
+  const fromFn = vi.fn(() => ({
+    select: selectResponse,
+    update: updateResponse,
+  }))
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      }),
+    },
+    from: fromFn,
+    getProfile: () => currentProfile,
+  }
+}
+
+function createBrowserSupabaseStub(profile: {
+  unit_id: string
+  rent_share: number
+  metadata: Record<string, unknown>
+  onboarding_steps: Record<string, boolean>
+}) {
+  const selectFn = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      single: vi.fn(async () => ({ data: profile, error: null })),
+    })),
+  }))
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      }),
+    },
+    from: vi.fn(() => ({
+      select: selectFn,
+    })),
+  }
+}
+
+beforeEach(() => {
+  createServerClientMock.mockReset()
+  createBrowserClientMock.mockReset()
+  cookiesMock.mockReset()
+  revalidatePathMock.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("onboarding progress actions", () => {
+  it("marks unit assignment complete and persists onboarding state", async () => {
+    const supabaseStub = createServerSupabaseStub()
+    createServerClientMock.mockReturnValue(supabaseStub as any)
+    cookiesMock.mockReturnValue({ get: vi.fn(), set: vi.fn(), delete: vi.fn() })
+
+    const formData = new FormData()
+    formData.append("unitId", "B2")
+
+    const result = await submitUnitAssignment(formData)
+
+    expect(result.success).toBe(true)
+    const updatedProfile = supabaseStub.getProfile()
+    expect(updatedProfile.unit_id).toBe("B2")
+    expect(updatedProfile.onboarding_steps?.unitAssignment).toBe(true)
+    expect(revalidatePathMock).toHaveBeenCalledWith("/onboarding")
+  })
+})
+
+describe("ChecklistProgress", () => {
+  it("renders 100% completion state", async () => {
+    const browserStub = createBrowserSupabaseStub({
+      unit_id: "A1",
+      rent_share: 920,
+      metadata: {
+        emergencyContacts: [{ name: "Alex Rivera", phone: "555-321-7654" }],
+      },
+      onboarding_steps: {
+        unitAssignment: true,
+        rentShare: true,
+        emergencyContacts: true,
+      },
+    })
+
+    createBrowserClientMock.mockReturnValue(browserStub as any)
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<ChecklistProgress />)
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toContain("All onboarding steps complete")
+
+    root.unmount()
+    container.remove()
+  })
+})


### PR DESCRIPTION
## Summary
- replace the onboarding page with a multi-step tenant flow powered by server actions for unit assignment, rent share, and emergency contact updates
- add a Supabase-backed onboarding checklist component plus shared helpers for step state and completion calculations
- persist onboarding progress on profiles, add jsdom for client tests, and cover updates with a new Vitest suite

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d30bc075308328aba746cf730aa636