### PR TITLE
Remediate Supabase Security Advisor findings for bookings and RLS

### DIFF
--- a/docs/operations/security-advisor-remediation-task-stubs.md
+++ b/docs/operations/security-advisor-remediation-task-stubs.md
@@ -1,0 +1,105 @@
+# Security Advisor Remediation Task Stubs
+
+## Context
+Supabase Security Advisor currently reports the following production issues:
+
+1. `Security Definer View` on `public.amenity_bookings`
+2. `RLS Disabled in Public` on `public.floorplan_annotations`
+3. `RLS Disabled in Public` on `public.data_integrity_findings`
+
+This document breaks each issue into implementation-ready task stubs so engineering, QA, and operations can track remediation work clearly.
+
+---
+
+## Task Stub 1 — Convert `public.amenity_bookings` to caller-context view
+
+**Issue**: Security Advisor flags `public.amenity_bookings` as a security definer view, which can evaluate with elevated privileges.
+
+### Objective
+Run the compatibility view with the caller's permissions and preserve read compatibility for existing consumers.
+
+### Implementation tasks
+- [ ] Add migration to set `security_invoker = true` on `public.amenity_bookings`.
+- [ ] Confirm all app-side read paths rely on `public.bookings` as canonical write target and use `amenity_bookings` only for compatibility reads.
+- [ ] Validate role behavior (`anon`, `authenticated tenant`, `manager`, `service_role`) against the updated view.
+- [ ] Re-run Supabase Security Advisor and confirm the `Security Definer View` error clears.
+
+### Acceptance criteria
+- [ ] `public.amenity_bookings` uses caller context (security invoker) after migration.
+- [ ] No regressions in booking history/analytics queries.
+- [ ] Security Advisor no longer reports this view-level error.
+
+### Owner / effort
+- **Suggested owner**: Backend platform engineer
+- **Estimate**: 0.5 day
+
+---
+
+## Task Stub 2 — Enable and enforce RLS on `public.floorplan_annotations`
+
+**Issue**: `public.floorplan_annotations` is in public schema with RLS disabled.
+
+### Objective
+Protect roommate-specific floorplan overlays so access is limited to in-unit participants and authorized managers/admins.
+
+### Implementation tasks
+- [ ] Enable RLS on `public.floorplan_annotations`.
+- [ ] Add `SELECT` policy to allow:
+  - assigned unit access via `public.can_access_unit(...)`
+  - plus annotation visibility checks (`profile_id IS NULL`, own profile, or manager/admin role).
+- [ ] Add `INSERT` policy requiring scoped unit access and ownership/manager-admin write authority.
+- [ ] Add `UPDATE`/`DELETE` policies restricting edits to creator or manager/admin in scope.
+- [ ] Execute RBAC verification tests for tenant, roommate, property manager, and admin personas.
+- [ ] Confirm dashboard floorplan overlay experience still works for expected roles.
+
+### Acceptance criteria
+- [ ] Unauthorized users cannot read or mutate roommate annotations.
+- [ ] Scoped roommates can read allowed overlays.
+- [ ] Managers/admins retain moderation/override access.
+- [ ] Security Advisor no longer reports RLS disabled for this table.
+
+### Owner / effort
+- **Suggested owner**: Backend + app feature pair
+- **Estimate**: 1 day
+
+---
+
+## Task Stub 3 — Enable and enforce RLS on `public.data_integrity_findings`
+
+**Issue**: `public.data_integrity_findings` has RLS disabled and may expose sensitive operational findings.
+
+### Objective
+Limit finding visibility to operational roles and keep write privileges scoped to service-side automation.
+
+### Implementation tasks
+- [ ] Enable RLS on `public.data_integrity_findings`.
+- [ ] Add `SELECT` policy for `property_manager` and `admin` roles.
+- [ ] Add service-role policy for insert/update/delete lifecycle operations.
+- [ ] Validate ops endpoints that surface integrity findings still return expected results for authorized users.
+- [ ] Confirm unauthenticated and tenant/roommate roles cannot query findings.
+
+### Acceptance criteria
+- [ ] Only authorized operations roles can view findings.
+- [ ] Service-side reconciliation jobs retain full write access.
+- [ ] Security Advisor no longer reports RLS disabled for this table.
+
+### Owner / effort
+- **Suggested owner**: Operations backend engineer
+- **Estimate**: 0.5 day
+
+---
+
+## Cross-cutting validation checklist
+
+- [ ] Run database migration in staging.
+- [ ] Run SQL verification script for RLS + policy coverage.
+- [ ] Re-run Security Advisor (`Errors` tab should show 0 for the three items above).
+- [ ] Record before/after screenshots in release notes.
+- [ ] Add migration reference to launch-readiness tracker.
+
+## Suggested rollout sequence
+1. Deploy migration to staging.
+2. Validate role behavior and feature smoke tests.
+3. Re-run advisor and save evidence.
+4. Deploy to production in low-traffic window.
+5. Re-run advisor post-release and attach final sign-off.

