### PR TITLE
Add resilient upstream client behavior and normalized integration errors

### DIFF
--- a/lib/calcom-service.ts
+++ b/lib/calcom-service.ts
@@ -1,231 +1,208 @@
-import { providerOutageMessage, retryWithBackoff } from "@/lib/resilience"
+import { incrementOperationalMetric } from "@/lib/observability/metrics"
+import {
+  providerOutageMessage,
+  resilientRequest,
+  UpstreamHttpError,
+} from "@/lib/resilience"
 
 interface CalComCreateBookingRequest {
-  start: string;
-  end: string;
-  title: string;
-  description?: string;
+  start: string
+  end: string
+  title: string
+  description?: string
   attendees: Array<{
-    email: string;
-    name?: string;
-  }>;
-  location?: string;
+    email: string
+    name?: string
+  }>
+  location?: string
 }
 
 interface CalComBookingResponse {
-  success: boolean;
-  bookingId?: string;
-  bookingUrl?: string;
-  error?: string;
+  success: boolean
+  bookingId?: string
+  bookingUrl?: string
+  error?: string
 }
 
 interface CalComEventType {
-  id: number;
-  title: string;
-  description?: string;
-  length: number;
-  slug: string;
-  hidden: boolean;
+  id: number
+  title: string
+  description?: string
+  length: number
+  slug: string
+  hidden: boolean
 }
 
 class CalComService {
-  private baseUrl: string;
-  private apiKey: string;
+  private baseUrl: string
+  private apiKey: string
 
   constructor(baseUrl: string, apiKey: string) {
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
+    this.baseUrl = baseUrl
+    this.apiKey = apiKey
   }
 
-  /**
-   * Get event types for a specific user or team
-   */
-  async getEventTypes(userSlug?: string): Promise<CalComEventType[]> {
-    const endpoint = userSlug
-      ? `${this.baseUrl}/api/v1/event-types/${userSlug}`
-      : `${this.baseUrl}/api/v1/event-types`;
+  private async request(path: string, init: RequestInit, operation: string): Promise<Response> {
+    const { value: response } = await resilientRequest(
+      async () => {
+        const response = await fetch(`${this.baseUrl}${path}`, {
+          ...init,
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            "Content-Type": "application/json",
+            ...(init.headers ?? {}),
+          },
+        })
 
-    try {
-      const { value: response } = await retryWithBackoff(
-        async () => {
-          const response = await fetch(endpoint, {
-            headers: {
-              'Authorization': `Bearer ${this.apiKey}`,
-              'Content-Type': 'application/json',
-            },
-          });
+        if (!response.ok) {
+          throw new UpstreamHttpError("calcom", operation, response.status, response.statusText)
+        }
 
-          if (!response.ok) {
-            throw new Error(`Failed to fetch event types: ${response.status} ${response.statusText}`);
+        return response
+      },
+      {
+        provider: "calcom",
+        operation,
+        retries: 2,
+        initialDelayMs: 250,
+        jitter: true,
+        timeoutMs: 6_000,
+        shouldRetry: (error) => {
+          if (error instanceof UpstreamHttpError) {
+            return error.status === 429 || error.status >= 500
           }
 
-          return response
+          return true
         },
-        { retries: 2, initialDelayMs: 250, jitter: true }
-      );
+        onCircuitOpen: () => {
+          incrementOperationalMetric("upstream_circuit_open_total", {
+            source: "calcom_service",
+            provider: "calcom",
+            operation,
+          })
+        },
+      }
+    )
 
-      const data = await response.json();
-      return data.eventTypes || [];
+    return response
+  }
+
+  async getEventTypes(userSlug?: string): Promise<CalComEventType[]> {
+    const endpoint = userSlug
+      ? `/api/v1/event-types/${userSlug}`
+      : "/api/v1/event-types"
+
+    try {
+      const response = await this.request(endpoint, { method: "GET" }, "get_event_types")
+      const data = await response.json()
+      return data.eventTypes || []
     } catch (error) {
-      console.error('Error fetching Cal.com event types:', error);
-      return [];
+      console.error("Error fetching Cal.com event types:", error)
+      return []
     }
   }
 
-  /**
-   * Create a booking for an event type
-   */
   async createBooking(
     eventTypeId: number,
     bookingData: CalComCreateBookingRequest
   ): Promise<CalComBookingResponse> {
     try {
-      const { value: response } = await retryWithBackoff(
-        async () => {
-          const response = await fetch(
-            `${this.baseUrl}/api/v1/bookings`,
-            {
-              method: 'POST',
-              headers: {
-                'Authorization': `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                eventTypeId,
-                start: bookingData.start,
-                end: bookingData.end,
-                title: bookingData.title,
-                description: bookingData.description,
-                attendees: bookingData.attendees,
-                location: bookingData.location,
-              }),
-            }
-          );
-
-          if (!response.ok) {
-            const errorData = await response.json().catch(() => ({}));
-            throw new Error(
-              errorData.message || `Failed to create booking: ${response.status} ${response.statusText}`
-            );
-          }
-
-          return response
+      const response = await this.request(
+        "/api/v1/bookings",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            eventTypeId,
+            start: bookingData.start,
+            end: bookingData.end,
+            title: bookingData.title,
+            description: bookingData.description,
+            attendees: bookingData.attendees,
+            location: bookingData.location,
+          }),
         },
-        { retries: 2, initialDelayMs: 350, jitter: true }
-      );
+        "create_booking"
+      )
 
-      const data = await response.json();
+      const data = await response.json()
 
       return {
         success: true,
         bookingId: data.booking?.id?.toString(),
         bookingUrl: data.booking?.url,
-      };
+      }
     } catch (error) {
-      console.error('Error creating Cal.com booking:', error);
+      console.error("Error creating Cal.com booking:", error)
       return {
         success: false,
-        error: providerOutageMessage('calcom'),
-      };
+        error: providerOutageMessage("calcom"),
+      }
     }
   }
 
-  /**
-   * Cancel a booking
-   */
   async cancelBooking(bookingId: string): Promise<boolean> {
     try {
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings/${bookingId}/cancel`,
-        {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-
-      return response.ok;
+      const response = await this.request(
+        `/api/v1/bookings/${bookingId}/cancel`,
+        { method: "POST" },
+        "cancel_booking"
+      )
+      return response.ok
     } catch (error) {
-      console.error('Error canceling Cal.com booking:', error);
-      return false;
+      console.error("Error canceling Cal.com booking:", error)
+      return false
     }
   }
 
-  /**
-   * Get booking details
-   */
   async getBooking(bookingId: string): Promise<any> {
     try {
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings/${bookingId}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch booking: ${response.statusText}`);
-      }
-
-      return await response.json();
+      const response = await this.request(
+        `/api/v1/bookings/${bookingId}`,
+        { method: "GET" },
+        "get_booking"
+      )
+      return await response.json()
     } catch (error) {
-      console.error('Error fetching Cal.com booking:', error);
-      return null;
+      console.error("Error fetching Cal.com booking:", error)
+      return null
     }
   }
 
-  /**
-   * Get bookings for a user
-   */
   async getUserBookings(
     userEmail: string,
     startDate?: string,
     endDate?: string
   ): Promise<any[]> {
     try {
-      const params = new URLSearchParams();
-      if (startDate) params.append('startDate', startDate);
-      if (endDate) params.append('endDate', endDate);
+      const params = new URLSearchParams()
+      if (startDate) params.append("startDate", startDate)
+      if (endDate) params.append("endDate", endDate)
+      params.append("userEmail", userEmail)
 
-      const response = await fetch(
-        `${this.baseUrl}/api/v1/bookings?${params.toString()}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
+      const response = await this.request(
+        `/api/v1/bookings?${params.toString()}`,
+        { method: "GET" },
+        "get_user_bookings"
+      )
 
-      if (!response.ok) {
-        throw new Error(`Failed to fetch user bookings: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-      return data.bookings || [];
+      const data = await response.json()
+      return data.bookings || []
     } catch (error) {
-      console.error('Error fetching Cal.com user bookings:', error);
-      return [];
+      console.error("Error fetching Cal.com user bookings:", error)
+      return []
     }
   }
 }
 
-// Create singleton instance
-const CALCOM_BASE_URL = process.env.CALCOM_BASE_URL || 'https://api.cal.com';
-const CALCOM_API_KEY = process.env.CALCOM_API_KEY || '';
+const CALCOM_BASE_URL = process.env.CALCOM_BASE_URL || "https://api.cal.com"
+const CALCOM_API_KEY = process.env.CALCOM_API_KEY || ""
 
 if (!CALCOM_API_KEY) {
-  console.warn('CALCOM_API_KEY is not configured');
+  console.warn("CALCOM_API_KEY is not configured")
 }
 
-export const calComService = new CalComService(CALCOM_BASE_URL, CALCOM_API_KEY);
+export const calComService = new CalComService(CALCOM_BASE_URL, CALCOM_API_KEY)
 
-// Amenity-specific booking functions
 export async function createAmenityBooking({
   amenityType,
   startTime,
@@ -234,26 +211,24 @@ export async function createAmenityBooking({
   userName,
   description,
 }: {
-  amenityType: string;
-  startTime: string;
-  endTime: string;
-  userEmail: string;
-  userName: string;
-  description?: string;
+  amenityType: string
+  startTime: string
+  endTime: string
+  userEmail: string
+  userName: string
+  description?: string
 }): Promise<CalComBookingResponse> {
-  // Get available event types for amenities
-  const eventTypes = await calComService.getEventTypes();
+  const eventTypes = await calComService.getEventTypes()
 
-  // Find the appropriate event type for the amenity
   const amenityEventType = eventTypes.find(
     (et) => et.title.toLowerCase().includes(amenityType.toLowerCase()) && !et.hidden
-  );
+  )
 
   if (!amenityEventType) {
     return {
       success: false,
       error: `No booking slot available for ${amenityType}. Please try a different time or contact support.`,
-    };
+    }
   }
 
   return await calComService.createBooking(amenityEventType.id, {
@@ -267,12 +242,12 @@ export async function createAmenityBooking({
         name: userName,
       },
     ],
-    location: 'Property Amenity',
-  });
+    location: "Property Amenity",
+  })
 }
 
 export async function cancelAmenityBooking(bookingId: string): Promise<boolean> {
-  return await calComService.cancelBooking(bookingId);
+  return await calComService.cancelBooking(bookingId)
 }
 
 export async function getAmenityBookings(
@@ -280,5 +255,5 @@ export async function getAmenityBookings(
   startDate?: string,
   endDate?: string
 ): Promise<any[]> {
-  return await calComService.getUserBookings(userEmail, startDate, endDate);
+  return await calComService.getUserBookings(userEmail, startDate, endDate)
 }

--- a/lib/documenso.ts
+++ b/lib/documenso.ts
@@ -1,297 +1,275 @@
-import { providerOutageMessage, retryWithBackoff } from '@/lib/resilience';
-import { DocumentSigningRequest, DocumentSigningResponse } from '@/types/documents';
+import { incrementOperationalMetric } from "@/lib/observability/metrics"
+import {
+  providerOutageMessage,
+  resilientRequest,
+  UpstreamHttpError,
+} from "@/lib/resilience"
+import { DocumentSigningRequest, DocumentSigningResponse } from "@/types/documents"
 
-const DOCUMENSO_BASE_URL = process.env.DOCUMENSO_BASE_URL || 'https://app.documenso.com';
-const DOCUMENSO_API_KEY = process.env.DOCUMENSO_API_KEY;
+const DOCUMENSO_BASE_URL = process.env.DOCUMENSO_BASE_URL || "https://app.documenso.com"
+const DOCUMENSO_API_KEY = process.env.DOCUMENSO_API_KEY
 
 if (!DOCUMENSO_API_KEY) {
-  console.warn('DOCUMENSO_API_KEY is not configured');
+  console.warn("DOCUMENSO_API_KEY is not configured")
 }
 
 const getAuthHeaders = (): Record<string, string> => ({
   Authorization: `Bearer ${DOCUMENSO_API_KEY}`,
-  'Content-Type': 'application/json',
-});
+  "Content-Type": "application/json",
+})
 
 export interface DocumensoDocument {
-  id: string;
-  title: string;
-  status: string;
-  createdAt: string;
-  updatedAt: string;
-  recipients: DocumensoRecipient[];
-  documentDataId: string;
+  id: string
+  title: string
+  status: string
+  createdAt: string
+  updatedAt: string
+  recipients: DocumensoRecipient[]
+  documentDataId: string
 }
 
 export interface DocumensoRecipient {
-  id: string;
-  email: string;
-  name?: string;
-  role: string;
-  signingOrder?: number;
-  token: string;
-  signedAt?: string;
-  status: string;
+  id: string
+  email: string
+  name?: string
+  role: string
+  signingOrder?: number
+  token: string
+  signedAt?: string
+  status: string
 }
 
 export interface DocumensoCreateDocumentRequest {
-  title: string;
-  documentDataId: string; // ID of uploaded document data
+  title: string
+  documentDataId: string
   recipients: {
-    email: string;
-    name?: string;
-    role: 'SIGNER' | 'APPROVER' | 'CC';
-    signingOrder?: number;
-  }[];
-  message?: string;
-  expiresAt?: string;
+    email: string
+    name?: string
+    role: "SIGNER" | "APPROVER" | "CC"
+    signingOrder?: number
+  }[]
+  message?: string
+  expiresAt?: string
 }
 
 export interface DocumensoCreateDocumentResponse {
-  id: string;
-  title: string;
-  status: string;
-  recipients: DocumensoRecipient[];
+  id: string
+  title: string
+  status: string
+  recipients: DocumensoRecipient[]
 }
 
 export interface DocumensoUploadResponse {
-  id: string;
-  documentDataId: string;
+  id: string
+  documentDataId: string
 }
 
 class DocumensoService {
-  private baseUrl: string;
-  private apiKey: string;
+  private baseUrl: string
+  private apiKey: string
 
   constructor(baseUrl: string, apiKey: string) {
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
+    this.baseUrl = baseUrl
+    this.apiKey = apiKey
   }
 
-  /**
-   * Upload a document to Documenso
-   */
-  async uploadDocument(file: File): Promise<DocumensoUploadResponse> {
-    const formData = new FormData();
-    formData.append('file', file);
-
-    const { value: response } = await retryWithBackoff(
+  private async request(path: string, init: RequestInit, operation: string): Promise<Response> {
+    const { value: response } = await resilientRequest(
       async () => {
-        const response = await fetch(`${this.baseUrl}/api/v1/documents/upload`, {
-          method: 'POST',
+        const response = await fetch(`${this.baseUrl}${path}`, {
+          ...init,
           headers: {
-            Authorization: `Bearer ${this.apiKey}`,
+            ...getAuthHeaders(),
+            ...(init.headers ?? {}),
           },
-          body: formData,
         })
 
         if (!response.ok) {
-          const error = await response.text();
-          throw new Error(`Documenso upload failed: ${response.status} ${error}`);
+          const errorText = await response.text().catch(() => response.statusText)
+          throw new UpstreamHttpError("documenso", operation, response.status, errorText)
         }
 
         return response
       },
-      { retries: 2, initialDelayMs: 300, jitter: true }
-    );
+      {
+        provider: "documenso",
+        operation,
+        retries: 2,
+        initialDelayMs: 300,
+        jitter: true,
+        timeoutMs: 8_000,
+        shouldRetry: (error) => {
+          if (error instanceof UpstreamHttpError) {
+            return error.status === 429 || error.status >= 500
+          }
+          return true
+        },
+        onCircuitOpen: () => {
+          incrementOperationalMetric("upstream_circuit_open_total", {
+            source: "documenso_service",
+            provider: "documenso",
+            operation,
+          })
+        },
+      }
+    )
 
-    return response.json();
+    return response
   }
 
-  /**
-   * Create a signing envelope for a document
-   */
+  async uploadDocument(file: File): Promise<DocumensoUploadResponse> {
+    const formData = new FormData()
+    formData.append("file", file)
+
+    const response = await this.request(
+      "/api/v1/documents/upload",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: formData,
+      },
+      "upload_document"
+    )
+
+    return response.json()
+  }
+
   async createDocumentSigningEnvelope(
     request: DocumensoCreateDocumentRequest
   ): Promise<DocumensoCreateDocumentResponse> {
-    const { value: response } = await retryWithBackoff(
-      async () => {
-        const response = await fetch(`${this.baseUrl}/api/v1/documents`, {
-          method: 'POST',
-          headers: getAuthHeaders(),
-          body: JSON.stringify(request),
-        })
-
-        if (!response.ok) {
-          const error = await response.text();
-          throw new Error(`Documenso create document failed: ${response.status} ${error}`);
-        }
-
-        return response
+    const response = await this.request(
+      "/api/v1/documents",
+      {
+        method: "POST",
+        body: JSON.stringify(request),
       },
-      { retries: 2, initialDelayMs: 300, jitter: true }
-    );
+      "create_document_signing_envelope"
+    )
 
-    return response.json();
+    return response.json()
   }
 
-  /**
-   * Get document details
-   */
   async getDocument(documentId: string): Promise<DocumensoDocument> {
-    const response = await fetch(`${this.baseUrl}/api/v1/documents/${documentId}`, {
-      method: 'GET',
-      headers: getAuthHeaders(),
-    });
+    const response = await this.request(
+      `/api/v1/documents/${documentId}`,
+      { method: "GET" },
+      "get_document"
+    )
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso get document failed: ${error}`);
-    }
-
-    return response.json();
+    return response.json()
   }
 
-  /**
-   * Get signing URL for a recipient
-   */
   async getSigningUrl(documentId: string, recipientId: string): Promise<string> {
-    const response = await fetch(
-      `${this.baseUrl}/api/v1/documents/${documentId}/recipients/${recipientId}/signing-url`,
-      {
-        method: 'GET',
-        headers: getAuthHeaders(),
-      }
-    );
+    const response = await this.request(
+      `/api/v1/documents/${documentId}/recipients/${recipientId}/signing-url`,
+      { method: "GET" },
+      "get_signing_url"
+    )
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso get signing URL failed: ${error}`);
-    }
-
-    const data = await response.json();
-    return data.signingUrl;
+    const data = await response.json()
+    return data.signingUrl
   }
 
-  /**
-   * Send signing reminder
-   */
   async sendSigningReminder(documentId: string, recipientId: string): Promise<void> {
-    const response = await fetch(
-      `${this.baseUrl}/api/v1/documents/${documentId}/recipients/${recipientId}/remind`,
-      {
-        method: 'POST',
-        headers: getAuthHeaders(),
-      }
-    );
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso send reminder failed: ${error}`);
-    }
+    await this.request(
+      `/api/v1/documents/${documentId}/recipients/${recipientId}/remind`,
+      { method: "POST" },
+      "send_signing_reminder"
+    )
   }
 
-  /**
-   * Cancel a document
-   */
   async cancelDocument(documentId: string): Promise<void> {
-    const response = await fetch(`${this.baseUrl}/api/v1/documents/${documentId}/cancel`, {
-      method: 'POST',
-      headers: getAuthHeaders(),
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso cancel document failed: ${error}`);
-    }
+    await this.request(
+      `/api/v1/documents/${documentId}/cancel`,
+      { method: "POST" },
+      "cancel_document"
+    )
   }
 
-  /**
-   * Create document from template
-   */
   async createFromTemplate(
     templateId: string,
     title: string,
-    recipients: DocumensoCreateDocumentRequest['recipients']
+    recipients: DocumensoCreateDocumentRequest["recipients"]
   ): Promise<DocumensoCreateDocumentResponse> {
-    const response = await fetch(`${this.baseUrl}/api/v1/templates/${templateId}/use`, {
-      method: 'POST',
-      headers: getAuthHeaders(),
-      body: JSON.stringify({
-        title,
-        recipients,
-      }),
-    });
+    const response = await this.request(
+      `/api/v1/templates/${templateId}/use`,
+      {
+        method: "POST",
+        body: JSON.stringify({ title, recipients }),
+      },
+      "create_from_template"
+    )
 
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Documenso create from template failed: ${error}`);
-    }
-
-    return response.json();
+    return response.json()
   }
 }
 
-// Export singleton instance
 export const documensoService = new DocumensoService(
   DOCUMENSO_BASE_URL,
-  DOCUMENSO_API_KEY || ''
-);
+  DOCUMENSO_API_KEY || ""
+)
 
-/**
- * Helper function to create a lease signing request
- */
 export async function createLeaseSigningRequest(
   request: DocumentSigningRequest & {
-    file: File;
-    tenantEmails: string[];
-    tenantNames?: string[];
-    propertyManagerEmail?: string;
-    propertyManagerName?: string;
+    file: File
+    tenantEmails: string[]
+    tenantNames?: string[]
+    propertyManagerEmail?: string
+    propertyManagerName?: string
   }
 ): Promise<DocumentSigningResponse> {
   try {
-    // Upload the document first
-    const uploadResponse = await documensoService.uploadDocument(request.file);
+    const uploadResponse = await documensoService.uploadDocument(request.file)
 
-    // Create recipients from tenant emails
-    const recipients: DocumensoCreateDocumentRequest['recipients'] = request.tenantEmails.map((email, index) => ({
+    const recipients: DocumensoCreateDocumentRequest["recipients"] = request.tenantEmails.map((email, index) => ({
       email,
-      name: request.tenantNames?.[index] || email.split('@')[0],
-      role: 'SIGNER' as const,
+      name: request.tenantNames?.[index] || email.split("@")[0],
+      role: "SIGNER" as const,
       signingOrder: index + 1,
-    }));
+    }))
 
-    const trimmedPropertyManagerEmail = request.propertyManagerEmail?.trim();
+    const trimmedPropertyManagerEmail = request.propertyManagerEmail?.trim()
 
     if (
-      trimmedPropertyManagerEmail
-      && !request.tenantEmails.some((email) => email.trim().toLowerCase() === trimmedPropertyManagerEmail.toLowerCase())
+      trimmedPropertyManagerEmail &&
+      !request.tenantEmails.some(
+        (email) => email.trim().toLowerCase() === trimmedPropertyManagerEmail.toLowerCase()
+      )
     ) {
       recipients.push({
         email: trimmedPropertyManagerEmail,
-        name: request.propertyManagerName?.trim() || 'Property Manager',
-        role: 'CC',
-      });
+        name: request.propertyManagerName?.trim() || "Property Manager",
+        role: "CC",
+      })
     }
 
-    // Create the document envelope
     const docResponse = await documensoService.createDocumentSigningEnvelope({
-      title: request.document_id, // Using document_id as title for now
+      title: request.document_id,
       documentDataId: uploadResponse.documentDataId,
       recipients,
       message: request.message,
       expiresAt: request.expires_in_days
         ? new Date(Date.now() + request.expires_in_days * 24 * 60 * 60 * 1000).toISOString()
         : undefined,
-    });
+    })
 
-    // Get signing URL for the first recipient
     const signingUrl = await documensoService.getSigningUrl(
       docResponse.id,
       docResponse.recipients[0].id
-    );
+    )
 
     return {
       success: true,
       envelope_id: docResponse.id,
       signing_url: signingUrl,
-    };
+    }
   } catch (error) {
-    console.error('Error creating lease signing request:', error);
+    console.error("Error creating lease signing request:", error)
     return {
       success: false,
-      error: providerOutageMessage('documenso'),
-    };
+      error: providerOutageMessage("documenso"),
+    }
   }
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -43,6 +43,15 @@ export interface SerializedApiError {
   details?: unknown
 }
 
+export interface OperatorErrorLog {
+  code: ErrorCode
+  status: number
+  message: string
+  details?: unknown
+  causeName?: string
+  causeMessage?: string
+}
+
 export function getErrorDocsUrl(code: ErrorCode): string {
   return `${ERROR_DOCS_PATH}#${code.toLowerCase()}`
 }
@@ -79,8 +88,88 @@ export class ApiError extends Error {
   }
 }
 
