### PR TITLE
Make support contact details configurable on contact page

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,61 +1,38 @@
-import React from "react";
 import SmartLink from "@/components/navigation/SmartLink"
-import { siteConfig } from '@/config/site'
-import { Icons } from '@/components/icons'
-import { cookies } from 'next/headers'
-import { Contact } from "@/components/forms/contact";
-import { createClient } from "@/utils/supa-server-actions";
-import { redirect } from "next/navigation";
-import { AiOutlineLoading3Quarters } from "react-icons/ai";
-import { type User } from '@supabase/supabase-js'
+import { Contact } from "@/components/forms/contact"
+import { Icons } from "@/components/icons"
+import { siteConfig } from "@/config/site"
 
-export default async function ContactPage() {
-  const cookieStore = cookies()
-  const supabase = createClient(cookieStore)  
+export default function ContactPage() {
+  const supportEmail = siteConfig.support.email
+  const supportPhone = siteConfig.support.phone
+  const supportPhoneHref = `tel:${supportPhone.replace(/[^\d+]/g, "")}`
 
-
-  const { data, error } = await supabase.auth.getUser()
-  if (error || !data?.user) {
-    redirect('/auth')
-  }
-
-
-         return (
-                        <div className="mt-10 px-2 lg:p-8">
-          <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
-            <div className="flex flex-col items-center space-y-2 text-center">
-      <SmartLink href="/auth" className="mb-8 inline-flex">
-        <span className="flex items-center space-x-2">
-          <Icons.logo className="size-6" />
-          <span className="inline-block font-bold">{siteConfig.name}</span>
-        </span>
-      </SmartLink>
-              <h1 className="text-2xl font-semibold tracking-tight">
-                Contact Us
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                Need help with the Share House Portal? Reach Alex Unni at{" "}
-                <a
-                  className="font-medium underline"
-                  href="mailto:alex@myunni.com"
-                >
-                  alex@myunni.com
-                </a>{" "}
-                or call{" "}
-                <a
-                  className="font-medium underline"
-                  href="tel:+14167063586"
-                >
-                  +1-416-706-3586
-                </a>
-                .
-              </p>
-            </div>
-                        <Contact/>
-                </div>
-               </div>
-        );
-
-
-
-  }
+  return (
+    <div className="mt-10 px-2 lg:p-8">
+      <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
+        <div className="flex flex-col items-center space-y-2 text-center">
+          <SmartLink href="/" className="mb-8 inline-flex">
+            <span className="flex items-center space-x-2">
+              <Icons.logo className="size-6" />
+              <span className="inline-block font-bold">{siteConfig.name}</span>
+            </span>
+          </SmartLink>
+          <h1 className="text-2xl font-semibold tracking-tight">Contact support</h1>
+          <p className="text-sm text-muted-foreground">
+            Need help with your household portal account? Reach our support team at{" "}
+            <a className="font-medium underline" href={`mailto:${supportEmail}`}>
+              {supportEmail}
+            </a>{" "}
+            or call{" "}
+            <a className="font-medium underline" href={supportPhoneHref}>
+              {supportPhone}
+            </a>
+            .
+          </p>
+        </div>
+        <Contact />
+      </div>
+    </div>
+  )
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -2,6 +2,9 @@ import { publicNav, roleNavigation } from "@/config/navigation"
 
 export type SiteConfig = typeof siteConfig
 
+const supportEmail = process.env.NEXT_PUBLIC_SUPPORT_EMAIL ?? "support@roomsily.com"
+const supportPhone = process.env.NEXT_PUBLIC_SUPPORT_PHONE ?? "+1-555-010-0000"
+
 export const siteConfig = {
   name: "Roomsily",
   description:
@@ -11,5 +14,9 @@ export const siteConfig = {
     login: "/auth",
     signup: "/onboarding",
     contact: "/contact",
+  },
+  support: {
+    email: supportEmail,
+    phone: supportPhone,
   },
 }

--- a/docs/engineering/environment-contract.md
+++ b/docs/engineering/environment-contract.md
@@ -17,6 +17,8 @@ This document defines the environment variables required to run **Share House Po
 | `NEXT_PUBLIC_SITE_URL` | Required | Required | Required | Site URL for auth callbacks and OAuth flows. |
 | `NEXT_PUBLIC_BASE_URL` | Required | Required | Required | API auth callback base URL. |
 | `VERCEL_URL` | Optional | Optional | Optional | Set automatically in Vercel previews/builds. |
+| `NEXT_PUBLIC_SUPPORT_EMAIL` | Optional | Recommended | Required | Public support email shown on `/contact`; falls back to `support@roomsily.com` when unset. |
+| `NEXT_PUBLIC_SUPPORT_PHONE` | Optional | Recommended | Required | Public support phone shown on `/contact`; falls back to `+1-555-010-0000` when unset. |
 | `NEXT_PUBLIC_SUPABASE_URL` | Required | Required | Required | Supabase project URL for public and server clients. Missing values trigger runtime configuration errors when Supabase clients initialize. |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Required | Required | Required | Public Supabase anon key. Can be replaced by `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`; if neither is set, initialization throws a configuration error. |
 | `SUPABASE_SERVICE_ROLE_KEY` | Required | Required | Required | Server-only key for privileged jobs/webhooks. |

--- a/tests/components/contact-page.test.tsx
+++ b/tests/components/contact-page.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/components/navigation/SmartLink", () => ({
+  default: ({ href, children, className }: { href: string; children: ReactNode; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock("@/components/forms/contact", () => ({
+  Contact: () => <div data-testid="contact-form">Contact form</div>,
+}))
+
+vi.mock("@/components/icons", () => ({
+  Icons: {
+    logo: ({ className }: { className?: string }) => <svg aria-hidden="true" className={className} />,
+  },
+}))
+
+vi.mock("@/config/site", () => ({
+  siteConfig: {
+    name: "Roomsily",
+    support: {
+      email: "configured-support@roomsily.test",
+      phone: "+1-222-333-4444",
+    },
+  },
+}))
+
+import ContactPage from "@/app/contact/page"
+
+describe("contact page support metadata", () => {
+  it("renders configured support contact details and removes legacy hardcoded copy", () => {
+    render(<ContactPage />)
+
+    expect(screen.getByText("configured-support@roomsily.test")).toBeInTheDocument()
+    expect(screen.getByText("+1-222-333-4444")).toBeInTheDocument()
+    expect(screen.queryByText("alex@myunni.com")).not.toBeInTheDocument()
+    expect(screen.queryByText("+1-416-706-3586")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Motivation
- Surface support contact information from configuration/env so the public support channel can be updated without code changes.
- Remove legacy hardcoded contact strings and simplify the contact page implementation to follow project conventions.
- Ensure the contact page's auth behavior is explicit: it should be public and reachable from public navigation.
- Document required env vars so deployments know how to configure support metadata.

### Description
- Added `support` fields to `siteConfig` in `config/site.ts` sourcing `NEXT_PUBLIC_SUPPORT_EMAIL` and `NEXT_PUBLIC_SUPPORT_PHONE` with safe defaults.
- Replaced `app/contact/page.tsx` implementation to render `siteConfig.support.email` and `siteConfig.support.phone`, normalized `tel:` link generation, and removed unused auth/server imports and forced redirect to `/auth` so the page is public.
- Added a component test `tests/components/contact-page.test.tsx` that asserts configured support contact details render and legacy hardcoded strings are absent.
- Updated `docs/engineering/environment-contract.md` to document the new `NEXT_PUBLIC_SUPPORT_EMAIL` and `NEXT_PUBLIC_SUPPORT_PHONE` entries and their fallback behavior.

### Testing
- Ran the component test with `pnpm test -- tests/components/contact-page.test.tsx`, which executed the Vitest suite; the new test passed and the full test run completed successfully (111 tests across 29 files passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4325c0888328b48242863d063c90)