### PR TITLE
Add shared webhook event persistence with idempotent processing

### DIFF
--- a/app/api/calcom/webhook/route.ts
+++ b/app/api/calcom/webhook/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server"
 
 import { toBookingInsert } from "@/lib/bookings/calcom-webhook"
 import type { Database, TablesInsert } from "@/lib/supabase"
+import { markWebhookEventStatus, registerWebhookEvent } from "@/lib/webhook-events"
 
 function createSupabaseAdminClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -79,9 +80,6 @@ export async function POST(request: Request) {
   }
 
   const booking = toBookingInsert(parsedBody)
-  if (!booking) {
-    return NextResponse.json({ ok: true, ignored: true })
-  }
 
   const supabase = createSupabaseAdminClient()
   if (!supabase) {
@@ -91,13 +89,54 @@ export async function POST(request: Request) {
     )
   }
 
+  const eventId = String(
+    parsedBody?.id ?? parsedBody?.payload?.bookingId ?? parsedBody?.payload?.uid ?? "unknown-event",
+  )
+  const eventType = String(parsedBody?.triggerEvent ?? "unknown")
+
+  const { isDuplicateProcessed } = await registerWebhookEvent(supabase, {
+    provider: "calcom",
+    eventId,
+    eventType,
+    payload: parsedBody,
+    rawPayload: rawBody,
+  })
+
+  if (isDuplicateProcessed) {
+    return NextResponse.json({ ok: true, duplicate: true })
+  }
+
+  if (!booking) {
+    await markWebhookEventStatus(supabase, {
+      provider: "calcom",
+      eventId,
+      status: "processed",
+    })
+    return NextResponse.json({ ok: true, ignored: true })
+  }
+
   const { error } = await upsertBookingRecord(supabase, booking)
   if (error) {
+    await markWebhookEventStatus(supabase, {
+      provider: "calcom",
+      eventId,
+      status: "failed",
+      errorMessage: error.message,
+      maxRetries: 3,
+      retriable: true,
+    })
     return NextResponse.json(
       { ok: false, message: "Failed to mirror booking", details: error.message },
       { status: 500 },
     )
   }
+
+  await markWebhookEventStatus(supabase, {
+    provider: "calcom",
+    eventId,
+    status: "processed",
+    maxRetries: 3,
+  })
 
   return NextResponse.json({
     ok: true,

--- a/app/api/documents/webhook/route.ts
+++ b/app/api/documents/webhook/route.ts
@@ -1,0 +1,95 @@
+import { createClient } from "@supabase/supabase-js"
+import { NextResponse } from "next/server"
+
+import type { Database, Json } from "@/lib/supabase"
+import { markWebhookEventStatus, registerWebhookEvent } from "@/lib/webhook-events"
+
+function createSupabaseAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return null
+  }
+
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}
+
+function hasValidSignature(request: Request) {
+  const secret = process.env.DOCUMENSO_WEBHOOK_SECRET
+  if (!secret) {
+    return true
+  }
+
+  const signature = request.headers.get("x-documenso-signature")
+  return signature === secret
+}
+
+export async function POST(request: Request) {
+  if (!hasValidSignature(request)) {
+    return NextResponse.json({ ok: false, message: "Invalid signature" }, { status: 401 })
+  }
+
+  const rawBody = await request.text()
+  let payload: Record<string, unknown>
+
+  try {
+    payload = JSON.parse(rawBody) as Record<string, unknown>
+  } catch {
+    return NextResponse.json({ ok: false, message: "Invalid payload" }, { status: 400 })
+  }
+
+  const supabase = createSupabaseAdminClient()
+  if (!supabase) {
+    return NextResponse.json(
+      { ok: false, message: "Supabase admin client unavailable" },
+      { status: 500 },
+    )
+  }
+
+  const eventId = String(payload.eventId ?? payload.id ?? "unknown-event")
+  const eventType = String(payload.event ?? payload.type ?? "unknown")
+
+  const { isDuplicateProcessed } = await registerWebhookEvent(supabase, {
+    provider: "documenso",
+    eventId,
+    eventType,
+    payload: payload as Json,
+    rawPayload: rawBody,
+  })
+
+  if (isDuplicateProcessed) {
+    return NextResponse.json({ ok: true, duplicate: true })
+  }
+
+  try {
+    await markWebhookEventStatus(supabase, {
+      provider: "documenso",
+      eventId,
+      status: "processed",
+      maxRetries: 3,
+    })
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to process document event"
+
+    await markWebhookEventStatus(supabase, {
+      provider: "documenso",
+      eventId,
+      status: "failed",
+      errorMessage: message,
+      maxRetries: 3,
+      retriable: true,
+    })
+
+    return NextResponse.json({ ok: false, message }, { status: 500 })
+  }
+}
+
+export const runtime = "nodejs"

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -9,6 +9,11 @@ import { incrementOperationalMetric } from "@/lib/observability/metrics"
 import { isLikelyTransientError, RetryExhaustedError, retryWithBackoff } from "@/lib/resilience"
 import { getStripe } from "@/lib/stripe"
 import type { Database, Json, TablesInsert } from "@/lib/supabase"
