### PR TITLE
Batch document access logging in getDocumentsAction

### DIFF
--- a/app/documents/actions/index.ts
+++ b/app/documents/actions/index.ts
@@ -8,6 +8,7 @@ import { documensoService } from '@/lib/documenso';
 import { fetchDocumentStats, fetchDocumentsList } from '@/lib/data/documents';
 import { fetchMemberRole } from '@/lib/data/members';
 import type { TypedSupabaseClient } from '@/utils/typed-supabase-client';
+import { createStructuredLogger } from '@/lib/observability/logger';
 import {
   Document,
   DocumentWithLease,
@@ -53,6 +54,10 @@ interface ActionResult<T = any> {
   error?: string;
   message?: string;
 }
+
+const documentsActionLogger = createStructuredLogger('server_action', {
+  component: 'documents_actions',
+});
 
 
 async function logAuditEvent(
@@ -116,12 +121,28 @@ export async function getDocumentsAction(
       return { success: false, error: 'Failed to fetch documents.' };
     }
 
-    // Log access
-    for (const doc of documents) {
-      await (supabase as any).rpc('log_document_access', {
-        p_document_id: doc.id,
+    const accessedDocumentIds = documents.map((doc) => doc.id);
+
+    if (accessedDocumentIds.length > 0) {
+      documentsActionLogger.info('documents_audit_batch_attempted', {
+        eventName: 'documents_audit_batch_attempted',
+        actorId: user.id,
+        auditBatchSize: accessedDocumentIds.length,
+      });
+
+      const auditPromise = (supabase as any).rpc('log_document_access_bulk', {
+        p_document_ids: accessedDocumentIds,
         p_action: 'view',
-        p_metadata: { source: 'documents_page' }
+        p_metadata: { source: 'documents_page' },
+      });
+
+      void auditPromise.catch((auditError: unknown) => {
+        documentsActionLogger.warn('documents_audit_batch_failed', {
+          eventName: 'documents_audit_batch_failed',
+          actorId: user.id,
+          auditBatchSize: accessedDocumentIds.length,
+          error: auditError instanceof Error ? auditError.message : String(auditError),
+        });
       });
     }
 

--- a/supabase/migrations/202605050001_log_document_access_bulk.sql
+++ b/supabase/migrations/202605050001_log_document_access_bulk.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION public.log_document_access_bulk(
+  p_document_ids UUID[],
+  p_action TEXT,
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS SETOF UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF COALESCE(array_length(p_document_ids, 1), 0) = 0 THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+    INSERT INTO public.document_access_logs (document_id, user_id, action, metadata)
+    SELECT doc_id, auth.uid(), p_action, p_metadata
+    FROM unnest(p_document_ids) AS doc_id
+    RETURNING id;
+END;
+$$;

--- a/tests/app/documents/get-documents-action.test.ts
+++ b/tests/app/documents/get-documents-action.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCookies = vi.fn();
+const mockGetUser = vi.fn();
+const mockRpc = vi.fn();
+const mockFetchMemberRole = vi.fn();
+const mockFetchDocumentsList = vi.fn();
+const loggerInfo = vi.fn();
+const loggerWarn = vi.fn();
+
+vi.mock('next/headers', () => ({
+  cookies: mockCookies,
+}));
+
+vi.mock('@/utils/supa-server-actions', () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+    rpc: mockRpc,
+  })),
+}));
+
+vi.mock('@/lib/data/members', () => ({
+  fetchMemberRole: mockFetchMemberRole,
+}));
+
+vi.mock('@/lib/data/documents', () => ({
+  fetchDocumentsList: mockFetchDocumentsList,
+  fetchDocumentStats: vi.fn(),
+}));
+
+vi.mock('@/lib/observability/logger', () => ({
+  createStructuredLogger: vi.fn(() => ({
+    info: loggerInfo,
+    warn: loggerWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+describe('getDocumentsAction audit logging', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockCookies.mockReturnValue({});
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockFetchMemberRole.mockResolvedValue('tenant');
+  });
+
+  it('skips audit call for empty document list', async () => {
+    mockFetchDocumentsList.mockResolvedValue([]);
+
+    const { getDocumentsAction } = await import('@/app/documents/actions');
+    const result = await getDocumentsAction();
+
+    expect(result.success).toBe(true);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('writes one bulk audit call for multi-document lists', async () => {
+    mockFetchDocumentsList.mockResolvedValue([{ id: 'doc-1' }, { id: 'doc-2' }]);
+    mockRpc.mockResolvedValue({ data: ['audit-1', 'audit-2'], error: null });
+
+    const { getDocumentsAction } = await import('@/app/documents/actions');
+    const result = await getDocumentsAction();
+
+    expect(result.success).toBe(true);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+    expect(mockRpc).toHaveBeenCalledWith('log_document_access_bulk', {
+      p_document_ids: ['doc-1', 'doc-2'],
+      p_action: 'view',
+      p_metadata: { source: 'documents_page' },
+    });
+    expect(loggerInfo).toHaveBeenCalledWith(
+      'documents_audit_batch_attempted',
+      expect.objectContaining({
+        auditBatchSize: 2,
+      }),
+    );
+  });
+
+  it('returns documents when audit write fails and records warning telemetry', async () => {
+    mockFetchDocumentsList.mockResolvedValue([{ id: 'doc-9' }]);
+    mockRpc.mockRejectedValue(new Error('audit insert failed'));
+
+    const { getDocumentsAction } = await import('@/app/documents/actions');
+    const result = await getDocumentsAction();
+
+    await Promise.resolve();
+
+    expect(result).toEqual({ success: true, data: [{ id: 'doc-9' }] });
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'documents_audit_batch_failed',
+      expect.objectContaining({
+        auditBatchSize: 1,
+        error: 'audit insert failed',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace N-per-document RPC calls with a single batched operation to reduce DB round-trips and contention when listing documents. 
- Make audit writes bounded/non-blocking so document listing does not fail when audit inserts have transient problems. 
- Capture simple telemetry around batch size and failures to aid operational visibility. 

### Description
- Replaced the per-document loop that invoked `rpc('log_document_access', ...)` with a single batched RPC call to `rpc('log_document_access_bulk', { p_document_ids, ... })` in `app/documents/actions/index.ts`. 
- Made audit writes non-blocking by not awaiting the RPC and handling errors via a `.catch()` that emits a warning rather than failing the listing. 
- Added structured telemetry using `createStructuredLogger` to emit `documents_audit_batch_attempted` and `documents_audit_batch_failed` with `auditBatchSize`, actor context, and error details. 
- Added a DB migration `supabase/migrations/202605050001_log_document_access_bulk.sql` that creates `public.log_document_access_bulk(UUID[], TEXT, JSONB)` to insert multiple `document_access_logs` rows in a single operation. 
- Added unit tests in `tests/app/documents/get-documents-action.test.ts` that mock Supabase and observability and cover empty lists, multi-document lists, and audit failure fallback behavior. 

### Testing
- Ran `pnpm vitest tests/app/documents/get-documents-action.test.ts`, which passed all tests (3 tests): empty list skips audit, multi-document list issues one bulk audit call, and audit failure records a warning while returning documents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c7b3e308328aef4b725f64345cc)