+export class ConfigurationApiError extends ApiError {
+  constructor(variableName: string, cause?: unknown) {
+    super("CONFIGURATION_ERROR", {
+      message: `Missing or invalid configuration for ${variableName}.`,
+      details: { variableName },
+      cause,
+    })
+    this.name = "ConfigurationApiError"
+  }
+}
+
+interface UpstreamServiceApiErrorOptions extends ApiErrorOptions {
+  operation: string
+  upstreamStatus?: number
+}
+
+export class UpstreamServiceApiError extends ApiError {
+  readonly provider: string
+
+  readonly operation: string
+
+  readonly upstreamStatus?: number
+
+  constructor(provider: string, options: UpstreamServiceApiErrorOptions) {
+    super("UPSTREAM_SERVICE_ERROR", {
+      ...options,
+      details: {
+        provider,
+        operation: options.operation,
+        upstreamStatus: options.upstreamStatus,
+        ...(typeof options.details === "object" && options.details !== null ? options.details : {}),
+      },
+    })
+    this.name = "UpstreamServiceApiError"
+    this.provider = provider
+    this.operation = options.operation
+    this.upstreamStatus = options.upstreamStatus
+  }
+}
+
+export class RequestValidationApiError extends ApiError {
+  constructor(message: string, details?: unknown) {
+    super("REQUEST_VALIDATION_ERROR", { message, details })
+    this.name = "RequestValidationApiError"
+  }
+}
+
 export function isApiError(error: unknown): error is ApiError {
   return error instanceof ApiError
+}
+
+function inferUpstreamFromError(error: Error): ApiError | null {
+  if (error.name === "OperationTimeoutError") {
+    return new UpstreamServiceApiError("unknown", {
+      operation: "unknown",
+      message: error.message,
+      details: { kind: "timeout" },
+      cause: error,
+    })
+  }
+
+  if (error.name === "CircuitOpenError") {
+    return new UpstreamServiceApiError("unknown", {
+      operation: "unknown",
+      message: error.message,
+      details: { kind: "circuit_open" },
+      cause: error,
+    })
+  }
+
+  if (error.name === "UpstreamHttpError") {
+    const maybeStatus = (error as Error & { status?: unknown }).status
+    return new UpstreamServiceApiError("unknown", {
+      operation: "unknown",
+      message: error.message,
+      upstreamStatus: typeof maybeStatus === "number" ? maybeStatus : undefined,
+      details: { kind: "http" },
+      cause: error,
+    })
+  }
+
+  return null
 }
 
 export function toApiError(
@@ -92,6 +181,11 @@ export function toApiError(
   }
 
   if (error instanceof Error) {
+    const inferredUpstreamError = inferUpstreamFromError(error)
+    if (inferredUpstreamError) {
+      return inferredUpstreamError
+    }
+
     return new ApiError(fallbackCode, {
       message: error.message,
       cause: error,
@@ -119,6 +213,20 @@ export function toApiError(
   }
 
   return new ApiError(fallbackCode)
+}
+
+export function toOperatorErrorLog(error: unknown): OperatorErrorLog {
+  const apiError = toApiError(error)
+  const cause = apiError.cause instanceof Error ? apiError.cause : undefined
+
+  return {
+    code: apiError.code,
+    status: apiError.status,
+    message: apiError.message,
+    details: apiError.details,
+    causeName: cause?.name,
+    causeMessage: cause?.message,
+  }
 }
 
 export function serializeError(error: ApiError): SerializedApiError {

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -3,6 +3,9 @@
 import { createSupbaseServerClient } from "@/utils/supaone"
 import { Resend } from "resend"
 
+import { incrementOperationalMetric } from "@/lib/observability/metrics"
+import { providerOutageMessage, resilientRequest } from "@/lib/resilience"
+
 export interface NotificationData {
   to: string | string[]
   subject: string
@@ -59,12 +62,32 @@ class NotificationService {
         throw new Error(`Email template '${notification.template}' not found`)
       }
 
-      const { data, error } = await this.resend.emails.send({
-        from: "Roomsily <notifications@roomsily.com>",
-        to: recipients,
-        subject: notification.subject,
-        html: emailContent,
-      })
+      const { value: resendResponse } = await resilientRequest(
+        async () =>
+          this.resend!.emails.send({
+            from: "Roomsily <notifications@roomsily.com>",
+            to: recipients,
+            subject: notification.subject,
+            html: emailContent,
+          }),
+        {
+          provider: "resend",
+          operation: "send_email",
+          retries: 2,
+          initialDelayMs: 250,
+          jitter: true,
+          timeoutMs: 5_000,
+          onCircuitOpen: () => {
+            incrementOperationalMetric("upstream_circuit_open_total", {
+              source: "notification_service",
+              provider: "resend",
+              operation: "send_email",
+            })
+          },
+        }
+      )
+
+      const { data, error } = resendResponse
 
       if (error) {
         console.error("Failed to send email:", error)
@@ -81,7 +104,7 @@ class NotificationService {
       console.error("Email sending error:", error)
       return {
         success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: providerOutageMessage("resend"),
       }
     }
   }

--- a/lib/observability/metrics.ts
+++ b/lib/observability/metrics.ts
@@ -11,6 +11,7 @@ export type OperationalMetricName =
   | "maintenance_sla_breaches_total"
   | "message_moderation_actions_total"
   | "auth_failures_total"
+  | "upstream_circuit_open_total"
 
 export interface MetricTags {
   source: string

--- a/lib/resilience.ts
+++ b/lib/resilience.ts
@@ -12,6 +12,22 @@ export interface RetryResult<T> {
   attempts: number
 }
 
+export interface CircuitState {
+  failures: number
+  openedAt?: number
+}
+
+export interface ResilientRequestOptions extends RetryOptions {
+  provider: string
+  operation: string
+  timeoutMs?: number
+  circuitFailureThreshold?: number
+  circuitResetMs?: number
+  onCircuitOpen?: (input: { provider: string; operation: string; failures: number }) => void
+}
+
+const circuitRegistry = new Map<string, CircuitState>()
+
 export class RetryExhaustedError extends Error {
   attempts: number
 
@@ -19,6 +35,39 @@ export class RetryExhaustedError extends Error {
     super(message, cause !== undefined ? { cause } : undefined)
     this.name = "RetryExhaustedError"
     this.attempts = attempts
+  }
+}
+
+export class OperationTimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(provider: string, operation: string, timeoutMs: number, cause?: unknown) {
+    super(
+      `${provider} ${operation} timed out after ${timeoutMs}ms`,
+      cause !== undefined ? { cause } : undefined
+    )
+    this.name = "OperationTimeoutError"
+    this.timeoutMs = timeoutMs
+  }
+}
+
+export class CircuitOpenError extends Error {
+  readonly retryAfterMs: number
+
+  constructor(provider: string, operation: string, retryAfterMs: number) {
+    super(`${provider} ${operation} blocked because circuit is open`)
+    this.name = "CircuitOpenError"
+    this.retryAfterMs = retryAfterMs
+  }
+}
+
+export class UpstreamHttpError extends Error {
+  readonly status: number
+
+  constructor(provider: string, operation: string, status: number, message: string, cause?: unknown) {
+    super(`${provider} ${operation} failed with HTTP ${status}: ${message}`, cause !== undefined ? { cause } : undefined)
+    this.name = "UpstreamHttpError"
+    this.status = status
   }
 }
 
@@ -39,25 +88,60 @@ function toDelay(attempt: number, options: RetryOptions) {
   return Math.floor(base / 2 + Math.random() * (base / 2))
 }
 
-export function isLikelyTransientError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
   }
 
-  const message = error.message.toLowerCase()
-  return (
-    message.includes("timed out") ||
-    message.includes("timeout") ||
-    message.includes("temporarily unavailable") ||
-    message.includes("rate limit") ||
-    message.includes("econnreset") ||
-    message.includes("econnrefused") ||
-    message.includes("enotfound") ||
-    message.includes("429") ||
-    message.includes("502") ||
-    message.includes("503") ||
-    message.includes("504")
-  )
+  return String(error)
+}
+
+export function isLikelyTransientError(error: unknown): boolean {
+  if (error instanceof UpstreamHttpError) {
+    return error.status === 429 || (error.status >= 500 && error.status <= 504)
+  }
+
+  if (error instanceof OperationTimeoutError) {
+    return true
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase()
+    return (
+      message.includes("timed out") ||
+      message.includes("timeout") ||
+      message.includes("temporarily unavailable") ||
+      message.includes("rate limit") ||
+      message.includes("econnreset") ||
+      message.includes("econnrefused") ||
+      message.includes("enotfound") ||
+      message.includes("429") ||
+      message.includes("502") ||
+      message.includes("503") ||
+      message.includes("504")
+    )
+  }
+
+  return false
+}
+
+async function withTimeout<T>(operation: () => Promise<T>, timeoutMs: number, provider: string, name: string): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<T>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new OperationTimeoutError(provider, name, timeoutMs))
+        }, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle)
+    }
+  }
 }
 
 export async function retryWithBackoff<T>(
@@ -75,11 +159,7 @@ export async function retryWithBackoff<T>(
     } catch (error) {
       const isLastAttempt = attempt > options.retries
       if (isLastAttempt) {
-        throw new RetryExhaustedError(
-          error instanceof Error ? error.message : "Retry attempts exhausted",
-          attempt,
-          error
-        )
+        throw new RetryExhaustedError(normalizeErrorMessage(error), attempt, error)
       }
 
       const retryable = options.shouldRetry
@@ -97,13 +177,103 @@ export async function retryWithBackoff<T>(
   throw new RetryExhaustedError("retryWithBackoff exhausted unexpectedly", options.retries + 1)
 }
 
-export function providerOutageMessage(provider: "stripe" | "calcom" | "documenso") {
+function circuitKey(provider: string, operation: string): string {
+  return `${provider}:${operation}`
+}
+
+function getCircuitState(provider: string, operation: string): CircuitState {
+  return circuitRegistry.get(circuitKey(provider, operation)) ?? { failures: 0 }
+}
+
+function setCircuitState(provider: string, operation: string, state: CircuitState) {
+  circuitRegistry.set(circuitKey(provider, operation), state)
+}
+
+function ensureCircuitClosed(options: ResilientRequestOptions) {
+  const state = getCircuitState(options.provider, options.operation)
+  const resetMs = options.circuitResetMs ?? 15_000
+
+  if (!state.openedAt) {
+    return
+  }
+
+  const retryAfterMs = resetMs - (Date.now() - state.openedAt)
+
+  if (retryAfterMs <= 0) {
+    setCircuitState(options.provider, options.operation, { failures: 0 })
+    return
+  }
+
+  throw new CircuitOpenError(options.provider, options.operation, retryAfterMs)
+}
+
+function markFailure(options: ResilientRequestOptions) {
+  const threshold = options.circuitFailureThreshold ?? 5
+  const state = getCircuitState(options.provider, options.operation)
+  const failures = state.failures + 1
+
+  if (failures >= threshold) {
+    const nextState = { failures, openedAt: Date.now() }
+    setCircuitState(options.provider, options.operation, nextState)
+    options.onCircuitOpen?.({
+      provider: options.provider,
+      operation: options.operation,
+      failures,
+    })
+    return
+  }
+
+  setCircuitState(options.provider, options.operation, {
+    failures,
+    openedAt: state.openedAt,
+  })
+}
+
+function markSuccess(options: ResilientRequestOptions) {
+  setCircuitState(options.provider, options.operation, { failures: 0 })
+}
+
+export async function resilientRequest<T>(
+  operation: () => Promise<T>,
+  options: ResilientRequestOptions
+): Promise<RetryResult<T>> {
+  ensureCircuitClosed(options)
+
+  const timeoutMs = options.timeoutMs ?? 6_000
+
+  try {
+    const result = await retryWithBackoff(
+      () => withTimeout(operation, timeoutMs, options.provider, options.operation),
+      options
+    )
+    markSuccess(options)
+    return result
+  } catch (error) {
+    if (isLikelyTransientError(error) || error instanceof RetryExhaustedError) {
+      markFailure(options)
+    }
+
+    throw error
+  }
+}
+
+
+
+export function resetResilienceState() {
+  circuitRegistry.clear()
+}
+
+export function providerOutageMessage(provider: "stripe" | "calcom" | "documenso" | "resend") {
   if (provider === "stripe") {
     return "Payments are temporarily unavailable. Please try again shortly or use the billing portal later."
   }
 
   if (provider === "calcom") {
     return "Amenity scheduling is temporarily degraded. Your request was not confirmed yet—please retry in a few minutes."
+  }
+
+  if (provider === "resend") {
+    return "Notifications are delayed because the email service is temporarily unavailable."
   }
 
   return "Document signing is temporarily unavailable. Your lease draft is saved and you can retry sending for signature shortly."

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,5 +1,8 @@
 import Stripe from "stripe"
 
+import { ConfigurationApiError, UpstreamServiceApiError } from "@/lib/errors"
+import { resilientRequest } from "@/lib/resilience"
+
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY
 
 if (!stripeSecretKey) {
@@ -9,11 +12,36 @@ if (!stripeSecretKey) {
 
 export function getStripe(): Stripe {
   if (!stripeSecretKey) {
-    throw new Error("Stripe is not configured. Set STRIPE_SECRET_KEY in your environment.")
+    throw new ConfigurationApiError("STRIPE_SECRET_KEY")
   }
 
   const apiVersion: Stripe.StripeConfig["apiVersion"] = "2024-06-20"
   return new Stripe(stripeSecretKey, { apiVersion })
+}
+
+export async function withStripeResilience<T>(
+  operation: string,
+  request: () => Promise<T>
+): Promise<T> {
+  try {
+    const { value } = await resilientRequest(request, {
+      provider: "stripe",
+      operation,
+      retries: 2,
+      initialDelayMs: 250,
+      jitter: true,
+      timeoutMs: 6_000,
+      circuitFailureThreshold: 4,
+    })
+
+    return value
+  } catch (error) {
+    throw new UpstreamServiceApiError("stripe", {
+      operation,
+      details: { originalMessage: error instanceof Error ? error.message : String(error) },
+      cause: error,
+    })
+  }
 }
 
 export function getAppBaseUrl(): string {
@@ -23,5 +51,3 @@ export function getAppBaseUrl(): string {
   }
   return "http://localhost:3000"
 }
-
-

--- a/tests/integration/services/calcom-service.test.ts
+++ b/tests/integration/services/calcom-service.test.ts
@@ -66,4 +66,54 @@ describe("Cal.com booking integration payloads", () => {
     expect(result.success).toBe(false)
     expect(result.error).toContain("No booking slot available for PlayStation")
   })
+
+  it("retries transient 5xx responses for event type lookup with bounded attempts", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("temporary", { status: 503, statusText: "Service Unavailable" }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ eventTypes: [] }), { status: 200 })) as typeof fetch
+
+    global.fetch = fetchMock
+
+    await createAmenityBooking({
+      amenityType: "Kitchen",
+      startTime: "2026-06-01T10:00:00.000Z",
+      endTime: "2026-06-01T11:00:00.000Z",
+      userEmail: "tenant@example.com",
+      userName: "Ava Tenant",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns outage message after bounded retries on booking timeouts", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            eventTypes: [{ id: 22, title: "Kitchen Shared", hidden: false }],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockRejectedValueOnce(new Error("timeout")) as typeof fetch
+
+    global.fetch = fetchMock
+
+    const result = await createAmenityBooking({
+      amenityType: "Kitchen",
+      startTime: "2026-06-01T10:00:00.000Z",
+      endTime: "2026-06-01T11:00:00.000Z",
+      userEmail: "tenant@example.com",
+      userName: "Ava Tenant",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("temporarily degraded")
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
 })

--- a/tests/integration/services/documenso-service.test.ts
+++ b/tests/integration/services/documenso-service.test.ts
@@ -141,4 +141,80 @@ describe("Documenso signing workflow payloads", () => {
       },
     ])
   })
+
+  it("retries transient upload failures with bounded attempts", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("upstream busy", { status: 503, statusText: "Service Unavailable" }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "upload-1", documentDataId: "doc-data-1" }), {
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "env-1",
+            title: "lease-2026",
+            status: "pending",
+            recipients: [
+              {
+                id: "recipient-1",
+                email: "roommate@example.com",
+                role: "SIGNER",
+                token: "token-1",
+                status: "pending",
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ signingUrl: "https://documenso.test/sign/recipient-1" }), {
+          status: 200,
+        })
+      ) as typeof fetch
+
+    global.fetch = fetchMock
+
+    const file = new File(["lease"], "lease.pdf", { type: "application/pdf" })
+
+    const response = await createLeaseSigningRequest({
+      document_id: "lease-2026",
+      file,
+      tenantEmails: ["roommate@example.com"],
+    })
+
+    expect(response.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it("returns outage message after bounded retries on envelope timeout", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "upload-1", documentDataId: "doc-data-1" }), {
+          status: 200,
+        })
+      )
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockRejectedValueOnce(new Error("timeout")) as typeof fetch
+
+    global.fetch = fetchMock
+
+    const file = new File(["lease"], "lease.pdf", { type: "application/pdf" })
+
+    const response = await createLeaseSigningRequest({
+      document_id: "lease-2026",
+      file,
+      tenantEmails: ["roommate@example.com"],
+    })
+
+    expect(response.success).toBe(false)
+    expect(response.error).toContain("temporarily unavailable")
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
 })

