### PR TITLE
Optimize dashboard loaders with scoped caching and realtime isolation

### DIFF
--- a/app/dashboard/(dashboard)/components/roommate-board-card.tsx
+++ b/app/dashboard/(dashboard)/components/roommate-board-card.tsx
@@ -1,45 +1,9 @@
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { getRoommateUpdates } from "../data"
-import { Badge } from "@/components/ui/badge"
-import SmartLink from "@/components/navigation/SmartLink"
 import { MessageSquare } from "lucide-react"
 
-const topicCopy: Record<"maintenance" | "announcement" | "logistics", { label: string; variant: "outline" | "secondary" | "default" }>
-  = {
-    maintenance: {
-      label: "Maintenance",
-      variant: "outline",
-    },
-    announcement: {
-      label: "Announcement",
-      variant: "secondary",
-    },
-    logistics: {
-      label: "Logistics",
-      variant: "default",
-    },
-  }
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
-function formatRelativeTime(timestamp: string) {
-  const now = new Date()
-  const date = new Date(timestamp)
-  const diff = now.getTime() - date.getTime()
-
-  const minutes = Math.round(diff / (1000 * 60))
-  if (minutes < 1) {
-    return "Just now"
-  }
-  if (minutes < 60) {
-    return `${minutes} min ago`
-  }
-  const hours = Math.round(minutes / 60)
-  if (hours < 24) {
-    return `${hours} hr${hours > 1 ? "s" : ""} ago`
-  }
-  const days = Math.round(hours / 24)
-  return `${days} day${days > 1 ? "s" : ""} ago`
-}
+import { getRoommateUpdates } from "../data"
+import { RoommateBoardRealtime } from "./roommate-board-realtime"
 
 export async function RoommateBoardCard() {
   const updates = await getRoommateUpdates()
@@ -58,32 +22,7 @@ export async function RoommateBoardCard() {
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        <ul className="space-y-3">
-          {updates.map((update) => {
-            const { label, variant } = topicCopy[update.topic]
-            return (
-              <li
-                key={update.id}
-                className="rounded-lg border border-transparent bg-muted/40 p-3 transition-colors hover:border-border/70 hover:bg-muted/60"
-              >
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                    <span>{update.author}</span>
-                    <Badge variant={variant}>{label}</Badge>
-                  </div>
-                  <span className="text-xs text-muted-foreground">{formatRelativeTime(update.timestamp)}</span>
-                </div>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{update.message}</p>
-              </li>
-            )
-          })}
-        </ul>
-
-        <SmartLink href="/messaging" className="inline-flex" intent="navigation">
-          <Button variant="outline" size="sm" className="w-full sm:w-auto">
-            Open message board
-          </Button>
-        </SmartLink>
+        <RoommateBoardRealtime initialUpdates={updates} />
       </CardContent>
     </Card>
   )

--- a/app/dashboard/(dashboard)/components/roommate-board-realtime.tsx
+++ b/app/dashboard/(dashboard)/components/roommate-board-realtime.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+
+import SmartLink from "@/components/navigation/SmartLink"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+import type { RoommateUpdate } from "../data"
+
+const topicCopy: Record<
+  "maintenance" | "announcement" | "logistics",
+  { label: string; variant: "outline" | "secondary" | "default" }
+> = {
+  maintenance: {
+    label: "Maintenance",
+    variant: "outline",
+  },
+  announcement: {
+    label: "Announcement",
+    variant: "secondary",
+  },
+  logistics: {
+    label: "Logistics",
+    variant: "default",
+  },
+}
+
+type Props = {
+  initialUpdates: RoommateUpdate[]
+}
+
+function formatRelativeTime(timestamp: string, referenceTime: number) {
+  const date = new Date(timestamp)
+  const diff = referenceTime - date.getTime()
+
+  const minutes = Math.round(diff / (1000 * 60))
+  if (minutes < 1) {
+    return "Just now"
+  }
+  if (minutes < 60) {
+    return `${minutes} min ago`
+  }
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) {
+    return `${hours} hr${hours > 1 ? "s" : ""} ago`
+  }
+  const days = Math.round(hours / 24)
+  return `${days} day${days > 1 ? "s" : ""} ago`
+}
+
+export function RoommateBoardRealtime({ initialUpdates }: Props) {
+  const router = useRouter()
+  const [referenceTime, setReferenceTime] = useState(() => Date.now())
+
+  useEffect(() => {
+    const relativeTimeInterval = window.setInterval(() => {
+      setReferenceTime(Date.now())
+    }, 60_000)
+
+    const refreshInterval = window.setInterval(() => {
+      router.refresh()
+    }, 30_000)
+
+    return () => {
+      window.clearInterval(relativeTimeInterval)
+      window.clearInterval(refreshInterval)
+    }
+  }, [router])
+
+  return (
+    <>
+      <ul className="space-y-3">
+        {initialUpdates.map((update) => {
+          const { label, variant } = topicCopy[update.topic]
+          return (
+            <li
+              key={update.id}
+              className="rounded-lg border border-transparent bg-muted/40 p-3 transition-colors hover:border-border/70 hover:bg-muted/60"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  <span>{update.author}</span>
+                  <Badge variant={variant}>{label}</Badge>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {formatRelativeTime(update.timestamp, referenceTime)}
+                </span>
+              </div>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                {update.message}
+              </p>
+            </li>
+          )
+        })}
+      </ul>
+
+      <SmartLink href="/messaging" className="inline-flex" intent="navigation">
+        <Button variant="outline" size="sm" className="w-full sm:w-auto">
+          Open message board
+        </Button>
+      </SmartLink>
+    </>
+  )
+}

