### PR TITLE
Add DB-level booking overlap guardrails (exclusion constraint + test)

### DIFF
--- a/supabase/migrations/202603030001_booking_conflict_guardrails.sql
+++ b/supabase/migrations/202603030001_booking_conflict_guardrails.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+-- Prevent overlapping active amenity bookings at the database layer.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'bookings_no_overlapping_active_slots'
+      AND conrelid = 'public.bookings'::regclass
+  ) THEN
+    ALTER TABLE public.bookings
+      ADD CONSTRAINT bookings_no_overlapping_active_slots
+      EXCLUDE USING gist (
+        amenity_id WITH =,
+        tstzrange(start_time, end_time, '[)') WITH &&
+      )
+      WHERE (status IN ('pending', 'confirmed'));
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_bookings_active_slot_gist
+  ON public.bookings
+  USING gist (amenity_id, tstzrange(start_time, end_time, '[)'))
+  WHERE status IN ('pending', 'confirmed');
+
+COMMIT;

--- a/supabase/tests/schema_consistency_checks.sql
+++ b/supabase/tests/schema_consistency_checks.sql
@@ -9,6 +9,7 @@ DECLARE
   missing_fk_count integer;
   missing_unique_count integer;
   missing_enum_count integer;
+  missing_exclusion_count integer;
   orphan_count bigint;
 BEGIN
   WITH expected_fks AS (
@@ -103,6 +104,23 @@ BEGIN
 
   IF missing_enum_count > 0 THEN
     RAISE EXCEPTION 'Enum coverage mismatch detected for % enum type(s)', missing_enum_count;
+  END IF;
+
+  SELECT count(*)
+  INTO missing_exclusion_count
+  FROM (VALUES
+    ('bookings', 'bookings_no_overlapping_active_slots')
+  ) AS expected_exclusion(table_name, constraint_name)
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    WHERE c.conname = expected_exclusion.constraint_name
+      AND c.conrelid = format('public.%s', expected_exclusion.table_name)::regclass
+      AND c.contype = 'x'
+  );
+
+  IF missing_exclusion_count > 0 THEN
+    RAISE EXCEPTION 'Missing % expected exclusion constraints', missing_exclusion_count;
   END IF;
 
   SELECT


### PR DESCRIPTION
### Motivation
- Prevent amenity double-booking race conditions by enforcing a database-level invariant for active bookings so overlaps cannot be persisted under concurrent writes.
- Ensure the booking integrity rule is protected from future regressions by making readiness checks assert the constraint's presence.

### Description
- Added a new Supabase migration `supabase/migrations/202603030001_booking_conflict_guardrails.sql` that enables `btree_gist`, adds an exclusion constraint `bookings_no_overlapping_active_slots` on `public.bookings` to block overlapping `pending`/`confirmed` slots for the same `amenity_id`, and creates a partial GiST index `idx_bookings_active_slot_gist` for active-slot lookups.
- Updated `supabase/tests/schema_consistency_checks.sql` to assert the presence of the new exclusion constraint during migration readiness validation.
- Kept changes focused to the DB migration and readiness tests to provide a race-safe booking guardrail without altering application-level booking logic.

### Testing
- Ran `pnpm -s test` and all test files completed successfully (`108` tests passed).
- Ran `pnpm -s lint` and the linter reported no issues.
- Ran `pnpm -s typecheck` and `pnpm -s build` and both completed successfully, including static page generation during the production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6f23d4f988328a6e99b39976a0510)