### PR TITLE
Harden RBAC route rules and document policy

### DIFF
--- a/docs/engineering/route-role-policy.md
+++ b/docs/engineering/route-role-policy.md
@@ -1,0 +1,19 @@
+# Route-to-role policy (RBAC)
+
+This table defines intent for protected route families enforced by `lib/auth-rbac.ts`.
+
+| Route family | Tenant / Roommate | Property manager | Admin | Notes |
+| --- | --- | --- | --- | --- |
+| `/dashboard` | ✅ | ✅ | ✅ | Base dashboard and tenant-facing sections. |
+| `/dashboard/operations` | ❌ | ✅ | ✅ | Property operations surfaces and management workflows. |
+| `/payments` | ✅ | ✅ | ✅ | Rent, receipts, and payment status surfaces. |
+| `/documents` | ✅ | ✅ | ✅ | Lease and signed-document access surfaces. |
+| `/bookings` | ✅ | ✅ | ✅ | Amenity reservations and booking history. |
+| `/maintenance` | ✅ | ✅ | ✅ | Maintenance request creation and status tracking. |
+| `/visitors` | ✅ | ✅ | ✅ | Overnight visitor registration and review. |
+| `/messaging` | ✅ | ✅ | ✅ | Realtime message board and moderation entry points. |
+| `/api/exports` | ❌ | ❌ | ✅ | Administrative exports endpoint family. |
+
+## Default deny for authenticated route prefixes
+
+If a route is under `AUTHENTICATED_ROUTE_PREFIXES` and does not match a row in this table, access is denied by default until an explicit role rule is added.

--- a/lib/auth-rbac.ts
+++ b/lib/auth-rbac.ts
@@ -21,8 +21,47 @@ const AUTHENTICATED_ROUTE_PREFIXES = [
   '/private',
 ]
 
+const TENANT_AND_ROOMMATE_ROLES: AppRole[] = ['tenant', 'roommate']
+const PROPERTY_MANAGER_ROLES: AppRole[] = ['property_manager']
+const ADMIN_ROLES: AppRole[] = ['admin']
+
 const ROLE_ROUTE_RULES: Array<{ prefix: string; allowed: AppRole[] }> = [
-  { prefix: '/dashboard/members', allowed: ['property_manager', 'admin'] },
+  {
+    prefix: '/dashboard/operations',
+    allowed: [...PROPERTY_MANAGER_ROLES, ...ADMIN_ROLES],
+  },
+  {
+    prefix: '/api/exports',
+    allowed: [...ADMIN_ROLES],
+  },
+  {
+    prefix: '/dashboard',
+    allowed: [...TENANT_AND_ROOMMATE_ROLES, ...PROPERTY_MANAGER_ROLES, ...ADMIN_ROLES],
+  },
+  {
+    prefix: '/payments',
+    allowed: [...TENANT_AND_ROOMMATE_ROLES, ...PROPERTY_MANAGER_ROLES, ...ADMIN_ROLES],
+  },
+  {
+    prefix: '/documents',
+    allowed: [...TENANT_AND_ROOMMATE_ROLES, ...PROPERTY_MANAGER_ROLES, ...ADMIN_ROLES],
+  },
+  {
+    prefix: '/bookings',
+    allowed: [...TENANT_AND_ROOMMATE_ROLES, ...PROPERTY_MANAGER_ROLES, ...ADMIN_ROLES],
+  },
+  {
+    prefix: '/maintenance',
+    allowed: [...TENANT_AND_ROOMMATE_ROLES, ...PROPERTY_MANAGER_ROLES, ...ADMIN_ROLES],
+  },
+  {
+    prefix: '/visitors',
+    allowed: [...TENANT_AND_ROOMMATE_ROLES, ...PROPERTY_MANAGER_ROLES, ...ADMIN_ROLES],
+  },
+  {
+    prefix: '/messaging',
+    allowed: [...TENANT_AND_ROOMMATE_ROLES, ...PROPERTY_MANAGER_ROLES, ...ADMIN_ROLES],
+  },
 ]
 
 function coerceRole(value: unknown): AppRole | null {
@@ -83,12 +122,12 @@ export function isRouteAllowedForRole(pathname: string, role: AppRole | null): b
     (entry) => pathname === entry.prefix || pathname.startsWith(`${entry.prefix}/`)
   )
 
-  if (!rule) {
-    return true
-  }
-
   if (!role) {
     return false
+  }
+
+  if (!rule) {
+    return !requiresAuthentication(pathname)
   }
 
   return rule.allowed.includes(role)

--- a/tests/auth-rbac.test.ts
+++ b/tests/auth-rbac.test.ts
@@ -21,11 +21,77 @@ describe('auth RBAC route helpers', () => {
     expect(requiresAuthentication('/about')).toBe(false)
   })
 
