### PR TITLE
Harden RBAC: remove legacy `user` role, fail-closed resolution, and centralize privileged checks

### DIFF
--- a/app/api/payments/reconciliation/export/route.ts
+++ b/app/api/payments/reconciliation/export/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/utils/supabase/server"
 
+import { isPrivilegedRole } from "@/lib/auth-rbac"
 import { jsonError, jsonErrorFromUnknown } from "@/lib/errors"
 
 function escapeCsv(value: string) {
@@ -28,7 +29,7 @@ export async function GET() {
       .eq("id", user.id)
       .maybeSingle()
 
-    if (!profile || !["property_manager", "admin"].includes(profile.role ?? "")) {
+    if (!profile || !isPrivilegedRole(profile.role)) {
       return jsonError("AUTH_UNAUTHORIZED", {
         message: "Only property managers and admins can export reconciliation CSV.",
       })

--- a/app/api/payments/reconciliation/triage/route.ts
+++ b/app/api/payments/reconciliation/triage/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/utils/supabase/server"
 
+import { isPrivilegedRole } from "@/lib/auth-rbac"
 import { jsonError, jsonErrorFromUnknown } from "@/lib/errors"
 
 const allowedTriageStatus = new Set(["open", "investigating", "resolved"])
@@ -22,7 +23,7 @@ export async function PATCH(req: Request) {
       .eq("id", user.id)
       .maybeSingle()
 
-    if (!profile || !["property_manager", "admin"].includes(profile.role ?? "")) {
+    if (!profile || !isPrivilegedRole(profile.role)) {
       return jsonError("AUTH_UNAUTHORIZED", {
         message: "Only property managers and admins can triage failed payments.",
       })

--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache"
 
 import { createSupbaseServerClient } from "@/utils/supaone"
+import { coerceRole } from "@/lib/auth-rbac"
 import type { Json } from "@/lib/supabase"
 import {
   computeOnboardingCompletion,
@@ -67,9 +68,8 @@ async function loadSelfProfile() {
     throw new Error("Unable to load your profile for onboarding.")
   }
 
-  const role = profile.role ?? "user"
-  const allowedRoles = new Set(["tenant", "roommate", "property_manager", "admin", "user"])
-  if (!allowedRoles.has(role)) {
+  const role = coerceRole(profile.role)
+  if (!role) {
     throw new Error("Your role is not allowed to update onboarding data.")
   }
 

--- a/docs/security/rbac-matrix.md
+++ b/docs/security/rbac-matrix.md
@@ -4,10 +4,14 @@ This matrix maps route-level access (middleware) and table-level actions (Supaba
 
 ## Roles
 
+Canonical application roles are strictly limited to:
+
 - `tenant`
 - `roommate`
 - `property_manager` (scoped to assigned units via `manager_unit_assignments`)
 - `admin` (global override)
+
+Legacy or unknown role strings (including historical `user`) are treated as `null` during role resolution. Middleware and privileged server checks fail closed when role resolution returns `null`.
 
 ## Route Access (Next.js middleware)
 

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -1,7 +1,6 @@
 import { jsonError } from "@/lib/errors"
+import { isPrivilegedRole, type PrivilegedAppRole } from "@/lib/auth-rbac"
 import { createClient } from "@/utils/supabase/server"
-
-const PRIVILEGED_ROLES = new Set(["property_manager", "admin"])
 
 type AuthenticatedApiContext = {
   supabase: ReturnType<typeof createClient>
@@ -9,7 +8,7 @@ type AuthenticatedApiContext = {
 }
 
 type PrivilegedApiContext = AuthenticatedApiContext & {
-  role: string
+  role: PrivilegedAppRole
 }
 
 export async function requireApiAuth(): Promise<AuthenticatedApiContext | Response> {
@@ -50,8 +49,8 @@ export async function requirePrivilegedApiAccess(): Promise<PrivilegedApiContext
     })
   }
 
-  const role = profile?.role ?? ""
-  if (!PRIVILEGED_ROLES.has(role)) {
+  const role = profile?.role
+  if (!isPrivilegedRole(role)) {
     return jsonError("AUTH_UNAUTHORIZED", {
       message: "Only property managers and admins can access this endpoint.",
     })

--- a/lib/auth-rbac.ts
+++ b/lib/auth-rbac.ts
@@ -2,8 +2,10 @@ import type { SupabaseClient, User } from '@supabase/supabase-js'
 
 import type { Database } from '@/lib/supabase'
 
-export const APP_ROLES = ['tenant', 'roommate', 'property_manager', 'admin', 'user'] as const
+export const APP_ROLES = ['tenant', 'roommate', 'property_manager', 'admin'] as const
 export type AppRole = (typeof APP_ROLES)[number]
+export const PRIVILEGED_APP_ROLES = ['property_manager', 'admin'] as const
+export type PrivilegedAppRole = (typeof PRIVILEGED_APP_ROLES)[number]
 
 export const PUBLIC_ROUTE_PREFIXES = ['/auth', '/about', '/contact', '/error']
 export const PUBLIC_EXACT_ROUTES = ['/', '/favicon.ico']
@@ -25,12 +27,19 @@ const ROLE_ROUTE_RULES: Array<{ prefix: string; allowed: AppRole[] }> = [
   { prefix: '/dashboard/members', allowed: ['property_manager', 'admin'] },
 ]
 
-function coerceRole(value: unknown): AppRole | null {
+export function coerceRole(value: unknown): AppRole | null {
   if (typeof value !== 'string') {
     return null
   }
 
   return (APP_ROLES as readonly string[]).includes(value) ? (value as AppRole) : null
+}
+
+export function isPrivilegedRole(value: unknown): value is PrivilegedAppRole {
+  return (
+    typeof value === 'string' &&
+    (PRIVILEGED_APP_ROLES as readonly string[]).includes(value)
+  )
 }
 
 export async function resolveSessionRole(
@@ -46,7 +55,7 @@ export async function resolveSessionRole(
     coerceRole(user.user_metadata?.role) ??
     coerceRole((user as User & { role?: unknown }).role)
 
-  if (claimedRole && claimedRole !== 'user') {
+  if (claimedRole) {
     return claimedRole
   }
 
@@ -58,10 +67,10 @@ export async function resolveSessionRole(
 
   if (error) {
     console.error('Failed to resolve profile role in middleware:', error.message)
-    return claimedRole
+    return null
   }
 
-  return coerceRole(data?.role) ?? claimedRole
+  return coerceRole(data?.role)
 }
 
 export function isPublicRoute(pathname: string): boolean {

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -2,10 +2,9 @@ import 'server-only'
 
 import { redirect } from 'next/navigation'
 
+import { isPrivilegedRole } from '@/lib/auth-rbac'
 import { fetchMemberRole } from '@/lib/data/members'
 import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
-
-export const PRIVILEGED_ROLES = ['property_manager', 'admin'] as const
 
 export async function requirePrivilegedAccess() {
   const supabase = await createSupbaseServerClientReadOnly()
@@ -19,7 +18,7 @@ export async function requirePrivilegedAccess() {
 
   const role = await fetchMemberRole(supabase as any, user.id)
 
-  if (!role || !PRIVILEGED_ROLES.includes(role as (typeof PRIVILEGED_ROLES)[number])) {
+  if (!isPrivilegedRole(role)) {
     redirect('/dashboard')
   }
 

--- a/tests/auth-rbac.test.ts
+++ b/tests/auth-rbac.test.ts
@@ -62,4 +62,49 @@ describe('resolveSessionRole', () => {
     expect(eq).toHaveBeenCalledWith('id', 'user-1')
     expect(maybeSingle).toHaveBeenCalled()
   })
+
+  it('maps unknown metadata roles to null when profile role is missing', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { role: null }, error: null })
+    const eq = vi.fn().mockReturnValue({ maybeSingle })
+    const select = vi.fn().mockReturnValue({ eq })
+    const from = vi.fn().mockReturnValue({ select })
+
+    const role = await resolveSessionRole({ from } as any, {
+      id: 'user-unknown',
+      app_metadata: { role: 'legacy_manager' },
+      user_metadata: { role: 'guest' },
+    } as any)
+
+    expect(role).toBeNull()
+  })
+
+  it('returns null when profile role is missing and no role metadata is present', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null })
+    const eq = vi.fn().mockReturnValue({ maybeSingle })
+    const select = vi.fn().mockReturnValue({ eq })
+    const from = vi.fn().mockReturnValue({ select })
+
+    const role = await resolveSessionRole({ from } as any, {
+      id: 'user-missing-role',
+      app_metadata: {},
+      user_metadata: {},
+    } as any)
+
+    expect(role).toBeNull()
+  })
+
+  it('treats legacy `user` metadata as unknown and uses canonical profile role during migration', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { role: 'tenant' }, error: null })
+    const eq = vi.fn().mockReturnValue({ maybeSingle })
+    const select = vi.fn().mockReturnValue({ eq })
+    const from = vi.fn().mockReturnValue({ select })
+
+    const role = await resolveSessionRole({ from } as any, {
+      id: 'legacy-user',
+      app_metadata: { role: 'user' },
+      user_metadata: {},
+    } as any)
+
+    expect(role).toBe('tenant')
+  })
 })


### PR DESCRIPTION
### Motivation
- Ensure authorization uses the product-defined canonical roles (`tenant`, `roommate`, `property_manager`, `admin`) and avoid implicit or legacy fallbacks that could grant unintended privileges. 
- Make unknown or legacy role values explicit by mapping them to `null` so middleware and privileged checks fail closed. 

### Description
- Remove the legacy `user` entry from `APP_ROLES` and introduce `PRIVILEGED_APP_ROLES` with a reusable `isPrivilegedRole` guard in `lib/auth-rbac.ts`, and export `coerceRole`. 
- Change `resolveSessionRole` to return `null` for unknown/legacy roles (no implicit fallback), and return canonical profile role only when it coerces successfully. 
- Replace ad-hoc privileged-role checks with `isPrivilegedRole` in server helpers and API endpoints (`lib/authz.ts`, `lib/api-auth.ts`, `app/api/payments/reconciliation/*`) so privileged routes fail closed when role resolution is `null`. 
- Tighten onboarding server-action validation to use `coerceRole` (no default `user`), add tests covering unknown/legacy role metadata and missing profile roles, and document canonical roles and fail-closed behavior in `docs/security/rbac-matrix.md`. 

### Testing
- Ran the unit tests for RBAC helpers with `pnpm vitest run tests/auth-rbac.test.ts`, which passed (8 tests). 
- Ran TypeScript checks with `pnpm typecheck` (`tsc --noEmit`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4327c2e08328910030a2c1e03eec)