### PR TITLE
Implement Supabase-backed todo actions with ownership checks

### DIFF
--- a/app/dashboard/todo/actions/index.ts
+++ b/app/dashboard/todo/actions/index.ts
@@ -1,9 +1,204 @@
-// "use server";
-export async function createTodo() {
-	console.log("create todo");
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { createClient } from "@/utils/supabase/server"
+
+export type TodoRecord = {
+  id: string
+  title: string
+  completed: boolean
+  author_id: string
+  created_at: string | null
+  updated_at: string | null
 }
-export async function updateTodoById(id: string) {
-	console.log("update todo");
+
+type TodoActionResult<T> = {
+  success: boolean
+  data?: T
+  error?: string
 }
-export async function deleteTodoById(id: string) {}
-export async function readTodos() {}
+
+function unauthorizedResult<T>(): TodoActionResult<T> {
+  return {
+    success: false,
+    error: "Unauthorized",
+  }
+}
+
+export async function createTodo(input: {
+  title: string
+  completed?: boolean
+}): Promise<TodoActionResult<TodoRecord>> {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return unauthorizedResult()
+  }
+
+  const { data, error } = await supabase
+    .from("todos")
+    .insert({
+      title: input.title,
+      completed: input.completed ?? false,
+      author_id: user.id,
+    })
+    .select("id, title, completed, author_id, created_at, updated_at")
+    .single()
+
+  if (error || !data) {
+    return {
+      success: false,
+      error: error?.message ?? "Unable to create todo",
+    }
+  }
+
+  revalidatePath("/dashboard/todo")
+
+  return {
+    success: true,
+    data: data as TodoRecord,
+  }
+}
+
+export async function updateTodoById(
+  id: string,
+  input: {
+    title?: string
+    completed?: boolean
+  },
+): Promise<TodoActionResult<TodoRecord>> {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return unauthorizedResult()
+  }
+
+  const payload: { title?: string; completed?: boolean; updated_at: string } = {
+    updated_at: new Date().toISOString(),
+  }
+
+  if (typeof input.title === "string") {
+    payload.title = input.title
+  }
+
+  if (typeof input.completed === "boolean") {
+    payload.completed = input.completed
+  }
+
+  const { data, error } = await supabase
+    .from("todos")
+    .update(payload)
+    .eq("id", id)
+    .eq("author_id", user.id)
+    .select("id, title, completed, author_id, created_at, updated_at")
+
+  if (error) {
+    return {
+      success: false,
+      error: error.message,
+    }
+  }
+
+  const todo = (data as TodoRecord[] | null)?.[0]
+
+  if (!todo) {
+    return {
+      success: false,
+      error: "Todo not found",
+    }
+  }
+
+  revalidatePath("/dashboard/todo")
+
+  return {
+    success: true,
+    data: todo,
+  }
+}
+
+export async function deleteTodoById(id: string): Promise<TodoActionResult<{ id: string }>> {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return unauthorizedResult()
+  }
+
+  const { data, error } = await supabase
+    .from("todos")
+    .delete()
+    .eq("id", id)
+    .eq("author_id", user.id)
+    .select("id")
+
+  if (error) {
+    return {
+      success: false,
+      error: error.message,
+    }
+  }
+
+  const deletedTodo = (data as { id: string }[] | null)?.[0]
+
+  if (!deletedTodo) {
+    return {
+      success: false,
+      error: "Todo not found",
+    }
+  }
+
+  revalidatePath("/dashboard/todo")
+
+  return {
+    success: true,
+    data: deletedTodo,
+  }
+}
+
+export async function readTodos(): Promise<TodoActionResult<TodoRecord[]>> {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return unauthorizedResult()
+  }
+
+  const { data, error } = await supabase
+    .from("todos")
+    .select("id, title, completed, author_id, created_at, updated_at")
+    .eq("author_id", user.id)
+
+  if (error) {
+    return {
+      success: false,
+      error: error.message,
+    }
+  }
+
+  const todos = ((data as TodoRecord[] | null) ?? []).sort((a, b) => {
+    const left = a.created_at ? new Date(a.created_at).getTime() : 0
+    const right = b.created_at ? new Date(b.created_at).getTime() : 0
+
+    return right - left
+  })
+
+  return {
+    success: true,
+    data: todos,
+  }
+}

