### PR TITLE
Remove Tailwind indicator from layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,6 @@ import { RouteSkeleton } from "@/components/feedback/RouteSkeleton"
 import { CookieButton } from "@/components/cookie-button"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
-import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 import { fontSans } from "@/lib/font"
@@ -155,7 +154,6 @@ enter your api info from termly.io or a provider of your choice
 
  */}
    <CookieButton />
-   <TailwindIndicator />
           </ThemeProvider>
 
 


### PR DESCRIPTION
## Summary
- remove the Tailwind breakpoint indicator from the root layout so the left corner button no longer renders

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d32d8659208328ac706ae204bb7098