### PR TITLE
Unify canonical role typing across auth and dashboard members

### DIFF
--- a/app/dashboard/(dashboard)/types.ts
+++ b/app/dashboard/(dashboard)/types.ts
@@ -1,3 +1,5 @@
+import type { AppRole } from "@/lib/roles"
+
 export type WelcomeMessage = {
   title: string
   subtitle: string
@@ -74,7 +76,7 @@ export type MaintenanceTicket = {
 export type FloorplanRoommate = {
   id: string
   name: string
-  role: "tenant" | "roommate" | "property_manager" | "admin" | "user"
+  role: AppRole
 }
 
 export type FloorplanAnnotation = {
@@ -109,7 +111,7 @@ export type FloorplanWorkspace = {
   svgMarkup: string
   currentVersion: number
   currentUserId: string
-  currentUserRole: "tenant" | "roommate" | "property_manager" | "admin" | "user"
+  currentUserRole: AppRole
   roommates: FloorplanRoommate[]
   annotations: FloorplanAnnotation[]
   annotationHistory: FloorplanAnnotationVersion[]

--- a/app/dashboard/members/components/LegacyMemberTable.tsx
+++ b/app/dashboard/members/components/LegacyMemberTable.tsx
@@ -11,8 +11,8 @@ const LEGACY_MEMBERS: DashboardMember[] = [
     status: "active",
   },
   {
-    name: "Non Admin User",
-    role: "user",
+    name: "Tenant Member",
+    role: "tenant",
     createdAt: new Date().toDateString(),
     status: "active",
   },
@@ -24,7 +24,7 @@ const LEGACY_MEMBERS: DashboardMember[] = [
   },
   {
     name: "Satoshi",
-    role: "user",
+    role: "roommate",
     createdAt: new Date().toDateString(),
     status: "active",
   },

--- a/app/dashboard/members/components/ListOfMembers.tsx
+++ b/app/dashboard/members/components/ListOfMembers.tsx
@@ -30,7 +30,12 @@ export default function ListOfMembers({
   return (
     <tbody>
       {members.map((member, index) => {
-        const roleTone = member.role === "admin" ? "success" : "warning"
+        const roleTone =
+          member.role === "admin"
+            ? "success"
+            : member.role === "property_manager"
+              ? "warning"
+              : "neutral"
         const statusTone = member.status === "active" ? "success" : "danger"
 
         return (

--- a/app/dashboard/members/components/create/CreateForm.tsx
+++ b/app/dashboard/members/components/create/CreateForm.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
 import { DashboardSubmitButton } from "@/app/dashboard/components/dashboard-submit-button"
+import { CANONICAL_ROLES } from "@/lib/roles"
 
 import { createMember } from "../../actions"
 
@@ -31,7 +32,7 @@ const FormSchema = z
     name: z.string().min(2, {
       message: "Username must be at least 2 characters.",
     }),
-    role: z.enum(["user", "admin"]),
+    role: z.enum(CANONICAL_ROLES),
     status: z.enum(["active", "resigned"]),
     email: z.string().email(),
     password: z.string().min(6, { message: "Password should be 6 characters" }),
@@ -43,14 +44,14 @@ const FormSchema = z
   })
 
 export default function MemberForm() {
-  const roles = ["admin", "user"]
+  const roles = CANONICAL_ROLES
   const status = ["active", "resigned"]
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       name: "",
-      role: "user",
+      role: "tenant",
       status: "active",
       email: "",
       password: "",

--- a/app/dashboard/members/components/edit/AdvanceForm.tsx
+++ b/app/dashboard/members/components/edit/AdvanceForm.tsx
@@ -22,20 +22,21 @@ import {
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
 import { DashboardSubmitButton } from "@/app/dashboard/components/dashboard-submit-button"
+import { CANONICAL_ROLES } from "@/lib/roles"
 
 const FormSchema = z.object({
-  role: z.enum(["admin", "user"]),
+  role: z.enum(CANONICAL_ROLES),
   status: z.enum(["active", "resigned"]),
 })
 
 export default function AdvanceForm() {
-  const roles = ["admin", "user"]
+  const roles = CANONICAL_ROLES
   const status = ["active", "resigned"]
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      role: "user",
+      role: "tenant",
       status: "active",
     },
   })

--- a/app/dashboard/members/data.ts
+++ b/app/dashboard/members/data.ts
@@ -2,9 +2,11 @@ import "server-only"
 
 import { cache } from "react"
 
+import type { AppRole } from "@/lib/roles"
+
 export type DashboardMember = {
         name: string
-        role: "admin" | "user"
+        role: AppRole
         createdAt: string
         status: "active" | "resigned"
 }
@@ -23,20 +25,20 @@ export const getDashboardMembers = cache(async (): Promise<DashboardMember[]> =>
                         status: "active",
                 },
                 {
-                        name: "Non Admin User",
-                        role: "user",
+                        name: "Tenant Member",
+                        role: "tenant",
                         createdAt: new Date().toDateString(),
                         status: "active",
                 },
                 {
-                        name: "Administrator",
-                        role: "admin",
+                        name: "Property Manager",
+                        role: "property_manager",
                         createdAt: new Date().toDateString(),
                         status: "resigned",
                 },
                 {
-                        name: "Satoshi",
-                        role: "user",
+                        name: "Roommate Member",
+                        role: "roommate",
                         createdAt: new Date().toDateString(),
                         status: "active",
                 },

--- a/config/navigation.ts
+++ b/config/navigation.ts
@@ -1,6 +1,7 @@
 import type { MainNavItem, SidebarNavItem } from "@/types/nav"
+import type { AppRole as PortalRole } from "@/lib/roles"
 
-export type PortalRole = "tenant" | "roommate" | "property_manager" | "admin"
+export type { PortalRole }
 export type NavTree = "public" | "tenant" | "property_manager" | "admin"
 export type NavigationDomain = "core" | "operations" | "account"
 

--- a/lib/auth-rbac.ts
+++ b/lib/auth-rbac.ts
@@ -1,9 +1,7 @@
 import type { SupabaseClient, User } from '@supabase/supabase-js'
 
+import { migrateLegacyRole, type AppRole } from '@/lib/roles'
 import type { Database } from '@/lib/supabase'
-
-export const APP_ROLES = ['tenant', 'roommate', 'property_manager', 'admin', 'user'] as const
-export type AppRole = (typeof APP_ROLES)[number]
 
 export const PUBLIC_ROUTE_PREFIXES = ['/auth', '/about', '/contact', '/error']
 export const PUBLIC_EXACT_ROUTES = ['/', '/favicon.ico']
@@ -26,11 +24,7 @@ const ROLE_ROUTE_RULES: Array<{ prefix: string; allowed: AppRole[] }> = [
 ]
 
 function coerceRole(value: unknown): AppRole | null {
-  if (typeof value !== 'string') {
-    return null
-  }
-
-  return (APP_ROLES as readonly string[]).includes(value) ? (value as AppRole) : null
+  return migrateLegacyRole(value)
 }
 
 export async function resolveSessionRole(
@@ -46,7 +40,7 @@ export async function resolveSessionRole(
     coerceRole(user.user_metadata?.role) ??
     coerceRole((user as User & { role?: unknown }).role)
 
-  if (claimedRole && claimedRole !== 'user') {
+  if (claimedRole) {
     return claimedRole
   }
 

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -3,9 +3,10 @@ import 'server-only'
 import { redirect } from 'next/navigation'
 
 import { fetchMemberRole } from '@/lib/data/members'
+import { migrateLegacyRole, type AppRole } from '@/lib/roles'
 import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
 
-export const PRIVILEGED_ROLES = ['property_manager', 'admin'] as const
+export const PRIVILEGED_ROLES: AppRole[] = ['property_manager', 'admin']
 
 export async function requirePrivilegedAccess() {
   const supabase = await createSupbaseServerClientReadOnly()
@@ -17,9 +18,9 @@ export async function requirePrivilegedAccess() {
     redirect('/auth')
   }
 
-  const role = await fetchMemberRole(supabase as any, user.id)
+  const role = migrateLegacyRole(await fetchMemberRole(supabase as any, user.id))
 
-  if (!role || !PRIVILEGED_ROLES.includes(role as (typeof PRIVILEGED_ROLES)[number])) {
+  if (!role || !PRIVILEGED_ROLES.includes(role)) {
     redirect('/dashboard')
   }
 

--- a/lib/floorplan-permissions.ts
+++ b/lib/floorplan-permissions.ts
@@ -1,3 +1,5 @@
+import type { AppRole } from "@/lib/roles"
+
 export type FloorplanMarkerType = "room" | "storage" | "chore"
 
 export type FloorplanVisibilityScope =
@@ -5,12 +7,7 @@ export type FloorplanVisibilityScope =
   | "selected_roommates"
   | "private"
 
-export type FloorplanRole =
-  | "tenant"
-  | "roommate"
-  | "property_manager"
-  | "admin"
-  | "user"
+export type FloorplanRole = AppRole
 
 export type FloorplanAnnotation = {
   id: string
@@ -31,7 +28,6 @@ const roleMarkerPermissions: Record<FloorplanRole, FloorplanMarkerType[]> = {
   roommate: ["storage", "chore"],
   property_manager: ["room", "storage", "chore"],
   admin: ["room", "storage", "chore"],
-  user: ["chore"],
 }
 
 export function getAllowedMarkerTypes(role: FloorplanRole): FloorplanMarkerType[] {

--- a/lib/role-cues.ts
+++ b/lib/role-cues.ts
@@ -1,4 +1,5 @@
 import type { PortalRole } from "@/config/navigation"
+import { migrateLegacyRole } from "@/lib/roles"
 
 const ROLE_LABELS: Record<PortalRole, string> = {
   tenant: "Tenant",
@@ -24,16 +25,7 @@ export type RoleCue = {
 export function normalizePortalRole(
   role: string | null | undefined
 ): PortalRole {
-  if (
-    role === "tenant" ||
-    role === "roommate" ||
-    role === "property_manager" ||
-    role === "admin"
-  ) {
-    return role
-  }
-
-  return "tenant"
+  return migrateLegacyRole(role) ?? "tenant"
 }
 
 export function getRoleCue(role: string | null | undefined): RoleCue {

--- a/lib/roles.ts
+++ b/lib/roles.ts
@@ -1,0 +1,29 @@
+export const CANONICAL_ROLES = ['tenant', 'roommate', 'property_manager', 'admin'] as const
+export type AppRole = (typeof CANONICAL_ROLES)[number]
+
+export const LEGACY_ROLE_MIGRATION_MAP = {
+  user: 'tenant',
+} as const
+
+export type LegacyAppRole = keyof typeof LEGACY_ROLE_MIGRATION_MAP
+export type KnownAppRole = AppRole | LegacyAppRole
+
+export function isCanonicalRole(value: unknown): value is AppRole {
+  return typeof value === 'string' && (CANONICAL_ROLES as readonly string[]).includes(value)
+}
+
+export function migrateLegacyRole(value: unknown): AppRole | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  if (isCanonicalRole(value)) {
+    return value
+  }
+
+  if (value in LEGACY_ROLE_MIGRATION_MAP) {
+    return LEGACY_ROLE_MIGRATION_MAP[value as LegacyAppRole]
+  }
+
+  return null
+}

--- a/tests/auth-rbac.test.ts
+++ b/tests/auth-rbac.test.ts
@@ -62,4 +62,18 @@ describe('resolveSessionRole', () => {
     expect(eq).toHaveBeenCalledWith('id', 'user-1')
     expect(maybeSingle).toHaveBeenCalled()
   })
+
+  it('maps legacy user role to canonical tenant role', async () => {
+    const supabase = {
+      from: vi.fn(),
+    }
+
+    const role = await resolveSessionRole(supabase as any, {
+      app_metadata: { role: 'user' },
+      user_metadata: {},
+    } as any)
+
+    expect(role).toBe('tenant')
+    expect(supabase.from).not.toHaveBeenCalled()
+  })
 })

--- a/tests/components/dashboard-members-todo-visual-states.test.tsx
+++ b/tests/components/dashboard-members-todo-visual-states.test.tsx
@@ -41,7 +41,7 @@ describe("dashboard members/todo visual states", () => {
             },
             {
               name: "Former",
-              role: "user",
+              role: "tenant",
               createdAt: "Yesterday",
               status: "resigned",
             },

--- a/tests/lib/roles.test.ts
+++ b/tests/lib/roles.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CANONICAL_ROLES,
+  isCanonicalRole,
+  migrateLegacyRole,
+} from '@/lib/roles'
+
+describe('roles helpers', () => {
+  it('exposes canonical portal roles', () => {
+    expect(CANONICAL_ROLES).toEqual(['tenant', 'roommate', 'property_manager', 'admin'])
+  })
+
+  it('recognizes canonical roles only', () => {
+    expect(isCanonicalRole('tenant')).toBe(true)
+    expect(isCanonicalRole('user')).toBe(false)
+    expect(isCanonicalRole('unknown')).toBe(false)
+  })
+
+  it('maps legacy roles through explicit migration path', () => {
+    expect(migrateLegacyRole('user')).toBe('tenant')
+    expect(migrateLegacyRole('admin')).toBe('admin')
+    expect(migrateLegacyRole('unknown')).toBeNull()
+  })
+})


### PR DESCRIPTION
### Motivation
- Centralise the app's role union to avoid divergent role definitions and accidental use of legacy values like `user`.
- Provide an explicit migration path for legacy role values so existing profiles can be normalised during the transition.
- Ensure UI, RBAC helpers and domain typing consume a single source of truth for roles to reduce runtime checks and type churn.

### Description
- Add a shared `lib/roles.ts` that exposes `CANONICAL_ROLES`, the `AppRole` type, `isCanonicalRole`, and `migrateLegacyRole` with an explicit mapping `user -> tenant`.
- Update `lib/auth-rbac.ts` and `lib/authz.ts` to use the shared role helpers and to normalise legacy values via `migrateLegacyRole` before making authorization decisions.
- Migrate dashboard/member code to canonical roles by updating `app/dashboard/members/data.ts`, `ListOfMembers.tsx`, `LegacyMemberTable.tsx`, `create/CreateForm.tsx`, and `edit/AdvanceForm.tsx` to use `CANONICAL_ROLES`/`AppRole` and default to `tenant` where appropriate.
- Replace ad-hoc role unions across domain types (floorplan/workspace types and `lib/floorplan-permissions.ts`) to use the shared `AppRole` type and remove implicit `user` handling.
- Update role normalisation used by the UI (`lib/role-cues.ts`) to call the central `migrateLegacyRole`, and re-export `PortalRole` from `config/navigation.ts` so navigation and role helpers align on the same type.
- Add unit tests for the roles helpers and update existing tests to expect canonical roles (new `tests/lib/roles.test.ts` and updates to `tests/auth-rbac.test.ts` and dashboard visual tests).

### Testing
- Ran targeted unit/test suite via `pnpm test -- tests/auth-rbac.test.ts tests/lib/roles.test.ts tests/components/dashboard-members-todo-visual-states.test.tsx tests/lib/role-cues.test.ts tests/lib/floorplan-permissions.test.ts` and observed success; the full test run reports all tests passed (`29 files`, `114 tests` passed).
- Ran static type checking with `pnpm typecheck` (`tsc --noEmit`) and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59de6ed848328b623422fb4f0b8b5)