--- a/app/dashboard/todo/components/CreateForm.tsx
+++ b/app/dashboard/todo/components/CreateForm.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useTransition } from "react"
+import { useRouter } from "next/navigation"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
@@ -17,6 +18,8 @@ import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { DashboardSubmitButton } from "@/app/dashboard/components/dashboard-submit-button"
 
+import { createTodo } from "../actions"
+
 const FormSchema = z.object({
   title: z.string().min(1, {
     message: "Title is required.",
@@ -24,7 +27,8 @@ const FormSchema = z.object({
 })
 
 export default function CreateForm() {
-  const [isPending] = useTransition()
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
@@ -34,15 +38,28 @@ export default function CreateForm() {
   })
 
   function onSubmit(data: z.infer<typeof FormSchema>) {
-    toast({
-      title: "You have successfully create todo.",
-      description: (
-        <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-          <code className="text-white">{data.title} is created</code>
-        </pre>
-      ),
+    startTransition(async () => {
+      const result = await createTodo({
+        title: data.title,
+      })
+
+      if (!result.success) {
+        toast({
+          title: "Failed to create todo",
+          description: result.error ?? "Unknown error",
+          variant: "destructive",
+        })
+        return
+      }
+
+      toast({
+        title: "Todo created",
+        description: `${result.data?.title ?? data.title} was added.`,
+      })
+
+      form.reset()
+      router.refresh()
     })
-    form.reset()
   }
 
   return (

--- a/app/dashboard/todo/components/DeleteTodoButton.tsx
+++ b/app/dashboard/todo/components/DeleteTodoButton.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { TrashIcon } from "@radix-ui/react-icons"
+
+import { Button } from "@/components/ui/button"
+import { toast } from "@/components/ui/use-toast"
+
+import { deleteTodoById } from "../actions"
+
+export default function DeleteTodoButton({ todoId }: { todoId: string }) {
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const result = await deleteTodoById(todoId)
+
+      if (!result.success) {
+        toast({
+          title: "Failed to delete todo",
+          description: result.error ?? "Unknown error",
+          variant: "destructive",
+        })
+        return
+      }
+
+      toast({
+        title: "Todo deleted",
+      })
+      router.refresh()
+    })
+  }
+
+  return (
+    <Button size="sm" variant="outline" className="gap-2" onClick={handleDelete} disabled={isPending}>
+      <TrashIcon />
+      {isPending ? "Deleting..." : "Delete"}
+    </Button>
+  )
+}

--- a/app/dashboard/todo/components/EditTodo.tsx
+++ b/app/dashboard/todo/components/EditTodo.tsx
@@ -2,10 +2,11 @@ import { Pencil1Icon } from "@radix-ui/react-icons"
 
 import { Button } from "@/components/ui/button"
 
+import type { TodoRecord } from "../actions"
 import DialogForm from "./DialogForm"
 import TodoForm from "./TodoForm"
 
-export default function EditTodo() {
+export default function EditTodo({ todo }: { todo: TodoRecord }) {
   return (
     <DialogForm
       id="update-trigger"
@@ -16,7 +17,7 @@ export default function EditTodo() {
           Edit
         </Button>
       }
-      form={<TodoForm isEdit />}
+      form={<TodoForm isEdit todo={todo} />}
     />
   )
 }

--- a/app/dashboard/todo/components/ListOfTodo.tsx
+++ b/app/dashboard/todo/components/ListOfTodo.tsx
@@ -1,37 +1,30 @@
-import { TrashIcon } from "@radix-ui/react-icons"
-
 import {
   dashboardEmptyStateClass,
   dashboardStatusBadgeVariants,
 } from "@/app/dashboard/components/dashboard-component-variants"
-import { Button } from "@/components/ui/button"
 import { TableCell, TableRow } from "@/components/ui/table"
 
+import { readTodos } from "../actions"
+import DeleteTodoButton from "./DeleteTodoButton"
 import EditTodo from "./EditTodo"
 
-type TodoRow = {
-  title: string
-  status: "completed" | "pending"
-  createdAt: string
-  createdBy: string
-}
+export default async function ListOfTodo() {
+  const result = await readTodos()
 
-const todos: TodoRow[] = [
-  {
-    title: "Subscribe to my channel",
-    status: "completed",
-    createdAt: new Date().toDateString(),
-    createdBy: "Garfield",
-  },
-  {
-    title: "Prepare parking rules announcement",
-    status: "pending",
-    createdAt: new Date().toDateString(),
-    createdBy: "Trender",
-  },
-]
+  if (!result.success) {
+    return (
+      <tbody>
+        <tr>
+          <td colSpan={5} className="p-2">
+            <div className={dashboardEmptyStateClass}>{result.error ?? "Unable to load todos."}</div>
+          </td>
+        </tr>
+      </tbody>
+    )
+  }
 
-export default function ListOfTodo() {
+  const todos = result.data ?? []
+
   if (!todos.length) {
     return (
       <tbody>
@@ -47,26 +40,25 @@ export default function ListOfTodo() {
   return (
     <tbody>
       {todos.map((todo, index) => (
-        <TableRow key={todo.title + index} className={index === 0 ? "bg-muted/40" : undefined}>
+        <TableRow key={todo.id} className={index === 0 ? "bg-muted/40" : undefined}>
           <TableCell className="font-medium text-foreground">{todo.title}</TableCell>
           <TableCell>
             <span
               className={dashboardStatusBadgeVariants({
-                tone: todo.status === "completed" ? "success" : "warning",
+                tone: todo.completed ? "success" : "warning",
               })}
             >
-              {todo.status}
+              {todo.completed ? "completed" : "pending"}
             </span>
           </TableCell>
-          <TableCell className="text-muted-foreground">{todo.createdAt}</TableCell>
-          <TableCell className="text-muted-foreground">{todo.createdBy}</TableCell>
+          <TableCell className="text-muted-foreground">
+            {todo.created_at ? new Date(todo.created_at).toLocaleDateString() : "-"}
+          </TableCell>
+          <TableCell className="text-muted-foreground">{todo.author_id}</TableCell>
           <TableCell className="text-right">
             <div className="flex items-center justify-end gap-2">
-              <Button size="sm" variant="outline" className="gap-2">
-                <TrashIcon />
-                Delete
-              </Button>
-              <EditTodo />
+              <DeleteTodoButton todoId={todo.id} />
+              <EditTodo todo={todo} />
             </div>
           </TableCell>
         </TableRow>

--- a/app/dashboard/todo/components/TodoForm.tsx
+++ b/app/dashboard/todo/components/TodoForm.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useTransition } from "react"
+import { useRouter } from "next/navigation"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
@@ -17,7 +19,7 @@ import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { DashboardSubmitButton } from "@/app/dashboard/components/dashboard-submit-button"
 
-import { createTodo, updateTodoById } from "../actions"
+import { createTodo, type TodoRecord, updateTodoById } from "../actions"
 
 const FormSchema = z.object({
   title: z.string().min(10, {
@@ -26,49 +28,58 @@ const FormSchema = z.object({
   completed: z.boolean(),
 })
 
-export default function TodoForm({ isEdit }: { isEdit: boolean }) {
+export default function TodoForm({
+  isEdit,
+  todo,
+}: {
+  isEdit: boolean
+  todo?: TodoRecord
+}) {
+  const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      title: "",
-      completed: false,
+      title: todo?.title ?? "",
+      completed: todo?.completed ?? false,
     },
   })
 
-  const handleCreateMember = (data: z.infer<typeof FormSchema>) => {
-    createTodo()
-    document.getElementById("create-trigger")?.click()
-
-    toast({
-      title: "You submitted the following values:",
-      description: (
-        <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-          <code className="text-white">{JSON.stringify(data, null, 2)}</code>
-        </pre>
-      ),
-    })
-  }
-
-  const handleUpdateMember = (data: z.infer<typeof FormSchema>) => {
-    updateTodoById("hello")
-    document.getElementById("update-trigger")?.click()
-
-    toast({
-      title: "You submitted the following values:",
-      description: (
-        <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-          <code className="text-white">{JSON.stringify(data, null, 2)}</code>
-        </pre>
-      ),
-    })
-  }
-
   function onSubmit(data: z.infer<typeof FormSchema>) {
-    if (isEdit) {
-      handleUpdateMember(data)
-    } else {
-      handleCreateMember(data)
-    }
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateTodoById(todo?.id ?? "", {
+            title: data.title,
+            completed: data.completed,
+          })
+        : await createTodo({
+            title: data.title,
+            completed: data.completed,
+          })
+
+      if (!result.success) {
+        toast({
+          title: isEdit ? "Failed to update todo" : "Failed to create todo",
+          description: result.error ?? "Unknown error",
+          variant: "destructive",
+        })
+        return
+      }
+
+      document.getElementById(isEdit ? "update-trigger" : "create-trigger")?.click()
+
+      toast({
+        title: isEdit ? "Todo updated" : "Todo created",
+        description: `${result.data?.title ?? data.title} saved successfully.`,
+      })
+
+      form.reset({
+        title: result.data?.title ?? "",
+        completed: result.data?.completed ?? false,
+      })
+      router.refresh()
+    })
   }
 
   return (
@@ -93,10 +104,7 @@ export default function TodoForm({ isEdit }: { isEdit: boolean }) {
           render={({ field }) => (
             <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4 shadow-sm">
               <FormControl>
-                <Checkbox
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                />
+                <Checkbox checked={field.value} onCheckedChange={field.onChange} />
               </FormControl>
               <div className="space-y-1 leading-none">
                 <FormLabel>Complete</FormLabel>
@@ -104,7 +112,7 @@ export default function TodoForm({ isEdit }: { isEdit: boolean }) {
             </FormItem>
           )}
         />
-        <DashboardSubmitButton label="Submit" />
+        <DashboardSubmitButton label="Submit" pending={isPending} />
       </form>
     </Form>
   )

--- a/tests/app/dashboard/todo/actions.test.ts
+++ b/tests/app/dashboard/todo/actions.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { revalidatePath, createClient } = vi.hoisted(() => ({
+  revalidatePath: vi.fn(),
+  createClient: vi.fn(),
+}))
+
+vi.mock("next/cache", () => ({
+  revalidatePath,
+}))
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient,
+}))
+
+import {
+  createTodo,
+  deleteTodoById,
+  readTodos,
+  updateTodoById,
+} from "@/app/dashboard/todo/actions"
+
+type Todo = {
+  id: string
+  title: string
+  completed: boolean
+  author_id: string
+  created_at: string
+  updated_at: string
+}
+
+function createSupabaseMock(options: {
+  userId?: string | null
+  todos?: Todo[]
+}) {
+  const state = {
+    todos: [...(options.todos ?? [])],
+  }
+
+  const userId = options.userId ?? null
+
+  const client = {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: {
+          user: userId ? { id: userId } : null,
+        },
+        error: null,
+      })),
+    },
+    from: vi.fn((table: string) => {
+      if (table !== "todos") {
+        throw new Error(`Unexpected table ${table}`)
+      }
+
+      return makeQueryBuilder(state)
+    }),
+  }
+
+  return { client, state }
+}
+
+function makeQueryBuilder(state: { todos: Todo[] }) {
+  let mode: "insert" | "update" | "delete" | "read" = "read"
+  let payload: Record<string, unknown> | null = null
+  const filters = new Map<string, string>()
+
+  const builder = {
+    insert(value: Record<string, unknown>) {
+      mode = "insert"
+      payload = value
+      return builder
+    },
+    update(value: Record<string, unknown>) {
+      mode = "update"
+      payload = value
+      return builder
+    },
+    delete() {
+      mode = "delete"
+      return builder
+    },
+    eq(field: string, value: string) {
+      filters.set(field, value)
+      return builder
+    },
+    select(_columns: string) {
+      return builder
+    },
+    single: async () => {
+      if (mode !== "insert" || !payload) {
+        return { data: null, error: { message: "invalid mode" } }
+      }
+
+      const newTodo: Todo = {
+        id: "new-todo",
+        title: String(payload.title ?? ""),
+        completed: Boolean(payload.completed),
+        author_id: String(payload.author_id ?? ""),
+        created_at: "2026-04-20T00:00:00.000Z",
+        updated_at: "2026-04-20T00:00:00.000Z",
+      }
+
+      state.todos.push(newTodo)
+
+      return { data: newTodo, error: null }
+    },
+    then(resolve: (value: { data: Todo[]; error: null }) => void) {
+      let data: Todo[] = []
+
+      if (mode === "read") {
+        const authorId = filters.get("author_id")
+        data = state.todos.filter((todo) => {
+          if (authorId && todo.author_id !== authorId) {
+            return false
+          }
+
+          return true
+        })
+      }
+
+      if (mode === "update") {
+        const id = filters.get("id")
+        const authorId = filters.get("author_id")
+
+        state.todos = state.todos.map((todo) => {
+          if (todo.id === id && todo.author_id === authorId) {
+            const nextTodo = {
+              ...todo,
+              ...payload,
+            } as Todo
+            data = [nextTodo]
+            return nextTodo
+          }
+
+          return todo
+        })
+      }
+
+      if (mode === "delete") {
+        const id = filters.get("id")
+        const authorId = filters.get("author_id")
+        const remaining: Todo[] = []
+
+        for (const todo of state.todos) {
+          if (todo.id === id && todo.author_id === authorId) {
+            data = [todo]
+            continue
+          }
+
+          remaining.push(todo)
+        }
+
+        state.todos = remaining
+      }
+
+      resolve({ data, error: null })
+      return Promise.resolve({ data, error: null })
+    },
+  }
+
+  return builder
+}
+
+describe("todo actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("creates a todo for the authenticated user", async () => {
+    const { client, state } = createSupabaseMock({ userId: "user-1" })
+    createClient.mockReturnValue(client)
+
+    const result = await createTodo({ title: "Pay rent", completed: false })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.author_id).toBe("user-1")
+    expect(state.todos).toHaveLength(1)
+    expect(revalidatePath).toHaveBeenCalledWith("/dashboard/todo")
+  })
+
+  it("lists only the authenticated user's todos", async () => {
+    const { client } = createSupabaseMock({
+      userId: "user-1",
+      todos: [
+        {
+          id: "todo-1",
+          title: "One",
+          completed: false,
+          author_id: "user-1",
+          created_at: "2026-04-20T10:00:00.000Z",
+          updated_at: "2026-04-20T10:00:00.000Z",
+        },
+        {
+          id: "todo-2",
+          title: "Two",
+          completed: false,
+          author_id: "user-2",
+          created_at: "2026-04-20T11:00:00.000Z",
+          updated_at: "2026-04-20T11:00:00.000Z",
+        },
+      ],
+    })
+    createClient.mockReturnValue(client)
+
+    const result = await readTodos()
+
+    expect(result.success).toBe(true)
+    expect(result.data).toHaveLength(1)
+    expect(result.data?.[0].author_id).toBe("user-1")
+  })
+
+  it("updates only a todo owned by the authenticated user", async () => {
+    const { client, state } = createSupabaseMock({
+      userId: "user-1",
+      todos: [
+        {
+          id: "todo-1",
+          title: "Original",
+          completed: false,
+          author_id: "user-1",
+          created_at: "2026-04-20T10:00:00.000Z",
+          updated_at: "2026-04-20T10:00:00.000Z",
+        },
+      ],
+    })
+    createClient.mockReturnValue(client)
+
+    const result = await updateTodoById("todo-1", {
+      title: "Updated",
+      completed: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(state.todos[0].title).toBe("Updated")
+    expect(state.todos[0].completed).toBe(true)
+  })
+
+  it("deletes only a todo owned by the authenticated user", async () => {
+    const { client, state } = createSupabaseMock({
+      userId: "user-1",
+      todos: [
+        {
+          id: "todo-1",
+          title: "Delete me",
+          completed: false,
+          author_id: "user-1",
+          created_at: "2026-04-20T10:00:00.000Z",
+          updated_at: "2026-04-20T10:00:00.000Z",
+        },
+      ],
+    })
+    createClient.mockReturnValue(client)
+
+    const result = await deleteTodoById("todo-1")
+
+    expect(result.success).toBe(true)
+    expect(state.todos).toHaveLength(0)
+  })
+
+  it("returns unauthorized for unauthenticated access", async () => {
+    const { client } = createSupabaseMock({ userId: null })
+    createClient.mockReturnValue(client)
+
+    const createResult = await createTodo({ title: "Task" })
+    const readResult = await readTodos()
+    const updateResult = await updateTodoById("todo-1", { title: "Nope" })
+    const deleteResult = await deleteTodoById("todo-1")
+
+    expect(createResult).toMatchObject({ success: false, error: "Unauthorized" })
+    expect(readResult).toMatchObject({ success: false, error: "Unauthorized" })
+    expect(updateResult).toMatchObject({ success: false, error: "Unauthorized" })
+    expect(deleteResult).toMatchObject({ success: false, error: "Unauthorized" })
+  })
+})

--- a/tests/components/dashboard-members-todo-visual-states.test.tsx
+++ b/tests/components/dashboard-members-todo-visual-states.test.tsx
@@ -24,6 +24,12 @@ vi.mock("@/components/ui/use-toast", () => ({
   toast: vi.fn(),
 }))
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+  }),
+}))
+
 import ListOfMembers from "@/app/dashboard/members/components/ListOfMembers"
 import TodoForm from "@/app/dashboard/todo/components/TodoForm"
 


### PR DESCRIPTION
### Motivation
- Re-enable server actions for the dashboard todo feature and persist todos to Supabase using a consistent `todos` schema (`id`, `title`, `completed`, `author_id`, `created_at`, `updated_at`).
- Enforce ownership so only the authenticated user may read/update/delete their own todos and ensure UI callers handle success/error states and refresh.

### Description
- Re-enabled `"use server"` and implemented `createTodo`, `readTodos`, `updateTodoById`, and `deleteTodoById` in `app/dashboard/todo/actions/index.ts` using the Supabase server client and returning a consistent `TodoActionResult` shape with ownership checks on `author_id` and `revalidatePath('/dashboard/todo')` after mutations.
- Updated server/client types with `TodoRecord` and added explicit error/success handling for DB failures and not-found cases.
- Updated UI callers to await server actions and explicitly handle success/error flows with toasts and `router.refresh()` in `app/dashboard/todo/components/{CreateForm,TodoForm,ListOfTodo,EditTodo}` and added a client `DeleteTodoButton` component wired to `deleteTodoById` for deletion UX.
- Added unit tests in `tests/app/dashboard/todo/actions.test.ts` to cover create/read/update/delete and unauthorized access, and adjusted `tests/components/dashboard-members-todo-visual-states.test.tsx` to mock `next/navigation` for `router.refresh()`.

### Testing
- Ran the focused test suite with `pnpm vitest run tests/app/dashboard/todo/actions.test.ts tests/components/dashboard-members-todo-visual-states.test.tsx` and all tests passed.
- Ran type checking with `pnpm typecheck` (`tsc --noEmit`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59de37b8c8328b3578e1a935afdde)