### PR TITLE
Refactor operations data to Supabase-backed queries

### DIFF
--- a/lib/operations/data.ts
+++ b/lib/operations/data.ts
@@ -2,6 +2,8 @@ import 'server-only'
 
 import { unstable_cache, unstable_noStore } from 'next/cache'
 
+import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+
 type KpiModule = {
   id: 'payments' | 'maintenance' | 'bookings' | 'moderation'
   title: string
@@ -68,36 +70,6 @@ export type PaginatedResult<T> = {
   totalPages: number
 }
 
-const financeRows: FinanceRow[] = [
-  { payment_id: 'pay_1001', tenant: 'Jordan Reed', unit: '3B', amount: 1260, status: 'succeeded', processed_at: '2025-02-01T09:10:00.000Z' },
-  { payment_id: 'pay_1002', tenant: 'Avery Stone', unit: '2A', amount: 980, status: 'failed', processed_at: '2025-02-03T11:00:00.000Z' },
-  { payment_id: 'pay_1003', tenant: 'Sam Lee', unit: '3B', amount: 1260, status: 'pending', processed_at: '2025-02-04T14:30:00.000Z' },
-]
-
-const maintenanceRows: MaintenanceRow[] = [
-  { request_id: 'mnt_201', title: 'Leaky kitchen faucet', priority: 'high', status: 'in_progress', unit: '3B', updated_at: '2025-02-05T08:15:00.000Z' },
-  { request_id: 'mnt_202', title: 'Hallway light outage', priority: 'normal', status: 'pending', unit: '2A', updated_at: '2025-02-05T09:45:00.000Z' },
-  { request_id: 'mnt_203', title: 'AC filter replacement', priority: 'low', status: 'completed', unit: '1C', updated_at: '2025-02-03T12:20:00.000Z' },
-]
-
-const bookingRows: BookingRow[] = [
-  { booking_id: 'bk_301', amenity: 'Kitchen', unit: '3B', status: 'confirmed', start_time: '2025-02-07T18:00:00.000Z', end_time: '2025-02-07T19:30:00.000Z' },
-  { booking_id: 'bk_302', amenity: 'Parking Spot 2', unit: '2A', status: 'pending', start_time: '2025-02-08T20:00:00.000Z', end_time: '2025-02-09T08:00:00.000Z' },
-  { booking_id: 'bk_303', amenity: 'TV Room', unit: '1C', status: 'cancelled', start_time: '2025-02-06T21:00:00.000Z', end_time: '2025-02-06T22:00:00.000Z' },
-]
-
-const moderationRows: ModerationRow[] = [
-  { message_id: 'msg_401', thread: 'Quiet hours policy', author: 'Taylor Kim', flag_reason: 'Harassment', status: 'open', created_at: '2025-02-05T10:30:00.000Z' },
-  { message_id: 'msg_402', thread: 'Parking swap request', author: 'Chris Park', flag_reason: 'Spam', status: 'resolved', created_at: '2025-02-04T16:40:00.000Z' },
-  { message_id: 'msg_403', thread: 'Maintenance updates', author: 'Jamie Fox', flag_reason: 'Abusive language', status: 'open', created_at: '2025-02-05T12:00:00.000Z' },
-]
-
-const visitorRows: VisitorRow[] = [
-  { visitor_id: 'vis_501', guest_name: 'Nina Ortiz', host: 'Jordan Reed', status: 'approved', check_in_date: '2025-02-09', check_out_date: '2025-02-11' },
-  { visitor_id: 'vis_502', guest_name: 'Luis Grant', host: 'Avery Stone', status: 'pending', check_in_date: '2025-02-10', check_out_date: '2025-02-10' },
-  { visitor_id: 'vis_503', guest_name: 'Mia Wong', host: 'Sam Lee', status: 'completed', check_in_date: '2025-02-01', check_out_date: '2025-02-03' },
-]
-
 function paginateRows<T>(rows: T[], options: PaginationOptions = {}): PaginatedResult<T> {
   const pageSize = Number.isFinite(options.pageSize) ? Math.min(Math.max(options.pageSize ?? 20, 1), 100) : 20
   const totalRows = rows.length
@@ -116,11 +88,215 @@ function paginateRows<T>(rows: T[], options: PaginationOptions = {}): PaginatedR
   }
 }
 
