### PR TITLE
Harden retention endpoint with per-entity rules and append-only execution logs

### DIFF
--- a/app/api/ops/retention/route.ts
+++ b/app/api/ops/retention/route.ts
@@ -1,5 +1,13 @@
 import { createClient } from "@supabase/supabase-js"
 
+import { writeRetentionExecutionAuditLog } from "@/lib/audit"
+import {
+  applyNotificationPurge,
+  applySignedDocumentMetadataMinimization,
+  applyVisitorLogAnonymization,
+  applyVisitorLogPurge,
+  buildRetentionPlan,
+} from "@/lib/data/retention"
 import { createStructuredLogger } from "@/lib/observability/logger"
 import type { Database } from "@/lib/supabase"
 
@@ -23,14 +31,33 @@ function isAuthorized(req: Request) {
   return received === expected
 }
 
-function isoDaysAgo(days: number) {
-  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+function parseDryRunMode(req: Request) {
+  const { searchParams } = new URL(req.url)
+  return searchParams.get("dryRun") === "true"
+}
+
+function parseActor(req: Request) {
+  const { searchParams } = new URL(req.url)
+  return searchParams.get("actor") ?? req.headers.get("x-retention-actor") ?? "system:cron-retention"
+}
+
+function parseJobId(req: Request) {
+  const { searchParams } = new URL(req.url)
+  return searchParams.get("jobId") ?? req.headers.get("x-job-id") ?? crypto.randomUUID()
 }
 
 export async function GET(req: Request) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID()
+  const dryRun = parseDryRunMode(req)
+  const actorId = parseActor(req)
+  const jobId = parseJobId(req)
+
   const logger = createStructuredLogger("job", {
     component: "retention_job",
-    requestId: req.headers.get("x-request-id") ?? crypto.randomUUID(),
+    requestId,
+    jobId,
+    actorId,
+    mode: dryRun ? "dry-run" : "execute",
   })
 
   if (!isAuthorized(req)) {
@@ -49,38 +76,53 @@ export async function GET(req: Request) {
     )
   }
 
-  const visitorRetentionDate = isoDaysAgo(180)
-  const notificationRetentionDate = isoDaysAgo(90)
-  const auditRetentionDate = isoDaysAgo(730)
+  const plan = buildRetentionPlan()
 
-  const [visitorDelete, notificationDelete, auditDelete] = await Promise.all([
-    supabase
-      .from("visitor_logs")
-      .delete()
-      .lt("departure_date", visitorRetentionDate),
-    supabase
-      .from("notifications")
-      .delete()
-      .lt("created_at", notificationRetentionDate),
-    supabase.from("audit_logs").delete().lt("occurred_at", auditRetentionDate),
+  const results = await Promise.all([
+    applyVisitorLogAnonymization(supabase, plan, { dryRun }),
+    applyVisitorLogPurge(supabase, plan, { dryRun }),
+    applySignedDocumentMetadataMinimization(supabase, plan, { dryRun }),
+    applyNotificationPurge(supabase, plan, { dryRun }),
   ])
 
+  await Promise.all(
+    results.map((result) =>
+      writeRetentionExecutionAuditLog(supabase, {
+        actorId,
+        jobId,
+        entity: result.entity,
+        mode: dryRun ? "dry-run" : "execute",
+        candidates: result.candidates,
+        affected: result.affected,
+        metadata: {
+          policy: plan,
+          requestId,
+        },
+        error: result.error,
+      })
+    )
+  )
+
+  const hasError = results.some((result) => Boolean(result.error))
+
   logger.info("retention_job_completed", {
-    visitorRetentionDate,
-    notificationRetentionDate,
-    auditRetentionDate,
-    visitorDeleteError: visitorDelete.error?.message,
-    notificationDeleteError: notificationDelete.error?.message,
-    auditDeleteError: auditDelete.error?.message,
+    dryRun,
+    actorId,
+    jobId,
+    policy: plan,
+    hasError,
+    results,
   })
 
-  return Response.json({
-    ok: !visitorDelete.error && !notificationDelete.error && !auditDelete.error,
-    visitorRetentionDate,
-    notificationRetentionDate,
-    auditRetentionDate,
-    visitorDeleteError: visitorDelete.error?.message ?? null,
-    notificationDeleteError: notificationDelete.error?.message ?? null,
-    auditDeleteError: auditDelete.error?.message ?? null,
-  })
+  return Response.json(
+    {
+      ok: !hasError,
+      dryRun,
+      actorId,
+      jobId,
+      policy: plan,
+      results,
+    },
+    { status: hasError ? 500 : 200 }
+  )
 }

--- a/docs/operations/data-integrity-retention.md
+++ b/docs/operations/data-integrity-retention.md
@@ -26,13 +26,20 @@ Behavior:
 
 Current retention windows:
 
-- `visitor_logs`: delete entries older than 180 days from `departure_date`.
+- `visitor_logs`: anonymize PII after 180 days from `check_out_date`; purge entries after 365 days.
+- `documents` (`status='signed'`): minimize searchable metadata after 365 days while retaining immutable audit evidence.
 - `notifications`: delete entries older than 90 days from `created_at`.
 
 Behavior:
 
 - Emits `retention_job_completed` structured log.
-- Returns per-table deletion error details for debugging.
+- Supports `dryRun=true` for preflight analysis.
+- Writes per-entity execution records to append-only `retention_execution_audit_logs` including `actor_id` and `job_id`.
+- Returns per-entity mutation/error details for debugging.
+
+Runbook:
+
+- See `docs/operations/runbooks/retention-scheduler.md` for Vercel Cron and incident fallback procedures.
 
 ## Operational cadence
 

--- a/docs/operations/runbooks/retention-scheduler.md
+++ b/docs/operations/runbooks/retention-scheduler.md
@@ -1,0 +1,90 @@
+# Retention Scheduler Runbook
+
+## Purpose
+
+This runbook describes how to execute and recover the retention job at `GET /api/ops/retention`, including daily Vercel cron execution and manual fallback procedures.
+
+## Schedule and trigger
+
+- **Primary scheduler**: Vercel Cron.
+- **Configured schedule**: `0 3 * * *` (daily at **03:00 UTC**).
+- **Configured path**: `/api/ops/retention`.
+- **Authentication**: `Authorization: Bearer ${CRON_SECRET}`.
+
+## Runtime options
+
+The endpoint supports optional query parameters:
+
+- `dryRun=true` — calculate candidate counts without mutating data.
+- `jobId=<id>` — explicit job identifier for traceability.
+- `actor=<actor-id>` — actor override recorded in append-only audit logs.
+
+Examples:
+
+```bash
+curl -sS -X GET \
+  "${NEXT_PUBLIC_APP_URL}/api/ops/retention?dryRun=true&jobId=retention-preflight-2026-04-25" \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  -H "x-request-id: retention-preflight-2026-04-25"
+```
+
+```bash
+curl -sS -X GET \
+  "${NEXT_PUBLIC_APP_URL}/api/ops/retention?jobId=retention-live-2026-04-25" \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  -H "x-retention-actor: system:incident-retention" \
+  -H "x-request-id: retention-live-2026-04-25"
+```
+
+## Retention behavior
+
+The job applies entity-specific rules:
+
+1. `visitor_logs.anonymize`
+   - anonymizes visitor PII for rows older than the anonymization window.
+2. `visitor_logs.purge`
+   - hard-deletes very old visitor rows after the purge window.
+3. `documents.signed_metadata_minimize`
+   - keeps signed document records while minimizing searchable PII fields.
+4. `notifications.purge`
+   - deletes stale notification rows.
+
+Each entity execution is written to append-only table `retention_execution_audit_logs` with:
+
+- `job_id`
+- `actor_id`
+- entity name, mode (`execute`/`dry-run`), candidates, affected counts
+- optional error payload
+
+## Manual incident fallback
+
+Use this when Vercel Cron is unhealthy or delayed.
+
+1. **Preflight dry-run**
+   - Run with `dryRun=true` and a unique `jobId`.
+   - Verify response has `ok: true` and plausible candidate counts.
+2. **Execute live run**
+   - Re-run without `dryRun` using a new `jobId`.
+3. **Validate append-only audit rows**
+   - Confirm exactly one log row per entity for the new `jobId`.
+4. **Re-run safety check**
+   - Trigger the same flow again to verify idempotency (`affected` should trend to `0`).
+
+## Verification checklist
+
+After each scheduled or manual run:
+
+- Endpoint status code is `200`.
+- JSON body includes `ok: true` and `results[]`.
+- No unexpected per-entity `error` values.
+- `retention_execution_audit_logs` has entries for the run's `jobId`.
+- Observability search for `retention_job_completed` includes `jobId` and `actorId`.
+
+## Escalation
+
+If retention repeatedly fails:
+
+1. Pause cron for `/api/ops/retention` in Vercel.
+2. Open a production incident and post failing `jobId`s.
+3. Run dry-run mode hourly until root cause is resolved.
+4. Resume cron and execute one manual live run with an explicit `jobId`.

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -1,6 +1,8 @@
 import 'server-only'
 
-import type { Json } from '@/lib/supabase'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { Database, Json } from '@/lib/supabase'
 import { createSupbaseServerClient } from '@/utils/supaone'
 
 export type AuditAction =
@@ -38,6 +40,41 @@ export async function writeAuditRecord(input: {
     console.error('Unable to persist audit record', {
       action: input.action,
       actorId: input.actorId,
+      error,
+    })
+  }
+}
+
+export async function writeRetentionExecutionAuditLog(
+  client: SupabaseClient<Database>,
+  input: {
+    actorId: string
+    jobId: string
+    entity: string
+    mode: 'execute' | 'dry-run'
+    candidates: number
+    affected: number
+    metadata?: Json
+    error?: string | null
+  }
+) {
+  const payload = {
+    actor_id: input.actorId,
+    job_id: input.jobId,
+    entity: input.entity,
+    mode: input.mode,
+    candidates: input.candidates,
+    affected: input.affected,
+    metadata: input.metadata ?? null,
+    error: input.error ?? null,
+    created_at: new Date().toISOString(),
+  }
+
+  const { error } = await (client as any).from('retention_execution_audit_logs').insert(payload)
+
+  if (error) {
+    console.error('Unable to persist retention execution audit log', {
+      ...payload,
       error,
     })
   }

--- a/lib/data/retention.ts
+++ b/lib/data/retention.ts
@@ -1,0 +1,197 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+const REDACTED_VISITOR_NAME = "[redacted]"
+const REDACTED_VISITOR_EMAIL = "redacted@example.invalid"
+const REDACTED_DOCUMENT_TITLE = "Signed document (redacted)"
+
+export interface RetentionPlan {
+  visitorAnonymizeBefore: string
+  visitorPurgeBefore: string
+  signedDocumentRedactBefore: string
+  notificationPurgeBefore: string
+}
+
+export interface RetentionExecutionOptions {
+  dryRun: boolean
+}
+
+export interface RetentionEntityResult {
+  entity: "visitor_logs.anonymize" | "visitor_logs.purge" | "documents.signed_metadata_minimize" | "notifications.purge"
+  candidates: number
+  affected: number
+  dryRun: boolean
+  error: string | null
+}
+
+function listIds(rows: Array<{ id: string }> | null | undefined) {
+  return (rows ?? []).map((row) => row.id)
+}
+
+export async function applyVisitorLogAnonymization(
+  client: SupabaseClient<Database>,
+  plan: RetentionPlan,
+  options: RetentionExecutionOptions
+): Promise<RetentionEntityResult> {
+  const entity: RetentionEntityResult["entity"] = "visitor_logs.anonymize"
+
+  const { data, error } = await (client as any)
+    .from("visitor_logs")
+    .select("id")
+    .lt("check_out_date", plan.visitorAnonymizeBefore)
+    .neq("guest_name", REDACTED_VISITOR_NAME)
+
+  if (error) {
+    return { entity, candidates: 0, affected: 0, dryRun: options.dryRun, error: error.message }
+  }
+
+  const ids = listIds(data)
+  if (options.dryRun || ids.length === 0) {
+    return { entity, candidates: ids.length, affected: 0, dryRun: options.dryRun, error: null }
+  }
+
+  const { error: updateError } = await (client as any)
+    .from("visitor_logs")
+    .update({
+      guest_name: REDACTED_VISITOR_NAME,
+      guest_email: REDACTED_VISITOR_EMAIL,
+      guest_phone: null,
+      emergency_contact: null,
+      special_notes: null,
+      reason: "[redacted by retention policy]",
+      purpose: "[redacted by retention policy]",
+      updated_at: new Date().toISOString(),
+    })
+    .in("id", ids)
+
+  return {
+    entity,
+    candidates: ids.length,
+    affected: updateError ? 0 : ids.length,
+    dryRun: options.dryRun,
+    error: updateError?.message ?? null,
+  }
+}
+
+export async function applyVisitorLogPurge(
+  client: SupabaseClient<Database>,
+  plan: RetentionPlan,
+  options: RetentionExecutionOptions
+): Promise<RetentionEntityResult> {
+  const entity: RetentionEntityResult["entity"] = "visitor_logs.purge"
+
+  const { data, error } = await (client as any)
+    .from("visitor_logs")
+    .select("id")
+    .lt("check_out_date", plan.visitorPurgeBefore)
+
+  if (error) {
+    return { entity, candidates: 0, affected: 0, dryRun: options.dryRun, error: error.message }
+  }
+
+  const ids = listIds(data)
+  if (options.dryRun || ids.length === 0) {
+    return { entity, candidates: ids.length, affected: 0, dryRun: options.dryRun, error: null }
+  }
+
+  const { error: deleteError } = await (client as any).from("visitor_logs").delete().in("id", ids)
+
+  return {
+    entity,
+    candidates: ids.length,
+    affected: deleteError ? 0 : ids.length,
+    dryRun: options.dryRun,
+    error: deleteError?.message ?? null,
+  }
+}
+
+export async function applySignedDocumentMetadataMinimization(
+  client: SupabaseClient<Database>,
+  plan: RetentionPlan,
+  options: RetentionExecutionOptions
+): Promise<RetentionEntityResult> {
+  const entity: RetentionEntityResult["entity"] = "documents.signed_metadata_minimize"
+
+  const { data, error } = await (client as any)
+    .from("documents")
+    .select("id,title,description")
+    .eq("status", "signed")
+    .lt("signed_at", plan.signedDocumentRedactBefore)
+
+  if (error) {
+    return { entity, candidates: 0, affected: 0, dryRun: options.dryRun, error: error.message }
+  }
+
+  const candidates = (data ?? []).filter(
+    (row: { title: string | null; description: string | null }) =>
+      row.title !== REDACTED_DOCUMENT_TITLE || row.description !== null
+  ) as Array<{ id: string }>
+
+  const ids = listIds(candidates)
+
+  if (options.dryRun || ids.length === 0) {
+    return { entity, candidates: ids.length, affected: 0, dryRun: options.dryRun, error: null }
+  }
+
+  const { error: updateError } = await (client as any)
+    .from("documents")
+    .update({
+      title: REDACTED_DOCUMENT_TITLE,
+      description: null,
+      updated_at: new Date().toISOString(),
+    })
+    .in("id", ids)
+
+  return {
+    entity,
+    candidates: ids.length,
+    affected: updateError ? 0 : ids.length,
+    dryRun: options.dryRun,
+    error: updateError?.message ?? null,
+  }
+}
+
+export async function applyNotificationPurge(
+  client: SupabaseClient<Database>,
+  plan: RetentionPlan,
+  options: RetentionExecutionOptions
+): Promise<RetentionEntityResult> {
+  const entity: RetentionEntityResult["entity"] = "notifications.purge"
+
+  const { data, error } = await (client as any)
+    .from("notifications")
+    .select("id")
+    .lt("created_at", plan.notificationPurgeBefore)
+
+  if (error) {
+    return { entity, candidates: 0, affected: 0, dryRun: options.dryRun, error: error.message }
+  }
+
+  const ids = listIds(data)
+  if (options.dryRun || ids.length === 0) {
+    return { entity, candidates: ids.length, affected: 0, dryRun: options.dryRun, error: null }
+  }
+
+  const { error: deleteError } = await (client as any).from("notifications").delete().in("id", ids)
+
+  return {
+    entity,
+    candidates: ids.length,
+    affected: deleteError ? 0 : ids.length,
+    dryRun: options.dryRun,
+    error: deleteError?.message ?? null,
+  }
+}
+
+export function buildRetentionPlan(now = new Date()): RetentionPlan {
+  const msPerDay = 24 * 60 * 60 * 1000
+  const isoDaysAgo = (days: number) => new Date(now.getTime() - days * msPerDay).toISOString()
+
+  return {
+    visitorAnonymizeBefore: isoDaysAgo(180),
+    visitorPurgeBefore: isoDaysAgo(365),
+    signedDocumentRedactBefore: isoDaysAgo(365),
+    notificationPurgeBefore: isoDaysAgo(90),
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -33,6 +33,18 @@ export type Database = {
         occurred_at: string | null
         created_at: string | null
       }>
+      retention_execution_audit_logs: SupabaseTable<{
+        id: string
+        actor_id: string
+        job_id: string
+        entity: string
+        mode: 'execute' | 'dry-run'
+        candidates: number
+        affected: number
+        error: string | null
+        metadata: Json | null
+        created_at: string
+      }>
       bookings: SupabaseTable<{
         id: string
         created_at: string | null

--- a/supabase/migrations/202604250001_retention_execution_audit_logs.sql
+++ b/supabase/migrations/202604250001_retention_execution_audit_logs.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS public.retention_execution_audit_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_id text NOT NULL,
+  job_id text NOT NULL,
+  entity text NOT NULL,
+  mode text NOT NULL CHECK (mode IN ('execute', 'dry-run')),
+  candidates integer NOT NULL DEFAULT 0,
+  affected integer NOT NULL DEFAULT 0,
+  error text,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_retention_execution_audit_logs_job_id
+  ON public.retention_execution_audit_logs(job_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_retention_execution_audit_logs_entity
+  ON public.retention_execution_audit_logs(entity, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.prevent_retention_execution_audit_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'retention_execution_audit_logs is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS retention_execution_audit_logs_prevent_update
+  ON public.retention_execution_audit_logs;
+CREATE TRIGGER retention_execution_audit_logs_prevent_update
+BEFORE UPDATE ON public.retention_execution_audit_logs
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_retention_execution_audit_mutation();
+
+DROP TRIGGER IF EXISTS retention_execution_audit_logs_prevent_delete
+  ON public.retention_execution_audit_logs;
+CREATE TRIGGER retention_execution_audit_logs_prevent_delete
+BEFORE DELETE ON public.retention_execution_audit_logs
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_retention_execution_audit_mutation();

--- a/tests/integration/api/retention.test.ts
+++ b/tests/integration/api/retention.test.ts
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const createClient = vi.fn()
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient,
+}))
+
+type VisitorLog = {
+  id: string
+  check_out_date: string
+  guest_name: string
+  guest_email: string
+  guest_phone: string | null
+  emergency_contact: string | null
+  special_notes: string | null
+  reason: string
+  purpose: string
+}
+
+type DocumentRow = {
+  id: string
+  status: string
+  signed_at: string | null
+  title: string
+  description: string | null
+}
+
+type NotificationRow = {
+  id: string
+  created_at: string
+}
+
+function createSupabaseMock(seed?: {
+  visitorLogs?: VisitorLog[]
+  documents?: DocumentRow[]
+  notifications?: NotificationRow[]
+}) {
+  const state = {
+    visitor_logs: seed?.visitorLogs ?? [],
+    documents: seed?.documents ?? [],
+    notifications: seed?.notifications ?? [],
+    retention_execution_audit_logs: [] as Array<Record<string, unknown>>,
+  }
+
+  const from = vi.fn((table: string) => {
+    if (table === "visitor_logs") {
+      return {
+        select: vi.fn(() => ({
+          lt: vi.fn((field: string, value: string) => ({
+            neq: vi.fn((neqField: string, neqValue: string) =>
+              Promise.resolve({
+                data: state.visitor_logs
+                  .filter((row) => row[field as keyof VisitorLog] < value)
+                  .filter((row) => row[neqField as keyof VisitorLog] !== neqValue)
+                  .map((row) => ({ id: row.id })),
+                error: null,
+              })
+            ),
+            then: (resolve: (value: { data: Array<{ id: string }>; error: null }) => unknown) =>
+              resolve({
+                data: state.visitor_logs
+                  .filter((row) => row[field as keyof VisitorLog] < value)
+                  .map((row) => ({ id: row.id })),
+                error: null,
+              }),
+          })),
+        })),
+        update: vi.fn((payload: Partial<VisitorLog>) => ({
+          in: vi.fn((_: string, ids: string[]) => {
+            state.visitor_logs = state.visitor_logs.map((row) =>
+              ids.includes(row.id) ? { ...row, ...payload } : row
+            )
+            return Promise.resolve({ data: null, error: null })
+          }),
+        })),
+        delete: vi.fn(() => ({
+          in: vi.fn((_: string, ids: string[]) => {
+            state.visitor_logs = state.visitor_logs.filter((row) => !ids.includes(row.id))
+            return Promise.resolve({ data: null, error: null })
+          }),
+        })),
+      }
+    }
+
+    if (table === "documents") {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn((field: string, value: string) => ({
+            lt: vi.fn((ltField: string, ltValue: string) =>
+              Promise.resolve({
+                data: state.documents
+                  .filter((row) => row[field as keyof DocumentRow] === value)
+                  .filter((row) => (row[ltField as keyof DocumentRow] ?? "") < ltValue)
+                  .map((row) => ({ id: row.id, title: row.title, description: row.description })),
+                error: null,
+              })
+            ),
+          })),
+        })),
+        update: vi.fn((payload: Partial<DocumentRow>) => ({
+          in: vi.fn((_: string, ids: string[]) => {
+            state.documents = state.documents.map((row) =>
+              ids.includes(row.id) ? { ...row, ...payload } : row
+            )
+            return Promise.resolve({ data: null, error: null })
+          }),
+        })),
+      }
+    }
+
+    if (table === "notifications") {
+      return {
+        select: vi.fn(() => ({
+          lt: vi.fn((field: string, value: string) =>
+            Promise.resolve({
+              data: state.notifications
+                .filter((row) => row[field as keyof NotificationRow] < value)
+                .map((row) => ({ id: row.id })),
+              error: null,
+            })
+          ),
+        })),
+        delete: vi.fn(() => ({
+          in: vi.fn((_: string, ids: string[]) => {
+            state.notifications = state.notifications.filter((row) => !ids.includes(row.id))
+            return Promise.resolve({ data: null, error: null })
+          }),
+        })),
+      }
+    }
+
+    if (table === "retention_execution_audit_logs") {
+      return {
+        insert: vi.fn((payload: Record<string, unknown>) => {
+          state.retention_execution_audit_logs.push(payload)
+          return Promise.resolve({ data: null, error: null })
+        }),
+      }
+    }
+
+    throw new Error(`Unexpected table: ${table}`)
+  })
+
+  createClient.mockReturnValue({ from })
+
+  return { state, from }
+}
+
+function daysAgo(days: number) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function authRequest(url = "http://localhost/api/ops/retention") {
+  return new Request(url, {
+    method: "GET",
+    headers: {
+      authorization: "Bearer test_secret",
+    },
+  })
+}
+
+describe("GET /api/ops/retention", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-25T00:00:00.000Z"))
+    process.env.CRON_SECRET = "test_secret"
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co"
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service_role"
+  })
+
+  it("handles boundary dates and applies retention only for older rows", async () => {
+    const { state } = createSupabaseMock({
+      visitorLogs: [
+        {
+          id: "v-anon",
+          check_out_date: daysAgo(181),
+          guest_name: "Guest A",
+          guest_email: "a@example.com",
+          guest_phone: "555-1000",
+          emergency_contact: "EC",
+          special_notes: "note",
+          reason: "vacation",
+          purpose: "vacation",
+        },
+        {
+          id: "v-boundary",
+          check_out_date: daysAgo(180),
+          guest_name: "Guest B",
+          guest_email: "b@example.com",
+          guest_phone: null,
+          emergency_contact: null,
+          special_notes: null,
+          reason: "visit",
+          purpose: "visit",
+        },
+      ],
+      documents: [
+        {
+          id: "d-old",
+          status: "signed",
+          signed_at: daysAgo(366),
+          title: "Signed lease for John",
+          description: "PII heavy",
+        },
+        {
+          id: "d-boundary",
+          status: "signed",
+          signed_at: daysAgo(365),
+          title: "Boundary document",
+          description: "Keep",
+        },
+      ],
+      notifications: [
+        { id: "n-old", created_at: daysAgo(91) },
+        { id: "n-boundary", created_at: daysAgo(90) },
+      ],
+    })
+
+    const { GET } = await import("@/app/api/ops/retention/route")
+    const response = await GET(authRequest())
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.ok).toBe(true)
+
+    expect(state.visitor_logs.find((row) => row.id === "v-anon")?.guest_name).toBe("[redacted]")
+    expect(state.visitor_logs.find((row) => row.id === "v-boundary")?.guest_name).toBe("Guest B")
+
+    expect(state.documents.find((row) => row.id === "d-old")?.title).toBe("Signed document (redacted)")
+    expect(state.documents.find((row) => row.id === "d-boundary")?.title).toBe("Boundary document")
+
+    expect(state.notifications.map((row) => row.id)).toEqual(["n-boundary"])
+    expect(state.retention_execution_audit_logs).toHaveLength(4)
+  })
+
+  it("supports dry-run mode without mutating rows", async () => {
+    const { state } = createSupabaseMock({
+      visitorLogs: [
+        {
+          id: "v1",
+          check_out_date: daysAgo(181),
+          guest_name: "Guest A",
+          guest_email: "a@example.com",
+          guest_phone: "555-1000",
+          emergency_contact: "EC",
+          special_notes: "note",
+          reason: "vacation",
+          purpose: "vacation",
+        },
+      ],
+      documents: [
+        {
+          id: "d1",
+          status: "signed",
+          signed_at: daysAgo(366),
+          title: "Signed lease",
+          description: "PII",
+        },
+      ],
+      notifications: [{ id: "n1", created_at: daysAgo(91) }],
+    })
+
+    const { GET } = await import("@/app/api/ops/retention/route")
+    const response = await GET(authRequest("http://localhost/api/ops/retention?dryRun=true&jobId=dry-001"))
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.dryRun).toBe(true)
+    expect(json.results.every((entry: { affected: number }) => entry.affected === 0)).toBe(true)
+
+    expect(state.visitor_logs[0].guest_name).toBe("Guest A")
+    expect(state.documents[0].title).toBe("Signed lease")
+    expect(state.notifications).toHaveLength(1)
+    expect(state.retention_execution_audit_logs).toHaveLength(4)
+    expect(state.retention_execution_audit_logs[0].mode).toBe("dry-run")
+  })
+
+  it("is idempotent across repeated runs", async () => {
+    const { state } = createSupabaseMock({
+      visitorLogs: [
+        {
+          id: "v1",
+          check_out_date: daysAgo(181),
+          guest_name: "Guest A",
+          guest_email: "a@example.com",
+          guest_phone: null,
+          emergency_contact: null,
+          special_notes: null,
+          reason: "vacation",
+          purpose: "vacation",
+        },
+      ],
+      documents: [
+        {
+          id: "d1",
+          status: "signed",
+          signed_at: daysAgo(366),
+          title: "Original title",
+          description: "sensitive",
+        },
+      ],
+      notifications: [{ id: "n1", created_at: daysAgo(91) }],
+    })
+
+    const { GET } = await import("@/app/api/ops/retention/route")
+
+    const first = await GET(authRequest("http://localhost/api/ops/retention?jobId=repeat-1"))
+    expect(first.status).toBe(200)
+
+    const second = await GET(authRequest("http://localhost/api/ops/retention?jobId=repeat-2"))
+    expect(second.status).toBe(200)
+
+    const secondJson = await second.json()
+    expect(secondJson.results.map((entry: { affected: number }) => entry.affected)).toEqual([0, 0, 0, 0])
+    expect(state.retention_execution_audit_logs).toHaveLength(8)
+  })
+})