+import {
+  appendWebhookPayloadMetadata,
+  markWebhookEventStatus,
+  registerWebhookEvent,
+} from "@/lib/webhook-events"
 
 class UnmappedPaymentEventError extends Error {
   eventId: string
@@ -113,53 +118,6 @@ function parseAmountInMajorUnits(amountInCents: number | null | undefined) {
   return amountInCents / 100
 }
 
-async function isDuplicateEvent(supabase: SupabaseClient<Database>, event: Stripe.Event) {
-  const payload: TablesInsert<"webhook_events"> = {
-    provider: "stripe",
-    event_id: event.id,
-    event_type: event.type,
-    status: "processing",
-    payload: event as unknown as Json,
-    processed_at: new Date().toISOString(),
-  }
-
-  const { error } = await supabase.from("webhook_events").insert(payload)
-
-  if (!error) {
-    return false
-  }
-
-  if (error.code === "23505") {
-    return true
-  }
-
-  throw error
-}
-
-async function markEventProcessed(
-  supabase: SupabaseClient<Database>,
-  eventId: string,
-  status: "processed" | "failed" | "dead_lettered",
-  options: { errorMessage?: string; retryCount?: number; maxRetries?: number } = {}
-) {
-  const now = new Date().toISOString()
-
-  await supabase
-    .from("webhook_events")
-    .update({
-      status,
-      error_message: options.errorMessage,
-      processed_at: now,
-      retry_count: options.retryCount ?? 0,
-      max_retries: options.maxRetries ?? 0,
-      dead_lettered_at: status === "dead_lettered" ? now : null,
-      last_attempt_at: now,
-      next_retry_at: null,
-    })
-    .eq("provider", "stripe")
-    .eq("event_id", eventId)
-}
-
 async function queueUnmappedPaymentEvent(
   supabase: SupabaseClient<Database>,
   params: {
@@ -179,21 +137,25 @@ async function queueUnmappedPaymentEvent(
       error_message: params.reason,
       processed_at: now,
       last_attempt_at: now,
-      payload: {
-        reconciliation: {
-          actionable: true,
-          triage_status: "open",
-          triage_notes: "",
-          queue_reason: "unmapped_payment_event",
-          webhook_event_type: params.eventType,
-          queued_at: now,
-          correlation_id: params.correlationId,
-          ...params.auditDetail,
-        },
-      },
+      next_retry_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
     })
     .eq("provider", "stripe")
     .eq("event_id", params.eventId)
+
+  await appendWebhookPayloadMetadata(supabase, {
+    provider: "stripe",
+    eventId: params.eventId,
+    metadata: {
+      actionable: "true",
+      triage_status: "open",
+      triage_notes: "",
+      queue_reason: "unmapped_payment_event",
+      webhook_event_type: params.eventType,
+      queued_at: now,
+      correlation_id: params.correlationId,
+      ...params.auditDetail,
+    },
+  })
 }
 
 async function upsertRentPayment(
@@ -691,8 +653,15 @@ export async function POST(req: Request) {
   }
 
   try {
-    const duplicate = await isDuplicateEvent(supabase, event)
-    if (duplicate) {
+    const { isDuplicateProcessed } = await registerWebhookEvent(supabase, {
+      provider: "stripe",
+      eventId: event.id,
+      eventType: event.type,
+      payload: event as unknown as Json,
+      rawPayload: rawBody,
+    })
+
+    if (isDuplicateProcessed) {
       return new Response("ok", { status: 200 })
     }
 
@@ -706,7 +675,12 @@ export async function POST(req: Request) {
 
     if (!HANDLED_EVENTS.has(event.type)) {
       logger.info("stripe_webhook_unhandled_event", { eventName: event.type })
-      await markEventProcessed(supabase, event.id, "processed", { maxRetries })
+      await markWebhookEventStatus(supabase, {
+        provider: "stripe",
+        eventId: event.id,
+        status: "processed",
+        maxRetries,
+      })
     } else {
       const result = await retryWithBackoff(
         async () => {
@@ -729,7 +703,10 @@ export async function POST(req: Request) {
         recordStripePaymentMetric("failure", event.type, correlationId)
       }
 
-      await markEventProcessed(supabase, event.id, "processed", {
+      await markWebhookEventStatus(supabase, {
+        provider: "stripe",
+        eventId: event.id,
+        status: "processed",
         retryCount: Math.max(result.attempts - 1, 0),
         maxRetries,
       })
@@ -799,7 +776,10 @@ export async function POST(req: Request) {
     })
 
     if (exhausted) {
-      await markEventProcessed(supabase, event.id, "dead_lettered", {
+      await markWebhookEventStatus(supabase, {
+        provider: "stripe",
+        eventId: event.id,
+        status: "dead_lettered",
         errorMessage: message,
         retryCount: Math.max(err.attempts - 1, 0),
         maxRetries: 3,
@@ -811,10 +791,14 @@ export async function POST(req: Request) {
       })
     }
 
-    await markEventProcessed(supabase, event.id, "failed", {
+    await markWebhookEventStatus(supabase, {
+      provider: "stripe",
+      eventId: event.id,
+      status: "failed",
       errorMessage: message,
       retryCount: 0,
       maxRetries: 3,
+      retriable: true,
     })
 
     return jsonError("INTERNAL_SERVER_ERROR", {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -173,11 +173,12 @@ export type Database = {
       }>
       webhook_events: SupabaseTable<{
         id: string
-        provider: 'stripe'
+        provider: 'stripe' | 'calcom' | 'documenso'
         event_id: string
         event_type: string
         status: 'processing' | 'processed' | 'failed' | 'dead_lettered'
         payload: Json | null
+        payload_hash: string | null
         error_message: string | null
         processed_at: string | null
         retry_count: number

--- a/lib/webhook-events.ts
+++ b/lib/webhook-events.ts
@@ -1,0 +1,152 @@
+import crypto from "node:crypto"
+
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database, Json, TablesUpdate } from "@/lib/supabase"
+
+export type WebhookProvider = "stripe" | "calcom" | "documenso"
+
+type WebhookStatus = Database["public"]["Tables"]["webhook_events"]["Row"]["status"]
+
+type RegisterWebhookEventParams = {
+  provider: WebhookProvider
+  eventId: string
+  eventType: string
+  payload: Json
+  rawPayload: string
+}
+
+type RegisterWebhookEventResult = {
+  isDuplicateProcessed: boolean
+  payloadHash: string
+}
+
+type MarkWebhookEventStatusParams = {
+  provider: WebhookProvider
+  eventId: string
+  status: WebhookStatus
+  errorMessage?: string | null
+  retryCount?: number
+  maxRetries?: number
+  retriable?: boolean
+}
+
+function buildPayloadHash(rawPayload: string) {
+  return crypto.createHash("sha256").update(rawPayload).digest("hex")
+}
+
+export async function registerWebhookEvent(
+  supabase: SupabaseClient<Database>,
+  params: RegisterWebhookEventParams,
+): Promise<RegisterWebhookEventResult> {
+  const payloadHash = buildPayloadHash(params.rawPayload)
+  const now = new Date().toISOString()
+
+  const { error } = await supabase.from("webhook_events").insert({
+    provider: params.provider,
+    event_id: params.eventId,
+    event_type: params.eventType,
+    status: "processing",
+    payload: params.payload,
+    payload_hash: payloadHash,
+    processed_at: now,
+    last_attempt_at: now,
+  })
+
+  if (!error) {
+    return { isDuplicateProcessed: false, payloadHash }
+  }
+
+  if (error.code !== "23505") {
+    throw error
+  }
+
+  const { data: existing, error: selectError } = await supabase
+    .from("webhook_events")
+    .select("status")
+    .eq("provider", params.provider)
+    .eq("event_id", params.eventId)
+    .maybeSingle()
+
+  if (selectError) {
+    throw selectError
+  }
+
+  if (existing?.status === "processed") {
+    return { isDuplicateProcessed: true, payloadHash }
+  }
+
+  await supabase
+    .from("webhook_events")
+    .update({
+      status: "processing",
+      payload: params.payload,
+      payload_hash: payloadHash,
+      error_message: null,
+      last_attempt_at: now,
+      next_retry_at: null,
+      dead_lettered_at: null,
+    })
+    .eq("provider", params.provider)
+    .eq("event_id", params.eventId)
+
+  return { isDuplicateProcessed: false, payloadHash }
+}
+
+export async function markWebhookEventStatus(
+  supabase: SupabaseClient<Database>,
+  params: MarkWebhookEventStatusParams,
+) {
+  const now = new Date().toISOString()
+  const update: TablesUpdate<"webhook_events"> = {
+    status: params.status,
+    error_message: params.errorMessage ?? null,
+    processed_at: now,
+    retry_count: params.retryCount ?? 0,
+    max_retries: params.maxRetries ?? 0,
+    dead_lettered_at: params.status === "dead_lettered" ? now : null,
+    last_attempt_at: now,
+    next_retry_at: params.retriable ? new Date(Date.now() + 5 * 60 * 1000).toISOString() : null,
+  }
+
+  await supabase
+    .from("webhook_events")
+    .update(update)
+    .eq("provider", params.provider)
+    .eq("event_id", params.eventId)
+}
+
+export async function appendWebhookPayloadMetadata(
+  supabase: SupabaseClient<Database>,
+  params: {
+    provider: WebhookProvider
+    eventId: string
+    metadata: Record<string, string | null>
+  },
+) {
+  const { data: existing } = await supabase
+    .from("webhook_events")
+    .select("payload")
+    .eq("provider", params.provider)
+    .eq("event_id", params.eventId)
+    .maybeSingle()
+
+  const payloadObject =
+    existing?.payload && typeof existing.payload === "object" && !Array.isArray(existing.payload)
+      ? (existing.payload as Record<string, unknown>)
+      : {}
+
+  await supabase
+    .from("webhook_events")
+    .update({
+      payload: {
+        ...payloadObject,
+        reconciliation: {
+          ...(payloadObject.reconciliation as Record<string, unknown> | undefined),
+          ...params.metadata,
+        },
+      } as Json,
+    })
+    .eq("provider", params.provider)
+    .eq("event_id", params.eventId)
+}

--- a/supabase/migrations/202604250001_webhook_events_provider_and_hash.sql
+++ b/supabase/migrations/202604250001_webhook_events_provider_and_hash.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+ALTER TABLE public.webhook_events
+  DROP CONSTRAINT IF EXISTS webhook_events_provider_check;
+
+ALTER TABLE public.webhook_events
+  ADD CONSTRAINT webhook_events_provider_check
+  CHECK (provider IN ('stripe', 'calcom', 'documenso'));
+
+ALTER TABLE public.webhook_events
+  ADD COLUMN IF NOT EXISTS payload_hash text;
+
+CREATE INDEX IF NOT EXISTS idx_webhook_events_payload_hash
+  ON public.webhook_events(provider, payload_hash)
+  WHERE payload_hash IS NOT NULL;
+
+COMMIT;

--- a/tests/integration/api/calcom-webhook-persistence.test.ts
+++ b/tests/integration/api/calcom-webhook-persistence.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const createClient = vi.fn()
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient,
+}))
+
+describe("POST /api/calcom/webhook persistence", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co"
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service_role"
+    delete process.env.CALCOM_WEBHOOK_SECRET
+  })
+
+  it("processes duplicate deliveries idempotently", async () => {
+    const processed = new Set<string>()
+    const bookingUpsert = vi.fn().mockResolvedValue({ data: null, error: null })
+
+    const webhookInsert = vi.fn(async (payload: { provider: string; event_id: string }) => {
+      const key = `${payload.provider}:${payload.event_id}`
+      if (processed.has(key)) {
+        return { data: null, error: { code: "23505" } }
+      }
+
+      processed.add(key)
+      return { data: null, error: null }
+    })
+
+    const webhookSelectMaybeSingle = vi.fn().mockResolvedValue({ data: { status: "processed" }, error: null })
+
+    const webhookUpdateEqEvent = vi.fn().mockResolvedValue({ data: null, error: null })
+    const webhookUpdateEqProvider = vi.fn(() => ({ eq: webhookUpdateEqEvent }))
+    const webhookUpdate = vi.fn(() => ({ eq: webhookUpdateEqProvider }))
+
+    const from = vi.fn((table: string) => {
+      if (table === "bookings") {
+        return {
+          upsert: bookingUpsert,
+        }
+      }
+
+      if (table === "webhook_events") {
+        return {
+          insert: webhookInsert,
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({ maybeSingle: webhookSelectMaybeSingle })),
+            })),
+          })),
+          update: webhookUpdate,
+        }
+      }
+
+      return {}
+    })
+
+    createClient.mockReturnValue({ from })
+
+    const { POST } = await import("@/app/api/calcom/webhook/route")
+
+    const payload = {
+      id: "cal_evt_1",
+      triggerEvent: "BOOKING_CREATED",
+      payload: {
+        bookingId: 101,
+        eventTypeId: 55,
+        eventTypeSlug: "kitchen",
+        title: "Kitchen booking",
+        startTime: "2026-06-01T10:00:00.000Z",
+        endTime: "2026-06-01T11:00:00.000Z",
+      },
+    }
+
+    const first = await POST(
+      new Request("http://localhost/api/calcom/webhook", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    )
+
+    const second = await POST(
+      new Request("http://localhost/api/calcom/webhook", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    )
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(bookingUpsert).toHaveBeenCalledTimes(1)
+    expect(webhookUpdateEqProvider).toHaveBeenCalledWith("provider", "calcom")
+    expect(webhookUpdateEqEvent).toHaveBeenCalledWith("event_id", "cal_evt_1")
+  })
+
+  it("marks failed processing as retriable while preserving payload", async () => {
+    const bookingUpsert = vi.fn().mockResolvedValue({ data: null, error: new Error("db write failed") })
+    const webhookInsert = vi.fn().mockResolvedValue({ data: null, error: null })
+
+    const webhookUpdateEqEvent = vi.fn().mockResolvedValue({ data: null, error: null })
+    const webhookUpdateEqProvider = vi.fn(() => ({ eq: webhookUpdateEqEvent }))
+    const webhookUpdate = vi.fn(() => ({ eq: webhookUpdateEqProvider }))
+
+    const from = vi.fn((table: string) => {
+      if (table === "bookings") {
+        return {
+          upsert: bookingUpsert,
+        }
+      }
+
+      if (table === "webhook_events") {
+        return {
+          insert: webhookInsert,
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) })),
+            })),
+          })),
+          update: webhookUpdate,
+        }
+      }
+
+      return {}
+    })
+
+    createClient.mockReturnValue({ from })
+
+    const { POST } = await import("@/app/api/calcom/webhook/route")
+
+    const payload = {
+      id: "cal_evt_2",
+      triggerEvent: "BOOKING_CREATED",
+      payload: {
+        bookingId: 202,
+        eventTypeId: 55,
+        eventTypeSlug: "kitchen",
+        title: "Kitchen booking",
+        startTime: "2026-06-01T10:00:00.000Z",
+        endTime: "2026-06-01T11:00:00.000Z",
+      },
+    }
+
+    const response = await POST(
+      new Request("http://localhost/api/calcom/webhook", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    )
+
+    expect(response.status).toBe(500)
+    expect(webhookInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "calcom",
+        event_id: "cal_evt_2",
+        payload,
+      }),
+    )
+
+    const failureUpdatePayload = webhookUpdate.mock.calls.at(-1)?.[0] as Record<string, unknown>
+    expect(failureUpdatePayload.status).toBe("failed")
+    expect(failureUpdatePayload.next_retry_at).toEqual(expect.any(String))
+    expect(failureUpdatePayload.payload).toBeUndefined()
+  })
+})