-  it('enforces role restrictions for manager pages', () => {
-    expect(isRouteAllowedForRole('/dashboard/members', 'admin')).toBe(true)
-    expect(isRouteAllowedForRole('/dashboard/members', 'property_manager')).toBe(true)
-    expect(isRouteAllowedForRole('/dashboard/members', 'tenant')).toBe(false)
-    expect(isRouteAllowedForRole('/dashboard', 'tenant')).toBe(true)
+  it('enforces tenant and roommate access for tenant-facing areas', () => {
+    const tenantFacingRoutes = [
+      '/dashboard',
+      '/payments',
+      '/documents',
+      '/bookings',
+      '/maintenance',
+      '/visitors',
+      '/messaging',
+    ]
+
+    tenantFacingRoutes.forEach((route) => {
+      expect(isRouteAllowedForRole(route, 'tenant')).toBe(true)
+      expect(isRouteAllowedForRole(route, 'roommate')).toBe(true)
+    })
+  })
+
+  it('enforces operations route for management roles only', () => {
+    expect(isRouteAllowedForRole('/dashboard/operations', 'property_manager')).toBe(true)
+    expect(isRouteAllowedForRole('/dashboard/operations', 'admin')).toBe(true)
+    expect(isRouteAllowedForRole('/dashboard/operations', 'tenant')).toBe(false)
+    expect(isRouteAllowedForRole('/dashboard/operations', 'roommate')).toBe(false)
+  })
+
+  it('enforces exports route for admin role only', () => {
+    expect(isRouteAllowedForRole('/api/exports', 'admin')).toBe(true)
+    expect(isRouteAllowedForRole('/api/exports', 'property_manager')).toBe(false)
+    expect(isRouteAllowedForRole('/api/exports', 'tenant')).toBe(false)
+    expect(isRouteAllowedForRole('/api/exports', 'roommate')).toBe(false)
+  })
+
+  it('enforces positive and negative route access for each role', () => {
+    const routeCases: Array<{ pathname: string; allowed: Array<'tenant' | 'roommate' | 'property_manager' | 'admin'> }> = [
+      { pathname: '/dashboard', allowed: ['tenant', 'roommate', 'property_manager', 'admin'] },
+      { pathname: '/dashboard/operations', allowed: ['property_manager', 'admin'] },
+      { pathname: '/payments', allowed: ['tenant', 'roommate', 'property_manager', 'admin'] },
+      { pathname: '/documents', allowed: ['tenant', 'roommate', 'property_manager', 'admin'] },
+      { pathname: '/bookings', allowed: ['tenant', 'roommate', 'property_manager', 'admin'] },
+      { pathname: '/maintenance', allowed: ['tenant', 'roommate', 'property_manager', 'admin'] },
+      { pathname: '/visitors', allowed: ['tenant', 'roommate', 'property_manager', 'admin'] },
+      { pathname: '/messaging', allowed: ['tenant', 'roommate', 'property_manager', 'admin'] },
+      { pathname: '/api/exports', allowed: ['admin'] },
+    ]
+    const roles: Array<'tenant' | 'roommate' | 'property_manager' | 'admin'> = [
+      'tenant',
+      'roommate',
+      'property_manager',
+      'admin',
+    ]
+
+    routeCases.forEach(({ pathname, allowed }) => {
+      roles.forEach((role) => {
+        expect(isRouteAllowedForRole(pathname, role)).toBe(allowed.includes(role))
+      })
+    })
+  })
+
+  it('denies protected routes when no role is present', () => {
+    expect(isRouteAllowedForRole('/dashboard', null)).toBe(false)
+    expect(isRouteAllowedForRole('/payments/history', null)).toBe(false)
+  })
+
+  it('denies unknown authenticated paths by default', () => {
+    expect(requiresAuthentication('/private/unlisted')).toBe(true)
+    expect(isRouteAllowedForRole('/private/unlisted', 'admin')).toBe(false)
+    expect(isRouteAllowedForRole('/private/unlisted', 'tenant')).toBe(false)
+  })
+
+  it('allows non-protected paths without explicit allowlist rules', () => {
+    expect(isRouteAllowedForRole('/help', null)).toBe(false)
+    expect(isRouteAllowedForRole('/help', 'tenant')).toBe(true)
   })
 })
 


### PR DESCRIPTION
### Motivation
- Reduce accidental over-permissive routes by explicitly mapping protected route families to capability tiers (`tenant/roommate`, `property_manager`, `admin`).
- Ensure unknown authenticated paths are denied by default to force explicit review when new protected pages are added.

### Description
- Expanded `ROLE_ROUTE_RULES` in `lib/auth-rbac.ts` to cover `/dashboard/operations`, `/payments`, `/documents`, `/bookings`, `/maintenance`, `/visitors`, `/messaging`, and `/api/exports` and grouped allowed roles by capability level. 
- Introduced role group constants (`TENANT_AND_ROOMMATE_ROLES`, `PROPERTY_MANAGER_ROLES`, `ADMIN_ROLES`) and applied them per route family. 
- Changed fallback authorization in `isRouteAllowedForRole` so that if no explicit rule matches, access is denied when the path is under `AUTHENTICATED_ROUTE_PREFIXES`. 
- Added comprehensive unit tests in `tests/auth-rbac.test.ts` covering positive and negative cases for each role and a regression asserting unknown authenticated paths are denied, and added `docs/engineering/route-role-policy.md` documenting the route-to-role intent and the default-deny policy.

### Testing
- Ran `pnpm vitest tests/auth-rbac.test.ts` and all tests in that file completed successfully. 
- Test run summary: `1 file` and `11 tests` executed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec46259b9c83288566d2f55e7bdc2e)