--- a/supabase/migrations/202603030002_security_advisor_remediation.sql
+++ b/supabase/migrations/202603030002_security_advisor_remediation.sql
@@ -1,0 +1,112 @@
+BEGIN;
+
+-- Ensure compatibility views execute with caller permissions, not creator privileges.
+ALTER VIEW IF EXISTS public.amenity_bookings
+  SET (security_invoker = true);
+
+-- Secure floorplan annotation overlays with explicit RLS.
+ALTER TABLE IF EXISTS public.floorplan_annotations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Floorplan annotations read scoped" ON public.floorplan_annotations;
+CREATE POLICY "Floorplan annotations read scoped" ON public.floorplan_annotations
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.floorplans f
+      WHERE f.id = floorplan_annotations.floorplan_id
+        AND public.can_access_unit(f.unit_id)
+    )
+    AND (
+      floorplan_annotations.profile_id IS NULL
+      OR floorplan_annotations.profile_id = auth.uid()
+      OR public.current_user_role() IN ('property_manager', 'admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "Floorplan annotations create scoped" ON public.floorplan_annotations;
+CREATE POLICY "Floorplan annotations create scoped" ON public.floorplan_annotations
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.floorplans f
+      WHERE f.id = floorplan_annotations.floorplan_id
+        AND public.can_access_unit(f.unit_id)
+    )
+    AND (
+      created_by = auth.uid()
+      OR public.current_user_role() IN ('property_manager', 'admin')
+    )
+    AND (
+      profile_id IS NULL
+      OR profile_id = auth.uid()
+      OR public.current_user_role() IN ('property_manager', 'admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "Floorplan annotations update scoped" ON public.floorplan_annotations;
+CREATE POLICY "Floorplan annotations update scoped" ON public.floorplan_annotations
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.floorplans f
+      WHERE f.id = floorplan_annotations.floorplan_id
+        AND public.can_access_unit(f.unit_id)
+    )
+    AND (
+      created_by = auth.uid()
+      OR public.current_user_role() IN ('property_manager', 'admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.floorplans f
+      WHERE f.id = floorplan_annotations.floorplan_id
+        AND public.can_access_unit(f.unit_id)
+    )
+    AND (
+      created_by = auth.uid()
+      OR public.current_user_role() IN ('property_manager', 'admin')
+    )
+    AND (
+      profile_id IS NULL
+      OR profile_id = auth.uid()
+      OR public.current_user_role() IN ('property_manager', 'admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "Floorplan annotations delete scoped" ON public.floorplan_annotations;
+CREATE POLICY "Floorplan annotations delete scoped" ON public.floorplan_annotations
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.floorplans f
+      WHERE f.id = floorplan_annotations.floorplan_id
+        AND public.can_access_unit(f.unit_id)
+    )
+    AND (
+      created_by = auth.uid()
+      OR public.current_user_role() IN ('property_manager', 'admin')
+    )
+  );
+
+-- Protect integrity findings table (contains potentially sensitive operational context).
+ALTER TABLE IF EXISTS public.data_integrity_findings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Managers can view integrity findings" ON public.data_integrity_findings;
+CREATE POLICY "Managers can view integrity findings" ON public.data_integrity_findings
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('property_manager', 'admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "Service role can manage integrity findings" ON public.data_integrity_findings;
+CREATE POLICY "Service role can manage integrity findings" ON public.data_integrity_findings
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Supabase Security Advisor reported three production issues: a security-definer view on `public.amenity_bookings` and missing RLS on `public.floorplan_annotations` and `public.data_integrity_findings`, which could expose sensitive operational and tenant data. 
- Fixes are required to run views in caller context and to enforce row-level security so only authorized roles and service processes can read or mutate sensitive tables.

### Description
- Add a new migration `supabase/migrations/202603030002_security_advisor_remediation.sql` that sets `public.amenity_bookings` to `security_invoker = true`, enables RLS on `public.floorplan_annotations` and `public.data_integrity_findings`, and creates scoped `SELECT`/`INSERT`/`UPDATE`/`DELETE` policies for annotations and manager/service-role policies for integrity findings. 
- The migration uses `ALTER VIEW IF EXISTS`, `ALTER TABLE IF EXISTS`, and `DROP/CREATE POLICY` so it is safe to run against staging/production variants. 
- Policies reuse existing helpers (`public.can_access_unit`, `public.current_user_role`) and preserve `service_role` write access for service-side jobs. 
- Add `docs/operations/security-advisor-remediation-task-stubs.md` containing concrete task stubs, acceptance criteria, rollout sequence, and validation checklist for tracking and handoff.

### Testing
- Run `pnpm lint` (Next.js ESLint) and it completed with no warnings or errors. 
- The migration and task-stub files were smoke-verified in the repo (files added and content inspected) prior to creating this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7653164d08328bf92ceb5c0fe28b7)