### PR TITLE
Centralize privileged authz helper and contract tests for export APIs

### DIFF
--- a/app/api/exports/bookings/route.ts
+++ b/app/api/exports/bookings/route.ts
@@ -1,23 +1,15 @@
 import { NextResponse } from 'next/server'
 
 import { writeAuditRecord } from '@/lib/audit'
-import { fetchMemberRole } from '@/lib/data/members'
+import { requirePrivilegedApiAccess } from '@/lib/authz'
 import { getBookingRows, toCsv } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET() {
-  const supabase = await createSupbaseServerClientReadOnly()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
-
-  const role = await fetchMemberRole(supabase as any, user.id)
-  if (role !== 'property_manager' && role !== 'admin') return NextResponse.json({ message: 'Forbidden' }, { status: 403 })
+  const auth = await requirePrivilegedApiAccess()
+  if ('response' in auth) return auth.response
 
   const csv = toCsv((await getBookingRows({ page: 1, pageSize: 1000 })).rows)
-  await writeAuditRecord({ action: 'operations.export.bookings', actorId: user.id, actorRole: role, targetType: 'bookings_export' })
+  await writeAuditRecord({ action: 'operations.export.csv.bookings', actorId: auth.user.id, actorRole: auth.role, targetType: 'bookings_export' })
 
   return new NextResponse(csv, {
     status: 200,

--- a/app/api/exports/finance/route.ts
+++ b/app/api/exports/finance/route.ts
@@ -1,27 +1,15 @@
 import { NextResponse } from 'next/server'
 
 import { writeAuditRecord } from '@/lib/audit'
-import { fetchMemberRole } from '@/lib/data/members'
+import { requirePrivilegedApiAccess } from '@/lib/authz'
 import { getFinanceRows, toCsv } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET() {
-  const supabase = await createSupbaseServerClientReadOnly()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
-  }
-
-  const role = await fetchMemberRole(supabase as any, user.id)
-  if (role !== 'property_manager' && role !== 'admin') {
-    return NextResponse.json({ message: 'Forbidden' }, { status: 403 })
-  }
+  const auth = await requirePrivilegedApiAccess()
+  if ('response' in auth) return auth.response
 
   const csv = toCsv((await getFinanceRows({ page: 1, pageSize: 1000 })).rows)
-  await writeAuditRecord({ action: 'operations.export.finance', actorId: user.id, actorRole: role, targetType: 'finance_export' })
+  await writeAuditRecord({ action: 'operations.export.csv.finance', actorId: auth.user.id, actorRole: auth.role, targetType: 'finance_export' })
 
   return new NextResponse(csv, {
     status: 200,

--- a/app/api/exports/maintenance/route.ts
+++ b/app/api/exports/maintenance/route.ts
@@ -1,23 +1,15 @@
 import { NextResponse } from 'next/server'
 
 import { writeAuditRecord } from '@/lib/audit'
-import { fetchMemberRole } from '@/lib/data/members'
+import { requirePrivilegedApiAccess } from '@/lib/authz'
 import { getMaintenanceRows, toCsv } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET() {
-  const supabase = await createSupbaseServerClientReadOnly()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
-
-  const role = await fetchMemberRole(supabase as any, user.id)
-  if (role !== 'property_manager' && role !== 'admin') return NextResponse.json({ message: 'Forbidden' }, { status: 403 })
+  const auth = await requirePrivilegedApiAccess()
+  if ('response' in auth) return auth.response
 
   const csv = toCsv((await getMaintenanceRows({ page: 1, pageSize: 1000 })).rows)
-  await writeAuditRecord({ action: 'operations.export.maintenance', actorId: user.id, actorRole: role, targetType: 'maintenance_export' })
+  await writeAuditRecord({ action: 'operations.export.csv.maintenance', actorId: auth.user.id, actorRole: auth.role, targetType: 'maintenance_export' })
 
   return new NextResponse(csv, {
     status: 200,

--- a/app/api/exports/visitors/route.ts
+++ b/app/api/exports/visitors/route.ts
@@ -1,29 +1,21 @@
 import { NextResponse } from 'next/server'
 
 import { writeAuditRecord } from '@/lib/audit'
-import { fetchMemberRole } from '@/lib/data/members'
+import { requirePrivilegedApiAccess } from '@/lib/authz'
 import { getVisitorRows, toCsv } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET() {
-  const supabase = await createSupbaseServerClientReadOnly()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
-
-  const role = await fetchMemberRole(supabase as any, user.id)
-  if (role !== 'property_manager' && role !== 'admin') return NextResponse.json({ message: 'Forbidden' }, { status: 403 })
+  const auth = await requirePrivilegedApiAccess()
+  if ('response' in auth) return auth.response
 
   const csv = toCsv((await getVisitorRows({ page: 1, pageSize: 1000 })).rows)
-  await writeAuditRecord({ action: 'operations.export.visitors', actorId: user.id, actorRole: role, targetType: 'visitors_export' })
+  await writeAuditRecord({ action: 'operations.export.csv.visitors', actorId: auth.user.id, actorRole: auth.role, targetType: 'visitors_export' })
 
   return new NextResponse(csv, {
     status: 200,
     headers: {
       'Content-Type': 'text/csv; charset=utf-8',
-      'Content-Disposition': `attachment; filename="visitor-logs-export-${new Date().toISOString().slice(0, 10)}.csv"`,
+      'Content-Disposition': `attachment; filename="visitors-export-${new Date().toISOString().slice(0, 10)}.csv"`,
     },
   })
 }

--- a/docs/security/rbac-matrix.md
+++ b/docs/security/rbac-matrix.md
@@ -56,3 +56,16 @@ This matrix maps route-level access (middleware) and table-level actions (Supaba
 ## Verification Script
 
 Use `supabase/tests/rls_rbac_verification.sql` to validate positive/negative RLS paths, including cross-unit read denial and admin override behavior.
+
+## API Export Guard Pattern
+
+- All operations export endpoints under `app/api/exports/*` must call `requirePrivilegedApiAccess()` from `lib/authz.ts` at the start of the request.
+- `requirePrivilegedApiAccess()` centralizes authentication and privileged-role authorization and returns either:
+  - `{ user, role, supabase }` for authorized `property_manager` and `admin` actors, or
+  - `{ response }` with standardized JSON payload/status (`401 Unauthorized` or `403 Forbidden`).
+- Guard usage pattern:
+  1. `const auth = await requirePrivilegedApiAccess()`
+  2. `if ('response' in auth) return auth.response`
+  3. continue route logic with `auth.user.id` and `auth.role` for audit attribution.
+
+This ensures consistent privileged export controls and avoids duplicated authz logic across export routes.

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -1,11 +1,24 @@
 import 'server-only'
 
+import { NextResponse } from 'next/server'
 import { redirect } from 'next/navigation'
 
 import { fetchMemberRole } from '@/lib/data/members'
 import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
 
 export const PRIVILEGED_ROLES = ['property_manager', 'admin'] as const
+
+type PrivilegedRole = (typeof PRIVILEGED_ROLES)[number]
+
+type PrivilegedApiAuthSuccess = {
+  user: { id: string }
+  role: PrivilegedRole
+  supabase: Awaited<ReturnType<typeof createSupbaseServerClientReadOnly>>
+}
+
+type PrivilegedApiAuthFailure = {
+  response: NextResponse<{ message: 'Unauthorized' | 'Forbidden' }>
+}
 
 export async function requirePrivilegedAccess() {
   const supabase = await createSupbaseServerClientReadOnly()
@@ -19,9 +32,27 @@ export async function requirePrivilegedAccess() {
 
   const role = await fetchMemberRole(supabase as any, user.id)
 
-  if (!role || !PRIVILEGED_ROLES.includes(role as (typeof PRIVILEGED_ROLES)[number])) {
+  if (!role || !PRIVILEGED_ROLES.includes(role as PrivilegedRole)) {
     redirect('/dashboard')
   }
 
   return { user, role }
+}
+
+export async function requirePrivilegedApiAccess(): Promise<PrivilegedApiAuthSuccess | PrivilegedApiAuthFailure> {
+  const supabase = await createSupbaseServerClientReadOnly()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { response: NextResponse.json({ message: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const role = await fetchMemberRole(supabase as any, user.id)
+  if (!role || !PRIVILEGED_ROLES.includes(role as PrivilegedRole)) {
+    return { response: NextResponse.json({ message: 'Forbidden' }, { status: 403 }) }
+  }
+
+  return { user: { id: user.id }, role: role as PrivilegedRole, supabase }
 }

--- a/tests/integration/api/exports-authz-contract.test.ts
+++ b/tests/integration/api/exports-authz-contract.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requirePrivilegedApiAccess = vi.fn()
+const writeAuditRecord = vi.fn()
+const getBookingRows = vi.fn()
+const getFinanceRows = vi.fn()
+const getMaintenanceRows = vi.fn()
+const getVisitorRows = vi.fn()
+const toCsv = vi.fn()
+
+vi.mock('@/lib/authz', () => ({ requirePrivilegedApiAccess }))
+vi.mock('@/lib/audit', () => ({ writeAuditRecord }))
+vi.mock('@/lib/operations/data', () => ({
+  getBookingRows,
+  getFinanceRows,
+  getMaintenanceRows,
+  getVisitorRows,
+  toCsv,
+}))
+
+const ROUTES = [
+  { name: 'bookings', path: '@/app/api/exports/bookings/route', getter: getBookingRows },
+  { name: 'finance', path: '@/app/api/exports/finance/route', getter: getFinanceRows },
+  { name: 'maintenance', path: '@/app/api/exports/maintenance/route', getter: getMaintenanceRows },
+  { name: 'visitors', path: '@/app/api/exports/visitors/route', getter: getVisitorRows },
+] as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  toCsv.mockReturnValue('col1,col2\nvalue1,value2')
+})
+
+describe('export endpoint authz contract', () => {
+  for (const route of ROUTES) {
+    it(`${route.name}: unauthenticated => 401`, async () => {
+      requirePrivilegedApiAccess.mockResolvedValueOnce({
+        response: Response.json({ message: 'Unauthorized' }, { status: 401 }),
+      })
+
+      const mod = await import(route.path)
+      const response = await mod.GET()
+
+      expect(response.status).toBe(401)
+      await expect(response.json()).resolves.toEqual({ message: 'Unauthorized' })
+    })
+
+    it(`${route.name}: non-privileged => 403`, async () => {
+      requirePrivilegedApiAccess.mockResolvedValueOnce({
+        response: Response.json({ message: 'Forbidden' }, { status: 403 }),
+      })
+
+      const mod = await import(route.path)
+      const response = await mod.GET()
+
+      expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toEqual({ message: 'Forbidden' })
+    })
+
+    it(`${route.name}: privileged => 200 with CSV headers`, async () => {
+      requirePrivilegedApiAccess.mockResolvedValueOnce({
+        user: { id: 'user-1' },
+        role: 'admin',
+        supabase: {},
+      })
+      route.getter.mockResolvedValueOnce({ rows: [{ id: 'row-1' }] })
+
+      const mod = await import(route.path)
+      const response = await mod.GET()
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toContain('text/csv')
+      expect(response.headers.get('Content-Disposition')).toContain(`filename="${route.name}-export-`)
+      await expect(response.text()).resolves.toContain('col1,col2')
+    })
+  }
+})


### PR DESCRIPTION
### Motivation
- Reduce duplicated auth/authz logic across export endpoints by centralizing privileged API guard behavior into a single helper. 
- Ensure consistent audit event names and CSV filename conventions for operations exports.
- Provide a contract test suite to assert uniform auth responses (`401`/`403`) and success CSV behavior across all export routes.

### Description
- Added `requirePrivilegedApiAccess()` in `lib/authz.ts` which returns either `{ user, role, supabase }` for authorized callers or a standardized `response` with `401`/`403` for API routes. 
- Migrated all export routes under `app/api/exports/*/route.ts` to use the new guard and the early-return pattern `if ('response' in auth) return auth.response`.
- Standardized audit actions to `operations.export.csv.<domain>` and normalized CSV filenames to `<domain>-export-YYYY-MM-DD.csv` for all exports. 
- Added a contract test `tests/integration/api/exports-authz-contract.test.ts` and documented the guard usage in `docs/security/rbac-matrix.md`.

### Testing
- Ran the contract suite with `pnpm -s vitest run tests/integration/api/exports-authz-contract.test.ts`, and all tests passed (12 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c7a5500832881f5cf19b86c0582)