### PR TITLE
Refactor readiness checks into core and optional probes

### DIFF
--- a/app/api/readiness/route.ts
+++ b/app/api/readiness/route.ts
@@ -1,13 +1,18 @@
 import { getReadinessSummary } from '@/lib/operations/dependency-health'
 
-export async function GET() {
-  const summary = await getReadinessSummary()
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const includeOptional = searchParams.get('full') === '1'
+
+  const summary = await getReadinessSummary({ includeOptional })
   const httpStatus = summary.status === 'healthy' ? 200 : summary.status === 'degraded' ? 206 : 503
 
   return Response.json(
     {
       status: summary.status,
-      dependencies: summary.dependencies,
+      core: summary.core,
+      optional: summary.optional,
+      includeOptional,
       timestamp: new Date().toISOString(),
     },
     { status: httpStatus }

--- a/docs/operations/launch-day-monitoring-dashboard.md
+++ b/docs/operations/launch-day-monitoring-dashboard.md
@@ -15,6 +15,8 @@ Provide a real-time command-center view of traffic health, application reliabili
 
 ### 2) Critical reliability indicators (middle row)
 
+- Core readiness status from `GET /api/readiness` (default probe mode: app process + Supabase).
+- Optional dependency panel from `GET /api/readiness?full=1` (Stripe, Cal.com, Documenso) for deeper diagnostics.
 - Webhook failure rate (`webhook_failures_total`) split by provider (`stripe`, `calcom`, `documenso`).
 - Auth failure trend (`auth_failures_total`) with baseline overlay.
 - Booking conflict count (`booking_conflicts_total`) and conflict % of validation attempts.
@@ -49,6 +51,12 @@ All widgets should support filters for:
 2. At launch: pin dashboard to incident channel and assign one operator per dashboard section.
 3. Every 15 minutes: snapshot funnel conversion and error budget burn in incident thread.
 4. On threshold breach: jump from widget to correlated logs via `correlationId` and execute linked runbook.
+
+## Alerting split: core vs optional dependencies
+
+- **Core failure alert (P1):** Trigger when `/api/readiness` returns `degraded` or `down` for two consecutive windows. Treat as tenant-impacting because core checks cover application process and Supabase DB connectivity.
+- **Optional failure alert (P2):** Trigger when `/api/readiness?full=1` reports any optional dependency as `degraded` or `down` for three consecutive windows. Keep the app available, but route to the owning integration responders.
+- **Escalation rule:** Promote optional incidents to P1 only if business KPIs (payment conversion, booking completion, lease workflows) drop below launch thresholds.
 
 ## Minimum data sources
 

--- a/docs/operations/resilience-runbook.md
+++ b/docs/operations/resilience-runbook.md
@@ -38,8 +38,19 @@ When providers are unavailable:
 ## 4) Health/readiness checks
 
 - Liveness: `GET /api/health`.
-- Readiness: `GET /api/readiness`.
+- Core readiness: `GET /api/readiness` (app process + Supabase DB connectivity). This endpoint determines service readiness and should page primary on-call when degraded/down.
+- Extended readiness: `GET /api/readiness?full=1` (adds Stripe, Cal.com, Documenso optional probes). Use for diagnostics and integration-specific paging.
 - Operations dashboard includes dependency health indicators for Supabase, Stripe, Cal.com, Documenso.
+
+### Alert handling policy
+
+- **Core check failure (`/api/readiness`)**
+  - Severity: P1 by default.
+  - Immediate actions: halt risky deploys, run Supabase connectivity triage, validate app error rates and auth flows.
+- **Optional check failure (`/api/readiness?full=1`)**
+  - Severity: P2 by default.
+  - Immediate actions: engage provider-specific playbook (payment outage, booking sync drift, document signing delays) while keeping core platform online.
+  - Promotion to P1: if optional degradation causes sustained tenant-facing failures in critical funnels.
 
 ## 5) Incident playbooks and testing cadence
 

--- a/lib/operations/dependency-health.ts
+++ b/lib/operations/dependency-health.ts
@@ -8,11 +8,27 @@ export type DependencyHealth = {
   message: string
 }
 
+export type CoreDependencyName = 'app' | 'supabase'
+
+export type CoreDependencyHealth = {
+  name: CoreDependencyName
+  status: DependencyStatus
+  message: string
+}
+
+export type OptionalDependencyHealth = DependencyHealth
+
+export type ReadinessSummary = {
+  status: DependencyStatus
+  core: CoreDependencyHealth[]
+  optional: OptionalDependencyHealth[]
+}
 
 const PROBE_TIMEOUT_MS = 2_000
 const HEALTH_CACHE_TTL_MS = 15_000
 
-let cachedDependencyHealth: { value: DependencyHealth[]; expiresAt: number } | null = null
+let cachedCoreHealth: { value: CoreDependencyHealth[]; expiresAt: number } | null = null
+let cachedOptionalHealth: { value: OptionalDependencyHealth[]; expiresAt: number } | null = null
 
 function normalizeBaseUrl(baseUrl: string) {
   return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
@@ -98,6 +114,14 @@ async function runProbe(
   }
 }
 
+function getAppProcessHealth(): CoreDependencyHealth {
+  return {
+    name: 'app',
+    status: 'healthy',
+    message: 'application process is running',
+  }
+}
+
 async function probeSupabase(): Promise<DependencyHealth> {
   return runProbe('supabase', ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'], () => {
     const baseUrl = normalizeBaseUrl(process.env.NEXT_PUBLIC_SUPABASE_URL!)
@@ -152,13 +176,15 @@ async function probeDocumenso(): Promise<DependencyHealth> {
   }))
 }
 
-export async function getDependencyHealth(): Promise<DependencyHealth[]> {
-  if (cachedDependencyHealth && cachedDependencyHealth.expiresAt > Date.now()) {
-    return cachedDependencyHealth.value
+export async function getCoreDependencyHealth(): Promise<CoreDependencyHealth[]> {
+  if (cachedCoreHealth && cachedCoreHealth.expiresAt > Date.now()) {
+    return cachedCoreHealth.value
   }
 
-  const value = await Promise.all([probeSupabase(), probeStripe(), probeCalcom(), probeDocumenso()])
-  cachedDependencyHealth = {
+  const [supabase] = await Promise.all([probeSupabase()])
+  const value: CoreDependencyHealth[] = [getAppProcessHealth(), supabase]
+
+  cachedCoreHealth = {
     value,
     expiresAt: Date.now() + HEALTH_CACHE_TTL_MS,
   }
@@ -166,17 +192,51 @@ export async function getDependencyHealth(): Promise<DependencyHealth[]> {
   return value
 }
 
-export function clearDependencyHealthCacheForTests() {
-  cachedDependencyHealth = null
+export async function getOptionalDependencyHealth(): Promise<OptionalDependencyHealth[]> {
+  if (cachedOptionalHealth && cachedOptionalHealth.expiresAt > Date.now()) {
+    return cachedOptionalHealth.value
+  }
+
+  const value = await Promise.all([probeStripe(), probeCalcom(), probeDocumenso()])
+  cachedOptionalHealth = {
+    value,
+    expiresAt: Date.now() + HEALTH_CACHE_TTL_MS,
+  }
+
+  return value
 }
 
-export async function getReadinessSummary() {
-  const dependencies = await getDependencyHealth()
+export async function getDependencyHealth(): Promise<DependencyHealth[]> {
+  const [core, optional] = await Promise.all([
+    getCoreDependencyHealth(),
+    getOptionalDependencyHealth(),
+  ])
+
+  return [...core, ...optional]
+}
+
+export function clearDependencyHealthCacheForTests() {
+  cachedCoreHealth = null
+  cachedOptionalHealth = null
+}
+
+function summarizeStatus(dependencies: Array<{ status: DependencyStatus }>): DependencyStatus {
   const hasDown = dependencies.some((dependency) => dependency.status === 'down')
+  if (hasDown) {
+    return 'down'
+  }
+
   const hasDegraded = dependencies.some((dependency) => dependency.status === 'degraded')
+  return hasDegraded ? 'degraded' : 'healthy'
+}
+
+export async function getReadinessSummary(options?: { includeOptional?: boolean }): Promise<ReadinessSummary> {
+  const core = await getCoreDependencyHealth()
+  const optional = options?.includeOptional ? await getOptionalDependencyHealth() : []
 
   return {
-    status: hasDown ? 'down' : hasDegraded ? 'degraded' : 'healthy',
-    dependencies,
+    status: summarizeStatus(core),
+    core,
+    optional,
   }
 }

--- a/tests/integration/api/readiness.test.ts
+++ b/tests/integration/api/readiness.test.ts
@@ -10,26 +10,29 @@ describe('GET /api/readiness', () => {
   it('returns 200 for healthy readiness', async () => {
     getReadinessSummary.mockResolvedValueOnce({
       status: 'healthy',
-      dependencies: [{ name: 'stripe', status: 'healthy', message: 'probe succeeded; response status=200' }],
+      core: [{ name: 'app', status: 'healthy', message: 'application process is running' }],
+      optional: [],
     })
 
     const { GET } = await import('@/app/api/readiness/route')
-    const response = await GET()
+    const response = await GET(new Request('https://example.com/api/readiness'))
 
     expect(response.status).toBe(200)
+    expect(getReadinessSummary).toHaveBeenCalledWith({ includeOptional: false })
     await expect(response.json()).resolves.toMatchObject({ status: 'healthy' })
   })
 
-  it('returns 206 for degraded readiness', async () => {
+  it('returns 206 for degraded readiness based on core dependencies', async () => {
     getReadinessSummary.mockResolvedValueOnce({
       status: 'degraded',
-      dependencies: [
-        { name: 'stripe', status: 'degraded', message: 'authentication failed; response status=401' },
+      core: [
+        { name: 'supabase', status: 'degraded', message: 'authentication failed; response status=401' },
       ],
+      optional: [],
     })
 
     const { GET } = await import('@/app/api/readiness/route')
-    const response = await GET()
+    const response = await GET(new Request('https://example.com/api/readiness'))
 
     expect(response.status).toBe(206)
     await expect(response.json()).resolves.toMatchObject({ status: 'degraded' })
@@ -38,13 +41,32 @@ describe('GET /api/readiness', () => {
   it('returns 503 for down readiness', async () => {
     getReadinessSummary.mockResolvedValueOnce({
       status: 'down',
-      dependencies: [{ name: 'supabase', status: 'down', message: 'probe failed; network error' }],
+      core: [{ name: 'supabase', status: 'down', message: 'probe failed; network error' }],
+      optional: [],
     })
 
     const { GET } = await import('@/app/api/readiness/route')
-    const response = await GET()
+    const response = await GET(new Request('https://example.com/api/readiness'))
 
     expect(response.status).toBe(503)
     await expect(response.json()).resolves.toMatchObject({ status: 'down' })
+  })
+
+  it('includes optional probes only when full=1', async () => {
+    getReadinessSummary.mockResolvedValueOnce({
+      status: 'healthy',
+      core: [{ name: 'app', status: 'healthy', message: 'application process is running' }],
+      optional: [{ name: 'stripe', status: 'healthy', message: 'probe succeeded; response status=200' }],
+    })
+
+    const { GET } = await import('@/app/api/readiness/route')
+    const response = await GET(new Request('https://example.com/api/readiness?full=1'))
+
+    expect(response.status).toBe(200)
+    expect(getReadinessSummary).toHaveBeenCalledWith({ includeOptional: true })
+    await expect(response.json()).resolves.toMatchObject({
+      includeOptional: true,
+      optional: [{ name: 'stripe', status: 'healthy' }],
+    })
   })
 })

--- a/tests/integration/dependency-health.test.ts
+++ b/tests/integration/dependency-health.test.ts
@@ -28,20 +28,30 @@ afterEach(() => {
 })
 
 describe('dependency health probes', () => {
-  it('reports healthy providers with response status in message', async () => {
+  it('reports healthy core and optional providers with response status in message', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ status: 200 })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { getDependencyHealth, getReadinessSummary, clearDependencyHealthCacheForTests } = await loadModule()
+    const {
+      getCoreDependencyHealth,
+      getOptionalDependencyHealth,
+      getReadinessSummary,
+      clearDependencyHealthCacheForTests,
+    } = await loadModule()
     clearDependencyHealthCacheForTests()
 
-    const dependencies = await getDependencyHealth()
-    const summary = await getReadinessSummary()
+    const core = await getCoreDependencyHealth()
+    const optional = await getOptionalDependencyHealth()
+    const summary = await getReadinessSummary({ includeOptional: true })
 
     expect(fetchMock).toHaveBeenCalledTimes(4)
     expect(summary.status).toBe('healthy')
-    expect(dependencies.every((dependency) => dependency.status === 'healthy')).toBe(true)
-    expect(dependencies[0]?.message).toContain('response status=200')
+    expect(core).toEqual([
+      { name: 'app', status: 'healthy', message: 'application process is running' },
+      { name: 'supabase', status: 'healthy', message: 'probe succeeded; response status=200' },
+    ])
+    expect(optional.every((dependency) => dependency.status === 'healthy')).toBe(true)
+    expect(summary.optional[0]?.message).toContain('response status=200')
   })
 
   it('classifies timeout failures as down', async () => {
@@ -59,10 +69,10 @@ describe('dependency health probes', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { getDependencyHealth, clearDependencyHealthCacheForTests } = await loadModule()
+    const { getOptionalDependencyHealth, clearDependencyHealthCacheForTests } = await loadModule()
     clearDependencyHealthCacheForTests()
 
-    const pending = getDependencyHealth()
+    const pending = getOptionalDependencyHealth()
     await vi.advanceTimersByTimeAsync(2_100)
     const dependencies = await pending
     const stripe = dependencies.find((dependency) => dependency.name === 'stripe')
@@ -81,15 +91,18 @@ describe('dependency health probes', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { getDependencyHealth, clearDependencyHealthCacheForTests } = await loadModule()
+    const { getOptionalDependencyHealth, getReadinessSummary, clearDependencyHealthCacheForTests } = await loadModule()
     clearDependencyHealthCacheForTests()
 
-    const first = await getDependencyHealth()
-    const second = await getDependencyHealth()
+    const first = await getOptionalDependencyHealth()
+    const second = await getOptionalDependencyHealth()
+    const summary = await getReadinessSummary()
     const calcom = first.find((dependency) => dependency.name === 'calcom')
 
     expect(calcom).toMatchObject({ status: 'degraded' })
     expect(calcom?.message).toContain('authentication failed')
+    expect(summary.status).toBe('healthy')
+    expect(summary.optional).toEqual([])
     expect(second).toEqual(first)
     expect(fetchMock).toHaveBeenCalledTimes(4)
   })


### PR DESCRIPTION
### Motivation

- Separate critical (core) readiness checks from optional external integrations so platform readiness is driven only by app + DB health.
- Avoid noisy paging/alerts for non-critical provider degradations while still exposing integration health for diagnostics. 

### Description

- Introduced core vs optional types and summary shape in `lib/operations/dependency-health.ts` and added `CoreDependencyHealth`, `OptionalDependencyHealth`, and `ReadinessSummary` types. 
- Implemented core checks: an `app` process liveness entry plus a Supabase probe via `getCoreDependencyHealth`, and moved Stripe/Cal.com/Documenso probes to `getOptionalDependencyHealth`. 
- Added `getReadinessSummary(options?: { includeOptional?: boolean })` which computes overall readiness from core checks only and returns `core` and `optional` arrays separately. 
- Kept aggregated `getDependencyHealth` to return combined lists when needed and added short-lived caching for core and optional probe results. 
- Updated the readiness route to accept `?full=1` and return `core`, `optional`, and `includeOptional` fields while deriving the HTTP status from core readiness in `app/api/readiness/route.ts`. 
- Updated monitoring docs (`docs/operations/launch-day-monitoring-dashboard.md`, `docs/operations/resilience-runbook.md`) to document the core-vs-optional alerting split and severity guidance. 
- Updated integration tests to reflect the new API contract and probe split (`tests/integration/dependency-health.test.ts`, `tests/integration/api/readiness.test.ts`).

### Testing

- Ran the integration tests with `pnpm vitest run tests/integration/dependency-health.test.ts tests/integration/api/readiness.test.ts` and all tests passed (7 tests). 
- Verified the new readiness route behavior in tests for both default (`includeOptional=false`) and `?full=1` (`includeOptional=true`) modes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa43e6ae08328b74bb0a1f7c91c68)