### PR TITLE
Improve auth layout and accessibility for narrow viewports

### DIFF
--- a/app/auth/components/AuthForm.tsx
+++ b/app/auth/components/AuthForm.tsx
@@ -229,14 +229,20 @@ export default function AuthForm({ initialMode = "login", notice, error }: AuthF
   }
 
   return (
-    <div className="w-96 space-y-6">
+    <div className="w-full max-w-md space-y-6">
       {notice ? <p className="rounded-md bg-muted p-3 text-sm">{notice}</p> : null}
       {error ? <p className="rounded-md border border-destructive/40 p-3 text-sm text-destructive">{error}</p> : null}
       <Tabs defaultValue={initialMode === "signup" ? "signup" : initialMode === "reset" ? "reset" : "login"}>
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="login">Login</TabsTrigger>
-          <TabsTrigger value="signup">Sign up</TabsTrigger>
-          <TabsTrigger value="reset">Reset</TabsTrigger>
+        <TabsList className="grid h-auto w-full grid-cols-3 gap-1">
+          <TabsTrigger className="px-2 text-xs sm:px-3 sm:text-sm" value="login">
+            Login
+          </TabsTrigger>
+          <TabsTrigger className="px-2 text-xs sm:px-3 sm:text-sm" value="signup">
+            Sign up
+          </TabsTrigger>
+          <TabsTrigger className="px-2 text-xs sm:px-3 sm:text-sm" value="reset">
+            Reset
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="login" className="space-y-6">
@@ -328,7 +334,7 @@ export default function AuthForm({ initialMode = "login", notice, error }: AuthF
                     <FormLabel>Account type</FormLabel>
                     <FormControl>
                       <select
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                         value={field.value}
                         onChange={field.onChange}
                       >

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -25,8 +25,8 @@ export default async function page({ searchParams }: AuthPageProps) {
     return redirect("/")
   }
   return (
-    <div className="mt-10 px-2 lg:p-8">
-      <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
+    <div className="mt-10 px-4 sm:px-6 lg:p-8">
+      <div className="mx-auto flex w-full max-w-md flex-col justify-center space-y-6">
         <div className="flex flex-col items-center space-y-2 text-center">
           <SmartLink href="/auth" className="mb-8 inline-flex">
             <span className="flex items-center space-x-2">
@@ -46,7 +46,7 @@ export default async function page({ searchParams }: AuthPageProps) {
           notice={searchParams?.message}
           error={searchParams?.error}
         />
-        <p className="px-8 text-center text-sm text-muted-foreground">
+        <p className="px-2 text-center text-sm text-muted-foreground sm:px-8">
           By clicking continue, you agree to our{" "}
           <SmartLink
             href="/terms"

--- a/tests/components/auth-form-mobile-layout.test.tsx
+++ b/tests/components/auth-form-mobile-layout.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockLoginWithEmailAndPassword = vi.fn()
+const mockRequestPasswordReset = vi.fn()
+const mockSignInWithWorkOS = vi.fn()
+const mockSignUpWithEmailAndPassword = vi.fn()
+const mockUpdatePassword = vi.fn()
+const mockToast = vi.fn()
+
+vi.mock("@/app/auth/actions", () => ({
+  loginWithEmailAndPassword: (...args: unknown[]) => mockLoginWithEmailAndPassword(...args),
+  requestPasswordReset: (...args: unknown[]) => mockRequestPasswordReset(...args),
+  signInWithWorkOS: (...args: unknown[]) => mockSignInWithWorkOS(...args),
+  signUpWithEmailAndPassword: (...args: unknown[]) => mockSignUpWithEmailAndPassword(...args),
+  updatePassword: (...args: unknown[]) => mockUpdatePassword(...args),
+}))
+
+vi.mock("@/components/ui/use-toast", () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}))
+
+import AuthForm from "@/app/auth/components/AuthForm"
+
+describe("AuthForm mobile layout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 320,
+      writable: true,
+    })
+
+    mockLoginWithEmailAndPassword.mockResolvedValue(JSON.stringify({ error: null }))
+    mockRequestPasswordReset.mockResolvedValue(JSON.stringify({ error: null }))
+    mockSignInWithWorkOS.mockResolvedValue(JSON.stringify({ error: null, url: "https://example.com/sso" }))
+    mockSignUpWithEmailAndPassword.mockResolvedValue(JSON.stringify({ error: null }))
+    mockUpdatePassword.mockResolvedValue(JSON.stringify({ error: null }))
+  })
+
+  it("uses responsive width and compact tab trigger spacing", () => {
+    const { container } = render(<AuthForm />)
+
+    const root = container.firstElementChild
+    expect(root).toHaveClass("w-full")
+    expect(root).toHaveClass("max-w-md")
+    expect(root).not.toHaveClass("w-96")
+
+    const tablist = screen.getByRole("tablist")
+    expect(tablist).toHaveClass("grid-cols-3")
+    expect(tablist).toHaveClass("gap-1")
+
+    const loginTab = screen.getByRole("tab", { name: /login/i })
+    expect(loginTab).toHaveClass("text-xs")
+    expect(loginTab).toHaveClass("sm:text-sm")
+  })
+
+  it("keeps form validation and focusable controls accessible on narrow viewports", async () => {
+    const user = userEvent.setup()
+    render(<AuthForm initialMode="signup" />)
+
+    const signupPanel = screen.getByRole("tabpanel", { name: /sign up/i })
+    const accountTypeSelect = within(signupPanel).getByLabelText(/account type/i)
+    expect(accountTypeSelect).toHaveClass("focus-visible:ring-2")
+
+    const createAccount = within(signupPanel).getByRole("button", { name: /create account/i })
+    await user.click(createAccount)
+
+    await waitFor(() => {
+      expect(within(signupPanel).getByText(/full name is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it("continues to surface toast errors for mobile SSO flows", async () => {
+    const user = userEvent.setup()
+    mockSignInWithWorkOS.mockResolvedValueOnce(JSON.stringify({ error: "SSO offline", url: null }))
+
+    render(<AuthForm />)
+
+    await user.click(screen.getByRole("button", { name: /continue with sso/i }))
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Unable to start SSO sign in",
+          description: "SSO offline",
+          variant: "destructive",
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
### Motivation
- Ensure the auth form is readable and centered on small devices without breaking desktop layout.
- Improve tab/button spacing and keyboard focus visibility for mobile users so controls and error messages remain accessible.

### Description
- Replaced the fixed container width with responsive sizing in `AuthForm` by changing `w-96` to `w-full max-w-md` and adjusted parent page wrapper padding to keep the form centered (`app/auth/components/AuthForm.tsx`, `app/auth/page.tsx`).
- Made tab triggers more compact and responsive by adding `gap-1` on the `TabsList` and small-screen text/padding classes on each `TabsTrigger` so labels stay readable at narrow widths (`app/auth/components/AuthForm.tsx`).
- Added `focus-visible` ring styles to the signup account-type `<select>` to preserve visible keyboard focus and accessibility on mobile (`app/auth/components/AuthForm.tsx`).
- Added a jsdom component test suite that asserts responsive classes, compact tab spacing, focus-ring presence, form validation visibility, and SSO toast error behavior (`tests/components/auth-form-mobile-layout.test.tsx`).

### Testing
- Ran the new component test file with `pnpm vitest run tests/components/auth-form-mobile-layout.test.tsx` and all tests passed (3 tests, 3 passed).
- No other automated tests were modified; the change is limited to layout/styles and the added unit tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4326c0308328a8f7a33832ea2a40)