### PR TITLE
Rename Supabase helper APIs to canonical createSupabase names

### DIFF
--- a/app/api/exports/bookings/route.ts
+++ b/app/api/exports/bookings/route.ts
@@ -3,10 +3,10 @@ import { NextResponse } from 'next/server'
 import { writeAuditRecord } from '@/lib/audit'
 import { fetchMemberRole } from '@/lib/data/members'
 import { getBookingRows, toCsv } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+import { createSupabaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET() {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
   const {
     data: { user },
   } = await supabase.auth.getUser()

--- a/app/api/exports/finance/route.ts
+++ b/app/api/exports/finance/route.ts
@@ -3,10 +3,10 @@ import { NextResponse } from 'next/server'
 import { writeAuditRecord } from '@/lib/audit'
 import { fetchMemberRole } from '@/lib/data/members'
 import { getFinanceRows, toCsv } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+import { createSupabaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET() {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
   const {
     data: { user },
   } = await supabase.auth.getUser()

--- a/app/api/exports/maintenance/route.ts
+++ b/app/api/exports/maintenance/route.ts
@@ -3,10 +3,10 @@ import { NextResponse } from 'next/server'
 import { writeAuditRecord } from '@/lib/audit'
 import { fetchMemberRole } from '@/lib/data/members'
 import { getMaintenanceRows, toCsv } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+import { createSupabaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET() {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
   const {
     data: { user },
   } = await supabase.auth.getUser()

--- a/app/api/exports/visitors/route.ts
+++ b/app/api/exports/visitors/route.ts
@@ -3,10 +3,10 @@ import { NextResponse } from 'next/server'
 import { writeAuditRecord } from '@/lib/audit'
 import { fetchMemberRole } from '@/lib/data/members'
 import { getVisitorRows, toCsv } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+import { createSupabaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET() {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
   const {
     data: { user },
   } = await supabase.auth.getUser()

--- a/app/api/search/global/route.ts
+++ b/app/api/search/global/route.ts
@@ -3,10 +3,10 @@ import { NextResponse } from 'next/server'
 import { writeAuditRecord } from '@/lib/audit'
 import { fetchMemberRole } from '@/lib/data/members'
 import { getGlobalSearchResults } from '@/lib/operations/data'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+import { createSupabaseServerClientReadOnly } from '@/utils/supaone'
 
 export async function GET(request: Request) {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
   const {
     data: { user },
   } = await supabase.auth.getUser()

--- a/app/auth/actions/index.tsx
+++ b/app/auth/actions/index.tsx
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
-import { createSupbaseServerClient } from "@/utils/supaone"
+import { createSupabaseServerClient } from "@/utils/supaone"
 import { hasSupabasePublicEnv } from "@/utils/supabase/env"
 import type { SignInWithSSO } from "@supabase/supabase-js"
 
@@ -46,7 +46,7 @@ export async function signUpWithEmailAndPassword(data: {
   }
 
   try {
-    const supabase = await createSupbaseServerClient()
+    const supabase = await createSupabaseServerClient()
     const result = await supabase.auth.signUp({
       email: data.email,
       password: data.password,
@@ -74,7 +74,7 @@ export async function requestPasswordReset(email: string) {
   }
 
   try {
-    const supabase = await createSupbaseServerClient()
+    const supabase = await createSupabaseServerClient()
     const redirectTo = process.env.NEXT_PUBLIC_SITE_URL
       ? `${process.env.NEXT_PUBLIC_SITE_URL}/auth/confirm?next=/auth?mode=reset`
       : undefined
@@ -95,7 +95,7 @@ export async function updatePassword(newPassword: string) {
   }
 
   try {
-    const supabase = await createSupbaseServerClient()
+    const supabase = await createSupabaseServerClient()
     const result = await supabase.auth.updateUser({ password: newPassword })
     return JSON.stringify(result)
   } catch (error) {
@@ -112,7 +112,7 @@ export async function loginWithEmailAndPassword(data: {
   }
 
   try {
-    const supabase = await createSupbaseServerClient()
+    const supabase = await createSupabaseServerClient()
     const result = await supabase.auth.signInWithPassword(data)
     revalidatePath("/", "layout")
 
@@ -123,7 +123,7 @@ export async function loginWithEmailAndPassword(data: {
 }
 
 export async function signInWithWorkOS(domain?: string) {
-  const supabase = await createSupbaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const trimmedDomain = domain?.trim()
   const workosProviderId = process.env.SUPABASE_WORKOS_CONNECTION_ID
@@ -169,7 +169,7 @@ export async function signInWithWorkOS(domain?: string) {
 }
 
 export async function signInWithGoogle() {
-  const supabase = await createSupbaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { data } = await supabase.auth.signInWithOAuth({
     provider: "google",
@@ -191,7 +191,7 @@ export async function signInWithGoogle() {
 
 export async function signInWithGoogle(): Promise<{ error?: string; url?: string }> {
   try {
-    const supabase = createSupbaseServerClient()
+    const supabase = createSupabaseServerClient()
 
     
     const { data, error } = await (await supabase).auth.signInWithOAuth({
@@ -230,7 +230,7 @@ export async function signInWithGoogle(): Promise<{ error?: string; url?: string
 */
 
 export async function signInWithGithub() {
-  const supabase = await createSupbaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const { data } = await supabase.auth.signInWithOAuth({
     provider: "github",
     options: {
@@ -243,7 +243,7 @@ export async function signInWithGithub() {
   }
 }
 export async function signInWithTwitter() {
-  const supabase = await createSupbaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const { data } = await supabase.auth.signInWithOAuth({
     provider: "twitter",
     options: {
@@ -256,7 +256,7 @@ export async function signInWithTwitter() {
   }
 }
 export async function signOut() {
-  const supabase = await createSupbaseServerClient()
+  const supabase = await createSupabaseServerClient()
   await supabase.auth.signOut()
   redirect("/")
 }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 // The client you created from the Server-Side Auth instructions
-import { createSupbaseServerClient } from '@/utils/supaone'
+import { createSupabaseServerClient } from '@/utils/supaone'
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
@@ -8,7 +8,7 @@ export async function GET(request: Request) {
   // if "next" is in param, use it as the redirect URL
   const next = searchParams.get('next') ?? '/'
   if (code) {
-    const supabase = await createSupbaseServerClient()
+    const supabase = await createSupabaseServerClient()
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
       const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,7 +1,7 @@
 import { type EmailOtpType } from '@supabase/supabase-js';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { createSupbaseServerClient } from '@/utils/supaone';
+import { createSupabaseServerClient } from '@/utils/supaone';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
   const token_hash = code ?? token_hash_searchParam;
 
   if (token_hash && type) {
-    const supabase = await createSupbaseServerClient();
+    const supabase = await createSupabaseServerClient();
 
     const { data } = await supabase.auth.verifyOtp({
       type,

--- a/app/dashboard/(dashboard)/components/onboarding-prompt-card.tsx
+++ b/app/dashboard/(dashboard)/components/onboarding-prompt-card.tsx
@@ -4,10 +4,10 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { computeOnboardingCompletion } from "@/lib/onboarding"
-import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+import { createSupabaseServerClientReadOnly } from "@/utils/supaone"
 
 export async function OnboardingPromptCard() {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
   const {
     data: { user },
   } = await supabase.auth.getUser()

--- a/app/dashboard/(dashboard)/production-data.ts
+++ b/app/dashboard/(dashboard)/production-data.ts
@@ -1,6 +1,6 @@
 import "server-only"
 
-import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+import { createSupabaseServerClientReadOnly } from "@/utils/supaone"
 
 import type {
   DashboardMetric,
@@ -123,7 +123,7 @@ function buildFallbackFloorplanWorkspace(currentUserId: string, currentUserRole:
 }
 
 async function getCurrentUserId() {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
   const {
     data: { user },
   } = await supabase.auth.getUser()
@@ -215,7 +215,7 @@ export async function fetchProductionRecentDocuments(): Promise<DocumentSummary[
 }
 
 export async function fetchProductionRoommateUpdates(): Promise<RoommateUpdate[]> {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
 
   const { data, error } = await supabase
     .from("threads")

--- a/app/dashboard/members/actions/index.tsx
+++ b/app/dashboard/members/actions/index.tsx
@@ -1,6 +1,6 @@
 "use server";
 
-import { createSupbaseServerClient } from "@/utils/supaone";
+import { createSupabaseServerClient } from "@/utils/supaone";
 
 import { redirect } from "next/navigation";
 

--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache"
 
-import { createSupbaseServerClient } from "@/utils/supaone"
+import { createSupabaseServerClient } from "@/utils/supaone"
 import type { Json } from "@/lib/supabase"
 import {
   computeOnboardingCompletion,
@@ -47,7 +47,7 @@ type OnboardingMetadata = {
 }
 
 async function loadSelfProfile() {
-  const supabase = await createSupbaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { user },
     error: userError,

--- a/app/onboarding/loaders.ts
+++ b/app/onboarding/loaders.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from "next/navigation"
 
-import { createSupbaseServerClientReadOnly } from "@/utils/supaone"
+import { createSupabaseServerClientReadOnly } from "@/utils/supaone"
 import { computeOnboardingCompletion } from "@/lib/onboarding"
 
 type OnboardingMetadata = {
@@ -31,7 +31,7 @@ type OnboardingMetadata = {
 }
 
 export async function loadOnboardingState() {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
 
   const {
     data: { user },

--- a/docs/engineering/conventions.md
+++ b/docs/engineering/conventions.md
@@ -34,6 +34,7 @@ The repository is organized to keep infrastructure, services, clients, and share
 - Follow functional component patterns with hooks in React. Avoid legacy class components unless required by dependencies.
 - Group tests alongside implementation files using the `.test.ts(x)` suffix.
 - Favor named exports; use default exports only for Next.js page components.
+- Supabase server helpers in `utils/supaone.tsx` must use canonical names: `createSupabaseServerClientReadOnly` and `createSupabaseServerClient`. Keep deprecated `Supbase` aliases only for temporary compatibility and do not use them in new code.
 
 ### Go (Backend Services)
 

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import type { Json } from '@/lib/supabase'
-import { createSupbaseServerClient } from '@/utils/supaone'
+import { createSupabaseServerClient } from '@/utils/supaone'
 
 export type AuditAction =
   | 'operations.dashboard.view'
@@ -24,7 +24,7 @@ export async function writeAuditRecord(input: {
   metadata?: Json
 }) {
   try {
-    const supabase = await createSupbaseServerClient()
+    const supabase = await createSupabaseServerClient()
     await supabase.from('audit_logs').insert({
       action: input.action,
       actor_id: input.actorId,

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -3,12 +3,12 @@ import 'server-only'
 import { redirect } from 'next/navigation'
 
 import { fetchMemberRole } from '@/lib/data/members'
-import { createSupbaseServerClientReadOnly } from '@/utils/supaone'
+import { createSupabaseServerClientReadOnly } from '@/utils/supaone'
 
 export const PRIVILEGED_ROLES = ['property_manager', 'admin'] as const
 
 export async function requirePrivilegedAccess() {
-  const supabase = await createSupbaseServerClientReadOnly()
+  const supabase = await createSupabaseServerClientReadOnly()
   const {
     data: { user },
   } = await supabase.auth.getUser()

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { createSupbaseServerClient } from "@/utils/supaone"
+import { createSupabaseServerClient } from "@/utils/supaone"
 import { Resend } from "resend"
 
 export interface NotificationData {
@@ -88,7 +88,7 @@ class NotificationService {
 
   async sendInAppNotification(notification: InAppNotification) {
     try {
-      const supabase = await createSupbaseServerClient()
+      const supabase = await createSupabaseServerClient()
 
       const { data, error } = await (supabase as any)
         .from("notifications")
@@ -140,7 +140,7 @@ class NotificationService {
 
   private async storeEmailNotification(notification: NotificationData) {
     try {
-      const supabase = await createSupbaseServerClient()
+      const supabase = await createSupabaseServerClient()
 
       await (supabase as any).from("email_notifications").insert({
         user_id: notification.userId,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint && pnpm check:supabase-helper-spelling",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:metadata": "vitest run tests/metadata",
@@ -34,7 +34,8 @@
     "js:budget": "node scripts/check-js-size.mjs",
     "check:legal-content": "node scripts/check-legal-content.mjs",
     "db:bootstrap": "bash scripts/bootstrap-local-db.sh",
-    "db:check-dashboard-schema": "bash scripts/check-dashboard-production-schema.sh"
+    "db:check-dashboard-schema": "bash scripts/check-dashboard-production-schema.sh",
+    "check:supabase-helper-spelling": "node scripts/check-supabase-helper-spelling.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/scripts/check-supabase-helper-spelling.mjs
+++ b/scripts/check-supabase-helper-spelling.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const roots = ['app', 'lib', 'utils'];
+const allowList = new Set(['utils/supaone.tsx']);
+const exts = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const disallowed = /\bSupbase\b|createSupbaseServerClient(ReadOnly)?\b/g;
+const violations = [];
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      walk(fullPath);
+      continue;
+    }
+
+    const normalizedPath = fullPath.replace(/\\/g, '/');
+    if (allowList.has(normalizedPath)) {
+      continue;
+    }
+
+    const ext = fullPath.slice(fullPath.lastIndexOf('.'));
+    if (!exts.has(ext)) {
+      continue;
+    }
+
+    const content = readFileSync(fullPath, 'utf8');
+    const lines = content.split('\n');
+    lines.forEach((line, index) => {
+      if (disallowed.test(line)) {
+        violations.push(`${fullPath}:${index + 1}: ${line.trim()}`);
+      }
+      disallowed.lastIndex = 0;
+    });
+  }
+}
+
+for (const root of roots) {
+  walk(root);
+}
+
+if (violations.length > 0) {
+  console.error('Found deprecated Supbase helper spelling. Use createSupabase... helpers instead.');
+  console.error(violations.join('\n'));
+  process.exit(1);
+}
+
+console.log('Supabase helper spelling check passed.');

--- a/utils/actions/index.tsx
+++ b/utils/actions/index.tsx
@@ -1,8 +1,8 @@
 "use server";
-import { createSupbaseServerClientReadOnly } from "../supaone";
+import { createSupabaseServerClientReadOnly } from "../supaone";
 
 export async function readUserSession() {
-	const supabase = await createSupbaseServerClientReadOnly();
+	const supabase = await createSupabaseServerClientReadOnly();
 
 	return supabase.auth.getSession();
 }

--- a/utils/supaone.tsx
+++ b/utils/supaone.tsx
@@ -2,9 +2,8 @@ import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import type { Database } from '@/lib/supabase'
 import { getSupabaseAnonKey, getSupabaseUrl } from '@/utils/supabase/env'
-import type { TypedSupabaseClient } from '@/utils/typed-supabase-client'
 
-export async function createSupbaseServerClientReadOnly() {
+export async function createSupabaseServerClientReadOnly() {
 	const cookieStore = cookies();
 
 	return createServerClient(
@@ -20,7 +19,7 @@ export async function createSupbaseServerClientReadOnly() {
 	);
 }
 
-export async function createSupbaseServerClient() {
+export async function createSupabaseServerClient() {
 	const cookieStore = cookies();
 
 	return createServerClient<Database>(
@@ -41,3 +40,13 @@ export async function createSupbaseServerClient() {
 		}
 	);
 }
+
+/**
+ * @deprecated Use createSupabaseServerClientReadOnly. Keep this alias for one release cycle.
+ */
+export const createSupbaseServerClientReadOnly = createSupabaseServerClientReadOnly;
+
+/**
+ * @deprecated Use createSupabaseServerClient. Keep this alias for one release cycle.
+ */
+export const createSupbaseServerClient = createSupabaseServerClient;


### PR DESCRIPTION
### Motivation

- Fix a recurring typo (`Supbase`) in the server-side Supabase helper names and standardise on the canonical `createSupabase...` names to avoid confusion and API drift. 
- Make the rename non-breaking by preserving temporary compatibility aliases for one release cycle to allow a safe migration across call sites. 
- Prevent regressions by adding an automated check that fails CI/lint if the misspelling is reintroduced outside the compatibility shim.

### Description

- Introduced canonical exports in `utils/supaone.tsx`: `createSupabaseServerClientReadOnly` and `createSupabaseServerClient`, and kept deprecated `createSupbase...` aliases with `@deprecated` comments for a single release-cycle transition. 
- Replaced imports/usages across `app/`, `lib/`, and `utils/` to use the canonical `createSupabase...` names (updated multiple files under `app/`, `lib/`, and `utils/`). 
- Added `scripts/check-supabase-helper-spelling.mjs` which scans `app`, `lib`, and `utils` for the `Supbase` typo or `createSupbase...` usage (allow-listing the alias file), and added `check:supabase-helper-spelling` to `package.json` and wired it into the `lint` script. 
- Updated contributor docs at `docs/engineering/conventions.md` to document the canonical helper names and the temporary alias policy.

### Testing

- Ran `pnpm check:supabase-helper-spelling` to validate the new guard script and ensure no disallowed `Supbase` usages exist outside the allow-listed shim, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c7ae2f48328b1881a74506536c6)