### PR TITLE
Add operational metrics for webhooks, bookings, and payment reconciliation

### DIFF
--- a/app/api/bookings/validate/route.ts
+++ b/app/api/bookings/validate/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server"
 
 import { amenityCatalog } from "@/lib/bookings/amenity-catalog"
 import { validateBookingPolicy } from "@/lib/bookings/policy"
+import { incrementOperationalMetric } from "@/lib/observability/metrics"
 import { createClient } from "@/utils/supa-server-actions"
 
 interface ValidateRequestBody {
@@ -51,6 +52,14 @@ export async function POST(request: Request) {
   })
 
   if (!policyResult.allowed) {
+    incrementOperationalMetric("booking_conflict_validation_rejections_total", {
+      source: "booking_validation",
+      provider: "supabase",
+      amenityId: amenity.id,
+      reason: "policy_violation",
+      severity: "medium",
+    })
+
     return NextResponse.json({
       ok: true,
       allowed: false,
@@ -79,6 +88,17 @@ export async function POST(request: Request) {
       { ok: false, message: "Unable to validate conflicts", details: error.message },
       { status: 500 },
     )
+  }
+
+  if (data.length > 0) {
+    incrementOperationalMetric("booking_conflict_validation_rejections_total", {
+      source: "booking_validation",
+      provider: "supabase",
+      amenityId: amenity.id,
+      reason: "overlap_conflict",
+      severity: "medium",
+      conflictCount: data.length,
+    })
   }
 
   return NextResponse.json({

--- a/app/api/ops/metrics/route.ts
+++ b/app/api/ops/metrics/route.ts
@@ -1,18 +1,46 @@
 import { requirePrivilegedApiAccess } from "@/lib/api-auth"
 import { createStructuredLogger, getCorrelationId } from "@/lib/observability/logger"
-import { incrementOperationalMetric } from "@/lib/observability/metrics"
+import { getOperationalMetricsSummary, incrementOperationalMetric, type CounterMetricName } from "@/lib/observability/metrics"
 
 const ALLOWED = new Set([
   "payment_attempts_total",
   "payment_success_total",
   "payment_failures_total",
   "booking_conflicts_total",
+  "booking_conflict_validation_rejections_total",
   "webhook_failures_total",
+  "webhook_delivery_success_total",
+  "webhook_delivery_failure_total",
+  "unmapped_payment_events_total",
+  "payment_reconciliation_failures_total",
   "maintenance_sla_met_total",
   "maintenance_sla_breaches_total",
   "message_moderation_actions_total",
   "auth_failures_total",
-] as const)
+] as const satisfies readonly CounterMetricName[])
+
+export async function GET(req: Request) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID()
+  const correlationId = getCorrelationId(req.headers, requestId)
+
+  const authContext = await requirePrivilegedApiAccess()
+  if (authContext instanceof Response) {
+    return authContext
+  }
+
+  return Response.json(
+    {
+      ok: true,
+      correlationId,
+      summary: getOperationalMetricsSummary(),
+    },
+    {
+      headers: {
+        "x-correlation-id": correlationId,
+      },
+    }
+  )
+}
 
 export async function POST(req: Request) {
   const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID()
@@ -38,7 +66,7 @@ export async function POST(req: Request) {
       return Response.json({ error: "Invalid metric name" }, { status: 400 })
     }
 
-    incrementOperationalMetric(body.metricName as any, {
+    incrementOperationalMetric(body.metricName as CounterMetricName, {
       source: "ops_metrics_route",
       correlationId,
       ...(body.tags ?? {}),

--- a/app/api/payments/reconciliation/export/route.ts
+++ b/app/api/payments/reconciliation/export/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/utils/supabase/server"
 
 import { jsonError, jsonErrorFromUnknown } from "@/lib/errors"
+import { incrementOperationalMetric } from "@/lib/observability/metrics"
 
 function escapeCsv(value: string) {
   if (/[",\n]/.test(value)) {
@@ -116,6 +117,13 @@ export async function GET() {
       },
     })
   } catch (error) {
+    incrementOperationalMetric("payment_reconciliation_failures_total", {
+      source: "payments_reconciliation_export",
+      provider: "supabase",
+      reason: error instanceof Error ? error.message : "unknown_error",
+      severity: "high",
+    })
+
     return jsonErrorFromUnknown(error, "DATA_FETCH_FAILED")
   }
 }

--- a/app/api/payments/reconciliation/triage/route.ts
+++ b/app/api/payments/reconciliation/triage/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/utils/supabase/server"
 
 import { jsonError, jsonErrorFromUnknown } from "@/lib/errors"
+import { incrementOperationalMetric } from "@/lib/observability/metrics"
 
 const allowedTriageStatus = new Set(["open", "investigating", "resolved"])
 
@@ -111,6 +112,13 @@ export async function PATCH(req: Request) {
 
     return Response.json({ ok: true })
   } catch (error) {
+    incrementOperationalMetric("payment_reconciliation_failures_total", {
+      source: "payments_reconciliation_triage",
+      provider: "supabase",
+      reason: error instanceof Error ? error.message : "unknown_error",
+      severity: "high",
+    })
+
     return jsonErrorFromUnknown(error, "DATA_FETCH_FAILED")
   }
 }

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -5,7 +5,7 @@ import type Stripe from "stripe"
 import { jsonError } from "@/lib/errors"
 import { sendEmailNotification, sendInAppNotification } from "@/lib/notifications"
 import { createStructuredLogger, getCorrelationId } from "@/lib/observability/logger"
-import { incrementOperationalMetric } from "@/lib/observability/metrics"
+import { incrementOperationalMetric, recordWebhookDeliveryMetric } from "@/lib/observability/metrics"
 import { isLikelyTransientError, RetryExhaustedError, retryWithBackoff } from "@/lib/resilience"
 import { getStripe } from "@/lib/stripe"
 import type { Database, Json, TablesInsert } from "@/lib/supabase"
@@ -614,6 +614,7 @@ const HANDLED_EVENTS = new Set([
 ])
 
 export async function POST(req: Request) {
+  const requestStartedAt = Date.now()
   const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID()
   const correlationId = getCorrelationId(req.headers, requestId)
   const logger = createStructuredLogger("webhook_processor", {
@@ -683,6 +684,18 @@ export async function POST(req: Request) {
       correlationId,
       severity: "critical",
     })
+    recordWebhookDeliveryMetric({
+      outcome: "failure",
+      latencyMs: Date.now() - requestStartedAt,
+      tags: {
+        source: "stripe_webhook",
+        provider: "stripe",
+        eventType: "unknown",
+        reason: "stripe_signature_verification_failed",
+        correlationId,
+        severity: "critical",
+      },
+    })
 
     return jsonError("REQUEST_VALIDATION_ERROR", {
       message,
@@ -693,6 +706,17 @@ export async function POST(req: Request) {
   try {
     const duplicate = await isDuplicateEvent(supabase, event)
     if (duplicate) {
+      recordWebhookDeliveryMetric({
+        outcome: "success",
+        latencyMs: Date.now() - requestStartedAt,
+        tags: {
+          source: "stripe_webhook",
+          provider: "stripe",
+          eventType: event.type,
+          correlationId,
+          reason: "duplicate_event",
+        },
+      })
       return new Response("ok", { status: 200 })
     }
 
@@ -740,6 +764,16 @@ export async function POST(req: Request) {
       stripeEventId: event.id,
       lifecyclePhase: "webhook.processed",
     })
+    recordWebhookDeliveryMetric({
+      outcome: "success",
+      latencyMs: Date.now() - requestStartedAt,
+      tags: {
+        source: "stripe_webhook",
+        provider: "stripe",
+        eventType: event.type,
+        correlationId,
+      },
+    })
 
     return new Response("ok", {
       status: 200,
@@ -770,6 +804,18 @@ export async function POST(req: Request) {
         auditDetail: err.auditDetail,
         correlationId,
       })
+      recordWebhookDeliveryMetric({
+        outcome: "failure",
+        latencyMs: Date.now() - requestStartedAt,
+        tags: {
+          source: "stripe_webhook",
+          provider: "stripe",
+          eventType: err.eventType,
+          correlationId,
+          reason: "tenant_mapping_missing",
+          severity: "warning",
+        },
+      })
 
       return new Response("ok", {
         status: 200,
@@ -796,6 +842,18 @@ export async function POST(req: Request) {
       reason: message,
       correlationId,
       severity: "critical",
+    })
+    recordWebhookDeliveryMetric({
+      outcome: "failure",
+      latencyMs: Date.now() - requestStartedAt,
+      tags: {
+        source: "stripe_webhook",
+        provider: "stripe",
+        eventType: event.type,
+        reason: message,
+        correlationId,
+        severity: "critical",
+      },
     })
 
     if (exhausted) {

--- a/docs/engineering/incident-playbook-observability.md
+++ b/docs/engineering/incident-playbook-observability.md
@@ -1,0 +1,68 @@
+# Incident Playbook: Webhook, Booking Validation, and Reconciliation Metrics
+
+_Last updated: 2026-04-25_
+
+This playbook covers high-signal alerts tied to operational metrics.
+
+## 1) Spike in Failed Webhook Signatures
+
+### Trigger
+- Alert fires on `webhook_delivery_failure_total` with `reason=stripe_signature_verification_failed`.
+
+### Immediate Actions (first 15 minutes)
+1. Confirm current Stripe webhook signing secret in environment configuration.
+2. Verify no recent deploy or secret rotation mismatch between Stripe dashboard and Vercel env vars.
+3. Query recent `webhook_events` rows for status/error spikes.
+4. Check if failures are isolated to one environment (`development`, `staging`, `production`).
+
+### Mitigation
+- Correct `STRIPE_WEBHOOK_SECRET` and redeploy.
+- If attack suspected, rotate secret and block unknown source traffic at edge controls.
+
+### Recovery Criteria
+- Failure rate returns below 5% for 15 consecutive minutes.
+- New Stripe events are being marked `processed`.
+
+## 2) Sustained Reconciliation Backlog
+
+### Trigger
+- Reconciliation backlog exceeds threshold (for example, >25 open failed rows for >=30 minutes).
+- `payment_reconciliation_failures_total` also trending upward.
+
+### Immediate Actions (first 30 minutes)
+1. Export reconciliation CSV from `/api/payments/reconciliation/export`.
+2. Triage top offenders (unmapped webhook events, repeated tenant mapping failures).
+3. Validate Supabase availability and recent schema changes impacting payment metadata.
+4. Confirm Stripe event processing status and dead-letter entries.
+
+### Mitigation
+- Assign on-call property manager/admin to triage queue ownership.
+- Patch missing tenant mappings and replay affected events where feasible.
+- If API-level failures continue, temporarily pause non-essential exports/triage jobs and focus recovery on ingestion pipeline.
+
+### Recovery Criteria
+- Open triage queue steadily decreases over two consecutive 15-minute checks.
+- No new P1 reconciliation failures in the last 30 minutes.
+
+## 3) Elevated Booking Conflict Validation Rejections
+
+### Trigger
+- `booking_conflict_validation_rejections_total` exceeds threshold in short interval.
+
+### Immediate Actions
+1. Split rejection volume by `reason` tag.
+2. If mostly `policy_violation`, review policy rollout or client-side validation drift.
+3. If mostly `overlap_conflict`, inspect amenity slot capacity/configuration and possible duplicate submissions.
+
+### Mitigation
+- Adjust booking policy limits if configuration regression is confirmed.
+- Add temporary client-side debounce/lockout for duplicate submit loops.
+
+### Recovery Criteria
+- Rejection rate returns to established baseline for same day-of-week traffic profile.
+
+## Incident Communications
+
+- Post updates every 15 minutes in the incident channel.
+- Include: current metric values, user impact, mitigation status, ETA.
+- Close with a post-incident summary and follow-up actions within 2 business days.

--- a/docs/engineering/observability-alert-thresholds.md
+++ b/docs/engineering/observability-alert-thresholds.md
@@ -1,0 +1,35 @@
+# Observability Alert Thresholds
+
+_Last updated: 2026-04-25_
+
+This document defines alert thresholds for webhook delivery, booking conflict validation, and payment reconciliation operations.
+
+## Alert Scope
+
+| Metric | Severity | Threshold | Evaluation Window | Suggested Response |
+| --- | --- | --- | --- | --- |
+| `webhook_delivery_failure_total` | P1 | `>= 10` failures OR failure rate `> 15%` | 5 minutes | Trigger webhook incident playbook immediately. |
+| `webhook_delivery_failure_total` with `reason=stripe_signature_verification_failed` | P1 | `>= 5` failures | 5 minutes | Treat as potential secret rotation/configuration drift. |
+| `webhook_delivery_failure_latency_ms` p95 | P2 | `> 4,000ms` | 15 minutes | Investigate Stripe/Supabase latency and retry pressure. |
+| `booking_conflict_validation_rejections_total` | P3 | `>= 75` rejections | 15 minutes | Validate policy configuration and potential UI misuse loops. |
+| `payment_reconciliation_failures_total` | P1 | `>= 6` failures | 10 minutes | Open incident; reconciliation flow is degraded. |
+| Reconciliation backlog (failed rows with open triage) | P2 | `> 25` rows for `>= 30` minutes | 30 minutes | Escalate to property manager on call. |
+
+## Notes on Metric Interpretation
+
+- `webhook_delivery_*` metrics include success/failure counters and latency histograms emitted by `/api/stripe/webhook`.
+- `booking_conflict_validation_rejections_total` includes both policy violations and overlap conflicts from `/api/bookings/validate`.
+- `payment_reconciliation_failures_total` tracks operational failures in reconciliation triage and export APIs.
+
+## Dashboard Panels
+
+Recommended dashboard panels:
+
+1. **Webhook delivery reliability**
+   - Success count, failure count, failure rate percentage.
+2. **Webhook latency**
+   - p50 and p95 for success and failure histograms.
+3. **Booking conflict rejection trend**
+   - Stacked by `reason` tag (`policy_violation`, `overlap_conflict`).
+4. **Payment reconciliation health**
+   - Failure count trend + open backlog count from reconciliation tables.

--- a/lib/observability/metrics.ts
+++ b/lib/observability/metrics.ts
@@ -1,16 +1,26 @@
 import { createStructuredLogger } from "@/lib/observability/logger"
 
-export type OperationalMetricName =
+export type CounterMetricName =
   | "payment_attempts_total"
   | "payment_success_total"
   | "payment_failures_total"
   | "booking_conflicts_total"
+  | "booking_conflict_validation_rejections_total"
   | "webhook_failures_total"
+  | "webhook_delivery_success_total"
+  | "webhook_delivery_failure_total"
   | "unmapped_payment_events_total"
+  | "payment_reconciliation_failures_total"
   | "maintenance_sla_met_total"
   | "maintenance_sla_breaches_total"
   | "message_moderation_actions_total"
   | "auth_failures_total"
+
+export type HistogramMetricName =
+  | "webhook_delivery_success_latency_ms"
+  | "webhook_delivery_failure_latency_ms"
+
+export type OperationalMetricName = CounterMetricName | HistogramMetricName
 
 export interface MetricTags {
   source: string
@@ -23,9 +33,55 @@ export interface MetricTags {
   [key: string]: string | number | boolean | undefined
 }
 
+interface HistogramState {
+  count: number
+  sum: number
+  min: number
+  max: number
+  samples: number[]
+}
+
 const metricsLogger = createStructuredLogger("route_handler", {
   component: "operational_metrics",
 })
+
+const counterStore = new Map<CounterMetricName, number>()
+const histogramStore = new Map<HistogramMetricName, HistogramState>()
+
+const MAX_HISTOGRAM_SAMPLES = 500
+
+function pushHistogramValue(name: HistogramMetricName, value: number) {
+  const existing =
+    histogramStore.get(name) ?? {
+      count: 0,
+      sum: 0,
+      min: Number.POSITIVE_INFINITY,
+      max: Number.NEGATIVE_INFINITY,
+      samples: [],
+    }
+
+  existing.count += 1
+  existing.sum += value
+  existing.min = Math.min(existing.min, value)
+  existing.max = Math.max(existing.max, value)
+
+  if (existing.samples.length >= MAX_HISTOGRAM_SAMPLES) {
+    existing.samples.shift()
+  }
+
+  existing.samples.push(value)
+  histogramStore.set(name, existing)
+}
+
+function percentileFromSamples(samples: number[], percentile: number) {
+  if (samples.length === 0) {
+    return 0
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.ceil((percentile / 100) * sorted.length) - 1)
+  return sorted[index]
+}
 
 export function recordOperationalMetric(
   name: OperationalMetricName,
@@ -37,11 +93,71 @@ export function recordOperationalMetric(
     metricValue: value,
     tags,
   })
+
+  if (name.endsWith("_ms")) {
+    pushHistogramValue(name as HistogramMetricName, value)
+    return
+  }
+
+  const metricName = name as CounterMetricName
+  counterStore.set(metricName, (counterStore.get(metricName) ?? 0) + value)
 }
 
 export function incrementOperationalMetric(
-  name: OperationalMetricName,
+  name: CounterMetricName,
   tags: MetricTags
 ) {
   recordOperationalMetric(name, 1, tags)
+}
+
+export function recordWebhookDeliveryMetric(params: {
+  outcome: "success" | "failure"
+  latencyMs: number
+  tags: MetricTags
+}) {
+  const outcomeMetric =
+    params.outcome === "success"
+      ? "webhook_delivery_success_total"
+      : "webhook_delivery_failure_total"
+  const latencyMetric =
+    params.outcome === "success"
+      ? "webhook_delivery_success_latency_ms"
+      : "webhook_delivery_failure_latency_ms"
+
+  incrementOperationalMetric(outcomeMetric, params.tags)
+  recordOperationalMetric(latencyMetric, params.latencyMs, params.tags)
+}
+
+export function getOperationalMetricsSummary() {
+  const counters = Object.fromEntries(counterStore.entries())
+
+  const histograms = Object.fromEntries(
+    Array.from(histogramStore.entries()).map(([name, state]) => {
+      const average = state.count > 0 ? state.sum / state.count : 0
+      return [
+        name,
+        {
+          count: state.count,
+          average,
+          min: Number.isFinite(state.min) ? state.min : 0,
+          max: Number.isFinite(state.max) ? state.max : 0,
+          p50: percentileFromSamples(state.samples, 50),
+          p95: percentileFromSamples(state.samples, 95),
+        },
+      ]
+    })
+  )
+
+  return {
+    generatedAt: new Date().toISOString(),
+    counters,
+    histograms,
+    health: {
+      webhookFailureRate:
+        (counters.webhook_delivery_failure_total ?? 0) /
+        Math.max((counters.webhook_delivery_success_total ?? 0) + (counters.webhook_delivery_failure_total ?? 0), 1),
+      bookingConflictValidationRejections: counters.booking_conflict_validation_rejections_total ?? 0,
+      paymentReconciliationFailures: counters.payment_reconciliation_failures_total ?? 0,
+    },
+  }
 }

--- a/tests/integration/api/stripe-webhook.test.ts
+++ b/tests/integration/api/stripe-webhook.test.ts
@@ -8,6 +8,7 @@ const sendInAppNotification = vi.fn()
 const createClient = vi.fn()
 const mockHeadersGet = vi.fn()
 const incrementOperationalMetric = vi.fn()
+const recordWebhookDeliveryMetric = vi.fn()
 
 vi.mock("next/headers", () => ({
   headers: async () => ({
@@ -42,6 +43,7 @@ vi.mock("@/lib/notifications", () => ({
 
 vi.mock("@/lib/observability/metrics", () => ({
   incrementOperationalMetric,
+  recordWebhookDeliveryMetric,
 }))
 
 describe("POST /api/stripe/webhook", () => {


### PR DESCRIPTION
### Motivation
- Provide observability for webhook delivery (success/failure and latency), booking conflict validation rejections, and payment reconciliation failures to surface operational issues quickly. 
- Expose a summarized health snapshot for dashboards and enable alerting/playbooks for common failure modes like signature verification spikes and reconciliation backlogs. 

### Description
- Expanded `lib/observability/metrics.ts` with new counter names, webhook latency histogram support, `recordWebhookDeliveryMetric` helper, in-memory aggregation, and `getOperationalMetricsSummary` for rollups. 
- Instrumented `app/api/stripe/webhook/route.ts` to emit webhook delivery success/failure counters and latency histograms for signature verification failures, duplicate events, unmapped events, processed events, and hard failures. 
- Instrumented `app/api/bookings/validate/route.ts` to increment `booking_conflict_validation_rejections_total` for policy violations and overlap conflicts and instrumented reconciliation endpoints (`app/api/payments/reconciliation/triage` and `.../export`) to emit `payment_reconciliation_failures_total` on error paths. 
- Updated `app/api/ops/metrics/route.ts` to accept the new metric names and added a privileged `GET` route that returns the `getOperationalMetricsSummary()` snapshot; added test adjustments and engineering docs for alert thresholds and an incident playbook under `docs/engineering/`. 

### Testing
- Ran the Stripe webhook integration tests with `pnpm -s vitest tests/integration/api/stripe-webhook.test.ts` and they passed (`4 tests`). 
- Ran TypeScript check with `pnpm -s tsc --noEmit` and the build type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4629af2c8328b4deeb36fa07db10)