### PR DESCRIPTION
### Motivation
- Strengthen data-retention behavior to meet privacy requirements by adding per-entity rules (anonymize vs purge) and reduce PII retained in searchable document fields.
- Ensure operational traceability of retention runs by recording actor and job metadata in an append-only audit store.
- Provide safe operational controls (dry-run, explicit jobId/actor) and a runbook for scheduled/incident invocation.

### Description
- Refactored the retention job at `GET /api/ops/retention` to accept `dryRun`, `actor`, and `jobId`, compute a unified retention plan, and run entity-specific retention operations via a new module `lib/data/retention.ts`.
- Implemented per-entity retention steps: `visitor_logs` anonymization (180 days) and purge (365 days), `documents` signed-metadata minimization (365 days) to remove searchable PII while keeping records, and `notifications` purge (90 days).
- Added append-only execution logging: new helper `writeRetentionExecutionAuditLog` in `lib/audit.ts`, a Supabase migration `supabase/migrations/202604250001_retention_execution_audit_logs.sql` creating `retention_execution_audit_logs` with update/delete guards, and TypeScript DB types updated in `lib/supabase.ts`.
- Added an operations runbook `docs/operations/runbooks/retention-scheduler.md` and updated `docs/operations/data-integrity-retention.md` with the new behavior and verification steps.
- Added integration tests `tests/integration/api/retention.test.ts` covering boundary cutoffs, `dryRun=true` behavior, and idempotent repeated runs.

### Testing
- Ran integration tests: `pnpm vitest tests/integration/api/retention.test.ts`, all tests passed (3 tests, including boundary, dry-run, and idempotency scenarios).
- The retention job emits structured logs (`retention_job_completed`) and writes per-entity rows to `retention_execution_audit_logs` as part of normal execution (verified by integration test assertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4627a0948328bc84722fb258b0e9)