### PR TITLE
Harden session role resolution with profile-first precedence

### DIFF
--- a/docs/security/authorization-model.md
+++ b/docs/security/authorization-model.md
@@ -19,6 +19,18 @@ data is exposed across buildings or portfolios.
 Role assignment is maintained within Supabase Auth profiles and synchronized to
 an internal `user_roles` table that records `(UserID, BuildingID, Role)` tuples.
 
+
+## Session Role Resolution Precedence
+For authenticated sessions, middleware resolves the route authorization role in this order:
+
+1. Query `profiles.role` in Supabase as the server-authoritative source.
+2. If the profile query fails due to a lookup error (for example, a transient database outage), fall back to Supabase Auth metadata role claims (`app_metadata.role`, then `user_metadata.role`).
+3. If the profile record is missing or contains an unknown role value, no role is granted.
+
+Additional guardrails:
+- Unknown role values from metadata are ignored.
+- The pseudo-role `user` never grants access to role-restricted routes.
+
 ## Tenancy and Building Scoping
 * All business entities include a `building_id` column. Composite indexes enforce
   `(building_id, id)` lookups for secure filtering.

--- a/lib/auth-rbac.ts
+++ b/lib/auth-rbac.ts
@@ -41,14 +41,10 @@ export async function resolveSessionRole(
     return null
   }
 
-  const claimedRole =
+  const metadataRole =
     coerceRole(user.app_metadata?.role) ??
     coerceRole(user.user_metadata?.role) ??
     coerceRole((user as User & { role?: unknown }).role)
-
-  if (claimedRole && claimedRole !== 'user') {
-    return claimedRole
-  }
 
   const { data, error } = await supabase
     .from('profiles')
@@ -58,10 +54,11 @@ export async function resolveSessionRole(
 
   if (error) {
     console.error('Failed to resolve profile role in middleware:', error.message)
-    return claimedRole
+    // Fallback to metadata only when profile lookup is unavailable (for example, transient DB errors).
+    return metadataRole
   }
 
-  return coerceRole(data?.role) ?? claimedRole
+  return coerceRole(data?.role)
 }
 
 export function isPublicRoute(pathname: string): boolean {
@@ -87,7 +84,7 @@ export function isRouteAllowedForRole(pathname: string, role: AppRole | null): b
     return true
   }
 
-  if (!role) {
+  if (!role || role === 'user') {
     return false
   }
 

--- a/tests/auth-rbac.test.ts
+++ b/tests/auth-rbac.test.ts
@@ -25,26 +25,13 @@ describe('auth RBAC route helpers', () => {
     expect(isRouteAllowedForRole('/dashboard/members', 'admin')).toBe(true)
     expect(isRouteAllowedForRole('/dashboard/members', 'property_manager')).toBe(true)
     expect(isRouteAllowedForRole('/dashboard/members', 'tenant')).toBe(false)
+    expect(isRouteAllowedForRole('/dashboard/members', 'user')).toBe(false)
     expect(isRouteAllowedForRole('/dashboard', 'tenant')).toBe(true)
   })
 })
 
 describe('resolveSessionRole', () => {
-  it('prefers trusted app metadata role', async () => {
-    const supabase = {
-      from: vi.fn(),
-    }
-
-    const role = await resolveSessionRole(supabase as any, {
-      app_metadata: { role: 'admin' },
-      user_metadata: {},
-    } as any)
-
-    expect(role).toBe('admin')
-    expect(supabase.from).not.toHaveBeenCalled()
-  })
-
-  it('falls back to profile role lookup', async () => {
+  it('prefers profile role when it conflicts with metadata role', async () => {
     const maybeSingle = vi.fn().mockResolvedValue({ data: { role: 'roommate' }, error: null })
     const eq = vi.fn().mockReturnValue({ maybeSingle })
     const select = vi.fn().mockReturnValue({ eq })
@@ -52,14 +39,55 @@ describe('resolveSessionRole', () => {
 
     const role = await resolveSessionRole({ from } as any, {
       id: 'user-1',
-      app_metadata: {},
+      app_metadata: { role: 'admin' },
       user_metadata: {},
     } as any)
 
     expect(role).toBe('roommate')
-    expect(from).toHaveBeenCalledWith('profiles')
-    expect(select).toHaveBeenCalledWith('role')
-    expect(eq).toHaveBeenCalledWith('id', 'user-1')
-    expect(maybeSingle).toHaveBeenCalled()
+  })
+
+  it('returns null when profile is missing even if metadata role exists', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null })
+    const eq = vi.fn().mockReturnValue({ maybeSingle })
+    const select = vi.fn().mockReturnValue({ eq })
+    const from = vi.fn().mockReturnValue({ select })
+
+    const role = await resolveSessionRole({ from } as any, {
+      id: 'user-2',
+      app_metadata: { role: 'tenant' },
+      user_metadata: {},
+    } as any)
+
+    expect(role).toBeNull()
+  })
+
+  it('falls back to metadata role when profile lookup errors', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: { message: 'db timeout' } })
+    const eq = vi.fn().mockReturnValue({ maybeSingle })
+    const select = vi.fn().mockReturnValue({ eq })
+    const from = vi.fn().mockReturnValue({ select })
+
+    const role = await resolveSessionRole({ from } as any, {
+      id: 'user-3',
+      app_metadata: { role: 'tenant' },
+      user_metadata: {},
+    } as any)
+
+    expect(role).toBe('tenant')
+  })
+
+  it('ignores unknown metadata roles', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: { message: 'db timeout' } })
+    const eq = vi.fn().mockReturnValue({ maybeSingle })
+    const select = vi.fn().mockReturnValue({ eq })
+    const from = vi.fn().mockReturnValue({ select })
+
+    const role = await resolveSessionRole({ from } as any, {
+      id: 'user-4',
+      app_metadata: { role: 'superadmin' },
+      user_metadata: {},
+    } as any)
+
+    expect(role).toBeNull()
   })
 })


### PR DESCRIPTION
### Motivation
- Ensure server-authoritative role data is used for authorization decisions by preferring `profiles.role` over client-provided metadata.
- Avoid accidentally granting access based on stale or tampered auth metadata and explicitly guard against the pseudo-role `user` being treated as an authorizing role.

### Description
- Refactored `resolveSessionRole` in `lib/auth-rbac.ts` to always query `profiles.role` first for authenticated users and treat that value as authoritative via `coerceRole`.
- Added an explicit fallback to metadata (`app_metadata.role`, `user_metadata.role`, legacy `role`) only when the profile lookup errors (e.g., transient DB failure), documented inline as the fallback condition.
- Changed `isRouteAllowedForRole` to deny access when `role` is `null` or the pseudo-role `user`, preventing `user` from authorizing restricted routes.
- Added unit tests in `tests/auth-rbac.test.ts` covering profile-vs-metadata precedence, missing profile with metadata present, metadata fallback on profile lookup error, and ignoring unknown metadata role values, and updated `docs/security/authorization-model.md` to match the implemented precedence and guardrails.

### Testing
- Ran `pnpm test tests/auth-rbac.test.ts` which executed the updated RBAC suite and all tests passed (`7 tests` passed).
- The test run observed and asserts the expected behaviors for profile precedence, metadata fallback on error, and unknown/`user` role handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c77cc788328b059569f2519302a)