--- a/app/dashboard/(dashboard)/data.ts
+++ b/app/dashboard/(dashboard)/data.ts
@@ -1,5 +1,7 @@
 import "server-only"
 import { cache } from "react"
+import { revalidateTag, unstable_cache, unstable_noStore } from "next/cache"
+
 import { readUserSession } from "@/utils/actions"
 import { hasSupabasePublicEnv } from "@/utils/supabase/env"
 
@@ -51,8 +53,32 @@ function resolveDashboardDataSource() {
 }
 
 const dashboardDataSource = resolveDashboardDataSource()
-
 const usingMockData = dashboardDataSource.toLowerCase() === "mock"
+
+export const DASHBOARD_CACHE_TAGS = {
+  welcome: "dashboard:welcome",
+  rent: "dashboard:rent",
+  documents: "dashboard:documents",
+  metrics: "dashboard:metrics",
+  quickActions: "dashboard:quick-actions",
+  bookings: "dashboard:bookings",
+  maintenance: "dashboard:maintenance",
+  floorplan: "dashboard:floorplan",
+} as const
+
+const DASHBOARD_REVALIDATE_SECONDS = {
+  welcome: 60 * 10,
+  rent: 60 * 3,
+  documents: 60 * 5,
+  metrics: 60 * 3,
+  quickActions: 60 * 5,
+  bookings: 60 * 2,
+  maintenance: 60 * 3,
+  floorplan: 60 * 10,
+} as const
+
+export type DashboardCacheTag =
+  (typeof DASHBOARD_CACHE_TAGS)[keyof typeof DASHBOARD_CACHE_TAGS]
 
 if (usingMockData) {
   console.warn(
@@ -80,8 +106,6 @@ async function fetchWelcomeMessage(): Promise<WelcomeMessage> {
     : fetchProductionWelcomeMessage()
 }
 
-export const getWelcomeMessage = cache(fetchWelcomeMessage)
-
 async function fetchDashboardRole() {
   const { data } = await readUserSession()
   const claimedRole =
@@ -91,6 +115,26 @@ async function fetchDashboardRole() {
     typeof claimedRole === "string" ? claimedRole : null
   )
 }
+
+async function fetchDashboardCacheScope() {
+  const { data } = await readUserSession()
+  return data.session?.user?.id ?? "anonymous"
+}
+
+const getDashboardCacheScope = cache(fetchDashboardCacheScope)
+
+const getWelcomeMessageCached = unstable_cache(
+  async (_scope: string) => fetchWelcomeMessage(),
+  ["dashboard-welcome-message"],
+  {
+    revalidate: DASHBOARD_REVALIDATE_SECONDS.welcome,
+    tags: [DASHBOARD_CACHE_TAGS.welcome],
+  }
+)
+
+export const getWelcomeMessage = cache(async () =>
+  getWelcomeMessageCached(await getDashboardCacheScope())
+)
 
 export const getDashboardRole = cache(fetchDashboardRole)
 
@@ -104,7 +148,18 @@ async function fetchRentSummary(): Promise<RentSummary> {
   return usingMockData ? fetchMockRentSummary() : fetchProductionRentSummary()
 }
 
-export const getRentSummary = cache(fetchRentSummary)
+const getRentSummaryCached = unstable_cache(
+  async (_scope: string) => fetchRentSummary(),
+  ["dashboard-rent-summary"],
+  {
+    revalidate: DASHBOARD_REVALIDATE_SECONDS.rent,
+    tags: [DASHBOARD_CACHE_TAGS.rent],
+  }
+)
+
+export const getRentSummary = cache(async () =>
+  getRentSummaryCached(await getDashboardCacheScope())
+)
 
 export function loadRentSummaryUncached() {
   return fetchRentSummary()
@@ -118,7 +173,18 @@ async function fetchRecentDocuments(): Promise<DocumentSummary[]> {
     : fetchProductionRecentDocuments()
 }
 
-export const getRecentDocuments = cache(fetchRecentDocuments)
+const getRecentDocumentsCached = unstable_cache(
+  async (_scope: string) => fetchRecentDocuments(),
+  ["dashboard-recent-documents"],
+  {
+    revalidate: DASHBOARD_REVALIDATE_SECONDS.documents,
+    tags: [DASHBOARD_CACHE_TAGS.documents],
+  }
+)
+
+export const getRecentDocuments = cache(async () =>
+  getRecentDocumentsCached(await getDashboardCacheScope())
+)
 
 export function loadRecentDocumentsUncached() {
   return fetchRecentDocuments()
@@ -132,7 +198,10 @@ async function fetchRoommateUpdates(): Promise<RoommateUpdate[]> {
     : fetchProductionRoommateUpdates()
 }
 
-export const getRoommateUpdates = cache(fetchRoommateUpdates)
+export async function getRoommateUpdates() {
+  unstable_noStore()
+  return fetchRoommateUpdates()
+}
 
 export function loadRoommateUpdatesUncached() {
   return fetchRoommateUpdates()
@@ -146,7 +215,18 @@ async function fetchDashboardMetrics(): Promise<DashboardMetric[]> {
     : fetchProductionDashboardMetrics()
 }
 
-export const getDashboardMetrics = cache(fetchDashboardMetrics)
+const getDashboardMetricsCached = unstable_cache(
+  async (_scope: string) => fetchDashboardMetrics(),
+  ["dashboard-metrics"],
+  {
+    revalidate: DASHBOARD_REVALIDATE_SECONDS.metrics,
+    tags: [DASHBOARD_CACHE_TAGS.metrics],
+  }
+)
+
+export const getDashboardMetrics = cache(async () =>
+  getDashboardMetricsCached(await getDashboardCacheScope())
+)
 
 export function loadDashboardMetricsUncached() {
   return fetchDashboardMetrics()
@@ -158,7 +238,18 @@ async function fetchQuickActions(): Promise<QuickAction[]> {
   return usingMockData ? fetchMockQuickActions() : fetchProductionQuickActions()
 }
 
-export const getQuickActions = cache(fetchQuickActions)
+const getQuickActionsCached = unstable_cache(
+  async (_scope: string) => fetchQuickActions(),
+  ["dashboard-quick-actions"],
+  {
+    revalidate: DASHBOARD_REVALIDATE_SECONDS.quickActions,
+    tags: [DASHBOARD_CACHE_TAGS.quickActions],
+  }
+)
+
+export const getQuickActions = cache(async () =>
+  getQuickActionsCached(await getDashboardCacheScope())
+)
 
 export function loadQuickActionsUncached() {
   return fetchQuickActions()
@@ -172,7 +263,18 @@ async function fetchUpcomingBookings(): Promise<UpcomingBooking[]> {
     : fetchProductionUpcomingBookings()
 }
 
-export const getUpcomingBookings = cache(fetchUpcomingBookings)
+const getUpcomingBookingsCached = unstable_cache(
+  async (_scope: string) => fetchUpcomingBookings(),
+  ["dashboard-upcoming-bookings"],
+  {
+    revalidate: DASHBOARD_REVALIDATE_SECONDS.bookings,
+    tags: [DASHBOARD_CACHE_TAGS.bookings],
+  }
+)
+
+export const getUpcomingBookings = cache(async () =>
+  getUpcomingBookingsCached(await getDashboardCacheScope())
+)
 
 export function loadUpcomingBookingsUncached() {
   return fetchUpcomingBookings()
@@ -186,7 +288,18 @@ async function fetchMaintenanceTickets(): Promise<MaintenanceTicket[]> {
     : fetchProductionMaintenanceTickets()
 }
 
-export const getMaintenanceTickets = cache(fetchMaintenanceTickets)
+const getMaintenanceTicketsCached = unstable_cache(
+  async (_scope: string) => fetchMaintenanceTickets(),
+  ["dashboard-maintenance-tickets"],
+  {
+    revalidate: DASHBOARD_REVALIDATE_SECONDS.maintenance,
+    tags: [DASHBOARD_CACHE_TAGS.maintenance],
+  }
+)
+
+export const getMaintenanceTickets = cache(async () =>
+  getMaintenanceTicketsCached(await getDashboardCacheScope())
+)
 
 export function loadMaintenanceTicketsUncached() {
   return fetchMaintenanceTickets()
@@ -200,10 +313,27 @@ async function fetchFloorplanWorkspace(): Promise<FloorplanWorkspace> {
     : fetchProductionFloorplanWorkspace()
 }
 
-export const getFloorplanWorkspace = cache(fetchFloorplanWorkspace)
+const getFloorplanWorkspaceCached = unstable_cache(
+  async (_scope: string) => fetchFloorplanWorkspace(),
+  ["dashboard-floorplan-workspace"],
+  {
+    revalidate: DASHBOARD_REVALIDATE_SECONDS.floorplan,
+    tags: [DASHBOARD_CACHE_TAGS.floorplan],
+  }
+)
+
+export const getFloorplanWorkspace = cache(async () =>
+  getFloorplanWorkspaceCached(await getDashboardCacheScope())
+)
 
 export function loadFloorplanWorkspaceUncached() {
   return fetchFloorplanWorkspace()
+}
+
+export async function revalidateDashboardCacheTag(tag: DashboardCacheTag) {
+  "use server"
+
+  revalidateTag(tag)
 }
 
 export type {

--- a/app/dashboard/(dashboard)/page.tsx
+++ b/app/dashboard/(dashboard)/page.tsx
@@ -20,7 +20,6 @@ import {
 } from "./components/skeletons"
 import { UpcomingBookingsCard } from "./components/upcoming-bookings-card"
 
-export const dynamic = "force-dynamic"
 
 export default function DashboardPage() {
   return (


### PR DESCRIPTION
### Motivation

- Reduce client hydration surface and move fetch-heavy dashboard logic to server-side caches so low-churn widgets don't bloat the first-load JS.
- Provide tag-based invalidation hooks to let mutation flows selectively refresh cached dashboard fragments.
- Keep realtime UI (roommate board) responsive while isolating its hydration to a small client component to avoid forcing the whole dashboard into client mode.

### Description

- Refactored `app/dashboard/(dashboard)/data.ts` to use Next.js `unstable_cache` per widget with explicit `revalidate` windows and introduced `DASHBOARD_CACHE_TAGS` and `DASHBOARD_REVALIDATE_SECONDS` for scoped caching and tag keys.
- Added `getDashboardCacheScope` (per-user cache scoping) and `revalidateDashboardCacheTag` server action to enable tag-based invalidation from server actions.
- Marked roommate updates as realtime-only with `unstable_noStore()` and moved periodic refresh / relative-time ticking into a focused client component `roommate-board-realtime.tsx` while `roommate-board-card.tsx` stays server-rendered and passes initial data.
- Removed `export const dynamic = "force-dynamic"` from the dashboard route so cached server loaders can take effect and minimize unnecessary dynamic rendering.

### Testing

- Ran `pnpm -s lint` and the linter completed with no errors.
- Ran `node scripts/check-js-size.mjs` which builds the app and validates JS bundle budgets; build succeeded and `/dashboard` remained inside the configured budget.
- Ran `node scripts/check-performance-budgets.mjs` and the performance budget configuration check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec462c245c8328b8e2f71987b03bfb)