### PR TITLE
Protect workspace routes by default and add middleware auth tests

### DIFF
--- a/lib/auth-rbac.ts
+++ b/lib/auth-rbac.ts
@@ -5,21 +5,16 @@ import type { Database } from '@/lib/supabase'
 export const APP_ROLES = ['tenant', 'roommate', 'property_manager', 'admin', 'user'] as const
 export type AppRole = (typeof APP_ROLES)[number]
 
-export const PUBLIC_ROUTE_PREFIXES = ['/auth', '/about', '/contact', '/error']
-export const PUBLIC_EXACT_ROUTES = ['/', '/favicon.ico']
-
-const AUTHENTICATED_ROUTE_PREFIXES = [
-  '/dashboard',
-  '/payments',
-  '/documents',
-  '/bookings',
-  '/messaging',
-  '/maintenance',
-  '/visitors',
-  '/schedule',
-  '/account',
-  '/private',
+export const PUBLIC_ROUTE_PREFIXES = [
+  '/auth',
+  '/about',
+  '/contact',
+  '/error',
+  '/terms',
+  '/privacy',
+  '/data-retention',
 ]
+export const PUBLIC_EXACT_ROUTES = ['/', '/favicon.ico']
 
 const ROLE_ROUTE_RULES: Array<{ prefix: string; allowed: AppRole[] }> = [
   { prefix: '/dashboard/members', allowed: ['property_manager', 'admin'] },
@@ -73,9 +68,9 @@ export function isPublicRoute(pathname: string): boolean {
 }
 
 export function requiresAuthentication(pathname: string): boolean {
-  return AUTHENTICATED_ROUTE_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
-  )
+  // Routing policy: every app page is authenticated by default unless explicitly listed as public above.
+  // Add new legal/marketing pages to PUBLIC_* lists so workspace routes like /chores and /supplies stay protected.
+  return !isPublicRoute(pathname)
 }
 
 export function isRouteAllowedForRole(pathname: string, role: AppRole | null): boolean {

--- a/tests/auth-rbac.test.ts
+++ b/tests/auth-rbac.test.ts
@@ -18,7 +18,10 @@ describe('auth RBAC route helpers', () => {
     expect(requiresAuthentication('/dashboard')).toBe(true)
     expect(requiresAuthentication('/payments/history')).toBe(true)
     expect(requiresAuthentication('/visitors')).toBe(true)
+    expect(requiresAuthentication('/chores')).toBe(true)
+    expect(requiresAuthentication('/supplies')).toBe(true)
     expect(requiresAuthentication('/about')).toBe(false)
+    expect(requiresAuthentication('/terms')).toBe(false)
   })
 
   it('enforces role restrictions for manager pages', () => {

--- a/tests/middleware-auth.test.ts
+++ b/tests/middleware-auth.test.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { middleware } from '@/middleware'
+
+const updateSessionMock = vi.fn()
+
+vi.mock('@/utils/supabase/middleware', () => ({
+  updateSession: (...args: unknown[]) => updateSessionMock(...args),
+}))
+
+describe('middleware auth protection', () => {
+  beforeEach(() => {
+    updateSessionMock.mockReset()
+  })
+
+  it('redirects unauthenticated chores requests to /auth', async () => {
+    updateSessionMock.mockResolvedValue({
+      supabase: {},
+      response: NextResponse.next(),
+      user: null,
+    })
+
+    const request = new NextRequest('http://localhost/chores')
+    const response = await middleware(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('http://localhost/auth?redirectTo=%2Fchores')
+  })
+
+  it('redirects unauthenticated supplies requests to /auth', async () => {
+    updateSessionMock.mockResolvedValue({
+      supabase: {},
+      response: NextResponse.next(),
+      user: null,
+    })
+
+    const request = new NextRequest('http://localhost/supplies')
+    const response = await middleware(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('http://localhost/auth?redirectTo=%2Fsupplies')
+  })
+
+  it('allows authenticated requests to continue', async () => {
+    updateSessionMock.mockResolvedValue({
+      supabase: {},
+      response: NextResponse.next(),
+      user: {
+        app_metadata: { role: 'tenant' },
+        user_metadata: {},
+      },
+    })
+
+    const request = new NextRequest('http://localhost/chores')
+    const response = await middleware(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+  })
+})


### PR DESCRIPTION
### Motivation
- Ensure workspace/tenant pages (e.g. `/chores`, `/supplies`) are protected by default so new sections do not accidentally bypass authentication. 
- Preserve intended public/legal pages (`/`, `/auth`, `/error`, `/terms`, `/privacy`, `/data-retention`) while switching to a denylist-style public routing policy.

### Description
- Switched auth gating in `lib/auth-rbac.ts` from an authenticated-prefix allowlist to a protected-by-default model by making `requiresAuthentication` return `!isPublicRoute(pathname)` and added an inline routing-policy comment. 
- Expanded `PUBLIC_ROUTE_PREFIXES` to include `/terms`, `/privacy`, and `/data-retention`. 
- Updated `tests/auth-rbac.test.ts` to assert `/chores` and `/supplies` require authentication and that legal pages remain public. 
- Added `tests/middleware-auth.test.ts` with middleware-focused tests that assert unauthenticated requests to `/chores` and `/supplies` are redirected to `/auth` with `redirectTo`, and that authenticated requests proceed.

### Testing
- Ran `pnpm vitest run tests/auth-rbac.test.ts tests/middleware-auth.test.ts` and both test files passed. 
- Test run summary: 2 test files succeeded, 8 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec43221f7c832891c7ae2610ffc37c)