--- a/tests/integration/api/stripe-webhook.test.ts
+++ b/tests/integration/api/stripe-webhook.test.ts
@@ -64,6 +64,7 @@ describe("POST /api/stripe/webhook", () => {
     const rentPaymentsInsert = vi.fn().mockResolvedValue({ data: null, error: null })
     const rentPaymentsUpsert = vi.fn().mockResolvedValue({ data: null, error: null })
     const webhookEventsInsert = vi.fn().mockResolvedValue({ data: null, error: null })
+    const webhookEventsSelectMaybeSingle = vi.fn().mockResolvedValue({ data: { payload: {} }, error: null })
 
     const updateEqEventId = vi.fn().mockResolvedValue({ data: null, error: null })
     const updateEqProvider = vi.fn(() => ({ eq: updateEqEventId }))
@@ -105,6 +106,11 @@ describe("POST /api/stripe/webhook", () => {
         return {
           insert: webhookEventsInsert,
           update,
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({ maybeSingle: webhookEventsSelectMaybeSingle })),
+            })),
+          })),
         }
       }
 


### PR DESCRIPTION
### Motivation
- Provide a single place to persist webhook deliveries (Stripe, Cal.com, Documenso) so duplicate deliveries are detected and business side-effects are not re-applied.
- Record payload hashes and processing metadata so retries, dead-lettering, and reconciliation can be managed reliably across providers.

