### PR TITLE
Repurpose /about into tenant-focused Portal Help

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,65 +1,96 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Star, Zap, Shield } from "lucide-react"
 
 import { Contact } from "@/components/forms/contact"
 
+const quickStartSteps = [
+  {
+    title: "Complete onboarding",
+    description:
+      "Confirm your unit assignment, rent share, emergency contacts, and vehicle details so roommates and property managers can coordinate safely.",
+  },
+  {
+    title: "Set up rent payments",
+    description:
+      "Connect a payment method, enable autopay if needed, and review due dates and receipts from the Payments workspace.",
+  },
+  {
+    title: "Book shared amenities",
+    description:
+      "Reserve shared spaces like kitchen, TV room, parking, and computer stations while avoiding booking conflicts.",
+  },
+  {
+    title: "Track documents and requests",
+    description:
+      "Use Documents for lease files and signed agreements, and Maintenance for issue reporting and progress updates.",
+  },
+]
+
+const faqItems = [
+  {
+    question: "Who can see my requests and bookings?",
+    answer:
+      "Roommates in your unit and authorized property managers can view booking and request status needed for household coordination.",
+  },
+  {
+    question: "How do overnight guest limits work?",
+    answer:
+      "Visitor requests are validated against your property policy before submission and notify roommates plus property management.",
+  },
+  {
+    question: "Where do I find signed lease agreements?",
+    answer:
+      "Open the Documents area to view the latest signed lease files, previous versions, and compliance records.",
+  },
+]
+
 export default function AboutPage() {
   return (
-    <div className="container mx-auto px-4 py-12">
-      <section className="mb-16 text-center">
-        <h1 className="mb-4 text-4xl font-bold">About Our Company</h1>
-        <p className="text-xl text-muted-foreground">
-          We&#39;re on a mission to revolutionize the industry with innovative solutions.
+    <div className="container mx-auto space-y-10 px-4 py-12">
+      <section className="space-y-3">
+        <h1 className="text-4xl font-bold">Portal Help</h1>
+        <p className="max-w-3xl text-muted-foreground">
+          Use this guide to get started with rent, amenity bookings, documents, and roommate coordination in the Share House
+          Portal.
         </p>
       </section>
 
-      <section className="mb-16">
-        <h2 className="mb-8 text-center text-2xl font-semibold">Our Team</h2>
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {teamMembers.map((member) => (
-            <div key={member.name}>
-              <Card>
-                <CardHeader className="text-center">
-                  <Avatar className="mx-auto mb-4 size-24">
-                    <AvatarImage src={member.avatar} alt={member.name} />
-                    <AvatarFallback>
-                      {member.name
-                        .split(" ")
-                        .map((n) => n[0])
-                        .join("")}
-                    </AvatarFallback>
-                  </Avatar>
-                  <CardTitle>{member.name}</CardTitle>
-                  <CardDescription>{member.role}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-center">{member.bio}</p>
-                </CardContent>
-              </Card>
-            </div>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">How it works</h2>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {quickStartSteps.map((step) => (
+            <Card key={step.title}>
+              <CardHeader>
+                <CardTitle>{step.title}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{step.description}</p>
+              </CardContent>
+            </Card>
           ))}
         </div>
       </section>
 
-      <section className="mb-16">
-        <h2 className="mb-8 text-center text-2xl font-semibold">Our Values</h2>
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
-          {values.map((value) => (
-            <div key={value.title} className="text-center">
-              <div className="mb-4">{value.icon}</div>
-              <h3 className="mb-2 text-xl font-semibold">{value.title}</h3>
-              <p className="text-muted-foreground">{value.description}</p>
-            </div>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Frequently asked questions</h2>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {faqItems.map((item) => (
+            <Card key={item.question}>
+              <CardHeader>
+                <CardTitle className="text-lg">{item.question}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{item.answer}</p>
+              </CardContent>
+            </Card>
           ))}
         </div>
       </section>
 
-      <section className="mb-16">
+      <section>
         <Card>
           <CardHeader>
-            <CardTitle className="mb-4 text-2xl font-semibold">Contact Us</CardTitle>
-            <CardDescription>Have questions? Get in touch with our team.</CardDescription>
+            <CardTitle>Need more help?</CardTitle>
+            <CardDescription>Contact property support for account, billing, or booking issues.</CardDescription>
           </CardHeader>
           <CardContent>
             <Contact />
@@ -69,42 +100,3 @@ export default function AboutPage() {
     </div>
   )
 }
-
-const teamMembers = [
-  {
-    name: "Jane Doe",
-    role: "CEO & Founder",
-    bio: "Visionary leader with 15+ years of experience in tech innovation.",
-    avatar: "/placeholder.svg?height=100&width=100",
-  },
-  {
-    name: "John Smith",
-    role: "CTO",
-    bio: "Tech guru passionate about creating cutting-edge solutions.",
-    avatar: "/placeholder.svg?height=100&width=100",
-  },
-  {
-    name: "Emily Brown",
-    role: "Head of Design",
-    bio: "Creative mind behind our stunning user interfaces and experiences.",
-    avatar: "/placeholder.svg?height=100&width=100",
-  },
-]
-
-const values = [
-  {
-    title: "Innovation",
-    description: "We constantly push boundaries to create groundbreaking solutions.",
-    icon: <Star className="mx-auto size-12 text-primary" />,
-  },
-  {
-    title: "Efficiency",
-    description: "We optimize our processes to deliver results quickly and effectively.",
-    icon: <Zap className="mx-auto size-12 text-primary" />,
-  },
-  {
-    title: "Integrity",
-    description: "We uphold the highest standards of honesty and transparency in all we do.",
-    icon: <Shield className="mx-auto size-12 text-primary" />,
-  },
-]

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -68,7 +68,7 @@ export function SiteFooter() {
                   className="text-muted-foreground transition-colors hover:text-primary"
                   intent="navigation"
                 >
-                  About Us
+                  Portal Help
                 </SmartLink>
               </li>
               <li>

--- a/config/navigation.ts
+++ b/config/navigation.ts
@@ -47,6 +47,7 @@ export const appWorkspaceNav: RoleNavItem[] = [
 
 export const publicNav: MainNavItem[] = [
   { title: "Home", href: "/", icon: "home" },
+  { title: "Portal Help", href: "/about" },
   { title: "Contact", href: "/contact", icon: "phone" },
 ]
 

--- a/lib/auth-rbac.ts
+++ b/lib/auth-rbac.ts
@@ -5,7 +5,7 @@ import type { Database } from '@/lib/supabase'
 export const APP_ROLES = ['tenant', 'roommate', 'property_manager', 'admin', 'user'] as const
 export type AppRole = (typeof APP_ROLES)[number]
 
-export const PUBLIC_ROUTE_PREFIXES = ['/auth', '/about', '/contact', '/error']
+export const PUBLIC_ROUTE_PREFIXES = ['/auth', '/contact', '/about', '/error']
 export const PUBLIC_EXACT_ROUTES = ['/', '/favicon.ico']
 
 const AUTHENTICATED_ROUTE_PREFIXES = [

--- a/tests/about-route.test.tsx
+++ b/tests/about-route.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import AboutPage from "@/app/about/page"
+
+vi.mock("@/components/forms/contact", () => ({
+  Contact: () => <div>Contact form placeholder</div>,
+}))
+
+describe("/about route", () => {
+  it("renders tenant-facing help content and excludes marketing-only sections", () => {
+    render(<AboutPage />)
+
+    expect(screen.getByRole("heading", { name: "Portal Help" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "How it works" })).toBeInTheDocument()
+    expect(screen.getByText(/Complete onboarding/i)).toBeInTheDocument()
+
+    expect(screen.queryByText("About Our Company")).not.toBeInTheDocument()
+    expect(screen.queryByText("Our Team")).not.toBeInTheDocument()
+    expect(screen.queryByText("Our Values")).not.toBeInTheDocument()
+  })
+})

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -30,7 +30,7 @@ describe("shared navigation configuration", () => {
       includeDisabled: false,
     }).map((item) => item.href)
 
-    expect(signedOut).toEqual(["/", "/contact"])
+    expect(signedOut).toEqual(["/", "/about", "/contact"])
     expect(signedIn).toEqual(
       expect.arrayContaining([
         "/dashboard",


### PR DESCRIPTION
### Motivation

- Remove marketing/company-centric content from the public site surface and provide practical, tenant-facing help aligned with the Share House Portal product scope. 
- Keep a public help route available for signed-out and signed-in users so onboarding and basic workflows are discoverable without marketing copy.

### Description

- Replaced marketing/team/value content in `app/about/page.tsx` with a tenant-focused "Portal Help" page containing quick-start onboarding steps, practical FAQs, and a contact/support card. 
- Updated public navigation in `config/navigation.ts` to surface the route as "Portal Help" and adjusted the site footer label in `components/site-footer.tsx` to match. 
- Ensured `/about` remains a public route by keeping it in `lib/auth-rbac.ts` public route prefixes (minor ordering normalization). 
- Added `tests/about-route.test.tsx` to assert the page renders tenant help content and not marketing headings, and updated `tests/navigation.test.ts` expectations to include `/about` in publicNav.

### Testing

- Ran `pnpm -s vitest run tests/about-route.test.tsx tests/navigation.test.ts tests/auth-rbac.test.ts`; an initial run failed due to `useRouter` usage inside the Contact component, so the test was updated to mock the `Contact` form and re-run. 
- After adding the mock, the three targeted test files passed: `tests/about-route.test.tsx`, `tests/navigation.test.ts`, and `tests/auth-rbac.test.ts` (all tests in those files succeeded). 
- Final test run reports all tests passed for the modified areas (12 tests across the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4324e7388328b773019b4e289f4b)