+async function fetchProfilesMap(userIds: string[]) {
+  if (userIds.length === 0) return new Map<string, { full_name: string | null; unit_id: string | null }>()
+
+  const supabase = await createSupbaseServerClientReadOnly()
+  const { data } = await (supabase as any)
+    .from('profiles')
+    .select('id, full_name, unit_id')
+    .in('id', userIds)
+
+  return new Map<string, { full_name: string | null; unit_id: string | null }>(
+    ((data ?? []) as Array<{ id: string; full_name: string | null; unit_id: string | null }>).map((profile) => [
+      profile.id,
+      { full_name: profile.full_name, unit_id: profile.unit_id },
+    ])
+  )
+}
+
+function normalizePaymentStatus(status: string | null): FinanceRow['status'] {
+  if (status === 'succeeded' || status === 'completed') return 'succeeded'
+  if (status === 'failed' || status === 'cancelled') return 'failed'
+  return 'pending'
+}
+
+async function fetchFinanceRows(): Promise<FinanceRow[]> {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const { data } = await (supabase as any)
+    .from('rent_payments')
+    .select('id, amount, status, processed_at, created_at, payer_name, user_id, tenant_id, unit, unit_id')
+
+  const payments = (data ?? []) as Array<{
+    id: string
+    amount: number | null
+    status: string | null
+    processed_at: string | null
+    created_at: string | null
+    payer_name: string | null
+    user_id: string | null
+    tenant_id: string | null
+    unit: string | null
+    unit_id: string | null
+  }>
+
+  const userIds = Array.from(new Set(payments.flatMap((payment) => [payment.tenant_id, payment.user_id]).filter(Boolean) as string[]))
+  const profiles = await fetchProfilesMap(userIds)
+
+  return payments
+    .map((payment) => {
+      const actorId = payment.tenant_id ?? payment.user_id ?? ''
+      const profile = profiles.get(actorId)
+      const processedAt = payment.processed_at ?? payment.created_at ?? new Date(0).toISOString()
+
+      return {
+        payment_id: payment.id,
+        tenant: payment.payer_name ?? profile?.full_name ?? 'Unknown tenant',
+        unit: payment.unit ?? payment.unit_id ?? profile?.unit_id ?? 'Unknown unit',
+        amount: Number(payment.amount ?? 0),
+        status: normalizePaymentStatus(payment.status),
+        processed_at: processedAt,
+      }
+    })
+    .sort((a, b) => new Date(b.processed_at).getTime() - new Date(a.processed_at).getTime())
+}
+
+async function fetchMaintenanceRows(): Promise<MaintenanceRow[]> {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const { data } = await (supabase as any)
+    .from('maintenance_requests')
+    .select('id, title, priority, status, unit_label, unit_id, updated_at, created_at')
+
+  return ((data ?? []) as Array<{
+    id: string
+    title: string
+    priority: MaintenanceRow['priority']
+    status: MaintenanceRow['status'] | 'cancelled'
+    unit_label: string | null
+    unit_id: string | null
+    updated_at: string | null
+    created_at: string | null
+  }>)
+    .filter((row) => row.status !== 'cancelled')
+    .map((row) => ({
+      request_id: row.id,
+      title: row.title,
+      priority: row.priority,
+      status: row.status as MaintenanceRow['status'],
+      unit: row.unit_label ?? row.unit_id ?? 'Unknown unit',
+      updated_at: row.updated_at ?? row.created_at ?? new Date(0).toISOString(),
+    }))
+    .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+}
+
+async function fetchBookingRows(): Promise<BookingRow[]> {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const { data } = await (supabase as any)
+    .from('bookings')
+    .select('id, amenity_name, tenant_id, status, start_time, end_time')
+
+  const bookings = (data ?? []) as Array<{
+    id: string
+    amenity_name: string
+    tenant_id: string | null
+    status: BookingRow['status']
+    start_time: string
+    end_time: string
+  }>
+
+  const tenantIds = Array.from(new Set(bookings.map((booking) => booking.tenant_id).filter(Boolean) as string[]))
+  const profiles = await fetchProfilesMap(tenantIds)
+
+  return bookings
+    .map((booking) => ({
+      booking_id: booking.id,
+      amenity: booking.amenity_name,
+      unit: (booking.tenant_id ? profiles.get(booking.tenant_id)?.unit_id : null) ?? 'Unknown unit',
+      status: booking.status,
+      start_time: booking.start_time,
+      end_time: booking.end_time,
+    }))
+    .sort((a, b) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime())
+}
+
+async function fetchModerationRows(): Promise<ModerationRow[]> {
+  const supabase = await createSupbaseServerClientReadOnly()
+
+  const [{ data: threads }, { data: messages }] = await Promise.all([
+    (supabase as any).from('threads').select('id, title, activity, flagged_at, deleted_at'),
+    (supabase as any).from('messages').select('id, thread_id, author_name, created_at'),
+  ])
+
+  const flaggedThreads = new Map<string, { title: string; activity: string | null; resolved: boolean }>(
+    ((threads ?? []) as Array<{
+      id: string
+      title: string
+      activity: string | null
+      flagged_at: string | null
+      deleted_at: string | null
+    }>)
+      .filter((thread) => Boolean(thread.flagged_at))
+      .map((thread) => [thread.id, { title: thread.title, activity: thread.activity, resolved: Boolean(thread.deleted_at) }])
+  )
+
+  return ((messages ?? []) as Array<{
+    id: string
+    thread_id: string
+    author_name: string | null
+    created_at: string
+  }>)
+    .filter((message) => flaggedThreads.has(message.thread_id))
+    .map((message) => {
+      const thread = flaggedThreads.get(message.thread_id)!
+      return {
+        message_id: message.id,
+        thread: thread.title,
+        author: message.author_name ?? 'Unknown author',
+        flag_reason: thread.activity ?? 'Flagged thread activity',
+        status: (thread.resolved ? 'resolved' : 'open') as ModerationRow['status'],
+        created_at: message.created_at,
+      }
+    })
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+}
+
+async function fetchVisitorRows(): Promise<VisitorRow[]> {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const { data } = await (supabase as any)
+    .from('visitor_logs')
+    .select('id, guest_name, host_id, status, check_in_date, check_out_date, created_at')
+
+  const visitors = (data ?? []) as Array<{
+    id: string
+    guest_name: string
+    host_id: string
+    status: VisitorRow['status']
+    check_in_date: string
+    check_out_date: string
+    created_at: string | null
+  }>
+
+  const hostIds = Array.from(new Set(visitors.map((visitor) => visitor.host_id).filter(Boolean) as string[]))
+  const profiles = await fetchProfilesMap(hostIds)
+
+  return visitors
+    .map((visitor) => ({
+      visitor_id: visitor.id,
+      guest_name: visitor.guest_name,
+      host: profiles.get(visitor.host_id)?.full_name ?? 'Unknown host',
+      status: visitor.status,
+      check_in_date: visitor.check_in_date,
+      check_out_date: visitor.check_out_date,
+    }))
+    .sort((a, b) => new Date(b.check_in_date).getTime() - new Date(a.check_in_date).getTime())
+}
+
 const getCachedOperationsKpis = unstable_cache(
   async (): Promise<KpiModule[]> => {
-    const successRate = Math.round((financeRows.filter((row) => row.status === 'succeeded').length / financeRows.length) * 100)
+    const [financeRows, maintenanceRows, bookingRows, moderationRows] = await Promise.all([
+      fetchFinanceRows(),
+      fetchMaintenanceRows(),
+      fetchBookingRows(),
+      fetchModerationRows(),
+    ])
+
+    const successRate = financeRows.length
+      ? Math.round((financeRows.filter((row) => row.status === 'succeeded').length / financeRows.length) * 100)
+      : 0
     const openMaintenance = maintenanceRows.filter((row) => row.status !== 'completed').length
-    const bookingUtilization = Math.round((bookingRows.filter((row) => row.status === 'confirmed').length / bookingRows.length) * 100)
+    const bookingUtilization = bookingRows.length
+      ? Math.round((bookingRows.filter((row) => row.status === 'confirmed').length / bookingRows.length) * 100)
+      : 0
     const unresolvedModeration = moderationRows.filter((row) => row.status === 'open').length
 
     return [
@@ -136,27 +312,31 @@ const getCachedOperationsKpis = unstable_cache(
 
 export const getOperationsKpis = async () => getCachedOperationsKpis()
 
-export async function getFinanceRows(options?: PaginationOptions) {
-  unstable_noStore()
-  return paginateRows(financeRows, options)
-}
-
-const getCachedMaintenanceRows = unstable_cache(async () => maintenanceRows, ['maintenance-rows'], {
+const getCachedFinanceRows = unstable_cache(async () => fetchFinanceRows(), ['finance-rows'], {
+  revalidate: 120,
+  tags: ['finance-rows'],
+})
+const getCachedMaintenanceRows = unstable_cache(async () => fetchMaintenanceRows(), ['maintenance-rows'], {
   revalidate: 300,
   tags: ['maintenance-rows'],
 })
-const getCachedBookingRows = unstable_cache(async () => bookingRows, ['booking-rows'], {
+const getCachedBookingRows = unstable_cache(async () => fetchBookingRows(), ['booking-rows'], {
   revalidate: 120,
   tags: ['booking-rows'],
 })
-const getCachedModerationRows = unstable_cache(async () => moderationRows, ['moderation-rows'], {
+const getCachedModerationRows = unstable_cache(async () => fetchModerationRows(), ['moderation-rows'], {
   revalidate: 120,
   tags: ['moderation-rows'],
 })
-const getCachedVisitorRows = unstable_cache(async () => visitorRows, ['visitor-rows'], {
+const getCachedVisitorRows = unstable_cache(async () => fetchVisitorRows(), ['visitor-rows'], {
   revalidate: 300,
   tags: ['visitor-rows'],
 })
+
+export async function getFinanceRows(options?: PaginationOptions) {
+  unstable_noStore()
+  return paginateRows(await getCachedFinanceRows(), options)
+}
 
 export async function getMaintenanceRows(options?: PaginationOptions) {
   return paginateRows(await getCachedMaintenanceRows(), options)
@@ -183,19 +363,27 @@ export async function getGlobalSearchResults(query: string) {
     }
   }
 
-  const allMaintenanceRows = await getCachedMaintenanceRows()
-  const allBookingRows = await getCachedBookingRows()
-  const allVisitorRows = await getCachedVisitorRows()
+  const [allFinanceRows, allMaintenanceRows, allBookingRows, allVisitorRows, documents] = await Promise.all([
+    getCachedFinanceRows(),
+    getCachedMaintenanceRows(),
+    getCachedBookingRows(),
+    getCachedVisitorRows(),
+    (async () => {
+      const supabase = await createSupbaseServerClientReadOnly()
+      const { data } = await (supabase as any).from('documents').select('id, title, status')
+      return (data ?? []) as Array<{ id: string; title: string; status: string }>
+    })(),
+  ])
 
   const tenants = Array.from(
-    new Set([...financeRows.map((row) => row.tenant), ...allVisitorRows.map((row) => row.host)])
+    new Set([...allFinanceRows.map((row) => row.tenant), ...allVisitorRows.map((row) => row.host)])
   )
     .filter((name) => name.toLowerCase().includes(q))
     .map((name) => ({ id: name.toLowerCase().replace(/\s+/g, '-'), name }))
 
   const units = Array.from(
     new Set([
-      ...financeRows.map((row) => row.unit),
+      ...allFinanceRows.map((row) => row.unit),
       ...allMaintenanceRows.map((row) => row.unit),
       ...allBookingRows.map((row) => row.unit),
     ])
@@ -207,17 +395,15 @@ export async function getGlobalSearchResults(query: string) {
     .filter((row) => row.title.toLowerCase().includes(q) || row.request_id.toLowerCase().includes(q))
     .map((row) => ({ id: row.request_id, title: row.title, status: row.status }))
 
-  const payments = financeRows
+  const payments = allFinanceRows
     .filter((row) => row.payment_id.toLowerCase().includes(q) || row.tenant.toLowerCase().includes(q))
     .map((row) => ({ id: row.payment_id, tenant: row.tenant, amount: row.amount, status: row.status }))
 
-  const documents = [
-    { id: 'doc_lease_3b', title: 'Lease Agreement - Unit 3B', status: 'signed' },
-    { id: 'doc_house_rules', title: 'House Rules - February', status: 'draft' },
-    { id: 'doc_notice_2a', title: 'Maintenance Notice - Unit 2A', status: 'pending_signature' },
-  ].filter((doc) => doc.title.toLowerCase().includes(q) || doc.id.toLowerCase().includes(q))
+  const matchingDocuments = documents.filter(
+    (doc) => doc.title.toLowerCase().includes(q) || doc.id.toLowerCase().includes(q)
+  )
 
-  return { tenants, units, requests, payments, documents }
+  return { tenants, units, requests, payments, documents: matchingDocuments }
 }
 
 export function toCsv<T extends Record<string, unknown>>(rows: T[]) {

--- a/tests/integration/operations/data-pagination-csv.test.ts
+++ b/tests/integration/operations/data-pagination-csv.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: (...args: any[]) => any) => fn,
+  unstable_noStore: vi.fn(),
+}))
+
+type Row = Record<string, unknown>
+
+const seeded = {
+  rent_payments: [
+    {
+      id: 'pay_003',
+      amount: 1200,
+      status: 'pending',
+      processed_at: '2026-03-03T12:00:00.000Z',
+      created_at: '2026-03-03T12:00:00.000Z',
+      payer_name: null,
+      user_id: 'user-3',
+      tenant_id: null,
+      unit: null,
+      unit_id: null,
+    },
+    {
+      id: 'pay_002',
+      amount: 1200,
+      status: 'failed',
+      processed_at: '2026-03-02T12:00:00.000Z',
+      created_at: '2026-03-02T12:00:00.000Z',
+      payer_name: 'Avery Stone',
+      user_id: 'user-2',
+      tenant_id: null,
+      unit: '2A',
+      unit_id: null,
+    },
+    {
+      id: 'pay_001',
+      amount: 1260,
+      status: 'succeeded',
+      processed_at: '2026-03-01T12:00:00.000Z',
+      created_at: '2026-03-01T12:00:00.000Z',
+      payer_name: null,
+      user_id: 'user-1',
+      tenant_id: null,
+      unit: null,
+      unit_id: null,
+    },
+  ],
+  maintenance_requests: [
+    {
+      id: 'mnt_1',
+      title: 'Leaky faucet',
+      priority: 'high',
+      status: 'in_progress',
+      unit_label: '3B',
+      unit_id: null,
+      updated_at: '2026-03-04T00:00:00.000Z',
+      created_at: '2026-03-03T00:00:00.000Z',
+    },
+  ],
+  bookings: [],
+  threads: [],
+  messages: [],
+  visitor_logs: [],
+  documents: [],
+  profiles: [
+    { id: 'user-1', full_name: 'Jordan Reed', unit_id: '3B' },
+    { id: 'user-2', full_name: 'Avery Stone', unit_id: '2A' },
+    { id: 'user-3', full_name: 'Sam Lee', unit_id: '1C' },
+  ],
+} as const
+
+function createSupabaseStub() {
+  return {
+    from(table: keyof typeof seeded) {
+      const state: { selectedRows: Row[] } = {
+        selectedRows: [...(seeded[table] as unknown as Row[])],
+      }
+
+      const builder: any = {
+        select() {
+          return builder
+        },
+        in(column: string, values: string[]) {
+          state.selectedRows = state.selectedRows.filter((row) => values.includes(String(row[column] ?? '')))
+          return Promise.resolve({ data: state.selectedRows, error: null })
+        },
+        then(resolve: (value: { data: Row[]; error: null }) => unknown) {
+          return Promise.resolve(resolve({ data: state.selectedRows, error: null }))
+        },
+      }
+
+      return builder
+    },
+  }
+}
+
+vi.mock('@/utils/supaone', () => ({
+  createSupbaseServerClientReadOnly: vi.fn(async () => createSupabaseStub()),
+}))
+
+describe('operations data integration: pagination + csv', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('paginates live finance rows from seeded Supabase data', async () => {
+    const { getFinanceRows } = await import('@/lib/operations/data')
+
+    const page1 = await getFinanceRows({ page: 1, pageSize: 2 })
+    const page2 = await getFinanceRows({ page: 2, pageSize: 2 })
+
+    expect(page1.totalRows).toBe(3)
+    expect(page1.totalPages).toBe(2)
+    expect(page1.rows.map((row) => row.payment_id)).toEqual(['pay_003', 'pay_002'])
+    expect(page2.rows.map((row) => row.payment_id)).toEqual(['pay_001'])
+    expect(page2.rows[0]).toMatchObject({ tenant: 'Jordan Reed', unit: '3B' })
+  })
+
+  it('exports correctly escaped csv from seeded operations rows', async () => {
+    const { toCsv } = await import('@/lib/operations/data')
+
+    const csv = toCsv([
+      {
+        request_id: 'mnt_10',
+        title: 'Kitchen "sink" leak',
+        priority: 'urgent',
+        status: 'pending',
+        unit: '2A',
+        updated_at: '2026-03-04T00:00:00.000Z',
+      },
+    ])
+
+    expect(csv).toContain('request_id,title,priority,status,unit,updated_at')
+    expect(csv).toContain('"Kitchen ""sink"" leak"')
+  })
+})


### PR DESCRIPTION
### Motivation
- Replace brittle hardcoded example rows with live data so operations dashboards, KPIs, search, and CSV exports reflect real Supabase state.

### Description
- Replaced static arrays in `lib/operations/data.ts` with Supabase reads for `rent_payments`, `maintenance_requests`, `bookings`, `threads`/`messages`, and `visitor_logs` while preserving the exported row types and pagination shape.
- Kept `paginateRows` and `toCsv` helpers and updated KPI computation to derive values from live query results via cached fetchers (`unstable_cache`).
- Updated global search to source `documents` from Supabase instead of hardcoded examples and used the new cached row fetchers for tenants/units/payments.
- Added integration tests at `tests/integration/operations/data-pagination-csv.test.ts` that mock a seeded Supabase client to validate pagination ordering and CSV escaping.

### Testing
- Ran `pnpm vitest run tests/integration/operations/data-pagination-csv.test.ts` and the new integration tests passed (2 tests).
- Ran `pnpm typecheck` (`tsc --noEmit`) to ensure types remained correct and the codebase typechecks successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59de612fc8328905fad9f28d743a3)