### Description
- Add a reusable helper `lib/webhook-events.ts` with `registerWebhookEvent`, `markWebhookEventStatus`, and `appendWebhookPayloadMetadata` to compute/store `payload_hash`, enforce duplicate detection by `provider + event_id`, and update status/retry metadata.
- Integrate the shared persistence into `app/api/stripe/webhook/route.ts` to replace local duplicate/status logic and to append reconciliation metadata for unmapped events instead of overwriting raw payload.
- Integrate the shared persistence into `app/api/calcom/webhook/route.ts` to short-circuit duplicates, mark retriable failures, and mark processed events after mirroring bookings.
- Add a Documenso webhook endpoint `app/api/documents/webhook/route.ts` that uses the same persistence API and duplicate handling.
- Extend Supabase typings in `lib/supabase.ts` and add a migration `supabase/migrations/202604250001_webhook_events_provider_and_hash.sql` to allow providers `stripe | calcom | documenso` and an indexed `payload_hash` column.
- Add integration tests `tests/integration/api/calcom-webhook-persistence.test.ts` and update `tests/integration/api/stripe-webhook.test.ts` mocks to exercise idempotency and retriable-failure persistence.

### Testing
- Ran: `npm test -- --run tests/integration/api/stripe-webhook.test.ts tests/integration/api/calcom-webhook-persistence.test.ts` and both test files completed successfully.
- Result: all tests in the run passed (`tests/integration/api/stripe-webhook.test.ts` and `tests/integration/api/calcom-webhook-persistence.test.ts` — total 6 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4626a94c8328ace1a0a43a1cb8a6)