--- a/tests/lib/resilience.test.ts
+++ b/tests/lib/resilience.test.ts
@@ -1,19 +1,28 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from "vitest"
 
-import { RetryExhaustedError, isLikelyTransientError, providerOutageMessage, retryWithBackoff } from '@/lib/resilience'
+import {
+  CircuitOpenError,
+  OperationTimeoutError,
+  RetryExhaustedError,
+  isLikelyTransientError,
+  providerOutageMessage,
+  resetResilienceState,
+  resilientRequest,
+  retryWithBackoff,
+} from "@/lib/resilience"
 
-describe('resilience utilities', () => {
-  it('retries transient failures and succeeds', async () => {
+describe("resilience utilities", () => {
+  it("retries transient failures and succeeds", async () => {
     let callCount = 0
 
     const result = await retryWithBackoff(
       async () => {
         callCount += 1
         if (callCount < 3) {
-          throw new Error('503 service unavailable')
+          throw new Error("503 service unavailable")
         }
 
-        return 'ok'
+        return "ok"
       },
       {
         retries: 3,
@@ -21,13 +30,13 @@ describe('resilience utilities', () => {
       }
     )
 
-    expect(result.value).toBe('ok')
+    expect(result.value).toBe("ok")
     expect(result.attempts).toBe(3)
   })
 
-  it('does not retry non-transient failures by default', async () => {
+  it("does not retry non-transient failures by default", async () => {
     const operation = vi.fn(async () => {
-      throw new Error('validation failed')
+      throw new Error("validation failed")
     })
 
     await expect(
@@ -35,15 +44,14 @@ describe('resilience utilities', () => {
         retries: 2,
         initialDelayMs: 1,
       })
-    ).rejects.toThrow('validation failed')
+    ).rejects.toThrow("validation failed")
 
     expect(operation).toHaveBeenCalledTimes(1)
   })
 
-
-  it('throws RetryExhaustedError when retries are exhausted', async () => {
+  it("throws RetryExhaustedError when retries are exhausted", async () => {
     const operation = vi.fn(async () => {
-      throw new Error('503 service unavailable')
+      throw new Error("503 service unavailable")
     })
 
     await expect(
@@ -56,14 +64,65 @@ describe('resilience utilities', () => {
     expect(operation).toHaveBeenCalledTimes(2)
   })
 
-  it('provides provider-safe outage messages', () => {
-    expect(providerOutageMessage('stripe')).toContain('temporarily unavailable')
-    expect(providerOutageMessage('calcom')).toContain('temporarily degraded')
-    expect(providerOutageMessage('documenso')).toContain('temporarily unavailable')
+  it("times out requests when operation exceeds timeout", async () => {
+    await expect(
+      resilientRequest(
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30))
+          return "late"
+        },
+        {
+          provider: "calcom",
+          operation: "timeout_test",
+          retries: 0,
+          timeoutMs: 5,
+        }
+      )
+    ).rejects.toMatchObject({
+      name: "RetryExhaustedError",
+      cause: expect.any(OperationTimeoutError),
+    })
   })
 
-  it('detects transient error messages', () => {
-    expect(isLikelyTransientError(new Error('504 timeout'))).toBe(true)
-    expect(isLikelyTransientError(new Error('invalid payload'))).toBe(false)
+  it("opens the circuit after repeated transient failures", async () => {
+    resetResilienceState()
+
+    await expect(
+      resilientRequest(
+        async () => {
+          throw new Error("503 service unavailable")
+        },
+        {
+          provider: "documenso",
+          operation: "create_document",
+          retries: 0,
+          circuitFailureThreshold: 1,
+          timeoutMs: 10,
+        }
+      )
+    ).rejects.toBeInstanceOf(Error)
+
+    await expect(
+      resilientRequest(
+        async () => "ok",
+        {
+          provider: "documenso",
+          operation: "create_document",
+          retries: 0,
+          timeoutMs: 10,
+        }
+      )
+    ).rejects.toBeInstanceOf(CircuitOpenError)
+  })
+
+  it("provides provider-safe outage messages", () => {
+    expect(providerOutageMessage("stripe")).toContain("temporarily unavailable")
+    expect(providerOutageMessage("calcom")).toContain("temporarily degraded")
+    expect(providerOutageMessage("documenso")).toContain("temporarily unavailable")
+  })
+
+  it("detects transient error messages", () => {
+    expect(isLikelyTransientError(new Error("504 timeout"))).toBe(true)
+    expect(isLikelyTransientError(new Error("invalid payload"))).toBe(false)
   })
 })


### PR DESCRIPTION
### Motivation
- Improve reliability of external integrations by adding bounded retries, jittered backoff, timeouts and circuit-open safeguards so transient upstream failures don't cascade into user-visible errors.
- Provide consistent error shapes for API routes and operator logs by normalising integration and configuration errors.
- Surface circuit-open events to observability so operators can track degraded provider behavior.

### Description
- Introduced a shared resilience utility `lib/resilience.ts` implementing jittered retry/backoff (`retryWithBackoff`), request timeouts, circuit state (open/close) and `resilientRequest` plus provider-safe outage messages (added `resend`).
- Applied resilience to upstream integrations by replacing ad-hoc fetch/retry logic in `lib/calcom-service.ts`, `lib/documenso.ts`, and `lib/notifications.ts` to use `resilientRequest` and emit `upstream_circuit_open_total` metrics on circuit open.
- Added `withStripeResilience` and switched `lib/stripe.ts` to throw a typed `ConfigurationApiError` when Stripe is not configured and wrap upstream failures into `UpstreamServiceApiError`.
- Normalised error types in `lib/errors.ts`: added `ConfigurationApiError`, `UpstreamServiceApiError`, `RequestValidationApiError`, `toOperatorErrorLog` and upstream-error inference so routes can map unknown failures to stable `ApiError` responses and operator-friendly logs.
- Added/updated tests to exercise failure modes and bounded retries: `tests/lib/resilience.test.ts`, `tests/integration/services/calcom-service.test.ts`, and `tests/integration/services/documenso-service.test.ts`.
- Added metric name `upstream_circuit_open_total` to `lib/observability/metrics.ts`.

### Testing
- Ran the focused test suite: `pnpm vitest run tests/lib/resilience.test.ts tests/integration/services/calcom-service.test.ts tests/integration/services/documenso-service.test.ts tests/api/errors.spec.ts` and all tests passed.
- Ran type-checking via `pnpm typecheck` (TypeScript `tsc --noEmit`) with no errors.
- Tests intentionally log upstream errors to stderr in a few cases (expected by the assertions) while verifying the code returns stable fallback shapes and metrics; assertions passed in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4628532483288f7ce909f3ecaa05)